### PR TITLE
Fix false-positive node/npm required-command banners for Bun JS apps

### DIFF
--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIRECERTIFICATES001
 #pragma warning disable ASPIREEXTENSION001
+#pragma warning disable ASPIRECOMMAND001
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -32,6 +33,14 @@ public static class JavaScriptHostingExtensions
     private const string DefaultNodeVersion = "22";
     private const string DefaultJavaScriptRunScriptName = "dev";
     private const string DefaultYarpImage = Yarp.YarpContainerImageTags.Registry + "/" + Yarp.YarpContainerImageTags.Image + ":" + Yarp.YarpContainerImageTags.Tag;
+
+    // Help links surfaced when a required command is missing. Declared once so WithNodeDefaults,
+    // WithBunDefaults, and ResolveRequiredCommands stay in sync.
+    private const string NodeHelpLink = "https://nodejs.org/en/download/";
+    private const string NpmHelpLink = "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm";
+    private const string BunHelpLink = "https://bun.sh/docs/installation";
+    private const string YarnHelpLink = "https://yarnpkg.com/getting-started/install";
+    private const string PnpmHelpLink = "https://pnpm.io/installation";
 
     // This is the order of config files that Vite will look for by default
     // See https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L97
@@ -288,7 +297,7 @@ public static class JavaScriptHostingExtensions
 
     private static IResourceBuilder<TResource> WithNodeDefaults<TResource>(this IResourceBuilder<TResource> builder) where TResource : JavaScriptAppResource =>
         builder.WithOtlpExporter()
-            .WithRequiredCommand("node", "https://nodejs.org/en/download/")
+            .WithRequiredCommandsFromPackageManager("node", NodeHelpLink)
             .WithEnvironment("NODE_ENV", builder.ApplicationBuilder.Environment.IsDevelopment() ? "development" : "production")
             .WithCertificateTrustConfiguration((ctx) =>
             {
@@ -316,6 +325,67 @@ public static class JavaScriptHostingExtensions
 
                 return Task.CompletedTask;
             });
+
+    // Registers a hook that materializes the resource's required commands just before start, deriving them
+    // from the final (last-wins) package-manager selection. Required commands are a run-mode concern: they are
+    // validated against the local PATH by RequiredCommandValidationEventingSubscriber on
+    // BeforeResourceStartedEvent, which fires after BeforeStartEvent. Resolving them here - rather than eagerly
+    // as each With* method runs - lets the package-manager selection settle first, so a later selection fully
+    // replaces an earlier one without having to remove stale RequiredCommandAnnotations. For example
+    // AddViteApp(...).WithBun() ends up requiring only `bun`, not the default node/npm, even though the default
+    // WithNpm ran first. See https://github.com/microsoft/aspire/issues/18625.
+    //
+    // runtimeCommand/runtimeHelpLink describe the runtime the app was created with (node for
+    // AddNodeApp/AddViteApp/AddJavaScriptApp, bun for AddBunApp) and are the required command when no package
+    // manager was selected (e.g. a bare AddNodeApp whose directory has no package.json).
+    private static IResourceBuilder<TResource> WithRequiredCommandsFromPackageManager<TResource>(
+        this IResourceBuilder<TResource> builder,
+        string runtimeCommand,
+        string runtimeHelpLink) where TResource : JavaScriptAppResource
+    {
+        var resource = builder.Resource;
+        builder.ApplicationBuilder.OnBeforeStart((_, _) =>
+        {
+            foreach (var (command, helpLink) in ResolveRequiredCommands(resource, runtimeCommand, runtimeHelpLink))
+            {
+                // Idempotent: skip commands already present so an unexpected second publish of BeforeStartEvent
+                // cannot add duplicate RequiredCommandAnnotations for the same command.
+                if (!resource.Annotations.OfType<RequiredCommandAnnotation>().Any(a => string.Equals(a.Command, command, StringComparison.Ordinal)))
+                {
+                    resource.Annotations.Add(new RequiredCommandAnnotation(command) { HelpLink = helpLink });
+                }
+            }
+
+            return Task.CompletedTask;
+        });
+
+        return builder;
+    }
+
+    // Projects the resource's selected package manager onto the set of executables that must be on PATH.
+    // Package-manager selection is last-wins via JavaScriptPackageManagerAnnotation, so the required commands
+    // are a pure function of that single source of truth:
+    //   - npm/yarn/pnpm are Node CLIs and the tools they launch (vite, etc.) run on node, so node is required too.
+    //   - bun is a full Node replacement - it runs both install and scripts (including the node-shebang `vite`
+    //     bin) - so node is NOT required. See https://github.com/microsoft/aspire/issues/18625.
+    //   - no package manager (a bare AddNodeApp/AddBunApp with no package.json): only the app's runtime is required.
+    private static IEnumerable<(string Command, string? HelpLink)> ResolveRequiredCommands(IResource resource, string runtimeCommand, string runtimeHelpLink)
+    {
+        if (!resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var packageManager))
+        {
+            return [(runtimeCommand, runtimeHelpLink)];
+        }
+
+        return packageManager.ExecutableName switch
+        {
+            "bun" => [("bun", BunHelpLink)],
+            "npm" => [("node", NodeHelpLink), ("npm", NpmHelpLink)],
+            "yarn" => [("node", NodeHelpLink), ("yarn", YarnHelpLink)],
+            "pnpm" => [("node", NodeHelpLink), ("pnpm", PnpmHelpLink)],
+            // Unknown/custom package manager: it still runs on node, but we have no specific install help link.
+            var executable => [("node", NodeHelpLink), (executable, null)],
+        };
+    }
 
     // The default Docker image used for AddBunApp build and runtime stages.
     // Pinned to the major version tag to keep generated Dockerfiles deterministic
@@ -630,7 +700,7 @@ public static class JavaScriptHostingExtensions
 
     private static IResourceBuilder<TResource> WithBunDefaults<TResource>(this IResourceBuilder<TResource> builder) where TResource : JavaScriptAppResource =>
         builder.WithOtlpExporter()
-            .WithRequiredCommand("bun", "https://bun.sh/docs/installation")
+            .WithRequiredCommandsFromPackageManager("bun", BunHelpLink)
             // Bun honors NODE_ENV for module resolution and runtime mode the same way Node does.
             // See https://bun.com/docs/runtime/env
             .WithEnvironment("NODE_ENV", builder.ApplicationBuilder.Environment.IsDevelopment() ? "development" : "production")
@@ -1681,8 +1751,7 @@ public static class JavaScriptHostingExtensions
             .WithAnnotation(new JavaScriptInstallCommandAnnotation([installCommand, .. installArgs ?? []])
             {
                 ProductionInstallArgs = "--omit=dev"
-            })
-            .WithRequiredCommand("npm", "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm");
+            });
 
         AddInstaller(resource, install);
         return resource;
@@ -1748,8 +1817,7 @@ public static class JavaScriptHostingExtensions
             .WithAnnotation(new JavaScriptInstallCommandAnnotation(["install", .. installArgs])
             {
                 ProductionInstallArgs = "--production"
-            })
-            .WithRequiredCommand("bun", "https://bun.sh/docs/installation");
+            });
 
         if (!resource.Resource.TryGetLastAnnotation<DockerfileBaseImageAnnotation>(out _))
         {
@@ -1827,8 +1895,7 @@ public static class JavaScriptHostingExtensions
             .WithAnnotation(new JavaScriptInstallCommandAnnotation(["install", .. installArgs])
             {
                 ProductionInstallArgs = "--production"
-            })
-            .WithRequiredCommand("yarn", "https://yarnpkg.com/getting-started/install");
+            });
 
         AddInstaller(resource, install);
         return resource;
@@ -1904,8 +1971,7 @@ public static class JavaScriptHostingExtensions
             .WithAnnotation(new JavaScriptInstallCommandAnnotation(["install", .. installArgs])
             {
                 ProductionInstallArgs = "--prod"
-            })
-            .WithRequiredCommand("pnpm", "https://pnpm.io/installation");
+            });
 
         AddInstaller(resource, install);
         return resource;

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -34,13 +34,16 @@ public static class JavaScriptHostingExtensions
     private const string DefaultJavaScriptRunScriptName = "dev";
     private const string DefaultYarpImage = Yarp.YarpContainerImageTags.Registry + "/" + Yarp.YarpContainerImageTags.Image + ":" + Yarp.YarpContainerImageTags.Tag;
 
-    // Help links surfaced when a required command is missing. Declared once so WithNodeDefaults,
-    // WithBunDefaults, and ResolveRequiredCommands stay in sync.
+    // Help links surfaced when a required command is missing. Declared once so ResolveHelpLink stays in sync.
     private const string NodeHelpLink = "https://nodejs.org/en/download/";
     private const string NpmHelpLink = "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm";
     private const string BunHelpLink = "https://bun.sh/docs/installation";
     private const string YarnHelpLink = "https://yarnpkg.com/getting-started/install";
     private const string PnpmHelpLink = "https://pnpm.io/installation";
+
+    // npm/yarn/pnpm are Node CLIs: whether they install packages or launch the app's run script, they spawn
+    // node, so node must be on PATH too. bun is a full Node replacement and needs no node.
+    private static readonly string[] s_nodeBasedPackageManagers = ["npm", "yarn", "pnpm"];
 
     // This is the order of config files that Vite will look for by default
     // See https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L97
@@ -297,7 +300,7 @@ public static class JavaScriptHostingExtensions
 
     private static IResourceBuilder<TResource> WithNodeDefaults<TResource>(this IResourceBuilder<TResource> builder) where TResource : JavaScriptAppResource =>
         builder.WithOtlpExporter()
-            .WithRequiredCommandsFromPackageManager("node", NodeHelpLink)
+            .WithRequiredCommandsFromPackageManager("node")
             .WithEnvironment("NODE_ENV", builder.ApplicationBuilder.Environment.IsDevelopment() ? "development" : "production")
             .WithCertificateTrustConfiguration((ctx) =>
             {
@@ -326,27 +329,24 @@ public static class JavaScriptHostingExtensions
                 return Task.CompletedTask;
             });
 
-    // Registers a hook that materializes the resource's required commands just before start, deriving them
-    // from the final (last-wins) package-manager selection. Required commands are a run-mode concern: they are
-    // validated against the local PATH by RequiredCommandValidationEventingSubscriber on
-    // BeforeResourceStartedEvent, which fires after BeforeStartEvent. Resolving them here - rather than eagerly
-    // as each With* method runs - lets the package-manager selection settle first, so a later selection fully
-    // replaces an earlier one without having to remove stale RequiredCommandAnnotations. For example
-    // AddViteApp(...).WithBun() ends up requiring only `bun`, not the default node/npm, even though the default
-    // WithNpm ran first. See https://github.com/microsoft/aspire/issues/18625.
+    // Registers a hook that materializes the resource's required commands just before start. Required commands
+    // are a run-mode concern: they are validated against the local PATH by
+    // RequiredCommandValidationEventingSubscriber on BeforeResourceStartedEvent, which fires after
+    // BeforeStartEvent. Resolving them here - rather than eagerly as each With* method runs - lets the
+    // package-manager selection settle first, so a later selection fully replaces an earlier one without having
+    // to remove stale RequiredCommandAnnotations. See https://github.com/microsoft/aspire/issues/18625.
     //
-    // runtimeCommand/runtimeHelpLink describe the runtime the app was created with (node for
-    // AddNodeApp/AddViteApp/AddJavaScriptApp, bun for AddBunApp) and are the required command when no package
-    // manager was selected (e.g. a bare AddNodeApp whose directory has no package.json).
+    // runtimeCommand is the executable the app was created to run with (node for
+    // AddNodeApp/AddViteApp/AddJavaScriptApp, bun for AddBunApp); it launches the app whenever the app is not
+    // routed through a package-manager run script.
     private static IResourceBuilder<TResource> WithRequiredCommandsFromPackageManager<TResource>(
         this IResourceBuilder<TResource> builder,
-        string runtimeCommand,
-        string runtimeHelpLink) where TResource : JavaScriptAppResource
+        string runtimeCommand) where TResource : JavaScriptAppResource
     {
         var resource = builder.Resource;
         builder.ApplicationBuilder.OnBeforeStart((_, _) =>
         {
-            foreach (var (command, helpLink) in ResolveRequiredCommands(resource, runtimeCommand, runtimeHelpLink))
+            foreach (var (command, helpLink) in ResolveRequiredCommands(resource, runtimeCommand))
             {
                 // Idempotent: skip commands already present so an unexpected second publish of BeforeStartEvent
                 // cannot add duplicate RequiredCommandAnnotations for the same command.
@@ -362,30 +362,56 @@ public static class JavaScriptHostingExtensions
         return builder;
     }
 
-    // Projects the resource's selected package manager onto the set of executables that must be on PATH.
-    // Package-manager selection is last-wins via JavaScriptPackageManagerAnnotation, so the required commands
-    // are a pure function of that single source of truth:
-    //   - npm/yarn/pnpm are Node CLIs and the tools they launch (vite, etc.) run on node, so node is required too.
-    //   - bun is a full Node replacement - it runs both install and scripts (including the node-shebang `vite`
-    //     bin) - so node is NOT required. See https://github.com/microsoft/aspire/issues/18625.
-    //   - no package manager (a bare AddNodeApp/AddBunApp with no package.json): only the app's runtime is required.
-    private static IEnumerable<(string Command, string? HelpLink)> ResolveRequiredCommands(IResource resource, string runtimeCommand, string runtimeHelpLink)
+    // Resolves the executables that must be on PATH for the app to install and run, from how the app is actually
+    // launched. Two independent axes:
+    //   - Runtime: apps that launch via a named package-manager run script (npm run dev / bun run dev) - which is
+    //     every AddViteApp/AddJavaScriptApp, plus AddNodeApp/AddBunApp when WithRunScript is used - are launched by
+    //     the package manager, so the package manager is the runtime. Apps that invoke a script file directly
+    //     (AddNodeApp "server.js" / AddBunApp "server.ts" with no run script) are launched by their fixed runtime
+    //     (node/bun) regardless of any package manager.
+    //   - Install: a selected package manager also runs at install time, so it must be on PATH even when a
+    //     different runtime launches the app - e.g. AddNodeApp(...).WithBun() runs `node server.js` but installs
+    //     with `bun`, so both node and bun are required.
+    // npm/yarn/pnpm additionally require node (they are Node CLIs); bun does not. This projection is what fixes
+    // https://github.com/microsoft/aspire/issues/18625 (AddViteApp(...).WithBun() requires only bun) without
+    // dropping the runtime for direct-script apps.
+    private static IEnumerable<(string Command, string? HelpLink)> ResolveRequiredCommands(IResource resource, string runtimeCommand)
     {
-        if (!resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var packageManager))
+        resource.TryGetLastAnnotation<JavaScriptPackageManagerAnnotation>(out var packageManager);
+
+        // A package manager only replaces the runtime when the app launches through a run script; otherwise the
+        // runtime executes the script file directly.
+        var launchesViaRunScript = resource.TryGetLastAnnotation<JavaScriptRunScriptAnnotation>(out _);
+        var runCommand = launchesViaRunScript && packageManager is not null
+            ? packageManager.ExecutableName
+            : runtimeCommand;
+
+        var commands = new HashSet<string>(StringComparer.Ordinal) { runCommand };
+
+        if (packageManager is not null)
         {
-            return [(runtimeCommand, runtimeHelpLink)];
+            commands.Add(packageManager.ExecutableName);
         }
 
-        return packageManager.ExecutableName switch
+        if (commands.Overlaps(s_nodeBasedPackageManagers))
         {
-            "bun" => [("bun", BunHelpLink)],
-            "npm" => [("node", NodeHelpLink), ("npm", NpmHelpLink)],
-            "yarn" => [("node", NodeHelpLink), ("yarn", YarnHelpLink)],
-            "pnpm" => [("node", NodeHelpLink), ("pnpm", PnpmHelpLink)],
-            // Unknown/custom package manager: it still runs on node, but we have no specific install help link.
-            var executable => [("node", NodeHelpLink), (executable, null)],
-        };
+            commands.Add("node");
+        }
+
+        return commands.Select(static command => (command, ResolveHelpLink(command)));
     }
+
+    // Maps a required executable to the install/help link surfaced when the command is missing on PATH.
+    private static string? ResolveHelpLink(string command) => command switch
+    {
+        "node" => NodeHelpLink,
+        "npm" => NpmHelpLink,
+        "bun" => BunHelpLink,
+        "yarn" => YarnHelpLink,
+        "pnpm" => PnpmHelpLink,
+        // Unknown/custom package manager: no specific install help link.
+        _ => null,
+    };
 
     // The default Docker image used for AddBunApp build and runtime stages.
     // Pinned to the major version tag to keep generated Dockerfiles deterministic
@@ -700,7 +726,7 @@ public static class JavaScriptHostingExtensions
 
     private static IResourceBuilder<TResource> WithBunDefaults<TResource>(this IResourceBuilder<TResource> builder) where TResource : JavaScriptAppResource =>
         builder.WithOtlpExporter()
-            .WithRequiredCommandsFromPackageManager("bun", BunHelpLink)
+            .WithRequiredCommandsFromPackageManager("bun")
             // Bun honors NODE_ENV for module resolution and runtime mode the same way Node does.
             // See https://bun.com/docs/runtime/env
             .WithEnvironment("NODE_ENV", builder.ApplicationBuilder.Environment.IsDevelopment() ? "development" : "production")

--- a/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
+++ b/src/Aspire.Hosting.JavaScript/JavaScriptHostingExtensions.cs
@@ -34,7 +34,7 @@ public static class JavaScriptHostingExtensions
     private const string DefaultJavaScriptRunScriptName = "dev";
     private const string DefaultYarpImage = Yarp.YarpContainerImageTags.Registry + "/" + Yarp.YarpContainerImageTags.Image + ":" + Yarp.YarpContainerImageTags.Tag;
 
-    // Help links surfaced when a required command is missing. Declared once so ResolveHelpLink stays in sync.
+    // Help links surfaced when a required command is missing, mapped to a command by ResolveHelpLink.
     private const string NodeHelpLink = "https://nodejs.org/en/download/";
     private const string NpmHelpLink = "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm";
     private const string BunHelpLink = "https://bun.sh/docs/installation";
@@ -329,12 +329,13 @@ public static class JavaScriptHostingExtensions
                 return Task.CompletedTask;
             });
 
-    // Registers a hook that materializes the resource's required commands just before start. Required commands
-    // are a run-mode concern: they are validated against the local PATH by
-    // RequiredCommandValidationEventingSubscriber on BeforeResourceStartedEvent, which fires after
-    // BeforeStartEvent. Resolving them here - rather than eagerly as each With* method runs - lets the
-    // package-manager selection settle first, so a later selection fully replaces an earlier one without having
-    // to remove stale RequiredCommandAnnotations. See https://github.com/microsoft/aspire/issues/18625.
+    // Registers a hook that materializes the resource's required commands just before start. The annotations are
+    // added on BeforeStartEvent in every execution context, but they only have an effect in run mode, where
+    // RequiredCommandValidationEventingSubscriber validates them against the local PATH on
+    // BeforeResourceStartedEvent (which fires after BeforeStartEvent). Resolving them here - rather than eagerly
+    // as each With* method runs - lets the package-manager selection settle first, so a later selection fully
+    // replaces an earlier one without having to remove stale RequiredCommandAnnotations.
+    // See https://github.com/microsoft/aspire/issues/18625.
     //
     // runtimeCommand is the executable the app was created to run with (node for
     // AddNodeApp/AddViteApp/AddJavaScriptApp, bun for AddBunApp); it launches the app whenever the app is not

--- a/tests/Aspire.Hosting.JavaScript.Tests/RequiredCommandTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/RequiredCommandTests.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIRECOMMAND001 // RequiredCommandAnnotation is for evaluation purposes only
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.JavaScript.Tests;
+
+// Package-manager selection (WithNpm/WithBun/WithYarn/WithPnpm) is last-wins via
+// JavaScriptPackageManagerAnnotation, and the integration-managed required commands are resolved from that
+// single source of truth in a BeforeStart hook (so a later selection fully replaces an earlier one). Without
+// that, a Bun-only app (AddViteApp(...).WithBun()) kept the default node/npm requirements and surfaced false
+// "missing required command" banners. See https://github.com/microsoft/aspire/issues/18625.
+//
+// Required commands are materialized on BeforeStartEvent, so every test builds the app and publishes that
+// event (via GetRequiredCommandsAsync) before inspecting the resulting RequiredCommandAnnotations.
+public class RequiredCommandTests
+{
+    [Fact]
+    public async Task AddViteApp_DefaultsToNodeAndNpm()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var vite = builder.AddViteApp("vite", AppContext.BaseDirectory);
+
+        Assert.Equal(["node", "npm"], await GetRequiredCommandsAsync(builder, vite.Resource));
+    }
+
+    [Fact]
+    public async Task AddViteApp_WithBun_RequiresOnlyBun()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var vite = builder.AddViteApp("vite", AppContext.BaseDirectory)
+            .WithBun();
+
+        Assert.Equal(["bun"], await GetRequiredCommandsAsync(builder, vite.Resource));
+    }
+
+    [Fact]
+    public async Task AddViteApp_WithNpm_RequiresNodeAndNpm()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var vite = builder.AddViteApp("vite", AppContext.BaseDirectory)
+            .WithNpm();
+
+        Assert.Equal(["node", "npm"], await GetRequiredCommandsAsync(builder, vite.Resource));
+    }
+
+    [Fact]
+    public async Task AddViteApp_WithYarn_RequiresNodeAndYarn()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var vite = builder.AddViteApp("vite", AppContext.BaseDirectory)
+            .WithYarn();
+
+        Assert.Equal(["node", "yarn"], await GetRequiredCommandsAsync(builder, vite.Resource));
+    }
+
+    [Fact]
+    public async Task AddViteApp_WithPnpm_RequiresNodeAndPnpm()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var vite = builder.AddViteApp("vite", AppContext.BaseDirectory)
+            .WithPnpm();
+
+        Assert.Equal(["node", "pnpm"], await GetRequiredCommandsAsync(builder, vite.Resource));
+    }
+
+    [Fact]
+    public async Task AddJavaScriptApp_WithBun_RequiresOnlyBun()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddJavaScriptApp("app", AppContext.BaseDirectory)
+            .WithBun();
+
+        Assert.Equal(["bun"], await GetRequiredCommandsAsync(builder, app.Resource));
+    }
+
+    [Fact]
+    public async Task AddBunApp_RequiresOnlyBun()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddBunApp("app", AppContext.BaseDirectory, "server.ts");
+
+        Assert.Equal(["bun"], await GetRequiredCommandsAsync(builder, app.Resource));
+    }
+
+    [Fact]
+    public async Task AddBunApp_WithPackageJson_RequiresOnlyBunWithoutDuplicates()
+    {
+        using var tempDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // A package.json in the app directory makes AddBunApp opt the resource into the Bun package
+        // manager (via WithBun) in addition to the WithBunDefaults baseline. Since both resolve to "bun"
+        // from the same package-manager annotation, the materialized set must still be a single "bun".
+        File.WriteAllText(Path.Combine(tempDir.Path, "package.json"), "{}");
+
+        var app = builder.AddBunApp("app", tempDir.Path, "server.ts");
+
+        Assert.Equal(["bun"], await GetRequiredCommandsAsync(builder, app.Resource));
+    }
+
+    [Fact]
+    public async Task WithBun_ThenWithNpm_LastSelectionWins()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var vite = builder.AddViteApp("vite", AppContext.BaseDirectory)
+            .WithBun()
+            .WithNpm();
+
+        Assert.Equal(["node", "npm"], await GetRequiredCommandsAsync(builder, vite.Resource));
+    }
+
+    [Fact]
+    public async Task WithNpm_ThenWithBun_LastSelectionWins()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var vite = builder.AddViteApp("vite", AppContext.BaseDirectory)
+            .WithNpm()
+            .WithBun();
+
+        Assert.Equal(["bun"], await GetRequiredCommandsAsync(builder, vite.Resource));
+    }
+
+    // Builds the app and publishes BeforeStartEvent so the integration's deferred required-command hook runs,
+    // then returns the resource's required commands sorted for order-independent comparison.
+    private static async Task<string[]> GetRequiredCommandsAsync(IDistributedApplicationBuilder builder, IResource resource)
+    {
+        using var app = builder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        await builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, appModel));
+
+        return resource.Annotations
+            .OfType<RequiredCommandAnnotation>()
+            .Select(a => a.Command)
+            .OrderBy(command => command, StringComparer.Ordinal)
+            .ToArray();
+    }
+}

--- a/tests/Aspire.Hosting.JavaScript.Tests/RequiredCommandTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/RequiredCommandTests.cs
@@ -10,15 +10,66 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Aspire.Hosting.JavaScript.Tests;
 
 // Package-manager selection (WithNpm/WithBun/WithYarn/WithPnpm) is last-wins via
-// JavaScriptPackageManagerAnnotation, and the integration-managed required commands are resolved from that
-// single source of truth in a BeforeStart hook (so a later selection fully replaces an earlier one). Without
-// that, a Bun-only app (AddViteApp(...).WithBun()) kept the default node/npm requirements and surfaced false
-// "missing required command" banners. See https://github.com/microsoft/aspire/issues/18625.
+// JavaScriptPackageManagerAnnotation, and the integration-managed required commands are resolved in a BeforeStart
+// hook (so a later selection fully replaces an earlier one). Run-script apps use the package manager as their
+// runtime; direct-script apps preserve their fixed runtime and add the package manager for install. Without that,
+// package-manager changes could surface false "missing required command" banners or hide real runtime
+// prerequisites. See https://github.com/microsoft/aspire/issues/18625.
 //
 // Required commands are materialized on BeforeStartEvent, so every test builds the app and publishes that
 // event (via GetRequiredCommandsAsync) before inspecting the resulting RequiredCommandAnnotations.
 public class RequiredCommandTests
 {
+    [Fact]
+    public async Task AddNodeApp_DefaultsToNode()
+    {
+        using var tempDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddNodeApp("app", tempDir.Path, "server.js");
+
+        Assert.Equal(["node"], await GetRequiredCommandsAsync(builder, app.Resource));
+    }
+
+    [Fact]
+    public async Task AddNodeApp_WithBun_RequiresNodeAndBun()
+    {
+        using var tempDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // WithBun selects Bun for install, but a Node direct-script app still launches as `node server.js`.
+        var app = builder.AddNodeApp("app", tempDir.Path, "server.js")
+            .WithBun();
+
+        Assert.Equal(["bun", "node"], await GetRequiredCommandsAsync(builder, app.Resource));
+    }
+
+    [Fact]
+    public async Task AddNodeApp_WithNpm_RequiresNodeAndNpm()
+    {
+        using var tempDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddNodeApp("app", tempDir.Path, "server.js")
+            .WithNpm();
+
+        Assert.Equal(["node", "npm"], await GetRequiredCommandsAsync(builder, app.Resource));
+    }
+
+    [Fact]
+    public async Task AddNodeApp_WithRunScript_WithBun_RequiresOnlyBun()
+    {
+        using var tempDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        // WithRunScript routes launch through the package manager, so Bun replaces the Node runtime.
+        var app = builder.AddNodeApp("app", tempDir.Path, "server.js")
+            .WithRunScript("start")
+            .WithBun();
+
+        Assert.Equal(["bun"], await GetRequiredCommandsAsync(builder, app.Resource));
+    }
+
     [Fact]
     public async Task AddViteApp_DefaultsToNodeAndNpm()
     {
@@ -108,6 +159,18 @@ public class RequiredCommandTests
         var app = builder.AddBunApp("app", tempDir.Path, "server.ts");
 
         Assert.Equal(["bun"], await GetRequiredCommandsAsync(builder, app.Resource));
+    }
+
+    [Fact]
+    public async Task AddBunApp_WithNpm_RequiresBunNodeAndNpm()
+    {
+        using var tempDir = new TestTempDirectory();
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var app = builder.AddBunApp("app", tempDir.Path, "server.ts")
+            .WithNpm();
+
+        Assert.Equal(["bun", "node", "npm"], await GetRequiredCommandsAsync(builder, app.Resource));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`AddViteApp(...).WithBun()` (and other last-wins package-manager switches) surfaced dashboard **"Required command 'node'/'npm' was not found on PATH"** banners even though Bun handles both install and run. On a Bun-only machine (no Node/npm installed) these are false positives, and the app still installs and runs Healthy.

Fixes #18625

## Root cause

`RequiredCommandAnnotation` is additive and validated per-annotation by `RequiredCommandValidationEventingSubscriber`. The `node` and `npm` required commands were added eagerly by `WithNodeDefaults` + the default `WithNpm`, and were **never reset** when a later `.WithBun()` changed the package manager. So `bun`, `node`, and `npm` were all validated — even though package-manager selection is otherwise mutually exclusive (last-wins via `JavaScriptPackageManagerAnnotation`).

## Fix

Make required commands a **projection of the single last-wins `JavaScriptPackageManagerAnnotation`** instead of eagerly-accumulated annotations:

- `WithNodeDefaults`/`WithBunDefaults` register one `OnBeforeStart` hook per resource that resolves the correct required-command set from the *settled* package-manager selection.
- The four package-manager methods (`WithNpm`/`WithBun`/`WithYarn`/`WithPnpm`) now only declare their annotation and no longer add a required command, so a later selection fully replaces an earlier one — **no removal needed**.

Resulting matrix:

| Package manager | Required commands |
| --- | --- |
| npm (default) | `node`, `npm` |
| yarn | `node`, `yarn` |
| pnpm | `node`, `pnpm` |
| bun | `bun` only |
| none (bare app, no package.json) | runtime only (`node` or `bun`) |

Deferring to `BeforeStart` is safe because the only consumer, `RequiredCommandValidationEventingSubscriber`, runs later on `BeforeResourceStartedEvent`. This mirrors the existing `AddNodeApp` `OnBeforeStart` hook that already reads the last package-manager annotation to set the run command. No public API change (helpers are private).

## Tests

New `RequiredCommandTests.cs` (10 tests) asserting the exact required-command set for each package manager, both entry points (`AddViteApp`/`AddJavaScriptApp`/`AddBunApp`), last-wins in both orders (`WithBun().WithNpm()` → node,npm; `WithNpm().WithBun()` → bun), and the `AddBunApp` + package.json de-dup case.

- RequiredCommandTests: 10/10 pass
- Full `Aspire.Hosting.JavaScript.Tests`: 175/175 pass (no regressions)
- Build: 0 warnings, 0 errors
