### PR TITLE
Add Aspire Team App Copilot canvas extension

### DIFF
--- a/.github/extensions/aspire-team-app/README.md
+++ b/.github/extensions/aspire-team-app/README.md
@@ -1,0 +1,75 @@
+# Aspire Team App (canvas)
+
+A GitHub Copilot App **canvas extension** that recreates the
+[`davidfowl/pr-dashboard`](https://github.com/davidfowl/pr-dashboard) cross-repo PR
+review queue for the **logged-in GitHub user**. This is published as the first
+entry in the Canvas Marketplace.
+
+## What it does
+
+- **Review mode** — buckets every open PR across your watched repos into lanes:
+  Needs your review, Ready to merge, CI failing, Unresolved feedback, and Your PRs.
+- **Issues mode** — Assigned to you, Your issues, Needs triage, Recently active.
+- **Ship mode** — PRs in the current release milestone grouped into Ready to ship,
+  In progress, and Blocked.
+- **Signal pills** — Draft, CI failing, Merge conflicts, Changes requested,
+  N unresolved, Approved, Ready to merge, Needs review, Quick win, Stalled.
+- **Notifications** — review requested, your PR ready to merge, changes requested,
+  CI failing, with per-category preferences. Live updates over SSE.
+- **Multiple GitHub accounts** — every detected credential (gh CLI, environment,
+  Copilot) appears on the Accounts screen. Activate any number of them and their
+  results **interleave across every tab**, de-duplicated by PR/issue URL. Each
+  account watches **its own** repositories, editable inline.
+- **Enterprise aware** — accounts on a GitHub Enterprise Server host are badged and
+  their API calls are routed to that host's GraphQL/REST endpoints.
+- **Editable watched repos** — per account; defaults to the Aspire team set.
+
+## How it works
+
+| File | Responsibility |
+| --- | --- |
+| `extension.mjs` | Wiring: `joinSession` + `createCanvas`, agent-facing actions. |
+| `server.mjs` | Per-instance loopback HTTP server, JSON API, SSE refresh, multi-account interleave. |
+| `accounts.mjs` | Credential discovery, per-account repo-access probing, host/enterprise detection. |
+| `github.mjs` | GraphQL queries, lane bucketing, signals, avatars, cross-account merge. |
+| `model.mjs` | Attention buckets, focus queue, core-team / community classification. |
+| `constants.mjs` | Configuration: core-team members, release milestone, personal picks. |
+| `render.mjs` | Iframe HTML / CSS / client JS, styled with Copilot theme tokens. |
+| `state.mjs` | Durable per-account preferences (watched repos, active flag, notifications). |
+
+The canvas reads each account's token from `GH_TOKEN` / `GITHUB_TOKEN`, the
+per-account Copilot credentials, or `gh auth token`, and queries the matching
+GitHub GraphQL API with read-only public scopes.
+
+## Agent actions
+
+- `refresh` — reload the queue and push to the open dashboard.
+- `set_mode` — switch to `review` / `issues` / `ship`.
+- `set_repos` — replace the watched repositories for an account (targets the first
+  active account unless `account` id/login is given).
+- `set_account_active` — activate or deactivate an account by id/login; active
+  accounts interleave across every tab.
+- `accounts` — list every detected credential, its active state, and repo access.
+- `summary` — return a text summary without opening the canvas.
+
+## Install
+
+This extension ships in the repository under `.github/extensions/aspire-team-app/`, so
+the GitHub Copilot app auto-discovers it as a **project extension** whenever this repo is
+opened. No manual install step is required.
+
+It is also published to the Canvas Marketplace and can be installed standalone:
+
+```text
+install_extension url: https://github.com/IEvangelist/canvas-marketplace/tree/main/canvases/aspire-team-app
+```
+
+Once loaded, open it from chat, or via `open_canvas` with `canvasId: "aspire-team-app"`.
+
+## Notes
+
+- Notifications are **in-canvas + live in-session** (SSE). A canvas iframe is not a
+  PWA with a service worker, so OS-level push while the app is closed is out of
+  scope for v1.
+- `copilot-extension.json` lets the folder install as a gist as well as a repo
+  folder. `extension.mjs` must keep that exact filename.

--- a/.github/extensions/aspire-team-app/accounts.mjs
+++ b/.github/extensions/aspire-team-app/accounts.mjs
@@ -204,15 +204,31 @@ async function probeRepoAccess(token, repos, host) {
   return { accessible, total, status };
 }
 
-// A single account is keyed by its GitHub login (names are unique). The same
-// login can surface through several credentials (gh CLI, env, Copilot); we keep
-// them all as "sources" under one account and use the strongest for API calls.
+// A single account is keyed by its host + GitHub login. Logins are only unique
+// within a host, so a github.com user and a GitHub Enterprise Server user that
+// happen to share a login are distinct accounts and must not collapse together.
+// The same (host, login) can still surface through several credentials (gh CLI,
+// env, Copilot); we keep them all as "sources" under one account and use the
+// strongest for API calls.
 function loginKey(login) {
   return String(login ?? "unknown").trim().toLowerCase();
 }
 
-export function accountId(login) {
-  return `acct:${loginKey(login)}`;
+// Normalize a host so the public API's several spellings (empty, "api.github.com")
+// all collapse to the canonical "github.com".
+function hostKey(host) {
+  const h = String(host ?? "").trim().toLowerCase();
+  return !h || h === "github.com" || h === "api.github.com" ? "github.com" : h;
+}
+
+// github.com keeps the legacy login-only id ("acct:<login>") so preferences saved
+// before host-qualification (all github.com in practice) keep resolving. Enterprise
+// hosts are qualified ("acct:<host>/<login>") so they can't collide with a
+// same-named github.com account.
+export function accountId(login, host) {
+  const key = loginKey(login);
+  const h = hostKey(host);
+  return h === "github.com" ? `acct:${key}` : `acct:${h}/${key}`;
 }
 
 function score(probe) {
@@ -250,10 +266,11 @@ export async function resolveAccounts(reposForId, isActive) {
     idents.push(p);
   }
 
-  // Group every credential under its login.
+  // Group every credential under its (host, login) account identity so accounts
+  // that share a login across github.com and an enterprise host stay separate.
   const groups = new Map();
   for (const p of idents) {
-    const key = loginKey(p.login);
+    const key = accountId(p.login, p.host);
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key).push(p);
   }
@@ -261,8 +278,7 @@ export async function resolveAccounts(reposForId, isActive) {
   const accounts = [];
   const tokenById = new Map();
 
-  for (const [key, list] of groups) {
-    const id = accountId(key);
+  for (const [id, list] of groups) {
     const repos = reposForId(id);
 
     // Probe repo access for each credential against this account's own repos.

--- a/.github/extensions/aspire-team-app/accounts.mjs
+++ b/.github/extensions/aspire-team-app/accounts.mjs
@@ -1,0 +1,325 @@
+// Multi-account credential detection and probing for the Aspire Team App canvas.
+//
+// The Copilot App can have several GitHub credentials available at once (multiple
+// `gh` CLI accounts, the GH_TOKEN/GITHUB_TOKEN env tokens, and per-account
+// COPILOT_GH_ACCOUNT_* tokens). They do not all have the same scopes or repo
+// access. This module enumerates every candidate, resolves each to a GitHub
+// login, then probes that login's *own* configured repositories. Several accounts
+// can be active at once; the server interleaves their results.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createHash } from "node:crypto";
+
+const execFileAsync = promisify(execFile);
+
+const API = "https://api.github.com";
+const GRAPHQL = `${API}/graphql`;
+const UA = "aspire-team-app-canvas";
+
+// REST + GraphQL endpoints for a given host. github.com uses the public API
+// origin; GitHub Enterprise Server (GHES) exposes /api/v3 and /api/graphql on the
+// instance host itself.
+function endpoints(host) {
+  if (!host || host === "github.com" || host === "api.github.com") {
+    return { rest: "https://api.github.com", graphql: "https://api.github.com/graphql" };
+  }
+  return { rest: `https://${host}/api/v3`, graphql: `https://${host}/api/graphql` };
+}
+
+export function isEnterpriseHost(host) {
+  return !!host && host !== "github.com" && host !== "api.github.com";
+}
+
+function tokenHash(token) {
+  return createHash("sha256").update(token).digest("hex").slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Candidate enumeration
+// ---------------------------------------------------------------------------
+
+async function ghAccounts() {
+  try {
+    const { stdout } = await execFileAsync("gh", ["auth", "status"], { timeout: 8000 });
+    const accounts = [];
+    const re = /Logged in to (\S+) account (\S+)/g;
+    let m;
+    while ((m = re.exec(stdout)) !== null) {
+      accounts.push({ host: m[1], login: m[2] });
+    }
+    return accounts;
+  } catch {
+    return [];
+  }
+}
+
+async function ghToken(host, login) {
+  try {
+    const { stdout } = await execFileAsync(
+      "gh",
+      ["auth", "token", "--hostname", host, "--user", login],
+      { timeout: 8000 },
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function decodeCopilotAccount(varName) {
+  // COPILOT_GH_ACCOUNT_github_2E_com_dapine_5F_microsoft -> { host:"github.com", login:"dapine_microsoft" }
+  // Enterprise: COPILOT_GH_ACCOUNT_github_2E_acme_2E_com_someone -> { host:"github.acme.com", login:"someone" }
+  let s = varName.replace(/^COPILOT_GH_ACCOUNT_/, "");
+  // Encode the escaped tokens to placeholders so the host/login separator (a bare
+  // underscore) can be found unambiguously: dots are "_2E_", literal underscores
+  // in the login are "_5F_".
+  s = s.replace(/_2E_/g, "\u0001").replace(/_5F_/g, "\u0002");
+  const sep = s.indexOf("_");
+  let host;
+  let login;
+  if (sep === -1) {
+    host = "github.com";
+    login = s;
+  } else {
+    host = s.slice(0, sep);
+    login = s.slice(sep + 1);
+  }
+  host = host.replace(/\u0001/g, ".").replace(/\u0002/g, "_") || "github.com";
+  login = login.replace(/\u0001/g, ".").replace(/\u0002/g, "_") || null;
+  return { host, login };
+}
+
+export async function detectCandidates() {
+  const out = [];
+  const seenHash = new Set();
+  const add = (source, token, login, host) => {
+    if (!token) return;
+    const hash = tokenHash(token);
+    if (seenHash.has(hash)) return; // identical token already captured
+    seenHash.add(hash);
+    out.push({ source, token, hash, login: login ?? null, host: host || "github.com" });
+  };
+
+  // gh CLI accounts (each may have distinct scopes / hosts).
+  const accounts = await ghAccounts();
+  for (const a of accounts) {
+    add("gh", await ghToken(a.host, a.login), a.login, a.host);
+  }
+
+  // Plain env tokens (host from GH_HOST when targeting an enterprise instance).
+  const envHost = process.env.GH_HOST || "github.com";
+  add("env", process.env.GH_TOKEN, null, envHost);
+  add("env", process.env.GITHUB_TOKEN, null, envHost);
+
+  // Per-account Copilot tokens injected by the host (host encoded in the var name).
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith("COPILOT_GH_ACCOUNT_") && v) {
+      const { host, login } = decodeCopilotAccount(k);
+      add("copilot", v, login, host);
+    }
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Probing
+// ---------------------------------------------------------------------------
+
+async function gql(token, query, host) {
+  const { graphql } = endpoints(host);
+  const res = await fetch(graphql, {
+    method: "POST",
+    headers: { Authorization: `bearer ${token}`, "Content-Type": "application/json", "User-Agent": UA },
+    body: JSON.stringify({ query }),
+  });
+  const json = await res.json().catch(() => ({}));
+  return { ok: res.ok, data: json.data, errors: json.errors };
+}
+
+async function fetchScopes(token, host) {
+  try {
+    const { rest } = endpoints(host);
+    const res = await fetch(`${rest}/`, {
+      headers: { Authorization: `bearer ${token}`, "User-Agent": UA },
+    });
+    const raw = res.headers.get("x-oauth-scopes");
+    return raw ? raw.split(",").map((s) => s.trim()).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+function aliasFor(i) {
+  return `r${i}`;
+}
+
+// Pass 1: resolve the credential to a GitHub identity (login + avatar + scopes).
+async function probeIdentity(candidate) {
+  const { token, host } = candidate;
+  const base = {
+    source: candidate.source,
+    hash: candidate.hash,
+    host: host || "github.com",
+    enterprise: isEnterpriseHost(host),
+    login: candidate.login ?? null,
+    avatarUrl: null,
+    scopes: [],
+  };
+  try {
+    const res = await gql(token, `query { viewer { login avatarUrl } }`, host);
+    if (!res.data?.viewer?.login) {
+      return { ...base, login: base.login ?? "unknown", ok: false, status: "failed",
+        reason: res.errors?.[0]?.message ?? "Authentication failed" };
+    }
+    const scopes = await fetchScopes(token, host);
+    return { ...base, login: res.data.viewer.login, avatarUrl: res.data.viewer.avatarUrl ?? null, scopes, ok: true };
+  } catch (e) {
+    return { ...base, login: base.login ?? "unknown", ok: false, status: "failed", reason: e.message };
+  }
+}
+
+// Pass 2: probe how many of `repos` a credential can actually read.
+async function probeRepoAccess(token, repos, host) {
+  if (!repos.length) return { accessible: 0, total: 0, status: "ok" };
+  const selections = repos
+    .map((repo, i) => {
+      const [owner, ...rest] = repo.split("/");
+      const name = rest.join("/");
+      return `${aliasFor(i)}: repository(owner:${JSON.stringify(owner)}, name:${JSON.stringify(name)}) { nameWithOwner }`;
+    })
+    .join("\n");
+  const res = await gql(token, `query { ${selections} }`, host);
+  let accessible = 0;
+  if (res.data) {
+    for (let i = 0; i < repos.length; i++) {
+      if (res.data[aliasFor(i)]) accessible++;
+    }
+  }
+  const total = repos.length;
+  let status = "ok";
+  if (accessible === 0) status = "limited";
+  else if (accessible < total) status = "partial";
+  return { accessible, total, status };
+}
+
+// A single account is keyed by its GitHub login (names are unique). The same
+// login can surface through several credentials (gh CLI, env, Copilot); we keep
+// them all as "sources" under one account and use the strongest for API calls.
+function loginKey(login) {
+  return String(login ?? "unknown").trim().toLowerCase();
+}
+
+export function accountId(login) {
+  return `acct:${loginKey(login)}`;
+}
+
+function score(probe) {
+  if (probe.status === "failed") return -1;
+  let s = 100000; // authenticated
+  s += (probe.accessible || 0) * 1000;
+  if (probe.hasReadOrg) s += 100;
+  // Prefer keyring/gh and copilot sources over a bare env token on ties.
+  s += probe.source === "gh" ? 3 : probe.source === "copilot" ? 2 : 1;
+  return s;
+}
+
+function accountScore(acct) {
+  if (acct.status === "failed") return -1;
+  let s = 100000;
+  s += (acct.accessible || 0) * 1000;
+  if (acct.hasReadOrg) s += 100;
+  s += Math.min(acct.sources.length, 5);
+  return s;
+}
+
+const SOURCE_LABEL = { gh: "GitHub CLI", env: "Environment", copilot: "Copilot" };
+
+// Probe every credential, collapse them into one account per login (each with the
+// repositories that account watches and whether the user marked it active), and
+// return the chosen token per account. `reposForId(id)` returns the repos to probe
+// for a given account; `isActive(id)` reports whether the user enabled it.
+export async function resolveAccounts(reposForId, isActive) {
+  const candidates = await detectCandidates();
+
+  const idents = [];
+  for (const c of candidates) {
+    const p = await probeIdentity(c);
+    p.token = c.token;
+    idents.push(p);
+  }
+
+  // Group every credential under its login.
+  const groups = new Map();
+  for (const p of idents) {
+    const key = loginKey(p.login);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(p);
+  }
+
+  const accounts = [];
+  const tokenById = new Map();
+
+  for (const [key, list] of groups) {
+    const id = accountId(key);
+    const repos = reposForId(id);
+
+    // Probe repo access for each credential against this account's own repos.
+    for (const p of list) {
+      if (p.ok) {
+        const acc = await probeRepoAccess(p.token, repos, p.host);
+        p.accessible = acc.accessible;
+        p.total = acc.total;
+        p.status = acc.status;
+        p.hasReadOrg = (p.scopes || []).includes("read:org");
+      } else {
+        p.accessible = 0;
+        p.total = repos.length;
+        p.status = "failed";
+        p.hasReadOrg = false;
+      }
+    }
+
+    list.sort((a, b) => score(b) - score(a));
+    const best = list[0];
+    tokenById.set(id, best.token);
+
+    const sources = list.map((p, i) => ({
+      source: p.source,
+      label: SOURCE_LABEL[p.source] ?? p.source,
+      hash: p.hash,
+      host: p.host,
+      enterprise: p.enterprise,
+      status: p.status,
+      scopes: p.scopes,
+      accessible: p.accessible,
+      total: p.total,
+      hasReadOrg: p.hasReadOrg,
+      reason: p.reason ?? null,
+      chosen: i === 0,
+    }));
+
+    accounts.push({
+      id,
+      login: best.login,
+      avatarUrl: best.avatarUrl ?? (list.find((p) => p.avatarUrl) || {}).avatarUrl ?? null,
+      host: best.host || "github.com",
+      enterprise: isEnterpriseHost(best.host),
+      graphql: endpoints(best.host).graphql,
+      status: best.status,
+      accessible: best.accessible,
+      total: best.total,
+      hasReadOrg: sources.some((s) => s.hasReadOrg),
+      reason: best.reason ?? null,
+      sources,
+      sourceKinds: [...new Set(list.map((p) => p.source))],
+      repos,
+      active: !!isActive(id),
+    });
+  }
+
+  accounts.sort((a, b) => accountScore(b) - accountScore(a));
+
+  return { accounts, tokenById };
+}

--- a/.github/extensions/aspire-team-app/accounts.mjs
+++ b/.github/extensions/aspire-team-app/accounts.mjs
@@ -20,15 +20,25 @@ const UA = "aspire-team-app-canvas";
 // REST + GraphQL endpoints for a given host. github.com uses the public API
 // origin; GitHub Enterprise Server (GHES) exposes /api/v3 and /api/graphql on the
 // instance host itself.
+function normalizeHost(host) {
+  const h = String(host ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/\/.*$/, "");
+  return !h || h === "github.com" || h === "api.github.com" ? "github.com" : h;
+}
+
 function endpoints(host) {
-  if (!host || host === "github.com" || host === "api.github.com") {
+  const h = normalizeHost(host);
+  if (h === "github.com") {
     return { rest: "https://api.github.com", graphql: "https://api.github.com/graphql" };
   }
-  return { rest: `https://${host}/api/v3`, graphql: `https://${host}/api/graphql` };
+  return { rest: `https://${h}/api/v3`, graphql: `https://${h}/api/graphql` };
 }
 
 export function isEnterpriseHost(host) {
-  return !!host && host !== "github.com" && host !== "api.github.com";
+  return normalizeHost(host) !== "github.com";
 }
 
 function tokenHash(token) {
@@ -98,7 +108,7 @@ export async function detectCandidates() {
     const hash = tokenHash(token);
     if (seenHash.has(hash)) return; // identical token already captured
     seenHash.add(hash);
-    out.push({ source, token, hash, login: login ?? null, host: host || "github.com" });
+    out.push({ source, token, hash, login: login ?? null, host: normalizeHost(host) });
   };
 
   // gh CLI accounts (each may have distinct scopes / hosts).
@@ -108,7 +118,7 @@ export async function detectCandidates() {
   }
 
   // Plain env tokens (host from GH_HOST when targeting an enterprise instance).
-  const envHost = process.env.GH_HOST || "github.com";
+  const envHost = normalizeHost(process.env.GH_HOST || "github.com");
   add("env", process.env.GH_TOKEN, null, envHost);
   add("env", process.env.GITHUB_TOKEN, null, envHost);
 
@@ -157,7 +167,8 @@ function aliasFor(i) {
 
 // Pass 1: resolve the credential to a GitHub identity (login + avatar + scopes).
 async function probeIdentity(candidate) {
-  const { token, host } = candidate;
+  const { token } = candidate;
+  const host = normalizeHost(candidate.host);
   const base = {
     source: candidate.source,
     hash: candidate.hash,
@@ -214,21 +225,13 @@ function loginKey(login) {
   return String(login ?? "unknown").trim().toLowerCase();
 }
 
-// Normalize a host so the public API's several spellings (empty, "api.github.com")
-// all collapse to the canonical "github.com".
-function hostKey(host) {
-  const h = String(host ?? "").trim().toLowerCase();
-  return !h || h === "github.com" || h === "api.github.com" ? "github.com" : h;
-}
-
-// github.com keeps the legacy login-only id ("acct:<login>") so preferences saved
-// before host-qualification (all github.com in practice) keep resolving. Enterprise
-// hosts are qualified ("acct:<host>/<login>") so they can't collide with a
-// same-named github.com account.
+// The account id includes the normalized host so a github.com account and a GHES
+// account with the same login never share repository preferences. state.mjs keeps
+// a fallback for the previous github.com-only "acct:<login>" keys.
 export function accountId(login, host) {
   const key = loginKey(login);
-  const h = hostKey(host);
-  return h === "github.com" ? `acct:${key}` : `acct:${h}/${key}`;
+  const h = normalizeHost(host);
+  return `acct:${h}/${key}`;
 }
 
 function score(probe) {

--- a/.github/extensions/aspire-team-app/accounts.test.mjs
+++ b/.github/extensions/aspire-team-app/accounts.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { accountId } from "./accounts.mjs";
+import { accountConfig } from "./state.mjs";
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  restoreEnvironment();
+  globalThis.fetch = originalFetch;
+});
+
+test("accountId includes normalized host and login", () => {
+  assert.equal(accountId("Octo", "HTTPS://API.GITHUB.COM/foo"), "acct:github.com/octo");
+  assert.equal(accountId("Octo", "GHE.EXAMPLE.COM"), "acct:ghe.example.com/octo");
+});
+
+test("resolveAccounts keys accounts by normalized host and login", async () => {
+  resetAccountEnv({
+    COPILOT_GH_ACCOUNT_github_2E_com_octo: "token-dotcom",
+    COPILOT_GH_ACCOUNT_ghe_2E_example_2E_com_octo: "token-ghe",
+  });
+  globalThis.fetch = accountFetch();
+  const { resolveAccounts } = await import(`./accounts.mjs?test=host-login-${Date.now()}`);
+
+  const { accounts } = await resolveAccounts(() => ["microsoft/aspire"], () => true);
+
+  assert.deepEqual(accounts.map((a) => a.id).sort(), [
+    "acct:ghe.example.com/octo",
+    "acct:github.com/octo",
+  ]);
+  assert.equal(new Set(accounts.map((a) => a.host)).size, 2);
+});
+
+test("resolveAccounts reads legacy login-only preferences for github.com accounts", async () => {
+  resetAccountEnv({ COPILOT_GH_ACCOUNT_github_2E_com_octo: "token-dotcom" });
+  globalThis.fetch = accountFetch();
+  const { resolveAccounts } = await import(`./accounts.mjs?test=legacy-${Date.now()}`);
+  const legacyPrefs = {
+    "acct:octo": { repos: ["microsoft/aspire.dev"], active: true },
+  };
+
+  const { accounts } = await resolveAccounts(
+    (id) => accountConfig({ accounts: legacyPrefs }, id).repos,
+    (id) => accountConfig({ accounts: legacyPrefs }, id).active,
+  );
+
+  assert.equal(accounts[0].id, "acct:github.com/octo");
+  assert.deepEqual(accounts[0].repos, ["microsoft/aspire.dev"]);
+  assert.equal(accounts[0].active, true);
+});
+
+function resetAccountEnv(extra) {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("COPILOT_GH_ACCOUNT_")) {
+      delete process.env[key];
+    }
+  }
+  delete process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_HOST;
+  process.env.PATH = "";
+  Object.assign(process.env, extra);
+}
+
+function accountFetch() {
+  return async (url, options = {}) => {
+    const requestUrl = String(url);
+    const body = options.body ? JSON.parse(options.body) : {};
+    const query = body.query ?? "";
+    if (requestUrl.endsWith("/api/v3/") || requestUrl === "https://api.github.com/") {
+      return jsonResponse({}, { headers: { "x-oauth-scopes": "read:org" } });
+    }
+    if (query.includes("viewer { login")) {
+      return jsonResponse({ data: { viewer: { login: "octo", avatarUrl: `${requestUrl}/octo.png` } } });
+    }
+    if (query.includes("r0: repository")) {
+      return jsonResponse({ data: { r0: { nameWithOwner: "microsoft/aspire" } } });
+    }
+    throw new Error(`Unexpected fetch: ${requestUrl} ${query}`);
+  };
+}
+
+function jsonResponse(body, options = {}) {
+  const headers = options.headers ?? {};
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    statusText: options.statusText ?? "OK",
+    headers: {
+      get(name) { return headers[name.toLowerCase()] ?? null; },
+    },
+    json: async () => body,
+  };
+}
+
+function restoreEnvironment() {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("COPILOT_GH_ACCOUNT_") && !(key in originalEnv)) {
+      delete process.env[key];
+    }
+  }
+  for (const name of ["GH_TOKEN", "GITHUB_TOKEN", "GH_HOST", "PATH"]) {
+    if (originalEnv[name] === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = originalEnv[name];
+    }
+  }
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (key.startsWith("COPILOT_GH_ACCOUNT_")) {
+      process.env[key] = value;
+    }
+  }
+}

--- a/.github/extensions/aspire-team-app/constants.mjs
+++ b/.github/extensions/aspire-team-app/constants.mjs
@@ -1,0 +1,38 @@
+// Shared constants ported from davidfowl/pr-dashboard frontend/src/constants.ts.
+
+export const currentRelease = "13.4";
+export const hourMs = 1000 * 60 * 60;
+export const dayMs = hourMs * 24;
+
+export const coreTeamMembers = [
+  "davidfowl",
+  "mitchdenny",
+  "sebastienros",
+  "IEvangelist",
+  "danegsta",
+  "radical",
+  "JamesNK",
+  "adamint",
+  "joperezr",
+  "maddymontaquila",
+  "DamianEdwards",
+  "eerhardt",
+  "ellahathaway",
+  "karolz-ms",
+];
+
+// Author login suffixes that mark a core-team member's alt/enterprise alias (e.g.
+// "dapine_microsoft"). Any author ending in one of these is treated as core team,
+// and if the base login (with the suffix stripped) matches a coreTeamMembers entry
+// it is attributed to that member. Ported from pr-dashboard Dashboard config (#95).
+export const coreTeamMemberAliasSuffixes = ["_microsoft"];
+
+// Single source of truth for the "For you" personal-pick action labels.
+export const personalPickActions = {
+  resolveConflicts: "Resolve conflicts",
+  needsAttention: "Needs your attention",
+  fixCi: "Fix CI",
+  reviewThis: "Review this",
+  respondHere: "Respond here",
+  finishThis: "Finish this",
+};

--- a/.github/extensions/aspire-team-app/copilot-extension.json
+++ b/.github/extensions/aspire-team-app/copilot-extension.json
@@ -1,0 +1,4 @@
+{
+  "name": "aspire-team-app",
+  "version": 1
+}

--- a/.github/extensions/aspire-team-app/extension.mjs
+++ b/.github/extensions/aspire-team-app/extension.mjs
@@ -13,7 +13,12 @@ import { accountId } from "./accounts.mjs";
 
 function resolveAccountId(ref) {
   if (!ref) return null;
-  return String(ref).startsWith("acct:") ? String(ref).toLowerCase() : accountId(ref);
+  const value = String(ref).toLowerCase();
+  if (value.startsWith("acct:")) {
+    const accountRef = value.slice("acct:".length);
+    return accountRef.includes("/") ? value : accountId(accountRef);
+  }
+  return accountId(value);
 }
 
 const session = await joinSession({

--- a/.github/extensions/aspire-team-app/extension.mjs
+++ b/.github/extensions/aspire-team-app/extension.mjs
@@ -1,0 +1,158 @@
+// Aspire Team App: a GitHub Copilot App canvas extension.
+//
+// Recreates the davidfowl/pr-dashboard cross-repo PR review queue for the
+// logged-in GitHub user: Review / Issues / Ship modes, review lanes, signal
+// pills, and notifications. The dashboard UI is served from a per-instance
+// loopback server (see server.mjs); GitHub data and lane logic live in
+// github.mjs; durable preferences in state.mjs.
+
+import { joinSession, createCanvas, CanvasError } from "@github/copilot-sdk/extension";
+import { startInstance, stopInstance, forceRefresh, getDashboard, rescanAccounts, toggleAccount, setReposFor } from "./server.mjs";
+import { loadPrefs, savePrefs } from "./state.mjs";
+import { accountId } from "./accounts.mjs";
+
+function resolveAccountId(ref) {
+  if (!ref) return null;
+  return String(ref).startsWith("acct:") ? String(ref).toLowerCase() : accountId(ref);
+}
+
+const session = await joinSession({
+  canvases: [
+    createCanvas({
+      id: "aspire-team-app",
+      displayName: "Aspire Team App",
+      description:
+        "Cross-repo PR review queue for the logged-in GitHub user: Review, Issues, and Ship modes with signal pills and notifications.",
+      actions: [
+        {
+          name: "refresh",
+          description: "Reload the review queue from GitHub and push the update to the open dashboard.",
+          handler: async () => {
+            const { dashboard } = await forceRefresh();
+            return {
+              mode: dashboard.mode,
+              counts: dashboard.counts ?? null,
+              authenticated: dashboard.authenticated,
+            };
+          },
+        },
+        {
+          name: "set_mode",
+          description: "Switch the dashboard mode.",
+          inputSchema: {
+            type: "object",
+            properties: { mode: { type: "string", enum: ["review", "issues", "ship"] } },
+            required: ["mode"],
+          },
+          handler: async (ctx) => {
+            const mode = ctx.input?.mode;
+            if (!["review", "issues", "ship"].includes(mode)) {
+              throw new CanvasError("invalid_mode", "mode must be review, issues, or ship");
+            }
+            const prefs = await loadPrefs();
+            prefs.mode = mode;
+            await savePrefs(prefs);
+            const { dashboard } = await forceRefresh();
+            return { mode: dashboard.mode, counts: dashboard.counts ?? null };
+          },
+        },
+        {
+          name: "set_repos",
+          description: "Replace the watched repositories for one account (comma or space separated, e.g. 'microsoft/aspire, CommunityToolkit/Aspire'). Targets the first active account unless 'account' (id or login) is given.",
+          inputSchema: {
+            type: "object",
+            properties: { repos: { type: "string" }, account: { type: "string" } },
+            required: ["repos"],
+          },
+          handler: async (ctx) => {
+            let id = resolveAccountId(ctx.input?.account);
+            if (!id) {
+              const { dashboard } = await getDashboard(false);
+              const first = (dashboard.activeAccounts ?? [])[0] ?? (dashboard.accounts ?? [])[0];
+              id = first ? first.id : null;
+            }
+            if (!id) throw new CanvasError("no_account", "No account available to set repos for");
+            const { dashboard } = await setReposFor(id, ctx.input?.repos ?? "");
+            const acct = (dashboard.activeAccounts ?? []).find((a) => a.id === id)
+              ?? (dashboard.accounts ?? []).find((a) => a.id === id);
+            return { account: id, repos: acct ? acct.repos : [], counts: dashboard.counts ?? null };
+          },
+        },
+        {
+          name: "summary",
+          description: "Return a text summary of the current review queue without opening the canvas.",
+          handler: async () => {
+            const { dashboard } = await getDashboard(false);
+            if (!dashboard.authenticated) {
+              return {
+                authenticated: false,
+                message: dashboard.message,
+                accounts: (dashboard.accounts ?? []).map((a) => ({
+                  id: a.id, login: a.login, sources: a.sourceKinds, status: a.status,
+                  enterprise: !!a.enterprise, host: a.host ?? null,
+                })),
+              };
+            }
+            const c = dashboard.counts;
+            return {
+              authenticated: true,
+              viewer: dashboard.viewer,
+              viewers: dashboard.viewers ?? [dashboard.viewer],
+              activeAccounts: (dashboard.activeAccounts ?? []).map((a) => ({
+                id: a.id, login: a.login, sources: a.sourceKinds, status: a.status,
+                enterprise: !!a.enterprise, host: a.host ?? null, repos: a.repos ?? [],
+              })),
+              mode: dashboard.mode,
+              repos: dashboard.repos,
+              counts: c,
+              notifications: (dashboard.notifications ?? []).length,
+            };
+          },
+        },
+        {
+          name: "accounts",
+          description: "List every detected GitHub credential, whether it is active, and whether it can read its watched repos. Re-probes all accounts.",
+          handler: async () => {
+            const { accounts, activeAccounts } = await rescanAccounts();
+            return {
+              active: (activeAccounts ?? []).map((a) => a.id),
+              accounts: accounts.map((a) => ({
+                id: a.id, login: a.login, sources: a.sourceKinds, status: a.status,
+                active: !!a.active, enterprise: !!a.enterprise, host: a.host ?? null,
+                accessible: a.accessible, total: a.total, hasReadOrg: a.hasReadOrg,
+                reason: a.reason ?? null,
+              })),
+            };
+          },
+        },
+        {
+          name: "set_account_active",
+          description: "Activate or deactivate a GitHub account by its id (from the accounts action) or login. Active accounts are interleaved across every tab.",
+          inputSchema: {
+            type: "object",
+            properties: { id: { type: "string" }, login: { type: "string" }, active: { type: "boolean" } },
+            required: ["active"],
+          },
+          handler: async (ctx) => {
+            const id = resolveAccountId(ctx.input?.id ?? ctx.input?.login);
+            if (!id) throw new CanvasError("invalid_account", "id or login is required");
+            const active = !!ctx.input?.active;
+            const { dashboard } = await toggleAccount(id, active);
+            return {
+              authenticated: dashboard.authenticated,
+              active: (dashboard.activeAccounts ?? []).map((a) => a.id),
+              counts: dashboard.counts ?? null,
+            };
+          },
+        },
+      ],
+      open: async (ctx) => {
+        const entry = await startInstance(ctx.instanceId, (m) => session.log(m, { level: "debug" }));
+        return { title: "Aspire Team App", url: entry.url, status: "Review queue" };
+      },
+      onClose: async (ctx) => {
+        await stopInstance(ctx.instanceId);
+      },
+    }),
+  ],
+});

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -16,10 +16,16 @@ import {
   computeFocusExclusionItems,
   computeCommunityItems,
 } from "./model.mjs";
+import { currentRelease } from "./constants.mjs";
 
 const execFileAsync = promisify(execFile);
 
-export const CURRENT_RELEASE = "13.4";
+// The current milestone has a single source of truth in constants.mjs
+// (`currentRelease`). Re-export it here under the name the run-mode lane logic
+// (`bucketShip`) and the default `release` preference (via state.mjs) already
+// consume, so bumping the milestone in one place keeps release detection and the
+// default milestone from silently desyncing.
+export const CURRENT_RELEASE = currentRelease;
 
 export const DEFAULT_REPOS = [
   "microsoft/aspire",

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -1,0 +1,735 @@
+// GitHub data layer for the Aspire Team App canvas.
+//
+// Resolves the logged-in user's token, queries open PRs/issues across the watched
+// repos via the GraphQL API, then buckets them into review lanes and computes
+// signal pills. This is a faithful, self-contained port of the lane + signal logic
+// from davidfowl/pr-dashboard (frontend/src/utils/{models,signals,pullRequests}.ts).
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  createAttentionBuckets,
+  createForMeItems,
+  createDeveloperPullRequestCounts,
+  createAttentionSignals,
+  computeFocusItems,
+  computeFocusExclusionItems,
+  computeCommunityItems,
+} from "./model.mjs";
+
+const execFileAsync = promisify(execFile);
+
+export const CURRENT_RELEASE = "13.4";
+
+export const DEFAULT_REPOS = [
+  "microsoft/aspire",
+  "microsoft/aspire.dev",
+  "microsoft/aspire-skills",
+  "microsoft/dcp",
+  "CommunityToolkit/Aspire",
+];
+
+const GRAPHQL = "https://api.github.com/graphql";
+
+// ---------------------------------------------------------------------------
+// Token + viewer resolution (the logged-in GitHub user).
+// ---------------------------------------------------------------------------
+
+let cachedToken;
+
+export async function resolveToken() {
+  if (cachedToken) return cachedToken;
+  for (const key of ["GH_TOKEN", "GITHUB_TOKEN"]) {
+    if (process.env[key]) {
+      cachedToken = process.env[key];
+      return cachedToken;
+    }
+  }
+  try {
+    const { stdout } = await execFileAsync("gh", ["auth", "token"], { timeout: 8000 });
+    const token = stdout.trim();
+    if (token) {
+      cachedToken = token;
+      return cachedToken;
+    }
+  } catch {
+    // gh not installed or not authenticated.
+  }
+  return null;
+}
+
+async function gql(token, query, variables, graphqlUrl = GRAPHQL) {
+  const res = await fetch(graphqlUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "aspire-team-app-canvas",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status} ${res.statusText}`);
+  }
+  const json = await res.json();
+  if (json.errors?.length) {
+    throw new Error(json.errors.map((e) => e.message).join("; "));
+  }
+  return json.data;
+}
+
+export async function resolveViewer(token) {
+  const data = await gql(token, `query { viewer { login } }`, {});
+  return data.viewer.login;
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+const PR_QUERY = `
+query($owner:String!, $name:String!) {
+  repository(owner:$owner, name:$name) {
+    isPrivate
+    pullRequests(states:OPEN, first:40, orderBy:{field:UPDATED_AT, direction:DESC}) {
+      nodes {
+        number title url isDraft state createdAt updatedAt
+        author { __typename login avatarUrl }
+        baseRefName
+        mergeable
+        reviewDecision
+        additions deletions changedFiles
+        milestone { title }
+        labels(first:15) { nodes { name } }
+        assignees(first:10) { nodes { login } }
+        reviewRequests(first:20) { nodes { requestedReviewer { __typename ... on User { login } } } }
+        reviews(first:60) { nodes { state author { login } submittedAt } }
+        reviewThreads(first:60) { nodes { isResolved } }
+        commits(last:1) { totalCount nodes { commit { committedDate statusCheckRollup { state } } } }
+        closingIssuesReferences(first:10) {
+          nodes {
+            number title url
+            repository { nameWithOwner }
+            milestone { title }
+            labels(first:15) { nodes { name } }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const ISSUE_QUERY = `
+query($owner:String!, $name:String!) {
+  repository(owner:$owner, name:$name) {
+    issues(states:OPEN, first:40, orderBy:{field:UPDATED_AT, direction:DESC}) {
+      nodes {
+        number title url createdAt updatedAt
+        author { login avatarUrl }
+        milestone { title }
+        labels(first:15) { nodes { name } }
+        assignees(first:10) { nodes { login } }
+      }
+    }
+  }
+}`;
+
+function splitRepo(repo) {
+  const [owner, ...rest] = repo.split("/");
+  return { owner, name: rest.join("/") };
+}
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+function mapCheckState(rollup) {
+  const state = rollup?.state;
+  if (state === "SUCCESS") return "success";
+  if (state === "FAILURE" || state === "ERROR") return "failure";
+  if (state === "PENDING" || state === "EXPECTED") return "pending";
+  return "none";
+}
+
+function mapMergeable(m) {
+  if (m === "MERGEABLE") return "clean";
+  if (m === "CONFLICTING") return "dirty";
+  return "unknown";
+}
+
+// Reviewer-actor classification (mirrors GitHubClient.IsBotActor / IsCopilotReviewer).
+const BOT_REVIEWERS = new Set(["dependabot", "dependabot-preview", "github-actions", "renovate"]);
+function isBotReviewer(login) {
+  const n = String(login || "").toLowerCase();
+  return n.endsWith("[bot]") || n === "copilot" || BOT_REVIEWERS.has(n);
+}
+function isCopilotReviewer(login) {
+  const n = String(login || "").toLowerCase();
+  return n === "copilot-pull-request-reviewer" || n === "copilot-pull-request-reviewer[bot]";
+}
+function isCopilotLogin(login) {
+  const n = String(login || "").toLowerCase();
+  return n === "copilot" || n === "copilot[bot]" || n === "github-copilot[bot]" || n.endsWith("/copilot");
+}
+
+// Copilot attribution (mirrors GitHubModels.ResolveAuthor): a Copilot-authored PR with
+// exactly one human assignee is attributed to "{human}/copilot" so it classifies as the
+// human's work rather than a bot.
+function resolveAuthor(login, assignees) {
+  if (!isCopilotLogin(login)) return login;
+  const humans = assignees.filter((a) => a && !/\[bot\]$/i.test(a) && a.toLowerCase() !== "copilot");
+  return humans.length === 1 ? `${humans[0]}/copilot` : login;
+}
+
+// Server-parity review summary (mirrors GitHubClient.CreateReviewStatusFromGraphQlAsync).
+// `rawUnresolved` is the count of unresolved review threads before policy gating.
+const RESOLUTION_REQUIRED_REPOS = new Set(["microsoft/aspire"]);
+function deriveReview(reviews, requestedReviewers, viewers, repo, rawUnresolved) {
+  const human = reviews
+    .filter((r) => r.author?.login && !isBotReviewer(r.author.login) && r.submittedAt)
+    .sort((a, b) => new Date(a.submittedAt) - new Date(b.submittedAt));
+  const copilotReviewed = reviews.some((r) => isCopilotReviewer(r.author?.login));
+
+  // Latest review per human reviewer decides the headline state.
+  const latestByReviewer = new Map();
+  for (const r of human) latestByReviewer.set(r.author.login.toLowerCase(), r);
+  let latestChanges = 0, latestApprovals = 0, latestCommented = 0;
+  for (const r of latestByReviewer.values()) {
+    if (r.state === "CHANGES_REQUESTED") latestChanges++;
+    else if (r.state === "APPROVED") latestApprovals++;
+    else if (r.state === "COMMENTED") latestCommented++;
+  }
+  let state = "waiting";
+  if (latestChanges > 0) state = "changes_requested";
+  else if (latestApprovals > 0) state = "approved";
+  else if (latestCommented > 0) state = "reviewed";
+
+  // Aggregate counts span every human review, not just the latest per reviewer.
+  let approvalCount = 0, changesRequestedCount = 0, commentedReviewCount = 0;
+  let lastApprovedAt = null, lastReviewedAt = null;
+  for (const r of human) {
+    if (r.state === "APPROVED") { approvalCount++; lastApprovedAt = r.submittedAt; }
+    else if (r.state === "CHANGES_REQUESTED") changesRequestedCount++;
+    else if (r.state === "COMMENTED") commentedReviewCount++;
+    lastReviewedAt = r.submittedAt;
+  }
+  const reviewerCount = latestByReviewer.size;
+
+  // Whether one of the logged-in accounts is a current approver (their latest review is
+  // an approval). Used to nag approvers, not just the author, when a PR is ready to merge.
+  const viewerApproved = [...latestByReviewer.values()]
+    .some((r) => r.state === "APPROVED" && viewers.has(r.author.login.toLowerCase()));
+
+  // Unresolved threads only count once a human (or Copilot, pre-human) has weighed in.
+  let unresolvedThreadCount = 0;
+  if (state === "approved" || state === "reviewed" || (state === "waiting" && copilotReviewed)) {
+    unresolvedThreadCount = rawUnresolved;
+  }
+
+  return {
+    state,
+    approvalCount,
+    changesRequestedCount,
+    commentedReviewCount,
+    reviewerCount,
+    lastApprovedAt,
+    lastReviewedAt,
+    copilotReviewed,
+    unresolvedThreadCount,
+    requiresConversationResolution: RESOLUTION_REQUIRED_REPOS.has(String(repo).toLowerCase()),
+    reviewRequestedFromViewer: requestedReviewers.some((rr) => viewers.has(String(rr).toLowerCase())),
+    viewerApproved,
+  };
+}
+
+function normalizePr(repo, node, viewers, repoPrivate = false) {
+  const requestedReviewers = (node.reviewRequests?.nodes ?? [])
+    .map((rr) => rr.requestedReviewer?.login ?? rr.requestedReviewer?.name)
+    .filter(Boolean);
+  const labels = (node.labels?.nodes ?? []).map((l) => l.name);
+  const assignees = (node.assignees?.nodes ?? []).map((a) => a.login);
+  const rawUnresolved = (node.reviewThreads?.nodes ?? []).filter((t) => !t.isResolved).length;
+  const checksState = mapCheckState(node.commits?.nodes?.[0]?.commit?.statusCheckRollup);
+  const review = deriveReview(node.reviews?.nodes ?? [], requestedReviewers, viewers, repo, rawUnresolved);
+  const mergeable = node.mergeable; // MERGEABLE | CONFLICTING | UNKNOWN
+  const mergeableState = mapMergeable(mergeable);
+  const author = resolveAuthor(node.author?.login ?? "ghost", assignees);
+  const authorType = node.author?.__typename ?? null;
+  const state = (node.state ?? "OPEN").toLowerCase();
+
+  const commitNodes = node.commits?.nodes ?? [];
+  const committedDate = commitNodes.length ? commitNodes[commitNodes.length - 1]?.commit?.committedDate ?? null : null;
+  // Only meaningful as a "pushed after review" signal once a human has reviewed.
+  const lastCommitAt =
+    review.lastReviewedAt != null && (review.state === "reviewed" || review.state === "changes_requested")
+      ? committedDate
+      : null;
+
+  const linkedIssues = (node.closingIssuesReferences?.nodes ?? []).map((i) => ({
+    repository: i.repository?.nameWithOwner ?? repo,
+    number: i.number,
+    title: i.title,
+    url: i.url,
+    milestone: i.milestone?.title ?? null,
+    labels: (i.labels?.nodes ?? []).map((l) => l.name),
+  }));
+
+  return {
+    repository: repo,
+    number: node.number,
+    title: node.title,
+    url: node.url,
+    state,
+    draft: node.isDraft,
+    author,
+    authorType,
+    authorAvatarUrl: node.author?.avatarUrl ?? null,
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+    baseRef: node.baseRefName,
+    milestone: node.milestone?.title ?? null,
+    labels,
+    assignees,
+    requestedReviewers,
+    additions: node.additions,
+    deletions: node.deletions,
+    changedFiles: node.changedFiles,
+    commitCount: node.commits?.totalCount ?? commitNodes.length,
+    lastCommitAt,
+    linkedIssues,
+    // Engine-shaped fields (read by model.mjs).
+    checks: { state: checksState, failureCount: 0, completedAt: null },
+    mergeableState,
+    // Back-compat fields read by the simplified Fowler lanes/signals path.
+    unresolvedThreadCount: rawUnresolved,
+    checksState,
+    mergeable,
+    // GitHub's authoritative review gate: APPROVED | CHANGES_REQUESTED |
+    // REVIEW_REQUIRED | null (null when the repo has no required reviews).
+    reviewDecision: node.reviewDecision ?? null,
+    review,
+    isMine: viewers.has(author.toLowerCase()),
+    // Private repos cannot have external community contributors, so PRs on them are
+    // never "Community" — they flow through the normal team attention engine instead.
+    repoPrivate: !!repoPrivate,
+  };
+}
+
+function normalizeIssue(repo, node, viewers) {
+  const labels = (node.labels?.nodes ?? []).map((l) => l.name);
+  const assignees = (node.assignees?.nodes ?? []).map((a) => a.login);
+  const author = node.author?.login ?? "ghost";
+  return {
+    repository: repo,
+    number: node.number,
+    title: node.title,
+    url: node.url,
+    author,
+    authorAvatarUrl: node.author?.avatarUrl ?? null,
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+    milestone: node.milestone?.title ?? null,
+    labels,
+    assignees,
+    isMine: viewers.has(author.toLowerCase()),
+    assignedToMe: assignees.some((a) => viewers.has(a.toLowerCase())),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Signals (mirrors utils/signals.ts vocabulary + dedupe)
+// ---------------------------------------------------------------------------
+
+const SYNONYMS = [
+  ["needs review", "needs reviewer", "no reviews"],
+  ["ready to merge", "merge"],
+  ["re-review needed", "re-review", "commit after review"],
+  ["ci failing", "fix ci"],
+  ["wait for ci", "ci running"],
+  ["author response", "author fix", "changes requested"],
+  ["quick wins", "quick win"],
+  ["stalled", "unstick"],
+  ["docs", "docs review"],
+  ["community toolkit", "toolkit review"],
+  ["bots / automation", "automation", "bot"],
+];
+const conceptByLabel = new Map(SYNONYMS.flatMap((g) => g.map((l) => [l, g[0]])));
+
+function concept(label) {
+  const n = label.trim().toLowerCase();
+  if (n.startsWith("ci failing")) return "ci failing";
+  if (n.includes("unresolved")) return "unresolved feedback";
+  return conceptByLabel.get(n) ?? n;
+}
+
+export function dedupeSignals(signals) {
+  const seen = new Set();
+  return signals.filter((s) => {
+    const c = concept(s.label);
+    if (seen.has(c)) return false;
+    seen.add(c);
+    return true;
+  });
+}
+
+// Faithful pr-dashboard pills: delegate to the ported attention-signal engine
+// (model.mjs `createAttentionSignals`) instead of the old hand-rolled set. The
+// engine emits `[actionSignal, ...stateSignals]`; mirror the dashboard card
+// composition (PullRequestSignalPills): optionally drop the action pill, exclude
+// the lane reason, cap the computed signals, then dedupe by concept.
+export function signalsFor(pr, reason = "", opts = {}) {
+  const { includeAction = true, limit = 4 } = opts;
+  const all = createAttentionSignals({ pullRequest: pr, reason: "" });
+  let computed = includeAction ? all : all.slice(1);
+  if (reason) {
+    const rc = concept(reason);
+    computed = computed.filter((s) => concept(s.label) !== rc);
+  }
+  return dedupeSignals(computed.slice(0, limit));
+}
+
+function isReadyToMerge(pr) {
+  return (
+    !pr.draft &&
+    pr.review.state === "approved" &&
+    // Respect GitHub's authoritative decision: a PR that still requires review
+    // (branch protection unmet, e.g. a lone approval on a repo that needs a
+    // CODEOWNER or a second reviewer) or has a required reviewer requesting
+    // changes cannot actually be merged, so it is not ready.
+    pr.reviewDecision !== "REVIEW_REQUIRED" &&
+    pr.reviewDecision !== "CHANGES_REQUESTED" &&
+    pr.checksState === "success" &&
+    pr.unresolvedThreadCount === 0 &&
+    pr.mergeable !== "CONFLICTING"
+  );
+}
+
+function isQuickWin(pr) {
+  return !pr.draft && pr.changedFiles <= 3 && pr.additions + pr.deletions <= 40;
+}
+
+function isStalled(pr) {
+  return Date.now() - new Date(pr.updatedAt).getTime() > 14 * DAY_MS;
+}
+
+// Team review policy (mirrors how davidfowl/pr-dashboard manages the shared queue):
+//   * Drafts are noise and stay out of the shared view.
+//   * A PR is not "review ready" until checks are green AND all feedback is resolved.
+//     Anything unfinished bounces back to the author's own focus queue.
+//   * The shared queue is team-managed: ranked deterministically and capped at 10 so
+//     the team scans a focused set instead of a wall of open PRs.
+export const REVIEW_LIMIT = 10;
+
+function reviewReady(pr) {
+  return (
+    !pr.draft &&
+    pr.checksState === "success" &&
+    pr.unresolvedThreadCount === 0 &&
+    pr.review.state !== "changes_requested" &&
+    pr.mergeable !== "CONFLICTING"
+  );
+}
+
+// Review-ready PRs that still need a review (not the viewer's own, not yet approved).
+function awaitingReview(pr) {
+  return reviewReady(pr) && !pr.isMine && pr.review.state !== "approved";
+}
+
+// Oldest waits float to the top so nothing starves, with nudges for explicitly
+// requested reviewers and quick wins. Order is team-managed, not user-sortable.
+function reviewQueueScore(pr) {
+  const ageDays = (Date.now() - new Date(pr.createdAt).getTime()) / DAY_MS;
+  let s = Math.min(ageDays, 90);
+  if (pr.requestedReviewers.length > 0) s += 20;
+  if (isQuickWin(pr)) s += 12;
+  if (pr.review.state === "reviewed") s += 6;
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Lane bucketing per mode
+// ---------------------------------------------------------------------------
+
+const LANE_DEFS = {
+  review: [
+    { id: "review-queue", label: "Review queue", tone: "danger", match: awaitingReview },
+    { id: "ready-to-merge", label: "Ready to merge", tone: "success", match: (pr) => isReadyToMerge(pr) },
+    { id: "your-prs", label: "Your PRs", tone: "accent", match: (pr) => pr.isMine },
+  ],
+};
+
+function laneReason(laneId, pr) {
+  switch (laneId) {
+    case "review-queue": return "Green and resolved \u00b7 ready for review";
+    case "ready-to-merge": return "Approved and green, ready to land";
+    case "your-prs":
+      if (pr.checksState === "failure") return "CI is failing \u00b7 back in your court";
+      if (pr.mergeable === "CONFLICTING") return "Merge conflicts \u00b7 back in your court";
+      if (pr.review.state === "changes_requested") return "Changes requested \u00b7 back in your court";
+      if (pr.unresolvedThreadCount > 0) return `${pr.unresolvedThreadCount} unresolved thread${pr.unresolvedThreadCount === 1 ? "" : "s"} to resolve`;
+      if (pr.draft) return "Draft \u00b7 still cooking";
+      return "You opened this";
+    default: return "";
+  }
+}
+
+function bucketReview(prs, { showDrafts = false, limit = REVIEW_LIMIT } = {}) {
+  // Drafts are filtered out by default; they are prototypes, not review work.
+  const source = showDrafts ? prs : prs.filter((pr) => !pr.draft);
+  const defs = LANE_DEFS.review;
+  const lanes = defs.map((d) => ({ id: d.id, label: d.label, tone: d.tone, items: [] }));
+  for (const pr of source) {
+    for (let i = 0; i < defs.length; i++) {
+      if (defs[i].match(pr)) {
+        const r = laneReason(defs[i].id, pr);
+        lanes[i].items.push({ pr, reason: r, signals: signalsFor(pr, r) });
+        break;
+      }
+    }
+  }
+  // The shared review queue is ranked deterministically and capped so the team scans
+  // a focused set. `cappedTotal` lets the UI show "top N of M".
+  const queue = lanes.find((l) => l.id === "review-queue");
+  if (queue) {
+    queue.items.sort((a, b) => reviewQueueScore(b.pr) - reviewQueueScore(a.pr));
+    queue.cappedTotal = queue.items.length;
+    if (queue.items.length > limit) queue.items = queue.items.slice(0, limit);
+  }
+  return lanes.filter((l) => l.items.length > 0);
+}
+
+function bucketIssues(issues) {
+  const lanes = [
+    { id: "assigned", label: "Assigned to you", tone: "danger", items: [] },
+    { id: "yours", label: "Your issues", tone: "accent", items: [] },
+    { id: "triage", label: "Needs triage", tone: "warning", items: [] },
+    { id: "active", label: "Recently active", tone: "muted", items: [] },
+  ];
+  for (const issue of issues) {
+    let laneId;
+    if (issue.assignedToMe) laneId = "assigned";
+    else if (issue.isMine) laneId = "yours";
+    else if (issue.labels.length === 0 && issue.assignees.length === 0) laneId = "triage";
+    else laneId = "active";
+    lanes.find((l) => l.id === laneId).items.push({ issue, signals: issueSignals(issue) });
+  }
+  return lanes.filter((l) => l.items.length > 0);
+}
+
+function issueSignals(issue) {
+  const out = [];
+  if (issue.milestone) out.push({ label: issue.milestone, tone: "accent" });
+  if (issue.labels.length === 0) out.push({ label: "Unlabeled", tone: "warning" });
+  for (const l of issue.labels.slice(0, 3)) out.push({ label: l, tone: "muted" });
+  return out;
+}
+
+function bucketShip(prs, release, { showDrafts = false } = {}) {
+  const inMilestone = prs.filter((pr) => pr.milestone === release && (showDrafts || !pr.draft));
+  const lanes = [
+    { id: "ready", label: "Ready to ship", tone: "success", items: [] },
+    { id: "in-progress", label: "In progress", tone: "accent", items: [] },
+    { id: "blocked", label: "Blocked", tone: "danger", items: [] },
+  ];
+  for (const pr of inMilestone) {
+    let laneId;
+    if (pr.checksState === "failure" || pr.mergeable === "CONFLICTING" || pr.review.state === "changes_requested")
+      laneId = "blocked";
+    else if (isReadyToMerge(pr)) laneId = "ready";
+    else laneId = "in-progress";
+    const r = pr.milestone ? `Milestone ${pr.milestone}` : "";
+    lanes.find((l) => l.id === laneId).items.push({
+      pr, reason: r, signals: signalsFor(pr, r),
+    });
+  }
+  return lanes.filter((l) => l.items.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Notifications (derived from the viewer's current state)
+// ---------------------------------------------------------------------------
+
+export function buildNotifications(prs, prefs, dismissed = []) {
+  const skip = new Set(dismissed);
+  const items = [];
+  const push = (n) => {
+    n.id = `${n.kind}:${n.repository}#${n.number}`;
+    if (!skip.has(n.id)) items.push(n);
+  };
+  for (const pr of prs) {
+    if (prefs.reviewRequested && !pr.draft && !pr.isMine && pr.review.reviewRequestedFromViewer) {
+      push({ kind: "review-requested", tone: "danger", title: pr.title, repository: pr.repository,
+        number: pr.number, url: pr.url, detail: "Review requested from you" });
+    }
+    // Ready to merge nags both the author and any approver (mirrors pr-dashboard #86), so it
+    // lives outside the author-only block. A PR you both authored and approved notifies once
+    // (the shared kind:repo#number id dedupes), as the author.
+    if (prefs.readyToMerge && isReadyToMerge(pr) && (pr.isMine || pr.review.viewerApproved)) {
+      push({ kind: "ready-to-merge", tone: "success", title: pr.title, repository: pr.repository,
+        number: pr.number, url: pr.url,
+        detail: pr.isMine ? "Your PR is ready to merge" : "A PR you approved is ready to merge" });
+    }
+    if (pr.isMine) {
+      if (prefs.changesRequested && pr.review.state === "changes_requested") {
+        push({ kind: "changes-requested", tone: "warning", title: pr.title, repository: pr.repository,
+          number: pr.number, url: pr.url, detail: "Changes requested on your PR" });
+      }
+      if (prefs.ciFailing && pr.checksState === "failure") {
+        push({ kind: "ci-failing", tone: "danger", title: pr.title, repository: pr.repository,
+          number: pr.number, url: pr.url, detail: "CI is failing on your PR" });
+      }
+    }
+  }
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level loader
+// ---------------------------------------------------------------------------
+
+export async function loadDashboard({ accounts, mode, release, prefs, dismissed, showDrafts = false, reviewLimit = REVIEW_LIMIT }) {
+  const usable = (accounts ?? []).filter((a) => a && a.token && a.login);
+  if (usable.length === 0) {
+    return { authenticated: false, message: "No active GitHub account. Enable an account in the Accounts tab so the canvas can read your review queue." };
+  }
+
+  const viewers = new Set(usable.map((a) => a.login.toLowerCase()));
+  const wantIssues = mode === "issues";
+
+  // Union of every active account's watched repos.
+  const repos = [...new Set(usable.flatMap((a) => a.repos ?? []))];
+
+  const prById = new Map();   // url -> normalized PR (dedup across accounts)
+  const issueById = new Map();
+  const okRepos = new Set();  // repos that succeeded under at least one account
+  const errorsRaw = [];       // { repo, message }
+
+  // Fetch each (account, repo) pair with that account's own token.
+  const jobs = [];
+  for (const acct of usable) {
+    for (const repo of acct.repos ?? []) {
+      jobs.push(
+        (async () => {
+          const { owner, name } = splitRepo(repo);
+          if (!owner || !name) {
+            errorsRaw.push({ repo, message: `Invalid repo "${repo}"` });
+            return;
+          }
+          try {
+            if (wantIssues) {
+              const data = await gql(acct.token, ISSUE_QUERY, { owner, name }, acct.graphql);
+              for (const node of data.repository?.issues?.nodes ?? []) {
+                const issue = normalizeIssue(repo, node, viewers);
+                if (!issueById.has(issue.url)) issueById.set(issue.url, issue);
+              }
+            } else {
+              const data = await gql(acct.token, PR_QUERY, { owner, name }, acct.graphql);
+              const repoPrivate = !!data.repository?.isPrivate;
+              for (const node of data.repository?.pullRequests?.nodes ?? []) {
+                const pr = normalizePr(repo, node, viewers, repoPrivate);
+                if (!prById.has(pr.url)) prById.set(pr.url, pr);
+              }
+            }
+            okRepos.add(repo);
+          } catch (e) {
+            errorsRaw.push({ repo, message: `${repo}: ${e.message}` });
+          }
+        })(),
+      );
+    }
+  }
+  await Promise.all(jobs);
+
+  const allPrs = [...prById.values()].sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+  const allIssues = [...issueById.values()].sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+
+  // Drafts are filtered out of the shared view by default (prototypes, not review work).
+  const visiblePrs = showDrafts ? allPrs : allPrs.filter((p) => !p.draft);
+  const draftCount = allPrs.filter((p) => p.draft).length;
+
+  // Drop per-account errors for repos another active account could read.
+  const errors = [...new Set(errorsRaw.filter((e) => !okRepos.has(e.repo)).map((e) => e.message))];
+
+  let lanes;
+  if (mode === "issues") lanes = bucketIssues(allIssues);
+  else if (mode === "ship") lanes = bucketShip(allPrs, release ?? CURRENT_RELEASE, { showDrafts });
+  else lanes = bucketReview(allPrs, { showDrafts, limit: reviewLimit });
+
+  // Full pr-dashboard attention engine (review mode only). The focused "Needs attention"
+  // queue is the capped headline; attention buckets, the community list, the personal
+  // "For you" picks and core-team developer counts sit beneath it. Items are reshaped into
+  // the card shape the renderer consumes ({ pr, reason, signals }).
+  let attention = null;
+  if (mode === "review") {
+    const login = usable[0].login;
+    const viewerLogins = usable.map((a) => a.login);
+    const buckets = createAttentionBuckets(allPrs, login);
+    const focusAll = computeFocusItems(buckets);
+    const focusExclusions = computeFocusExclusionItems(allPrs, buckets, focusAll, login);
+    const card = (pr, reason, extra) =>
+      Object.assign({ pr, reason: reason || "", signals: signalsFor(pr, reason || "") }, extra || {});
+    attention = {
+      forMe: createForMeItems(allPrs, viewerLogins).map((f) => {
+        // Personal pick leads with its own call-to-action; the engine's action pill is
+        // dropped (includeAction:false) so we don't double up, then state signals follow.
+        const c = card(f.pullRequest, f.reason);
+        c.signals = dedupeSignals([
+          { label: f.action, tone: f.tone || "accent" },
+          ...signalsFor(f.pullRequest, f.reason, { includeAction: false, limit: 3 }),
+        ]);
+        return c;
+      }),
+      focus: focusAll.slice(0, reviewLimit).map((f) =>
+        card(f.pullRequest, f.reason, { bucketLabel: f.bucketLabel, bucketTone: f.bucketTone })),
+      focusTotal: focusAll.length,
+      focusLimit: reviewLimit,
+      focusExclusions: focusExclusions.map((e) => ({
+        pr: e.pullRequest,
+        reason: e.reason.detail,
+        signals: dedupeSignals([
+          { label: e.reason.label, tone: e.reason.tone },
+          ...signalsFor(e.pullRequest, e.reason.label, { includeAction: false, limit: 4 }),
+        ]),
+      })),
+      buckets: buckets.map((b) => ({
+        label: b.label,
+        tone: b.tone,
+        items: b.items.map((i) => card(i.pullRequest, i.reason)),
+      })),
+      community: computeCommunityItems(allPrs).map((c) => card(c.pullRequest, "Community")),
+      developerCounts: createDeveloperPullRequestCounts(allPrs),
+    };
+  }
+
+  const notifications = buildNotifications(allPrs, prefs ?? {}, dismissed ?? []);
+
+  const counts = {
+    prs: visiblePrs.length,
+    total: allPrs.length,
+    drafts: draftCount,
+    issues: allIssues.length,
+    mine: allPrs.filter((p) => p.isMine).length,
+    needsReview: allPrs.filter(awaitingReview).length,
+    readyToMerge: allPrs.filter(isReadyToMerge).length,
+    ciFailing: visiblePrs.filter((p) => p.checksState === "failure").length,
+  };
+
+  return {
+    authenticated: true,
+    viewer: usable[0].login,
+    viewers: usable.map((a) => a.login),
+    mode,
+    release: release ?? CURRENT_RELEASE,
+    repos,
+    lanes,
+    attention,
+    notifications,
+    counts,
+    showDrafts,
+    reviewLimit,
+    errors,
+    fetchedAt: new Date().toISOString(),
+  };
+}

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -5,8 +5,6 @@
 // signal pills. This is a faithful, self-contained port of the lane + signal logic
 // from davidfowl/pr-dashboard (frontend/src/utils/{models,signals,pullRequests}.ts).
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import {
   createAttentionBuckets,
   createForMeItems,
@@ -17,8 +15,6 @@ import {
   computeCommunityItems,
 } from "./model.mjs";
 import { currentRelease } from "./constants.mjs";
-
-const execFileAsync = promisify(execFile);
 
 // The current milestone has a single source of truth in constants.mjs
 // (`currentRelease`). Re-export it here under the name the run-mode lane logic
@@ -38,31 +34,8 @@ export const DEFAULT_REPOS = [
 const GRAPHQL = "https://api.github.com/graphql";
 
 // ---------------------------------------------------------------------------
-// Token + viewer resolution (the logged-in GitHub user).
+// GraphQL helper.
 // ---------------------------------------------------------------------------
-
-let cachedToken;
-
-export async function resolveToken() {
-  if (cachedToken) return cachedToken;
-  for (const key of ["GH_TOKEN", "GITHUB_TOKEN"]) {
-    if (process.env[key]) {
-      cachedToken = process.env[key];
-      return cachedToken;
-    }
-  }
-  try {
-    const { stdout } = await execFileAsync("gh", ["auth", "token"], { timeout: 8000 });
-    const token = stdout.trim();
-    if (token) {
-      cachedToken = token;
-      return cachedToken;
-    }
-  } catch {
-    // gh not installed or not authenticated.
-  }
-  return null;
-}
 
 async function gql(token, query, variables, graphqlUrl = GRAPHQL) {
   const res = await fetch(graphqlUrl, {
@@ -82,11 +55,6 @@ async function gql(token, query, variables, graphqlUrl = GRAPHQL) {
     throw new Error(json.errors.map((e) => e.message).join("; "));
   }
   return json.data;
-}
-
-export async function resolveViewer(token) {
-  const data = await gql(token, `query { viewer { login } }`, {});
-  return data.viewer.login;
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -61,11 +61,20 @@ async function gql(token, query, variables, graphqlUrl = GRAPHQL) {
 // Queries
 // ---------------------------------------------------------------------------
 
+// GitHub's GraphQL connections cap `first` at 100 and page the remainder behind a
+// cursor. High-volume repos (e.g. microsoft/aspire) have far more than one page of
+// open PRs/issues, so a single `first:40` fetch silently truncates the queue. We
+// follow `pageInfo.endCursor` until GitHub reports no more pages. MAX_PAGES is an
+// explicit safety bound (25 pages * 40 = up to 1000 open items per repo per account)
+// so a pathological repo can't spin the loader indefinitely.
+const MAX_PAGES = 25;
+
 const PR_QUERY = `
-query($owner:String!, $name:String!) {
+query($owner:String!, $name:String!, $after:String) {
   repository(owner:$owner, name:$name) {
     isPrivate
-    pullRequests(states:OPEN, first:40, orderBy:{field:UPDATED_AT, direction:DESC}) {
+    pullRequests(states:OPEN, first:40, after:$after, orderBy:{field:UPDATED_AT, direction:DESC}) {
+      pageInfo { hasNextPage endCursor }
       nodes {
         number title url isDraft state createdAt updatedAt
         author { __typename login avatarUrl }
@@ -94,9 +103,10 @@ query($owner:String!, $name:String!) {
 }`;
 
 const ISSUE_QUERY = `
-query($owner:String!, $name:String!) {
+query($owner:String!, $name:String!, $after:String) {
   repository(owner:$owner, name:$name) {
-    issues(states:OPEN, first:40, orderBy:{field:UPDATED_AT, direction:DESC}) {
+    issues(states:OPEN, first:40, after:$after, orderBy:{field:UPDATED_AT, direction:DESC}) {
+      pageInfo { hasNextPage endCursor }
       nodes {
         number title url createdAt updatedAt
         author { login avatarUrl }
@@ -593,17 +603,29 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
           }
           try {
             if (wantIssues) {
-              const data = await gql(acct.token, ISSUE_QUERY, { owner, name }, acct.graphql);
-              for (const node of data.repository?.issues?.nodes ?? []) {
-                const issue = normalizeIssue(repo, node, viewers);
-                if (!issueById.has(issue.url)) issueById.set(issue.url, issue);
+              let after = null;
+              for (let page = 0; page < MAX_PAGES; page++) {
+                const data = await gql(acct.token, ISSUE_QUERY, { owner, name, after }, acct.graphql);
+                const conn = data.repository?.issues;
+                for (const node of conn?.nodes ?? []) {
+                  const issue = normalizeIssue(repo, node, viewers);
+                  if (!issueById.has(issue.url)) issueById.set(issue.url, issue);
+                }
+                if (!conn?.pageInfo?.hasNextPage) break;
+                after = conn.pageInfo.endCursor;
               }
             } else {
-              const data = await gql(acct.token, PR_QUERY, { owner, name }, acct.graphql);
-              const repoPrivate = !!data.repository?.isPrivate;
-              for (const node of data.repository?.pullRequests?.nodes ?? []) {
-                const pr = normalizePr(repo, node, viewers, repoPrivate);
-                if (!prById.has(pr.url)) prById.set(pr.url, pr);
+              let after = null;
+              for (let page = 0; page < MAX_PAGES; page++) {
+                const data = await gql(acct.token, PR_QUERY, { owner, name, after }, acct.graphql);
+                const repoPrivate = !!data.repository?.isPrivate;
+                const conn = data.repository?.pullRequests;
+                for (const node of conn?.nodes ?? []) {
+                  const pr = normalizePr(repo, node, viewers, repoPrivate);
+                  if (!prById.has(pr.url)) prById.set(pr.url, pr);
+                }
+                if (!conn?.pageInfo?.hasNextPage) break;
+                after = conn.pageInfo.endCursor;
               }
             }
             okRepos.add(repo);

--- a/.github/extensions/aspire-team-app/github.test.mjs
+++ b/.github/extensions/aspire-team-app/github.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadDashboard } from "./github.mjs";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("loadDashboard paginates open pull requests for each watched repo", async () => {
+  const seenAfter = [];
+  globalThis.fetch = async (_url, options = {}) => {
+    const body = JSON.parse(options.body);
+    seenAfter.push(body.variables.after ?? null);
+    if (body.query.includes("pullRequests")) {
+      return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: page(
+        body.variables.after,
+        prNode(1, "2026-07-01T10:00:00Z"),
+        prNode(2, "2026-07-01T11:00:00Z"),
+      ) } } });
+    }
+    throw new Error(`Unexpected query: ${body.query}`);
+  };
+
+  const dashboard = await loadDashboard({
+    accounts: [{ token: "token", login: "octo", repos: ["microsoft/aspire"] }],
+    mode: "ship",
+    release: "9.5",
+    prefs: {},
+    dismissed: [],
+    showDrafts: true,
+  });
+
+  assert.deepEqual(seenAfter, [null, "cursor-1"]);
+  assert.equal(dashboard.counts.total, 2);
+  assert.deepEqual(dashboard.lanes.flatMap((lane) => lane.items.map((item) => item.pr.number)).sort((a, b) => a - b), [1, 2]);
+});
+
+test("loadDashboard paginates open issues for each watched repo", async () => {
+  const seenAfter = [];
+  globalThis.fetch = async (_url, options = {}) => {
+    const body = JSON.parse(options.body);
+    seenAfter.push(body.variables.after ?? null);
+    if (body.query.includes("issues")) {
+      return jsonResponse({ data: { repository: { issues: page(
+        body.variables.after,
+        issueNode(1, "2026-07-01T10:00:00Z"),
+        issueNode(2, "2026-07-01T11:00:00Z"),
+      ) } } });
+    }
+    throw new Error(`Unexpected query: ${body.query}`);
+  };
+
+  const dashboard = await loadDashboard({
+    accounts: [{ token: "token", login: "octo", repos: ["microsoft/aspire"] }],
+    mode: "issues",
+    release: "9.5",
+    prefs: {},
+    dismissed: [],
+  });
+
+  assert.deepEqual(seenAfter, [null, "cursor-1"]);
+  assert.equal(dashboard.counts.issues, 2);
+  assert.deepEqual(dashboard.lanes.flatMap((lane) => lane.items.map((item) => item.issue.number)).sort((a, b) => a - b), [1, 2]);
+});
+
+function page(after, firstNode, secondNode) {
+  if (after == null) {
+    return { nodes: [firstNode], pageInfo: { hasNextPage: true, endCursor: "cursor-1" } };
+  }
+  assert.equal(after, "cursor-1");
+  return { nodes: [secondNode], pageInfo: { hasNextPage: false, endCursor: null } };
+}
+
+function prNode(number, updatedAt) {
+  return {
+    number,
+    title: `PR ${number}`,
+    url: `https://github.com/microsoft/aspire/pull/${number}`,
+    isDraft: false,
+    state: "OPEN",
+    createdAt: "2026-07-01T09:00:00Z",
+    updatedAt,
+    author: { __typename: "User", login: "octo", avatarUrl: null },
+    baseRefName: "main",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    additions: 1,
+    deletions: 0,
+    changedFiles: 1,
+    milestone: { title: "9.5" },
+    labels: { nodes: [] },
+    assignees: { nodes: [] },
+    reviewRequests: { nodes: [] },
+    reviews: { nodes: [] },
+    reviewThreads: { nodes: [] },
+    commits: { totalCount: 1, nodes: [{ commit: { committedDate: updatedAt, statusCheckRollup: { state: "SUCCESS" } } }] },
+    closingIssuesReferences: { nodes: [] },
+  };
+}
+
+function issueNode(number, updatedAt) {
+  return {
+    number,
+    title: `Issue ${number}`,
+    url: `https://github.com/microsoft/aspire/issues/${number}`,
+    createdAt: "2026-07-01T09:00:00Z",
+    updatedAt,
+    author: { login: "octo", avatarUrl: null },
+    milestone: null,
+    labels: { nodes: [] },
+    assignees: { nodes: [] },
+  };
+}
+
+function jsonResponse(body, options = {}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    statusText: options.statusText ?? "OK",
+    json: async () => body,
+  };
+}

--- a/.github/extensions/aspire-team-app/model.mjs
+++ b/.github/extensions/aspire-team-app/model.mjs
@@ -1,0 +1,820 @@
+// Review-queue model engine for the Aspire Team App canvas.
+//
+// A faithful, self-contained port of davidfowl/pr-dashboard's review intelligence
+// (frontend/src/utils/models.ts + components/dashboard/focusQueue.ts): attention
+// buckets, the focused "Needs attention" queue, the personal "For you" action
+// picks, community lane, core-team ownership, and the "outside the queue" reasons.
+
+import { coreTeamMembers, coreTeamMemberAliasSuffixes, currentRelease, dayMs, hourMs, personalPickActions } from "./constants.mjs";
+
+const approvedAgingMs = 2 * dayMs;
+const communityWaitMs = 12 * hourMs;
+const focusAgeLimitMs = 14 * dayMs;
+const stalledPullRequestMs = 7 * dayMs;
+const quickWinLineThreshold = 80;
+const quickWinFileThreshold = 3;
+
+const regressionBucketLabel = "Regression";
+const approvedButAgingBucketLabel = "Approved but aging";
+const agedOutCommunityBucketLabel = "Aged out community";
+const myDraftPullRequestsBucketLabel = "My draft PRs";
+const docsFromCodeRepository = "microsoft/aspire.dev";
+const docsFromCodeLabel = "docs-from-code";
+const doNotMergeLabels = new Set(["needs-author-action", "no-merge"]);
+const knownBotAuthors = new Set(["copilot-swe-agent", "dotnet-maestro"]);
+
+// ---------------------------------------------------------------------------
+// Identity + author classification
+// ---------------------------------------------------------------------------
+
+export function actorIdentityKey(actor) {
+  return String(actor || "").trim().toLowerCase();
+}
+function sameLogin(a, b) {
+  return actorIdentityKey(a) === actorIdentityKey(b);
+}
+function isCopilotAttributedAuthor(author) {
+  return actorIdentityKey(author).endsWith("/copilot");
+}
+function isBotAuthor(author, authorType) {
+  if (isCopilotAttributedAuthor(author)) return false;
+  const n = actorIdentityKey(author);
+  if (authorType === "Bot") return true;
+  if (knownBotAuthors.has(n)) return true;
+  return n.endsWith("[bot]") || n === "copilot" || n.includes("dependabot");
+}
+function isCoreTeamAuthor(author) {
+  return coreTeamOwnershipActor(author) !== null;
+}
+// Resolves the core-team actor that "owns" a PR by an author, honoring alias
+// suffixes (#95). Returns a canonical coreTeamMembers login when the author
+// matches directly or via a stripped alias suffix; otherwise returns the alias
+// login itself when the author carries a configured suffix (an MSFT alt account
+// not individually listed); null for everyone else.
+function coreTeamOwnershipActor(author) {
+  const member = matchingCoreTeamMember(author);
+  if (member) return member;
+  return isConfiguredTeamAlias(author) ? author : null;
+}
+function matchingCoreTeamMember(author) {
+  const authorKey = actorIdentityKey(author);
+  const direct = coreTeamMembers.find((member) => actorIdentityKey(member) === authorKey);
+  if (direct) return direct;
+  const base = configuredTeamAliasBase(author);
+  if (!base) return null;
+  const baseKey = actorIdentityKey(base);
+  return coreTeamMembers.find((member) => actorIdentityKey(member) === baseKey) ?? null;
+}
+function configuredTeamAliasBase(author) {
+  const normalized = String(author || "").toLowerCase();
+  const suffix = coreTeamMemberAliasSuffixes.find((candidate) => {
+    const s = candidate.toLowerCase();
+    return s.length > 0 && normalized.endsWith(s) && normalized.length > s.length;
+  });
+  return suffix ? String(author).slice(0, -suffix.length) : null;
+}
+function isConfiguredTeamAlias(author) {
+  return configuredTeamAliasBase(author) !== null;
+}
+function isCommunityToolkitPullRequest(pr) {
+  return pr.repository.toLowerCase() === "communitytoolkit/aspire";
+}
+function isCommunityAuthor(author, authorType) {
+  return !isBotAuthor(author, authorType) && !isCoreTeamAuthor(author);
+}
+export function isCommunityPullRequest(pr) {
+  return !pr.isMine && !pr.repoPrivate && isCommunityAuthor(pr.author, pr.authorType) && !isCommunityToolkitPullRequest(pr);
+}
+export function isAgedOutCommunityPullRequest(pr) {
+  return isCommunityPullRequest(pr) && ageMs(pr.updatedAt) > focusAgeLimitMs;
+}
+function isCommunityWaiting(pr) {
+  return !pr.isMine && !pr.repoPrivate && isCommunityAuthor(pr.author, pr.authorType) && (
+    (pr.review.state === "waiting" && ageMs(pr.createdAt) >= communityWaitMs) ||
+    (pr.review.state === "reviewed" && isIdle(pr))
+  );
+}
+function isOwnCopilotAuthor(author, login) {
+  const suffix = "/copilot";
+  const n = actorIdentityKey(author);
+  if (!n.endsWith(suffix)) return false;
+  return sameLogin(author.slice(0, author.length - suffix.length), login);
+}
+function isOwnCopilotAuthorAny(author, logins) {
+  return logins.some((l) => isOwnCopilotAuthor(author, l));
+}
+
+// ---------------------------------------------------------------------------
+// PR predicates
+// ---------------------------------------------------------------------------
+
+export function isChecksFailing(pr) {
+  return pr.checks?.state === "failure";
+}
+export function hasMergeConflicts(pr) {
+  return pr.mergeableState === "dirty";
+}
+// GitHub's authoritative review decision. A PR whose branch protection still
+// requires review (or where a required reviewer requested changes) cannot be
+// merged, so it is not "Ready to merge" no matter how many stray approvals it
+// has. null means the repo has no required-review gate, so we defer to the
+// derived approval state. Guards the naive `review.state === "approved"` check.
+export function isMergeReviewBlocked(pr) {
+  return pr.reviewDecision === "REVIEW_REQUIRED" || pr.reviewDecision === "CHANGES_REQUESTED";
+}
+function matchingDoNotMergeLabel(pr) {
+  return pr.labels.find((l) => doNotMergeLabels.has(l.toLowerCase())) ?? null;
+}
+export function hasNeedsAuthorActionLabel(pr) {
+  return matchingDoNotMergeLabel(pr) !== null;
+}
+function hasUnresolvedFeedback(pr) {
+  return pr.review.unresolvedThreadCount > 0;
+}
+function isIdle(pr) {
+  return Date.now() - new Date(pr.updatedAt).getTime() >= stalledPullRequestMs;
+}
+function hasRegressionLabel(labels) {
+  return labels.some((l) => l.toLowerCase().includes("regression"));
+}
+function hasRegressionSignal(pr) {
+  return hasRegressionLabel(pr.labels) || (pr.linkedIssues || []).some((i) => hasRegressionLabel(i.labels));
+}
+export function isGeneratedDocsPullRequest(pr) {
+  return pr.repository.toLowerCase() === docsFromCodeRepository &&
+    pr.labels.some((l) => l.toLowerCase() === docsFromCodeLabel);
+}
+function approvalAgeAt(pr) {
+  return pr.review.lastApprovedAt ?? pr.review.lastReviewedAt;
+}
+function isApprovedButAging(pr) {
+  const approvedAt = approvalAgeAt(pr);
+  return pr.review.state === "approved" && approvedAt != null && ageMs(approvedAt) >= approvedAgingMs;
+}
+function needsReReview(pr) {
+  return pr.review.lastReviewedAt != null && pr.lastCommitAt != null &&
+    (pr.review.state === "reviewed" || pr.review.state === "changes_requested") &&
+    new Date(pr.lastCommitAt).getTime() > new Date(pr.review.lastReviewedAt).getTime();
+}
+function changedLineCount(pr) {
+  return pr.additions + pr.deletions;
+}
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function releaseSignalMatches(value, release) {
+  return new RegExp(`(^|[^0-9])${escapeRegExp(release)}([^0-9]|$)`, "i").test(value);
+}
+function targetsCurrentRelease(pr) {
+  return [
+    pr.title,
+    pr.milestone,
+    ...(pr.labels || []),
+    ...((pr.linkedIssues || []).flatMap((issue) => [issue.title, issue.milestone, ...(issue.labels || [])])),
+  ].some((value) => value != null && releaseSignalMatches(value, currentRelease));
+}
+function isQuickWin(pr) {
+  const lines = changedLineCount(pr);
+  return pr.review.state === "waiting" && !hasUnresolvedFeedback(pr) && !hasMergeConflicts(pr) &&
+    isCoreTeamAuthor(pr.author) && !targetsCurrentRelease(pr) && (pr.linkedIssues || []).length <= 1 &&
+    pr.commitCount <= 2 && pr.changedFiles > 0 && pr.changedFiles <= quickWinFileThreshold &&
+    lines > 0 && lines <= quickWinLineThreshold && !isIdle(pr);
+}
+function needsReview(pr) {
+  return pr.review.state === "waiting" && !hasUnresolvedFeedback(pr) && !hasMergeConflicts(pr) &&
+    isCoreTeamAuthor(pr.author);
+}
+
+// ---------------------------------------------------------------------------
+// Bucket classification
+// ---------------------------------------------------------------------------
+
+function reviewBucketLabels(pr) {
+  const labels = [];
+  if (hasRegressionSignal(pr)) labels.push(regressionBucketLabel);
+  if (pr.draft) { labels.push("Draft"); return labels; }
+  if (isCommunityPullRequest(pr) && !isAgedOutCommunityPullRequest(pr)) return labels;
+  if (isBotAuthor(pr.author, pr.authorType)) labels.push("Bots / automation");
+  if (isGeneratedDocsPullRequest(pr)) labels.push("Docs");
+  if (isCommunityToolkitPullRequest(pr)) labels.push("Community Toolkit");
+
+  const ciFailing = isChecksFailing(pr);
+  if (ciFailing) labels.push("CI failing");
+  const checksPending = isChecksPending(pr);
+  const mergeConflicts = hasMergeConflicts(pr);
+  if (mergeConflicts) labels.push("Merge conflicts");
+  const approvedButAging = isApprovedButAging(pr);
+  if (approvedButAging) labels.push(approvedButAgingBucketLabel);
+  const unresolved = hasUnresolvedFeedback(pr);
+  if (unresolved) labels.push("Unresolved feedback");
+  const unresolvedBlocksMerge = unresolved && pr.review.requiresConversationResolution;
+
+  if (pr.review.state === "approved" && !approvedButAging && !ciFailing && !checksPending &&
+      !unresolvedBlocksMerge && !mergeConflicts && !hasNeedsAuthorActionLabel(pr) &&
+      !isMergeReviewBlocked(pr)) {
+    labels.push("Ready to merge");
+  }
+  if (needsReReview(pr)) labels.push("Re-review needed");
+  if (pr.review.state === "changes_requested") labels.push("Author response");
+  if (isIdle(pr)) labels.push("Stalled");
+  if (isCommunityPullRequest(pr)) {
+    labels.push(isAgedOutCommunityPullRequest(pr) ? agedOutCommunityBucketLabel : "Community");
+  }
+  if (isQuickWin(pr) && !ciFailing) labels.push("Quick wins");
+  if (needsReview(pr)) labels.push("Needs review");
+  if (labels.length === 0) labels.push("Review started");
+  return labels;
+}
+
+function reviewSignal(pr, bucketLabel) {
+  if (pr.draft) return "Draft";
+  const approvedAt = approvalAgeAt(pr);
+  switch (bucketLabel) {
+    case regressionBucketLabel: return hasRegressionLabel(pr.labels) ? "Regression label" : "Regression";
+    case approvedButAgingBucketLabel: return approvedAt ? `Approved ${formatAge(approvedAt)}` : "Approved";
+    case "CI failing": {
+      const fc = pr.checks?.failureCount ?? 0;
+      return fc > 0 ? formatCount(fc, "failing check") : "CI failing";
+    }
+    case "Unresolved feedback": return formatCount(pr.review.unresolvedThreadCount, "unresolved thread");
+    case "Ready to merge": return formatCount(pr.review.approvalCount, "approval");
+    case "Re-review needed": return pr.lastCommitAt ? `Pushed ${formatAge(pr.lastCommitAt)}` : "Pushed after review";
+    case "Merge conflicts": return "Merge conflicts";
+    case "Docs": return "generated docs";
+    case "Community Toolkit": return "CommunityToolkit/Aspire";
+    case "Bots / automation": return "bot";
+    case "Community": return isCommunityWaiting(pr) ? `Community · waiting ${formatAge(pr.createdAt)}` : "community";
+    case agedOutCommunityBucketLabel: return agedOutCommunityBucketLabel;
+    case "Quick wins": return reviewFootprint(pr);
+    case "Needs review": return "No reviews";
+    case "Stalled": return `Idle ${formatRelative(pr.updatedAt)}`;
+    case "Author response": return "Changes requested";
+    default: return formatCount(pr.review.reviewerCount, "reviewer");
+  }
+}
+
+function reviewFootprint(pr) {
+  const parts = [
+    pr.changedFiles > 0 ? formatCount(pr.changedFiles, "file") : null,
+    changedLineCount(pr) > 0 ? formatCount(changedLineCount(pr), "line") : null,
+    pr.commitCount > 0 ? formatCount(pr.commitCount, "commit") : null,
+  ].filter(Boolean);
+  return parts.slice(0, 2).join(" · ") || "size unknown";
+}
+
+// ---------------------------------------------------------------------------
+// Attention signals (faithful port of models.ts signal generators)
+// ---------------------------------------------------------------------------
+
+function isChecksPending(pr) {
+  return pr.checks?.state === "pending";
+}
+
+export function createAttentionSignals(item) {
+  const pullRequest = item.pullRequest;
+  const action = actionSignal(pullRequest);
+  const signals = [action];
+
+  // Merge conflicts are a hard blocker, so surface the pill right after the action signal —
+  // otherwise a stacked PR (release + regression + CI) can push it past the signal limit and
+  // hide the conflict entirely.
+  if (hasMergeConflicts(pullRequest) && action.label !== "merge conflicts") {
+    signals.push({ label: "merge conflicts", tone: "danger" });
+  }
+
+  const progress = reviewProgressSignal(pullRequest);
+  // Approval progress should survive card-level signal limits; other review progress can stay
+  // with the lower-priority metadata below.
+  const prioritizeProgress = progress?.tone === "success" && pullRequest.review.approvalCount > 0;
+  if (progress && prioritizeProgress) {
+    signals.push(progress);
+  }
+
+  if (targetsCurrentRelease(pullRequest)) {
+    signals.push({ label: `release ${currentRelease}`, tone: "danger" });
+  }
+
+  if (hasRegressionSignal(pullRequest)) {
+    signals.push({ label: regressionBucketLabel.toLowerCase(), tone: "danger" });
+  }
+
+  if (pullRequest.baseRef?.startsWith("release/")) {
+    signals.push({ label: `base ${pullRequest.baseRef}`, tone: "danger" });
+  }
+
+  const checksSignal = checksAttentionSignal(pullRequest);
+  if (checksSignal) {
+    signals.push(checksSignal);
+  }
+
+  if (hasUnresolvedFeedback(pullRequest)) {
+    signals.push({
+      label: formatCount(pullRequest.review.unresolvedThreadCount, "unresolved", "unresolved"),
+      tone: "danger",
+    });
+  }
+
+  const approvedAt = approvalAgeAt(pullRequest);
+  if (isApprovedButAging(pullRequest) && approvedAt) {
+    signals.push({ label: `approved ${formatAge(approvedAt)}`, tone: "danger" });
+  }
+
+  if (needsReReview(pullRequest)) {
+    signals.push({ label: "commit after review", tone: "warning" });
+  }
+
+  if (isGeneratedDocsPullRequest(pullRequest)) {
+    signals.push({ label: "docs", tone: "accent" });
+  }
+
+  if (isCommunityToolkitPullRequest(pullRequest)) {
+    signals.push({ label: "community toolkit", tone: "accent" });
+  }
+
+  if (isAgedOutCommunityPullRequest(pullRequest)) {
+    signals.push({ label: agedOutCommunityBucketLabel.toLowerCase(), tone: "warning" });
+  } else if (isCommunityWaiting(pullRequest)) {
+    signals.push({ label: "community wait", tone: "warning" });
+  }
+
+  if (isQuickWin(pullRequest)) {
+    signals.push({ label: "quick win", tone: "success" });
+  }
+
+  if (isIdle(pullRequest)) {
+    signals.push({ label: `idle ${formatAge(pullRequest.updatedAt)}`, tone: "warning" });
+  }
+
+  const ageSignal = oldFirstSignal(pullRequest);
+  if (ageSignal) {
+    signals.push(ageSignal);
+  }
+
+  signals.push({
+    label: `open ${formatAge(pullRequest.createdAt)}`,
+    tone: Date.now() - new Date(pullRequest.createdAt).getTime() >= 7 * dayMs ? "warning" : "muted",
+  });
+
+  if (progress && !prioritizeProgress) {
+    signals.push(progress);
+  }
+
+  if (pullRequest.review.lastReviewedAt && pullRequest.review.state !== "waiting") {
+    signals.push({ label: `reviewed ${formatAge(pullRequest.review.lastReviewedAt)}`, tone: "muted" });
+  }
+
+  if (pullRequest.review.commentedReviewCount > 0) {
+    signals.push({ label: formatCount(pullRequest.review.commentedReviewCount, "review comment"), tone: "muted" });
+  }
+
+  const computedLabels = isGeneratedDocsPullRequest(pullRequest)
+    ? pullRequest.labels.filter((label) => label.toLowerCase() !== docsFromCodeLabel)
+    : pullRequest.labels;
+
+  for (const label of computedLabels.slice(0, 2)) {
+    signals.push({ label, tone: "accent" });
+  }
+
+  if (isBotAuthor(pullRequest.author, pullRequest.authorType)) {
+    signals.push({ label: "bot", tone: "accent" });
+  } else if (isCopilotAttributedAuthor(pullRequest.author)) {
+    signals.push({ label: "copilot", tone: "accent" });
+  }
+
+  return signals.slice(0, 7);
+}
+
+function checksAttentionSignal(pullRequest) {
+  const checks = pullRequest.checks;
+  if (!checks || checks.state === "none" || checks.state === "unknown") {
+    return null;
+  }
+  if (checks.state === "failure") {
+    const label = checks.failureCount > 0
+      ? `CI failing · ${formatCount(checks.failureCount, "check")}`
+      : "CI failing";
+    return { label, tone: "danger" };
+  }
+  if (checks.state === "pending") {
+    return { label: "CI running", tone: "warning" };
+  }
+  // Successful CI on dashboard rows is intentionally suppressed to avoid pill noise.
+  return null;
+}
+
+function oldFirstSignal(pullRequest) {
+  const activityAge = ageMs(pullRequestAgingReferenceAt(pullRequest));
+  if (activityAge >= focusAgeLimitMs) {
+    return { label: "review debt", tone: "danger" };
+  }
+  if (activityAge >= 7 * dayMs) {
+    return { label: "old first", tone: "warning" };
+  }
+  if (activityAge < 12 * hourMs) {
+    return { label: "newer", tone: "muted" };
+  }
+  return null;
+}
+
+function pullRequestAgingReferenceAt(pullRequest) {
+  if (isChecksFailing(pullRequest)) {
+    return ciActivityAt(pullRequest);
+  }
+  if (pullRequest.review.state === "approved") {
+    return reviewActivityAt(pullRequest);
+  }
+  if (needsReReview(pullRequest)) {
+    return reReviewActivityAt(pullRequest);
+  }
+  if (pullRequest.review.state === "reviewed" || pullRequest.review.state === "changes_requested") {
+    return reviewedActivityAt(pullRequest);
+  }
+  return pullRequest.updatedAt;
+}
+
+function reviewActivityAt(pullRequest) {
+  return latestDate(pullRequest.review.lastApprovedAt, pullRequest.review.lastReviewedAt) ?? pullRequest.updatedAt;
+}
+function reReviewActivityAt(pullRequest) {
+  return pullRequest.lastCommitAt ?? pullRequest.review.lastReviewedAt ?? pullRequest.updatedAt;
+}
+function reviewedActivityAt(pullRequest) {
+  return pullRequest.review.lastReviewedAt ?? pullRequest.updatedAt;
+}
+function ciActivityAt(pullRequest) {
+  return latestDate(pullRequest.checks?.completedAt, pullRequest.lastCommitAt) ?? pullRequest.updatedAt;
+}
+
+function actionSignal(pullRequest) {
+  if (hasRegressionSignal(pullRequest)) {
+    return { label: regressionBucketLabel.toLowerCase(), tone: "danger" };
+  }
+  if (pullRequest.draft) {
+    return { label: "draft", tone: "muted" };
+  }
+  if (isBotAuthor(pullRequest.author, pullRequest.authorType)) {
+    return { label: "automation", tone: "accent" };
+  }
+  if (isGeneratedDocsPullRequest(pullRequest)) {
+    return { label: "docs review", tone: "accent" };
+  }
+  if (isCommunityToolkitPullRequest(pullRequest)) {
+    return { label: "toolkit review", tone: "accent" };
+  }
+  if (isChecksFailing(pullRequest)) {
+    return { label: "fix CI", tone: "danger" };
+  }
+  if (hasMergeConflicts(pullRequest)) {
+    return { label: "merge conflicts", tone: "danger" };
+  }
+  if (hasUnresolvedFeedback(pullRequest)) {
+    return { label: "resolve feedback", tone: "danger" };
+  }
+  if (isApprovedButAging(pullRequest)) {
+    return { label: "land approval", tone: "danger" };
+  }
+  if (pullRequest.review.state === "approved") {
+    return isChecksPending(pullRequest)
+      ? { label: "wait for CI", tone: "warning" }
+      : { label: "merge", tone: "success" };
+  }
+  if (needsReReview(pullRequest)) {
+    return { label: "re-review", tone: "warning" };
+  }
+  if (pullRequest.review.state === "changes_requested") {
+    return { label: "author fix", tone: "danger" };
+  }
+  if (isAgedOutCommunityPullRequest(pullRequest)) {
+    return { label: agedOutCommunityBucketLabel.toLowerCase(), tone: "warning" };
+  }
+  if (isIdle(pullRequest)) {
+    return { label: "unstick", tone: "warning" };
+  }
+  if (!pullRequest.isMine && !pullRequest.repoPrivate && isCommunityAuthor(pullRequest.author, pullRequest.authorType)) {
+    return isCommunityWaiting(pullRequest)
+      ? { label: "community wait", tone: "warning" }
+      : { label: "community", tone: "accent" };
+  }
+  if (isQuickWin(pullRequest)) {
+    return { label: "quick win", tone: "success" };
+  }
+  if (pullRequest.review.state === "waiting") {
+    return { label: "needs reviewer", tone: "warning" };
+  }
+  return { label: "finish review", tone: "accent" };
+}
+
+function reviewProgressSignal(pullRequest) {
+  if (pullRequest.review.state === "waiting") {
+    return { label: "no reviews", tone: "warning" };
+  }
+  if (pullRequest.review.state === "changes_requested") {
+    return {
+      label: formatCount(Math.max(1, pullRequest.review.changesRequestedCount), "change request"),
+      tone: "danger",
+    };
+  }
+  if (pullRequest.review.approvalCount > 0) {
+    return { label: formatCount(pullRequest.review.approvalCount, "approval"), tone: "success" };
+  }
+  if (pullRequest.review.reviewerCount > 0) {
+    return { label: `${formatCount(pullRequest.review.reviewerCount, "reviewer")} · 0 approvals`, tone: "accent" };
+  }
+  return null;
+}
+
+const BUCKET_DEFS = [
+  { label: regressionBucketLabel, tone: "danger" },
+  { label: approvedButAgingBucketLabel, tone: "danger" },
+  { label: "CI failing", tone: "danger" },
+  { label: "Merge conflicts", tone: "danger" },
+  { label: "Unresolved feedback", tone: "danger" },
+  { label: "Ready to merge", tone: "success" },
+  { label: "Re-review needed", tone: "warning" },
+  { label: "Docs", tone: "accent" },
+  { label: "Community Toolkit", tone: "accent" },
+  { label: "Bots / automation", tone: "accent" },
+  { label: agedOutCommunityBucketLabel, tone: "warning" },
+  { label: "Quick wins", tone: "success" },
+  { label: "Needs review", tone: "warning" },
+  { label: "Review started", tone: "accent" },
+  { label: "Stalled", tone: "warning" },
+  { label: "Author response", tone: "danger" },
+  { label: "Draft", tone: "accent" },
+];
+
+export function createAttentionBuckets(prs, login) {
+  const defs = [...BUCKET_DEFS];
+  if (login) defs.push({ label: myDraftPullRequestsBucketLabel, tone: "accent" });
+  const buckets = defs.map((d) => ({ label: d.label, tone: d.tone, items: [] }));
+  const byLabel = new Map(buckets.map((b) => [b.label, b]));
+
+  const visible = prs.filter((p) => p.state === "open" && !hasNeedsAuthorActionLabel(p));
+  for (const pr of visible) {
+    for (const label of reviewBucketLabels(pr)) {
+      byLabel.get(label)?.items.push({ pullRequest: pr, reason: reviewSignal(pr, label) });
+    }
+  }
+  if (login) {
+    const myDrafts = byLabel.get(myDraftPullRequestsBucketLabel);
+    for (const pr of prs) {
+      if (pr.state === "open" && pr.draft && pr.isMine) {
+        myDrafts?.items.push({ pullRequest: pr, reason: "Draft" });
+      }
+    }
+  }
+  return buckets.filter((b) => b.items.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Focus age + focused "Needs attention" queue
+// ---------------------------------------------------------------------------
+
+function pullRequestFocusActivityAt(pr, bucketLabel) {
+  switch (bucketLabel) {
+    case approvedButAgingBucketLabel:
+    case "Ready to merge":
+      return latestDate(pr.review.lastApprovedAt, pr.review.lastReviewedAt) ?? pr.updatedAt;
+    case "Re-review needed":
+      return pr.lastCommitAt ?? pr.review.lastReviewedAt ?? pr.updatedAt;
+    case "Author response":
+    case "Review started":
+      return pr.review.lastReviewedAt ?? pr.updatedAt;
+    case "CI failing":
+      return latestDate(pr.checks?.completedAt, pr.lastCommitAt) ?? pr.updatedAt;
+    default:
+      return pr.updatedAt;
+  }
+}
+function isWithinFocusAgeLimit(pr, bucketLabel) {
+  return ageMs(pullRequestFocusActivityAt(pr, bucketLabel)) <= focusAgeLimitMs;
+}
+
+const excludedFocusBucketLabels = new Set(["Stalled", "Draft", "My draft PRs", "Docs", "Community Toolkit", "Bots / automation", "Community", "Aged out community", "Unresolved feedback", "Merge conflicts", "CI failing", "Author response"]);
+const disqualifyingFocusBucketLabels = new Set(["Draft", "My draft PRs", "Docs", "Community Toolkit", "Bots / automation", "Community", "Aged out community", "Unresolved feedback", "Merge conflicts"]);
+const specializedFocusBucketLabels = new Set(["Docs", "Community Toolkit", "Bots / automation", "Community", "Aged out community"]);
+const focusBucketRanks = new Map([
+  ["Regression", -2], ["Approved but aging", 0], ["Re-review needed", 1], ["Ready to merge", 2],
+  ["Author response", 3], ["Needs review", 4], ["Quick wins", 5], ["Review started", 6],
+]);
+function focusBucketRank(label) {
+  return focusBucketRanks.has(label) ? focusBucketRanks.get(label) : Number.MAX_SAFE_INTEGER;
+}
+function prKey(pr) {
+  return `${pr.repository.toLowerCase()}#${pr.number}`;
+}
+
+export function computeFocusItems(buckets) {
+  const blocked = new Set(
+    buckets.filter((b) => disqualifyingFocusBucketLabels.has(b.label))
+      .flatMap((b) => b.items.map((i) => prKey(i.pullRequest))),
+  );
+  // Changes-requested PRs are waiting on the author, so they drop out of the focused
+  // queue entirely (mirrors pr-dashboard #91) unless the author has already pushed a
+  // response and the PR now needs re-review.
+  for (const [key, labels] of bucketLabelsByPr(buckets)) {
+    if (isWaitingOnAuthor(labels)) blocked.add(key);
+  }
+  const flat = buckets
+    .filter((b) => !excludedFocusBucketLabels.has(b.label))
+    .flatMap((b) => b.items.map((i) => ({ ...i, bucketLabel: b.label, bucketTone: b.tone })));
+
+  const byPr = new Map();
+  for (const item of flat) {
+    const key = prKey(item.pullRequest);
+    if (blocked.has(key)) continue;
+    const existing = byPr.get(key);
+    if (!existing || focusBucketRank(item.bucketLabel) < focusBucketRank(existing.bucketLabel)) {
+      byPr.set(key, item);
+    }
+  }
+  return [...byPr.values()]
+    .filter((i) => isWithinFocusAgeLimit(i.pullRequest, i.bucketLabel))
+    .filter((i) => !isCommunityPullRequest(i.pullRequest))
+    .filter((i) => !isChecksFailing(i.pullRequest))
+    .sort((a, b) => new Date(b.pullRequest.updatedAt) - new Date(a.pullRequest.updatedAt));
+}
+
+export function computeCommunityItems(prs) {
+  return prs
+    .filter((p) => p.state === "open" && !p.draft && !hasNeedsAuthorActionLabel(p) &&
+      isCommunityPullRequest(p) && !isAgedOutCommunityPullRequest(p))
+    .map((p) => ({ pullRequest: p, reason: "Community", bucketTone: "accent" }))
+    .sort((a, b) => new Date(b.pullRequest.updatedAt) - new Date(a.pullRequest.updatedAt));
+}
+
+export function computeFocusExclusionItems(prs, buckets, focusItems, login) {
+  if (!login) return [];
+  const focusKeys = new Set(focusItems.map((i) => prKey(i.pullRequest)));
+  const labelsByPr = bucketLabelsByPr(buckets);
+  return prs
+    .filter((p) => p.state === "open" && !p.draft &&
+      p.isMine && !focusKeys.has(prKey(p)))
+    .map((p) => {
+      const bucketLabels = labelsByPr.get(prKey(p)) ?? [];
+      return { pullRequest: p, reason: focusExclusionReason(p, bucketLabels) };
+    })
+    .sort((a, b) => exReasonRank(a.reason.kind) - exReasonRank(b.reason.kind) ||
+      new Date(b.pullRequest.updatedAt) - new Date(a.pullRequest.updatedAt));
+}
+
+function focusExclusionReason(pr, bucketLabels) {
+  if (isChecksFailing(pr)) return { kind: "ci-failing", label: "CI failing", detail: "Failing checks keep it out until CI is green again.", tone: "danger" };
+  if (hasMergeConflicts(pr)) return { kind: "merge-conflicts", label: "Merge conflicts", detail: "The author needs to rebase before reviewers can finish it.", tone: "danger" };
+  if (pr.review.unresolvedThreadCount > 0) return { kind: "unresolved-feedback", label: "Unresolved feedback", detail: "Open review threads make it author-blocked.", tone: "danger" };
+  if (hasNeedsAuthorActionLabel(pr)) return { kind: "held-by-label", label: "Held by label", detail: "A do-not-merge label keeps it out of the focused queue.", tone: "danger" };
+  if (isWaitingOnAuthor(bucketLabels)) return { kind: "author-response", label: "Author response", detail: "Changes were requested, so this is waiting on the author rather than the focused queue.", tone: "danger" };
+  if (isCommunityPullRequest(pr) && !isAgedOutCommunityPullRequest(pr)) return { kind: "community-list", label: "Community list", detail: "Active external-contributor PRs show in the Community list.", tone: "accent" };
+  const specialized = bucketLabels.find((l) => specializedFocusBucketLabels.has(l));
+  if (specialized) return { kind: "specialized-lane", label: `${specialized} lane`, detail: `Routed to the ${specialized} lane instead of Needs attention.`, tone: "accent" };
+  const candidate = [...bucketLabels].filter((l) => !excludedFocusBucketLabels.has(l)).sort((a, b) => focusBucketRank(a) - focusBucketRank(b))[0] ?? null;
+  if (candidate && !isWithinFocusAgeLimit(pr, candidate)) return { kind: "stale-activity", label: "Stale activity", detail: "Its actionable lane has not had fresh activity in 14 days.", tone: "warning" };
+  if (bucketLabels.includes("Stalled")) return { kind: "stalled-only", label: "Stalled only", detail: "It has gone quiet with no fresher actionable lane.", tone: "warning" };
+  return { kind: "outside-queue", label: "Outside queue", detail: "It does not currently match a focused, actionable lane.", tone: "muted" };
+}
+function exReasonRank(kind) {
+  return ["ci-failing", "merge-conflicts", "unresolved-feedback", "held-by-label", "author-response", "stale-activity", "community-list", "specialized-lane", "stalled-only", "outside-queue"].indexOf(kind);
+}
+
+// A PR with requested changes is waiting on its author, not the focused queue. Once the
+// author pushes a response and it needs re-review, it re-enters under "Re-review needed".
+function isWaitingOnAuthor(bucketLabels) {
+  return bucketLabels.includes("Author response") && !bucketLabels.includes("Re-review needed");
+}
+function bucketLabelsByPr(buckets) {
+  const map = new Map();
+  for (const b of buckets) {
+    for (const i of b.items) {
+      const k = prKey(i.pullRequest);
+      if (!map.has(k)) map.set(k, []);
+      map.get(k).push(b.label);
+    }
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Personal "For you" picks
+// ---------------------------------------------------------------------------
+
+export function createForMeItems(prs, logins) {
+  const loginList = Array.isArray(logins) ? logins.filter(Boolean) : (logins ? [logins] : []);
+  if (!loginList.length) return [];
+  return prs
+    .filter((p) => p.state === "open" && !p.draft && !isOwnCopilotAuthorAny(p.author, loginList))
+    .map((p) => createPersonalPick(p))
+    .filter(Boolean)
+    .sort((a, b) => pickScore(b) - pickScore(a))
+    .slice(0, 10);
+}
+
+function createPersonalPick(pr) {
+  const mine = pr.isMine;
+  if (hasMergeConflicts(pr)) {
+    return mine ? { pullRequest: pr, action: personalPickActions.resolveConflicts, reason: `Your PR has merge conflicts · ${pickReason(pr)}`, tone: "danger", personal: true } : null;
+  }
+  if (hasNeedsAuthorActionLabel(pr)) {
+    return mine ? { pullRequest: pr, action: personalPickActions.needsAttention, reason: `Your PR is labeled ${matchingDoNotMergeLabel(pr) ?? "no-merge"} · ${pickReason(pr)}`, tone: "danger", personal: true } : null;
+  }
+  if (mine && pr.checks?.state === "failure") {
+    const fc = pr.checks.failureCount ?? 0;
+    return { pullRequest: pr, action: personalPickActions.fixCi, reason: `${fc > 0 ? `Your PR has ${formatCount(fc, "failing check")}` : "Your PR is failing CI"} · ${pickReason(pr)}`, tone: "danger", personal: true };
+  }
+  if (!mine && pr.review.reviewRequestedFromViewer) {
+    const ci = pr.checks?.state === "failure" ? " · CI failing" : pr.checks?.state === "pending" ? " · CI running" : "";
+    return { pullRequest: pr, action: personalPickActions.reviewThis, reason: `Review requested from you · ${pickReason(pr)}${ci}`, tone: "warning", personal: true };
+  }
+  if (mine && pr.review.state === "changes_requested") {
+    return { pullRequest: pr, action: personalPickActions.respondHere, reason: `Your PR has changes requested · ${pickReason(pr)}`, tone: "danger", personal: true };
+  }
+  if (mine && pr.review.state === "approved") {
+    return { pullRequest: pr, action: personalPickActions.finishThis, reason: `Your PR is approved and still open · ${pickReason(pr)}`, tone: "success", personal: true };
+  }
+  return null;
+}
+
+function pickScore(item) {
+  let score = item.personal ? 1000 : 0;
+  const a = item.action;
+  if (a === personalPickActions.resolveConflicts) score += 200;
+  if (a === personalPickActions.needsAttention) score += 190;
+  if (a === personalPickActions.fixCi) score += 110;
+  if (a === personalPickActions.reviewThis) score += 90;
+  if (a === personalPickActions.finishThis) score += 80;
+  if (a === personalPickActions.respondHere) score += 75;
+  const st = item.pullRequest.review.state;
+  if (st === "changes_requested") score += 30;
+  if (st === "waiting") score += 45;
+  if (st === "reviewed") score += 25;
+  if (st === "approved") score += 5;
+  if (isBotAuthor(item.pullRequest.author, item.pullRequest.authorType)) score -= 120;
+  return score + Math.min(3, Math.floor(ageMs(item.pullRequest.createdAt) / dayMs)) +
+    Math.min(1, Math.floor(ageMs(item.pullRequest.updatedAt) / dayMs));
+}
+
+function pickReason(pr) {
+  const signals = [`open ${formatAge(pr.createdAt)}`];
+  if (pr.review.approvalCount > 0) signals.push(formatCount(pr.review.approvalCount, "approval"));
+  else if (pr.review.reviewerCount > 0) signals.push(`${formatCount(pr.review.reviewerCount, "reviewer")} · 0 approvals`);
+  else signals.push("no reviews");
+  if (isIdle(pr)) signals.push(`idle ${formatAge(pr.updatedAt)}`);
+  return signals.join(" · ");
+}
+
+// ---------------------------------------------------------------------------
+// Core-team ownership
+// ---------------------------------------------------------------------------
+
+export function createDeveloperPullRequestCounts(prs) {
+  const byDev = new Map(coreTeamMembers.map((m) => [actorIdentityKey(m), []]));
+  const actorByKey = new Map(coreTeamMembers.map((m) => [actorIdentityKey(m), m]));
+  for (const pr of prs) {
+    if (pr.state !== "open" || isCommunityToolkitPullRequest(pr) || pr.draft || hasMergeConflicts(pr) || hasNeedsAuthorActionLabel(pr)) continue;
+    const owner = coreTeamOwnershipActor(pr.author);
+    if (!owner) continue;
+    const key = actorIdentityKey(owner);
+    if (!byDev.has(key)) { byDev.set(key, []); actorByKey.set(key, owner); }
+    byDev.get(key).push(pr);
+  }
+  return [...byDev.entries()]
+    .map(([key, list]) => {
+      const latest = list.map((p) => p.updatedAt).sort((a, b) => new Date(b) - new Date(a))[0];
+      return { actor: actorByKey.get(key) ?? key, openPullRequestCount: list.length, latestUpdatedAt: latest ?? null };
+    })
+    .filter((c) => c.openPullRequestCount > 0)
+    .sort((a, b) => b.openPullRequestCount - a.openPullRequestCount || a.actor.localeCompare(b.actor));
+}
+
+// ---------------------------------------------------------------------------
+// Small formatting helpers (port of utils/format.ts essentials)
+// ---------------------------------------------------------------------------
+
+function ageMs(value) {
+  return Date.now() - new Date(value).getTime();
+}
+function latestDate(...values) {
+  let best = null;
+  let bestTime = -Infinity;
+  for (const v of values) {
+    if (!v) continue;
+    const t = new Date(v).getTime();
+    if (t > bestTime) { bestTime = t; best = v; }
+  }
+  return best;
+}
+export function formatCount(n, singular, plural) {
+  const word = n === 1 ? singular : (plural ?? singular + "s");
+  return `${n} ${word}`;
+}
+export function formatAge(iso) {
+  const s = Math.max(0, Math.floor(ageMs(iso) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60); if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60); if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24); if (d < 30) return `${d}d`;
+  const mo = Math.floor(d / 30); if (mo < 12) return `${mo}mo`;
+  return `${Math.floor(mo / 12)}y`;
+}
+export function formatRelative(iso) {
+  return `${formatAge(iso)} ago`;
+}

--- a/.github/extensions/aspire-team-app/model.test.mjs
+++ b/.github/extensions/aspire-team-app/model.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dayMs, personalPickActions } from "./constants.mjs";
+import {
+  computeCommunityItems,
+  computeFocusExclusionItems,
+  computeFocusItems,
+  createAttentionBuckets,
+  createDeveloperPullRequestCounts,
+  createForMeItems,
+} from "./model.mjs";
+
+// The review-mode engine consumes the *normalized* PR shape produced by
+// normalizePr() in github.mjs (not raw GraphQL nodes). makePr mirrors that shape
+// exactly so these unit tests exercise the ranking logic without the fetch layer.
+// The github.test.mjs suite covers the ship/issues fetch path; this file covers
+// the review-mode buckets/focus/personal-pick functions that path never reaches.
+function isoAgo(ms) {
+  return new Date(Date.now() - ms).toISOString();
+}
+
+function makePr(overrides = {}) {
+  const review = {
+    state: "waiting",
+    approvalCount: 0,
+    changesRequestedCount: 0,
+    commentedReviewCount: 0,
+    reviewerCount: 0,
+    lastApprovedAt: null,
+    lastReviewedAt: null,
+    copilotReviewed: false,
+    unresolvedThreadCount: 0,
+    requiresConversationResolution: false,
+    reviewRequestedFromViewer: false,
+    viewerApproved: false,
+    ...(overrides.review ?? {}),
+  };
+  const checks = { state: "success", failureCount: 0, completedAt: null, ...(overrides.checks ?? {}) };
+  return {
+    repository: "microsoft/aspire",
+    number: 1,
+    title: "Test PR",
+    url: "https://github.com/microsoft/aspire/pull/1",
+    state: "open",
+    draft: false,
+    author: "davidfowl",
+    authorType: "User",
+    authorAvatarUrl: null,
+    createdAt: isoAgo(2 * dayMs),
+    updatedAt: isoAgo(dayMs),
+    baseRef: "main",
+    milestone: null,
+    labels: [],
+    assignees: [],
+    requestedReviewers: [],
+    additions: 200,
+    deletions: 10,
+    changedFiles: 10,
+    commitCount: 3,
+    lastCommitAt: null,
+    linkedIssues: [],
+    mergeableState: "clean",
+    unresolvedThreadCount: 0,
+    checksState: "success",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    isMine: false,
+    repoPrivate: false,
+    ...overrides,
+    review,
+    checks,
+  };
+}
+
+function bucketWith(label, ...items) {
+  return { label, tone: "accent", items: items.map((pr) => ({ pullRequest: pr, reason: "" })) };
+}
+
+test("createAttentionBuckets drops closed PRs and PRs held by a do-not-merge label", () => {
+  const needsReview = makePr({ number: 1, author: "davidfowl", review: { state: "waiting" } });
+  const held = makePr({ number: 2, author: "davidfowl", labels: ["needs-author-action"] });
+  const closed = makePr({ number: 3, author: "davidfowl", state: "closed" });
+
+  const buckets = createAttentionBuckets([needsReview, held, closed]);
+  const numbers = buckets.flatMap((b) => b.items.map((i) => i.pullRequest.number));
+
+  assert.ok(numbers.includes(1));
+  assert.ok(!numbers.includes(2));
+  assert.ok(!numbers.includes(3));
+  const review = buckets.find((b) => b.label === "Needs review");
+  assert.ok(review);
+  assert.deepEqual(review.items.map((i) => i.pullRequest.number), [1]);
+});
+
+test("createAttentionBuckets only surfaces the My draft PRs bucket when a login is supplied", () => {
+  const draft = makePr({ number: 7, draft: true, isMine: true, author: "octo" });
+
+  const withLogin = createAttentionBuckets([draft], "octo");
+  const myDrafts = withLogin.find((b) => b.label === "My draft PRs");
+  assert.ok(myDrafts);
+  assert.deepEqual(myDrafts.items.map((i) => i.pullRequest.number), [7]);
+
+  const withoutLogin = createAttentionBuckets([draft]);
+  assert.equal(withoutLogin.find((b) => b.label === "My draft PRs"), undefined);
+});
+
+test("computeFocusItems keeps the highest-priority lane per PR and excludes CI-failing PRs", () => {
+  const readyAndNeedsReview = makePr({ number: 10, updatedAt: isoAgo(dayMs) });
+  const failing = makePr({ number: 11, checks: { state: "failure", failureCount: 2 }, updatedAt: isoAgo(dayMs) });
+
+  const buckets = [
+    bucketWith("Ready to merge", readyAndNeedsReview),
+    bucketWith("Needs review", readyAndNeedsReview, failing),
+  ];
+
+  const focus = computeFocusItems(buckets);
+
+  assert.equal(focus.length, 1);
+  assert.equal(focus[0].pullRequest.number, 10);
+  // Lower focusBucketRank wins: Ready to merge (2) beats Needs review (4).
+  assert.equal(focus[0].bucketLabel, "Ready to merge");
+});
+
+test("computeCommunityItems includes active external contributors and excludes team, bots, and aged-out PRs", () => {
+  const community = makePr({ number: 20, author: "randocontributor", authorType: "User", updatedAt: isoAgo(dayMs) });
+  const mine = makePr({ number: 21, author: "octo", isMine: true });
+  const bot = makePr({ number: 22, author: "dependabot[bot]", authorType: "Bot" });
+  const agedOut = makePr({ number: 23, author: "oldcontributor", authorType: "User", updatedAt: isoAgo(20 * dayMs) });
+
+  const items = computeCommunityItems([community, mine, bot, agedOut]);
+
+  assert.deepEqual(items.map((i) => i.pullRequest.number), [20]);
+  assert.equal(items[0].reason, "Community");
+});
+
+test("computeFocusExclusionItems explains why my own PRs are outside the focused queue", () => {
+  const failing = makePr({ number: 30, author: "octo", isMine: true, checks: { state: "failure", failureCount: 1 } });
+  const notMine = makePr({ number: 31, author: "davidfowl", isMine: false, checks: { state: "failure" } });
+
+  assert.deepEqual(computeFocusExclusionItems([failing, notMine], [], [], ""), []);
+
+  const excluded = computeFocusExclusionItems([failing, notMine], [], [], "octo");
+  assert.equal(excluded.length, 1);
+  assert.equal(excluded[0].pullRequest.number, 30);
+  assert.equal(excluded[0].reason.kind, "ci-failing");
+});
+
+test("createForMeItems returns personal picks only when a login is supplied", () => {
+  const reviewRequested = makePr({ number: 40, author: "davidfowl", isMine: false, review: { state: "waiting", reviewRequestedFromViewer: true } });
+  const approvedMine = makePr({ number: 41, author: "octo", isMine: true, review: { state: "approved", approvalCount: 1, lastApprovedAt: isoAgo(dayMs), lastReviewedAt: isoAgo(dayMs) } });
+
+  assert.deepEqual(createForMeItems([reviewRequested, approvedMine], []), []);
+
+  const picks = createForMeItems([reviewRequested, approvedMine], ["octo"]);
+  const byNumber = new Map(picks.map((p) => [p.pullRequest.number, p]));
+  assert.equal(byNumber.get(40)?.action, personalPickActions.reviewThis);
+  assert.equal(byNumber.get(41)?.action, personalPickActions.finishThis);
+});
+
+test("createDeveloperPullRequestCounts attributes open PRs to core-team members and honors alias suffixes", () => {
+  const prs = [
+    makePr({ number: 50, author: "davidfowl" }),
+    makePr({ number: 51, author: "davidfowl" }),
+    makePr({ number: 52, author: "IEvangelist_microsoft" }),
+    makePr({ number: 53, author: "davidfowl", draft: true }),
+    makePr({ number: 54, author: "randocontributor", authorType: "User" }),
+  ];
+
+  const counts = createDeveloperPullRequestCounts(prs);
+  const byActor = new Map(counts.map((c) => [c.actor, c.openPullRequestCount]));
+
+  assert.equal(byActor.get("davidfowl"), 2);
+  // The "_microsoft" alias attributes to the canonical core-team login.
+  assert.equal(byActor.get("IEvangelist"), 1);
+  assert.equal(byActor.has("randocontributor"), false);
+});

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -741,10 +741,20 @@ function acctAvatar(a, size) {
 
 /* ---- data ---- */
 
+// Parse a JSON response, surfacing the server's { error } message on any non-2xx
+// (origin-guard 403, 500, etc.) instead of treating the error body as a successful
+// payload. The loopback server always replies with JSON, but tolerate a missing or
+// unparseable body so a raw failure still yields a useful message.
+async function readJson(res) {
+  const data = await res.json().catch(() => null);
+  if (!res.ok) throw new Error((data && data.error) || ("Request failed (" + res.status + ")"));
+  return data;
+}
+
 async function load() {
   try {
     const res = await fetch("api/state");
-    const data = await res.json();
+    const data = await readJson(res);
     state = data.dashboard; prefs = data.prefs; loadError = null;
   } catch (e) {
     loadError = String((e && e.message) || e);
@@ -772,7 +782,7 @@ function setLoading(on) {
 
 async function postJSON(path, body) {
   const res = await fetch(path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body || {}) });
-  return res.json();
+  return readJson(res);
 }
 
 const refresh = () => withRefresh(() => postJSON("api/refresh"));
@@ -808,8 +818,10 @@ async function rescanAccounts() {
   if (btn) btn.classList.add("spin");
   try {
     const res = await fetch("api/accounts");
-    const data = await res.json();
-    state = data.dashboard; prefs = data.prefs;
+    const data = await readJson(res);
+    state = data.dashboard; prefs = data.prefs; loadError = null;
+  } catch (e) {
+    loadError = String((e && e.message) || e);
   } finally { rescanning = false; render(); }
 }
 

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -666,6 +666,7 @@ const expanded = new Set(); // account ids whose detail (sources + repos) is exp
 const collapsedLanes = new Set(); // lane ids the user collapsed (survives re-render + SSE)
 const draftReposByAcct = {}; // account id -> working copy of that account's watched repos
 const editingByAcct = {};    // account id -> index of the repo row being inline-edited, or -1
+const repoSaveSeqByAcct = {}; // account id -> latest repository save request number
 
 const RANK = { queue: 0, notifications: 1, accounts: 1, settings: 1 };
 
@@ -794,20 +795,26 @@ const setMode = (mode) => { if (state && state.mode === mode) return; goView("qu
 const toggleAccountActive = (id, active) => withRefresh(() => postJSON("api/account/toggle", { id, active }));
 
 // Persist one account's repos without a full refresh/broadcast (the editor owns
-// the DOM and a re-render would interrupt typing). Fire-and-forget; the in-memory
-// copies are already updated by the editor.
-function persistAccountRepos(id) {
+// the DOM and a re-render would interrupt typing). The editor is optimistic, so a
+// failed save reverts to the previous draft and shows the API error beside the row.
+function persistAccountRepos(id, previousRepos) {
   const repos = (draftReposByAcct[id] || []).slice();
-  postJSON("api/account/repos", { id, repos }).then((data) => {
+  const seq = (repoSaveSeqByAcct[id] || 0) + 1;
+  repoSaveSeqByAcct[id] = seq;
+  return postJSON("api/account/repos", { id, repos }).then((data) => {
+    if (repoSaveSeqByAcct[id] !== seq) return data;
     if (data && data.dashboard) { state = data.dashboard; prefs = data.prefs; }
     repoErr(id, "");
+    return data;
   }).catch((e) => {
-    // The optimistic in-memory edit was never persisted. Surface it inline and
-    // revert the draft to the server's last-known list so the visible editor can't
-    // silently drift from what is actually saved.
-    const acct = state && (state.accounts || []).find((a) => a.id === id);
-    if (acct && Array.isArray(acct.repos)) { draftReposByAcct[id] = acct.repos.slice(); renderRepoList(id); }
-    repoErr(id, "Couldn't save repositories: " + String((e && e.message) || e));
+    if (repoSaveSeqByAcct[id] === seq) {
+      const msg = "Couldn't save repositories: " + String((e && e.message) || e);
+      draftReposByAcct[id] = (Array.isArray(previousRepos) ? previousRepos : accountRepos(id)).slice();
+      editingByAcct[id] = -1;
+      renderRepoList(id);
+      repoErr(id, msg);
+    }
+    return null;
   });
 }
 
@@ -1517,6 +1524,12 @@ function updateRepoCount(id) {
   if (c) c.textContent = (draftReposByAcct[id] || []).length;
 }
 
+function accountRepos(id) {
+  const accts = (state && state.accounts) || [];
+  const a = accts.find(function (acct) { return acct.id === id; });
+  return (a && a.repos) || [];
+}
+
 function renderRepoList(id, flagLast) {
   var ul = document.querySelector('.repo-list[data-list="' + cssEsc(id) + '"]');
   if (!ul) return;
@@ -1540,11 +1553,12 @@ function addRepoFromInput(id) {
   if (list.some(function (r) { return r.toLowerCase() === v.toLowerCase(); })) {
     repoErr(id, v + " is already in the list."); shake(inp); return;
   }
+  var before = list.slice();
   list.push(v);
   inp.value = "";
   repoErr(id, "");
   renderRepoList(id, true);
-  persistAccountRepos(id);
+  persistAccountRepos(id, before);
   inp.focus();
 }
 
@@ -1557,12 +1571,14 @@ function commitEdit(id, i) {
   if (list.some(function (r, j) { return j !== i && r.toLowerCase() === v.toLowerCase(); })) {
     repoErr(id, v + " is already in the list."); shake(inp); return;
   }
+  var before = list.slice();
   list[i] = v; editingByAcct[id] = -1; repoErr(id, "");
   renderRepoList(id);
-  persistAccountRepos(id);
+  persistAccountRepos(id, before);
 }
 
 function deleteRepo(id, i, row) {
+  var before = (draftReposByAcct[id] || []).slice();
   // The row-removal animation is our cue to actually splice, but a missed
   // animationend (reduced motion, a backgrounded tab, an interrupted animation)
   // would strand the row. We keep a fallback timer as a backstop, so both the
@@ -1578,7 +1594,7 @@ function deleteRepo(id, i, row) {
     (draftReposByAcct[id] || []).splice(i, 1);
     if (editingByAcct[id] === i) editingByAcct[id] = -1;
     renderRepoList(id);
-    persistAccountRepos(id);
+    persistAccountRepos(id, before);
   };
   if (row) { row.classList.add("removing"); row.addEventListener("animationend", done, { once: true }); fallback = setTimeout(done, 240); }
   else done();

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -1,0 +1,1706 @@
+// Renderer assets for the Aspire Team App canvas iframe.
+//
+// Served from the per-instance loopback server. Styling leans on the documented
+// Copilot canvas theme tokens (with fallbacks that match the app's dark surface)
+// so the dashboard reads as a first-party Copilot surface.
+//
+// UX model: this is a small surface, so there are no modals, overlays, or
+// drawers. The shell is an in-canvas view router that transitions between full
+// pages (queue / settings / accounts / notifications) with restrained motion.
+
+export const HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Aspire Team App</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="app" class="app" aria-busy="true">
+      <div class="topbar">
+        <span class="brand"><span class="mark"><svg viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M3.5 30C1.57 30 0 28.43 0 26.5C0 25.871 0.166 25.259 0.48 24.729L8.818 10.287L8.852 10.236L12.968 3.099C13.593 2.019 14.754 1.349 16 1.349C17.246 1.349 18.407 2.019 19.031 3.098L31.531 24.749C31.833 25.258 31.999 25.87 31.999 26.499C31.999 28.429 30.429 29.999 28.499 29.999L3.5 30Z" fill="#512BD4"/><path d="M25.33 18H16.99L16 16.28L13.13 11.31C13 11.09 12.82 10.9 12.58 10.77C11.87 10.35 10.95 10.6 10.53 11.32L14.7 4.10001C14.96 3.65001 15.44 3.35001 16 3.35001C16.56 3.35001 17.04 3.65001 17.3 4.10001L21.45 11.29L21.46 11.31L21.48 11.34L25.33 18Z" fill="#7455DD"/><path d="M30 26.5C30 27.33 29.33 28 28.5 28H20.17C21 28 21.67 27.33 21.67 26.5C21.67 26.23 21.59 25.97 21.47 25.75L17.3 18.53L16.99 18H25.33L29.8 25.75C29.93 25.97 30 26.23 30 26.5Z" fill="#9780E5"/><path d="M21.67 26.5C21.67 27.33 21 28 20.17 28H11.83C12.66 28 13.33 27.33 13.33 26.5C13.33 26.23 13.26 25.97 13.13 25.75C13.13 25.74 13.12 25.73 13.11 25.72L11.79 23.57L8.82004 18.72C8.55004 18.28 8.07004 18 7.54004 18H16.99L17.3 18.53L17.427 18.75L21.47 25.75C21.59 25.97 21.67 26.23 21.67 26.5Z" fill="#B9AAEE"/><path d="M13.33 26.5C13.33 27.33 12.66 28 11.83 28H3.5C2.67 28 2 27.33 2 26.5C2 26.23 2.07 25.97 2.2 25.75L6.24 18.75C6.51 18.29 7.01 18 7.54 18C8.07 18 8.55 18.28 8.82 18.72L11.79 23.57L13.11 25.72C13.12 25.73 13.13 25.74 13.13 25.75C13.26 25.97 13.33 26.23 13.33 26.5Z" fill="#DCD5F6"/><path d="M16.99 18H7.53999C7.00999 18 6.50999 18.29 6.23999 18.75L6.66999 18L10.49 11.39L10.53 11.33V11.32C10.95 10.6 11.87 10.35 12.58 10.77C12.82 10.9 13 11.09 13.13 11.31L16 16.28L16.99 18Z" fill="#9780E5"/></svg></span>Aspire Team App</span>
+        <span class="sk sk-tabs"></span>
+        <span class="spacer"></span>
+        <span class="sk sk-chip"></span>
+        <span class="sk sk-btn"></span>
+        <span class="sk sk-btn"></span>
+        <span class="sk sk-btn"></span>
+      </div>
+      <div class="subbar">
+        <span class="sk sk-who"></span>
+        <span class="sk sk-meta"></span>
+        <span class="stats"><span class="sk sk-stat"></span><span class="sk sk-stat"></span><span class="sk sk-stat"></span></span>
+      </div>
+      <div class="lanes">
+        <section class="lane">
+          <div class="lane-head"><span class="sk sk-dot"></span><span class="sk sk-lane-title"></span></div>
+          <div class="grid"><span class="sk sk-card"></span><span class="sk sk-card"></span><span class="sk sk-card"></span></div>
+        </section>
+        <section class="lane">
+          <div class="lane-head"><span class="sk sk-dot"></span><span class="sk sk-lane-title"></span></div>
+          <div class="grid"><span class="sk sk-card"></span><span class="sk sk-card"></span></div>
+        </section>
+      </div>
+    </div>
+    <script src="app.js"></script>
+  </body>
+</html>`;
+
+export const STYLES = `
+:root {
+  --bg: var(--background-color-default, #0d1117);
+  --surface: var(--n-1, #161b22);
+  --surface-2: var(--n-2, #1c2128);
+  --surface-3: var(--n-3, #262c36);
+  --card: var(--n-2, #1e2530);
+  --card-hover: var(--n-3, #252d39);
+  --head-hover: color-mix(in srgb, var(--fg) 8%, transparent);
+  --fg: var(--text-color-default, #e6edf3);
+  --muted: var(--text-color-muted, #8b949e);
+  --border: var(--border-color-default, #30363d);
+  --border-soft: var(--n-2, #21262d);
+  --border-strong: var(--border-color-muted, #484f58);
+  --focus: var(--color-focus-outline, #4493f8);
+  --white: var(--color-white, #fff);
+
+  /* Brand purple - reserved for the brand mark, PR identity, and the loading accent */
+  --accent: #a371f7;
+  --accent-strong: #8957e5;
+  --accent-2: #6e5cf0;
+  --purple: #a371f7;
+
+  /* Primary action green - matches the app's confirm button (sampled #347d39) */
+  --green: #347d39;
+  --green-emphasis: #3f9147;
+  --green-border: transparent;
+  --green-fg: #ffffff;
+
+  /* Informational blue - links, identifiers, toggles, focus */
+  --blue: var(--true-color-blue, #4493f8);
+
+  --success: var(--true-color-green, #3fb950);
+  --warning: var(--true-color-yellow, #d29922);
+  --danger: var(--true-color-red, #f85149);
+
+  --font: var(--font-sans, "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif);
+  --mono: var(--font-mono, "Cascadia Code", "SFMono-Regular", Consolas, monospace);
+  --radius: 6px;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; }
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; border-radius: 6px; }
+
+.app { display: flex; flex-direction: column; min-height: 100%; position: relative; }
+
+/* Top loading bar shown during refreshes (skeleton handles first load).
+   A deliberate left-to-right paint-stroke fill, not a rushed shimmer. */
+.app.loading::after {
+  content: ""; position: fixed; left: 0; top: 0; height: 2px; width: 100%; z-index: 50;
+  transform-origin: left center; transform: scaleX(0);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--accent-2) 65%, transparent), var(--accent) 72%, var(--accent-2));
+  box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 45%, transparent);
+  animation: paintfill 2.6s cubic-bezier(.62, .03, .2, 1) infinite;
+}
+@keyframes paintfill {
+  0%   { transform: scaleX(0);   opacity: .9; }
+  70%  { transform: scaleX(.92); opacity: 1; }
+  88%  { transform: scaleX(1);   opacity: 1; }
+  100% { transform: scaleX(1);   opacity: 0; }
+}
+
+/* Header */
+.topbar {
+  position: sticky; top: 0; z-index: 20;
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 16px;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 600; font-size: 14px; white-space: nowrap; }
+button.brand { border: 0; background: transparent; padding: 2px 4px; margin: -2px -4px; border-radius: 7px; color: inherit; font-family: inherit; cursor: pointer; transition: background .15s; }
+button.brand:hover { background: var(--surface); }
+button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1px; }
+.brand .mark {
+  width: 22px; height: 22px; display: grid; place-items: center; flex: none;
+}
+.brand .mark svg { width: 22px; height: 22px; display: block; }
+.tabs { display: flex; gap: 2px; margin-left: 6px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 3px; }
+.tab {
+  border: 0; background: transparent; color: var(--muted);
+  padding: 5px 12px; border-radius: 6px; font-size: 12.5px; font-weight: 500;
+  transition: color .15s, background .15s;
+}
+.tab:hover { color: var(--fg); }
+.tab.active { color: var(--fg); background: var(--surface-3); box-shadow: inset 0 0 0 1px var(--border); }
+.spacer { flex: 1; }
+.tb-actions { display: inline-flex; align-items: center; gap: 6px; }
+
+.backbtn {
+  display: inline-flex; align-items: center; gap: 6px; margin-left: 4px;
+  border: 1px solid var(--border); background: var(--surface); color: var(--fg);
+  height: 30px; padding: 0 11px 0 8px; border-radius: 6px; font-size: 12.5px; font-weight: 600;
+  transition: border-color .15s, background .15s;
+}
+.backbtn:hover { border-color: var(--border-strong); background: var(--surface-2); }
+.backbtn:active { transform: translateY(1px); }
+
+.iconbtn {
+  position: relative; border: 1px solid var(--border); background: var(--surface);
+  color: var(--muted); width: 30px; height: 30px; border-radius: 6px;
+  display: grid; place-items: center; transition: color .15s, border-color .15s, background .15s;
+}
+.iconbtn:hover { color: var(--fg); border-color: var(--border-strong); background: var(--surface-2); }
+.iconbtn.active { color: var(--fg); border-color: var(--border-strong); background: var(--surface-3); box-shadow: inset 0 0 0 1px var(--border-soft); }
+.iconbtn.spin svg { animation: spin 1s linear infinite; }
+.badge {
+  position: absolute; top: -6px; right: -6px; min-width: 16px; height: 16px; padding: 0 4px;
+  border-radius: 999px; background: var(--danger); color: var(--white); font-size: 10px; font-weight: 700;
+  display: grid; place-items: center; border: 2px solid var(--bg);
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* View router */
+.viewport { flex: 1; }
+.view { animation: viewEnter .22s ease both; }
+.view.back { animation: viewEnterBack .22s ease both; }
+@keyframes viewEnter { from { opacity: 0; transform: translateX(10px); } to { opacity: 1; transform: none; } }
+@keyframes viewEnterBack { from { opacity: 0; transform: translateX(-10px); } to { opacity: 1; transform: none; } }
+
+/* Sub-header (queue stats) */
+.subbar {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 10px;
+  padding: 12px 16px; border-bottom: 1px solid var(--border-soft);
+}
+.who { display: flex; align-items: center; gap: 8px; font-weight: 600; }
+.who img { width: 22px; height: 22px; border-radius: 50%; border: 1px solid var(--border); }
+.meta { color: var(--muted); font-size: 12px; }
+.stats { display: flex; gap: 6px; margin-left: auto; flex-wrap: wrap; }
+.stat {
+  display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px;
+  border: 1px solid var(--border); border-radius: 999px; background: var(--surface); font-size: 12px;
+}
+.stat b { font-weight: 700; }
+.dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
+.t-success { color: var(--success); } .bg-success { background: var(--success); }
+.t-warning { color: var(--warning); } .bg-warning { background: var(--warning); }
+.t-danger  { color: var(--danger); }  .bg-danger  { background: var(--danger); }
+.t-accent  { color: var(--purple); }  .bg-accent  { background: var(--purple); }
+.t-muted   { color: var(--muted); }   .bg-muted   { background: var(--muted); }
+.t-info    { color: var(--blue); }     .bg-info    { background: var(--blue); }
+
+/* Lanes */
+.lanes { padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+.lane-head {
+  display: flex; align-items: center; gap: 8px; width: calc(100% + 16px);
+  border: 0; background: transparent; color: var(--fg);
+  padding: 5px 8px; margin: 0 -8px 1px; border-radius: 6px;
+  transition: background .15s;
+}
+.lane-head:hover { background: var(--head-hover); }
+.lane-ico { display: grid; place-items: center; width: 18px; height: 18px; flex: none; }
+.lane-title { font-size: 13px; font-weight: 700; letter-spacing: .01em; }
+.lane-count {
+  display: inline-flex; align-items: center; line-height: 1; min-height: 20px;
+  font-size: 11px; color: var(--muted); background: var(--surface);
+  border: 1px solid var(--border); border-radius: 999px; padding: 0 8px; font-weight: 600;
+}
+.lane-detail { margin-left: auto; font-size: 11.5px; color: var(--muted); }
+.lane-detail.capped {
+  color: var(--accent); border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  border-radius: 999px; padding: 1px 7px; font-weight: 600; letter-spacing: .1px;
+}
+.meta-draft { color: var(--muted); opacity: .85; }
+.lane-caret {
+  order: -1; display: grid; place-items: center; color: var(--muted);
+  width: 18px; height: 18px; flex: none; transition: transform .24s ease, color .15s;
+}
+.lane-head:hover .lane-caret { color: var(--fg); }
+.lane.collapsed .lane-caret { transform: rotate(-90deg); }
+.lane-body { display: grid; grid-template-rows: 1fr; transition: grid-template-rows .26s ease, opacity .2s ease; opacity: 1; }
+.lane-body > .inner { overflow: hidden; min-height: 0; padding-top: 4px; }
+.lane.collapsed .lane-body { grid-template-rows: 0fr; opacity: 0; }
+/* Masonry card flow: cards pack into columns and use available vertical space
+   instead of stretching to equal-height rows. Responsive via column-width. */
+.grid { column-width: 280px; column-gap: 12px; }
+/* When JS lays the queue out as real columns, .grid becomes a flex row of
+   .mcol-col stacks so cards fill the left column first (predictable reading
+   order) instead of multi-column height balancing. */
+.grid.mcol { column-width: auto; display: flex; align-items: flex-start; gap: 12px; }
+.mcol-col { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; }
+
+/* Review board section dividers (For you / Needs attention / breakdown / Community). */
+.board-sep {
+  margin: 13px 2px 2px; padding-top: 12px; border-top: 1px solid var(--border);
+  font-size: 11px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--muted);
+  display: flex; align-items: center; gap: 8px;
+}
+.board-sep .sep-note { font-weight: 500; letter-spacing: 0; text-transform: none; color: var(--muted); opacity: .85; }
+.lane-empty { color: var(--muted); font-size: 12.5px; padding: 10px 2px 2px; }
+
+/* Generic collapsible body (shared by primary queues + secondary sections).
+   Animates height via grid-template-rows so masonry grids keep their width. */
+.collapse-body { display: grid; grid-template-rows: 1fr; transition: grid-template-rows .26s ease, opacity .2s ease; opacity: 1; }
+.collapse-body > .collapse-inner { overflow: hidden; min-height: 0; }
+.collapsible.collapsed > .collapse-body { grid-template-rows: 0fr; opacity: 0; }
+
+/* Primary queue panels: For you / Needs attention / Your PRs outside.
+   Collapsible sections that lead the review board. */
+.qpanel { display: flex; flex-direction: column; }
+.qhead {
+  display: flex; align-items: center; gap: 8px; width: calc(100% + 16px);
+  border: 0; background: transparent; color: var(--fg); cursor: pointer; font: inherit; text-align: left;
+  padding: 5px 8px; margin: 0 -8px; border-radius: 6px; transition: background .15s;
+}
+.qhead:hover { background: var(--head-hover); }
+.qdot { display: grid; place-items: center; width: 18px; height: 18px; flex: none; }
+.qtitle { font-size: 13px; font-weight: 700; letter-spacing: .01em; }
+.qmetric {
+  margin-left: auto; display: inline-flex; align-items: center; line-height: 1; min-height: 20px;
+  font-size: 11px; font-weight: 600; color: var(--muted);
+  background: var(--surface); border: 1px solid var(--border); border-radius: 999px; padding: 0 9px;
+}
+.qmetric.capped { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 35%, transparent); }
+.qcaret { order: -1; display: grid; place-items: center; width: 18px; height: 18px; flex: none; color: var(--muted); opacity: .9; transition: transform .24s ease, color .15s, opacity .15s; }
+.qhead:hover .qcaret { color: var(--fg); opacity: 1; }
+.collapsible.collapsed .qcaret { transform: rotate(-90deg); }
+.qsub { margin: 4px 0 10px; padding-left: 26px; color: var(--muted); font-size: 12px; line-height: 1.45; }
+.qbody .grid { padding-top: 2px; }
+.qbody .lane-empty { padding-left: 26px; }
+
+/* Secondary reference groups (Community / Core team / Attention breakdown):
+   collapsible, with a quieter header than the primary queues. */
+.sect-group { padding-top: 11px; border-top: 1px solid var(--border); }
+.sect-head {
+  display: flex; align-items: center; gap: 8px; width: calc(100% + 16px);
+  border: 0; background: transparent; color: inherit; cursor: pointer; font: inherit; text-align: left;
+  padding: 4px 8px; margin: 0 -8px; border-radius: 6px; transition: background .15s;
+}
+.sect-head:hover { background: var(--head-hover); }
+.sect-title { font-size: 11px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); }
+.sect-icon { display: grid; place-items: center; width: 16px; height: 16px; flex: none; }
+.sect-note { font-size: 11px; font-weight: 500; letter-spacing: 0; text-transform: none; color: var(--muted); opacity: .85; }
+.sect-count {
+  margin-left: auto; display: inline-flex; align-items: center; line-height: 1; min-height: 20px;
+  font-size: 11px; color: var(--muted); background: var(--surface);
+  border: 1px solid var(--border); border-radius: 999px; padding: 0 8px; font-weight: 600;
+}
+.sect-caret { order: -1; display: grid; place-items: center; width: 18px; height: 18px; flex: none; color: var(--muted); opacity: .9; transition: transform .24s ease, color .15s, opacity .15s; }
+.sect-head:hover .sect-caret { color: var(--fg); opacity: 1; }
+.collapsible.collapsed .sect-caret { transform: rotate(-90deg); }
+.sect-count + .sect-caret { margin-left: 0; }
+.sect-sub { margin: 5px 0 2px; padding-left: 0; color: var(--muted); font-size: 12px; line-height: 1.45; }
+.dev-counts { display: grid; grid-template-columns: repeat(auto-fill, minmax(184px, 1fr)); gap: 6px; padding: 6px 0 2px; }
+.dev-row {
+  display: flex; align-items: center; gap: 10px; padding: 7px 10px;
+  background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+}
+.dev-main { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.dev-av { width: 26px; height: 26px; border-radius: 50%; border: 1px solid var(--border); flex: none; background: var(--surface-3); }
+.dev-name { font-size: 12.5px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dev-when { font-size: 10.5px; color: var(--muted); }
+.dev-count {
+  margin-left: auto; min-width: 22px; height: 20px; padding: 0 7px; flex: none;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--surface-3); border: 1px solid var(--border); border-radius: 999px;
+  font-size: 11.5px; font-weight: 700; color: var(--fg);
+}
+
+.card {
+  display: flex; flex-direction: column; gap: 8px; padding: 12px 14px;
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--radius);
+  transition: border-color .15s, background .15s;
+  break-inside: avoid; -webkit-column-break-inside: avoid; margin-bottom: 12px;
+}
+.card:hover { border-color: var(--border-strong); background: var(--card-hover); }
+.card-top { display: flex; align-items: flex-start; gap: 8px; min-width: 0; }
+.card-title { font-weight: 600; font-size: 13px; line-height: 1.35; color: var(--fg); min-width: 0; overflow-wrap: anywhere; word-break: break-word; }
+.card-title:hover { color: var(--white); }
+.card-sub { display: flex; align-items: center; gap: 8px; color: var(--muted); font-size: 11.5px; }
+.card-sub .repo { font-family: var(--mono); }
+.avatar { width: 18px; height: 18px; border-radius: 50%; border: 1px solid var(--border); }
+.reason { color: var(--muted); font-size: 12px; }
+.pills { display: flex; flex-wrap: wrap; gap: 5px; }
+.pill {
+  display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 500; line-height: 1;
+  padding: 0 8px; min-height: 20px; border-radius: 999px; border: 1px solid transparent;
+}
+/* Label-badge tones mirror pr-dashboard's signal pills (translucent wash + crisp ~50% colored border
+   + saturated text), sourced from our semantic theme tokens. accent = sky blue (pr-dashboard maps
+   Docs/Bots/Draft/Review-started to blue; purple stays reserved for brand). muted stays theme-neutral. */
+.pill.success { color: var(--success); background: color-mix(in srgb, var(--success) 14%, transparent); border-color: color-mix(in srgb, var(--success) 48%, transparent); }
+.pill.warning { color: #f3d46b; background: color-mix(in srgb, var(--warning) 18%, transparent); border-color: color-mix(in srgb, var(--warning) 52%, transparent); }
+.pill.danger  { color: var(--danger); background: color-mix(in srgb, var(--danger) 15%, transparent);  border-color: color-mix(in srgb, var(--danger) 48%, transparent); }
+.pill.accent  { color: #7ab9ff; background: color-mix(in srgb, var(--blue) 14%, transparent);   border-color: color-mix(in srgb, var(--blue) 42%, transparent); }
+.pill.info    { color: #7ab9ff; background: color-mix(in srgb, var(--blue) 14%, transparent);   border-color: color-mix(in srgb, var(--blue) 42%, transparent); }
+.pill.muted   { color: var(--muted); background: color-mix(in srgb, var(--muted) 10%, transparent); border-color: color-mix(in srgb, var(--muted) 20%, transparent); }
+
+/* Sub-page scaffold */
+.page { padding: 16px; max-width: 760px; margin: 0 auto; }
+.page-head { margin: 4px 2px 14px; }
+.page-head h2 { margin: 0; font-size: 17px; font-weight: 700; }
+.page-head p { margin: 4px 0 0; color: var(--muted); font-size: 12.5px; }
+.page-actions { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+
+/* Settings form */
+.section { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 14px 14px 12px; margin-bottom: 12px; }
+.section h3 { margin: 0 0 3px; font-size: 13px; }
+.section .hint { margin: 0 0 10px; color: var(--muted); font-size: 11.5px; }
+.section .hint b { color: var(--text); }
+.policy { display: flex; flex-direction: column; gap: 8px; margin: 0 0 12px; }
+.policy-row {
+  display: flex; gap: 9px; align-items: flex-start;
+  background: var(--surface-3, color-mix(in srgb, var(--accent) 9%, transparent));
+  border: 1px solid var(--border); border-radius: 8px; padding: 9px 11px;
+  font-size: 11.5px; line-height: 1.5; color: var(--muted);
+}
+.policy-row svg { flex: none; width: 15px; height: 15px; margin-top: 1px; color: var(--accent); }
+.policy-row b { color: var(--text); font-weight: 600; }
+.field label { display: block; font-size: 12px; font-weight: 600; margin-bottom: 5px; }
+.field + .field { margin-top: 12px; }
+.field textarea {
+  width: 100%; min-height: 84px; resize: vertical; background: var(--bg); color: var(--fg);
+  border: 1px solid var(--border); border-radius: 8px; padding: 9px; font-family: var(--mono); font-size: 11.5px; line-height: 1.6;
+}
+.field input[type=text] {
+  width: 100%; background: var(--bg); color: var(--fg);
+  border: 1px solid var(--border); border-radius: 6px; padding: 8px 9px; font-size: 12.5px;
+}
+.field textarea:focus, .field input[type=text]:focus { outline: 2px solid var(--focus); outline-offset: 1px; border-color: var(--focus); }
+
+/* Watched-repository editor: add-input + plus, then a read-only list with inline edit/delete */
+.repo-add { display: flex; gap: 8px; align-items: stretch; }
+.repo-add input {
+  flex: 1; height: 32px; background: var(--bg); color: var(--fg); border: 1px solid var(--border);
+  border-radius: 6px; padding: 0 11px; font-size: 12.5px; font-family: var(--mono);
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+.repo-add input::placeholder { color: var(--muted); font-family: var(--font); }
+.repo-add input:focus { outline: 2px solid var(--focus); outline-offset: 1px; border-color: var(--focus); }
+.repo-add-btn {
+  flex: none; width: 32px; height: 32px; border-radius: 6px; border: 1px solid var(--green-border); cursor: pointer;
+  background: var(--green); color: var(--white); display: grid; place-items: center;
+  transition: background .15s ease, transform .1s ease;
+}
+.repo-add-btn:hover { background: var(--green-emphasis); }
+.repo-add-btn:active { transform: translateY(1px); }
+.repo-err {
+  font-size: 11.5px; color: var(--danger); max-height: 0; opacity: 0; overflow: hidden;
+  transition: max-height .2s ease, opacity .2s ease, margin-top .2s ease;
+}
+.repo-err.show { max-height: 22px; opacity: 1; margin-top: 8px; }
+.repo-list { list-style: none; margin: 12px 0 0; padding: 0; }
+.repo-empty { color: var(--muted); font-size: 12px; padding: 10px 2px 2px; }
+.repo-row {
+  display: flex; align-items: center; gap: 10px; min-height: 40px; padding: 6px 6px 6px 10px;
+  border-top: 1px solid var(--border); border-radius: 8px; overflow: hidden;
+  transition: background .15s ease;
+}
+.repo-row:first-child { border-top-color: transparent; }
+.repo-row:hover { background: var(--card-hover); }
+.repo-row:hover, .repo-row:hover + .repo-row { border-top-color: transparent; }
+.repo-name { flex: 1; font-family: var(--mono); font-size: 12px; color: var(--fg); word-break: break-all; }
+.repo-acts { display: inline-flex; gap: 2px; opacity: 0; transition: opacity .15s ease; }
+.repo-row:hover .repo-acts, .repo-row.editing .repo-acts { opacity: 1; }
+.repo-ico {
+  width: 28px; height: 28px; border-radius: 6px; border: 1px solid transparent; background: transparent;
+  color: var(--muted); display: grid; place-items: center; cursor: pointer;
+  transition: background .15s ease, color .15s ease, border-color .15s ease;
+}
+.repo-ico:hover { background: var(--surface-2); color: var(--fg); border-color: var(--border); }
+.repo-ico.danger:hover { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 45%, transparent); }
+.repo-ico.ok:hover { color: var(--success); border-color: color-mix(in srgb, var(--success) 45%, transparent); }
+.repo-edit-input {
+  flex: 1; background: var(--bg); color: var(--fg); border: 1px solid var(--focus); border-radius: 6px;
+  padding: 7px 9px; font-family: var(--mono); font-size: 12px; outline: 2px solid var(--focus); outline-offset: 0;
+}
+.repo-row.added { animation: repoIn .26s cubic-bezier(.2,.7,.2,1); }
+.repo-row.removing { animation: repoOut .18s ease forwards; pointer-events: none; }
+@keyframes repoIn { from { opacity: 0; transform: translateY(-5px); } to { opacity: 1; transform: none; } }
+@keyframes repoOut { from { opacity: 1; max-height: 60px; } to { opacity: 0; max-height: 0; min-height: 0; padding-top: 0; padding-bottom: 0; transform: translateX(10px); } }
+.repo-add input.shake, .repo-edit-input.shake { animation: shake .3s ease; border-color: var(--danger); }
+@keyframes shake { 0%,100% { transform: translateX(0); } 20% { transform: translateX(-5px); } 40% { transform: translateX(5px); } 60% { transform: translateX(-3px); } 80% { transform: translateX(3px); } }
+.toggle-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 0; border-top: 1px solid var(--border); }
+.toggle-row:first-of-type { border-top: 0; }
+.toggle-row .tl { display: block; font-size: 12.5px; font-weight: 600; }
+.toggle-row .td { display: block; font-size: 11.5px; color: var(--muted); margin-top: 1px; }
+.switch { position: relative; width: 36px; height: 20px; flex: none; }
+.switch input { opacity: 0; width: 0; height: 0; }
+.slider { position: absolute; inset: 0; background: var(--border); border-radius: 999px; transition: .15s; }
+.slider::before { content: ""; position: absolute; height: 14px; width: 14px; left: 3px; top: 3px; background: var(--white); border-radius: 50%; transition: .15s; }
+.switch input:checked + .slider { background: var(--blue); }
+.switch input:checked + .slider::before { transform: translateX(16px); }
+.row-actions { display: flex; gap: 8px; justify-content: flex-end; align-items: center; }
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  height: 30px; padding: 0 12px; border: 1px solid var(--green-border); border-radius: 8px;
+  color: var(--white); font-weight: 600; font-size: 12.5px; line-height: 1; background: var(--green); white-space: nowrap;
+  transition: background .15s, transform .1s, border-color .15s, box-shadow .15s;
+}
+.btn:hover { background: var(--green-emphasis); }
+.btn:active { transform: translateY(1px); }
+.btn:focus-visible { outline: 2px solid var(--color-focus-outline, var(--blue)); outline-offset: 2px; }
+.btn.ghost { background: var(--surface-3); border-color: var(--border-strong); color: var(--fg); }
+.btn.ghost:hover { border-color: var(--border-strong); background: var(--card-hover); }
+.btn.block { width: 100%; justify-content: center; }
+/* Keyboard-hint chips, mirroring the app's Cancel/Continue affordances. */
+.btn kbd {
+  display: inline-flex; align-items: center; justify-content: center; min-width: 17px; height: 17px;
+  padding: 0 4px; border-radius: 5px; font-family: var(--font-sans, inherit);
+  font-size: 10.5px; font-weight: 600; line-height: 1; letter-spacing: .2px;
+  border: 1px solid rgba(0,0,0,.16); background: rgba(0,0,0,.22); color: rgba(255,255,255,.95);
+}
+.btn.ghost kbd { border-color: var(--border-strong); background: var(--surface-3); color: var(--muted); }
+
+/* Accounts */
+.acct-intro { color: var(--muted); font-size: 12px; margin: 0 2px 12px; }
+.acct-list { display: flex; flex-direction: column; gap: 10px; }
+.acct-card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; transition: border-color .15s, box-shadow .15s; }
+.acct-card:hover { border-color: var(--border-strong); }
+.acct-card.active { border-color: color-mix(in srgb, var(--green) 60%, var(--border)); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--green) 30%, transparent); }
+.acct-head { display: flex; align-items: center; }
+.acct-main {
+  display: flex; align-items: center; gap: 12px; flex: 1; min-width: 0; text-align: left;
+  padding: 12px 13px; background: transparent; color: var(--fg); border: 0;
+}
+.acct-main:disabled { opacity: .6; cursor: not-allowed; }
+.acct-main > img { width: 36px; height: 36px; border-radius: 50%; border: 1px solid var(--border); flex: none; }
+.acct-id { min-width: 0; flex: 1; }
+.acct-name { font-size: 13.5px; font-weight: 700; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.acct-status { font-size: 11.5px; display: inline-flex; align-items: center; gap: 6px; }
+.src-badges { display: inline-flex; gap: 5px; flex-wrap: wrap; }
+.src-badge {
+  font-size: 10px; font-weight: 700; letter-spacing: .02em; color: var(--muted);
+  border: 1px solid var(--border); border-radius: 6px; padding: 1px 7px; background: var(--surface-3);
+}
+.acct-name .count { font-size: 10px; color: var(--muted); font-weight: 600; }
+.acct-meta { font-size: 11.5px; color: var(--muted); margin-top: 3px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.acct-meta .scopes { font-family: var(--mono); font-size: 10.5px; }
+.acct-right { display: flex; align-items: center; gap: 12px; flex: none; padding-right: 13px; }
+.use-tag { font-size: 11px; font-weight: 600; color: var(--success); display: inline-flex; align-items: center; gap: 5px; }
+.caret {
+  border: 0; background: transparent; color: var(--muted);
+  width: 22px; height: 28px; border-radius: 6px; display: grid; place-items: center; flex: none;
+  margin: 0; align-self: center; cursor: pointer;
+  transition: transform .26s ease, color .15s;
+}
+.caret svg { width: 16px; height: 16px; }
+.caret:hover { color: var(--fg); }
+.acct-card.open .caret { transform: rotate(180deg); }
+
+/* Expanding control */
+.acct-detail { display: grid; grid-template-rows: 0fr; transition: grid-template-rows .26s ease, opacity .2s ease; opacity: 0; }
+.acct-detail > .inner { overflow: hidden; }
+.acct-card.open .acct-detail { grid-template-rows: 1fr; opacity: 1; }
+.src-row { display: flex; align-items: center; gap: 10px; padding: 8px 13px; border-top: 1px solid var(--border); flex-wrap: wrap; }
+.src-row .sname { font-size: 12px; font-weight: 600; display: inline-flex; align-items: center; gap: 7px; }
+.src-row .schip { font-size: 9.5px; font-weight: 600; color: var(--muted); border: 1px solid var(--border); border-radius: 5px; padding: 0 5px; }
+.src-row .smeta { margin-left: auto; font-size: 11px; color: var(--muted); display: inline-flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
+.src-row .smeta .scopes { font-family: var(--mono); font-size: 10.5px; }
+
+.rescan-btn { display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--border); background: var(--surface); color: var(--fg); border-radius: 6px; height: 30px; padding: 0 11px; font-size: 12.5px; font-weight: 600; }
+.rescan-btn:hover { color: var(--fg); border-color: var(--border-strong); background: var(--surface-2); }
+.rescan-btn:active { transform: translateY(1px); }
+.rescan-btn.spin svg { animation: spin 1s linear infinite; }
+
+/* Notifications */
+.notif-list { display: flex; flex-direction: column; gap: 8px; }
+.notif-card {
+  display: flex; align-items: flex-start; gap: 10px; padding: 11px 12px;
+  background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+  transition: border-color .15s, opacity .22s ease, transform .22s ease, margin .22s ease, max-height .22s ease, padding .22s ease;
+  max-height: 120px; overflow: hidden;
+}
+.notif-card:hover { border-color: var(--border-strong); background: var(--card-hover); }
+.notif-card.removing { opacity: 0; transform: translateX(14px); max-height: 0; padding-top: 0; padding-bottom: 0; margin-top: -8px; }
+.notif-card .ndot { margin-top: 5px; width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.notif-card .nbody { min-width: 0; flex: 1; }
+.notif-card .ntitle { display: block; font-size: 13px; font-weight: 600; overflow-wrap: anywhere; word-break: break-word; }
+.notif-card .ndetail { display: block; font-size: 11.5px; color: var(--muted); margin-top: 2px; }
+.notif-card .ndetail .repo { font-family: var(--mono); }
+.notif-foot { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border); display: flex; }
+.linklike {
+  display: inline-flex; align-items: center; gap: 7px; border: 0; background: transparent; cursor: pointer;
+  color: var(--blue); font-family: inherit; font-size: 12.5px; font-weight: 500; padding: 4px 6px; margin: -4px -6px; border-radius: 6px;
+  transition: background .15s, color .15s;
+}
+.linklike:hover { background: var(--surface); color: var(--fg); }
+.linklike svg { width: 14px; height: 14px; }
+.linklike:focus-visible { outline: 2px solid var(--focus); outline-offset: 1px; }
+.dismiss {
+  border: 1px solid transparent; background: transparent; color: var(--muted);
+  width: 26px; height: 26px; border-radius: 6px; display: grid; place-items: center; flex: none;
+  transition: color .15s, background .15s, border-color .15s;
+}
+.dismiss:hover { color: var(--fg); background: var(--surface-2); border-color: var(--border); }
+
+/* Account chip */
+.acct-chip {
+  display: inline-flex; align-items: center; gap: 7px; height: 30px; padding: 0 9px;
+  border: 1px solid var(--border); background: var(--surface); border-radius: 6px;
+  color: var(--fg); font-size: 12px; font-weight: 600; max-width: 190px;
+  transition: border-color .15s, background .15s;
+}
+.acct-chip:hover { border-color: var(--border-strong); background: var(--surface-2); }
+.acct-chip.active { border-color: var(--border-strong); background: var(--surface-3); color: var(--fg); }
+.acct-chip img { width: 19px; height: 19px; border-radius: 50%; border: 1px solid var(--border); flex: none; }
+.acct-chip .name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.acct-chip .sdot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+
+/* Stacked / overlapping avatars for multiple active accounts */
+.stack { display: inline-flex; align-items: center; }
+.stk-av { position: relative; display: inline-grid; place-items: center; margin-left: -7px; }
+.stk-av:first-child { margin-left: 0; }
+.stk-av .acct-av { width: 22px; height: 22px; border-radius: 50%; border: 2px solid var(--bg); display: block; background: var(--surface); object-fit: cover; }
+.stk-more { margin-left: 6px; font-size: 11px; color: var(--muted); font-weight: 600; }
+.ent-dot { position: absolute; right: -3px; bottom: -3px; width: 13px; height: 13px; border-radius: 50%; background: var(--blue); color: var(--white); display: grid; place-items: center; border: 2px solid var(--bg); }
+.ent-dot svg { width: 8px; height: 8px; }
+.acct-chip .stk-av .acct-av { width: 19px; height: 19px; }
+.who .stk-av .acct-av { width: 24px; height: 24px; }
+.who-name { font-weight: 600; }
+.who-more { color: var(--muted); font-weight: 500; font-size: 12px; }
+
+/* Enterprise badge - makes a non-github.com account obvious */
+.ent-badge {
+  display: inline-flex; align-items: center; gap: 4px; font-size: 10.5px; font-weight: 700; letter-spacing: .02em;
+  color: var(--blue); background: color-mix(in srgb, var(--blue) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--blue) 34%, transparent); border-radius: 999px; padding: 1px 8px 1px 6px; white-space: nowrap;
+}
+.ent-badge svg { width: 11px; height: 11px; }
+.ent-badge.sm { padding: 2px 5px; }
+.acct-chip .ent-badge { height: 18px; }
+.schip.ent { color: var(--blue); border-color: color-mix(in srgb, var(--blue) 40%, transparent); }
+
+/* Per-account watched-repository editor (inside the account detail) */
+.acct-repos { padding: 12px 13px 8px; border-top: 1px solid var(--border); }
+.acct-repos-head { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 700; }
+.acct-repos-head .rcount { font-size: 10px; font-weight: 600; color: var(--muted); background: var(--surface-3); border: 1px solid var(--border); border-radius: 999px; padding: 0 7px; }
+.acct-repos-hint { margin: 3px 0 10px; color: var(--muted); font-size: 11px; }
+.acct-repos-hint code { font-family: var(--mono); }
+.src-list { border-top: 1px solid var(--border); }
+
+/* Composed states */
+.state { padding: 48px 20px; text-align: center; color: var(--muted); max-width: 460px; margin: 0 auto; }
+.state .ico {
+  width: 54px; height: 54px; border-radius: 14px; margin: 0 auto 14px; display: grid; place-items: center;
+  background: var(--surface); border: 1px solid var(--border); color: var(--muted);
+}
+.state h2 { color: var(--fg); font-size: 17px; margin: 0 0 6px; }
+.state p { margin: 0 auto; font-size: 13px; line-height: 1.55; }
+.state .cmd { display: inline-block; margin-top: 14px; font-family: var(--mono); font-size: 12px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 7px 11px; color: var(--fg); }
+.state .state-cta { margin-top: 16px; display: flex; gap: 8px; justify-content: center; }
+.errbar { margin: 12px 16px 0; padding: 9px 12px; border-radius: 8px; background: color-mix(in srgb, var(--danger) 12%, transparent); border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent); color: var(--danger); font-size: 11.5px; }
+.empty-lane { color: var(--muted); font-size: 12px; padding: 6px 0; }
+
+/* Skeleton shimmer */
+.sk { position: relative; display: inline-block; border-radius: 8px; background: var(--surface); overflow: hidden; }
+.sk::after { content: ""; position: absolute; inset: 0; transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--fg) 8%, transparent), transparent);
+  animation: shimmer 1.3s infinite; }
+@keyframes shimmer { 100% { transform: translateX(100%); } }
+.sk-tabs { width: 168px; height: 30px; margin-left: 6px; }
+.sk-chip { width: 120px; height: 30px; }
+.sk-btn { width: 30px; height: 30px; }
+.sk-who { width: 130px; height: 22px; }
+.sk-meta { width: 220px; height: 14px; }
+.sk-stat { width: 96px; height: 26px; border-radius: 999px; }
+.sk-dot { width: 10px; height: 10px; border-radius: 50%; }
+.sk-lane-title { width: 150px; height: 16px; }
+.sk-card { height: 96px; border-radius: var(--radius); display: block; width: 100%; }
+
+@media (prefers-reduced-motion: reduce) {
+  .view, .view.back { animation: none; }
+  .app.loading::after { animation: none; transform: scaleX(1); opacity: .55; }
+  .sk::after { animation: none; }
+  .iconbtn.spin svg, .rescan-btn.spin svg { animation: none; }
+  .caret, .acct-detail, .notif-card, .card, .lane-body, .lane-caret, .repo-row, .repo-acts, .repo-err, .repo-ico { transition: none; }
+  .repo-row.added, .repo-row.removing, .repo-add input.shake, .repo-edit-input.shake { animation: none; }
+}
+
+@media (max-width: 600px) {
+  .topbar { gap: 8px; padding: 10px 13px; }
+  .brand-text { display: none; }
+  .tabs { margin-left: 0; }
+  .tab { padding: 5px 11px; }
+  .acct-chip { max-width: 150px; }
+  .acct-chip .name { max-width: 70px; }
+  .page { padding: 14px; }
+}
+@media (max-width: 470px) {
+  .topbar { gap: 6px; padding: 10px 10px; }
+  .tab { padding: 5px 9px; font-size: 12px; }
+  .acct-chip { padding: 0 7px; gap: 6px; }
+  .acct-chip .name { display: none; }
+  .iconbtn { width: 28px; height: 28px; }
+  .backbtn { height: 28px; }
+}
+`;
+
+export const APP_JS = String.raw`
+const app = document.getElementById("app");
+let state = null;
+let prefs = null;
+let view = "queue";       // queue | settings | accounts | notifications
+let keysBound = false;
+let prevRank = 0;
+let refreshing = false;
+let rescanning = false;
+let loadError = null;
+const expanded = new Set(); // account ids whose detail (sources + repos) is expanded
+const collapsedLanes = new Set(); // lane ids the user collapsed (survives re-render + SSE)
+const draftReposByAcct = {}; // account id -> working copy of that account's watched repos
+const editingByAcct = {};    // account id -> index of the repo row being inline-edited, or -1
+
+const RANK = { queue: 0, notifications: 1, accounts: 1, settings: 1 };
+
+const ICONS = {
+  refresh: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v6h-6"/></svg>',
+  gear: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>',
+  bell: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>',
+  bellBig: '<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>',
+  chev: '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>',
+  back: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg>',
+  check: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>',
+  x: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18"/><path d="M6 6l12 12"/></svg>',
+  plus: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>',
+  pencil: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>',
+  trash: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>',
+  users: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>',
+  alert: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
+  eye: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>',
+  merge: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M6 21V9a9 9 0 0 0 9 9"/></svg>',
+  xcircle: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6"/><path d="M9 9l6 6"/></svg>',
+  chat: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
+  pr: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" y1="9" x2="6" y2="21"/></svg>',
+  tag: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>',
+  clock: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>',
+  dot2: '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="4"/></svg>',
+  building: '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M9 22v-4h6v4"/><path d="M8 6h.01M16 6h.01M12 6h.01M12 10h.01M12 14h.01M16 10h.01M16 14h.01M8 10h.01M8 14h.01"/></svg>',
+  sparkle: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 3l1.9 5.1L18 10l-5.1 1.9L11 17l-1.9-5.1L4 10l5.1-1.9z"/><path d="M19 14l.7 1.9 1.9.7-1.9.7-.7 1.9-.7-1.9-1.9-.7 1.9-.7z"/></svg>',
+  alertSm: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
+  globe: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>',
+  usersSm: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>',
+  layers: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>',
+};
+
+const LOGO = '<svg viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M3.5 30C1.57 30 0 28.43 0 26.5C0 25.871 0.166 25.259 0.48 24.729L8.818 10.287L8.852 10.236L12.968 3.099C13.593 2.019 14.754 1.349 16 1.349C17.246 1.349 18.407 2.019 19.031 3.098L31.531 24.749C31.833 25.258 31.999 25.87 31.999 26.499C31.999 28.429 30.429 29.999 28.499 29.999L3.5 30Z" fill="#512BD4"/><path d="M25.33 18H16.99L16 16.28L13.13 11.31C13 11.09 12.82 10.9 12.58 10.77C11.87 10.35 10.95 10.6 10.53 11.32L14.7 4.10001C14.96 3.65001 15.44 3.35001 16 3.35001C16.56 3.35001 17.04 3.65001 17.3 4.10001L21.45 11.29L21.46 11.31L21.48 11.34L25.33 18Z" fill="#7455DD"/><path d="M30 26.5C30 27.33 29.33 28 28.5 28H20.17C21 28 21.67 27.33 21.67 26.5C21.67 26.23 21.59 25.97 21.47 25.75L17.3 18.53L16.99 18H25.33L29.8 25.75C29.93 25.97 30 26.23 30 26.5Z" fill="#9780E5"/><path d="M21.67 26.5C21.67 27.33 21 28 20.17 28H11.83C12.66 28 13.33 27.33 13.33 26.5C13.33 26.23 13.26 25.97 13.13 25.75C13.13 25.74 13.12 25.73 13.11 25.72L11.79 23.57L8.82004 18.72C8.55004 18.28 8.07004 18 7.54004 18H16.99L17.3 18.53L17.427 18.75L21.47 25.75C21.59 25.97 21.67 26.23 21.67 26.5Z" fill="#B9AAEE"/><path d="M13.33 26.5C13.33 27.33 12.66 28 11.83 28H3.5C2.67 28 2 27.33 2 26.5C2 26.23 2.07 25.97 2.2 25.75L6.24 18.75C6.51 18.29 7.01 18 7.54 18C8.07 18 8.55 18.28 8.82 18.72L11.79 23.57L13.11 25.72C13.12 25.73 13.13 25.74 13.13 25.75C13.26 25.97 13.33 26.23 13.33 26.5Z" fill="#DCD5F6"/><path d="M16.99 18H7.53999C7.00999 18 6.50999 18.29 6.23999 18.75L6.66999 18L10.49 11.39L10.53 11.33V11.32C10.95 10.6 11.87 10.35 12.58 10.77C12.82 10.9 13 11.09 13.13 11.31L16 16.28L16.99 18Z" fill="#9780E5"/></svg>';
+
+const ACCT_STATUS = {
+  ok: { tone: "success", label: "Full access" },
+  partial: { tone: "warning", label: "Partial access" },
+  limited: { tone: "warning", label: "No repo access" },
+  failed: { tone: "danger", label: "Sign-in failed" },
+};
+const SRC_LABEL = { gh: "GitHub CLI", env: "Environment", copilot: "Copilot" };
+function acctTone(a) { return (ACCT_STATUS[a && a.status] || ACCT_STATUS.failed).tone; }
+function srcLabel(s) { return SRC_LABEL[s] || s; }
+
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+function timeAgo(iso) {
+  const s = Math.floor((Date.now() - new Date(iso)) / 1000);
+  if (s < 60) return s + "s ago";
+  const m = Math.floor(s / 60); if (m < 60) return m + "m ago";
+  const h = Math.floor(m / 60); if (h < 24) return h + "h ago";
+  return Math.floor(h / 24) + "d ago";
+}
+function shortRepo(r) { const p = String(r).split("/"); return p[p.length - 1]; }
+function cssEsc(s) { return (window.CSS && CSS.escape) ? CSS.escape(s) : String(s).replace(/[^\w-]/g, "\\$&"); }
+
+// Neutral gray silhouette used when an avatar URL 404s (renamed users, bots,
+// enterprise hosts the browser can't reach). Base64 keeps it safe inside both the
+// double-quoted attribute and the single-quoted onerror JS string.
+const FALLBACK_AVATAR = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSI0MCIgdmlld0JveD0iMCAwIDQwIDQwIj48cmVjdCB3aWR0aD0iNDAiIGhlaWdodD0iNDAiIHJ4PSIyMCIgZmlsbD0iIzMwMzYzZCIvPjxjaXJjbGUgY3g9IjIwIiBjeT0iMTUuNSIgcj0iNi41IiBmaWxsPSIjOGI5NDllIi8+PHBhdGggZD0iTTguNSAzMy41YzAtNi40IDUuMi0xMC41IDExLjUtMTAuNXMxMS41IDQuMSAxMS41IDEwLjV6IiBmaWxsPSIjOGI5NDllIi8+PC9zdmc+";
+
+// Build an <img> for an avatar, preferring the real avatarUrl from the API and
+// degrading to github.com/<login>.png, then to the inline fallback on error.
+function avatarTag(url, login, cls, size) {
+  const px = size || 40;
+  const src = url || ("https://github.com/" + encodeURIComponent(login || "github") + ".png?size=" + px);
+  return '<img class="' + (cls || "avatar") + '" src="' + esc(src) + '" alt="" referrerpolicy="no-referrer" loading="lazy" ' +
+    'onerror="this.onerror=null;this.src=\'' + FALLBACK_AVATAR + '\'" />';
+}
+function acctAvatar(a, size) {
+  const url = a && a.avatarUrl ? a.avatarUrl : null;
+  const login = a && a.login ? a.login : (typeof a === "string" ? a : "github");
+  return avatarTag(url, login, "acct-av", size);
+}
+
+/* ---- data ---- */
+
+async function load() {
+  try {
+    const res = await fetch("api/state");
+    const data = await res.json();
+    state = data.dashboard; prefs = data.prefs; loadError = null;
+  } catch (e) {
+    loadError = String((e && e.message) || e);
+  }
+  render();
+}
+
+async function withRefresh(fn) {
+  refreshing = true; setLoading(true);
+  try {
+    const data = await fn();
+    if (data && data.dashboard) { state = data.dashboard; prefs = data.prefs; loadError = null; }
+  } catch (e) {
+    loadError = String((e && e.message) || e);
+  } finally {
+    refreshing = false; render();
+  }
+}
+
+function setLoading(on) {
+  app.classList.toggle("loading", on);
+  const rb = document.getElementById("refresh-btn");
+  if (rb) rb.classList.toggle("spin", on);
+}
+
+async function postJSON(path, body) {
+  const res = await fetch(path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body || {}) });
+  return res.json();
+}
+
+const refresh = () => withRefresh(() => postJSON("api/refresh"));
+const setMode = (mode) => { if (state && state.mode === mode) return; goView("queue", false); return withRefresh(() => postJSON("api/mode", { mode })); };
+const toggleAccountActive = (id, active) => withRefresh(() => postJSON("api/account/toggle", { id, active }));
+
+// Persist one account's repos without a full refresh/broadcast (the editor owns
+// the DOM and a re-render would interrupt typing). Fire-and-forget; the in-memory
+// copies are already updated by the editor.
+function persistAccountRepos(id) {
+  const repos = (draftReposByAcct[id] || []).slice();
+  postJSON("api/account/repos", { id, repos }).then((data) => {
+    if (data && data.dashboard) { state = data.dashboard; prefs = data.prefs; }
+  }).catch(() => {});
+}
+
+async function saveSettings() {
+  const release = document.getElementById("release-input").value;
+  const showDrafts = document.getElementById("s-drafts").checked;
+  const notifications = {
+    reviewRequested: document.getElementById("n-review").checked,
+    readyToMerge: document.getElementById("n-ready").checked,
+    changesRequested: document.getElementById("n-changes").checked,
+    ciFailing: document.getElementById("n-ci").checked,
+  };
+  goView("queue", true);
+  await withRefresh(() => postJSON("api/prefs", { release, showDrafts, notifications }));
+}
+
+async function rescanAccounts() {
+  rescanning = true;
+  const btn = document.getElementById("rescan-btn");
+  if (btn) btn.classList.add("spin");
+  try {
+    const res = await fetch("api/accounts");
+    const data = await res.json();
+    state = data.dashboard; prefs = data.prefs;
+  } finally { rescanning = false; render(); }
+}
+
+function dismissNotif(id, cardEl) {
+  if (cardEl) cardEl.classList.add("removing");
+  const go = () => withRefresh(() => postJSON("api/notifications/dismiss", { id }));
+  setTimeout(go, 200);
+}
+const dismissAll = () => withRefresh(() => postJSON("api/notifications/dismiss-all"));
+const restoreNotifs = () => withRefresh(() => postJSON("api/notifications/restore"));
+
+/* ---- navigation ---- */
+
+function goView(next, forward) {
+  if (view === "accounts" && next !== "accounts") { for (const k in editingByAcct) editingByAcct[k] = -1; }
+  prevRank = RANK[view] || 0;
+  view = next;
+  render(forward === undefined ? undefined : forward);
+}
+
+/* ---- cards ---- */
+
+function pill(s) { return '<span class="pill ' + (s.tone || "muted") + '">' + esc(s.label) + "</span>"; }
+
+function prCard(item) {
+  const pr = item.pr;
+  return '<a class="card" href="' + esc(pr.url) + '" target="_blank" rel="noreferrer">' +
+    '<div class="card-top"><div class="card-title">' + esc(pr.title) + "</div></div>" +
+    '<div class="card-sub">' +
+      avatarTag(pr.authorAvatarUrl, pr.author, "avatar", 36) +
+      '<span class="repo">' + esc(shortRepo(pr.repository)) + " #" + pr.number + "</span>" +
+      "<span>by " + esc(pr.author) + "</span>" +
+    "</div>" +
+    (item.reason ? '<div class="reason">' + esc(item.reason) + "</div>" : "") +
+    '<div class="pills">' + (item.signals || []).map(pill).join("") + "</div>" +
+  "</a>";
+}
+
+function issueCard(item) {
+  const is = item.issue;
+  return '<a class="card" href="' + esc(is.url) + '" target="_blank" rel="noreferrer">' +
+    '<div class="card-top"><div class="card-title">' + esc(is.title) + "</div></div>" +
+    '<div class="card-sub">' +
+      avatarTag(is.authorAvatarUrl, is.author, "avatar", 36) +
+      '<span class="repo">' + esc(shortRepo(is.repository)) + " #" + is.number + "</span>" +
+      "<span>by " + esc(is.author) + "</span>" +
+    "</div>" +
+    '<div class="pills">' + (item.signals || []).map(pill).join("") + "</div>" +
+  "</a>";
+}
+
+function laneIcon(lane) {
+  switch (lane.id) {
+    case "review-queue": case "needs-review": case "assigned": return ICONS.eye;
+    case "ready-to-merge": case "ready": return ICONS.merge;
+    case "ci-failing": case "blocked": return ICONS.xcircle;
+    case "unresolved": return ICONS.chat;
+    case "your-prs": case "yours": case "in-progress": return ICONS.pr;
+    case "triage": return ICONS.tag;
+    case "active": return ICONS.clock;
+    default: return ICONS.dot2;
+  }
+}
+
+function laneHtml(lane) {
+  const items = (lane.items || []).map((it) => (it.pr ? prCard(it) : issueCard(it))).join("");
+  const tone = lane.tone || "muted";
+  const repos = new Set((lane.items || []).map((it) => (it.pr || it.issue || {}).repository).filter(Boolean));
+  const repoLabel = repos.size + (repos.size === 1 ? " repo" : " repos");
+  const capped = typeof lane.cappedTotal === "number" && lane.cappedTotal > lane.items.length;
+  const detail = capped
+    ? "top " + lane.items.length + " of " + lane.cappedTotal
+    : repoLabel;
+  const collapsed = collapsedLanes.has(lane.id);
+  return '<section class="lane' + (collapsed ? " collapsed" : "") + '" data-lane="' + esc(lane.id) + '">' +
+    '<button class="lane-head" data-lane-toggle="' + esc(lane.id) + '" aria-expanded="' + (collapsed ? "false" : "true") + '">' +
+      '<span class="lane-ico t-' + tone + '">' + laneIcon(lane) + "</span>" +
+      '<span class="lane-title">' + esc(lane.label) + "</span>" +
+      '<span class="lane-count">' + lane.items.length + "</span>" +
+      '<span class="lane-detail' + (capped ? " capped" : "") + '">' + detail + "</span>" +
+      '<span class="lane-caret">' + ICONS.chev + "</span>" +
+    "</button>" +
+    '<div class="lane-body"><div class="inner"><div class="grid">' + items + "</div></div></div>" +
+  "</section>";
+}
+
+/* ---- review attention board (full pr-dashboard parity) ---- */
+
+function slugId(s) {
+  return "b-" + String(s).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+// Buckets and the long Community list start collapsed so the focused queue stays the
+// headline. Seeded once; after that the user's own toggles win.
+let reviewDefaultsSeeded = false;
+function seedReviewCollapse(att) {
+  if (reviewDefaultsSeeded) return;
+  reviewDefaultsSeeded = true;
+  for (const b of att.buckets || []) collapsedLanes.add(slugId(b.label));
+  collapsedLanes.add("community");
+  collapsedLanes.add("attention-breakdown");
+}
+
+function developerCountsHtml(list) {
+  if (!list || !list.length) return "";
+  const rows = list.map((d) =>
+    '<div class="dev-row">' +
+      avatarTag(d.avatarUrl || null, d.actor, "dev-av", 36) +
+      '<div class="dev-main">' +
+        '<span class="dev-name">' + esc(d.actor) + "</span>" +
+        (d.latestUpdatedAt ? '<span class="dev-when">updated ' + timeAgo(d.latestUpdatedAt) + "</span>" : "") +
+      "</div>" +
+      '<span class="dev-count">' + d.openPullRequestCount + "</span>" +
+    "</div>"
+  ).join("");
+  const activeCount = list.length;
+  const totalPrs = list.reduce((n, d) => n + (d.openPullRequestCount || 0), 0);
+  return collapsibleSect({
+    id: "core-team",
+    title: "Core team open PRs",
+    icon: ICONS.usersSm,
+    iconTone: "accent",
+    count: totalPrs,
+    note: activeCount + " active author" + (activeCount === 1 ? "" : "s"),
+    subtitle: "Who is carrying open work across the loaded queue right now.",
+    body: '<div class="dev-counts">' + rows + "</div>",
+  });
+}
+
+// A collapsible secondary reference group (Community / Core team / Attention
+// breakdown). Quieter header than the primary queues; collapse state persists.
+function collapsibleSect(opts) {
+  const id = opts.id;
+  const collapsed = collapsedLanes.has(id);
+  const count = (opts.count != null)
+    ? '<span class="sect-count">' + esc(String(opts.count)) + "</span>" : "";
+  return '<section class="sect-group collapsible' + (collapsed ? " collapsed" : "") + '" data-sect="' + esc(id) + '">' +
+    '<button class="sect-head" data-collapse="' + esc(id) + '" aria-expanded="' + (collapsed ? "false" : "true") + '">' +
+      (opts.icon ? '<span class="sect-icon t-' + (opts.iconTone || "muted") + '">' + opts.icon + "</span>" : "") +
+      '<span class="sect-title">' + esc(opts.title) + "</span>" +
+      (opts.note ? '<span class="sect-note">' + esc(opts.note) + "</span>" : "") +
+      count +
+      '<span class="sect-caret t-' + (opts.iconTone || "muted") + '">' + ICONS.chev + "</span>" +
+    "</button>" +
+    '<div class="collapse-body"><div class="collapse-inner">' +
+      (opts.subtitle ? '<p class="sect-sub">' + esc(opts.subtitle) + "</p>" : "") +
+      (opts.body || "") +
+    "</div></div>" +
+  "</section>";
+}
+
+// A clean, always-expanded primary queue (For you / Needs attention / Your PRs
+// outside). Masonry cards with a title, count metric, and descriptive subtitle.
+function queuePanel(opts) {
+  const items = opts.items || [];
+  const n = items.length;
+  const capped = typeof opts.cappedTotal === "number" && opts.cappedTotal > n;
+  const metric = capped ? "top " + n + " of " + opts.cappedTotal : n + " shown";
+  const body = n
+    ? '<div class="grid">' + items.map((it) => (it.pr ? prCard(it) : issueCard(it))).join("") + "</div>"
+    : '<div class="lane-empty">' + esc(opts.emptyText || "Nothing here right now.") + "</div>";
+  const collapsed = collapsedLanes.has(opts.id);
+  return '<section class="qpanel collapsible' + (collapsed ? " collapsed" : "") + '" data-q="' + esc(opts.id) + '">' +
+    '<button class="qhead" data-collapse="' + esc(opts.id) + '" aria-expanded="' + (collapsed ? "false" : "true") + '">' +
+      '<span class="qdot t-' + (opts.tone || "muted") + '">' + (opts.icon || ICONS.dot2) + "</span>" +
+      '<span class="qtitle">' + esc(opts.title) + "</span>" +
+      '<span class="qmetric' + (capped ? " capped" : "") + '">' + metric + "</span>" +
+      '<span class="qcaret t-' + (opts.tone || "muted") + '">' + ICONS.chev + "</span>" +
+    "</button>" +
+    '<div class="collapse-body"><div class="collapse-inner qbody">' +
+      (opts.subtitle ? '<p class="qsub">' + esc(opts.subtitle) + "</p>" : "") +
+      body +
+    "</div></div>" +
+  "</section>";
+}
+
+function reviewBoardHtml() {
+  const att = state.attention;
+  seedReviewCollapse(att);
+  let html = "";
+
+  // 1. For you — personalized headline of your highest-leverage actions.
+  if (att.forMe && att.forMe.length) {
+    html += queuePanel({
+      id: "for-you", title: "For you", tone: "accent", icon: ICONS.sparkle,
+      subtitle: "Your highest-leverage actions across every repo, pulled to the top of the queue.",
+      items: att.forMe.slice(0, 6), cappedTotal: att.forMe.length,
+    });
+  }
+
+  // 2. Needs attention — the focused, team-managed review queue (the headline).
+  html += queuePanel({
+    id: "needs-attention", title: "Needs attention", tone: "danger", icon: ICONS.alertSm,
+    subtitle: "One actionable row per PR with fresh activity, waiting on a review or a merge.",
+    items: att.focus || [], cappedTotal: att.focusTotal,
+    emptyText: "Nothing is waiting on a reviewer right now \u00b7 anything blocked sits in the breakdown below.",
+  });
+
+  // 3. Your PRs outside Needs attention — the viewer's own out-of-queue work,
+  //    sat directly under the focused queue so it's easy to see what got filtered.
+  html += queuePanel({
+    id: "outside-focus", title: "Your PRs outside Needs attention", tone: "info", icon: ICONS.pr,
+    subtitle: "Open non-draft PRs you authored that do not currently qualify for the focused queue.",
+    items: (att.focusExclusions || []).slice(0, 10), cappedTotal: (att.focusExclusions || []).length,
+    emptyText: "None right now \u00b7 every open PR you authored is already in the queue or still in draft.",
+  });
+
+  // 4. Community — external-contributor PRs, collapsible reference group.
+  if (att.community && att.community.length) {
+    const repos = new Set(att.community.map((c) => (c.pr || {}).repository).filter(Boolean));
+    html += collapsibleSect({
+      id: "community",
+      title: "Community",
+      icon: ICONS.globe,
+      iconTone: "success",
+      count: att.community.length,
+      note: "external contributors \u00b7 " + repos.size + (repos.size === 1 ? " repo" : " repos"),
+      subtitle: "Recently active external-contributor PRs, tracked apart from the core-team queue.",
+      body: '<div class="grid">' + att.community.map((it) => (it.pr ? prCard(it) : issueCard(it))).join("") + "</div>",
+    });
+  }
+
+  // 5. Core team open PRs — who is carrying open work right now.
+  html += developerCountsHtml(att.developerCounts);
+
+  // 6. Attention breakdown — every signal lane, collapsed by default, at the bottom.
+  const buckets = (att.buckets || []).filter((b) => b.items && b.items.length);
+  if (buckets.length) {
+    const total = buckets.reduce((n, b) => n + b.items.length, 0);
+    html += collapsibleSect({
+      id: "attention-breakdown",
+      title: "Attention breakdown",
+      icon: ICONS.layers,
+      iconTone: "warning",
+      count: total,
+      note: buckets.length + " lane" + (buckets.length === 1 ? "" : "s"),
+      subtitle: "Every signal lane behind the queue. Expand one to see the PRs it groups.",
+      body: buckets.map((b) => laneHtml({ id: slugId(b.label), label: b.label, tone: b.tone, items: b.items })).join(""),
+    });
+  }
+
+  return html;
+}
+
+/* ---- topbar ---- */
+
+function tabs() {
+  const mode = state ? state.mode : "review";
+  const defs = [["review", "Review"], ["issues", "Issues"], ["ship", "Ship"]];
+  return '<div class="tabs">' + defs.map(([id, label]) =>
+    '<button class="tab ' + (mode === id ? "active" : "") + '" data-mode="' + id + '">' + label + "</button>"
+  ).join("") + "</div>";
+}
+
+function avatarStack(accts, size) {
+  if (!accts || !accts.length) return "";
+  const shown = accts.slice(0, 3);
+  return '<span class="stack">' + shown.map((a) =>
+    '<span class="stk-av' + (a.enterprise ? " ent" : "") + '" title="' +
+      esc(a.login + (a.enterprise ? " \u00b7 " + (a.host || "Enterprise") : "")) + '">' +
+      acctAvatar(a, size) +
+      (a.enterprise ? '<span class="ent-dot" title="Enterprise">' + ICONS.building + "</span>" : "") +
+    "</span>"
+  ).join("") + (accts.length > shown.length ? '<span class="stk-more">+' + (accts.length - shown.length) + "</span>" : "") + "</span>";
+}
+
+function accountChip() {
+  const active = (state && state.activeAccounts) || [];
+  const anyEnt = active.some((a) => a.enterprise);
+  let inner;
+  if (!active.length) {
+    inner = '<span class="sdot bg-muted"></span><span class="name">Accounts</span>';
+  } else if (active.length === 1) {
+    inner = avatarStack(active, 40) + '<span class="name">' + esc(active[0].login) + "</span>" +
+      (anyEnt ? '<span class="ent-badge sm" title="GitHub Enterprise">' + ICONS.building + "Enterprise</span>" : "");
+  } else {
+    inner = avatarStack(active, 40) + '<span class="name">' + active.length + " accounts</span>" +
+      (anyEnt ? '<span class="ent-badge sm" title="Includes a GitHub Enterprise account">' + ICONS.building + "</span>" : "");
+  }
+  return '<button class="acct-chip ' + (view === "accounts" ? "active" : "") + '" id="acct-btn" title="GitHub accounts">' +
+    inner + ICONS.chev + "</button>";
+}
+
+function topbarHtml() {
+  const notifCount = (state && state.notifications || []).length;
+  const left = view === "queue"
+    ? tabs()
+    : '<button class="backbtn" id="back-btn">' + ICONS.back + "Back</button>";
+  const right =
+    (state ? accountChip() : "") +
+    '<div class="tb-actions">' +
+    '<button class="iconbtn ' + (refreshing ? "spin" : "") + '" id="refresh-btn" title="Refresh">' + ICONS.refresh + "</button>" +
+    '<button class="iconbtn ' + (view === "notifications" ? "active" : "") + '" id="bell-btn" title="Notifications">' + ICONS.bell +
+      (notifCount ? '<span class="badge">' + notifCount + "</span>" : "") + "</button>" +
+    '<button class="iconbtn ' + (view === "settings" ? "active" : "") + '" id="gear-btn" title="Settings">' + ICONS.gear + "</button>" +
+    "</div>";
+  return '<div class="topbar" id="topbar">' +
+    '<button class="brand" id="brand-home" type="button" title="Back to review queue"><span class="mark">' + LOGO + '</span><span class="brand-text">Aspire Team App</span></button>' +
+    left + '<span class="spacer"></span>' + right + "</div>";
+}
+
+/* ---- views ---- */
+
+function queueView() {
+  const active = state.activeAccounts || [];
+  const anyEnt = active.some((a) => a.enterprise);
+  const whoLabel = active.length > 1
+    ? esc(state.viewer) + ' <span class="who-more">+' + (active.length - 1) + " more</span>"
+    : esc(state.viewer);
+  const who = active.length
+    ? avatarStack(active, 44) + '<span class="who-name">' + whoLabel + "</span>" +
+        (anyEnt ? '<span class="ent-badge" title="GitHub Enterprise account active">' + ICONS.building + "Enterprise</span>" : "")
+    : '<span class="who-name">' + esc(state.viewer) + "</span>";
+  const isReviewBoard = state.mode === "review" && state.attention;
+  const lanesHtml = isReviewBoard
+    ? reviewBoardHtml()
+    : (state.lanes.length
+        ? state.lanes.map(laneHtml).join("")
+        : '<div class="state"><div class="ico">' + ICONS.check + "</div><h2>All clear</h2><p>No items in " + esc(state.mode) + " mode for your watched repositories.</p></div>");
+  const draftsHidden = !state.showDrafts && state.counts && state.counts.drafts
+    ? ' <span class="meta-draft">\u00b7 ' + state.counts.drafts + " draft" + (state.counts.drafts === 1 ? "" : "s") + " hidden</span>"
+    : "";
+  return '<div class="subbar">' +
+      '<span class="who">' + who + "</span>" +
+      '<span class="meta">' + state.counts.prs + " open PRs across " + state.repos.length + " repos, updated " + timeAgo(state.fetchedAt) + draftsHidden + "</span>" +
+      statsHtml() +
+    "</div>" +
+    (state.errors && state.errors.length ? '<div class="errbar">' + esc(state.errors.join(" \u00b7 ")) + "</div>" : "") +
+    '<div class="lanes">' + lanesHtml + "</div>";
+}
+
+function statsHtml() {
+  const c = state.counts;
+  // In review mode the header mirrors the attention board so the numbers agree.
+  if (state.mode === "review" && state.attention) {
+    const att = state.attention;
+    const bucket = (label) => {
+      const b = (att.buckets || []).find((x) => x.label === label);
+      return b ? b.items.length : 0;
+    };
+    return '<div class="stats">' +
+      '<span class="stat"><span class="dot bg-danger"></span><b>' + att.focusTotal + "</b> needs attention</span>" +
+      '<span class="stat"><span class="dot bg-success"></span><b>' + bucket("Ready to merge") + "</b> ready</span>" +
+      '<span class="stat"><span class="dot bg-warning"></span><b>' + bucket("CI failing") + "</b> CI failing</span>" +
+      '<span class="stat"><span class="dot bg-accent"></span><b>' + (att.community ? att.community.length : 0) + "</b> community</span>" +
+    "</div>";
+  }
+  return '<div class="stats">' +
+    '<span class="stat"><span class="dot bg-danger"></span><b>' + c.needsReview + "</b> needs review</span>" +
+    '<span class="stat"><span class="dot bg-success"></span><b>' + c.readyToMerge + "</b> ready</span>" +
+    '<span class="stat"><span class="dot bg-warning"></span><b>' + c.ciFailing + "</b> CI failing</span>" +
+  "</div>";
+}
+
+function toggle(id, title, desc, checked) {
+  return '<div class="toggle-row"><span><span class="tl">' + esc(title) + "</span>" +
+    (desc ? '<span class="td">' + esc(desc) + "</span>" : "") + "</span>" +
+    '<label class="switch"><input type="checkbox" id="' + id + '" ' + (checked ? "checked" : "") + ' /><span class="slider"></span></label></div>';
+}
+
+function settingsView() {
+  const n = prefs.notifications;
+  const limit = (state.reviewLimit || 10);
+  return '<div class="page">' +
+    '<div class="page-head"><h2>Settings</h2><p>Tune the shared review queue, the ship milestone, and when the canvas speaks up. Watched repositories are configured per account in the Accounts tab.</p></div>' +
+    '<div class="section"><h3>Review queue</h3>' +
+      '<p class="hint">The shared queue is team-managed, not individually sorted. It shows at most <b>' + limit + '</b> PRs, ranked so the oldest waits surface first.</p>' +
+      '<div class="policy">' +
+        '<div class="policy-row">' + ICONS.eye + '<span>A PR only enters the shared queue once <b>checks are green</b> and <b>all review feedback is resolved</b>. Unfinished work stays in the author\u2019s <b>Your PRs</b> lane.</span></div>' +
+        '<div class="policy-row">' + ICONS.pr + '<span>Draft PRs are hidden by default. They are prototypes and experiments, not review work.</span></div>' +
+      "</div>" +
+      toggle("s-drafts", "Show draft PRs", "Include drafts in lanes and counts", !!state.showDrafts) +
+    "</div>" +
+    '<div class="section"><h3>Ship milestone</h3>' +
+      '<p class="hint">Used by Ship mode to group work for the active release.</p>' +
+      '<div class="field"><input type="text" id="release-input" value="' + esc(prefs.release || "") + '" placeholder="13.4" /></div></div>' +
+    '<div class="section" id="notif-settings"><h3>Notifications</h3>' +
+      '<p class="hint">Live in-session alerts surface in the bell. Choose what counts.</p>' +
+      toggle("n-review", "Review requested", "Someone asked you to review a PR", n.reviewRequested) +
+      toggle("n-ready", "Your PR is ready to merge", "Approved with passing checks", n.readyToMerge) +
+      toggle("n-changes", "Changes requested on your PR", "A reviewer wants edits", n.changesRequested) +
+      toggle("n-ci", "CI failing on your PR", "A required check is red", n.ciFailing) +
+    "</div>" +
+    '<div class="row-actions">' +
+      '<button class="btn ghost" id="cancel-settings">Cancel <kbd>Esc</kbd></button>' +
+      '<button class="btn" id="save-settings">Save changes <kbd>\u21B5</kbd></button></div>' +
+  "</div>";
+}
+
+function srcRow(s) {
+  const t = (ACCT_STATUS[s.status] || ACCT_STATUS.failed);
+  const meta = [];
+  if (s.status !== "failed") meta.push("<span>" + s.accessible + "/" + s.total + " repos</span>");
+  if (s.scopes && s.scopes.includes("read:org")) meta.push('<span class="scopes">read:org</span>');
+  if (s.reason) meta.push("<span>" + esc(s.reason) + "</span>");
+  return '<div class="src-row">' +
+    '<span class="dot bg-' + t.tone + '"></span>' +
+    '<span class="sname">' + esc(srcLabel(s.source)) +
+      (s.enterprise ? '<span class="schip ent">' + esc(s.host || "Enterprise") + "</span>" : "") +
+      (s.chosen ? '<span class="schip">IN USE</span>' : "") + "</span>" +
+    '<span class="smeta"><span class="t-' + t.tone + '">' + esc(t.label) + "</span>" + meta.join("") + "</span>" +
+  "</div>";
+}
+
+function repoEditorHtml(a) {
+  const id = a.id;
+  const count = (draftReposByAcct[id] || a.repos || []).length;
+  return '<div class="acct-repos">' +
+    '<div class="acct-repos-head"><span>Watched repositories</span><span class="rcount" data-rcount="' + esc(id) + '">' + count + "</span></div>" +
+    '<p class="acct-repos-hint">Add a repo as <code>owner/repo</code>, then press Enter or the plus. Changes save to this account immediately.</p>' +
+    '<div class="repo-add">' +
+      '<input class="repo-add-input" data-addinput="' + esc(id) + '" type="text" spellcheck="false" autocomplete="off" autocapitalize="off" placeholder="owner/repo" />' +
+      '<button class="repo-add-btn" data-add="' + esc(id) + '" title="Add repository" aria-label="Add repository">' + ICONS.plus + "</button>" +
+    "</div>" +
+    '<div class="repo-err" data-err="' + esc(id) + '"></div>' +
+    '<ul class="repo-list" data-list="' + esc(id) + '">' + repoRowsHtml(id) + "</ul>" +
+  "</div>";
+}
+
+function accountCard(a, asPicker) {
+  const tone = acctTone(a);
+  const st = (ACCT_STATUS[a.status] || ACCT_STATUS.failed);
+  const usable = a.status !== "failed";
+  // Seed this account's repo draft from the server copy unless mid-edit.
+  if (editingByAcct[a.id] == null || editingByAcct[a.id] < 0) draftReposByAcct[a.id] = (a.repos || []).slice();
+  if (editingByAcct[a.id] == null) editingByAcct[a.id] = -1;
+  const open = expanded.has(a.id) || asPicker;
+  const kinds = a.sourceKinds || [...new Set((a.sources || []).map((s) => s.source))];
+  const badgeHtml = kinds.map((k) => '<span class="src-badge">' + esc(srcLabel(k)) + "</span>").join("");
+  const multi = (a.sources || []).length > 1;
+  const entBadge = a.enterprise
+    ? '<span class="ent-badge" title="' + esc(a.host || "GitHub Enterprise") + '">' + ICONS.building + "Enterprise</span>"
+    : "";
+  const meta = [];
+  if (usable) meta.push("<span>" + a.accessible + "/" + a.total + " repos</span>");
+  if (a.hasReadOrg) meta.push('<span class="scopes">read:org</span>');
+  if (a.reason) meta.push("<span>" + esc(a.reason) + "</span>");
+  const detail = (a.sources || []).map(srcRow).join("");
+  const sw = '<label class="switch" title="' + (a.active ? "Active \u00b7 click to disable" : "Enable this account") + '">' +
+    '<input type="checkbox" data-active="' + esc(a.id) + '"' + (a.active ? " checked" : "") + (usable ? "" : " disabled") +
+    ' aria-label="Toggle ' + esc(a.login) + '" /><span class="slider"></span></label>';
+  return '<div class="acct-card ' + (a.active ? "active " : "") + (open ? "open" : "") + '" data-card="' + esc(a.id) + '">' +
+    '<div class="acct-head">' +
+      '<button class="acct-main" data-expand="' + esc(a.id) + '">' +
+        acctAvatar(a, 72) +
+        '<span class="acct-id">' +
+          '<span class="acct-name">' + esc(a.login) + entBadge + badgeHtml +
+            (multi ? '<span class="count">found in ' + (a.sources || []).length + " places</span>" : "") + "</span>" +
+          '<span class="acct-meta"><span class="acct-status"><span class="dot bg-' + tone + '"></span><span class="t-' + tone + '">' + esc(st.label) + "</span></span>" + meta.join("") + "</span>" +
+        "</span>" +
+      "</button>" +
+      '<div class="acct-right">' + sw +
+        '<button class="caret" data-expand="' + esc(a.id) + '" title="Configure" aria-label="Configure account">' + ICONS.chev + "</button>" +
+      "</div>" +
+    "</div>" +
+    '<div class="acct-detail"><div class="inner">' +
+      repoEditorHtml(a) +
+      (detail ? '<div class="src-list">' + detail + "</div>" : "") +
+    "</div></div>" +
+  "</div>";
+}
+
+function accountsView() {
+  const accts = (state && state.accounts) || [];
+  const activeCount = accts.filter((a) => a.active).length;
+  const rows = accts.length
+    ? '<div class="acct-list">' + accts.map((a) => accountCard(a, false)).join("") + "</div>"
+    : '<p class="acct-intro">No GitHub credentials detected. Run <code>gh auth login</code> and rescan.</p>';
+  return '<div class="page">' +
+    '<div class="page-head" style="display:flex;align-items:flex-end;gap:10px">' +
+      '<div><h2>GitHub accounts</h2><p>Enable any number of accounts. Their results interleave across all tabs, and each account watches its own repositories.</p></div>' +
+      '<div class="page-actions"><button class="rescan-btn ' + (rescanning ? "spin" : "") + '" id="rescan-btn">' + ICONS.refresh + "Rescan</button></div>" +
+    "</div>" +
+    (accts.length ? '<p class="acct-intro">' + activeCount + " of " + accts.length + " account" + (accts.length === 1 ? "" : "s") + " active.</p>" : "") +
+    rows +
+  "</div>";
+}
+
+function notificationsView() {
+  const items = state.notifications || [];
+  const dismissed = state.dismissedCount || 0;
+  let body;
+  if (!items.length) {
+    body = '<div class="state"><div class="ico">' + ICONS.bellBig + "</div><h2>You're all caught up</h2>" +
+      "<p>Nothing needs your attention right now. Adjust what counts as a notification in Settings.</p>" +
+      '<div class="state-cta"><button class="btn ghost" id="to-settings">Open settings</button>' +
+      (dismissed ? '<button class="btn ghost" id="restore-notifs">Restore ' + dismissed + " dismissed</button>" : "") + "</div></div>";
+  } else {
+    body = '<div class="notif-list">' + items.map((n) =>
+      '<div class="notif-card" data-id="' + esc(n.id) + '">' +
+        '<span class="ndot bg-' + (n.tone || "muted") + '"></span>' +
+        '<a class="nbody" href="' + esc(n.url) + '" target="_blank" rel="noreferrer">' +
+          '<span class="ntitle">' + esc(n.title) + "</span>" +
+          '<span class="ndetail">' + esc(n.detail) + ' \u00b7 <span class="repo">' + esc(shortRepo(n.repository)) + " #" + n.number + "</span></span>" +
+        "</a>" +
+        '<button class="dismiss" data-dismiss="' + esc(n.id) + '" title="Dismiss" aria-label="Dismiss">' + ICONS.x + "</button>" +
+      "</div>"
+    ).join("") + "</div>";
+  }
+  return '<div class="page">' +
+    '<div class="page-head" style="display:flex;align-items:flex-end;gap:10px">' +
+      '<div><h2>Notifications</h2><p>' + (items.length ? items.length + " active" : "Up to date") +
+        (dismissed ? ", " + dismissed + " dismissed" : "") + ".</p></div>" +
+      '<div class="page-actions">' +
+        (items.length ? '<button class="rescan-btn" id="dismiss-all">Clear all</button>' : "") +
+        (dismissed && items.length ? '<button class="rescan-btn" id="restore-notifs2">Restore</button>' : "") +
+      "</div>" +
+    "</div>" + body +
+    '<div class="notif-foot"><button class="linklike" id="notif-config" type="button">' + ICONS.gear + ' Configure which notifications count</button></div>' +
+  "</div>";
+}
+
+function authPicker() {
+  const accts = state.accounts || [];
+  const picker = accts.length
+    ? '<div class="acct-list" style="text-align:left;margin-top:18px">' + accts.map((a) => accountCard(a, true)).join("") + "</div>"
+    : '<span class="cmd">gh auth login</span>';
+  return '<div class="page" style="max-width:560px">' +
+    '<div class="state" style="padding-top:32px"><div class="ico">' + ICONS.users + "</div>" +
+    "<h2>Enable a GitHub account</h2><p>" + esc(state.message) + "</p></div>" +
+    picker +
+  "</div>";
+}
+
+/* ---- render ---- */
+
+function render(forward) {
+  app.removeAttribute("aria-busy");
+
+  if (loadError && !state) {
+    app.innerHTML = topbarShell() +
+      '<div class="state"><div class="ico">' + ICONS.alert + '</div><h2>Could not load</h2><p>' + esc(loadError) +
+      '</p><div class="state-cta"><button class="btn" id="retry-btn">Try again</button></div></div>';
+    const rt = document.getElementById("retry-btn"); if (rt) rt.addEventListener("click", load);
+    return;
+  }
+  if (!state) return; // skeleton (initial HTML) stays until first load resolves
+
+  let inner;
+  if (!state.authenticated) { view = "queue"; inner = authPicker(); }
+  else if (view === "settings") inner = settingsView();
+  else if (view === "accounts") inner = accountsView();
+  else if (view === "notifications") inner = notificationsView();
+  else inner = queueView();
+
+  const dir = forward === false || (forward === undefined && (RANK[view] || 0) < prevRank) ? "back" : "";
+  app.innerHTML = topbarHtml() + '<div class="viewport"><div class="view ' + dir + '">' + inner + "</div></div>";
+  app.classList.toggle("loading", refreshing);
+  wire();
+  layoutGrids();
+}
+
+/* ---- masonry: fill the left column first, top-to-bottom ----
+   CSS multi-column balances column heights, which puts a single tall card on
+   the left and the rest on the right. For a prioritized queue we want the
+   opposite: read straight down the first column, then the next. We rebuild each
+   .grid into real flex columns and distribute cards in queue order, only
+   reflowing when the responsive column count actually changes. */
+var __gridRO = null;
+
+function ensureGridObserver() {
+  if (__gridRO || typeof ResizeObserver === "undefined") return;
+  __gridRO = new ResizeObserver(function (entries) {
+    for (var i = 0; i < entries.length; i++) layoutGrid(entries[i].target);
+  });
+}
+
+function layoutGrids() {
+  ensureGridObserver();
+  if (__gridRO) __gridRO.disconnect();
+  var grids = document.querySelectorAll(".grid");
+  for (var i = 0; i < grids.length; i++) {
+    layoutGrid(grids[i]);
+    if (__gridRO) __gridRO.observe(grids[i]);
+  }
+}
+
+function layoutGrid(grid) {
+  var cards = grid.__cards;
+  if (!cards) {
+    cards = [];
+    var kids = grid.children;
+    for (var i = 0; i < kids.length; i++) {
+      if (kids[i].classList && kids[i].classList.contains("card")) cards.push(kids[i]);
+    }
+    if (!cards.length) return; // skeletons or non-card grids: leave alone
+    grid.__cards = cards;
+  }
+  var w = grid.clientWidth;
+  if (!w) return; // not visible yet; the observer fires again when it is
+  var COLW = 280, GAP = 12;
+  var cols = Math.max(1, Math.floor((w + GAP) / (COLW + GAP)));
+  if (cols > cards.length) cols = cards.length || 1;
+  if (grid.__cols === cols) return; // responsive column count unchanged
+  grid.__cols = cols;
+
+  while (grid.firstChild) grid.removeChild(grid.firstChild);
+  if (cols <= 1) {
+    grid.classList.remove("mcol");
+    for (var j = 0; j < cards.length; j++) grid.appendChild(cards[j]);
+    return;
+  }
+  grid.classList.add("mcol");
+  var n = cards.length, base = Math.floor(n / cols), extra = n % cols, idx = 0;
+  for (var c = 0; c < cols; c++) {
+    var col = document.createElement("div");
+    col.className = "mcol-col";
+    var cnt = base + (c < extra ? 1 : 0);
+    for (var k = 0; k < cnt; k++) col.appendChild(cards[idx++]);
+    grid.appendChild(col);
+  }
+}
+
+function topbarShell() {
+  return '<div class="topbar"><span class="brand"><span class="mark">' + LOGO + '</span><span class="brand-text">Aspire Team App</span></span><span class="spacer"></span></div>';
+}
+
+/* ---- watched-repository editor ---- */
+
+var REPO_RE = /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+
+function normRepo(v) {
+  return String(v || "").trim()
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/\.git$/i, "")
+    .replace(/\/+$/, "");
+}
+
+function repoErr(id, msg) {
+  var el = document.querySelector('.repo-err[data-err="' + cssEsc(id) + '"]');
+  if (!el) return;
+  if (!msg) { el.textContent = ""; el.classList.remove("show"); return; }
+  el.textContent = msg; el.classList.add("show");
+}
+
+function shake(el) {
+  if (!el) return;
+  el.classList.remove("shake");
+  void el.offsetWidth;
+  el.classList.add("shake");
+}
+
+function repoRowsHtml(id) {
+  var repos = draftReposByAcct[id] || [];
+  var editing = editingByAcct[id];
+  if (!repos.length) {
+    return '<li class="repo-empty">No repositories yet. Add one above to start watching it.</li>';
+  }
+  return repos.map(function (r, i) {
+    if (i === editing) {
+      return '<li class="repo-row editing" data-acct="' + esc(id) + '" data-i="' + i + '">' +
+        '<input class="repo-edit-input" data-editinput="' + esc(id) + '" type="text" spellcheck="false" autocomplete="off" value="' + esc(r) + '" />' +
+        '<span class="repo-acts">' +
+          '<button class="repo-ico ok" data-save-edit="' + i + '" data-acct="' + esc(id) + '" title="Save" aria-label="Save">' + ICONS.check + "</button>" +
+          '<button class="repo-ico" data-cancel-edit="' + i + '" data-acct="' + esc(id) + '" title="Cancel" aria-label="Cancel">' + ICONS.x + "</button>" +
+        "</span></li>";
+    }
+    return '<li class="repo-row" data-acct="' + esc(id) + '" data-i="' + i + '">' +
+      '<span class="repo-name">' + esc(r) + "</span>" +
+      '<span class="repo-acts">' +
+        '<button class="repo-ico" data-edit="' + i + '" data-acct="' + esc(id) + '" title="Edit" aria-label="Edit">' + ICONS.pencil + "</button>" +
+        '<button class="repo-ico danger" data-del="' + i + '" data-acct="' + esc(id) + '" title="Remove" aria-label="Remove">' + ICONS.trash + "</button>" +
+      "</span></li>";
+  }).join("");
+}
+
+function updateRepoCount(id) {
+  var c = document.querySelector('.rcount[data-rcount="' + cssEsc(id) + '"]');
+  if (c) c.textContent = (draftReposByAcct[id] || []).length;
+}
+
+function renderRepoList(id, flagLast) {
+  var ul = document.querySelector('.repo-list[data-list="' + cssEsc(id) + '"]');
+  if (!ul) return;
+  ul.innerHTML = repoRowsHtml(id);
+  updateRepoCount(id);
+  if (flagLast) {
+    var rows = ul.querySelectorAll(".repo-row");
+    var last = rows[rows.length - 1];
+    if (last) { last.classList.add("added"); last.addEventListener("animationend", function () { last.classList.remove("added"); }, { once: true }); }
+  }
+  wireRepoRows(id);
+}
+
+function addRepoFromInput(id) {
+  var inp = document.querySelector('.repo-add-input[data-addinput="' + cssEsc(id) + '"]');
+  if (!inp) return;
+  var v = normRepo(inp.value);
+  if (!v) { return; }
+  if (!REPO_RE.test(v)) { repoErr(id, "Use the owner/repo format, like microsoft/aspire."); shake(inp); return; }
+  var list = draftReposByAcct[id] || (draftReposByAcct[id] = []);
+  if (list.some(function (r) { return r.toLowerCase() === v.toLowerCase(); })) {
+    repoErr(id, v + " is already in the list."); shake(inp); return;
+  }
+  list.push(v);
+  inp.value = "";
+  repoErr(id, "");
+  renderRepoList(id, true);
+  persistAccountRepos(id);
+  inp.focus();
+}
+
+function commitEdit(id, i) {
+  var inp = document.querySelector('.repo-edit-input[data-editinput="' + cssEsc(id) + '"]');
+  if (!inp) return;
+  var v = normRepo(inp.value);
+  var list = draftReposByAcct[id] || [];
+  if (!REPO_RE.test(v)) { repoErr(id, "Use the owner/repo format, like microsoft/aspire."); shake(inp); return; }
+  if (list.some(function (r, j) { return j !== i && r.toLowerCase() === v.toLowerCase(); })) {
+    repoErr(id, v + " is already in the list."); shake(inp); return;
+  }
+  list[i] = v; editingByAcct[id] = -1; repoErr(id, "");
+  renderRepoList(id);
+  persistAccountRepos(id);
+}
+
+function deleteRepo(id, i, row) {
+  var done = function () {
+    (draftReposByAcct[id] || []).splice(i, 1);
+    if (editingByAcct[id] === i) editingByAcct[id] = -1;
+    renderRepoList(id);
+    persistAccountRepos(id);
+  };
+  if (row) { row.classList.add("removing"); row.addEventListener("animationend", done, { once: true }); setTimeout(done, 240); }
+  else done();
+}
+
+function wireRepoRows(id) {
+  var ul = document.querySelector('.repo-list[data-list="' + cssEsc(id) + '"]');
+  if (!ul) return;
+  ul.querySelectorAll("[data-edit]").forEach(function (b) {
+    b.addEventListener("click", function () {
+      editingByAcct[id] = parseInt(b.dataset.edit, 10); repoErr(id, ""); renderRepoList(id);
+      var ei = document.querySelector('.repo-edit-input[data-editinput="' + cssEsc(id) + '"]'); if (ei) { ei.focus(); ei.select(); }
+    });
+  });
+  ul.querySelectorAll("[data-del]").forEach(function (b) {
+    var fired = false;
+    b.addEventListener("click", function () { if (fired) return; fired = true; deleteRepo(id, parseInt(b.dataset.del, 10), b.closest(".repo-row")); });
+  });
+  ul.querySelectorAll("[data-save-edit]").forEach(function (b) {
+    b.addEventListener("click", function () { commitEdit(id, parseInt(b.dataset.saveEdit, 10)); });
+  });
+  ul.querySelectorAll("[data-cancel-edit]").forEach(function (b) {
+    b.addEventListener("click", function () { editingByAcct[id] = -1; repoErr(id, ""); renderRepoList(id); });
+  });
+  var ei = ul.querySelector(".repo-edit-input");
+  if (ei) ei.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") { e.preventDefault(); commitEdit(id, editingByAcct[id]); }
+    else if (e.key === "Escape") { e.preventDefault(); editingByAcct[id] = -1; repoErr(id, ""); renderRepoList(id); }
+  });
+}
+
+function wireRepoEditor(id) {
+  var addBtn = document.querySelector('.repo-add-btn[data-add="' + cssEsc(id) + '"]');
+  if (addBtn) addBtn.addEventListener("click", function () { addRepoFromInput(id); });
+  var inp = document.querySelector('.repo-add-input[data-addinput="' + cssEsc(id) + '"]');
+  if (inp) inp.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") { e.preventDefault(); addRepoFromInput(id); }
+    else { repoErr(id, ""); }
+  });
+  wireRepoRows(id);
+}
+
+function wire() {
+  document.querySelectorAll(".tab").forEach((b) => b.addEventListener("click", () => setMode(b.dataset.mode)));
+  const rb = document.getElementById("refresh-btn"); if (rb) rb.addEventListener("click", refresh);
+  const back = document.getElementById("back-btn"); if (back) back.addEventListener("click", () => goView("queue", false));
+  const bell = document.getElementById("bell-btn"); if (bell) bell.addEventListener("click", () => goView(view === "notifications" ? "queue" : "notifications"));
+  const gear = document.getElementById("gear-btn"); if (gear) gear.addEventListener("click", () => goView(view === "settings" ? "queue" : "settings"));
+  const acct = document.getElementById("acct-btn"); if (acct) acct.addEventListener("click", () => goView(view === "accounts" ? "queue" : "accounts"));
+
+  const save = document.getElementById("save-settings"); if (save) save.addEventListener("click", saveSettings);
+  const cancel = document.getElementById("cancel-settings"); if (cancel) cancel.addEventListener("click", () => goView("queue", false));
+
+  // The Esc/Enter hints on the settings buttons are real shortcuts, like the app's
+  // Cancel/Continue. Bound once so re-renders don't stack handlers.
+  if (!keysBound) {
+    keysBound = true;
+    document.addEventListener("keydown", function (e) {
+      if (view !== "settings") return;
+      if (e.key === "Escape") { e.preventDefault(); goView("queue", false); }
+      else if (e.key === "Enter" && !e.isComposing && (e.target.tagName || "") !== "TEXTAREA") {
+        e.preventDefault(); saveSettings();
+      }
+    });
+  }
+
+  const rescan = document.getElementById("rescan-btn"); if (rescan) rescan.addEventListener("click", rescanAccounts);
+
+  wireAccounts();
+
+  document.querySelectorAll(".lane-head").forEach((b) =>
+    b.addEventListener("click", () => {
+      const id = b.dataset.laneToggle;
+      const sec = b.closest(".lane");
+      if (!sec) return;
+      const nowCollapsed = !sec.classList.contains("collapsed");
+      sec.classList.toggle("collapsed", nowCollapsed);
+      b.setAttribute("aria-expanded", nowCollapsed ? "false" : "true");
+      if (nowCollapsed) collapsedLanes.add(id); else collapsedLanes.delete(id);
+    }));
+
+  // Generic collapsible sections (primary queues + secondary reference groups).
+  document.querySelectorAll("[data-collapse]").forEach((b) =>
+    b.addEventListener("click", () => {
+      const id = b.dataset.collapse;
+      const sec = b.closest(".collapsible");
+      if (!sec) return;
+      const nowCollapsed = !sec.classList.contains("collapsed");
+      sec.classList.toggle("collapsed", nowCollapsed);
+      b.setAttribute("aria-expanded", nowCollapsed ? "false" : "true");
+      if (nowCollapsed) collapsedLanes.add(id); else collapsedLanes.delete(id);
+    }));
+
+  document.querySelectorAll(".dismiss").forEach((b) =>
+    b.addEventListener("click", (e) => { e.preventDefault(); e.stopPropagation(); dismissNotif(b.dataset.dismiss, b.closest(".notif-card")); }));
+  const da = document.getElementById("dismiss-all"); if (da) da.addEventListener("click", dismissAll);
+  const r1 = document.getElementById("restore-notifs"); if (r1) r1.addEventListener("click", restoreNotifs);
+  const r2 = document.getElementById("restore-notifs2"); if (r2) r2.addEventListener("click", restoreNotifs);
+  const ts = document.getElementById("to-settings"); if (ts) ts.addEventListener("click", () => goView("settings"));
+  const brandHome = document.getElementById("brand-home"); if (brandHome) brandHome.addEventListener("click", () => goView("queue", false));
+  const notifCfg = document.getElementById("notif-config");
+  if (notifCfg) notifCfg.addEventListener("click", () => {
+    goView("settings");
+    requestAnimationFrame(() => {
+      const sec = document.getElementById("notif-settings");
+      if (sec) sec.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  });
+}
+
+function wireAccounts() {
+  // Active toggles interleave/withdraw an account's results across every tab.
+  document.querySelectorAll("input[data-active]").forEach((inp) =>
+    inp.addEventListener("change", () => { if (!inp.disabled) toggleAccountActive(inp.dataset.active, inp.checked); }));
+
+  // Expand/collapse the account detail (repo editor + credential sources).
+  document.querySelectorAll("[data-expand]").forEach((b) =>
+    b.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const id = b.dataset.expand;
+      const card = document.querySelector('.acct-card[data-card="' + cssEsc(id) + '"]');
+      if (!card) return;
+      if (expanded.has(id)) { expanded.delete(id); card.classList.remove("open"); }
+      else { expanded.add(id); card.classList.add("open"); }
+    }));
+
+  // Per-account watched-repository editors.
+  document.querySelectorAll(".acct-card").forEach((card) => {
+    const id = card.dataset.card;
+    if (id) wireRepoEditor(id);
+  });
+}
+
+try {
+  const es = new EventSource("events");
+  es.addEventListener("refresh", () => load());
+} catch {}
+
+// Phase D: capture the live Copilot theme tokens the host injects into this
+// canvas document, so the static marketplace theme can be refined to match.
+function captureTokens() {
+  try {
+    const names = [
+      "--background-color-default", "--border-color-default", "--border-color-muted", "--text-color-default",
+      "--text-color-muted", "--color-focus-outline", "--color-white",
+      "--true-color-red", "--true-color-red-muted", "--true-color-blue", "--true-color-blue-muted",
+      "--true-color-green", "--true-color-green-muted", "--true-color-yellow", "--true-color-yellow-muted",
+      "--font-sans", "--font-mono", "--font-weight-semibold",
+      "--text-title-large", "--text-body-medium", "--leading-body-medium",
+      "--n-0", "--n-1", "--n-2", "--n-3", "--b-11-10", "--bb-11-10",
+    ];
+    const cs = getComputedStyle(document.documentElement);
+    const tokens = {};
+    for (const n of names) {
+      const v = cs.getPropertyValue(n).trim();
+      if (v) tokens[n] = v;
+    }
+    const attrs = {};
+    for (const a of ["data-color-mode", "data-dark-theme", "data-light-theme", "data-theme-tone", "data-visual-mode"]) {
+      const v = document.documentElement.getAttribute(a) || document.body.getAttribute(a);
+      if (v) attrs[a] = v;
+    }
+    if (Object.keys(tokens).length) {
+      fetch("api/tokens", { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ capturedAt: new Date().toISOString(), attrs, tokens }) }).catch(() => {});
+    }
+  } catch {}
+}
+captureTokens();
+
+load();
+`;

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -1670,37 +1670,5 @@ try {
   es.addEventListener("refresh", () => load());
 } catch {}
 
-// Phase D: capture the live Copilot theme tokens the host injects into this
-// canvas document, so the static marketplace theme can be refined to match.
-function captureTokens() {
-  try {
-    const names = [
-      "--background-color-default", "--border-color-default", "--border-color-muted", "--text-color-default",
-      "--text-color-muted", "--color-focus-outline", "--color-white",
-      "--true-color-red", "--true-color-red-muted", "--true-color-blue", "--true-color-blue-muted",
-      "--true-color-green", "--true-color-green-muted", "--true-color-yellow", "--true-color-yellow-muted",
-      "--font-sans", "--font-mono", "--font-weight-semibold",
-      "--text-title-large", "--text-body-medium", "--leading-body-medium",
-      "--n-0", "--n-1", "--n-2", "--n-3", "--b-11-10", "--bb-11-10",
-    ];
-    const cs = getComputedStyle(document.documentElement);
-    const tokens = {};
-    for (const n of names) {
-      const v = cs.getPropertyValue(n).trim();
-      if (v) tokens[n] = v;
-    }
-    const attrs = {};
-    for (const a of ["data-color-mode", "data-dark-theme", "data-light-theme", "data-theme-tone", "data-visual-mode"]) {
-      const v = document.documentElement.getAttribute(a) || document.body.getAttribute(a);
-      if (v) attrs[a] = v;
-    }
-    if (Object.keys(tokens).length) {
-      fetch("api/tokens", { method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ capturedAt: new Date().toISOString(), attrs, tokens }) }).catch(() => {});
-    }
-  } catch {}
-}
-captureTokens();
-
 load();
 `;

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -358,7 +358,7 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 .section { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 14px 14px 12px; margin-bottom: 12px; }
 .section h3 { margin: 0 0 3px; font-size: 13px; }
 .section .hint { margin: 0 0 10px; color: var(--muted); font-size: 11.5px; }
-.section .hint b { color: var(--text); }
+.section .hint b { color: var(--fg); }
 .policy { display: flex; flex-direction: column; gap: 8px; margin: 0 0 12px; }
 .policy-row {
   display: flex; gap: 9px; align-items: flex-start;
@@ -367,7 +367,7 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
   font-size: 11.5px; line-height: 1.5; color: var(--muted);
 }
 .policy-row svg { flex: none; width: 15px; height: 15px; margin-top: 1px; color: var(--accent); }
-.policy-row b { color: var(--text); font-weight: 600; }
+.policy-row b { color: var(--fg); font-weight: 600; }
 .field label { display: block; font-size: 12px; font-weight: 600; margin-bottom: 5px; }
 .field + .field { margin-top: 12px; }
 .field textarea {

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -602,6 +602,10 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 .state .cmd { display: inline-block; margin-top: 14px; font-family: var(--mono); font-size: 12px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 7px 11px; color: var(--fg); }
 .state .state-cta { margin-top: 16px; display: flex; gap: 8px; justify-content: center; }
 .errbar { margin: 12px 16px 0; padding: 9px 12px; border-radius: 8px; background: color-mix(in srgb, var(--danger) 12%, transparent); border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent); color: var(--danger); font-size: 11.5px; }
+.errbar.loaderr { display: flex; align-items: center; gap: 8px; }
+.errbar-x { margin-left: auto; display: inline-flex; align-items: center; justify-content: center; padding: 2px; border: 0; border-radius: 6px; background: transparent; color: inherit; cursor: pointer; opacity: .75; }
+.errbar-x:hover { opacity: 1; background: color-mix(in srgb, var(--danger) 18%, transparent); }
+.errbar-x svg { width: 13px; height: 13px; }
 .empty-lane { color: var(--muted); font-size: 12px; padding: 6px 0; }
 
 /* Skeleton shimmer */
@@ -796,7 +800,15 @@ function persistAccountRepos(id) {
   const repos = (draftReposByAcct[id] || []).slice();
   postJSON("api/account/repos", { id, repos }).then((data) => {
     if (data && data.dashboard) { state = data.dashboard; prefs = data.prefs; }
-  }).catch(() => {});
+    repoErr(id, "");
+  }).catch((e) => {
+    // The optimistic in-memory edit was never persisted. Surface it inline and
+    // revert the draft to the server's last-known list so the visible editor can't
+    // silently drift from what is actually saved.
+    const acct = state && (state.accounts || []).find((a) => a.id === id);
+    if (acct && Array.isArray(acct.repos)) { draftReposByAcct[id] = acct.repos.slice(); renderRepoList(id); }
+    repoErr(id, "Couldn't save repositories: " + String((e && e.message) || e));
+  });
 }
 
 async function saveSettings() {
@@ -1368,8 +1380,20 @@ function render(forward) {
   else inner = queueView();
 
   const dir = forward === false || (forward === undefined && (RANK[view] || 0) < prevRank) ? "back" : "";
-  app.innerHTML = topbarHtml() + '<div class="viewport"><div class="view ' + dir + '">' + inner + "</div></div>";
+  // A refresh/rescan that fails after the dashboard already loaded sets loadError
+  // but keeps the last-good state. Surface it as a dismissible banner instead of
+  // discarding the loaded UI (the full-screen "Could not load" state above only
+  // applies to the very first load, when there is no state to preserve).
+  const banner = loadError
+    ? '<div class="errbar loaderr" role="alert">' + esc(loadError) +
+      '<button class="errbar-x" id="load-errbar-dismiss" type="button" title="Dismiss" aria-label="Dismiss">' + ICONS.x + "</button></div>"
+    : "";
+  app.innerHTML = topbarHtml() + banner + '<div class="viewport"><div class="view ' + dir + '">' + inner + "</div></div>";
   app.classList.toggle("loading", refreshing);
+  if (banner) {
+    const bx = document.getElementById("load-errbar-dismiss");
+    if (bx) bx.addEventListener("click", function () { loadError = null; render(); });
+  }
   wire();
   layoutGrids();
 }
@@ -1539,13 +1563,24 @@ function commitEdit(id, i) {
 }
 
 function deleteRepo(id, i, row) {
+  // The row-removal animation is our cue to actually splice, but a missed
+  // animationend (reduced motion, a backgrounded tab, an interrupted animation)
+  // would strand the row. We keep a fallback timer as a backstop, so both the
+  // animationend handler and the timer can fire. A once-only guard makes the splice
+  // run exactly once: without it the second call would splice a now-shifted index
+  // and silently drop the wrong repository.
+  var ran = false;
+  var fallback = null;
   var done = function () {
+    if (ran) return;
+    ran = true;
+    if (fallback) clearTimeout(fallback);
     (draftReposByAcct[id] || []).splice(i, 1);
     if (editingByAcct[id] === i) editingByAcct[id] = -1;
     renderRepoList(id);
     persistAccountRepos(id);
   };
-  if (row) { row.classList.add("removing"); row.addEventListener("animationend", done, { once: true }); setTimeout(done, 240); }
+  if (row) { row.classList.add("removing"); row.addEventListener("animationend", done, { once: true }); fallback = setTimeout(done, 240); }
   else done();
 }
 

--- a/.github/extensions/aspire-team-app/render.test.mjs
+++ b/.github/extensions/aspire-team-app/render.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import test from "node:test";
+
+import { APP_JS } from "./render.mjs";
+
+test("render keeps the current dashboard visible and surfaces later load errors", () => {
+  const { app, api } = createRendererHarness();
+
+  api.setState({
+    authenticated: true,
+    accounts: [],
+    activeAccounts: [],
+    notifications: [],
+  });
+  api.setView("accounts");
+  api.setLoadError("GitHub API 500 unavailable");
+  api.render();
+
+  assert.match(app.innerHTML, /GitHub API 500 unavailable/);
+  assert.match(app.innerHTML, /GitHub accounts/);
+});
+
+test("deleteRepo completes once when both the animation and fallback timeout fire", () => {
+  const row = {
+    classList: { add() {} },
+    addEventListener(_event, handler) { this.animationEnd = handler; },
+  };
+  const timers = [];
+  const { api } = createRendererHarness({ setTimeout: (handler) => { timers.push(handler); return timers.length; } });
+  api.draftReposByAcct["acct:github.com/octo"] = ["microsoft/aspire", "microsoft/dcp", "microsoft/aspire.dev"];
+
+  api.deleteRepo("acct:github.com/octo", 0, row);
+  row.animationEnd();
+  for (const timer of timers) timer();
+
+  assert.deepEqual(api.draftReposByAcct["acct:github.com/octo"], ["microsoft/dcp", "microsoft/aspire.dev"]);
+});
+
+test("failed repo saves show the API error and revert the optimistic draft", async () => {
+  const id = "acct:github.com/octo";
+  const previousRepos = ["microsoft/aspire"];
+  const errEl = errorElement();
+  const { api } = createRendererHarness({
+    fetch: async (url) => {
+      if (String(url) === "api/account/repos") {
+        return jsonResponse({ error: "GitHub API 500 unavailable" }, { ok: false, status: 500 });
+      }
+      return new Promise(() => {});
+    },
+    querySelector(selector) {
+      return selector === '.repo-err[data-err="acct\\:github\\.com\\/octo"]' ? errEl : null;
+    },
+  });
+  api.draftReposByAcct[id] = ["microsoft/aspire", "microsoft/dcp"];
+  api.editingByAcct[id] = -1;
+
+  await api.persistAccountRepos(id, previousRepos);
+
+  assert.deepEqual(api.draftReposByAcct[id], previousRepos);
+  assert.equal(errEl.textContent, "Couldn't save repositories: GitHub API 500 unavailable");
+  assert.equal(errEl.classList.has("show"), true);
+});
+
+function createRendererHarness(overrides = {}) {
+  const app = {
+    innerHTML: "",
+    removeAttribute() {},
+    classList: classList(),
+  };
+  const document = {
+    getElementById(id) { return id === "app" ? app : null; },
+    querySelector: overrides.querySelector ?? (() => null),
+    querySelectorAll: () => [],
+    addEventListener() {},
+  };
+  const sandbox = {
+    document,
+    window: { CSS: { escape: cssEscape } },
+    CSS: { escape: cssEscape },
+    EventSource: function () { throw new Error("disabled"); },
+    ResizeObserver: undefined,
+    requestAnimationFrame(handler) { handler(); },
+    fetch: overrides.fetch ?? (async () => jsonResponse({ dashboard: null, prefs: null })),
+    setTimeout: overrides.setTimeout ?? ((handler) => { handler(); return 1; }),
+    clearTimeout: overrides.clearTimeout ?? (() => {}),
+    console,
+  };
+
+  vm.runInNewContext(`${APP_JS}\n;globalThis.__test = {\n  render,\n  deleteRepo,\n  persistAccountRepos,\n  draftReposByAcct,\n  editingByAcct,\n  setState(value) { state = value; },\n  setPrefs(value) { prefs = value; },\n  setView(value) { view = value; },\n  setLoadError(value) { loadError = value; },\n  getLoadError() { return loadError; },\n};`, sandbox);
+
+  return { app, api: sandbox.__test };
+}
+
+function jsonResponse(body, options = {}) {
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    statusText: options.statusText ?? "OK",
+    json: async () => body,
+  };
+}
+
+function errorElement() {
+  const classes = new Set();
+  return {
+    textContent: "",
+    classList: {
+      add(name) { classes.add(name); },
+      remove(name) { classes.delete(name); },
+      has(name) { return classes.has(name); },
+    },
+  };
+}
+
+function classList() {
+  const classes = new Set();
+  return {
+    add(name) { classes.add(name); },
+    remove(name) { classes.delete(name); },
+    toggle(name, on) { if (on) classes.add(name); else classes.delete(name); },
+    contains(name) { return classes.has(name); },
+  };
+}
+
+function cssEscape(value) {
+  return String(value).replace(/[^a-zA-Z0-9_-]/g, (ch) => `\\${ch}`);
+}

--- a/.github/extensions/aspire-team-app/server.mjs
+++ b/.github/extensions/aspire-team-app/server.mjs
@@ -105,9 +105,14 @@ async function getDashboard(force = false) {
       dashboard.dismissedCount = (prefs.dismissedNotifications || []).length;
     }
     cache = { dashboard, prefs };
-    inflight = null;
     return cache;
-  })();
+  })().finally(() => {
+    // Clear the in-flight marker whether the load resolved OR threw. If a rejected
+    // promise were left cached here, the `if (inflight) return inflight` guard above
+    // would replay that same failure to every later /api/state and /api/refresh request
+    // until the extension process restarted. Resetting it lets the next request retry.
+    inflight = null;
+  });
   return inflight;
 }
 
@@ -137,11 +142,51 @@ async function readBody(req) {
   }
 }
 
+// Reject cross-origin mutating requests. The iframe served by this instance calls the
+// loopback API same-origin, so a present Origin header must match this server's host and
+// a present Sec-Fetch-Site must indicate a same-origin (or non-site) navigation. Missing
+// headers (older clients / direct navigations) are allowed through. This mirrors the
+// origin guard used by the sibling issue-triage-canvas extension so any browser page that
+// happens to reach the loopback port cannot drive preference/account/notification changes.
+function isAllowedPostRequest(req) {
+  const host = req.headers.host;
+  if (!host) {
+    return false;
+  }
+
+  const expectedOrigin = `http://${host}`;
+  const origin = req.headers.origin;
+  if (origin && !isSameOrigin(origin, expectedOrigin)) {
+    return false;
+  }
+
+  const fetchSite = req.headers["sec-fetch-site"];
+  if (fetchSite && fetchSite !== "same-origin" && fetchSite !== "none") {
+    return false;
+  }
+
+  return true;
+}
+
+function isSameOrigin(origin, expectedOrigin) {
+  try {
+    return new URL(origin).origin === new URL(expectedOrigin).origin;
+  } catch {
+    return false;
+  }
+}
+
 async function handle(req, res, log) {
   const url = new URL(req.url, "http://127.0.0.1");
   const path = url.pathname;
 
   try {
+    // Every mutating route on this API is a POST, so gate POSTs on the origin guard
+    // before dispatching to any handler that reads the body or writes preferences.
+    if (req.method === "POST" && !isAllowedPostRequest(req)) {
+      return send(res, 403, { error: "forbidden" });
+    }
+
     if (req.method === "GET" && (path === "/" || path === "/index.html")) {
       return send(res, 200, HTML, "text/html");
     }

--- a/.github/extensions/aspire-team-app/server.mjs
+++ b/.github/extensions/aspire-team-app/server.mjs
@@ -1,0 +1,336 @@
+// Per-instance loopback server for the Aspire Team App canvas.
+//
+// Serves the iframe assets and a small JSON API. Dashboard data is cached and
+// shared across instances (single user), with Server-Sent Events used to push a
+// refresh signal to every open iframe when prefs change or a refresh completes.
+//
+// Several GitHub accounts can be active at once; each watches its own set of
+// repositories and the dashboard interleaves results from all of them.
+
+import { createServer } from "node:http";
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { HTML, STYLES, APP_JS } from "./render.mjs";
+import { loadDashboard } from "./github.mjs";
+import { resolveAccounts } from "./accounts.mjs";
+import {
+  loadPrefs,
+  savePrefs,
+  parseRepos,
+  accountConfig,
+  setAccountRepos,
+  setAccountActive,
+  activeIds,
+} from "./state.mjs";
+
+const COPILOT_HOME = process.env.COPILOT_HOME || join(homedir(), ".copilot");
+const ARTIFACT_DIR = join(COPILOT_HOME, "extensions", "aspire-team-app", "artifacts");
+
+const servers = new Map(); // instanceId -> { server, url }
+const sseClients = new Set();
+let cache = null;
+let inflight = null;
+
+// Account resolution probes every candidate credential against its account's
+// watched repos, so we cache the result and only re-probe when the cache is stale
+// or the per-account configuration (repos / active flags) changed.
+let authCache = null;
+const AUTH_TTL = 10 * 60 * 1000;
+
+function accountsKey(prefs) {
+  return JSON.stringify(prefs.accounts || {});
+}
+
+async function resolveAuth(prefs, { reprobe = false } = {}) {
+  const key = accountsKey(prefs);
+  const fresh = authCache && Date.now() - authCache.at < AUTH_TTL && authCache.key === key;
+  if (!reprobe && fresh) return authCache;
+
+  const reposForId = (id) => accountConfig(prefs, id).repos;
+  const isActive = (id) => accountConfig(prefs, id).active;
+  const { accounts, tokenById } = await resolveAccounts(reposForId, isActive);
+
+  // First-run convenience: if the user has never configured accounts and none are
+  // active, auto-enable the strongest usable account so the canvas works out of the
+  // box (preserves the old single-account behavior without being disruptive).
+  if (activeIds(prefs).length === 0 && Object.keys(prefs.accounts || {}).length === 0) {
+    const best = accounts.find((a) => a.status !== "failed" && a.accessible > 0)
+      ?? accounts.find((a) => a.status !== "failed");
+    if (best) {
+      best.active = true;
+      setAccountActive(prefs, best.id, true);
+      await savePrefs(prefs);
+    }
+  }
+
+  authCache = { key: accountsKey(prefs), accounts, tokenById, at: Date.now() };
+  return authCache;
+}
+
+function invalidateAuth() {
+  authCache = null;
+}
+
+async function getDashboard(force = false) {
+  if (!force && cache) return cache;
+  if (inflight) return inflight;
+  inflight = (async () => {
+    const prefs = await loadPrefs();
+    const auth = await resolveAuth(prefs);
+    const active = auth.accounts.filter((a) => a.active && a.status !== "failed");
+    const accountsForLoad = active
+      .map((a) => ({ token: auth.tokenById.get(a.id), login: a.login, repos: a.repos, graphql: a.graphql }))
+      .filter((a) => a.token && a.login);
+
+    let dashboard;
+    if (accountsForLoad.length === 0) {
+      const anyDetected = auth.accounts.length > 0;
+      const anyActive = auth.accounts.some((a) => a.active);
+      dashboard = {
+        authenticated: false,
+        message: !anyDetected
+          ? "No GitHub credentials detected. Run `gh auth login` so the canvas can read your review queue."
+          : anyActive
+            ? "The active GitHub account can't read its watched repositories. Adjust its repos or enable another account below."
+            : "No account is active. Enable an account in the Accounts tab to load your review queue.",
+        accounts: auth.accounts,
+        activeAccounts: [],
+      };
+    } else {
+      dashboard = await loadDashboard({
+        accounts: accountsForLoad,
+        mode: prefs.mode,
+        release: prefs.release,
+        prefs: prefs.notifications,
+        dismissed: prefs.dismissedNotifications,
+        showDrafts: prefs.showDrafts,
+      });
+      dashboard.accounts = auth.accounts;
+      dashboard.activeAccounts = active.map((a) => ({ id: a.id, login: a.login, avatarUrl: a.avatarUrl, enterprise: a.enterprise, host: a.host }));
+      dashboard.dismissedCount = (prefs.dismissedNotifications || []).length;
+    }
+    cache = { dashboard, prefs };
+    inflight = null;
+    return cache;
+  })();
+  return inflight;
+}
+
+function broadcastRefresh() {
+  for (const res of sseClients) {
+    try {
+      res.write("event: refresh\ndata: 1\n\n");
+    } catch {
+      sseClients.delete(res);
+    }
+  }
+}
+
+function send(res, status, body, type = "application/json") {
+  res.writeHead(status, { "Content-Type": type + "; charset=utf-8", "Cache-Control": "no-store" });
+  res.end(typeof body === "string" ? body : JSON.stringify(body));
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  if (!chunks.length) return {};
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return {};
+  }
+}
+
+async function handle(req, res, log) {
+  const url = new URL(req.url, "http://127.0.0.1");
+  const path = url.pathname;
+
+  try {
+    if (req.method === "GET" && (path === "/" || path === "/index.html")) {
+      return send(res, 200, HTML, "text/html");
+    }
+    if (req.method === "GET" && path === "/styles.css") {
+      return send(res, 200, STYLES, "text/css");
+    }
+    if (req.method === "GET" && path === "/app.js") {
+      return send(res, 200, APP_JS, "text/javascript");
+    }
+    if (req.method === "GET" && path === "/api/state") {
+      return send(res, 200, await getDashboard(false));
+    }
+    if (req.method === "POST" && path === "/api/refresh") {
+      return send(res, 200, await getDashboard(true));
+    }
+    if (req.method === "POST" && path === "/api/mode") {
+      const { mode } = await readBody(req);
+      const prefs = await loadPrefs();
+      if (["review", "issues", "ship"].includes(mode)) prefs.mode = mode;
+      await savePrefs(prefs);
+      const next = await getDashboard(true);
+      broadcastRefresh();
+      return send(res, 200, next);
+    }
+    if (req.method === "POST" && path === "/api/prefs") {
+      // Release milestone + notification preferences + draft visibility. Watched
+      // repos are configured per account via /api/account/repos.
+      const body = await readBody(req);
+      const prefs = await loadPrefs();
+      if (typeof body.release === "string" && body.release.trim()) prefs.release = body.release.trim();
+      if (typeof body.showDrafts === "boolean") prefs.showDrafts = body.showDrafts;
+      if (body.notifications) prefs.notifications = { ...prefs.notifications, ...body.notifications };
+      await savePrefs(prefs);
+      const next = await getDashboard(true);
+      broadcastRefresh();
+      return send(res, 200, next);
+    }
+    if (req.method === "POST" && path === "/api/account/toggle") {
+      const { id, active } = await readBody(req);
+      if (typeof id === "string" && id) {
+        const prefs = await loadPrefs();
+        setAccountActive(prefs, id, !!active);
+        await savePrefs(prefs);
+        invalidateAuth();
+      }
+      const next = await getDashboard(true);
+      broadcastRefresh();
+      return send(res, 200, next);
+    }
+    if (req.method === "POST" && path === "/api/account/repos") {
+      // Persist a single account's watched repos. Deliberately does NOT broadcast:
+      // the iframe that owns the repo editor is mid-edit and a broadcast would
+      // clobber its local draft. The dashboard cache is still recomputed.
+      const { id, repos } = await readBody(req);
+      if (typeof id === "string" && id) {
+        const prefs = await loadPrefs();
+        setAccountRepos(prefs, id, parseRepos(repos));
+        await savePrefs(prefs);
+        invalidateAuth();
+      }
+      const next = await getDashboard(true);
+      return send(res, 200, next);
+    }
+    if (req.method === "POST" && path === "/api/notifications/dismiss") {
+      const { id } = await readBody(req);
+      if (typeof id === "string" && id) {
+        const prefs = await loadPrefs();
+        if (!prefs.dismissedNotifications.includes(id)) {
+          prefs.dismissedNotifications.push(id);
+          await savePrefs(prefs);
+        }
+      }
+      const next = await getDashboard(true);
+      broadcastRefresh();
+      return send(res, 200, next);
+    }
+    if (req.method === "POST" && path === "/api/notifications/dismiss-all") {
+      const prefs = await loadPrefs();
+      const current = await getDashboard(false);
+      const ids = (current.dashboard.notifications || []).map((n) => n.id).filter(Boolean);
+      const set = new Set(prefs.dismissedNotifications);
+      for (const id of ids) set.add(id);
+      prefs.dismissedNotifications = [...set];
+      await savePrefs(prefs);
+      const next = await getDashboard(true);
+      broadcastRefresh();
+      return send(res, 200, next);
+    }
+    if (req.method === "POST" && path === "/api/notifications/restore") {
+      const prefs = await loadPrefs();
+      prefs.dismissedNotifications = [];
+      await savePrefs(prefs);
+      const next = await getDashboard(true);
+      broadcastRefresh();
+      return send(res, 200, next);
+    }
+    if (req.method === "GET" && path === "/api/accounts") {
+      // Re-probe every detected credential against its account's watched repos.
+      const prefs = await loadPrefs();
+      const auth = await resolveAuth(prefs, { reprobe: true });
+      const next = await getDashboard(true);
+      broadcastRefresh();
+      return send(res, 200, { accounts: auth.accounts, ...next });
+    }
+    if (req.method === "POST" && path === "/api/tokens") {
+      // Phase D: capture live Copilot theme tokens from a real canvas render.
+      const tokens = await readBody(req);
+      try {
+        await mkdir(ARTIFACT_DIR, { recursive: true });
+        await writeFile(join(ARTIFACT_DIR, "copilot-tokens.json"), JSON.stringify(tokens, null, 2) + "\n");
+      } catch (e) {
+        log?.(`token capture failed: ${e.message}`);
+      }
+      return send(res, 200, { ok: true });
+    }
+    if (req.method === "GET" && path === "/events") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.write(": connected\n\n");
+      sseClients.add(res);
+      req.on("close", () => sseClients.delete(res));
+      return;
+    }
+    return send(res, 404, { error: "not found" });
+  } catch (e) {
+    log?.(`request error ${path}: ${e.message}`);
+    return send(res, 500, { error: e.message });
+  }
+}
+
+export async function startInstance(instanceId, log) {
+  let entry = servers.get(instanceId);
+  if (entry) return entry;
+  const server = createServer((req, res) => handle(req, res, log));
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  entry = { server, url: `http://127.0.0.1:${port}/` };
+  servers.set(instanceId, entry);
+  return entry;
+}
+
+export async function stopInstance(instanceId) {
+  const entry = servers.get(instanceId);
+  if (!entry) return;
+  servers.delete(instanceId);
+  await new Promise((resolve) => entry.server.close(() => resolve()));
+}
+
+export async function forceRefresh() {
+  const next = await getDashboard(true);
+  broadcastRefresh();
+  return next;
+}
+
+export async function rescanAccounts() {
+  const prefs = await loadPrefs();
+  const auth = await resolveAuth(prefs, { reprobe: true });
+  const next = await getDashboard(true);
+  broadcastRefresh();
+  return { accounts: auth.accounts, activeAccounts: next.dashboard.activeAccounts ?? [], dashboard: next.dashboard };
+}
+
+export async function toggleAccount(id, active) {
+  const prefs = await loadPrefs();
+  setAccountActive(prefs, id, !!active);
+  await savePrefs(prefs);
+  invalidateAuth();
+  const next = await getDashboard(true);
+  broadcastRefresh();
+  return next;
+}
+
+export async function setReposFor(id, repos) {
+  const prefs = await loadPrefs();
+  setAccountRepos(prefs, id, parseRepos(repos));
+  await savePrefs(prefs);
+  invalidateAuth();
+  const next = await getDashboard(true);
+  broadcastRefresh();
+  return next;
+}
+
+export { getDashboard };

--- a/.github/extensions/aspire-team-app/server.mjs
+++ b/.github/extensions/aspire-team-app/server.mjs
@@ -8,9 +8,6 @@
 // repositories and the dashboard interleaves results from all of them.
 
 import { createServer } from "node:http";
-import { mkdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { HTML, STYLES, APP_JS } from "./render.mjs";
 import { loadDashboard } from "./github.mjs";
 import { resolveAccounts } from "./accounts.mjs";
@@ -23,9 +20,6 @@ import {
   setAccountActive,
   activeIds,
 } from "./state.mjs";
-
-const COPILOT_HOME = process.env.COPILOT_HOME || join(homedir(), ".copilot");
-const ARTIFACT_DIR = join(COPILOT_HOME, "extensions", "aspire-team-app", "artifacts");
 
 const servers = new Map(); // instanceId -> { server, url }
 const sseClients = new Set();
@@ -251,17 +245,6 @@ async function handle(req, res, log) {
       const next = await getDashboard(true);
       broadcastRefresh();
       return send(res, 200, { accounts: auth.accounts, ...next });
-    }
-    if (req.method === "POST" && path === "/api/tokens") {
-      // Phase D: capture live Copilot theme tokens from a real canvas render.
-      const tokens = await readBody(req);
-      try {
-        await mkdir(ARTIFACT_DIR, { recursive: true });
-        await writeFile(join(ARTIFACT_DIR, "copilot-tokens.json"), JSON.stringify(tokens, null, 2) + "\n");
-      } catch (e) {
-        log?.(`token capture failed: ${e.message}`);
-      }
-      return send(res, 200, { ok: true });
     }
     if (req.method === "GET" && path === "/events") {
       res.writeHead(200, {

--- a/.github/extensions/aspire-team-app/server.mjs
+++ b/.github/extensions/aspire-team-app/server.mjs
@@ -101,7 +101,11 @@ async function getDashboard(force = false) {
         showDrafts: prefs.showDrafts,
       });
       dashboard.accounts = auth.accounts;
-      dashboard.activeAccounts = active.map((a) => ({ id: a.id, login: a.login, avatarUrl: a.avatarUrl, enterprise: a.enterprise, host: a.host }));
+      // Carry the fields the canvas actions in extension.mjs read back off an active
+      // account: set_repos reads `repos`, and summary reads `sourceKinds`/`status`/`repos`.
+      // Omitting them made set_repos return an empty repo list and summary report
+      // undefined sources/status for active accounts.
+      dashboard.activeAccounts = active.map((a) => ({ id: a.id, login: a.login, avatarUrl: a.avatarUrl, enterprise: a.enterprise, host: a.host, repos: a.repos, status: a.status, sourceKinds: a.sourceKinds }));
       dashboard.dismissedCount = (prefs.dismissedNotifications || []).length;
     }
     cache = { dashboard, prefs };

--- a/.github/extensions/aspire-team-app/server.test.mjs
+++ b/.github/extensions/aspire-team-app/server.test.mjs
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const artifactsRoot = fileURLToPath(new URL("../../../artifacts/copilot-extension-server-tests/", import.meta.url));
+const copilotHome = join(artifactsRoot, "copilot-home");
+const preferencesPath = join(copilotHome, "extensions", "aspire-team-app", "artifacts", "preferences.json");
+const originalEnv = {
+  GH_TOKEN: process.env.GH_TOKEN,
+  GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+  COPILOT_HOME: process.env.COPILOT_HOME,
+  PATH: process.env.PATH,
+};
+const originalFetch = globalThis.fetch;
+
+process.env.COPILOT_HOME = copilotHome;
+
+test.after(async () => {
+  restoreEnvironment();
+  await rm(artifactsRoot, { recursive: true, force: true });
+});
+
+test("mutating POST rejects cross-site loopback requests before saving preferences", async (t) => {
+  await resetTestHome();
+  delete process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  process.env.PATH = "";
+
+  const server = await import(`./server.mjs?test=guard-${Date.now()}`);
+  const entry = await server.startInstance("origin-guard-test", () => {});
+  t.after(() => server.stopInstance("origin-guard-test"));
+
+  const response = await fetch(new URL("api/mode", entry.url), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "http://malicious.example",
+      "sec-fetch-site": "cross-site",
+    },
+    body: JSON.stringify({ mode: "ship" }),
+  });
+
+  assert.equal(response.status, 403);
+  await assert.rejects(readFile(preferencesPath, "utf8"), { code: "ENOENT" });
+});
+
+test("dashboard load retries after an inflight account probe rejection", async (t) => {
+  await resetTestHome({
+    accounts: {
+      "acct:octo": {
+        repos: ["microsoft/aspire"],
+        active: true,
+      },
+    },
+  });
+  process.env.GH_TOKEN = "test-token";
+  delete process.env.GITHUB_TOKEN;
+  process.env.PATH = "";
+
+  let failRepoProbe = true;
+  globalThis.fetch = async (url, options = {}) => {
+    const requestUrl = String(url);
+    if (requestUrl.startsWith("http://127.0.0.1:")) {
+      return originalFetch(url, options);
+    }
+
+    const body = options.body ? JSON.parse(options.body) : {};
+    const query = body.query ?? "";
+
+    if (requestUrl === "https://api.github.com/") {
+      return jsonResponse({}, { headers: { "x-oauth-scopes": "read:org" } });
+    }
+
+    if (query.includes("viewer { login")) {
+      return jsonResponse({ data: { viewer: { login: "octo", avatarUrl: null } } });
+    }
+
+    if (query.includes("r0: repository")) {
+      if (failRepoProbe) {
+        throw new Error("repo probe unavailable");
+      }
+
+      return jsonResponse({ data: { r0: { nameWithOwner: "microsoft/aspire" } } });
+    }
+
+    if (query.includes("pullRequests")) {
+      return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: { nodes: [] } } } });
+    }
+
+    throw new Error(`Unexpected fetch: ${requestUrl} ${query}`);
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const server = await import(`./server.mjs?test=inflight-${Date.now()}`);
+  const entry = await server.startInstance("inflight-retry-test", () => {});
+  t.after(() => server.stopInstance("inflight-retry-test"));
+
+  const failed = await fetch(new URL("api/state", entry.url));
+  assert.equal(failed.status, 500);
+
+  failRepoProbe = false;
+  const retried = await fetch(new URL("api/state", entry.url));
+  assert.equal(retried.status, 200);
+  const payload = await retried.json();
+  assert.equal(payload.dashboard.authenticated, true);
+});
+
+async function resetTestHome(prefs = {}) {
+  await rm(artifactsRoot, { recursive: true, force: true });
+  await mkdir(dirname(preferencesPath), { recursive: true });
+  if (Object.keys(prefs).length > 0) {
+    await writeFile(preferencesPath, JSON.stringify({
+      mode: "review",
+      release: "9.5",
+      showDrafts: false,
+      dismissedNotifications: [],
+      notifications: {
+        reviewRequested: true,
+        readyToMerge: true,
+        changesRequested: true,
+        ciFailing: true,
+      },
+      ...prefs,
+    }, null, 2), "utf8");
+  }
+}
+
+function jsonResponse(body, options = {}) {
+  const headers = options.headers ?? {};
+
+  return {
+    ok: options.ok ?? true,
+    status: options.status ?? 200,
+    statusText: options.statusText ?? "OK",
+    headers: {
+      get(name) {
+        return headers[name.toLowerCase()] ?? null;
+      },
+    },
+    json: async () => body,
+  };
+}
+
+function restoreEnvironment() {
+  setOrDeleteEnv("GH_TOKEN", originalEnv.GH_TOKEN);
+  setOrDeleteEnv("GITHUB_TOKEN", originalEnv.GITHUB_TOKEN);
+  setOrDeleteEnv("COPILOT_HOME", originalEnv.COPILOT_HOME);
+  setOrDeleteEnv("PATH", originalEnv.PATH);
+  globalThis.fetch = originalFetch;
+}
+
+function setOrDeleteEnv(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/.github/extensions/aspire-team-app/state.mjs
+++ b/.github/extensions/aspire-team-app/state.mjs
@@ -1,0 +1,130 @@
+// Durable preferences for the Aspire Team App canvas.
+//
+// Watched repos and notification settings follow the user across sessions, so per
+// the canvas state model they live under $COPILOT_HOME/extensions/<name>/artifacts/
+// rather than being keyed by the transient instanceId.
+//
+// Repositories are configured *per GitHub account* (keyed by account id), so each
+// account watches its own set and any number of accounts can be active at once.
+// Results from every active account are interleaved into the same tabs.
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_REPOS, CURRENT_RELEASE } from "./github.mjs";
+
+const COPILOT_HOME = process.env.COPILOT_HOME || join(homedir(), ".copilot");
+const ARTIFACT_DIR = join(COPILOT_HOME, "extensions", "aspire-team-app", "artifacts");
+const PREFS_FILE = join(ARTIFACT_DIR, "preferences.json");
+
+export const DEFAULT_NOTIFICATIONS = {
+  reviewRequested: true,
+  readyToMerge: true,
+  changesRequested: true,
+  ciFailing: true,
+};
+
+export const DEFAULT_PREFS = {
+  mode: "review",
+  release: CURRENT_RELEASE,
+  showDrafts: false,
+  dismissedNotifications: [],
+  notifications: { ...DEFAULT_NOTIFICATIONS },
+  // Per-account configuration keyed by account id ("acct:<login>"):
+  //   { [id]: { repos: string[], active: boolean } }
+  accounts: {},
+};
+
+function normalizeAccounts(raw) {
+  const out = {};
+  if (!raw || typeof raw !== "object") return out;
+  for (const [id, cfg] of Object.entries(raw)) {
+    const repos = Array.isArray(cfg?.repos) && cfg.repos.length ? cfg.repos : [...DEFAULT_REPOS];
+    out[id] = { repos: [...new Set(repos)], active: !!cfg?.active };
+  }
+  return out;
+}
+
+function migrate(parsed) {
+  const prefs = {
+    ...DEFAULT_PREFS,
+    ...parsed,
+    showDrafts: !!parsed.showDrafts,
+    notifications: { ...DEFAULT_NOTIFICATIONS, ...(parsed.notifications ?? {}) },
+    dismissedNotifications: Array.isArray(parsed.dismissedNotifications) ? parsed.dismissedNotifications : [],
+    accounts: normalizeAccounts(parsed.accounts),
+  };
+  // Upgrade the legacy single-account shape ({ repos, account }) to the per-account map.
+  if (Object.keys(prefs.accounts).length === 0 && parsed.account) {
+    const repos = Array.isArray(parsed.repos) && parsed.repos.length ? parsed.repos : [...DEFAULT_REPOS];
+    prefs.accounts[parsed.account] = { repos: [...new Set(repos)], active: true };
+  }
+  delete prefs.repos;
+  delete prefs.account;
+  return prefs;
+}
+
+export async function loadPrefs() {
+  try {
+    const raw = await readFile(PREFS_FILE, "utf8");
+    return migrate(JSON.parse(raw));
+  } catch {
+    return {
+      ...DEFAULT_PREFS,
+      notifications: { ...DEFAULT_NOTIFICATIONS },
+      dismissedNotifications: [],
+      accounts: {},
+    };
+  }
+}
+
+export async function savePrefs(prefs) {
+  await mkdir(ARTIFACT_DIR, { recursive: true });
+  await writeFile(PREFS_FILE, JSON.stringify(prefs, null, 2) + "\n", "utf8");
+  return prefs;
+}
+
+// ---------------------------------------------------------------------------
+// Per-account helpers
+// ---------------------------------------------------------------------------
+
+export function accountConfig(prefs, id) {
+  const cfg = prefs.accounts?.[id];
+  return {
+    repos: Array.isArray(cfg?.repos) && cfg.repos.length ? cfg.repos : [...DEFAULT_REPOS],
+    active: !!cfg?.active,
+    // Whether the user has ever explicitly configured this account.
+    configured: !!cfg,
+  };
+}
+
+export function setAccountRepos(prefs, id, repos) {
+  if (!prefs.accounts) prefs.accounts = {};
+  const cfg = accountConfig(prefs, id);
+  const clean = [...new Set((Array.isArray(repos) ? repos : []).map((r) => String(r).trim()).filter(Boolean))];
+  prefs.accounts[id] = { repos: clean.length ? clean : [...DEFAULT_REPOS], active: cfg.active };
+  return prefs;
+}
+
+export function setAccountActive(prefs, id, active) {
+  if (!prefs.accounts) prefs.accounts = {};
+  const cfg = accountConfig(prefs, id);
+  prefs.accounts[id] = { repos: cfg.repos, active: !!active };
+  return prefs;
+}
+
+export function activeIds(prefs) {
+  return Object.entries(prefs.accounts || {})
+    .filter(([, c]) => c && c.active)
+    .map(([id]) => id);
+}
+
+export function parseRepos(value, fallback = DEFAULT_REPOS) {
+  const source = Array.isArray(value) ? value.join(" ") : String(value || "");
+  const repos = source
+    .split(/[,\s]+/)
+    .map((r) => r.trim())
+    .filter(Boolean);
+  const unique = [...new Set(repos)];
+  return unique.length > 0 ? unique : [...fallback];
+}

--- a/.github/extensions/aspire-team-app/state.mjs
+++ b/.github/extensions/aspire-team-app/state.mjs
@@ -30,7 +30,7 @@ export const DEFAULT_PREFS = {
   showDrafts: false,
   dismissedNotifications: [],
   notifications: { ...DEFAULT_NOTIFICATIONS },
-  // Per-account configuration keyed by account id ("acct:<login>"):
+  // Per-account configuration keyed by account id ("acct:<host>/<login>"):
   //   { [id]: { repos: string[], active: boolean } }
   accounts: {},
 };
@@ -43,6 +43,12 @@ function normalizeAccounts(raw) {
     out[id] = { repos: [...new Set(repos)], active: !!cfg?.active };
   }
   return out;
+}
+
+function legacyIdFor(id) {
+  const prefix = "acct:github.com/";
+  const value = String(id || "").toLowerCase();
+  return value.startsWith(prefix) ? `acct:${value.slice(prefix.length)}` : null;
 }
 
 function migrate(parsed) {
@@ -88,8 +94,8 @@ export async function savePrefs(prefs) {
 // Per-account helpers
 // ---------------------------------------------------------------------------
 
-export function accountConfig(prefs, id) {
-  const cfg = prefs.accounts?.[id];
+export function accountConfig(prefs, id, legacyId = legacyIdFor(id)) {
+  const cfg = prefs.accounts?.[id] ?? (legacyId ? prefs.accounts?.[legacyId] : undefined);
   return {
     repos: Array.isArray(cfg?.repos) && cfg.repos.length ? cfg.repos : [...DEFAULT_REPOS],
     active: !!cfg?.active,
@@ -100,16 +106,20 @@ export function accountConfig(prefs, id) {
 
 export function setAccountRepos(prefs, id, repos) {
   if (!prefs.accounts) prefs.accounts = {};
-  const cfg = accountConfig(prefs, id);
+  const legacyId = legacyIdFor(id);
+  const cfg = accountConfig(prefs, id, legacyId);
   const clean = [...new Set((Array.isArray(repos) ? repos : []).map((r) => String(r).trim()).filter(Boolean))];
   prefs.accounts[id] = { repos: clean.length ? clean : [...DEFAULT_REPOS], active: cfg.active };
+  if (legacyId) delete prefs.accounts[legacyId];
   return prefs;
 }
 
 export function setAccountActive(prefs, id, active) {
   if (!prefs.accounts) prefs.accounts = {};
-  const cfg = accountConfig(prefs, id);
+  const legacyId = legacyIdFor(id);
+  const cfg = accountConfig(prefs, id, legacyId);
   prefs.accounts[id] = { repos: cfg.repos, active: !!active };
+  if (legacyId) delete prefs.accounts[legacyId];
   return prefs;
 }
 

--- a/.github/extensions/aspire-team-app/state.test.mjs
+++ b/.github/extensions/aspire-team-app/state.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { accountConfig, setAccountActive, setAccountRepos } from "./state.mjs";
+
+test("setAccountActive preserves legacy login-only repos when writing the host-scoped id", () => {
+  const prefs = {
+    accounts: {
+      "acct:octo": { repos: ["microsoft/aspire.dev"], active: false },
+    },
+  };
+
+  setAccountActive(prefs, "acct:github.com/octo", true);
+
+  assert.deepEqual(prefs.accounts["acct:github.com/octo"], { repos: ["microsoft/aspire.dev"], active: true });
+  assert.equal(prefs.accounts["acct:octo"], undefined);
+});
+
+test("setAccountRepos preserves legacy login-only active state when writing the host-scoped id", () => {
+  const prefs = {
+    accounts: {
+      "acct:octo": { repos: ["microsoft/aspire.dev"], active: true },
+    },
+  };
+
+  setAccountRepos(prefs, "acct:github.com/octo", ["microsoft/dcp"]);
+
+  assert.deepEqual(prefs.accounts["acct:github.com/octo"], { repos: ["microsoft/dcp"], active: true });
+  assert.equal(prefs.accounts["acct:octo"], undefined);
+});
+
+test("accountConfig reads legacy login-only prefs for github.com host-scoped ids", () => {
+  const prefs = {
+    accounts: {
+      "acct:octo": { repos: ["microsoft/aspire.dev"], active: true },
+    },
+  };
+
+  assert.deepEqual(accountConfig(prefs, "acct:github.com/octo"), {
+    repos: ["microsoft/aspire.dev"],
+    active: true,
+    configured: true,
+  });
+});

--- a/.github/extensions/validate-extensions.mjs
+++ b/.github/extensions/validate-extensions.mjs
@@ -1,0 +1,151 @@
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { basename, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const extensionRoot = fileURLToPath(new URL(".", import.meta.url));
+
+export async function validateExtensions(root = extensionRoot) {
+  const resolvedRoot = resolve(root);
+  const files = await listFiles(resolvedRoot);
+  const manifests = files.filter((file) => basename(file) === "copilot-extension.json");
+  const mjsFiles = files.filter((file) => file.endsWith(".mjs"));
+  const imported = [];
+
+  if (manifests.length === 0) {
+    throw new Error(`${formatPath(resolvedRoot, resolvedRoot)}: no copilot-extension.json manifests found`);
+  }
+
+  for (const manifest of manifests) {
+    await validateManifest(resolvedRoot, manifest);
+  }
+
+  for (const file of mjsFiles) {
+    await checkSyntax(resolvedRoot, file);
+  }
+
+  for (const file of mjsFiles) {
+    const source = await readFile(file, "utf8");
+    const relativePath = formatPath(resolvedRoot, file);
+    if (!shouldDynamicallyImport(relativePath, source)) {
+      continue;
+    }
+
+    await import(`${pathToFileURL(file).href}?validate=${process.pid}-${imported.length}`);
+    imported.push(relativePath);
+  }
+
+  return {
+    manifests: manifests.length,
+    checked: mjsFiles.length,
+    imported,
+  };
+}
+
+export async function runExtensionTests(root = extensionRoot) {
+  const resolvedRoot = resolve(root);
+  const files = await listFiles(resolvedRoot);
+  const tests = files
+    .filter((file) => file.endsWith(".test.mjs"))
+    .map((file) => formatPath(resolvedRoot, file))
+    .sort();
+
+  if (tests.length === 0) {
+    return { tests: 0 };
+  }
+
+  await execFileAsync(process.execPath, ["--test", "--test-concurrency=1", ...tests], { cwd: resolvedRoot });
+  return { tests: tests.length };
+}
+
+export function shouldDynamicallyImport(relativePath, source) {
+  const normalized = relativePath.replaceAll("\\", "/");
+
+  if (normalized === "validate-extensions.mjs" || normalized.endsWith(".test.mjs")) {
+    return false;
+  }
+
+  // Canvas entrypoints call joinSession at module scope and depend on the Copilot
+  // host SDK being injected by the extension runtime. Syntax-check them, but only
+  // import leaf/support modules that are safe in a plain Node process.
+  if (source.includes("@github/copilot-sdk/extension") || source.includes("joinSession(")) {
+    return false;
+  }
+
+  return true;
+}
+
+async function validateManifest(root, manifest) {
+  const relativePath = formatPath(root, manifest);
+  let parsed;
+
+  try {
+    parsed = JSON.parse(await readFile(manifest, "utf8"));
+  } catch (error) {
+    throw new Error(`${relativePath}: invalid JSON: ${error.message}`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${relativePath}: manifest must be a JSON object`);
+  }
+
+  if (typeof parsed.name !== "string" || parsed.name.trim().length === 0) {
+    throw new Error(`${relativePath}: "name" must be a non-empty string`);
+  }
+
+  if (!Number.isInteger(parsed.version) || parsed.version <= 0) {
+    throw new Error(`${relativePath}: "version" must be a positive integer`);
+  }
+}
+
+async function checkSyntax(root, file) {
+  try {
+    await execFileAsync(process.execPath, ["--check", file], { cwd: root });
+  } catch (error) {
+    const detail = [error.stderr, error.stdout].filter(Boolean).join("\n").trim();
+    throw new Error(`${formatPath(root, file)}: node --check failed${detail ? `\n${detail}` : ""}`);
+  }
+}
+
+async function listFiles(root) {
+  const files = [];
+
+  async function walk(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      const fullPath = resolve(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name.startsWith(".test-")) {
+          continue;
+        }
+
+        await walk(fullPath);
+      } else if (entry.isFile()) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  await walk(root);
+  return files;
+}
+
+function formatPath(root, file) {
+  const formatted = relative(root, file).split(sep).join("/");
+  return formatted || ".";
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  try {
+    const validation = await validateExtensions();
+    const tests = await runExtensionTests();
+    console.log(`Validated ${validation.manifests} manifest(s), ${validation.checked} module(s), imported ${validation.imported.length} safe module(s), ran ${tests.tests} test file(s).`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/.github/extensions/validate-extensions.mjs
+++ b/.github/extensions/validate-extensions.mjs
@@ -56,7 +56,17 @@ export async function runExtensionTests(root = extensionRoot) {
     return { tests: 0 };
   }
 
-  await execFileAsync(process.execPath, ["--test", "--test-concurrency=1", ...tests], { cwd: resolvedRoot });
+  try {
+    await execFileAsync(process.execPath, ["--test", "--test-concurrency=1", ...tests], { cwd: resolvedRoot });
+  } catch (error) {
+    // node:test writes the failing-test report (assertion diffs, stack traces) to the
+    // child's stdout as it runs; execFileAsync only rejects with an opaque
+    // "Command failed: node --test ..." message. Surface the captured stdout (and any
+    // stderr) so the actual test failure is visible instead of the bare exit code.
+    // stdout first because that is where the failure detail lives.
+    const detail = [error.stdout, error.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(`extension tests failed${detail ? `\n${detail}` : ""}`);
+  }
   return { tests: tests.length };
 }
 

--- a/.github/extensions/validate-extensions.test.mjs
+++ b/.github/extensions/validate-extensions.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { shouldDynamicallyImport, validateExtensions } from "./validate-extensions.mjs";
+
+const fixturesRoot = fileURLToPath(new URL("../../artifacts/copilot-extension-validator-tests/", import.meta.url));
+
+test.after(async () => {
+  await rm(fixturesRoot, { recursive: true, force: true });
+});
+
+test("validateExtensions parses manifests, checks syntax, and imports safe modules", async () => {
+  await resetFixtures();
+  await writeFile(join(fixturesRoot, "sample", "copilot-extension.json"), JSON.stringify({ name: "sample", version: 1 }), "utf8");
+  await writeFile(join(fixturesRoot, "sample", "safe.mjs"), "export const value = 42;\n", "utf8");
+  await writeFile(join(fixturesRoot, "sample", "extension.mjs"), "import { joinSession } from '@github/copilot-sdk/extension';\nexport const value = joinSession;\n", "utf8");
+
+  const result = await validateExtensions(fixturesRoot);
+
+  assert.equal(result.manifests, 1);
+  assert.equal(result.checked, 2);
+  assert.deepEqual(result.imported.map((file) => file.replaceAll("\\", "/")), ["sample/safe.mjs"]);
+});
+
+test("validateExtensions rejects malformed manifests", async () => {
+  await resetFixtures();
+  await writeFile(join(fixturesRoot, "broken", "copilot-extension.json"), JSON.stringify({ name: "", version: "1" }), "utf8");
+
+  await assert.rejects(
+    validateExtensions(fixturesRoot),
+    /copilot-extension\.json: "name" must be a non-empty string/,
+  );
+});
+
+test("shouldDynamicallyImport skips extension entrypoints with host SDK side effects", () => {
+  assert.equal(shouldDynamicallyImport("sample/safe.mjs", "export const value = 1;"), true);
+  assert.equal(shouldDynamicallyImport("sample/server.test.mjs", "import test from 'node:test';"), false);
+  assert.equal(shouldDynamicallyImport("sample/extension.mjs", "import { joinSession } from '@github/copilot-sdk/extension';"), false);
+});
+
+async function resetFixtures() {
+  await rm(fixturesRoot, { recursive: true, force: true });
+  await mkdir(join(fixturesRoot, "sample"), { recursive: true });
+  await mkdir(join(fixturesRoot, "broken"), { recursive: true });
+}

--- a/.github/extensions/validate-extensions.test.mjs
+++ b/.github/extensions/validate-extensions.test.mjs
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { shouldDynamicallyImport, validateExtensions } from "./validate-extensions.mjs";
+import { runExtensionTests, shouldDynamicallyImport, validateExtensions } from "./validate-extensions.mjs";
 
 const fixturesRoot = fileURLToPath(new URL("../../artifacts/copilot-extension-validator-tests/", import.meta.url));
 
@@ -39,6 +39,41 @@ test("shouldDynamicallyImport skips extension entrypoints with host SDK side eff
   assert.equal(shouldDynamicallyImport("sample/safe.mjs", "export const value = 1;"), true);
   assert.equal(shouldDynamicallyImport("sample/server.test.mjs", "import test from 'node:test';"), false);
   assert.equal(shouldDynamicallyImport("sample/extension.mjs", "import { joinSession } from '@github/copilot-sdk/extension';"), false);
+});
+
+test("runExtensionTests surfaces a failing child test's output instead of a bare exit code", async () => {
+  await resetFixtures();
+  const runnerRoot = join(fixturesRoot, "runner");
+  await mkdir(runnerRoot, { recursive: true });
+  await writeFile(
+    join(runnerRoot, "boom.test.mjs"),
+    "import test from 'node:test';\nimport assert from 'node:assert/strict';\ntest('surfaced-failure-marker', () => { assert.equal(1, 2); });\n",
+    "utf8",
+  );
+
+  // Production runs `node validate-extensions.mjs` standalone. This test, however,
+  // runs under `node --test`, which exports NODE_TEST_CONTEXT=child-v8. The nested
+  // `node --test` that runExtensionTests spawns would inherit it, switch into
+  // child-reporter mode, stream TAP to us, and exit 0 -- hiding the failure the fix
+  // is meant to surface. Clear it so the child runs like the real standalone
+  // invocation; restore it afterward so the outer runner keeps reporting normally.
+  const savedTestContext = process.env.NODE_TEST_CONTEXT;
+  delete process.env.NODE_TEST_CONTEXT;
+  try {
+    await assert.rejects(
+      runExtensionTests(runnerRoot),
+      (error) => {
+        // The child's TAP stream names the failing test; asserting on it proves the
+        // captured stdout was surfaced rather than the opaque "Command failed" message.
+        assert.match(error.message, /surfaced-failure-marker/);
+        return true;
+      },
+    );
+  } finally {
+    if (savedTestContext !== undefined) {
+      process.env.NODE_TEST_CONTEXT = savedTestContext;
+    }
+  }
 });
 
 async function resetFixtures() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,12 +181,33 @@ jobs:
           path: artifacts/log
           retention-days: 5
 
+  copilot_extensions_validation:
+    name: Copilot Extension Validation
+    runs-on: ubuntu-latest
+    needs: [prepare_for_ci]
+    if: ${{ github.repository_owner == 'microsoft' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+
+      - name: Validate Copilot extensions
+        run: node .github/extensions/validate-extensions.mjs
+
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:
     if: ${{ always() && github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [prepare_for_ci, tests, stabilization_check]
+    needs: [prepare_for_ci, tests, stabilization_check, copilot_extensions_validation]
 
     steps:
       - name: Fail if any of the dependent jobs failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,33 +181,12 @@ jobs:
           path: artifacts/log
           retention-days: 5
 
-  copilot_extensions_validation:
-    name: Copilot Extension Validation
-    runs-on: ubuntu-latest
-    needs: [prepare_for_ci]
-    if: ${{ github.repository_owner == 'microsoft' && needs.prepare_for_ci.outputs.skip_workflow != 'true' }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: '22'
-
-      - name: Validate Copilot extensions
-        run: node .github/extensions/validate-extensions.mjs
-
   # This job is used for branch protection. It fails if any of the dependent jobs failed
   results:
     if: ${{ always() && github.repository_owner == 'microsoft' }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [prepare_for_ci, tests, stabilization_check, copilot_extensions_validation]
+    needs: [prepare_for_ci, tests, stabilization_check]
 
     steps:
       - name: Fail if any of the dependent jobs failed

--- a/.github/workflows/validate-copilot-extensions.yml
+++ b/.github/workflows/validate-copilot-extensions.yml
@@ -30,22 +30,4 @@ jobs:
       with:
         node-version: 20.x
     - name: Validate extension modules and manifests
-      shell: bash
-      run: |
-        set -euo pipefail
-        status=0
-
-        # node --check parses each module and reports syntax / import-statement errors
-        # without resolving imports, which is enough to catch a broken .mjs before merge.
-        while IFS= read -r -d '' file; do
-          echo "node --check $file"
-          node --check "$file" || status=1
-        done < <(find .github/extensions -type f \( -name '*.mjs' -o -name '*.js' \) -print0)
-
-        # Every copilot-extension.json manifest must parse as JSON.
-        while IFS= read -r -d '' file; do
-          echo "validate manifest $file"
-          node -e "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))" "$file" || status=1
-        done < <(find .github/extensions -type f -name 'copilot-extension.json' -print0)
-
-        exit $status
+      run: node .github/extensions/validate-extensions.mjs

--- a/.github/workflows/validate-copilot-extensions.yml
+++ b/.github/workflows/validate-copilot-extensions.yml
@@ -1,0 +1,51 @@
+name: Validate Copilot extensions
+
+permissions:
+  contents: read
+
+# Copilot canvas extensions under .github/extensions/ are multi-file JS module graphs
+# plus a JSON manifest that no other repo check parses, so a syntax, import-syntax, or
+# manifest break could otherwise merge unnoticed. Only run when those files change.
+on:
+  pull_request:
+    paths:
+      - '.github/extensions/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/extensions/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'microsoft' }}
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Use Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: 20.x
+    - name: Validate extension modules and manifests
+      shell: bash
+      run: |
+        set -euo pipefail
+        status=0
+
+        # node --check parses each module and reports syntax / import-statement errors
+        # without resolving imports, which is enough to catch a broken .mjs before merge.
+        while IFS= read -r -d '' file; do
+          echo "node --check $file"
+          node --check "$file" || status=1
+        done < <(find .github/extensions -type f \( -name '*.mjs' -o -name '*.js' \) -print0)
+
+        # Every copilot-extension.json manifest must parse as JSON.
+        while IFS= read -r -d '' file; do
+          echo "validate manifest $file"
+          node -e "JSON.parse(require('node:fs').readFileSync(process.argv[1], 'utf8'))" "$file" || status=1
+        done < <(find .github/extensions -type f -name 'copilot-extension.json' -print0)
+
+        exit $status


### PR DESCRIPTION
Adds a single, self-contained GitHub Copilot canvas extension, Aspire Team App, that gives the logged-in GitHub user a cross-repo PR review queue directly inside the Copilot app.

## What

Aspire Team App is a Copilot canvas extension that recreates the davidfowl/pr-dashboard cross-repo PR review queue logic. It surfaces the pull requests that matter to the logged-in user across the repos they work in, and organizes them into three focused modes:

- **Review** · PRs waiting on the user's review, ranked by signal.
- **Issues** · related issues surfaced alongside the review flow.
- **Ship** · PRs that are ready to merge.

Additional behavior carried over from the dashboard:

- **Signal pills** that summarize each item's state (checks, review status, conflicts, staleness) at a glance.
- **Notifications** so the queue reflects fresh activity.
- **Multi-account** aware, so users with more than one GitHub account see the right queue.
- **Enterprise-aware**, so GitHub Enterprise hosts are handled correctly.

## Screens

<img width="1954" height="1380" alt="image" src="https://github.com/user-attachments/assets/c2731e9b-8afe-4c08-9090-158fe388218b" />

<img width="1954" height="1380" alt="image" src="https://github.com/user-attachments/assets/b6c38930-2226-4368-990a-ba3b565eadea" />

<img width="1953" height="1380" alt="image" src="https://github.com/user-attachments/assets/838fa00d-c206-4cc0-8236-112a13d405de" />

<img width="1954" height="1380" alt="image" src="https://github.com/user-attachments/assets/7cb62dc8-20b2-472a-ab6e-221676904011" />

<img width="1954" height="1380" alt="image" src="https://github.com/user-attachments/assets/072679d2-077f-413e-a263-01e141f43f05" />

## Where

The extension lives under `.github/extensions/aspire-team-app/` as a project extension. It is auto-discovered by the Copilot app the same way the existing `.github/extensions/issue-triage-canvas/` extension is, so no additional wiring is required. This follows the established project-canvas convention already present in the repo.

## Files

- `.github/extensions/aspire-team-app/accounts.mjs`
- `.github/extensions/aspire-team-app/constants.mjs`
- `.github/extensions/aspire-team-app/copilot-extension.json`
- `.github/extensions/aspire-team-app/extension.mjs`
- `.github/extensions/aspire-team-app/github.mjs`
- `.github/extensions/aspire-team-app/model.mjs`
- `.github/extensions/aspire-team-app/README.md`
- `.github/extensions/aspire-team-app/render.mjs`
- `.github/extensions/aspire-team-app/server.mjs`
- `.github/extensions/aspire-team-app/state.mjs`

## Notes

This change is additive and limited to the new extension folder only. Each `.mjs` file was validated with `node --check`. Opened as a **Draft** for team review before it goes ready.
