### PR TITLE
Update CODEOWNERS for extension

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,4 +34,4 @@
 /playground/AspireWithMaui           @jfversluis
 
 # vs code extension
-/extension                           @adamint
+/extension                           @adamint @ellahathaway


### PR DESCRIPTION
Adds `@ellahathaway` as a code owner for the `/extension` directory in `.github/CODEOWNERS`.