### PR TITLE
Fix single-file AppHost describe targeting

### DIFF
--- a/extension/src/editor/AppHostFilePresenceWatcher.ts
+++ b/extension/src/editor/AppHostFilePresenceWatcher.ts
@@ -20,7 +20,7 @@ export class AppHostFilePresenceWatcher implements vscode.Disposable {
     private static readonly _changeDebounceMs = 250;
 
     private readonly _disposables: vscode.Disposable[] = [];
-    private _lastValue = false;
+    private _lastAppHostPath: string | undefined;
     private _changeTimer: NodeJS.Timeout | undefined;
     private _updateVersion = 0;
     private _updateTask: Promise<void> = Promise.resolve();
@@ -59,25 +59,25 @@ export class AppHostFilePresenceWatcher implements vscode.Disposable {
     }
 
     private async _update(version: number): Promise<void> {
-        const value = await this._anyVisibleEditorIsAppHost();
+        const appHostPath = await this._getVisibleAppHostPath();
         if (version !== this._updateVersion) {
             return;
         }
 
-        if (value === this._lastValue) {
+        if (appHostPath === this._lastAppHostPath) {
             return;
         }
-        this._lastValue = value;
-        this._repository.setAppHostFileOpen(value);
+        this._lastAppHostPath = appHostPath;
+        this._repository.setAppHostFileOpen(appHostPath !== undefined, appHostPath);
     }
 
-    private async _anyVisibleEditorIsAppHost(): Promise<boolean> {
+    private async _getVisibleAppHostPath(): Promise<string | undefined> {
         for (const editor of vscode.window.visibleTextEditors) {
             if (await getParserForDocument(editor.document)) {
-                return true;
+                return editor.document.uri.fsPath;
             }
         }
-        return false;
+        return undefined;
     }
 
     dispose(): void {

--- a/extension/src/test/appHostDataRepository.test.ts
+++ b/extension/src/test/appHostDataRepository.test.ts
@@ -4042,15 +4042,36 @@ suite('AppHostDataRepository AppHost-file gate', () => {
         subscriptions.forEach(subscription => subscription.dispose());
     });
 
-    test('opening AppHost file with hidden panel starts describe watch', async () => {
+    test('opening AppHost file with hidden panel starts describe watch for that file', async () => {
         const repository = new AppHostDataRepository(terminalProvider);
 
         repository.activate();
-        repository.setAppHostFileOpen(true);
+        repository.setAppHostFileOpen(true, '/workspace/TestShop.AppHost/AppHost.cs');
         await waitForMicrotasks();
 
         assert.strictEqual(spawnStub.calledOnce, true);
-        assert.deepStrictEqual(spawnStub.firstCall.args[2], ['describe', '--follow', '--format', 'json', '--include-disabled-commands']);
+        assert.deepStrictEqual(spawnStub.firstCall.args[2], ['describe', '--follow', '--format', 'json', '--include-disabled-commands', '--apphost', '/workspace/TestShop.AppHost/AppHost.cs']);
+
+        repository.dispose();
+    });
+
+    test('changing open AppHost file retargets single-file describe watch', async () => {
+        const firstChildProcess = new TestChildProcess();
+        const secondChildProcess = new TestChildProcess();
+        spawnStub.onFirstCall().returns(firstChildProcess);
+        spawnStub.onSecondCall().returns(secondChildProcess);
+        const repository = new AppHostDataRepository(terminalProvider);
+
+        repository.activate();
+        repository.setAppHostFileOpen(true, '/workspace/First.AppHost/AppHost.cs');
+        await waitForMicrotasks();
+
+        repository.setAppHostFileOpen(true, '/workspace/Second.AppHost/AppHost.cs');
+        await waitForMicrotasks();
+
+        assert.strictEqual(firstChildProcess.killed, true);
+        assert.strictEqual(spawnStub.calledTwice, true);
+        assert.deepStrictEqual(spawnStub.secondCall.args[2], ['describe', '--follow', '--format', 'json', '--include-disabled-commands', '--apphost', '/workspace/Second.AppHost/AppHost.cs']);
 
         repository.dispose();
     });

--- a/extension/src/test/appHostFilePresenceWatcher.test.ts
+++ b/extension/src/test/appHostFilePresenceWatcher.test.ts
@@ -120,14 +120,15 @@ suite('AppHostFilePresenceWatcher', () => {
     });
 
     test('constructor reports true when an AppHost file is already visible', async () => {
-        visibleEditors = [makeEditor('/test/AppHost.cs', appHostCsContent)];
+        const appHostPath = '/test/AppHost.cs';
+        visibleEditors = [makeEditor(appHostPath, appHostCsContent)];
 
         const watcher = new AppHostFilePresenceWatcher(repository);
         await waitForUpdate(watcher);
 
         assert.strictEqual(setOpenSpy.calledOnce, true);
         assert.strictEqual(setOpenSpy.firstCall.args[0], true);
-        assert.strictEqual(setOpenSpy.firstCall.args[1], '/test/AppHost.cs');
+        assert.strictEqual(setOpenSpy.firstCall.args[1], vscode.Uri.file(appHostPath).fsPath);
         watcher.dispose();
     });
 
@@ -143,18 +144,20 @@ suite('AppHostFilePresenceWatcher', () => {
     });
 
     test('visibility change between AppHost files reports the new file path', async () => {
-        visibleEditors = [makeEditor('/test/First.AppHost/AppHost.cs', appHostCsContent)];
+        const firstAppHostPath = '/test/First.AppHost/AppHost.cs';
+        const secondAppHostPath = '/test/Second.AppHost/AppHost.cs';
+        visibleEditors = [makeEditor(firstAppHostPath, appHostCsContent)];
         const watcher = new AppHostFilePresenceWatcher(repository);
         await waitForUpdate(watcher);
         assert.strictEqual(setOpenSpy.calledOnce, true);
 
-        visibleEditors = [makeEditor('/test/Second.AppHost/AppHost.cs', appHostCsContent)];
+        visibleEditors = [makeEditor(secondAppHostPath, appHostCsContent)];
         captured.visibilityListeners.forEach(l => l(visibleEditors));
         await waitForUpdate(watcher);
 
         assert.strictEqual(setOpenSpy.callCount, 2);
         assert.strictEqual(setOpenSpy.secondCall.args[0], true);
-        assert.strictEqual(setOpenSpy.secondCall.args[1], '/test/Second.AppHost/AppHost.cs');
+        assert.strictEqual(setOpenSpy.secondCall.args[1], vscode.Uri.file(secondAppHostPath).fsPath);
         watcher.dispose();
     });
 

--- a/extension/src/test/appHostFilePresenceWatcher.test.ts
+++ b/extension/src/test/appHostFilePresenceWatcher.test.ts
@@ -127,6 +127,7 @@ suite('AppHostFilePresenceWatcher', () => {
 
         assert.strictEqual(setOpenSpy.calledOnce, true);
         assert.strictEqual(setOpenSpy.firstCall.args[0], true);
+        assert.strictEqual(setOpenSpy.firstCall.args[1], '/test/AppHost.cs');
         watcher.dispose();
     });
 
@@ -138,6 +139,22 @@ suite('AppHostFilePresenceWatcher', () => {
 
         assert.strictEqual(setOpenSpy.calledOnce, true);
         assert.strictEqual(setOpenSpy.firstCall.args[0], true);
+        watcher.dispose();
+    });
+
+    test('visibility change between AppHost files reports the new file path', async () => {
+        visibleEditors = [makeEditor('/test/First.AppHost/AppHost.cs', appHostCsContent)];
+        const watcher = new AppHostFilePresenceWatcher(repository);
+        await waitForUpdate(watcher);
+        assert.strictEqual(setOpenSpy.calledOnce, true);
+
+        visibleEditors = [makeEditor('/test/Second.AppHost/AppHost.cs', appHostCsContent)];
+        captured.visibilityListeners.forEach(l => l(visibleEditors));
+        await waitForUpdate(watcher);
+
+        assert.strictEqual(setOpenSpy.callCount, 2);
+        assert.strictEqual(setOpenSpy.secondCall.args[0], true);
+        assert.strictEqual(setOpenSpy.secondCall.args[1], '/test/Second.AppHost/AppHost.cs');
         watcher.dispose();
     });
 

--- a/extension/src/views/AppHostDataRepository.ts
+++ b/extension/src/views/AppHostDataRepository.ts
@@ -194,6 +194,7 @@ export class AppHostDataRepository {
     private _viewMode: ViewMode = 'workspace';
     private _panelVisible = false;
     private _appHostFileOpen = false;
+    private _appHostFilePath: string | undefined;
     private _hasEverBeenDataActive = false;
 
     // ── Workspace mode state (describe --follow) ──
@@ -394,22 +395,30 @@ export class AppHostDataRepository {
     }
 
     /**
-     * Signals whether at least one visible editor currently shows an AppHost file.
+     * Signals whether at least one visible editor currently shows an AppHost file, and which
+     * AppHost file should be used when there is no workspace-scoped AppHost selection.
      *
      * When `true`, the repository will run the same data-source(s) it would when the
      * tree-view panel is visible.  This lets code-lens decorations on a freshly-created
      * AppHost file show live resource state without the user first opening the panel.
      */
-    setAppHostFileOpen(open: boolean): void {
-        if (this._appHostFileOpen === open) {
+    setAppHostFileOpen(open: boolean, appHostPath?: string): void {
+        const nextAppHostFilePath = open ? appHostPath : undefined;
+        if (this._appHostFileOpen === open && isSameOptionalAppHostPath(this._appHostFilePath, nextAppHostFilePath)) {
             return;
         }
         const wasDataActive = this._dataActive;
+        const previousDescribeAppHostPath = this._workspaceDescribeAppHostPath;
         this._appHostFileOpen = open;
+        this._appHostFilePath = nextAppHostFilePath;
         const becameDataActive = !wasDataActive && this._dataActive;
         const resumedFromInactive = becameDataActive && this._hasEverBeenDataActive;
         if (this._dataActive) {
             this._hasEverBeenDataActive = true;
+        }
+        if (!isSameOptionalAppHostPath(previousDescribeAppHostPath, this._workspaceDescribeAppHostPath)) {
+            this._stopDescribeWatch({ clearWorkspaceResources: true });
+            this._describeRestartDelay = 5000;
         }
         this._syncPolling(resumedFromInactive);
     }
@@ -638,6 +647,16 @@ export class AppHostDataRepository {
         }
 
         return this._workspaceAppHostDiscoveryComplete && this._workspaceAppHostPath !== undefined;
+    }
+
+    private get _workspaceDescribeAppHostPath(): string | undefined {
+        if (this._workspaceAppHostPath) {
+            return this._workspaceAppHostPath;
+        }
+
+        // With no workspace folders, workspace discovery cannot select an AppHost.
+        // Use the visible AppHost editor instead of falling back to the extension host cwd.
+        return !this._workspaceAppHostDiscoveryUsesWorkspaceRoot ? this._appHostFilePath : undefined;
     }
 
     private _syncPolling(refreshBeforeFollowOnResume = false): void {
@@ -884,8 +903,9 @@ export class AppHostDataRepository {
             if (includeDisabledCommands) {
                 args.push('--include-disabled-commands');
             }
-            if (this._workspaceAppHostPath) {
-                args.push('--apphost', this._workspaceAppHostPath);
+            const describeAppHostPath = this._workspaceDescribeAppHostPath;
+            if (describeAppHostPath) {
+                args.push('--apphost', describeAppHostPath);
             }
 
             extensionLogOutputChannel.info('Starting aspire describe --follow for workspace resources');
@@ -2359,6 +2379,10 @@ function isSameAppHostPath(left: string | undefined, right: string | undefined):
     }
 
     return getComparisonKey(path.normalize(left)) === getComparisonKey(path.normalize(right));
+}
+
+function isSameOptionalAppHostPath(left: string | undefined, right: string | undefined): boolean {
+    return (left === undefined && right === undefined) || isSameAppHostPath(left, right);
 }
 
 function isMatchingAppHostInstance(left: AppHostDisplayInfo, right: AppHostDisplayInfo): boolean {


### PR DESCRIPTION
## Description

Fixes #18579

When VS Code opens a single AppHost file without a workspace folder, the extension now targets that open file for workspace resource discovery instead of letting `aspire describe --follow` resolve from the extension host's current working directory.

The AppHost file presence watcher now reports the visible AppHost document path to `AppHostDataRepository`. In no-workspace mode, the repository passes that path through as `--apphost <path>` and retargets the describe stream when the visible AppHost file changes. Normal workspace discovery still takes precedence when a workspace-selected AppHost exists.

### User-facing usage

Open a standalone AppHost file such as `TestShop.AppHost/AppHost.cs` without opening a folder. The extension's hidden `describe --follow` stream now runs against that file:

```text
aspire describe --follow --format json --include-disabled-commands --apphost <open AppHost file>
```

### Validation

```text
./extension/build.sh
corepack yarn run lint
corepack yarn run compile-tests && corepack yarn run unit-test --config <short-path test config> --code-version 1.127.0 --grep "AppHostFilePresenceWatcher|AppHostDataRepository AppHost-file gate"
```


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

<!-- daily-work-queue:v1 repo=microsoft/aspire pr=18619 head=8535371ca9b2cd265720c7a6f04469b4f135e1c9 lane=implementation-validation status=validation-complete-live-proof-passed-adam-ready-decision tracking=issue-18579-single-file-describe ledger=2026-07-02T20:41:00Z -->