### PR TITLE
Fix DotNetSdkInstaller to use runtime selector's dotnet executable

### DIFF
--- a/src/Aspire.Cli/Configuration/AspireSettings.cs
+++ b/src/Aspire.Cli/Configuration/AspireSettings.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Aspire.Cli.Configuration;
+
+/// <summary>
+/// Configuration settings for Aspire CLI stored in settings.json.
+/// </summary>
+internal sealed class AspireSettings
+{
+    /// <summary>
+    /// .NET SDK configuration.
+    /// </summary>
+    [JsonPropertyName("dotnet")]
+    public DotNetSettings? DotNet { get; set; }
+}
+
+/// <summary>
+/// .NET SDK configuration settings.
+/// </summary>
+internal sealed class DotNetSettings
+{
+    /// <summary>
+    /// The mode to use for .NET SDK selection.
+    /// Valid values: "private", "system", "custom"
+    /// </summary>
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+
+    /// <summary>
+    /// The specific SDK version to use.
+    /// </summary>
+    [JsonPropertyName("sdkVersion")]
+    public string? SdkVersion { get; set; }
+
+    /// <summary>
+    /// Custom path to dotnet executable (when mode is "custom").
+    /// </summary>
+    [JsonPropertyName("customPath")]
+    public string? CustomPath { get; set; }
+
+    /// <summary>
+    /// Legacy alias for preferring private SDK installation.
+    /// </summary>
+    [JsonPropertyName("preferPrivate")]
+    public bool? PreferPrivate { get; set; }
+}

--- a/src/Aspire.Cli/DotNet/DotNetRuntimeSelector.cs
+++ b/src/Aspire.Cli/DotNet/DotNetRuntimeSelector.cs
@@ -1,0 +1,313 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Aspire.Cli.Configuration;
+using Aspire.Cli.Interaction;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+
+namespace Aspire.Cli.DotNet;
+
+/// <summary>
+/// Default implementation of <see cref="IDotNetRuntimeSelector"/>.
+/// </summary>
+internal sealed class DotNetRuntimeSelector(
+    ILogger<DotNetRuntimeSelector> logger,
+    IConfiguration configuration,
+    IDotNetSdkInstaller sdkInstaller,
+    IInteractionService interactionService,
+    IAnsiConsole console) : IDotNetRuntimeSelector
+{
+    private string? _dotNetExecutablePath;
+    private DotNetRuntimeMode _mode = DotNetRuntimeMode.System;
+    private readonly Dictionary<string, string> _environmentVariables = new();
+
+    /// <inheritdoc />
+    public string DotNetExecutablePath => _dotNetExecutablePath ?? "dotnet";
+
+    /// <inheritdoc />
+    public DotNetRuntimeMode Mode => _mode;
+
+    /// <inheritdoc />
+    public async Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        // Check environment variables first
+        var disablePrivateSdk = Environment.GetEnvironmentVariable("ASPIRE_DISABLE_PRIVATE_SDK") == "1";
+        var overrideVersion = Environment.GetEnvironmentVariable("ASPIRE_DOTNET_SDK_VERSION") 
+            ?? configuration["overrideMinimumSdkVersion"];
+        
+        // Load settings from ~/.aspire/settings.json
+        var settings = await LoadSettingsAsync();
+        
+        // Determine the required SDK version
+        var requiredVersion = overrideVersion 
+            ?? settings?.DotNet?.SdkVersion 
+            ?? DotNetSdkInstaller.MinimumSdkVersion;
+
+        // Determine the preferred mode
+        var preferredMode = DetermineModeFromSettings(settings, disablePrivateSdk);
+
+        // Check if system SDK meets requirements
+        var systemSdkAvailable = await sdkInstaller.CheckAsync(requiredVersion, cancellationToken);
+
+        switch (preferredMode)
+        {
+            case DotNetRuntimeMode.System:
+                if (systemSdkAvailable)
+                {
+                    _mode = DotNetRuntimeMode.System;
+                    _dotNetExecutablePath = "dotnet";
+                    return true;
+                }
+                else if (!disablePrivateSdk)
+                {
+                    // Fall back to private if system doesn't work
+                    return await TryInitializePrivateAsync(requiredVersion, cancellationToken);
+                }
+                else
+                {
+                    logger.LogError("System .NET SDK {Version} not available and private SDK disabled", requiredVersion);
+                    return false;
+                }
+
+            case DotNetRuntimeMode.Private:
+                if (!disablePrivateSdk)
+                {
+                    return await TryInitializePrivateAsync(requiredVersion, cancellationToken);
+                }
+                else
+                {
+                    logger.LogWarning("Private SDK requested but disabled by environment variable");
+                    if (systemSdkAvailable)
+                    {
+                        _mode = DotNetRuntimeMode.System;
+                        _dotNetExecutablePath = "dotnet";
+                        return true;
+                    }
+                    return false;
+                }
+
+            case DotNetRuntimeMode.Custom:
+                var customPath = settings?.DotNet?.CustomPath;
+                if (!string.IsNullOrEmpty(customPath) && File.Exists(customPath))
+                {
+                    _mode = DotNetRuntimeMode.Custom;
+                    _dotNetExecutablePath = customPath;
+                    return true;
+                }
+                logger.LogError("Custom dotnet path not found: {Path}", customPath);
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public IDictionary<string, string> GetEnvironmentVariables()
+    {
+        return new Dictionary<string, string>(_environmentVariables);
+    }
+
+    private async Task<AspireSettings?> LoadSettingsAsync()
+    {
+        try
+        {
+            var aspireHome = Environment.GetEnvironmentVariable("ASPIRE_HOME") 
+                ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
+            
+            var settingsPath = Path.Combine(aspireHome, "settings.json");
+            
+            if (!File.Exists(settingsPath))
+            {
+                return null;
+            }
+
+            var json = await File.ReadAllTextAsync(settingsPath);
+            return JsonSerializer.Deserialize(json, JsonSourceGenerationContext.Default.AspireSettings);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to load settings.json");
+            return null;
+        }
+    }
+
+    private static DotNetRuntimeMode DetermineModeFromSettings(AspireSettings? settings, bool disablePrivateSdk)
+    {
+        if (settings?.DotNet == null)
+        {
+            return DotNetRuntimeMode.System;
+        }
+
+        // Check for legacy preferPrivate setting
+        if (settings.DotNet.PreferPrivate == true && !disablePrivateSdk)
+        {
+            return DotNetRuntimeMode.Private;
+        }
+
+        return settings.DotNet.Mode?.ToLowerInvariant() switch
+        {
+            "private" when !disablePrivateSdk => DotNetRuntimeMode.Private,
+            "system" => DotNetRuntimeMode.System,
+            "custom" => DotNetRuntimeMode.Custom,
+            _ => DotNetRuntimeMode.System
+        };
+    }
+
+    private async Task<bool> TryInitializePrivateAsync(string requiredVersion, CancellationToken cancellationToken)
+    {
+        var aspireHome = Environment.GetEnvironmentVariable("ASPIRE_HOME") 
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
+        
+        var privateSdkPath = Path.Combine(aspireHome, "sdk", requiredVersion);
+        var privateDotNetPath = Path.Combine(privateSdkPath, "dotnet");
+        
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            privateDotNetPath += ".exe";
+        }
+
+        // Check if private SDK already exists and works
+        if (File.Exists(privateDotNetPath))
+        {
+            _mode = DotNetRuntimeMode.Private;
+            _dotNetExecutablePath = privateDotNetPath;
+            
+            // Set environment variables to isolate the private SDK
+            _environmentVariables["DOTNET_ROOT"] = privateSdkPath;
+            _environmentVariables["DOTNET_HOST_PATH"] = privateDotNetPath;
+            
+            return true;
+        }
+
+        // Private SDK doesn't exist, offer to install it
+        return await OfferToInstallPrivateSdkAsync(requiredVersion, privateSdkPath, privateDotNetPath, cancellationToken);
+    }
+
+    private async Task<bool> OfferToInstallPrivateSdkAsync(string requiredVersion, string privateSdkPath, string privateDotNetPath, CancellationToken cancellationToken)
+    {
+        var autoInstall = Environment.GetEnvironmentVariable("ASPIRE_AUTO_INSTALL") == "1";
+        
+        if (!autoInstall)
+        {
+            console.MarkupLine($"[yellow]Required .NET SDK version {requiredVersion} is not available on the system PATH.[/]");
+            console.MarkupLine($"[green]Would you like to install a private copy under ~/.aspire/sdk?[/]");
+            
+            if (!await interactionService.ConfirmAsync("Install private .NET SDK?", defaultValue: false, cancellationToken))
+            {
+                return false;
+            }
+        }
+
+        try
+        {
+            await console.Status()
+                .Spinner(Spinner.Known.Dots)
+                .StartAsync($"Installing .NET SDK {requiredVersion}...", async ctx =>
+                {
+                    ctx.Status($"Creating directory {privateSdkPath}...");
+                    Directory.CreateDirectory(privateSdkPath);
+
+                    ctx.Status($"Downloading and installing .NET SDK {requiredVersion}...");
+                    await InstallPrivateSdkAsync(requiredVersion, privateSdkPath, cancellationToken);
+                });
+
+            if (File.Exists(privateDotNetPath))
+            {
+                console.MarkupLine($"[green]Successfully installed private .NET SDK to {privateSdkPath}[/]");
+                
+                _mode = DotNetRuntimeMode.Private;
+                _dotNetExecutablePath = privateDotNetPath;
+                
+                // Set environment variables to isolate the private SDK
+                _environmentVariables["DOTNET_ROOT"] = privateSdkPath;
+                _environmentVariables["DOTNET_HOST_PATH"] = privateDotNetPath;
+                
+                return true;
+            }
+            else
+            {
+                console.MarkupLine("[red]Failed to install private .NET SDK[/]");
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to install private .NET SDK");
+            console.MarkupLine($"[red]Installation failed: {ex.Message}[/]");
+            return false;
+        }
+    }
+
+    private static async Task InstallPrivateSdkAsync(string requiredVersion, string installPath, CancellationToken cancellationToken)
+    {
+        // Use dotnet-install script to install the SDK
+        var scriptUrl = Environment.GetEnvironmentVariable("ASPIRE_DOTNET_INSTALL_SCRIPT_URL");
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        
+        if (string.IsNullOrEmpty(scriptUrl))
+        {
+            scriptUrl = isWindows 
+                ? "https://dot.net/v1/dotnet-install.ps1"
+                : "https://dot.net/v1/dotnet-install.sh";
+        }
+
+        var tempDir = Path.GetTempPath();
+        var scriptName = isWindows ? "dotnet-install.ps1" : "dotnet-install.sh";
+        var scriptPath = Path.Combine(tempDir, scriptName);
+
+        // Download the install script
+        using var httpClient = new HttpClient();
+        var scriptContent = await httpClient.GetStringAsync(scriptUrl, cancellationToken);
+        await File.WriteAllTextAsync(scriptPath, scriptContent, cancellationToken);
+
+        if (!isWindows)
+        {
+            // Make script executable on Unix
+            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        // Run the install script
+        var arguments = isWindows
+            ? $"-ExecutionPolicy Bypass -File \"{scriptPath}\" -Version {requiredVersion} -InstallDir \"{installPath}\" -NoPath"
+            : $"\"{scriptPath}\" --version {requiredVersion} --install-dir \"{installPath}\" --no-path";
+
+        var executable = isWindows ? "powershell" : "bash";
+        
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+        
+        await process.WaitForExitAsync(cancellationToken);
+        
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync(cancellationToken);
+            throw new InvalidOperationException($"dotnet-install script failed with exit code {process.ExitCode}: {error}");
+        }
+
+        // Clean up the script
+        try
+        {
+            File.Delete(scriptPath);
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+}

--- a/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
+++ b/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
@@ -12,7 +12,7 @@ namespace Aspire.Cli.DotNet;
 /// <summary>
 /// Default implementation of <see cref="IDotNetSdkInstaller"/> that checks for dotnet on the system PATH.
 /// </summary>
-internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration configuration) : IDotNetSdkInstaller
+internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration configuration, Lazy<IDotNetRuntimeSelector> runtimeSelector) : IDotNetSdkInstaller
 {
     /// <summary>
     /// The minimum .NET SDK version required for Aspire.
@@ -25,7 +25,7 @@ internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration conf
         // Check for configuration override first
         var overrideVersion = configuration["overrideMinimumSdkVersion"];
         var minimumVersion = !string.IsNullOrEmpty(overrideVersion) ? overrideVersion : MinimumSdkVersion;
-        
+
         return CheckAsync(minimumVersion, cancellationToken);
     }
 
@@ -38,6 +38,10 @@ internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration conf
             return true;
         }
 
+        // Use the runtime selector's dotnet executable if it has been initialized,
+        // so that private SDK installations are recognized.
+        var dotnetExecutable = runtimeSelector.Value.DotNetExecutablePath;
+
         try
         {
             // Add --arch flag to ensure we only get SDKs that match the current architecture
@@ -48,7 +52,7 @@ internal sealed class DotNetSdkInstaller(IFeatures features, IConfiguration conf
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "dotnet",
+                    FileName = dotnetExecutable,
                     Arguments = arguments,
                     UseShellExecute = false,
                     RedirectStandardOutput = true,

--- a/src/Aspire.Cli/DotNet/IDotNetRuntimeSelector.cs
+++ b/src/Aspire.Cli/DotNet/IDotNetRuntimeSelector.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.DotNet;
+
+/// <summary>
+/// Service responsible for selecting and managing the .NET runtime to use.
+/// </summary>
+internal interface IDotNetRuntimeSelector
+{
+    /// <summary>
+    /// Gets the path to the dotnet executable to use.
+    /// </summary>
+    string DotNetExecutablePath { get; }
+
+    /// <summary>
+    /// Gets the mode being used (private, system, or custom).
+    /// </summary>
+    DotNetRuntimeMode Mode { get; }
+
+    /// <summary>
+    /// Initializes the runtime selector, potentially installing a private SDK if needed.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if initialization succeeded, false otherwise.</returns>
+    Task<bool> InitializeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets environment variables that should be set when launching processes.
+    /// </summary>
+    /// <returns>Dictionary of environment variables.</returns>
+    IDictionary<string, string> GetEnvironmentVariables();
+}
+
+/// <summary>
+/// Represents the mode of .NET runtime selection.
+/// </summary>
+internal enum DotNetRuntimeMode
+{
+    /// <summary>
+    /// Use the system-installed .NET SDK.
+    /// </summary>
+    System,
+
+    /// <summary>
+    /// Use a private .NET SDK installed under ~/.aspire/sdk.
+    /// </summary>
+    Private,
+
+    /// <summary>
+    /// Use a custom path specified by the user.
+    /// </summary>
+    Custom
+}

--- a/src/Aspire.Cli/JsonSourceGenerationContext.cs
+++ b/src/Aspire.Cli/JsonSourceGenerationContext.cs
@@ -3,12 +3,14 @@
 
 using System.Text.Json.Serialization;
 using System.Text.Json.Nodes;
+using Aspire.Cli.Configuration;
 
 namespace Aspire.Cli;
 
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(CliSettings))]
 [JsonSerializable(typeof(JsonObject))]
+[JsonSerializable(typeof(AspireSettings))]
 internal partial class JsonSourceGenerationContext : JsonSerializerContext
 {
 }

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -117,6 +117,11 @@ public class Program
         builder.Services.AddSingleton<AspireCliTelemetry>();
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
         builder.Services.AddSingleton<IDotNetSdkInstaller, DotNetSdkInstaller>();
+        
+        // .NET Runtime Selection and Process Launching
+        builder.Services.AddSingleton<IDotNetRuntimeSelector, DotNetRuntimeSelector>();
+        builder.Services.AddSingleton<IProcessLauncher, ProcessLauncher>();
+        
         builder.Services.AddTransient<IAppHostBackchannel, AppHostBackchannel>();
         builder.Services.AddSingleton<INuGetPackageCache, NuGetPackageCache>();
         builder.Services.AddHostedService<NuGetPackagePrefetcher>();
@@ -207,6 +212,10 @@ public class Program
         Console.OutputEncoding = Encoding.UTF8;
 
         using var app = await BuildApplicationAsync(args);
+
+        // Initialize the .NET runtime selector 
+        var runtimeSelector = app.Services.GetRequiredService<IDotNetRuntimeSelector>();
+        await runtimeSelector.InitializeAsync();
 
         await app.StartAsync().ConfigureAwait(false);
 

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -116,10 +116,11 @@ public class Program
         builder.Services.AddSingleton<IFeatures, Features>();
         builder.Services.AddSingleton<AspireCliTelemetry>();
         builder.Services.AddTransient<IDotNetCliRunner, DotNetCliRunner>();
-        builder.Services.AddSingleton<IDotNetSdkInstaller, DotNetSdkInstaller>();
-        
-        // .NET Runtime Selection and Process Launching
         builder.Services.AddSingleton<IDotNetRuntimeSelector, DotNetRuntimeSelector>();
+        builder.Services.AddSingleton<Lazy<IDotNetRuntimeSelector>>(sp => new Lazy<IDotNetRuntimeSelector>(sp.GetRequiredService<IDotNetRuntimeSelector>));
+        builder.Services.AddSingleton<IDotNetSdkInstaller, DotNetSdkInstaller>();
+
+        // .NET Runtime Selection and Process Launching
         builder.Services.AddSingleton<IProcessLauncher, ProcessLauncher>();
         
         builder.Services.AddTransient<IAppHostBackchannel, AppHostBackchannel>();

--- a/src/Aspire.Cli/Utils/IProcessLauncher.cs
+++ b/src/Aspire.Cli/Utils/IProcessLauncher.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Service responsible for launching processes with the correct .NET runtime.
+/// </summary>
+internal interface IProcessLauncher
+{
+    /// <summary>
+    /// Launches a dotnet process with the specified arguments.
+    /// </summary>
+    /// <param name="arguments">Arguments to pass to dotnet.</param>
+    /// <param name="workingDirectory">Working directory for the process.</param>
+    /// <param name="environmentVariables">Additional environment variables.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The exit code of the process.</returns>
+    Task<int> LaunchDotNetAsync(
+        string arguments,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Launches a generic process with the specified executable and arguments.
+    /// </summary>
+    /// <param name="executablePath">Path to the executable.</param>
+    /// <param name="arguments">Arguments to pass to the executable.</param>
+    /// <param name="workingDirectory">Working directory for the process.</param>
+    /// <param name="environmentVariables">Additional environment variables.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The exit code of the process.</returns>
+    Task<int> LaunchAsync(
+        string executablePath,
+        string? arguments = null,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Aspire.Cli/Utils/ProcessLauncher.cs
+++ b/src/Aspire.Cli/Utils/ProcessLauncher.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Cli.DotNet;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Default implementation of <see cref="IProcessLauncher"/> that uses the configured .NET runtime.
+/// </summary>
+internal class ProcessLauncher(
+    ILogger<ProcessLauncher> logger,
+    IDotNetRuntimeSelector runtimeSelector) : IProcessLauncher
+{
+    /// <inheritdoc />
+    public async Task<int> LaunchDotNetAsync(
+        string arguments,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await LaunchAsync(
+            runtimeSelector.DotNetExecutablePath,
+            arguments,
+            workingDirectory,
+            environmentVariables,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<int> LaunchAsync(
+        string executablePath,
+        string? arguments = null,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null,
+        CancellationToken cancellationToken = default)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            Arguments = arguments ?? string.Empty,
+            UseShellExecute = false,
+            CreateNoWindow = false
+        };
+
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            startInfo.WorkingDirectory = workingDirectory;
+        }
+
+        // Apply environment variables from runtime selector
+        var runtimeEnvVars = runtimeSelector.GetEnvironmentVariables();
+        foreach (var kvp in runtimeEnvVars)
+        {
+            startInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+        }
+
+        // Apply additional environment variables
+        if (environmentVariables != null)
+        {
+            foreach (var kvp in environmentVariables)
+            {
+                startInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+            }
+        }
+
+        logger.LogDebug("Launching process: {Executable} {Arguments}", executablePath, arguments);
+
+        using var process = new Process { StartInfo = startInfo };
+        
+        process.Start();
+        await process.WaitForExitAsync(cancellationToken);
+
+        logger.LogDebug("Process exited with code: {ExitCode}", process.ExitCode);
+        
+        return process.ExitCode;
+    }
+}

--- a/src/Aspire.Cli/Utils/SdkInstallHelper.cs
+++ b/src/Aspire.Cli/Utils/SdkInstallHelper.cs
@@ -14,7 +14,49 @@ namespace Aspire.Cli.Utils;
 internal static class SdkInstallHelper
 {
     /// <summary>
+    /// Ensures that the .NET SDK is installed and available, attempting installation if needed.
+    /// </summary>
+    /// <param name="sdkInstaller">The SDK installer service.</param>
+    /// <param name="interactionService">The interaction service for user communication.</param>
+    /// <param name="runtimeSelector">The runtime selector for managing private SDK installation.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the SDK is available or was successfully installed, false otherwise.</returns>
+    public static async Task<bool> EnsureSdkInstalledAsync(
+        IDotNetSdkInstaller sdkInstaller,
+        IInteractionService interactionService,
+        IDotNetRuntimeSelector runtimeSelector,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sdkInstaller);
+        ArgumentNullException.ThrowIfNull(interactionService);
+        ArgumentNullException.ThrowIfNull(runtimeSelector);
+
+        // First, try to initialize the runtime selector (which may install a private SDK)
+        var isInitialized = await runtimeSelector.InitializeAsync(cancellationToken);
+        
+        if (!isInitialized)
+        {
+            var sdkErrorMessage = string.Format(CultureInfo.InvariantCulture, ErrorStrings.MininumSdkVersionMissing, DotNetSdkInstaller.MinimumSdkVersion);
+            interactionService.DisplayError(sdkErrorMessage);
+            return false;
+        }
+
+        // Re-check the SDK after initialization
+        var isSdkAvailable = await sdkInstaller.CheckAsync(cancellationToken);
+
+        if (!isSdkAvailable)
+        {
+            var sdkErrorMessage = string.Format(CultureInfo.InvariantCulture, ErrorStrings.MininumSdkVersionMissing, DotNetSdkInstaller.MinimumSdkVersion);
+            interactionService.DisplayError(sdkErrorMessage);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Ensures that the .NET SDK is installed and available, displaying an error message if it's not.
+    /// This is the legacy method signature for backwards compatibility.
     /// </summary>
     /// <param name="sdkInstaller">The SDK installer service.</param>
     /// <param name="interactionService">The interaction service for user communication.</param>

--- a/src/Aspire.Cli/Utils/SdkLockHelper.cs
+++ b/src/Aspire.Cli/Utils/SdkLockHelper.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Cli.Utils;
+
+/// <summary>
+/// Helper class for managing concurrent SDK installations with file locking.
+/// </summary>
+internal static class SdkLockHelper
+{
+    /// <summary>
+    /// Acquires a lock for SDK installation to prevent concurrent installations.
+    /// </summary>
+    /// <param name="sdkVersion">The SDK version being installed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A disposable lock that should be disposed when installation is complete.</returns>
+    public static async Task<IDisposable> AcquireSdkLockAsync(string sdkVersion, CancellationToken cancellationToken = default)
+    {
+        var aspireHome = Environment.GetEnvironmentVariable("ASPIRE_HOME") 
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aspire");
+        
+        var stateDir = Path.Combine(aspireHome, "state");
+        Directory.CreateDirectory(stateDir);
+        
+        var lockFileName = $"sdk-lock-{sdkVersion}.lock";
+        var lockFilePath = Path.Combine(stateDir, lockFileName);
+        
+        // Wait for any existing lock to be released
+        var maxWaitTime = TimeSpan.FromMinutes(10); // Maximum wait time
+        var startTime = DateTime.UtcNow;
+        
+        while (File.Exists(lockFilePath))
+        {
+            if (DateTime.UtcNow - startTime > maxWaitTime)
+            {
+                // Remove stale lock file if it's too old (more than 30 minutes)
+                var lockFileInfo = new FileInfo(lockFilePath);
+                if (DateTime.UtcNow - lockFileInfo.CreationTimeUtc > TimeSpan.FromMinutes(30))
+                {
+                    try
+                    {
+                        File.Delete(lockFilePath);
+                        break;
+                    }
+                    catch
+                    {
+                        // If we can't delete it, another process might be using it
+                    }
+                }
+                
+                throw new TimeoutException($"Timeout waiting for SDK installation lock for version {sdkVersion}");
+            }
+            
+            await Task.Delay(1000, cancellationToken);
+        }
+        
+        // Create lock file
+        await File.WriteAllTextAsync(lockFilePath, 
+            $"Locked by process {Environment.ProcessId} at {DateTime.UtcNow:O}", 
+            cancellationToken);
+        
+        return new SdkLock(lockFilePath);
+    }
+
+    private sealed class SdkLock : IDisposable
+    {
+        private readonly string _lockFilePath;
+        private bool _disposed;
+
+        public SdkLock(string lockFilePath)
+        {
+            _lockFilePath = lockFilePath;
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                try
+                {
+                    if (File.Exists(_lockFilePath))
+                    {
+                        File.Delete(_lockFilePath);
+                    }
+                }
+                catch
+                {
+                    // Ignore errors when cleaning up lock file
+                }
+                
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/tests/Aspire.Cli.Tests/DotNet/DotNetRuntimeSelectorTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNet/DotNetRuntimeSelectorTests.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Aspire.Cli.DotNet;
+using Aspire.Cli.Interaction;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Aspire.Cli.Tests.DotNet;
+
+public class DotNetRuntimeSelectorTests
+{
+    [Fact]
+    public void Constructor_SetsDefaultValues()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder().Build();
+        var sdkInstaller = new TestSdkInstaller();
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+        Assert.Equal(DotNetRuntimeMode.System, selector.Mode);
+        Assert.Equal("dotnet", selector.DotNetExecutablePath);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithAvailableSystemSdk_ReturnsTrue()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder().Build();
+        var sdkInstaller = new TestSdkInstaller { CheckResult = true };
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+        var result = await selector.InitializeAsync();
+
+        Assert.True(result);
+        Assert.Equal(DotNetRuntimeMode.System, selector.Mode);
+        Assert.Equal("dotnet", selector.DotNetExecutablePath);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithDisablePrivateSdkEnvVar_StopsAtSystemCheck()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder().Build();
+        var sdkInstaller = new TestSdkInstaller { CheckResult = false };
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        // Set environment variable
+        Environment.SetEnvironmentVariable("ASPIRE_DISABLE_PRIVATE_SDK", "1");
+
+        try
+        {
+            var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+            var result = await selector.InitializeAsync();
+
+            Assert.False(result);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPIRE_DISABLE_PRIVATE_SDK", null);
+        }
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithVersionOverride_UsesOverrideVersion()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new[]
+            {
+                new KeyValuePair<string, string?>("overrideMinimumSdkVersion", "8.0.100")
+            })
+            .Build();
+        
+        var sdkInstaller = new TestSdkInstaller { CheckResult = true };
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+        var result = await selector.InitializeAsync();
+
+        Assert.True(result);
+        Assert.Equal("8.0.100", sdkInstaller.LastCheckedVersion);
+    }
+
+    [Fact]
+    public void GetEnvironmentVariables_ReturnsEmptyDictionary_WhenNotInitialized()
+    {
+        var logger = NullLogger<DotNetRuntimeSelector>.Instance;
+        var configuration = new ConfigurationBuilder().Build();
+        var sdkInstaller = new TestSdkInstaller();
+        var interactionService = new TestInteractionService();
+        var console = new TestAnsiConsole();
+
+        var selector = new DotNetRuntimeSelector(logger, configuration, sdkInstaller, interactionService, console);
+
+        var envVars = selector.GetEnvironmentVariables();
+
+        Assert.Empty(envVars);
+    }
+
+    private sealed class TestSdkInstaller : IDotNetSdkInstaller
+    {
+        public bool CheckResult { get; set; } = true;
+        public string? LastCheckedVersion { get; private set; }
+
+        public Task<bool> CheckAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(CheckResult);
+        }
+
+        public Task<bool> CheckAsync(string minimumVersion, CancellationToken cancellationToken = default)
+        {
+            LastCheckedVersion = minimumVersion;
+            return Task.FromResult(CheckResult);
+        }
+
+        public Task InstallAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    private sealed class TestInteractionService : IInteractionService
+    {
+        public Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action) => action();
+        public void ShowStatus(string statusText, Action action) => action();
+        public Task<string> PromptForStringAsync(string promptText, string? defaultValue = null, Func<string, Spectre.Console.ValidationResult>? validator = null, bool isSecret = false, bool required = false, CancellationToken cancellationToken = default) => Task.FromResult(defaultValue ?? string.Empty);
+        public Task<bool> ConfirmAsync(string promptText, bool defaultValue = true, CancellationToken cancellationToken = default) => Task.FromResult(defaultValue);
+        public Task<T> PromptForSelectionAsync<T>(string promptText, IEnumerable<T> choices, Func<T, string> choiceFormatter, CancellationToken cancellationToken = default) where T : notnull => Task.FromResult(choices.First());
+        public int DisplayIncompatibleVersionError(Aspire.Cli.Backchannel.AppHostIncompatibleException ex, string appHostHostingVersion) => 1;
+        public void DisplayError(string errorMessage) { }
+        public void DisplayMessage(string emoji, string message) { }
+        public void DisplayPlainText(string text) { }
+        public void DisplayMarkdown(string markdown) { }
+        public void DisplaySuccess(string message) { }
+        public void DisplaySubtleMessage(string message) { }
+        public void DisplayDashboardUrls((string BaseUrlWithLoginToken, string? CodespacesUrlWithLoginToken) dashboardUrls) { }
+        public void DisplayLines(IEnumerable<(string Stream, string Line)> lines) { }
+        public void DisplayCancellationMessage() { }
+        public void DisplayEmptyLine() { }
+        public void DisplayVersionUpdateNotification(string newerVersion) { }
+        public void WriteConsoleLog(string message, int? lineNumber = null, string? type = null, bool isErrorMessage = false) { }
+    }
+
+    private sealed class TestAnsiConsole : IAnsiConsole
+    {
+        public Profile Profile => new Profile(new TestConsoleOutput(), Encoding.UTF8);
+        public IAnsiConsoleCursor Cursor => throw new NotImplementedException();
+        public IAnsiConsoleInput Input => throw new NotImplementedException();
+        public IExclusivityMode ExclusivityMode => throw new NotImplementedException();
+        public RenderPipeline Pipeline => throw new NotImplementedException();
+
+        public void Clear(bool home) { }
+        public void Write(IRenderable renderable) { }
+    }
+
+    private sealed class TestConsoleOutput : IAnsiConsoleOutput
+    {
+        public TextWriter Writer => Console.Out;
+        public bool IsTerminal => false;
+        public int Width => 80;
+        public int Height => 25;
+
+        public void SetEncoding(Encoding encoding) { }
+    }
+}

--- a/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
@@ -12,7 +12,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task CheckAsync_WhenDotNetIsAvailable_ReturnsTrue()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         // This test assumes the test environment has .NET SDK installed
         var result = await installer.CheckAsync();
@@ -23,7 +23,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task CheckAsync_WithMinimumVersion_WhenDotNetIsAvailable_ReturnsTrue()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         // This test assumes the test environment has .NET SDK installed with a version >= 8.0.0
         var result = await installer.CheckAsync("8.0.0");
@@ -34,7 +34,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task CheckAsync_WithActualMinimumVersion_BehavesCorrectly()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         // Use the actual minimum version constant and check the behavior
         // Since this test environment has 8.0.117, it should return false for 9.0.302
@@ -48,7 +48,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task CheckAsync_WithHighMinimumVersion_ReturnsFalse()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         // Use an unreasonably high version that should not exist
         var result = await installer.CheckAsync("99.0.0");
@@ -59,7 +59,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task CheckAsync_WithInvalidMinimumVersion_ReturnsFalse()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         // Use an invalid version string
         var result = await installer.CheckAsync("invalid.version");
@@ -70,7 +70,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task InstallAsync_ThrowsNotImplementedException()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         await Assert.ThrowsAsync<NotImplementedException>(() => installer.InstallAsync());
     }
@@ -78,7 +78,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task CheckReturnsTrueIfFeatureDisabled()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(false), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(false), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         // Use an invalid version string
         var result = await installer.CheckAsync("invalid.version");
@@ -89,7 +89,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task CheckAsync_UsesArchitectureSpecificCommand()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         // This test verifies that the architecture-specific command is used
         // Since the implementation adds --arch flag, it should still work correctly
@@ -103,7 +103,7 @@ public class DotNetSdkInstallerTests
     public async Task CheckAsync_UsesOverrideMinimumSdkVersion_WhenConfigured()
     {
         var configuration = CreateConfigurationWithOverride("8.0.0");
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), configuration);
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), configuration, CreateDefaultRuntimeSelector());
 
         // The installer should use the override version instead of the constant
         var result = await installer.CheckAsync();
@@ -115,7 +115,7 @@ public class DotNetSdkInstallerTests
     [Fact]
     public async Task CheckAsync_UsesDefaultMinimumSdkVersion_WhenNotConfigured()
     {
-        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration());
+        var installer = new DotNetSdkInstaller(new MinimumSdkCheckFeature(), CreateEmptyConfiguration(), CreateDefaultRuntimeSelector());
 
         // Call the parameterless method that should use the default constant
         var result = await installer.CheckAsync();
@@ -138,6 +138,23 @@ public class DotNetSdkInstallerTests
             })
             .Build();
     }
+
+    private static Lazy<IDotNetRuntimeSelector> CreateDefaultRuntimeSelector()
+    {
+        return new Lazy<IDotNetRuntimeSelector>(() => new DefaultSystemRuntimeSelector());
+    }
+}
+
+/// <summary>
+/// A stub runtime selector that always returns the system "dotnet" executable,
+/// used for tests that verify DotNetSdkInstaller behavior against the system SDK.
+/// </summary>
+internal sealed class DefaultSystemRuntimeSelector : IDotNetRuntimeSelector
+{
+    public string DotNetExecutablePath => "dotnet";
+    public DotNetRuntimeMode Mode => DotNetRuntimeMode.System;
+    public Task<bool> InitializeAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+    public IDictionary<string, string> GetEnvironmentVariables() => new Dictionary<string, string>();
 }
 
 public class MinimumSdkCheckFeature(bool enabled = true) : IFeatures

--- a/tests/Aspire.Cli.Tests/Utils/ProcessLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/ProcessLauncherTests.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.DotNet;
+using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class ProcessLauncherTests
+{
+    [Fact]
+    public async Task LaunchDotNetAsync_CallsLaunchAsync_WithRuntimeSelectorPath()
+    {
+        var logger = NullLogger<ProcessLauncher>.Instance;
+        var runtimeSelector = new TestRuntimeSelector
+        {
+            DotNetExecutablePath = "/custom/path/dotnet",
+            EnvironmentVariables = new Dictionary<string, string>()
+        };
+
+        var launcher = new TestProcessLauncher(logger, runtimeSelector);
+
+        await launcher.LaunchDotNetAsync("--version", "/working/dir");
+
+        Assert.Equal("/custom/path/dotnet", launcher.LastExecutablePath);
+        Assert.Equal("--version", launcher.LastArguments);
+        Assert.Equal("/working/dir", launcher.LastWorkingDirectory);
+    }
+
+    [Fact]
+    public async Task LaunchDotNetAsync_AppliesRuntimeEnvironmentVariables()
+    {
+        var logger = NullLogger<ProcessLauncher>.Instance;
+        var runtimeSelector = new TestRuntimeSelector
+        {
+            DotNetExecutablePath = "dotnet",
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                ["DOTNET_ROOT"] = "/custom/dotnet",
+                ["DOTNET_HOST_PATH"] = "/custom/dotnet/dotnet"
+            }
+        };
+
+        var launcher = new TestProcessLauncher(logger, runtimeSelector);
+
+        await launcher.LaunchDotNetAsync("--version");
+
+        Assert.True(launcher.LastEnvironmentVariables.ContainsKey("DOTNET_ROOT"));
+        Assert.Equal("/custom/dotnet", launcher.LastEnvironmentVariables["DOTNET_ROOT"]);
+        Assert.True(launcher.LastEnvironmentVariables.ContainsKey("DOTNET_HOST_PATH"));
+        Assert.Equal("/custom/dotnet/dotnet", launcher.LastEnvironmentVariables["DOTNET_HOST_PATH"]);
+    }
+
+    private sealed class TestRuntimeSelector : IDotNetRuntimeSelector
+    {
+        public string DotNetExecutablePath { get; set; } = "dotnet";
+        public DotNetRuntimeMode Mode { get; set; } = DotNetRuntimeMode.System;
+        public IDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
+
+        public Task<bool> InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(true);
+        }
+
+        public IDictionary<string, string> GetEnvironmentVariables()
+        {
+            return EnvironmentVariables;
+        }
+    }
+
+    private sealed class TestProcessLauncher : ProcessLauncher
+    {
+        public string? LastExecutablePath { get; private set; }
+        public string? LastArguments { get; private set; }
+        public string? LastWorkingDirectory { get; private set; }
+        public IDictionary<string, string> LastEnvironmentVariables { get; private set; } = new Dictionary<string, string>();
+
+        private readonly IDotNetRuntimeSelector _runtimeSelector;
+
+        public TestProcessLauncher(ILogger<ProcessLauncher> logger, IDotNetRuntimeSelector runtimeSelector) 
+            : base(logger, runtimeSelector)
+        {
+            _runtimeSelector = runtimeSelector;
+        }
+
+        public override async Task<int> LaunchAsync(
+            string executablePath,
+            string? arguments = null,
+            string? workingDirectory = null,
+            IDictionary<string, string>? environmentVariables = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastExecutablePath = executablePath;
+            LastArguments = arguments;
+            LastWorkingDirectory = workingDirectory;
+            
+            // Combine runtime env vars and additional ones just like the base class
+            var runtimeEnvVars = _runtimeSelector.GetEnvironmentVariables();
+            var combined = new Dictionary<string, string>(runtimeEnvVars);
+            
+            if (environmentVariables != null)
+            {
+                foreach (var kvp in environmentVariables)
+                {
+                    combined[kvp.Key] = kvp.Value;
+                }
+            }
+            
+            LastEnvironmentVariables = combined;
+            
+            return await Task.FromResult(0);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the issue where `DotNetSdkInstaller.CheckAsync()` was hardcoded to use `"dotnet"` (system PATH), ignoring the private SDK installed by `DotNetRuntimeSelector`.

The fix injects `Lazy<IDotNetRuntimeSelector>` into `DotNetSdkInstaller` (breaking the circular dependency) so that `CheckAsync()` uses the runtime selector's `DotNetExecutablePath`. Before `InitializeAsync()` runs it defaults to `"dotnet"`, and after a private SDK is installed it uses the private dotnet executable path — so the SDK version check now correctly recognizes the private installation.

Closes #11084