### PR TITLE
Recommend the VS Code extension in aspire doctor

### DIFF
--- a/docs/specs/cli-output-formats.md
+++ b/docs/specs/cli-output-formats.md
@@ -468,7 +468,7 @@ The JSON form includes secret values. Do not redirect it to logs or files unless
   ],
   "summary": {
     "passed": 2,
-    "warnings": 1,
+    "warnings": 2,
     "failed": 0
   }
 }

--- a/docs/specs/cli-output-formats.md
+++ b/docs/specs/cli-output-formats.md
@@ -451,6 +451,19 @@ The JSON form includes secret values. Do not redirect it to logs or files unless
       "message": "Container runtime is not running.",
       "fix": "Start Docker Desktop.",
       "link": "https://learn.microsoft.com/dotnet/aspire/"
+    },
+    {
+      "category": "devtools",
+      "name": "vscode-extension",
+      "status": "warning",
+      "message": "VS Code is installed, but the Aspire extension is not installed",
+      "fix": "Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.",
+      "link": "https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode",
+      "metadata": {
+        "vsCodeInstalled": true,
+        "extensionInstalled": false,
+        "extensionId": "microsoft-aspire.aspire-vscode"
+      }
     }
   ],
   "summary": {
@@ -462,6 +475,8 @@ The JSON form includes secret values. Do not redirect it to logs or files unless
 ```
 
 `status` is one of `pass`, `warning`, or `fail`. Individual checks can include `details`, `fix`, `link`, or command-specific `metadata`.
+
+The `devtools` category surfaces development-tooling recommendations. The `vscode-extension` check only appears when VS Code is detected: it reports `warning` when the [Aspire VS Code extension](https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode) is missing and `pass` when it is installed. Its `metadata` exposes `vsCodeInstalled` (bool), `extensionInstalled` (bool), and `extensionId` (string).
 
 ### `aspire config info`
 

--- a/docs/specs/cli-output-formats.md
+++ b/docs/specs/cli-output-formats.md
@@ -458,7 +458,7 @@ The JSON form includes secret values. Do not redirect it to logs or files unless
       "status": "warning",
       "message": "VS Code is installed, but the Aspire extension is not installed",
       "fix": "Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.",
-      "link": "https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode",
+      "link": "https://aka.ms/aspire/vscode-extension",
       "metadata": {
         "vsCodeInstalled": true,
         "extensionInstalled": false,
@@ -476,7 +476,7 @@ The JSON form includes secret values. Do not redirect it to logs or files unless
 
 `status` is one of `pass`, `warning`, or `fail`. Individual checks can include `details`, `fix`, `link`, or command-specific `metadata`.
 
-The `devtools` category surfaces development-tooling recommendations. The `vscode-extension` check only appears when VS Code is detected: it reports `warning` when the [Aspire VS Code extension](https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode) is missing and `pass` when it is installed. Its `metadata` exposes `vsCodeInstalled` (bool), `extensionInstalled` (bool), and `extensionId` (string).
+The `devtools` category surfaces development-tooling recommendations. The `vscode-extension` check only appears when VS Code is detected: it reports `warning` when the [Aspire VS Code extension](https://aka.ms/aspire/vscode-extension) is missing and `pass` when it is installed. Its `metadata` exposes `vsCodeInstalled` (bool), `extensionInstalled` (bool), and `extensionId` (string).
 
 ### `aspire config info`
 

--- a/src/Aspire.Cli/Commands/DoctorCommand.cs
+++ b/src/Aspire.Cli/Commands/DoctorCommand.cs
@@ -228,6 +228,7 @@ internal sealed class DoctorCommand : BaseCommand
             "apphost" => DoctorCommandStrings.AppHostCategoryHeader,
             "container" => DoctorCommandStrings.ContainerCategoryHeader,
             "environment" => DoctorCommandStrings.EnvironmentCategoryHeader,
+            "devtools" => DoctorCommandStrings.DevelopmentToolsCategoryHeader,
             _ => category
         };
     }
@@ -241,6 +242,7 @@ internal sealed class DoctorCommand : BaseCommand
             "sdk" => 2,
             "container" => 3,
             "environment" => 4,
+            "devtools" => 5,
             _ => 99
         };
     }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -588,6 +588,7 @@ public class Program
         builder.Services.AddSingleton<IEnvironmentCheck, DeprecatedAgentConfigCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, LegacySettingsFileCheck>();
         builder.Services.AddSingleton<IEnvironmentCheck, PendingMigrationsCheck>();
+        builder.Services.AddSingleton<IEnvironmentCheck, VsCodeExtensionCheck>();
         builder.Services.AddSingleton<IEnvironmentChecker, EnvironmentChecker>();
 
         // MCP server transport factory - creates transport only when needed to avoid

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -139,7 +139,7 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("DevelopmentToolsCategoryHeader", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Aspire extension for VS Code is installed.
         /// </summary>
@@ -148,7 +148,7 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("VsCodeExtensionInstalledMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to VS Code is installed, but the Aspire extension is not installed.
         /// </summary>
@@ -157,7 +157,7 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("VsCodeExtensionMissingMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience..
         /// </summary>
@@ -166,7 +166,7 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("VsCodeExtensionMissingFix", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Summary: {0} passed, {1} warnings, {2} failed.
         /// </summary>

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -132,7 +132,7 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Development tools.
+        ///   Looks up a localized string similar to Development Tools.
         /// </summary>
         public static string DevelopmentToolsCategoryHeader {
             get {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -132,6 +132,42 @@ namespace Aspire.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Development tools.
+        /// </summary>
+        public static string DevelopmentToolsCategoryHeader {
+            get {
+                return ResourceManager.GetString("DevelopmentToolsCategoryHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Aspire extension for VS Code is installed.
+        /// </summary>
+        public static string VsCodeExtensionInstalledMessage {
+            get {
+                return ResourceManager.GetString("VsCodeExtensionInstalledMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VS Code is installed, but the Aspire extension is not installed.
+        /// </summary>
+        public static string VsCodeExtensionMissingMessage {
+            get {
+                return ResourceManager.GetString("VsCodeExtensionMissingMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience..
+        /// </summary>
+        public static string VsCodeExtensionMissingFix {
+            get {
+                return ResourceManager.GetString("VsCodeExtensionMissingFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Summary: {0} passed, {1} warnings, {2} failed.
         /// </summary>
         public static string SummaryFormat {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -83,7 +83,7 @@
     <value>Environment</value>
   </data>
   <data name="DevelopmentToolsCategoryHeader" xml:space="preserve">
-    <value>Development tools</value>
+    <value>Development Tools</value>
   </data>
   <data name="VsCodeExtensionInstalledMessage" xml:space="preserve">
     <value>Aspire extension for VS Code is installed</value>

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -82,6 +82,18 @@
   <data name="EnvironmentCategoryHeader" xml:space="preserve">
     <value>Environment</value>
   </data>
+  <data name="DevelopmentToolsCategoryHeader" xml:space="preserve">
+    <value>Development tools</value>
+  </data>
+  <data name="VsCodeExtensionInstalledMessage" xml:space="preserve">
+    <value>Aspire extension for VS Code is installed</value>
+  </data>
+  <data name="VsCodeExtensionMissingMessage" xml:space="preserve">
+    <value>VS Code is installed, but the Aspire extension is not installed</value>
+  </data>
+  <data name="VsCodeExtensionMissingFix" xml:space="preserve">
+    <value>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</value>
+  </data>
   <data name="SummaryFormat" xml:space="preserve">
     <value>Summary: {0} passed, {1} warnings, {2} failed</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Prostředí</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Umgebung</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Entorno</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Environnement</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Ambiente</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">環境</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">환경</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Środowisko</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Ambiente</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Среда</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">Ortam</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">环境</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -322,6 +322,11 @@
         <target state="new">HTTPS development certificate is trusted</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevelopmentToolsCategoryHeader">
+        <source>Development tools</source>
+        <target state="new">Development tools</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">
         <source>Environment</source>
         <target state="translated">環境</target>
@@ -424,6 +429,21 @@ The current layout continues to work — this is a non-blocking warning.</target
       <trans-unit id="VersionUnknown">
         <source>unknown</source>
         <target state="new">unknown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionInstalledMessage">
+        <source>Aspire extension for VS Code is installed</source>
+        <target state="new">Aspire extension for VS Code is installed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingFix">
+        <source>Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</source>
+        <target state="new">Install the Aspire extension from the VS Code Marketplace for an integrated Aspire experience.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsCodeExtensionMissingMessage">
+        <source>VS Code is installed, but the Aspire extension is not installed</source>
+        <target state="new">VS Code is installed, but the Aspire extension is not installed</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -323,8 +323,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DevelopmentToolsCategoryHeader">
-        <source>Development tools</source>
-        <target state="new">Development tools</target>
+        <source>Development Tools</source>
+        <target state="new">Development Tools</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentCategoryHeader">

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentCheckResult.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentCheckResult.cs
@@ -37,6 +37,11 @@ internal static class EnvironmentCheckCategories
     /// Checks that report SDK state.
     /// </summary>
     internal const string Sdk = "sdk";
+
+    /// <summary>
+    /// Checks that report development tooling state (for example, editor extensions).
+    /// </summary>
+    internal const string DevelopmentTools = "devtools";
 }
 
 /// <summary>

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Aspire.Cli.Resources;
+
+namespace Aspire.Cli.Utils.EnvironmentChecker;
+
+/// <summary>
+/// Recommends installing the Aspire VS Code extension when VS Code is present but the extension is not.
+/// </summary>
+/// <remarks>
+/// The check is intentionally silent when VS Code is not detected: there is nothing to recommend
+/// outside of a VS Code environment, so it returns an empty result and no row is rendered.
+/// </remarks>
+internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
+{
+    internal const string CheckName = "vscode-extension";
+
+    /// <summary>
+    /// The unique identifier of the Aspire VS Code extension (<c>&lt;publisher&gt;.&lt;name&gt;</c>).
+    /// </summary>
+    internal const string ExtensionId = "microsoft-aspire.aspire-vscode";
+
+    /// <summary>
+    /// The marketplace URL used as the fix link when the extension is missing.
+    /// </summary>
+    internal const string MarketplaceUrl = "https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode";
+
+    private readonly Func<VsCodeExtensionDetection> _detect;
+
+    public VsCodeExtensionCheck(IEnvironment environment, CliExecutionContext executionContext)
+        : this(() => Detect(environment, executionContext.HomeDirectory))
+    {
+    }
+
+    internal VsCodeExtensionCheck(Func<VsCodeExtensionDetection> detect)
+    {
+        ArgumentNullException.ThrowIfNull(detect);
+
+        _detect = detect;
+    }
+
+    // Runs after the fast environment/OS checks; this is a cheap filesystem probe with no process spawn.
+    public int Order => 60;
+
+    public Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var detection = _detect();
+
+        // Nothing to recommend when the user is not running VS Code.
+        if (!detection.VsCodeInstalled)
+        {
+            return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([]);
+        }
+
+        var extensionInstalled = detection.ExtensionInstalled;
+        var result = new EnvironmentCheckResult
+        {
+            Category = EnvironmentCheckCategories.DevelopmentTools,
+            Name = CheckName,
+            Status = extensionInstalled ? EnvironmentCheckStatus.Pass : EnvironmentCheckStatus.Warning,
+            Message = extensionInstalled
+                ? DoctorCommandStrings.VsCodeExtensionInstalledMessage
+                : DoctorCommandStrings.VsCodeExtensionMissingMessage,
+            Fix = extensionInstalled ? null : DoctorCommandStrings.VsCodeExtensionMissingFix,
+            Link = extensionInstalled ? null : MarketplaceUrl,
+            Metadata = BuildMetadata(detection)
+        };
+
+        return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([result]);
+    }
+
+    internal static VsCodeExtensionDetection Detect(IEnvironment environment, DirectoryInfo homeDirectory)
+    {
+        var vsCodeInstalled = IsVsCodeInstalled(environment);
+        if (!vsCodeInstalled)
+        {
+            return new VsCodeExtensionDetection(VsCodeInstalled: false, ExtensionInstalled: false);
+        }
+
+        var extensionInstalled = IsExtensionInstalled(environment, homeDirectory);
+        return new VsCodeExtensionDetection(VsCodeInstalled: true, ExtensionInstalled: extensionInstalled);
+    }
+
+    private static bool IsVsCodeInstalled(IEnvironment environment)
+    {
+        // When doctor is invoked from an integrated terminal, VS Code advertises itself via TERM_PROGRAM.
+        // See https://code.visualstudio.com/docs/terminal/shell-integration.
+        if (string.Equals(environment.GetEnvironmentVariable("TERM_PROGRAM"), "vscode", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Otherwise fall back to probing for the CLI launchers on PATH (stable and Insiders).
+        return PathLookupHelper.FindFullPathFromPath("code") is not null
+            || PathLookupHelper.FindFullPathFromPath("code-insiders") is not null;
+    }
+
+    private static bool IsExtensionInstalled(IEnvironment environment, DirectoryInfo homeDirectory)
+    {
+        foreach (var extensionsDirectory in GetExtensionDirectories(environment, homeDirectory))
+        {
+            if (DirectoryContainsExtension(extensionsDirectory))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> GetExtensionDirectories(IEnvironment environment, DirectoryInfo homeDirectory)
+    {
+        // VSCODE_EXTENSIONS overrides the default extensions location when set.
+        var overrideDirectory = environment.GetEnvironmentVariable("VSCODE_EXTENSIONS");
+        if (!string.IsNullOrWhiteSpace(overrideDirectory))
+        {
+            yield return overrideDirectory;
+        }
+
+        var home = homeDirectory.FullName;
+
+        // Default extension roots for desktop (stable/Insiders) and remote/server installs.
+        yield return Path.Combine(home, ".vscode", "extensions");
+        yield return Path.Combine(home, ".vscode-insiders", "extensions");
+        yield return Path.Combine(home, ".vscode-server", "extensions");
+        yield return Path.Combine(home, ".vscode-server-insiders", "extensions");
+    }
+
+    private static bool DirectoryContainsExtension(string extensionsDirectory)
+    {
+        if (!Directory.Exists(extensionsDirectory))
+        {
+            return false;
+        }
+
+        try
+        {
+            // Installed extensions live in per-version folders named "<publisher>.<name>-<version>",
+            // lowercased by VS Code, for example "microsoft-aspire.aspire-vscode-1.2.3". A case-insensitive
+            // prefix match tolerates any installed version without spawning the VS Code CLI.
+            foreach (var directory in Directory.EnumerateDirectories(extensionsDirectory))
+            {
+                var folderName = Path.GetFileName(directory);
+                if (folderName.StartsWith(ExtensionId + "-", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Treat an unreadable extensions directory as "not found" rather than failing the whole doctor run.
+            return false;
+        }
+
+        return false;
+    }
+
+    private static JsonObject BuildMetadata(VsCodeExtensionDetection detection)
+        => new()
+        {
+            ["vsCodeInstalled"] = detection.VsCodeInstalled,
+            ["extensionInstalled"] = detection.ExtensionInstalled,
+            ["extensionId"] = ExtensionId
+        };
+}
+
+/// <summary>
+/// Captures whether VS Code and the Aspire VS Code extension were detected.
+/// </summary>
+internal sealed record VsCodeExtensionDetection(bool VsCodeInstalled, bool ExtensionInstalled);

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
@@ -139,10 +139,16 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
 
         try
         {
+            // IgnoreInaccessible lets the probe skip an unreadable extension folder and keep scanning
+            // the rest, instead of throwing and reporting the whole extensions root as "not found" (a
+            // false warning even when the Aspire extension is installed alongside an inaccessible one).
+            // The parameterless EnumerateDirectories overload uses legacy behavior that throws instead.
+            var enumerationOptions = new EnumerationOptions { IgnoreInaccessible = true };
+
             // Installed extensions live in per-version folders named "<publisher>.<name>-<version>",
             // lowercased by VS Code, for example "microsoft-aspire.aspire-vscode-1.2.3". A case-insensitive
             // prefix match tolerates any installed version without spawning the VS Code CLI.
-            foreach (var directory in Directory.EnumerateDirectories(extensionsDirectory))
+            foreach (var directory in Directory.EnumerateDirectories(extensionsDirectory, "*", enumerationOptions))
             {
                 var folderName = Path.GetFileName(directory);
                 if (folderName.StartsWith(ExtensionId + "-", StringComparison.OrdinalIgnoreCase))

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
@@ -27,18 +27,26 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
     /// </summary>
     internal const string MarketplaceUrl = "https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode";
 
-    private readonly Func<VsCodeExtensionDetection> _detect;
+    private readonly IEnvironment _environment;
+    private readonly CliExecutionContext _executionContext;
+    private readonly Func<string, string?> _commandResolver;
 
     public VsCodeExtensionCheck(IEnvironment environment, CliExecutionContext executionContext)
-        : this(() => Detect(environment, executionContext.HomeDirectory))
+        : this(environment, executionContext, PathLookupHelper.FindFullPathFromPath)
     {
     }
 
-    internal VsCodeExtensionCheck(Func<VsCodeExtensionDetection> detect)
+    // Defaults commandResolver to the real PATH lookup; the internal constructor lets tests inject a
+    // deterministic resolver (see the Detect overload below for why the resolver is a seam).
+    internal VsCodeExtensionCheck(IEnvironment environment, CliExecutionContext executionContext, Func<string, string?> commandResolver)
     {
-        ArgumentNullException.ThrowIfNull(detect);
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(commandResolver);
 
-        _detect = detect;
+        _environment = environment;
+        _executionContext = executionContext;
+        _commandResolver = commandResolver;
     }
 
     // Runs after the fast environment/OS checks; this is a cheap filesystem probe with no process spawn.
@@ -48,7 +56,7 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var detection = _detect();
+        var detection = Detect(_environment, _executionContext.HomeDirectory, _commandResolver);
 
         // Nothing to recommend when the user is not running VS Code.
         if (!detection.VsCodeInstalled)
@@ -163,18 +171,10 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
             };
 
             // Installed extensions live in per-version folders named "<publisher>.<name>-<version>",
-            // lowercased by VS Code, for example "microsoft-aspire.aspire-vscode-1.2.3". A case-insensitive
-            // prefix match tolerates any installed version without spawning the VS Code CLI. Requiring a
-            // digit immediately after the trailing '-' pins the match to the version segment so a different
-            // extension whose id starts with ours (e.g. "microsoft-aspire.aspire-vscode-extras-1.0.0") is
-            // not treated as a match.
-            var prefix = ExtensionId + "-";
+            // lowercased by VS Code, for example "microsoft-aspire.aspire-vscode-1.2.3".
             foreach (var directory in Directory.EnumerateDirectories(extensionsDirectory, "*", enumerationOptions))
             {
-                var folderName = Path.GetFileName(directory);
-                if (folderName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                    && folderName.Length > prefix.Length
-                    && char.IsAsciiDigit(folderName[prefix.Length]))
+                if (IsVersionedExtensionFolder(Path.GetFileName(directory)))
                 {
                     return true;
                 }
@@ -187,6 +187,18 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
         }
 
         return false;
+    }
+
+    // Matches an extension folder name against the Aspire extension id. A case-insensitive prefix match
+    // tolerates any installed version without spawning the VS Code CLI. Requiring a digit immediately
+    // after the trailing '-' pins the match to the version segment so a different extension whose id
+    // starts with ours (e.g. "microsoft-aspire.aspire-vscode-extras-1.0.0") is not treated as a match.
+    private static bool IsVersionedExtensionFolder(string folderName)
+    {
+        const string prefix = ExtensionId + "-";
+        return folderName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            && folderName.Length > prefix.Length
+            && char.IsAsciiDigit(folderName[prefix.Length]);
     }
 
     private static JsonObject BuildMetadata(VsCodeExtensionDetection detection)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
@@ -23,9 +23,10 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
     internal const string ExtensionId = "microsoft-aspire.aspire-vscode";
 
     /// <summary>
-    /// The marketplace URL used as the fix link when the extension is missing.
+    /// The marketplace URL used as the fix link when the extension is missing. This is an aka.ms
+    /// redirect so the ultimate destination can be updated without shipping a new CLI build.
     /// </summary>
-    internal const string MarketplaceUrl = "https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode";
+    internal const string MarketplaceUrl = "https://aka.ms/aspire/vscode-extension";
 
     private readonly IEnvironment _environment;
     private readonly CliExecutionContext _executionContext;
@@ -64,21 +65,36 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
             return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([]);
         }
 
-        var extensionInstalled = detection.ExtensionInstalled;
-        var result = new EnvironmentCheckResult
+        var metadata = BuildMetadata(detection);
+
+        // The Aspire extension is installed: report a clean pass with no fix or link.
+        if (detection.ExtensionInstalled)
+        {
+            var pass = new EnvironmentCheckResult
+            {
+                Category = EnvironmentCheckCategories.DevelopmentTools,
+                Name = CheckName,
+                Status = EnvironmentCheckStatus.Pass,
+                Message = DoctorCommandStrings.VsCodeExtensionInstalledMessage,
+                Metadata = metadata
+            };
+
+            return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([pass]);
+        }
+
+        // VS Code is present but the extension is missing: warn and point at the marketplace.
+        var warning = new EnvironmentCheckResult
         {
             Category = EnvironmentCheckCategories.DevelopmentTools,
             Name = CheckName,
-            Status = extensionInstalled ? EnvironmentCheckStatus.Pass : EnvironmentCheckStatus.Warning,
-            Message = extensionInstalled
-                ? DoctorCommandStrings.VsCodeExtensionInstalledMessage
-                : DoctorCommandStrings.VsCodeExtensionMissingMessage,
-            Fix = extensionInstalled ? null : DoctorCommandStrings.VsCodeExtensionMissingFix,
-            Link = extensionInstalled ? null : MarketplaceUrl,
-            Metadata = BuildMetadata(detection)
+            Status = EnvironmentCheckStatus.Warning,
+            Message = DoctorCommandStrings.VsCodeExtensionMissingMessage,
+            Fix = DoctorCommandStrings.VsCodeExtensionMissingFix,
+            Link = MarketplaceUrl,
+            Metadata = metadata
         };
 
-        return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([result]);
+        return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([warning]);
     }
 
     internal static VsCodeExtensionDetection Detect(IEnvironment environment, DirectoryInfo homeDirectory)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/VsCodeExtensionCheck.cs
@@ -74,8 +74,15 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
     }
 
     internal static VsCodeExtensionDetection Detect(IEnvironment environment, DirectoryInfo homeDirectory)
+        => Detect(environment, homeDirectory, PathLookupHelper.FindFullPathFromPath);
+
+    // The command resolver is injected so tests can exercise the PATH-based detection fallback
+    // deterministically; PathLookupHelper.FindFullPathFromPath reads the real process PATH, which
+    // cannot be mocked via IEnvironment and would otherwise leave that branch untested (and flaky
+    // on machines that happen to have "code" on PATH).
+    internal static VsCodeExtensionDetection Detect(IEnvironment environment, DirectoryInfo homeDirectory, Func<string, string?> commandResolver)
     {
-        var vsCodeInstalled = IsVsCodeInstalled(environment);
+        var vsCodeInstalled = IsVsCodeInstalled(environment, commandResolver);
         if (!vsCodeInstalled)
         {
             return new VsCodeExtensionDetection(VsCodeInstalled: false, ExtensionInstalled: false);
@@ -85,7 +92,7 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
         return new VsCodeExtensionDetection(VsCodeInstalled: true, ExtensionInstalled: extensionInstalled);
     }
 
-    private static bool IsVsCodeInstalled(IEnvironment environment)
+    private static bool IsVsCodeInstalled(IEnvironment environment, Func<string, string?> commandResolver)
     {
         // When doctor is invoked from an integrated terminal, VS Code advertises itself via TERM_PROGRAM.
         // See https://code.visualstudio.com/docs/terminal/shell-integration.
@@ -95,8 +102,8 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
         }
 
         // Otherwise fall back to probing for the CLI launchers on PATH (stable and Insiders).
-        return PathLookupHelper.FindFullPathFromPath("code") is not null
-            || PathLookupHelper.FindFullPathFromPath("code-insiders") is not null;
+        return commandResolver("code") is not null
+            || commandResolver("code-insiders") is not null;
     }
 
     private static bool IsExtensionInstalled(IEnvironment environment, DirectoryInfo homeDirectory)
@@ -114,11 +121,15 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
 
     private static IEnumerable<string> GetExtensionDirectories(IEnvironment environment, DirectoryInfo homeDirectory)
     {
-        // VSCODE_EXTENSIONS overrides the default extensions location when set.
+        // VSCODE_EXTENSIONS overrides the default extensions location entirely: when it is set,
+        // VS Code loads extensions only from that directory, so we must probe only it. Falling through
+        // to the default roots here could report the Aspire extension as installed from ~/.vscode even
+        // though the running VS Code instance (using the override) would not load it — a false "pass".
         var overrideDirectory = environment.GetEnvironmentVariable("VSCODE_EXTENSIONS");
         if (!string.IsNullOrWhiteSpace(overrideDirectory))
         {
             yield return overrideDirectory;
+            yield break;
         }
 
         var home = homeDirectory.FullName;
@@ -143,15 +154,27 @@ internal sealed class VsCodeExtensionCheck : IEnvironmentCheck
             // the rest, instead of throwing and reporting the whole extensions root as "not found" (a
             // false warning even when the Aspire extension is installed alongside an inaccessible one).
             // The parameterless EnumerateDirectories overload uses legacy behavior that throws instead.
-            var enumerationOptions = new EnumerationOptions { IgnoreInaccessible = true };
+            // AttributesToSkip is reset to None (the default EnumerationOptions skips Hidden/System) so an
+            // extension folder is never silently ignored because of an unexpected attribute.
+            var enumerationOptions = new EnumerationOptions
+            {
+                IgnoreInaccessible = true,
+                AttributesToSkip = FileAttributes.None
+            };
 
             // Installed extensions live in per-version folders named "<publisher>.<name>-<version>",
             // lowercased by VS Code, for example "microsoft-aspire.aspire-vscode-1.2.3". A case-insensitive
-            // prefix match tolerates any installed version without spawning the VS Code CLI.
+            // prefix match tolerates any installed version without spawning the VS Code CLI. Requiring a
+            // digit immediately after the trailing '-' pins the match to the version segment so a different
+            // extension whose id starts with ours (e.g. "microsoft-aspire.aspire-vscode-extras-1.0.0") is
+            // not treated as a match.
+            var prefix = ExtensionId + "-";
             foreach (var directory in Directory.EnumerateDirectories(extensionsDirectory, "*", enumerationOptions))
             {
                 var folderName = Path.GetFileName(directory);
-                if (folderName.StartsWith(ExtensionId + "-", StringComparison.OrdinalIgnoreCase))
+                if (folderName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                    && folderName.Length > prefix.Length
+                    && char.IsAsciiDigit(folderName[prefix.Length]))
                 {
                     return true;
                 }

--- a/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils.EnvironmentChecker;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class VsCodeExtensionCheckTests
+{
+    [Fact]
+    public async Task CheckAsync_ReturnsEmpty_WhenVsCodeNotInstalled()
+    {
+        var check = new VsCodeExtensionCheck(() => new VsCodeExtensionDetection(VsCodeInstalled: false, ExtensionInstalled: false));
+
+        var results = await check.CheckAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ReturnsWarning_WhenExtensionMissing()
+    {
+        var check = new VsCodeExtensionCheck(() => new VsCodeExtensionDetection(VsCodeInstalled: true, ExtensionInstalled: false));
+
+        var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(EnvironmentCheckCategories.DevelopmentTools, result.Category);
+        Assert.Equal(VsCodeExtensionCheck.CheckName, result.Name);
+        Assert.Equal(EnvironmentCheckStatus.Warning, result.Status);
+        Assert.Equal(DoctorCommandStrings.VsCodeExtensionMissingMessage, result.Message);
+        Assert.Equal(DoctorCommandStrings.VsCodeExtensionMissingFix, result.Fix);
+        Assert.Equal(VsCodeExtensionCheck.MarketplaceUrl, result.Link);
+        Assert.NotNull(result.Metadata);
+        Assert.True(result.Metadata["vsCodeInstalled"]!.GetValue<bool>());
+        Assert.False(result.Metadata["extensionInstalled"]!.GetValue<bool>());
+        Assert.Equal(VsCodeExtensionCheck.ExtensionId, result.Metadata["extensionId"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task CheckAsync_ReturnsPass_WhenExtensionInstalled()
+    {
+        var check = new VsCodeExtensionCheck(() => new VsCodeExtensionDetection(VsCodeInstalled: true, ExtensionInstalled: true));
+
+        var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(EnvironmentCheckCategories.DevelopmentTools, result.Category);
+        Assert.Equal(EnvironmentCheckStatus.Pass, result.Status);
+        Assert.Equal(DoctorCommandStrings.VsCodeExtensionInstalledMessage, result.Message);
+        Assert.Null(result.Fix);
+        Assert.Null(result.Link);
+        Assert.NotNull(result.Metadata);
+        Assert.True(result.Metadata["vsCodeInstalled"]!.GetValue<bool>());
+        Assert.True(result.Metadata["extensionInstalled"]!.GetValue<bool>());
+    }
+
+    [Fact]
+    public void Detect_FindsExtension_ViaVsCodeExtensionsOverride()
+    {
+        using var home = new TempDirectory();
+        using var extensions = new TempDirectory();
+        Directory.CreateDirectory(Path.Combine(extensions.Path, "microsoft-aspire.aspire-vscode-1.2.3"));
+
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode",
+            ["VSCODE_EXTENSIONS"] = extensions.Path
+        });
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+
+        Assert.True(detection.VsCodeInstalled);
+        Assert.True(detection.ExtensionInstalled);
+    }
+
+    [Fact]
+    public void Detect_MatchesExtensionFolder_CaseInsensitively()
+    {
+        using var home = new TempDirectory();
+        using var extensions = new TempDirectory();
+        Directory.CreateDirectory(Path.Combine(extensions.Path, "Microsoft-Aspire.Aspire-VSCode-9.9.9"));
+
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode",
+            ["VSCODE_EXTENSIONS"] = extensions.Path
+        });
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+
+        Assert.True(detection.ExtensionInstalled);
+    }
+
+    [Fact]
+    public void Detect_ReportsExtensionMissing_WhenOnlyUnrelatedExtensionsPresent()
+    {
+        using var home = new TempDirectory();
+        using var extensions = new TempDirectory();
+        Directory.CreateDirectory(Path.Combine(extensions.Path, "ms-dotnettools.csharp-2.0.0"));
+
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode",
+            ["VSCODE_EXTENSIONS"] = extensions.Path
+        });
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+
+        Assert.True(detection.VsCodeInstalled);
+        Assert.False(detection.ExtensionInstalled);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            DirectoryInfo = Directory.CreateTempSubdirectory("aspire-vscode-check-tests");
+        }
+
+        public DirectoryInfo DirectoryInfo { get; }
+
+        public string Path => DirectoryInfo.FullName;
+
+        public void Dispose()
+        {
+            try
+            {
+                DirectoryInfo.Delete(recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
@@ -228,6 +228,27 @@ public class VsCodeExtensionCheckTests
         Assert.False(detection.ExtensionInstalled);
     }
 
+    [Fact]
+    public void Detect_ReportsExtensionMissing_WhenExtensionsDirectoryDoesNotExist()
+    {
+        using var home = new TempDirectory();
+        // Point the override at a path that is never created so DirectoryContainsExtension hits the
+        // Directory.Exists == false guard. VS Code being present must still yield a clean "missing"
+        // result rather than throwing on the absent directory.
+        var missingExtensionsDirectory = Path.Combine(home.Path, "does-not-exist");
+
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode",
+            ["VSCODE_EXTENSIONS"] = missingExtensionsDirectory
+        });
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+
+        Assert.True(detection.VsCodeInstalled);
+        Assert.False(detection.ExtensionInstalled);
+    }
+
     private sealed class TempDirectory : IDisposable
     {
         public TempDirectory()

--- a/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
@@ -53,6 +53,7 @@ public class VsCodeExtensionCheckTests
         Assert.NotNull(result.Metadata);
         Assert.True(result.Metadata["vsCodeInstalled"]!.GetValue<bool>());
         Assert.True(result.Metadata["extensionInstalled"]!.GetValue<bool>());
+        Assert.Equal(VsCodeExtensionCheck.ExtensionId, result.Metadata["extensionId"]!.GetValue<string>());
     }
 
     [Fact]
@@ -74,13 +75,17 @@ public class VsCodeExtensionCheckTests
         Assert.True(detection.ExtensionInstalled);
     }
 
-    [Fact]
-    public void Detect_FindsExtension_ViaDefaultHomeExtensionsDirectory()
+    [Theory]
+    [InlineData(".vscode")]
+    [InlineData(".vscode-insiders")]
+    [InlineData(".vscode-server")]
+    [InlineData(".vscode-server-insiders")]
+    public void Detect_FindsExtension_ViaEachDefaultExtensionsRoot(string rootFolder)
     {
         using var home = new TempDirectory();
-        // Exercise the default desktop extensions root (~/.vscode/extensions) rather than the
-        // VSCODE_EXTENSIONS override, guarding GetExtensionDirectories path composition.
-        Directory.CreateDirectory(Path.Combine(home.Path, ".vscode", "extensions", "microsoft-aspire.aspire-vscode-1.2.3"));
+        // Exercise each default extensions root that GetExtensionDirectories composes (desktop
+        // stable/Insiders and remote/server) rather than the VSCODE_EXTENSIONS override.
+        Directory.CreateDirectory(Path.Combine(home.Path, rootFolder, "extensions", "microsoft-aspire.aspire-vscode-1.2.3"));
 
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
@@ -91,6 +96,56 @@ public class VsCodeExtensionCheckTests
 
         Assert.True(detection.VsCodeInstalled);
         Assert.True(detection.ExtensionInstalled);
+    }
+
+    [Fact]
+    public void Detect_IgnoresDefaultRoots_WhenVsCodeExtensionsOverrideSet()
+    {
+        using var home = new TempDirectory();
+        using var overrideDirectory = new TempDirectory();
+        // The extension is present in the default desktop root but absent from the override directory.
+        // VSCODE_EXTENSIONS makes VS Code load only the override, so detection must report it missing.
+        Directory.CreateDirectory(Path.Combine(home.Path, ".vscode", "extensions", "microsoft-aspire.aspire-vscode-1.2.3"));
+
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode",
+            ["VSCODE_EXTENSIONS"] = overrideDirectory.Path
+        });
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+
+        Assert.True(detection.VsCodeInstalled);
+        Assert.False(detection.ExtensionInstalled);
+    }
+
+    [Theory]
+    [InlineData("code")]
+    [InlineData("code-insiders")]
+    public void Detect_DetectsVsCode_ViaPathFallback_WhenTermProgramNotVsCode(string launcherOnPath)
+    {
+        using var home = new TempDirectory();
+        // No TERM_PROGRAM, so detection falls back to probing the CLI launchers on PATH via the
+        // injected resolver.
+        var environment = new TestEnvironment(new Dictionary<string, string?>());
+        string? Resolver(string command) => string.Equals(command, launcherOnPath, StringComparison.Ordinal) ? "/usr/bin/" + command : null;
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo, Resolver);
+
+        Assert.True(detection.VsCodeInstalled);
+        Assert.False(detection.ExtensionInstalled);
+    }
+
+    [Fact]
+    public void Detect_ReportsVsCodeNotInstalled_WhenTermProgramAbsentAndNotOnPath()
+    {
+        using var home = new TempDirectory();
+        var environment = new TestEnvironment(new Dictionary<string, string?>());
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo, _ => null);
+
+        Assert.False(detection.VsCodeInstalled);
+        Assert.False(detection.ExtensionInstalled);
     }
 
     [Fact]
@@ -127,6 +182,26 @@ public class VsCodeExtensionCheckTests
         var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
 
         Assert.True(detection.VsCodeInstalled);
+        Assert.False(detection.ExtensionInstalled);
+    }
+
+    [Fact]
+    public void Detect_ReportsExtensionMissing_WhenFolderSharesPrefixWithDifferentId()
+    {
+        using var home = new TempDirectory();
+        using var extensions = new TempDirectory();
+        // A different extension whose id begins with ours. Without the digit boundary the prefix match
+        // would incorrectly treat this as the Aspire extension.
+        Directory.CreateDirectory(Path.Combine(extensions.Path, "microsoft-aspire.aspire-vscode-extras-1.0.0"));
+
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode",
+            ["VSCODE_EXTENSIONS"] = extensions.Path
+        });
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+
         Assert.False(detection.ExtensionInstalled);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
@@ -75,6 +75,25 @@ public class VsCodeExtensionCheckTests
     }
 
     [Fact]
+    public void Detect_FindsExtension_ViaDefaultHomeExtensionsDirectory()
+    {
+        using var home = new TempDirectory();
+        // Exercise the default desktop extensions root (~/.vscode/extensions) rather than the
+        // VSCODE_EXTENSIONS override, guarding GetExtensionDirectories path composition.
+        Directory.CreateDirectory(Path.Combine(home.Path, ".vscode", "extensions", "microsoft-aspire.aspire-vscode-1.2.3"));
+
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode"
+        });
+
+        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+
+        Assert.True(detection.VsCodeInstalled);
+        Assert.True(detection.ExtensionInstalled);
+    }
+
+    [Fact]
     public void Detect_MatchesExtensionFolder_CaseInsensitively()
     {
         using var home = new TempDirectory();

--- a/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
@@ -12,7 +12,11 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public async Task CheckAsync_ReturnsEmpty_WhenVsCodeNotInstalled()
     {
-        var check = new VsCodeExtensionCheck(() => new VsCodeExtensionDetection(VsCodeInstalled: false, ExtensionInstalled: false));
+        using var home = new TempDirectory();
+        // No TERM_PROGRAM and nothing resolvable on PATH, so real detection reports VS Code absent.
+        var environment = new TestEnvironment(new Dictionary<string, string?>());
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home.DirectoryInfo, homeDirectory: home.DirectoryInfo);
+        var check = new VsCodeExtensionCheck(environment, executionContext, _ => null);
 
         var results = await check.CheckAsync(TestContext.Current.CancellationToken);
 
@@ -22,7 +26,16 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public async Task CheckAsync_ReturnsWarning_WhenExtensionMissing()
     {
-        var check = new VsCodeExtensionCheck(() => new VsCodeExtensionDetection(VsCodeInstalled: true, ExtensionInstalled: false));
+        using var home = new TempDirectory();
+        using var extensions = new TempDirectory();
+        // VS Code is present (TERM_PROGRAM) but the override extensions directory is empty.
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode",
+            ["VSCODE_EXTENSIONS"] = extensions.Path
+        });
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home.DirectoryInfo, homeDirectory: home.DirectoryInfo);
+        var check = new VsCodeExtensionCheck(environment, executionContext, _ => null);
 
         var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
 
@@ -41,7 +54,17 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public async Task CheckAsync_ReturnsPass_WhenExtensionInstalled()
     {
-        var check = new VsCodeExtensionCheck(() => new VsCodeExtensionDetection(VsCodeInstalled: true, ExtensionInstalled: true));
+        using var home = new TempDirectory();
+        using var extensions = new TempDirectory();
+        // VS Code is present and the Aspire extension is installed in the override extensions directory.
+        Directory.CreateDirectory(Path.Combine(extensions.Path, "microsoft-aspire.aspire-vscode-1.2.3"));
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            ["TERM_PROGRAM"] = "vscode",
+            ["VSCODE_EXTENSIONS"] = extensions.Path
+        });
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home.DirectoryInfo, homeDirectory: home.DirectoryInfo);
+        var check = new VsCodeExtensionCheck(environment, executionContext, _ => null);
 
         var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
 

--- a/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/VsCodeExtensionCheckTests.cs
@@ -7,15 +7,16 @@ using Aspire.Cli.Utils.EnvironmentChecker;
 
 namespace Aspire.Cli.Tests.Commands;
 
-public class VsCodeExtensionCheckTests
+public class VsCodeExtensionCheckTests(ITestOutputHelper outputHelper)
 {
     [Fact]
     public async Task CheckAsync_ReturnsEmpty_WhenVsCodeNotInstalled()
     {
-        using var home = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
         // No TERM_PROGRAM and nothing resolvable on PATH, so real detection reports VS Code absent.
         var environment = new TestEnvironment(new Dictionary<string, string?>());
-        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home.DirectoryInfo, homeDirectory: home.DirectoryInfo);
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home, homeDirectory: home);
         var check = new VsCodeExtensionCheck(environment, executionContext, _ => null);
 
         var results = await check.CheckAsync(TestContext.Current.CancellationToken);
@@ -26,15 +27,16 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public async Task CheckAsync_ReturnsWarning_WhenExtensionMissing()
     {
-        using var home = new TempDirectory();
-        using var extensions = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var extensions = workspace.CreateDirectory("extensions");
         // VS Code is present (TERM_PROGRAM) but the override extensions directory is empty.
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             ["TERM_PROGRAM"] = "vscode",
-            ["VSCODE_EXTENSIONS"] = extensions.Path
+            ["VSCODE_EXTENSIONS"] = extensions.FullName
         });
-        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home.DirectoryInfo, homeDirectory: home.DirectoryInfo);
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home, homeDirectory: home);
         var check = new VsCodeExtensionCheck(environment, executionContext, _ => null);
 
         var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
@@ -54,16 +56,17 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public async Task CheckAsync_ReturnsPass_WhenExtensionInstalled()
     {
-        using var home = new TempDirectory();
-        using var extensions = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var extensions = workspace.CreateDirectory("extensions");
         // VS Code is present and the Aspire extension is installed in the override extensions directory.
-        Directory.CreateDirectory(Path.Combine(extensions.Path, "microsoft-aspire.aspire-vscode-1.2.3"));
+        Directory.CreateDirectory(Path.Combine(extensions.FullName, "microsoft-aspire.aspire-vscode-1.2.3"));
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             ["TERM_PROGRAM"] = "vscode",
-            ["VSCODE_EXTENSIONS"] = extensions.Path
+            ["VSCODE_EXTENSIONS"] = extensions.FullName
         });
-        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home.DirectoryInfo, homeDirectory: home.DirectoryInfo);
+        var executionContext = TestExecutionContextHelper.CreateExecutionContext(home, homeDirectory: home);
         var check = new VsCodeExtensionCheck(environment, executionContext, _ => null);
 
         var result = Assert.Single(await check.CheckAsync(TestContext.Current.CancellationToken));
@@ -82,17 +85,18 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public void Detect_FindsExtension_ViaVsCodeExtensionsOverride()
     {
-        using var home = new TempDirectory();
-        using var extensions = new TempDirectory();
-        Directory.CreateDirectory(Path.Combine(extensions.Path, "microsoft-aspire.aspire-vscode-1.2.3"));
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var extensions = workspace.CreateDirectory("extensions");
+        Directory.CreateDirectory(Path.Combine(extensions.FullName, "microsoft-aspire.aspire-vscode-1.2.3"));
 
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             ["TERM_PROGRAM"] = "vscode",
-            ["VSCODE_EXTENSIONS"] = extensions.Path
+            ["VSCODE_EXTENSIONS"] = extensions.FullName
         });
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+        var detection = VsCodeExtensionCheck.Detect(environment, home);
 
         Assert.True(detection.VsCodeInstalled);
         Assert.True(detection.ExtensionInstalled);
@@ -105,17 +109,18 @@ public class VsCodeExtensionCheckTests
     [InlineData(".vscode-server-insiders")]
     public void Detect_FindsExtension_ViaEachDefaultExtensionsRoot(string rootFolder)
     {
-        using var home = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
         // Exercise each default extensions root that GetExtensionDirectories composes (desktop
         // stable/Insiders and remote/server) rather than the VSCODE_EXTENSIONS override.
-        Directory.CreateDirectory(Path.Combine(home.Path, rootFolder, "extensions", "microsoft-aspire.aspire-vscode-1.2.3"));
+        Directory.CreateDirectory(Path.Combine(home.FullName, rootFolder, "extensions", "microsoft-aspire.aspire-vscode-1.2.3"));
 
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             ["TERM_PROGRAM"] = "vscode"
         });
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+        var detection = VsCodeExtensionCheck.Detect(environment, home);
 
         Assert.True(detection.VsCodeInstalled);
         Assert.True(detection.ExtensionInstalled);
@@ -124,19 +129,20 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public void Detect_IgnoresDefaultRoots_WhenVsCodeExtensionsOverrideSet()
     {
-        using var home = new TempDirectory();
-        using var overrideDirectory = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var overrideDirectory = workspace.CreateDirectory("override");
         // The extension is present in the default desktop root but absent from the override directory.
         // VSCODE_EXTENSIONS makes VS Code load only the override, so detection must report it missing.
-        Directory.CreateDirectory(Path.Combine(home.Path, ".vscode", "extensions", "microsoft-aspire.aspire-vscode-1.2.3"));
+        Directory.CreateDirectory(Path.Combine(home.FullName, ".vscode", "extensions", "microsoft-aspire.aspire-vscode-1.2.3"));
 
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             ["TERM_PROGRAM"] = "vscode",
-            ["VSCODE_EXTENSIONS"] = overrideDirectory.Path
+            ["VSCODE_EXTENSIONS"] = overrideDirectory.FullName
         });
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+        var detection = VsCodeExtensionCheck.Detect(environment, home);
 
         Assert.True(detection.VsCodeInstalled);
         Assert.False(detection.ExtensionInstalled);
@@ -147,13 +153,14 @@ public class VsCodeExtensionCheckTests
     [InlineData("code-insiders")]
     public void Detect_DetectsVsCode_ViaPathFallback_WhenTermProgramNotVsCode(string launcherOnPath)
     {
-        using var home = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
         // No TERM_PROGRAM, so detection falls back to probing the CLI launchers on PATH via the
         // injected resolver.
         var environment = new TestEnvironment(new Dictionary<string, string?>());
         string? Resolver(string command) => string.Equals(command, launcherOnPath, StringComparison.Ordinal) ? "/usr/bin/" + command : null;
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo, Resolver);
+        var detection = VsCodeExtensionCheck.Detect(environment, home, Resolver);
 
         Assert.True(detection.VsCodeInstalled);
         Assert.False(detection.ExtensionInstalled);
@@ -162,10 +169,11 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public void Detect_ReportsVsCodeNotInstalled_WhenTermProgramAbsentAndNotOnPath()
     {
-        using var home = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
         var environment = new TestEnvironment(new Dictionary<string, string?>());
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo, _ => null);
+        var detection = VsCodeExtensionCheck.Detect(environment, home, _ => null);
 
         Assert.False(detection.VsCodeInstalled);
         Assert.False(detection.ExtensionInstalled);
@@ -174,17 +182,18 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public void Detect_MatchesExtensionFolder_CaseInsensitively()
     {
-        using var home = new TempDirectory();
-        using var extensions = new TempDirectory();
-        Directory.CreateDirectory(Path.Combine(extensions.Path, "Microsoft-Aspire.Aspire-VSCode-9.9.9"));
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var extensions = workspace.CreateDirectory("extensions");
+        Directory.CreateDirectory(Path.Combine(extensions.FullName, "Microsoft-Aspire.Aspire-VSCode-9.9.9"));
 
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             ["TERM_PROGRAM"] = "vscode",
-            ["VSCODE_EXTENSIONS"] = extensions.Path
+            ["VSCODE_EXTENSIONS"] = extensions.FullName
         });
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+        var detection = VsCodeExtensionCheck.Detect(environment, home);
 
         Assert.True(detection.ExtensionInstalled);
     }
@@ -192,17 +201,18 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public void Detect_ReportsExtensionMissing_WhenOnlyUnrelatedExtensionsPresent()
     {
-        using var home = new TempDirectory();
-        using var extensions = new TempDirectory();
-        Directory.CreateDirectory(Path.Combine(extensions.Path, "ms-dotnettools.csharp-2.0.0"));
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var extensions = workspace.CreateDirectory("extensions");
+        Directory.CreateDirectory(Path.Combine(extensions.FullName, "ms-dotnettools.csharp-2.0.0"));
 
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             ["TERM_PROGRAM"] = "vscode",
-            ["VSCODE_EXTENSIONS"] = extensions.Path
+            ["VSCODE_EXTENSIONS"] = extensions.FullName
         });
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+        var detection = VsCodeExtensionCheck.Detect(environment, home);
 
         Assert.True(detection.VsCodeInstalled);
         Assert.False(detection.ExtensionInstalled);
@@ -211,19 +221,20 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public void Detect_ReportsExtensionMissing_WhenFolderSharesPrefixWithDifferentId()
     {
-        using var home = new TempDirectory();
-        using var extensions = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
+        var extensions = workspace.CreateDirectory("extensions");
         // A different extension whose id begins with ours. Without the digit boundary the prefix match
         // would incorrectly treat this as the Aspire extension.
-        Directory.CreateDirectory(Path.Combine(extensions.Path, "microsoft-aspire.aspire-vscode-extras-1.0.0"));
+        Directory.CreateDirectory(Path.Combine(extensions.FullName, "microsoft-aspire.aspire-vscode-extras-1.0.0"));
 
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             ["TERM_PROGRAM"] = "vscode",
-            ["VSCODE_EXTENSIONS"] = extensions.Path
+            ["VSCODE_EXTENSIONS"] = extensions.FullName
         });
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+        var detection = VsCodeExtensionCheck.Detect(environment, home);
 
         Assert.False(detection.ExtensionInstalled);
     }
@@ -231,11 +242,12 @@ public class VsCodeExtensionCheckTests
     [Fact]
     public void Detect_ReportsExtensionMissing_WhenExtensionsDirectoryDoesNotExist()
     {
-        using var home = new TempDirectory();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var home = workspace.CreateDirectory("home");
         // Point the override at a path that is never created so DirectoryContainsExtension hits the
         // Directory.Exists == false guard. VS Code being present must still yield a clean "missing"
         // result rather than throwing on the absent directory.
-        var missingExtensionsDirectory = Path.Combine(home.Path, "does-not-exist");
+        var missingExtensionsDirectory = Path.Combine(home.FullName, "does-not-exist");
 
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
@@ -243,32 +255,9 @@ public class VsCodeExtensionCheckTests
             ["VSCODE_EXTENSIONS"] = missingExtensionsDirectory
         });
 
-        var detection = VsCodeExtensionCheck.Detect(environment, home.DirectoryInfo);
+        var detection = VsCodeExtensionCheck.Detect(environment, home);
 
         Assert.True(detection.VsCodeInstalled);
         Assert.False(detection.ExtensionInstalled);
-    }
-
-    private sealed class TempDirectory : IDisposable
-    {
-        public TempDirectory()
-        {
-            DirectoryInfo = Directory.CreateTempSubdirectory("aspire-vscode-check-tests");
-        }
-
-        public DirectoryInfo DirectoryInfo { get; }
-
-        public string Path => DirectoryInfo.FullName;
-
-        public void Dispose()
-        {
-            try
-            {
-                DirectoryInfo.Delete(recursive: true);
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-            {
-            }
-        }
     }
 }


### PR DESCRIPTION
## Description

When developers use Aspire inside VS Code without the Aspire extension, they miss the integrated experience and there is nothing prompting them to install it. `aspire doctor` is the natural place to surface that recommendation, but it had no notion of editor tooling.

This adds a `VsCodeExtensionCheck` that detects when VS Code is present but the Aspire extension (`microsoft-aspire.aspire-vscode`) is not installed, and reports a **warning** recommending installation (with a Marketplace link) under a new **"Development tools"** category. When the extension is installed it reports a pass; when VS Code is not detected at all the check stays silent so it never adds noise outside a VS Code environment.

Approach and notable details:

- Reuses the same VS Code presence signals the CLI already relies on: the `TERM_PROGRAM=vscode` environment variable (integrated terminal) plus `code`/`code-insiders` on `PATH`.
- Detects the extension with a cheap filesystem probe of the standard extension roots (`~/.vscode*/extensions`, remote/server dirs, and the `VSCODE_EXTENSIONS` override), matching the `microsoft-aspire.aspire-vscode-<version>` folder case-insensitively. No VS Code CLI is spawned, and an unreadable directory is treated as "not found" rather than failing the whole doctor run.
- Follows the existing `OperatingSystemCheck` pattern with a delegate-injection seam so tests exercise the detection logic without touching the real filesystem or process `PATH`.
- Adds the `devtools` category (rendering + ordering), localized resource strings (resx, Designer.cs, and all xlf files via `UpdateXlf`), DI registration, and JSON metadata (`vsCodeInstalled`, `extensionInstalled`, `extensionId`). The `cli-output-formats` spec is updated to match.

Verified with a clean build (0 warnings/errors), 6 passing unit tests, and manual `aspire doctor` / `--format json` runs.

Fixes: #18300

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No