### PR TITLE
Sync Aspire Team App canvas with latest pr-dashboard logic

### DIFF
--- a/.github/extensions/aspire-team-app/constants.mjs
+++ b/.github/extensions/aspire-team-app/constants.mjs
@@ -27,6 +27,28 @@ export const coreTeamMembers = [
 // it is attributed to that member. Ported from pr-dashboard Dashboard config (#95).
 export const coreTeamMemberAliasSuffixes = ["_microsoft"];
 
+// Repos where specific check failures are non-blocking (informational only), so an
+// aggregate "failure" rollup driven solely by these checks should not read as red CI.
+// Ported from pr-dashboard server appsettings.json `NonBlockingCheckFailureRules`.
+// A rule matches a failing check when its trimmed, lowercased name equals one of
+// `checkNames` OR contains one of `checkNameContains`. Example: the aspire-1p
+// "GitOps/GitHubPop" proof-of-presence gate stays green in the review queue while
+// still being visible to the owning team.
+export const nonBlockingCheckFailureRules = [
+  {
+    repository: "devdiv-microsoft/aspire-1p",
+    label: "proof of presence",
+    checkNames: ["GitOps/GitHubPop"],
+    checkNameContains: ["proof of presence"],
+  },
+];
+
+// Markers for the Issues focus buckets (ported from pr-dashboard models.ts). These
+// are matched case-insensitively via substring (title/label) or login equality.
+export const ctiTeamTitleMarker = "[aspiree2e]";
+export const afscromeIssueAuthor = "afscrome";
+export const releaseBlockingLabelMarker = "blocking-release";
+
 // Single source of truth for the "For you" personal-pick action labels.
 export const personalPickActions = {
   resolveConflicts: "Resolve conflicts",

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -115,7 +115,7 @@ query($owner:String!, $name:String!, $after:String) {
       pageInfo { hasNextPage endCursor }
       nodes {
         number title url createdAt updatedAt
-        author { login avatarUrl }
+        author { __typename login avatarUrl }
         milestone { title }
         labels(first:15) { nodes { name } }
         assignees(first:10) { nodes { login } }
@@ -343,6 +343,10 @@ function normalizeIssue(repo, node, viewers) {
     url: node.url,
     author,
     authorAvatarUrl: node.author?.avatarUrl ?? null,
+    // __typename is the precise bot signal used by isBotAuthor's fast path. Issues
+    // fetch it just like PRs (normalizePr) so a Bot-typed author whose login lacks
+    // "bot" still earns the bot pill; the login string heuristics remain the fallback.
+    authorType: node.author?.__typename ?? null,
     createdAt: node.createdAt,
     updatedAt: node.updatedAt,
     milestone: node.milestone?.title ?? null,

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -6,13 +6,19 @@
 // from davidfowl/pr-dashboard (frontend/src/utils/{models,signals,pullRequests}.ts).
 
 import {
+  actorIdentityKey,
   createAttentionBuckets,
   createForMeItems,
   createDeveloperPullRequestCounts,
   createAttentionSignals,
+  createFocusIssueBuckets,
+  createIssueSignals,
   computeFocusItems,
   computeFocusExclusionItems,
   computeCommunityItems,
+  isChecksFailing,
+  shouldHideFromSharedPullRequestLists,
+  visibleCheckState,
 } from "./model.mjs";
 import { currentRelease } from "./constants.mjs";
 
@@ -137,6 +143,25 @@ function mapCheckState(rollup) {
   return "none";
 }
 
+// Build the engine-shaped ChecksStatus from the list-level rollup. The PR-list GraphQL query
+// deliberately carries only `statusCheckRollup { state }` (mirroring pr-dashboard's lean list
+// query, which enriches per-check detail lazily server-side). We therefore report zero per-check
+// detail: the non-blocking-check helpers in model.mjs treat this indeterminate shape correctly
+// (an aggregate failure on a rule-covered repo reads as "unknown" rather than red).
+function mapChecks(rollup) {
+  return {
+    state: mapCheckState(rollup),
+    totalCount: 0,
+    successCount: 0,
+    failureCount: 0,
+    pendingCount: 0,
+    neutralCount: 0,
+    skippedCount: 0,
+    completedAt: null,
+    failingChecks: [],
+  };
+}
+
 function mapMergeable(m) {
   if (m === "MERGEABLE") return "clean";
   if (m === "CONFLICTING") return "dirty";
@@ -235,7 +260,11 @@ function normalizePr(repo, node, viewers, repoPrivate = false) {
   const labels = (node.labels?.nodes ?? []).map((l) => l.name);
   const assignees = (node.assignees?.nodes ?? []).map((a) => a.login);
   const rawUnresolved = (node.reviewThreads?.nodes ?? []).filter((t) => !t.isResolved).length;
-  const checksState = mapCheckState(node.commits?.nodes?.[0]?.commit?.statusCheckRollup);
+  const checks = mapChecks(node.commits?.nodes?.[0]?.commit?.statusCheckRollup);
+  // Visible state honors non-blocking check rules: an aggregate failure driven only by
+  // informational checks (e.g. aspire-1p proof-of-presence) reads as unknown/pending here,
+  // so the simplified lane/ship/count paths don't treat it as red CI.
+  const checksState = visibleCheckState({ repository: repo, checks }) ?? "none";
   const review = deriveReview(node.reviews?.nodes ?? [], requestedReviewers, viewers, repo, rawUnresolved);
   const mergeable = node.mergeable; // MERGEABLE | CONFLICTING | UNKNOWN
   const mergeableState = mapMergeable(mergeable);
@@ -284,7 +313,7 @@ function normalizePr(repo, node, viewers, repoPrivate = false) {
     lastCommitAt,
     linkedIssues,
     // Engine-shaped fields (read by model.mjs).
-    checks: { state: checksState, failureCount: 0, completedAt: null },
+    checks,
     mergeableState,
     // Back-compat fields read by the simplified Fowler lanes/signals path.
     unresolvedThreadCount: rawUnresolved,
@@ -294,7 +323,9 @@ function normalizePr(repo, node, viewers, repoPrivate = false) {
     // REVIEW_REQUIRED | null (null when the repo has no required reviews).
     reviewDecision: node.reviewDecision ?? null,
     review,
-    isMine: viewers.has(author.toLowerCase()),
+    // Key off the human identity so a Copilot PR attributed to me ("me/copilot") still
+    // counts as mine. actorIdentityKey strips the "/copilot" suffix and punctuation.
+    isMine: [...viewers].some((viewer) => actorIdentityKey(viewer) === actorIdentityKey(author)),
     // Private repos cannot have external community contributors, so PRs on them are
     // never "Community" — they flow through the normal team attention engine instead.
     repoPrivate: !!repoPrivate,
@@ -417,8 +448,15 @@ function reviewReady(pr) {
 }
 
 // Review-ready PRs that still need a review (not the viewer's own, not yet approved).
+// Also honor the shared-list hide rule so PRs flagged for author action (draft, conflicts,
+// or a needs-author-action label) never surface in the team's shared review queue.
 function awaitingReview(pr) {
-  return reviewReady(pr) && !pr.isMine && pr.review.state !== "approved";
+  return (
+    reviewReady(pr) &&
+    !pr.isMine &&
+    pr.review.state !== "approved" &&
+    !shouldHideFromSharedPullRequestLists(pr)
+  );
 }
 
 // Oldest waits float to the top so nothing starves, with nudges for explicitly
@@ -484,30 +522,37 @@ function bucketReview(prs, { showDrafts = false, limit = REVIEW_LIMIT } = {}) {
   return lanes.filter((l) => l.items.length > 0);
 }
 
-function bucketIssues(issues) {
-  const lanes = [
-    { id: "assigned", label: "Assigned to you", tone: "danger", items: [] },
-    { id: "yours", label: "Your issues", tone: "accent", items: [] },
-    { id: "triage", label: "Needs triage", tone: "warning", items: [] },
-    { id: "active", label: "Recently active", tone: "muted", items: [] },
-  ];
-  for (const issue of issues) {
-    let laneId;
-    if (issue.assignedToMe) laneId = "assigned";
-    else if (issue.isMine) laneId = "yours";
-    else if (issue.labels.length === 0 && issue.assignees.length === 0) laneId = "triage";
-    else laneId = "active";
-    lanes.find((l) => l.id === laneId).items.push({ issue, signals: issueSignals(issue) });
-  }
-  return lanes.filter((l) => l.items.length > 0);
-}
+// Issues view: pr-dashboard focus buckets (Regression / CTI team / afscrome finds, plus a
+// per-viewer "My issues" lane) using the ported `createFocusIssueBuckets` + `createIssueSignals`.
+// Focus buckets only cover a curated subset, so residual lanes catch everything else and keep
+// no open issue from silently dropping out of the view.
+function bucketIssues(issues, login) {
+  const covered = new Set();
+  const toItem = (issue) => {
+    covered.add(issue.url);
+    return { issue, signals: createIssueSignals(issue) };
+  };
 
-function issueSignals(issue) {
-  const out = [];
-  if (issue.milestone) out.push({ label: issue.milestone, tone: "accent" });
-  if (issue.labels.length === 0) out.push({ label: "Unlabeled", tone: "warning" });
-  for (const l of issue.labels.slice(0, 3)) out.push({ label: l, tone: "muted" });
-  return out;
+  const lanes = createFocusIssueBuckets(issues, login).map((bucket) => ({
+    id: `focus-${bucket.label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")}`,
+    label: bucket.label,
+    tone: bucket.tone,
+    items: bucket.issues.map(toItem),
+  }));
+
+  const residual = issues.filter((issue) => !covered.has(issue.url));
+  const isUntriaged = (issue) => issue.labels.length === 0 && issue.assignees.length === 0;
+  const triage = residual.filter(isUntriaged);
+  const active = residual.filter((issue) => !isUntriaged(issue));
+
+  if (triage.length) {
+    lanes.push({ id: "triage", label: "Needs triage", tone: "warning", items: triage.map(toItem) });
+  }
+  if (active.length) {
+    lanes.push({ id: "active", label: "Recently active", tone: "muted", items: active.map(toItem) });
+  }
+
+  return lanes.filter((lane) => lane.items.length > 0);
 }
 
 function bucketShip(prs, release, { showDrafts = false } = {}) {
@@ -649,7 +694,7 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
   const errors = [...new Set(errorsRaw.filter((e) => !okRepos.has(e.repo)).map((e) => e.message))];
 
   let lanes;
-  if (mode === "issues") lanes = bucketIssues(allIssues);
+  if (mode === "issues") lanes = bucketIssues(allIssues, usable[0].login);
   else if (mode === "ship") lanes = bucketShip(allPrs, release ?? CURRENT_RELEASE, { showDrafts });
   else lanes = bucketReview(allPrs, { showDrafts, limit: reviewLimit });
 

--- a/.github/extensions/aspire-team-app/github.test.mjs
+++ b/.github/extensions/aspire-team-app/github.test.mjs
@@ -108,7 +108,7 @@ function issueNode(number, updatedAt) {
     url: `https://github.com/microsoft/aspire/issues/${number}`,
     createdAt: "2026-07-01T09:00:00Z",
     updatedAt,
-    author: { login: "octo", avatarUrl: null },
+    author: { __typename: "User", login: "octo", avatarUrl: null },
     milestone: null,
     labels: { nodes: [] },
     assignees: { nodes: [] },

--- a/.github/extensions/aspire-team-app/model.mjs
+++ b/.github/extensions/aspire-team-app/model.mjs
@@ -25,6 +25,21 @@ const stalledPullRequestMs = 7 * dayMs;
 const quickWinLineThreshold = 80;
 const quickWinFileThreshold = 3;
 
+// Faithful port of pr-dashboard's normalizeCheckFailureRules guard (dashboardConfig.ts,
+// davidfowl/pr-dashboard#96): a non-blocking check-failure rule is only honored when it
+// names a repository, a label, AND at least one concrete check matcher. Without this,
+// a matcher-less rule (a plausible constants.mjs typo) makes hasNonBlockingCheckFailureRule
+// treat every aggregate "failure" rollup on that repo as non-blocking, silently hiding all
+// red CI for the repo. Dropping matcher-less rules keeps such a config mistake from
+// suppressing genuine failures.
+export function filterCheckFailureRules(rules) {
+  return (rules ?? []).filter((rule) =>
+    rule.repository
+    && rule.label
+    && ((rule.checkNames?.length ?? 0) > 0 || (rule.checkNameContains?.length ?? 0) > 0));
+}
+const activeNonBlockingCheckFailureRules = filterCheckFailureRules(nonBlockingCheckFailureRules);
+
 const regressionBucketLabel = "Regression";
 const approvedButAgingBucketLabel = "Approved but aging";
 const agedOutCommunityBucketLabel = "Aged out community";
@@ -189,10 +204,10 @@ function isNonBlockingAggregateFailure(pr) {
 }
 
 function hasNonBlockingCheckFailureRule(repository) {
-  return nonBlockingCheckFailureRules.some((rule) => sameRepository(rule.repository, repository));
+  return activeNonBlockingCheckFailureRules.some((rule) => sameRepository(rule.repository, repository));
 }
 function matchingNonBlockingCheckFailureRule(repository, name) {
-  return nonBlockingCheckFailureRules.find((rule) =>
+  return activeNonBlockingCheckFailureRules.find((rule) =>
     sameRepository(rule.repository, repository) && matchesNonBlockingCheckFailureName(rule, name)) ?? null;
 }
 function sameRepository(first, second) {
@@ -200,8 +215,8 @@ function sameRepository(first, second) {
 }
 function matchesNonBlockingCheckFailureName(rule, name) {
   const normalized = String(name || "").trim().toLowerCase();
-  return rule.checkNames.some((checkName) => normalized === checkName.toLowerCase())
-    || rule.checkNameContains.some((fragment) => normalized.includes(fragment.toLowerCase()));
+  return (rule.checkNames ?? []).some((checkName) => normalized === checkName.toLowerCase())
+    || (rule.checkNameContains ?? []).some((fragment) => normalized.includes(fragment.toLowerCase()));
 }
 export function hasMergeConflicts(pr) {
   return pr.mergeableState === "dirty";

--- a/.github/extensions/aspire-team-app/model.mjs
+++ b/.github/extensions/aspire-team-app/model.mjs
@@ -5,7 +5,18 @@
 // buckets, the focused "Needs attention" queue, the personal "For you" action
 // picks, community lane, core-team ownership, and the "outside the queue" reasons.
 
-import { coreTeamMembers, coreTeamMemberAliasSuffixes, currentRelease, dayMs, hourMs, personalPickActions } from "./constants.mjs";
+import {
+  afscromeIssueAuthor,
+  coreTeamMembers,
+  coreTeamMemberAliasSuffixes,
+  ctiTeamTitleMarker,
+  currentRelease,
+  dayMs,
+  hourMs,
+  nonBlockingCheckFailureRules,
+  personalPickActions,
+  releaseBlockingLabelMarker,
+} from "./constants.mjs";
 
 const approvedAgingMs = 2 * dayMs;
 const communityWaitMs = 12 * hourMs;
@@ -28,20 +39,34 @@ const knownBotAuthors = new Set(["copilot-swe-agent", "dotnet-maestro"]);
 // ---------------------------------------------------------------------------
 
 export function actorIdentityKey(actor) {
-  return String(actor || "").trim().toLowerCase();
+  // A "{human}/copilot" author identifies as the human who started the Copilot PR, so
+  // ownership, core-team matching, and dedupe all key off that human. We also strip any
+  // non-alphanumeric characters so alias punctuation ("karolz-ms", "IEvangelist_microsoft")
+  // normalizes consistently on both sides of a comparison. Ported from pr-dashboard
+  // models.ts `actorIdentityKey`.
+  const normalized = String(actor || "").toLowerCase();
+  const human = normalized.endsWith("/copilot")
+    ? normalized.slice(0, -"/copilot".length)
+    : normalized;
+  return human.replace(/[^a-z0-9]/g, "");
 }
 function sameLogin(a, b) {
   return actorIdentityKey(a) === actorIdentityKey(b);
 }
 function isCopilotAttributedAuthor(author) {
-  return actorIdentityKey(author).endsWith("/copilot");
+  // Check the raw author, not actorIdentityKey: the latter strips "/copilot" (and all
+  // punctuation) as part of keying to the human owner, so it can never end with "/copilot".
+  return String(author || "").toLowerCase().endsWith("/copilot");
 }
 function isBotAuthor(author, authorType) {
   if (isCopilotAttributedAuthor(author)) return false;
-  const n = actorIdentityKey(author);
+  // GraphQL __typename is the most precise signal when present; the string checks mirror
+  // pr-dashboard models.ts `isBotAuthor` (raw lowercased login, not the punctuation-stripped
+  // identity key). `github-actions` and the configured bot logins round out the list.
   if (authorType === "Bot") return true;
+  const n = String(author || "").toLowerCase();
   if (knownBotAuthors.has(n)) return true;
-  return n.endsWith("[bot]") || n === "copilot" || n.includes("dependabot");
+  return n.endsWith("[bot]") || n.includes("bot") || n === "copilot" || n === "github-actions";
 }
 function isCoreTeamAuthor(author) {
   return coreTeamOwnershipActor(author) !== null;
@@ -95,10 +120,12 @@ function isCommunityWaiting(pr) {
   );
 }
 function isOwnCopilotAuthor(author, login) {
+  // Match on the raw author: actorIdentityKey strips "/copilot", so the suffix test must
+  // run against the original string before comparing the human base via sameLogin.
   const suffix = "/copilot";
-  const n = actorIdentityKey(author);
-  if (!n.endsWith(suffix)) return false;
-  return sameLogin(author.slice(0, author.length - suffix.length), login);
+  const raw = String(author || "");
+  if (!raw.toLowerCase().endsWith(suffix)) return false;
+  return sameLogin(raw.slice(0, raw.length - suffix.length), login);
 }
 function isOwnCopilotAuthorAny(author, logins) {
   return logins.some((l) => isOwnCopilotAuthor(author, l));
@@ -109,7 +136,72 @@ function isOwnCopilotAuthorAny(author, logins) {
 // ---------------------------------------------------------------------------
 
 export function isChecksFailing(pr) {
-  return pr.checks?.state === "failure";
+  // A "failure" rollup is only real red CI when it isn't driven purely by checks a
+  // non-blocking rule marks informational. Ported from pr-dashboard models.ts.
+  return pr.checks?.state === "failure"
+    && !isNonBlockingAggregateFailure(pr)
+    && !nonBlockingOnlyFailureRule(pr);
+}
+
+// The check state to display/act on after accounting for non-blocking rules. Mirrors
+// pr-dashboard models.ts `visibleCheckState`:
+//   * An aggregate failure on a rule-covered repo with no per-check detail yet is
+//     "unknown" (the dashboard lazily fetches details; we surface it as indeterminate).
+//   * When every failing check matches a non-blocking rule, the PR is effectively
+//     pending (if anything is still running) or success.
+//   * Otherwise the raw rollup state stands.
+export function visibleCheckState(pr) {
+  if (isNonBlockingAggregateFailure(pr)) {
+    return "unknown";
+  }
+  if (!nonBlockingOnlyFailureRule(pr)) {
+    return pr.checks?.state;
+  }
+  return (pr.checks?.pendingCount ?? 0) > 0 ? "pending" : "success";
+}
+
+// Every failing check on the PR maps to a non-blocking rule for its repo (and the rollup
+// reported no other failures), so the failure is informational only. Returns the matched
+// rule, else null. Defensive against the lean list-level checks shape (no failingChecks).
+function nonBlockingOnlyFailureRule(pr) {
+  const checks = pr.checks;
+  if (!checks || checks.state !== "failure") {
+    return null;
+  }
+  const failing = checks.failingChecks ?? [];
+  if ((checks.failureCount ?? 0) !== failing.length || failing.length === 0) {
+    return null;
+  }
+  const matchingRules = failing.map((check) => matchingNonBlockingCheckFailureRule(pr.repository, check.name));
+  return matchingRules.every((rule) => rule != null) ? matchingRules[0] ?? null : null;
+}
+
+// A "failure" rollup on a rule-covered repo where no individual check detail is available
+// yet (totalCount/failureCount/failingChecks all zero). This is the list-level shape the
+// dashboard treats as indeterminate rather than red.
+function isNonBlockingAggregateFailure(pr) {
+  const checks = pr.checks;
+  return checks?.state === "failure"
+    && hasNonBlockingCheckFailureRule(pr.repository)
+    && (checks.totalCount ?? 0) === 0
+    && (checks.failureCount ?? 0) === 0
+    && (checks.failingChecks ?? []).length === 0;
+}
+
+function hasNonBlockingCheckFailureRule(repository) {
+  return nonBlockingCheckFailureRules.some((rule) => sameRepository(rule.repository, repository));
+}
+function matchingNonBlockingCheckFailureRule(repository, name) {
+  return nonBlockingCheckFailureRules.find((rule) =>
+    sameRepository(rule.repository, repository) && matchesNonBlockingCheckFailureName(rule, name)) ?? null;
+}
+function sameRepository(first, second) {
+  return String(first).toLowerCase() === String(second).toLowerCase();
+}
+function matchesNonBlockingCheckFailureName(rule, name) {
+  const normalized = String(name || "").trim().toLowerCase();
+  return rule.checkNames.some((checkName) => normalized === checkName.toLowerCase())
+    || rule.checkNameContains.some((fragment) => normalized.includes(fragment.toLowerCase()));
 }
 export function hasMergeConflicts(pr) {
   return pr.mergeableState === "dirty";
@@ -127,6 +219,12 @@ function matchingDoNotMergeLabel(pr) {
 }
 export function hasNeedsAuthorActionLabel(pr) {
   return matchingDoNotMergeLabel(pr) !== null;
+}
+// A PR that belongs on its author's own plate, not the shared review/ship lists: still a
+// draft, conflicting, or explicitly labeled do-not-merge. Ported from pr-dashboard
+// models.ts `shouldHideFromSharedPullRequestLists`.
+export function shouldHideFromSharedPullRequestLists(pr) {
+  return pr.draft || hasMergeConflicts(pr) || hasNeedsAuthorActionLabel(pr);
 }
 function hasUnresolvedFeedback(pr) {
   return pr.review.unresolvedThreadCount > 0;
@@ -267,7 +365,8 @@ function reviewFootprint(pr) {
 // ---------------------------------------------------------------------------
 
 function isChecksPending(pr) {
-  return pr.checks?.state === "pending";
+  const state = visibleCheckState(pr);
+  return state === "pending" || state === "unknown";
 }
 
 export function createAttentionSignals(item) {
@@ -388,6 +487,16 @@ function checksAttentionSignal(pullRequest) {
   const checks = pullRequest.checks;
   if (!checks || checks.state === "none" || checks.state === "unknown") {
     return null;
+  }
+  // An aggregate failure that's only the non-blocking rule (or indeterminate detail) gets
+  // no red CI pill. When every failing check maps to a rule, surface the rule's label as a
+  // warning instead of "CI failing". Ported from pr-dashboard models.ts checksAttentionSignal.
+  if (isNonBlockingAggregateFailure(pullRequest)) {
+    return null;
+  }
+  const nonBlockingFailure = nonBlockingOnlyFailureRule(pullRequest);
+  if (nonBlockingFailure) {
+    return { label: nonBlockingFailure.label, tone: "warning" };
   }
   if (checks.state === "failure") {
     const label = checks.failureCount > 0
@@ -716,12 +825,13 @@ function createPersonalPick(pr) {
   if (hasNeedsAuthorActionLabel(pr)) {
     return mine ? { pullRequest: pr, action: personalPickActions.needsAttention, reason: `Your PR is labeled ${matchingDoNotMergeLabel(pr) ?? "no-merge"} · ${pickReason(pr)}`, tone: "danger", personal: true } : null;
   }
-  if (mine && pr.checks?.state === "failure") {
+  if (mine && isChecksFailing(pr)) {
     const fc = pr.checks.failureCount ?? 0;
     return { pullRequest: pr, action: personalPickActions.fixCi, reason: `${fc > 0 ? `Your PR has ${formatCount(fc, "failing check")}` : "Your PR is failing CI"} · ${pickReason(pr)}`, tone: "danger", personal: true };
   }
   if (!mine && pr.review.reviewRequestedFromViewer) {
-    const ci = pr.checks?.state === "failure" ? " · CI failing" : pr.checks?.state === "pending" ? " · CI running" : "";
+    const visibleState = visibleCheckState(pr);
+    const ci = isChecksFailing(pr) ? " · CI failing" : visibleState === "pending" ? " · CI running" : "";
     return { pullRequest: pr, action: personalPickActions.reviewThis, reason: `Review requested from you · ${pickReason(pr)}${ci}`, tone: "warning", personal: true };
   }
   if (mine && pr.review.state === "changes_requested") {
@@ -783,6 +893,208 @@ export function createDeveloperPullRequestCounts(prs) {
     })
     .filter((c) => c.openPullRequestCount > 0)
     .sort((a, b) => b.openPullRequestCount - a.openPullRequestCount || a.actor.localeCompare(b.actor));
+}
+
+// ---------------------------------------------------------------------------
+// Issues focus buckets + signals (port of pr-dashboard models.ts ship-week issue
+// intelligence). Adapted for the GraphQL issue shape this extension collects: we do
+// NOT have per-issue linked-PR data (the dashboard's dedicated server endpoint supplies
+// `linkedOpenPullRequests`), so any signal that depends on it ("Needs PR", the open-PR
+// count pill, and the linked-PR validation branch) is skipped rather than guessed, which
+// would otherwise mislabel every issue "Needs PR".
+// ---------------------------------------------------------------------------
+
+const ctiTeamIssueBucketLabel = "CTI team";
+const afscromeIssueBucketLabel = "afscrome finds";
+const myIssuesBucketLabel = "My issues";
+const releaseBlockingSignalLabel = "Blocking release";
+const staleIssueMs = 7 * dayMs;
+const coldIssueMs = 14 * dayMs;
+
+const validationTerms = ["validation", "validate", "verify", "verification", "test", "e2e", "servicing validation"];
+const installerTerms = ["installer", "install", "workload", "acquisition", "setup", "visual studio", " vs ", "sdk"];
+const typeScriptTerms = ["typescript", " ts ", "javascript", " js ", "node", "polyglot", "apphost"];
+const cliTerms = ["cli", "channel", "version", "versioning", "feed", "template"];
+const docsTerms = ["docs", "documentation", "release notes", "readme", "release readiness", "announcement"];
+
+// Each definition matches a class of issue that deserves its own focus lane. `countsAsDomain`
+// marks the issue as already owned by a domain (suppresses the "Unowned" pill); `needsValidation`
+// forces the "Needs validation" pill.
+const focusIssueBucketDefinitions = [
+  { label: regressionBucketLabel, tone: "danger", matches: (issue) => hasRegressionLabel(issue.labels) },
+  { label: ctiTeamIssueBucketLabel, tone: "warning", matches: isCtiTeamIssue, countsAsDomain: true, needsValidation: true, suppressNeedsPr: true },
+  { label: afscromeIssueBucketLabel, tone: "success", matches: isAfscromeIssue },
+];
+
+const shipWeekIssueSignalToneByLabel = new Map([
+  ...focusIssueBucketDefinitions.map((definition) => [definition.label, definition.tone]),
+  ["Needs PR", "danger"],
+  ["Needs validation", "warning"],
+  ["Installer/acquisition", "accent"],
+  ["TypeScript/polyglot", "accent"],
+  ["CLI channel/versioning", "accent"],
+  ["Docs/release readiness", "success"],
+  ["Unowned", "warning"],
+]);
+
+function isCtiTeamIssue(issue) {
+  return String(issue.title || "").toLowerCase().includes(ctiTeamTitleMarker);
+}
+function isAfscromeIssue(issue) {
+  return sameLogin(issue.author, afscromeIssueAuthor);
+}
+function hasReleaseBlockingLabel(labels) {
+  return (labels || []).some((label) => label.toLowerCase().includes(releaseBlockingLabelMarker));
+}
+function matchingFocusIssueBucketDefinitions(issue) {
+  return focusIssueBucketDefinitions.filter((definition) => definition.matches(issue));
+}
+function firstFocusIssueBucketDefinition(issue) {
+  return matchingFocusIssueBucketDefinitions(issue)[0];
+}
+function targetsCurrentReleaseIssue(issue) {
+  if (!currentRelease) return false;
+  return [issue.title, issue.milestone, ...(issue.labels || [])]
+    .some((value) => value != null && releaseSignalMatches(value, currentRelease));
+}
+function issueMatchesTerms(issue, terms) {
+  const searchText = ` ${[issue.title, issue.author, ...(issue.labels || [])].join(" ").toLowerCase()} `;
+  return terms.some((term) => searchText.includes(term));
+}
+// Whether per-issue linked-PR data is available. This extension does not fetch it, so the
+// value is treated as unknown and the linked-PR-derived signals are omitted.
+function linkedOpenPullRequestCount(issue) {
+  return Array.isArray(issue.linkedOpenPullRequests) ? issue.linkedOpenPullRequests.length : null;
+}
+
+// Focus lanes for the Issues view. Returns non-empty buckets (each sorted newest-first),
+// plus a per-login "My issues" bucket when a login is supplied. Ported from pr-dashboard
+// models.ts `createFocusIssueBuckets`.
+export function createFocusIssueBuckets(issues, login) {
+  const definitions = login
+    ? [
+      ...focusIssueBucketDefinitions,
+      {
+        label: myIssuesBucketLabel,
+        tone: "accent",
+        matches: (issue) => (issue.assignees || []).some((assignee) => sameLogin(assignee, login)),
+      },
+    ]
+    : focusIssueBucketDefinitions;
+
+  return definitions
+    .map(({ matches, ...definition }) => {
+      const bucketIssues = issues
+        .filter(matches)
+        .sort((first, second) => new Date(second.updatedAt).getTime() - new Date(first.updatedAt).getTime());
+      return bucketIssues.length === 0 ? null : { ...definition, issues: bucketIssues };
+    })
+    .filter((bucket) => bucket !== null);
+}
+
+// Signal pills for a single issue (leading action pill + release/domain/idle/label context).
+// Ported from pr-dashboard models.ts `createIssueSignals`, minus the linked-PR pills.
+export function createIssueSignals(issue) {
+  const action = issueActionSignal(issue);
+  const signals = [action];
+
+  if (currentRelease && targetsCurrentReleaseIssue(issue)) {
+    signals.push({ label: `release ${currentRelease}`, tone: "danger" });
+  }
+
+  const linkedCount = linkedOpenPullRequestCount(issue);
+  if (linkedCount != null && linkedCount > 0) {
+    signals.push({ label: formatCount(linkedCount, "open PR"), tone: "warning" });
+  }
+
+  for (const signalLabel of shipWeekIssueSignalLabels(issue)) {
+    if (signalLabel !== action.label) {
+      signals.push({ label: signalLabel, tone: shipWeekIssueSignalToneByLabel.get(signalLabel) ?? "muted" });
+    }
+  }
+
+  const updatedAge = ageMs(issue.updatedAt);
+  if (updatedAge >= coldIssueMs) {
+    signals.push({ label: `idle ${formatAge(issue.updatedAt)}`, tone: "danger" });
+  } else if (updatedAge >= staleIssueMs) {
+    signals.push({ label: `idle ${formatAge(issue.updatedAt)}`, tone: "warning" });
+  }
+
+  if (issue.milestone) {
+    signals.push({ label: "milestone", tone: "accent" });
+  }
+
+  for (const label of (issue.labels || []).slice(0, 2)) {
+    signals.push({ label, tone: "accent" });
+  }
+
+  if (isBotAuthor(issue.author, issue.authorType)) {
+    signals.push({ label: "bot", tone: "accent" });
+  }
+
+  return dedupeIssueSignals(signals).slice(0, 7);
+}
+
+function issueActionSignal(issue) {
+  if (hasReleaseBlockingLabel(issue.labels)) {
+    return { label: releaseBlockingSignalLabel, tone: "danger" };
+  }
+  const focusDefinition = firstFocusIssueBucketDefinition(issue);
+  if (focusDefinition) {
+    return { label: focusDefinition.label, tone: focusDefinition.tone };
+  }
+  // "Needs PR" (linkedCount === 0) is intentionally omitted: without linked-PR data we
+  // cannot tell an issue has no PR, and defaulting to "Needs PR" would tag everything.
+  if ((issue.assignees || []).length === 0) {
+    return { label: "Unowned", tone: "warning" };
+  }
+  return { label: "Needs validation", tone: "warning" };
+}
+
+function shipWeekIssueSignalLabels(issue) {
+  const labels = [];
+  let domainMatch = false;
+  const focusDefinitions = matchingFocusIssueBucketDefinitions(issue);
+  const linkedCount = linkedOpenPullRequestCount(issue);
+
+  for (const definition of focusDefinitions) {
+    labels.push(definition.label);
+    domainMatch = domainMatch || definition.countsAsDomain === true;
+  }
+
+  // "Needs PR" only when we positively know there are zero linked PRs.
+  if (linkedCount === 0 && !focusDefinitions.some((definition) => definition.suppressNeedsPr)) {
+    labels.push("Needs PR");
+  }
+
+  if (
+    focusDefinitions.some((definition) => definition.needsValidation)
+    || (linkedCount != null && linkedCount > 0)
+    || issueMatchesTerms(issue, validationTerms)
+  ) {
+    labels.push("Needs validation");
+  }
+
+  if (issueMatchesTerms(issue, installerTerms)) { labels.push("Installer/acquisition"); domainMatch = true; }
+  if (issueMatchesTerms(issue, typeScriptTerms)) { labels.push("TypeScript/polyglot"); domainMatch = true; }
+  if (issueMatchesTerms(issue, cliTerms)) { labels.push("CLI channel/versioning"); domainMatch = true; }
+  if (issueMatchesTerms(issue, docsTerms)) { labels.push("Docs/release readiness"); domainMatch = true; }
+
+  if ((issue.assignees || []).length === 0 && !domainMatch) {
+    labels.push("Unowned");
+  }
+
+  return labels;
+}
+
+function dedupeIssueSignals(signals) {
+  const seen = new Set();
+  return signals.filter((signal) => {
+    const key = signal.label.trim().toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/extensions/aspire-team-app/model.test.mjs
+++ b/.github/extensions/aspire-team-app/model.test.mjs
@@ -12,6 +12,7 @@ import {
   createFocusIssueBuckets,
   createForMeItems,
   createIssueSignals,
+  filterCheckFailureRules,
   isChecksFailing,
   shouldHideFromSharedPullRequestLists,
   visibleCheckState,
@@ -237,6 +238,20 @@ test("visibleCheckState and isChecksFailing honor non-blocking check rules", () 
   });
   assert.equal(visibleCheckState(nonBlockingOnly), "success");
   assert.equal(isChecksFailing(nonBlockingOnly), false);
+});
+
+test("filterCheckFailureRules drops rules missing a repository, label, or concrete matcher", () => {
+  const valid = { repository: "devdiv-microsoft/aspire-1p", label: "proof of presence", checkNames: ["GitOps/GitHubPop"], checkNameContains: [] };
+  const containsOnly = { repository: "org/repo", label: "informational", checkNames: [], checkNameContains: ["proof of presence"] };
+  const noMatchers = { repository: "org/repo", label: "informational", checkNames: [], checkNameContains: [] };
+  const noRepo = { repository: "", label: "informational", checkNames: ["x"], checkNameContains: [] };
+  const noLabel = { repository: "org/repo", label: "", checkNames: ["x"], checkNameContains: [] };
+
+  // A rule with no concrete matcher would otherwise mark every aggregate failure on its
+  // repo non-blocking, hiding all red CI. Only rules that actually name a check survive.
+  assert.deepEqual(filterCheckFailureRules([valid, containsOnly, noMatchers, noRepo, noLabel]), [valid, containsOnly]);
+  assert.deepEqual(filterCheckFailureRules([]), []);
+  assert.deepEqual(filterCheckFailureRules(undefined), []);
 });
 
 test("shouldHideFromSharedPullRequestLists hides drafts, conflicts, and needs-author-action PRs", () => {

--- a/.github/extensions/aspire-team-app/model.test.mjs
+++ b/.github/extensions/aspire-team-app/model.test.mjs
@@ -308,4 +308,9 @@ test("createIssueSignals leads with the highest-priority action pill", () => {
   // Pills are capped at 7 even with many labels.
   const noisy = makeIssue({ number: 5, milestone: "13.4", labels: ["a", "b", "c", "d", "e"] });
   assert.ok(createIssueSignals(noisy).length <= 7);
+
+  // The precise GraphQL __typename === "Bot" fast-path earns a bot pill even when the
+  // login has no "bot" substring (normalizeIssue now carries authorType for issues).
+  const botTyped = makeIssue({ number: 6, author: "dependa", authorType: "Bot" });
+  assert.ok(createIssueSignals(botTyped).some((s) => s.label === "bot"));
 });

--- a/.github/extensions/aspire-team-app/model.test.mjs
+++ b/.github/extensions/aspire-team-app/model.test.mjs
@@ -3,12 +3,18 @@ import test from "node:test";
 
 import { dayMs, personalPickActions } from "./constants.mjs";
 import {
+  actorIdentityKey,
   computeCommunityItems,
   computeFocusExclusionItems,
   computeFocusItems,
   createAttentionBuckets,
   createDeveloperPullRequestCounts,
+  createFocusIssueBuckets,
   createForMeItems,
+  createIssueSignals,
+  isChecksFailing,
+  shouldHideFromSharedPullRequestLists,
+  visibleCheckState,
 } from "./model.mjs";
 
 // The review-mode engine consumes the *normalized* PR shape produced by
@@ -36,7 +42,20 @@ function makePr(overrides = {}) {
     viewerApproved: false,
     ...(overrides.review ?? {}),
   };
-  const checks = { state: "success", failureCount: 0, completedAt: null, ...(overrides.checks ?? {}) };
+  // Mirrors the engine-shaped ChecksStatus normalizePr() emits: the lean list-level query
+  // yields zeroed per-check detail, so failingChecks defaults empty and the counts are 0.
+  const checks = {
+    state: "success",
+    totalCount: 0,
+    successCount: 0,
+    failureCount: 0,
+    pendingCount: 0,
+    neutralCount: 0,
+    skippedCount: 0,
+    completedAt: null,
+    failingChecks: [],
+    ...(overrides.checks ?? {}),
+  };
   return {
     repository: "microsoft/aspire",
     number: 1,
@@ -174,4 +193,104 @@ test("createDeveloperPullRequestCounts attributes open PRs to core-team members 
   // The "_microsoft" alias attributes to the canonical core-team login.
   assert.equal(byActor.get("IEvangelist"), 1);
   assert.equal(byActor.has("randocontributor"), false);
+});
+
+function isoAgoIssue(ms) {
+  return new Date(Date.now() - ms).toISOString();
+}
+
+function makeIssue(overrides = {}) {
+  return {
+    repository: "microsoft/aspire",
+    number: 1,
+    title: "Test issue",
+    url: "https://github.com/microsoft/aspire/issues/1",
+    author: "octo",
+    authorType: "User",
+    authorAvatarUrl: null,
+    createdAt: isoAgoIssue(2 * dayMs),
+    updatedAt: isoAgoIssue(dayMs),
+    milestone: null,
+    labels: [],
+    assignees: [],
+    isMine: false,
+    assignedToMe: false,
+    ...overrides,
+  };
+}
+
+test("visibleCheckState and isChecksFailing honor non-blocking check rules", () => {
+  const normalFailure = makePr({ repository: "microsoft/aspire", checks: { state: "failure", totalCount: 2, failureCount: 2 } });
+  assert.equal(visibleCheckState(normalFailure), "failure");
+  assert.equal(isChecksFailing(normalFailure), true);
+
+  // aspire-1p reports a bare aggregate "failure" before per-check detail is fetched. With a
+  // non-blocking rule for that repo and zero per-check detail, it is indeterminate, not red.
+  const aggregateFailure = makePr({ repository: "devdiv-microsoft/aspire-1p", checks: { state: "failure" } });
+  assert.equal(visibleCheckState(aggregateFailure), "unknown");
+  assert.equal(isChecksFailing(aggregateFailure), false);
+
+  // A failure whose only failing check matches the rule downgrades to success (nothing pending).
+  const nonBlockingOnly = makePr({
+    repository: "devdiv-microsoft/aspire-1p",
+    checks: { state: "failure", totalCount: 1, failureCount: 1, failingChecks: [{ name: "GitOps/GitHubPop" }] },
+  });
+  assert.equal(visibleCheckState(nonBlockingOnly), "success");
+  assert.equal(isChecksFailing(nonBlockingOnly), false);
+});
+
+test("shouldHideFromSharedPullRequestLists hides drafts, conflicts, and needs-author-action PRs", () => {
+  assert.equal(shouldHideFromSharedPullRequestLists(makePr()), false);
+  assert.equal(shouldHideFromSharedPullRequestLists(makePr({ draft: true })), true);
+  assert.equal(shouldHideFromSharedPullRequestLists(makePr({ mergeableState: "dirty" })), true);
+  assert.equal(shouldHideFromSharedPullRequestLists(makePr({ labels: ["needs-author-action"] })), true);
+});
+
+test("actorIdentityKey attributes a Copilot-authored PR to its human owner", () => {
+  assert.equal(actorIdentityKey("davidfowl/copilot"), "davidfowl");
+  assert.equal(actorIdentityKey("IEvangelist_microsoft"), "ievangelistmicrosoft");
+
+  const counts = createDeveloperPullRequestCounts([makePr({ number: 60, author: "davidfowl/copilot" })]);
+  const byActor = new Map(counts.map((c) => [c.actor, c.openPullRequestCount]));
+  assert.equal(byActor.get("davidfowl"), 1);
+});
+
+test("createFocusIssueBuckets groups regression, CTI team, afscrome finds, and my issues", () => {
+  const regression = makeIssue({ number: 1, labels: ["regression"] });
+  const cti = makeIssue({ number: 2, title: "Flaky [aspiree2e] run" });
+  const afscrome = makeIssue({ number: 3, author: "afscrome" });
+  const mine = makeIssue({ number: 4, assignees: ["octo"] });
+  const other = makeIssue({ number: 5 });
+
+  const buckets = createFocusIssueBuckets([regression, cti, afscrome, mine, other], "octo");
+  const byLabel = new Map(buckets.map((b) => [b.label, b.issues.map((i) => i.number)]));
+
+  assert.deepEqual(byLabel.get("Regression"), [1]);
+  assert.deepEqual(byLabel.get("CTI team"), [2]);
+  assert.deepEqual(byLabel.get("afscrome finds"), [3]);
+  assert.deepEqual(byLabel.get("My issues"), [4]);
+  // Issue 5 matches no focus definition, so no bucket surfaces it.
+  assert.equal(buckets.some((b) => b.issues.some((i) => i.number === 5)), false);
+
+  // Without a login the per-viewer "My issues" lane is omitted.
+  const withoutLogin = createFocusIssueBuckets([mine], undefined);
+  assert.equal(withoutLogin.find((b) => b.label === "My issues"), undefined);
+});
+
+test("createIssueSignals leads with the highest-priority action pill", () => {
+  const releaseBlocking = makeIssue({ number: 1, labels: ["blocking-release"] });
+  assert.equal(createIssueSignals(releaseBlocking)[0].label, "Blocking release");
+
+  const regression = makeIssue({ number: 2, labels: ["regression"] });
+  assert.equal(createIssueSignals(regression)[0].label, "Regression");
+
+  const unowned = makeIssue({ number: 3, assignees: [] });
+  assert.equal(createIssueSignals(unowned)[0].label, "Unowned");
+
+  const owned = makeIssue({ number: 4, assignees: ["octo"] });
+  assert.equal(createIssueSignals(owned)[0].label, "Needs validation");
+
+  // Pills are capped at 7 even with many labels.
+  const noisy = makeIssue({ number: 5, milestone: "13.4", labels: ["a", "b", "c", "d", "e"] });
+  assert.ok(createIssueSignals(noisy).length <= 7);
 });

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -333,6 +333,7 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 .avatar { width: 18px; height: 18px; border-radius: 50%; border: 1px solid var(--border); }
 .reason { color: var(--muted); font-size: 12px; }
 .pills { display: flex; flex-wrap: wrap; gap: 5px; }
+.pills:empty { display: none; }
 .pill {
   display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 500; line-height: 1;
   padding: 0 8px; min-height: 20px; border-radius: 999px; border: 1px solid transparent;
@@ -356,7 +357,9 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 
 /* Settings form */
 .section { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 14px 14px 12px; margin-bottom: 12px; }
-.section h3 { margin: 0 0 3px; font-size: 13px; }
+.section.current { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); box-shadow: inset 3px 0 0 var(--accent); }
+.section h3 { margin: 0 0 3px; font-size: 13px; display: flex; align-items: center; gap: 7px; }
+.section h3 svg { color: var(--accent); }
 .section .hint { margin: 0 0 10px; color: var(--muted); font-size: 11.5px; }
 .section .hint b { color: var(--fg); }
 .policy { display: flex; flex-direction: column; gap: 8px; margin: 0 0 12px; }
@@ -668,7 +671,7 @@ const draftReposByAcct = {}; // account id -> working copy of that account's wat
 const editingByAcct = {};    // account id -> index of the repo row being inline-edited, or -1
 const repoSaveSeqByAcct = {}; // account id -> latest repository save request number
 
-const RANK = { queue: 0, notifications: 1, accounts: 1, settings: 1 };
+const RANK = { queue: 0, notifications: 1, accounts: 1, settings: 1, filters: 1 };
 
 const ICONS = {
   refresh: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v6h-6"/></svg>',
@@ -698,6 +701,8 @@ const ICONS = {
   globe: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>',
   usersSm: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>',
   layers: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>',
+  info: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
+  funnel: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>',
 };
 
 const LOGO = '<svg viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M3.5 30C1.57 30 0 28.43 0 26.5C0 25.871 0.166 25.259 0.48 24.729L8.818 10.287L8.852 10.236L12.968 3.099C13.593 2.019 14.754 1.349 16 1.349C17.246 1.349 18.407 2.019 19.031 3.098L31.531 24.749C31.833 25.258 31.999 25.87 31.999 26.499C31.999 28.429 30.429 29.999 28.499 29.999L3.5 30Z" fill="#512BD4"/><path d="M25.33 18H16.99L16 16.28L13.13 11.31C13 11.09 12.82 10.9 12.58 10.77C11.87 10.35 10.95 10.6 10.53 11.32L14.7 4.10001C14.96 3.65001 15.44 3.35001 16 3.35001C16.56 3.35001 17.04 3.65001 17.3 4.10001L21.45 11.29L21.46 11.31L21.48 11.34L25.33 18Z" fill="#7455DD"/><path d="M30 26.5C30 27.33 29.33 28 28.5 28H20.17C21 28 21.67 27.33 21.67 26.5C21.67 26.23 21.59 25.97 21.47 25.75L17.3 18.53L16.99 18H25.33L29.8 25.75C29.93 25.97 30 26.23 30 26.5Z" fill="#9780E5"/><path d="M21.67 26.5C21.67 27.33 21 28 20.17 28H11.83C12.66 28 13.33 27.33 13.33 26.5C13.33 26.23 13.26 25.97 13.13 25.75C13.13 25.74 13.12 25.73 13.11 25.72L11.79 23.57L8.82004 18.72C8.55004 18.28 8.07004 18 7.54004 18H16.99L17.3 18.53L17.427 18.75L21.47 25.75C21.59 25.97 21.67 26.23 21.67 26.5Z" fill="#B9AAEE"/><path d="M13.33 26.5C13.33 27.33 12.66 28 11.83 28H3.5C2.67 28 2 27.33 2 26.5C2 26.23 2.07 25.97 2.2 25.75L6.24 18.75C6.51 18.29 7.01 18 7.54 18C8.07 18 8.55 18.28 8.82 18.72L11.79 23.57L13.11 25.72C13.12 25.73 13.13 25.74 13.13 25.75C13.26 25.97 13.33 26.23 13.33 26.5Z" fill="#DCD5F6"/><path d="M16.99 18H7.53999C7.00999 18 6.50999 18.29 6.23999 18.75L6.66999 18L10.49 11.39L10.53 11.33V11.32C10.95 10.6 11.87 10.35 12.58 10.77C12.82 10.9 13 11.09 13.13 11.31L16 16.28L16.99 18Z" fill="#9780E5"/></svg>';
@@ -875,7 +880,7 @@ function prCard(item) {
       "<span>by " + esc(pr.author) + "</span>" +
     "</div>" +
     (item.reason ? '<div class="reason">' + esc(item.reason) + "</div>" : "") +
-    '<div class="pills">' + (item.signals || []).map(pill).join("") + "</div>" +
+    ((item.signals && item.signals.length) ? '<div class="pills">' + item.signals.map(pill).join("") + "</div>" : "") +
   "</a>";
 }
 
@@ -888,7 +893,7 @@ function issueCard(item) {
       '<span class="repo">' + esc(shortRepo(is.repository)) + " #" + is.number + "</span>" +
       "<span>by " + esc(is.author) + "</span>" +
     "</div>" +
-    '<div class="pills">' + (item.signals || []).map(pill).join("") + "</div>" +
+    ((item.signals && item.signals.length) ? '<div class="pills">' + item.signals.map(pill).join("") + "</div>" : "") +
   "</a>";
 }
 
@@ -1133,6 +1138,7 @@ function topbarHtml() {
     (state ? accountChip() : "") +
     '<div class="tb-actions">' +
     '<button class="iconbtn ' + (refreshing ? "spin" : "") + '" id="refresh-btn" title="Refresh">' + ICONS.refresh + "</button>" +
+    '<button class="iconbtn ' + (view === "filters" ? "active" : "") + '" id="filters-btn" title="What\u2019s filtered">' + ICONS.funnel + "</button>" +
     '<button class="iconbtn ' + (view === "notifications" ? "active" : "") + '" id="bell-btn" title="Notifications">' + ICONS.bell +
       (notifCount ? '<span class="badge">' + notifCount + "</span>" : "") + "</button>" +
     '<button class="iconbtn ' + (view === "settings" ? "active" : "") + '" id="gear-btn" title="Settings">' + ICONS.gear + "</button>" +
@@ -1199,6 +1205,46 @@ function toggle(id, title, desc, checked) {
   return '<div class="toggle-row"><span><span class="tl">' + esc(title) + "</span>" +
     (desc ? '<span class="td">' + esc(desc) + "</span>" : "") + "</span>" +
     '<label class="switch"><input type="checkbox" id="' + id + '" ' + (checked ? "checked" : "") + ' /><span class="slider"></span></label></div>';
+}
+
+function filtersView() {
+  const mode = state.mode;
+  const modeName = { review: "Review", issues: "Issues", ship: "Ship" }[mode] || "Review";
+  const cur = (m) => (mode === m ? " current" : "");
+  const drafts = state.counts && state.counts.drafts;
+  const draftLine = state.showDrafts
+    ? "Draft PRs are <b>shown</b> right now."
+    : "Draft PRs are <b>hidden</b> right now" + (drafts ? " (" + drafts + " hidden)" : "") + ".";
+  return '<div class="page">' +
+    '<div class="page-head"><h2>What\u2019s filtered</h2><p>This queue is curated, not a raw list. Here is exactly what each mode surfaces, holds back, or routes elsewhere, so a missing PR or issue is never a mystery. You are viewing <b>' + esc(modeName) + '</b> mode.</p></div>' +
+
+    '<div class="section' + cur("review") + '"><h3>' + ICONS.eye + " Review</h3>" +
+      '<div class="policy">' +
+        '<div class="policy-row">' + ICONS.merge + "<span>A PR reaches the <b>shared review queue</b> only once <b>checks are green</b> and <b>all feedback is resolved</b>. Unfinished work stays in the author\u2019s <b>Your PRs</b> lane.</span></div>" +
+        '<div class="policy-row">' + ICONS.pr + "<span><b>Drafts, merge conflicts, and needs-author-action</b> PRs are routed out of the shared lists, so reviewers only see PRs that are genuinely ready.</span></div>" +
+        '<div class="policy-row">' + ICONS.xcircle + "<span><b>CI-failing</b> PRs are held out of Needs attention. A failure driven only by informational <b>aspire-1p checks</b> (proof of presence) is not counted as red.</span></div>" +
+        '<div class="policy-row">' + ICONS.usersSm + "<span>PRs you authored <b>as yourself or via Copilot</b> both count as yours, so delegated work still lands in your lanes and developer totals.</span></div>" +
+      "</div>" +
+    "</div>" +
+
+    '<div class="section' + cur("issues") + '"><h3>' + ICONS.tag + " Issues</h3>" +
+      '<div class="policy">' +
+        '<div class="policy-row">' + ICONS.alertSm + "<span><b>Focus buckets</b> surface the issues that matter first: regressions, CTI team items ([aspiree2e]), afscrome finds, and your own issues.</span></div>" +
+        '<div class="policy-row">' + ICONS.dot2 + "<span>Everything else lands in <b>Needs triage</b> (unlabeled and unassigned) or <b>Recently active</b>, so no open issue silently drops off.</span></div>" +
+      "</div>" +
+    "</div>" +
+
+    '<div class="section' + cur("ship") + '"><h3>' + ICONS.merge + " Ship</h3>" +
+      '<div class="policy">' +
+        '<div class="policy-row">' + ICONS.clock + "<span>Groups open work for the active milestone (<b>" + esc(prefs.release || state.release || "\u2014") + "</b>) so the release view stays focused on what is landing now.</span></div>" +
+      "</div>" +
+    "</div>" +
+
+    '<div class="section"><h3>Drafts</h3>' +
+      '<p class="hint">' + draftLine + " Drafts are prototypes and experiments, not review work. Change this in Settings.</p>" +
+      '<div class="row-actions"><button class="btn ghost" id="filters-to-settings">Open settings</button></div>' +
+    "</div>" +
+  "</div>";
 }
 
 function settingsView() {
@@ -1382,6 +1428,7 @@ function render(forward) {
   let inner;
   if (!state.authenticated) { view = "queue"; inner = authPicker(); }
   else if (view === "settings") inner = settingsView();
+  else if (view === "filters") inner = filtersView();
   else if (view === "accounts") inner = accountsView();
   else if (view === "notifications") inner = notificationsView();
   else inner = queueView();
@@ -1643,16 +1690,20 @@ function wire() {
   const back = document.getElementById("back-btn"); if (back) back.addEventListener("click", () => goView("queue", false));
   const bell = document.getElementById("bell-btn"); if (bell) bell.addEventListener("click", () => goView(view === "notifications" ? "queue" : "notifications"));
   const gear = document.getElementById("gear-btn"); if (gear) gear.addEventListener("click", () => goView(view === "settings" ? "queue" : "settings"));
+  const filt = document.getElementById("filters-btn"); if (filt) filt.addEventListener("click", () => goView(view === "filters" ? "queue" : "filters"));
   const acct = document.getElementById("acct-btn"); if (acct) acct.addEventListener("click", () => goView(view === "accounts" ? "queue" : "accounts"));
 
   const save = document.getElementById("save-settings"); if (save) save.addEventListener("click", saveSettings);
   const cancel = document.getElementById("cancel-settings"); if (cancel) cancel.addEventListener("click", () => goView("queue", false));
+  const fToSettings = document.getElementById("filters-to-settings"); if (fToSettings) fToSettings.addEventListener("click", () => goView("settings"));
 
   // The Esc/Enter hints on the settings buttons are real shortcuts, like the app's
-  // Cancel/Continue. Bound once so re-renders don't stack handlers.
+  // Cancel/Continue. Bound once so re-renders don't stack handlers. Esc also backs
+  // out of the filters info page, which has no Enter action of its own.
   if (!keysBound) {
     keysBound = true;
     document.addEventListener("keydown", function (e) {
+      if (view === "filters" && e.key === "Escape") { e.preventDefault(); goView("queue", false); return; }
       if (view !== "settings") return;
       if (e.key === "Escape") { e.preventDefault(); goView("queue", false); }
       else if (e.key === "Enter" && !e.isComposing && (e.target.tagName || "") !== "TEXTAREA") {

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -701,7 +701,6 @@ const ICONS = {
   globe: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>',
   usersSm: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>',
   layers: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>',
-  info: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
   funnel: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>',
 };
 


### PR DESCRIPTION
Syncs the Aspire Team App Copilot canvas extension with the latest davidfowl/pr-dashboard model logic, and ports two of the dashboard's recent presentation improvements.

## What

Ports the newest pr-dashboard model rules into the extension so the shared Review, Issues, and Ship views behave like the dashboard the team already relies on:

- **Non-blocking check-failure rules.** Adds the aspire-1p "proof of presence" rule so an aggregate CI failure driven only by informational checks (for example `GitOps/GitHubPop`) no longer reads as red CI. Backed by a faithful `visibleCheckState` / `isChecksFailing` pass, with `nonBlockingOnlyFailureRule` and `isNonBlockingAggregateFailure` helpers. A rule is only honored when it names a repository, a label, and at least one concrete check matcher (`filterCheckFailureRules`, mirroring the dashboard's `normalizeCheckFailureRules` guard from #96), so a matcher-less config entry can never silently suppress genuine red CI.
- **`/copilot` identity attribution.** `actorIdentityKey` now strips a `/copilot` suffix (and punctuation) so a Copilot-authored PR counts toward, and is "mine" for, its human owner. Applied to `isMine` on both PRs and the developer PR counts.
- **Shared-list hide filter.** `shouldHideFromSharedPullRequestLists` (draft, conflicting, or needs-author-action) keeps author-owned PRs out of the shared review queue.
- **`isBotAuthor` parity.** Raw-login bot detection matching the dashboard, alongside the existing `authorType` and configured bot-login checks.
- **Issues focus buckets and signals.** A ported focus-bucket engine (Regression, CTI team, afscrome finds, plus a per-viewer My issues lane) with issue signal pills (action pill, release, idle, milestone, labels, bot), and residual Needs triage / Recently active lanes so no open issue drops out of the view.

The extension stays config-value faithful: dashboard config values (the non-blocking rule, CTI/afscrome markers, release-blocking marker) are baked into `constants.mjs` rather than porting the dashboard's server-config plumbing. Linked-PR-derived issue pills are omitted because this extension does not fetch per-issue linked-PR data, so they are skipped rather than guessed.

Deferred intentionally: the dashboard's server-computed ship-week release-scope grouping and its new agent review queue endpoint (#96, #99) both need a dedicated server API this self-contained canvas does not expose, and its browser Web Push / PWA notification stack are all out of scope.

## Presentation

Ports two of the dashboard's recent UX refinements, adapted to this canvas's no-overlay, in-canvas view-router design:

- **"What's filtered" page.** A new topbar funnel button opens a routed full page (closed via Back or Esc) that explains, per mode, what the queue surfaces, holds back, or routes elsewhere: the green-checks-and-resolved gate, drafts/conflicts/needs-author-action routing, the non-blocking aspire-1p checks, you-plus-Copilot attribution, the Issues focus buckets, and Ship milestone grouping. The section matching the active mode is highlighted. This mirrors the dashboard's filter-info affordance while staying faithful to the app's routed-page language rather than introducing a modal.
- **Card row cleanup.** Cards with no signal pills no longer reserve an empty pill row, so rows sit tighter, matching the dashboard's collapse-empty-marker pass.

## Where

Lives under `.github/extensions/aspire-team-app/` as a project extension auto-discovered by the Copilot app, matching the existing `issue-triage-canvas` convention. The diff is limited to this self-contained extension folder.

## Files

- `constants.mjs` · adds the non-blocking check-failure rule and Issues markers (CTI title marker, afscrome author, release-blocking label marker).
- `model.mjs` · non-blocking check-state engine (including the `filterCheckFailureRules` concrete-matcher guard), `/copilot` identity and bot-author parity, `shouldHideFromSharedPullRequestLists`, and the Issues focus-bucket / signal engine.
- `github.mjs` · engine-shaped `checks` object, `checksState` routed through `visibleCheckState`, identity-aware `isMine`, shared-list hide filter on the review queue, and focus-bucket-based issue lanes.
- `render.mjs` · presentation-only: the routed "What's filtered" page (topbar funnel button, active-mode highlight) and the empty-pill-row cleanup on cards.
- `model.test.mjs` · unit tests for non-blocking checks, the check-rule matcher guard, `/copilot` attribution, the hide filter, focus buckets, and issue signals.

## Validation

`node --check` passes on every module and the repo extension validator (`node .github/extensions/validate-extensions.mjs`) runs green: 1 manifest, 17 modules, 7 test files, all 26 extension tests pass.

Opened as a Draft for team review.