### PR TITLE
Fix detached aspire start backchannel hash mismatch on symlinked paths (#18566 follow-up)

### DIFF
--- a/src/Aspire.Cli/Commands/AppHostLauncher.cs
+++ b/src/Aspire.Cli/Commands/AppHostLauncher.cs
@@ -15,6 +15,7 @@ using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Commands;
@@ -138,12 +139,16 @@ internal sealed class AppHostLauncher(
         executionContext.AppHostCliLogFilePath = childLogFile;
         var (executablePath, childArgs) = BuildChildProcessArgs(effectiveAppHostFile, childLogFile, isolated, globalArgs, additionalArgs);
 
-        // Compute the expected socket prefix for backchannel detection
+        // Compute the expected socket prefix for backchannel detection. The AppHost keys its
+        // auxiliary backchannel socket file on the symlink-resolved AppHost path, so the primary
+        // hash we wait on must also be computed from the resolved path (see ComputeDetachedMatchHashes).
+        var socketKeyPath = PathNormalizer.ResolveSymlinks(effectiveAppHostFile.FullName);
         var expectedSocketPrefix = AppHostHelper.ComputeAuxiliarySocketPrefix(
+            socketKeyPath,
+            executionContext.HomeDirectory.FullName);
+        var (expectedHash, legacyHashes) = ComputeDetachedMatchHashes(
             effectiveAppHostFile.FullName,
             executionContext.HomeDirectory.FullName);
-        var expectedHash = AppHostHelper.ExtractHashFromSocketPath(expectedSocketPrefix)!;
-        var legacyHashes = AppHostHelper.ComputeLegacyHashes(effectiveAppHostFile.FullName);
 
         logger.LogDebug("Waiting for socket with prefix: {SocketPrefix}, Hash: {Hash}", expectedSocketPrefix, expectedHash);
         if (legacyHashes.Length > 0)
@@ -225,6 +230,58 @@ internal sealed class AppHostLauncher(
                 throw;
             }
         }
+    }
+
+    /// <summary>
+    /// Computes the primary and fallback auxiliary-backchannel socket hashes used to match a
+    /// detached AppHost's backchannel connection during launch.
+    /// </summary>
+    /// <remarks>
+    /// The AppHost keys its auxiliary backchannel socket <em>file name</em> on the symlink-resolved
+    /// AppHost path (see <c>AuxiliaryBackchannelService.GetSocketKeyAppHostPath</c> in Aspire.Hosting),
+    /// and <see cref="Backchannel.AuxiliaryBackchannelMonitor"/> keys discovered connections by the
+    /// hash embedded in that file name. The OS reports the AppHost path in its physical form
+    /// (for example, on macOS <c>/var/folders/...</c> is a symlink to <c>/private/var/folders/...</c>),
+    /// which is exactly what the AppHost hashes — so the CLI must hash the <em>resolved</em> path to
+    /// compute the primary hash it waits on. Without this, a detached <c>aspire start</c> from a
+    /// symlinked temp path (the default on macOS) never matches the AppHost's socket and times out.
+    /// <para>
+    /// The fallback set keeps the raw (unresolved) path's hashes so the CLI still matches AppHosts /
+    /// instances that keyed their socket on the unresolved path — most importantly an AppHost built
+    /// against an older <c>Aspire.Hosting</c> that predates the symlink-resolved socket key, or a path
+    /// with no symlinks where resolved == raw. Two distinct hash spaces are searched: the compact
+    /// AppHost id used by current socket file names, and the legacy hex hashes used by
+    /// <c>auxi.sock.{hash}</c>-style names (<see cref="AppHostHelper.ComputeLegacyHashes"/>).
+    /// </para>
+    /// </remarks>
+    /// <param name="appHostPath">The AppHost project file or assembly path as supplied to the CLI.</param>
+    /// <param name="homeDirectory">The user's home directory.</param>
+    /// <returns>
+    /// The primary expected hash (the compact AppHost id of the resolved path) and the de-duplicated
+    /// fallback hashes to also search: the compact AppHost id of the raw path plus the legacy hex
+    /// hashes of both the resolved and raw paths (including any Windows drive-letter casing variants).
+    /// </returns>
+    internal static (string ExpectedHash, string[] FallbackHashes) ComputeDetachedMatchHashes(string appHostPath, string homeDirectory)
+    {
+        var socketKeyPath = PathNormalizer.ResolveSymlinks(appHostPath);
+
+        var expectedHash = AppHostHelper.ExtractHashFromSocketPath(
+            AppHostHelper.ComputeAuxiliarySocketPrefix(socketKeyPath, homeDirectory))!;
+
+        // Current socket file names embed the compact AppHost id (a different hash space than the
+        // legacy hex hashes below), so include the raw path's compact id explicitly. This is what
+        // matches a still-running AppHost that keyed its socket on the unresolved path before the
+        // AppHost side started resolving symlinks.
+        var rawCompactHash = AppHostHelper.ExtractHashFromSocketPath(
+            AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPath, homeDirectory))!;
+
+        var fallbackHashes = new[] { rawCompactHash }
+            .Concat(AppHostHelper.ComputeLegacyHashes(socketKeyPath))
+            .Concat(AppHostHelper.ComputeLegacyHashes(appHostPath))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return (expectedHash, fallbackHashes);
     }
 
     private async Task StopExistingInstancesAsync(FileInfo effectiveAppHostFile, CancellationToken cancellationToken)

--- a/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/AppHostLauncherTests.cs
@@ -16,6 +16,7 @@ using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Telemetry;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Hosting;
+using Aspire.Hosting.Backchannel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -65,6 +66,57 @@ public class AppHostLauncherTests(ITestOutputHelper outputHelper)
         Assert.StartsWith("cli_20260212T180000000_detach-child_", fileName, StringComparison.Ordinal);
         Assert.EndsWith(".log", fileName, StringComparison.Ordinal);
         Assert.DoesNotContain($"_{Environment.ProcessId}", fileName, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComputeDetachedMatchHashes_ResolvesSymlinkForPrimaryHash_AndKeepsRawHashInFallback()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var homeDirectory = workspace.WorkspaceRoot.FullName;
+
+        // Reference the same AppHost through a directory symlink ("link" -> "real"). This mirrors the
+        // macOS temp-path shape (/var/folders/... is a symlink to /private/var/folders/...) that made
+        // detached `aspire start` wait on a hash the AppHost never used.
+        var realDirectory = workspace.WorkspaceRoot.CreateSubdirectory("real");
+        var symlinkDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "link");
+        Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+
+        var realProjectPath = Path.Combine(realDirectory.FullName, "AppHost.csproj");
+        File.WriteAllText(realProjectPath, "<Project />");
+        var appHostPathViaSymlink = Path.Combine(symlinkDirectory, "AppHost.csproj");
+
+        var resolvedPath = PathNormalizer.ResolveSymlinks(appHostPathViaSymlink);
+        // The test is only meaningful when resolution actually rewrites the path.
+        Assert.NotEqual(appHostPathViaSymlink, resolvedPath);
+
+        var resolvedPathHash = AppHostHelper.ExtractHashFromSocketPath(
+            AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedPath, homeDirectory))!;
+        var rawPathHash = AppHostHelper.ExtractHashFromSocketPath(
+            AppHostHelper.ComputeAuxiliarySocketPrefix(appHostPathViaSymlink, homeDirectory))!;
+        var rawFallbackHashes = AppHostHelper.ComputeLegacyHashes(appHostPathViaSymlink);
+        var resolvedFallbackHashes = AppHostHelper.ComputeLegacyHashes(resolvedPath);
+
+        var (expectedHash, fallbackHashes) = AppHostLauncher.ComputeDetachedMatchHashes(appHostPathViaSymlink, homeDirectory);
+
+        // The primary hash is computed from the resolved path — the value the AppHost actually keys
+        // its socket on — and therefore differs from the raw-path hash the buggy code waited on.
+        Assert.Equal(resolvedPathHash, expectedHash);
+        Assert.NotEqual(rawPathHash, expectedHash);
+
+        // The fallback set keeps the raw path's compact hash so an AppHost still keyed on the
+        // unresolved path continues to match, plus the legacy hex hashes of both paths.
+        Assert.Contains(rawPathHash, fallbackHashes);
+        Assert.Contains(rawFallbackHashes[0], fallbackHashes);
+        Assert.Contains(resolvedFallbackHashes[0], fallbackHashes);
+
+        // Cross-side agreement: the AppHost builds its socket file name with the same shared code,
+        // keyed on the resolved path (AuxiliaryBackchannelService resolves symlinks before naming the
+        // socket via ComputeSocketPath, which embeds ComputeAppHostId(resolvedPath)). The CLI's
+        // primary hash must equal that embedded id so it waits on exactly the AppHost's socket.
+        Assert.Equal(BackchannelConstants.ComputeAppHostId(resolvedPath), expectedHash);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/AppHostHelperTests.cs
@@ -440,6 +440,43 @@ public class AppHostHelperTests(ITestOutputHelper outputHelper)
         Assert.Collection(remainingSockets, socket => Assert.Equal(liveSocket, socket));
     }
 
+    [Fact]
+    public void ComputeAuxiliarySocketPrefix_ResolvedSymlinkPath_MatchesRealTargetPrefix()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Symlink resolution test only runs on Linux/macOS where unprivileged symlink creation is reliable.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var homeDirectory = workspace.WorkspaceRoot.FullName;
+
+        // Build a directory symlink ("link" -> "real") and reference the same on-disk AppHost
+        // through both paths. This reproduces the macOS temp-path shape where /var/folders/...
+        // is a symlink to /private/var/folders/..., so the symlinked and real paths are the same
+        // file but differ textually.
+        var realDirectory = workspace.WorkspaceRoot.CreateSubdirectory("real");
+        var symlinkDirectory = Path.Combine(workspace.WorkspaceRoot.FullName, "link");
+        Directory.CreateSymbolicLink(symlinkDirectory, realDirectory.FullName);
+
+        var realProjectPath = Path.Combine(realDirectory.FullName, "TestAppHost.csproj");
+        File.WriteAllText(realProjectPath, "<Project />");
+        var projectFileViaSymlink = Path.Combine(symlinkDirectory, "TestAppHost.csproj");
+
+        // The AppHost keys its auxiliary backchannel socket on the symlink-resolved path, so the CLI
+        // must resolve the symlinked path to arrive at the same socket prefix as the real target.
+        var resolvedViaSymlink = PathNormalizer.ResolveSymlinks(projectFileViaSymlink);
+        var resolvedRealTarget = PathNormalizer.ResolveSymlinks(realProjectPath);
+        Assert.Equal(resolvedRealTarget, resolvedViaSymlink);
+
+        var prefixViaResolvedSymlink = AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedViaSymlink, homeDirectory);
+        var prefixForRealTarget = AppHostHelper.ComputeAuxiliarySocketPrefix(resolvedRealTarget, homeDirectory);
+        Assert.Equal(prefixForRealTarget, prefixViaResolvedSymlink);
+
+        // The raw (unresolved) symlinked path hashes to a different prefix — exactly the mismatch that
+        // caused detached `aspire start` to wait on a hash the AppHost never used and time out.
+        var prefixViaRawSymlink = AppHostHelper.ComputeAuxiliarySocketPrefix(projectFileViaSymlink, homeDirectory);
+        Assert.NotEqual(prefixForRealTarget, prefixViaRawSymlink);
+    }
+
     [Theory]
     [InlineData("10.0.0", true)]
     [InlineData("9.2.0", true)]


### PR DESCRIPTION
## Description

Follow-up to #18566 (stacked on its branch `dev/karolz/analyze-managed-process-leaks`; please merge into that branch, not `main`).

While PR-testing #18566 on macOS, detached `aspire start` timed out (120s) on the default temp-path shape (`/var/folders/...`, a symlink to `/private/var/folders/...`) even though the AppHost started and reached dashboard readiness. Passing the `realpath` up front made it succeed.

### Root cause

The auxiliary backchannel socket is keyed by a hash of the AppHost path, and #18566 made the two sides disagree:

- **AppHost side (changed by #18566):** `AuxiliaryBackchannelService.GetAuxiliaryBackchannelSocketPath` now keys the socket file name on the **symlink-resolved** path via `GetSocketKeyAppHostPath` → `PathNormalizer.ResolveSymlinks`. So the socket embeds `ComputeAppHostId(/private/var/...)`.
- **CLI launcher side (unchanged):** `AppHostLauncher` computed the expected hash from the **unresolved** `effectiveAppHostFile.FullName`. `BackchannelConstants.ComputeAppHostId` → `NormalizePath` does not resolve symlinks.

`AuxiliaryBackchannelMonitor` keys discovered connections by the hash embedded in the socket file name (the AppHost's resolved-path hash), so `GetConnectionsByHash(expectedHash)` never matched and detached `start` timed out. (`aspire run` is unaffected — it connects over the explicit `ASPIRE_BACKCHANNEL_PATH`, not by hash.)

### Fix

`AppHostLauncher.ComputeDetachedMatchHashes(appHostPath, homeDirectory)` computes the **primary** expected hash from the symlink-resolved path (matching the AppHost's socket key) and keeps the **raw** (unresolved) path hashes as a fallback so already-running AppHosts keyed on the unresolved path (older `Aspire.Hosting`, or paths without symlinks) still match. The fallback searches both hash spaces used by socket file names: the compact `appHostId` (modern names) and the legacy hex hashes. `BackchannelConstants.ComputeAppHostId`/`NormalizePath` are unchanged, and the AppHost-side resolution is not reverted.

### Validation

- `AppHostLauncherTests.ComputeDetachedMatchHashes_ResolvesSymlinkForPrimaryHash_AndKeepsRawHashInFallback` asserts the primary hash equals `BackchannelConstants.ComputeAppHostId(resolvedPath)` — the exact value the AppHost embeds — for a real `/var`-style directory symlink, and that the raw compact + legacy hashes are in the fallback.
- `AppHostHelperTests.ComputeAuxiliarySocketPrefix_ResolvedSymlinkPath_MatchesRealTargetPrefix` covers the helper level.
- The existing `LaunchDetachedAsync_*` harness tests exercise the real `LaunchDetachedAsync → wait → GetConnectionsByHash` flow on a `/var/folders` workspace; they reproduced the `TimeoutException` before the fix and pass after.
- `dotnet test tests/Aspire.Cli.Tests` filtered to `*.AppHostHelperTests` + `*.AppHostLauncherTests`: 69 total, 0 failed, 64 passed, 5 skipped (Windows-only). Build clean, 0 warnings.

A full external `aspire start` binary run against a dogfood build is the remaining end-to-end confirmation (the locally-built `-dev` CLI has no packaged managed/dashboard layout); it should reproduce the original `/var/folders` scenario against the dogfood CLI from this PR.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship (into the #18566 branch).
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
