### PR TITLE
Fix structured logs resource filter after reconnect

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -46,6 +46,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private Subscription? _resourcesSubscription;
     private Subscription? _logsSubscription;
     private bool _resourceChanged;
+    private bool _routeResourceSelectionPending;
     private string? _elementIdBeforeDetailsViewOpened;
     private string? _pendingFocusElementId;
     private AspirePageContentLayout? _contentLayout;
@@ -285,6 +286,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             PageViewModel.SelectedResource = _resourceViewModels.GetResource(Logger, ResourceName, canSelectGrouping: true, PageViewModel.SelectedResource);
         }
 
+        _routeResourceSelectionPending = ResourceName is not null && PageViewModel.SelectedResource.Id is null;
         ViewModel.ResourceKey = GetSelectedResourceKey();
         UpdateSubscription();
     }
@@ -292,6 +294,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private Task HandleSelectedResourceChangedAsync()
     {
         _resourceChanged = true;
+        _routeResourceSelectionPending = false;
 
         return this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: true);
     }
@@ -522,7 +525,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         return new StructuredLogsPageState
         {
             LogLevelText = PageViewModel.SelectedLogLevel.Id?.ToString().ToLowerInvariant(),
-            SelectedResource = PageViewModel.SelectedResource.Id is not null ? PageViewModel.SelectedResource.Name : null,
+            SelectedResource = PageViewModel.SelectedResource.Id is not null ? PageViewModel.SelectedResource.Name : (_routeResourceSelectionPending ? ResourceName : null),
             Filters = ViewModel.Filters
         };
     }
@@ -530,6 +533,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     public async Task UpdateViewModelFromQueryAsync(StructuredLogsPageViewModel viewModel)
     {
         viewModel.SelectedResource = _resourceViewModels.GetResource(Logger, ResourceName, canSelectGrouping: true, _allResource);
+        _routeResourceSelectionPending = ResourceName is not null && viewModel.SelectedResource.Id is null;
         ViewModel.ResourceKey = GetSelectedResourceKey();
 
         if (LogLevelText is not null && Enum.TryParse<LogLevel>(LogLevelText, ignoreCase: true, out var logLevel))

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -47,6 +47,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private Subscription? _logsSubscription;
     private bool _resourceChanged;
     private bool _routeResourceSelectionPending;
+    private bool _resourceSelectionChangePending;
     private string? _elementIdBeforeDetailsViewOpened;
     private string? _pendingFocusElementId;
     private AspirePageContentLayout? _contentLayout;
@@ -281,12 +282,16 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         _resourceViewModels = ResourcesSelectHelpers.CreateResources(_resources);
         _resourceViewModels.Insert(0, _allResource);
 
-        if (ResourceName is not null)
+        if (ResourceName is not null && !_resourceSelectionChangePending)
         {
             PageViewModel.SelectedResource = _resourceViewModels.GetResource(Logger, ResourceName, canSelectGrouping: true, PageViewModel.SelectedResource);
+            _routeResourceSelectionPending = PageViewModel.SelectedResource.Id is null;
+        }
+        else if (ResourceName is null)
+        {
+            _routeResourceSelectionPending = false;
         }
 
-        _routeResourceSelectionPending = ResourceName is not null && PageViewModel.SelectedResource.Id is null;
         ViewModel.ResourceKey = GetSelectedResourceKey();
         UpdateSubscription();
     }
@@ -295,6 +300,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     {
         _resourceChanged = true;
         _routeResourceSelectionPending = false;
+        _resourceSelectionChangePending = true;
 
         return this.AfterViewModelChangedAsync(_contentLayout, waitToApplyMobileChange: true);
     }
@@ -534,6 +540,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     {
         viewModel.SelectedResource = _resourceViewModels.GetResource(Logger, ResourceName, canSelectGrouping: true, _allResource);
         _routeResourceSelectionPending = ResourceName is not null && viewModel.SelectedResource.Id is null;
+        _resourceSelectionChangePending = false;
         ViewModel.ResourceKey = GetSelectedResourceKey();
 
         if (LogLevelText is not null && Enum.TryParse<LogLevel>(LogLevelText, ignoreCase: true, out var logLevel))
@@ -573,7 +580,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
         // The route can restore a resource filter before telemetry has recreated the
         // corresponding dropdown option after reconnecting to a restarted AppHost.
-        if (ResourceName is not null)
+        if (_routeResourceSelectionPending && ResourceName is not null)
         {
             return new ResourceKey(ResourceName, InstanceId: null);
         }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -279,6 +279,14 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         _resources = TelemetryRepository.GetResources();
         _resourceViewModels = ResourcesSelectHelpers.CreateResources(_resources);
         _resourceViewModels.Insert(0, _allResource);
+
+        if (ResourceName is not null)
+        {
+            PageViewModel.SelectedResource = _resourceViewModels.GetResource(Logger, ResourceName, canSelectGrouping: true, PageViewModel.SelectedResource);
+        }
+
+        ViewModel.ResourceKey = GetSelectedResourceKey();
+        UpdateSubscription();
     }
 
     private Task HandleSelectedResourceChangedAsync()
@@ -302,11 +310,13 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
 
     private void UpdateSubscription()
     {
+        var selectedResourceKey = GetSelectedResourceKey();
+
         // Subscribe to updates.
-        if (_logsSubscription is null || _logsSubscription.ResourceKey != PageViewModel.SelectedResource.Id?.GetResourceKey())
+        if (_logsSubscription is null || _logsSubscription.ResourceKey != selectedResourceKey)
         {
             _logsSubscription?.Dispose();
-            _logsSubscription = TelemetryRepository.OnNewLogs(PageViewModel.SelectedResource.Id?.GetResourceKey(), SubscriptionType.Read, async () =>
+            _logsSubscription = TelemetryRepository.OnNewLogs(selectedResourceKey, SubscriptionType.Read, async () =>
             {
                 ViewModel.ClearData();
                 await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
@@ -367,7 +377,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             entry,
             DialogService,
             DialogService.CreateDialogCallback(this, HandleFilterDialog),
-            propertyKeys: TelemetryRepository.GetLogPropertyKeys(PageViewModel.SelectedResource.Id?.GetResourceKey()),
+            propertyKeys: TelemetryRepository.GetLogPropertyKeys(GetSelectedResourceKey()),
             knownKeys: KnownStructuredLogFields.AllFields,
             getFieldValues: TelemetryRepository.GetLogsFieldValues,
             FilterLoc);
@@ -520,7 +530,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     public async Task UpdateViewModelFromQueryAsync(StructuredLogsPageViewModel viewModel)
     {
         viewModel.SelectedResource = _resourceViewModels.GetResource(Logger, ResourceName, canSelectGrouping: true, _allResource);
-        ViewModel.ResourceKey = PageViewModel.SelectedResource.Id?.GetResourceKey();
+        ViewModel.ResourceKey = GetSelectedResourceKey();
 
         if (LogLevelText is not null && Enum.TryParse<LogLevel>(LogLevelText, ignoreCase: true, out var logLevel))
         {
@@ -548,6 +558,23 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         }
 
         await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
+    }
+
+    private ResourceKey? GetSelectedResourceKey()
+    {
+        if (PageViewModel.SelectedResource.Id is { } selectedResource)
+        {
+            return selectedResource.GetResourceKey();
+        }
+
+        // The route can restore a resource filter before telemetry has recreated the
+        // corresponding dropdown option after reconnecting to a restarted AppHost.
+        if (ResourceName is not null)
+        {
+            return new ResourceKey(ResourceName, InstanceId: null);
+        }
+
+        return null;
     }
 
     private bool IsGenAILogEntry(OtlpLogEntry logEntry)

--- a/src/Aspire.Dashboard/Model/Otlp/ResourcesSelectHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/ResourcesSelectHelpers.cs
@@ -24,31 +24,30 @@ public static class ResourcesSelectHelpers
         }
         else if (instanceIdMatches.Count == 0)
         {
+            // Fallback to matching on resource name. This is commonly used when there is only one instance of the resource.
+            var replicaSetMatches = allowedMatches.Where(e => e.Id?.Type != OtlpResourceType.Instance && string.Equals(name, e.Id?.ReplicaSetName, StringComparisons.ResourceName)).ToList();
+            if (replicaSetMatches.Count == 1)
+            {
+                return SingleMatch(resources, logger, name, replicaSetMatches[0]);
+            }
+            else if (replicaSetMatches.Count > 1)
+            {
+                return MultipleMatches(allowedMatches, logger, name, replicaSetMatches);
+            }
+
             var displayNameMatches = allowedMatches.Where(e => string.Equals(name, e.Name, StringComparisons.ResourceName)).ToList();
             if (displayNameMatches.Count == 1)
             {
                 return SingleMatch(resources, logger, name, displayNameMatches[0]);
             }
-            else if (displayNameMatches.Count > 1)
-            {
-                return MultipleMatches(allowedMatches, logger, name, displayNameMatches);
-            }
-
-            // Fallback to matching on resource name. This is commonly used when there is only one instance of the resource.
-            var replicaSetMatches = allowedMatches.Where(e => e.Id?.Type != OtlpResourceType.Instance && string.Equals(name, e.Id?.ReplicaSetName, StringComparisons.ResourceName)).ToList();
-
-            if (replicaSetMatches.Count == 1)
-            {
-                return SingleMatch(resources, logger, name, replicaSetMatches[0]);
-            }
-            else if (replicaSetMatches.Count == 0)
+            else if (displayNameMatches.Count == 0)
             {
                 // No matches found so return the passed in fallback.
                 return SingleMatch(resources, logger, name, fallbackViewModel, fallback: true);
             }
             else
             {
-                return MultipleMatches(allowedMatches, logger, name, replicaSetMatches);
+                return MultipleMatches(allowedMatches, logger, name, displayNameMatches);
             }
         }
         else

--- a/src/Aspire.Dashboard/Model/Otlp/ResourcesSelectHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/ResourcesSelectHelpers.cs
@@ -42,6 +42,16 @@ public static class ResourcesSelectHelpers
             }
             else if (displayNameMatches.Count == 0)
             {
+                var priorReplicaDisplayNameMatches = allowedMatches.Where(e => IsPriorReplicaDisplayNameMatch(name, e.Id)).ToList();
+                if (priorReplicaDisplayNameMatches.Count == 1)
+                {
+                    return SingleMatch(resources, logger, name, priorReplicaDisplayNameMatches[0]);
+                }
+                else if (priorReplicaDisplayNameMatches.Count > 1)
+                {
+                    return MultipleMatches(allowedMatches, logger, name, priorReplicaDisplayNameMatches);
+                }
+
                 // No matches found so return the passed in fallback.
                 return SingleMatch(resources, logger, name, fallbackViewModel, fallback: true);
             }
@@ -53,6 +63,31 @@ public static class ResourcesSelectHelpers
         else
         {
             return MultipleMatches(allowedMatches, logger, name, instanceIdMatches);
+        }
+
+        static bool IsPriorReplicaDisplayNameMatch(string name, ResourceTypeDetails? details)
+        {
+            if (details is not { Type: OtlpResourceType.Singleton, InstanceId: { } instanceId, ReplicaSetName: { } replicaSetName })
+            {
+                return false;
+            }
+
+            if (!name.StartsWith(replicaSetName + "-", StringComparisons.ResourceName))
+            {
+                return false;
+            }
+
+            // A route can be restored from a previous multi-replica session before
+            // enough telemetry has arrived to recreate the replica dropdown entries.
+            // Example:
+            //   route:      TestApp-11111111
+            //   singleton:  TestApp-11111111-1111-1111-1111-111111111111
+            // Treat that route as the singleton until a sibling arrives and the
+            // normal display-name match can take over.
+            var routeInstanceSuffix = name[(replicaSetName.Length + 1)..];
+            return routeInstanceSuffix.Length == 8 &&
+                routeInstanceSuffix.All(char.IsAsciiHexDigit) &&
+                instanceId.EndsWith(routeInstanceSuffix, StringComparisons.ResourceName);
         }
 
         static SelectViewModel<ResourceTypeDetails> SingleMatch(ICollection<SelectViewModel<ResourceTypeDetails>> resources, ILogger logger, string name, SelectViewModel<ResourceTypeDetails> match, bool fallback = false)

--- a/src/Aspire.Dashboard/Model/Otlp/ResourcesSelectHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/ResourcesSelectHelpers.cs
@@ -24,6 +24,16 @@ public static class ResourcesSelectHelpers
         }
         else if (instanceIdMatches.Count == 0)
         {
+            var displayNameMatches = allowedMatches.Where(e => string.Equals(name, e.Name, StringComparisons.ResourceName)).ToList();
+            if (displayNameMatches.Count == 1)
+            {
+                return SingleMatch(resources, logger, name, displayNameMatches[0]);
+            }
+            else if (displayNameMatches.Count > 1)
+            {
+                return MultipleMatches(allowedMatches, logger, name, displayNameMatches);
+            }
+
             // Fallback to matching on resource name. This is commonly used when there is only one instance of the resource.
             var replicaSetMatches = allowedMatches.Where(e => e.Id?.Type != OtlpResourceType.Instance && string.Equals(name, e.Id?.ReplicaSetName, StringComparisons.ResourceName)).ToList();
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.Controls;
+using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
@@ -297,7 +298,24 @@ public partial class StructuredLogsTests : DashboardTestContext
                         }
                     }
                 }
-            },
+            }
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("TestApp", cut.Instance.PageViewModel.SelectedResource.Name);
+            Assert.Equal("TestApp", viewModel.ResourceKey?.Name);
+            Assert.Equal(selectedInstanceId.ToString(), viewModel.ResourceKey?.InstanceId);
+
+            var logs = viewModel.GetLogs();
+            var log = Assert.Single(logs.Items);
+            Assert.Equal("TestApp", log.ResourceView.ResourceKey.Name);
+            Assert.Equal(selectedInstanceId.ToString(), log.ResourceView.ResourceKey.InstanceId);
+            Assert.Equal(1, logs.TotalItemCount);
+        });
+
+        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
             new ResourceLogs
             {
                 Resource = CreateResource(name: "TestApp", instanceId: siblingInstanceId.ToString()),
@@ -318,14 +336,107 @@ public partial class StructuredLogsTests : DashboardTestContext
         cut.WaitForAssertion(() =>
         {
             Assert.Equal(selectedResourceName, cut.Instance.PageViewModel.SelectedResource.Name);
-            Assert.Equal("TestApp", viewModel.ResourceKey?.Name);
-            Assert.Equal(selectedInstanceId.ToString(), viewModel.ResourceKey?.InstanceId);
 
             var logs = viewModel.GetLogs();
             var log = Assert.Single(logs.Items);
-            Assert.Equal("TestApp", log.ResourceView.ResourceKey.Name);
             Assert.Equal(selectedInstanceId.ToString(), log.ResourceView.ResourceKey.InstanceId);
             Assert.Equal(1, logs.TotalItemCount);
+        });
+    }
+
+    [Fact]
+    public async Task Render_MobilePendingResourceSelection_ResourceUpdateDoesNotRestoreRouteResource()
+    {
+        SetupStructureLogsServices();
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: "TestApp"));
+
+        var viewport = new ViewportInformation(IsDesktop: false, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "TestApp", instanceId: "test-instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Route resource log")
+                        }
+                    }
+                }
+            },
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "OtherApp", instanceId: "other-instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Pending selection log")
+                        }
+                    }
+                }
+            }
+        });
+
+        var cut = RenderComponent<StructuredLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "TestApp");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+        var page = cut.Instance;
+
+        Assert.Equal("TestApp", page.PageViewModel.SelectedResource.Name);
+
+        page.PageViewModel.SelectedResource = new SelectViewModel<ResourceTypeDetails>
+        {
+            Id = ResourceTypeDetails.CreateSingleton("OtherApp-other-instance", "OtherApp"),
+            Name = "OtherApp"
+        };
+
+        await InvokeHandleSelectedResourceChangedAsync(cut, page);
+
+        var layout = cut.FindComponent<AspirePageContentLayout>().Instance;
+        Assert.Contains(nameof(PageExtensions.AfterViewModelChangedAsync), layout.DialogCloseListeners.Keys);
+        Assert.EndsWith(DashboardUrls.StructuredLogsUrl(resource: "TestApp"), navigationManager.Uri);
+
+        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "ThirdApp", instanceId: "third-instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Resource refresh trigger")
+                        }
+                    }
+                }
+            }
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("OtherApp", page.PageViewModel.SelectedResource.Name);
+            Assert.Equal("OtherApp", page.ViewModel.ResourceKey?.Name);
+            Assert.Equal("other-instance", page.ViewModel.ResourceKey?.InstanceId);
         });
     }
 
@@ -522,5 +633,15 @@ public partial class StructuredLogsTests : DashboardTestContext
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         Services.AddSingleton<ILogger<StructuredLogs>>(NullLogger<StructuredLogs>.Instance);
         Services.AddSingleton<StructuredLogsViewModel>();
+    }
+
+    private static Task InvokeHandleSelectedResourceChangedAsync(IRenderedComponent<StructuredLogs> cut, StructuredLogs page)
+    {
+        return cut.InvokeAsync(() =>
+        {
+            var method = typeof(StructuredLogs).GetMethod("HandleSelectedResourceChangedAsync", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            return (Task)method.Invoke(page, null)!;
+        });
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -231,6 +231,104 @@ public partial class StructuredLogsTests : DashboardTestContext
     }
 
     [Fact]
+    public void Render_RouteReplicaDisplayNameBeforeTelemetryArrives_FiltersLogsWhenResourcesArrive()
+    {
+        SetupStructureLogsServices();
+
+        var selectedInstanceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var siblingInstanceId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var selectedResourceName = $"TestApp-{selectedInstanceId.ToString("N")[^8..]}";
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        var uri = navigationManager.ToAbsoluteUri(DashboardUrls.StructuredLogsUrl(resource: selectedResourceName));
+        navigationManager.NavigateTo(uri.OriginalString);
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<StructuredLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, selectedResourceName);
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var viewModel = Services.GetRequiredService<StructuredLogsViewModel>();
+        viewModel.StartIndex = 0;
+        viewModel.Count = 100;
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+
+        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "OtherApp", instanceId: "other-instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Other resource log")
+                        }
+                    }
+                }
+            }
+        });
+
+        cut.WaitForAssertion(() => Assert.Empty(viewModel.GetLogs().Items));
+
+        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "TestApp", instanceId: selectedInstanceId.ToString()),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Selected resource log")
+                        }
+                    }
+                }
+            },
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "TestApp", instanceId: siblingInstanceId.ToString()),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Sibling resource log")
+                        }
+                    }
+                }
+            }
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(selectedResourceName, cut.Instance.PageViewModel.SelectedResource.Name);
+            Assert.Equal("TestApp", viewModel.ResourceKey?.Name);
+            Assert.Equal(selectedInstanceId.ToString(), viewModel.ResourceKey?.InstanceId);
+
+            var logs = viewModel.GetLogs();
+            var log = Assert.Single(logs.Items);
+            Assert.Equal("TestApp", log.ResourceView.ResourceKey.Name);
+            Assert.Equal(selectedInstanceId.ToString(), log.ResourceView.ResourceKey.InstanceId);
+            Assert.Equal(1, logs.TotalItemCount);
+        });
+    }
+
+    [Fact]
     public void Render_FiltersWithSpecialCharacters_SuccessfullyParsed()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -150,6 +150,87 @@ public partial class StructuredLogsTests : DashboardTestContext
     }
 
     [Fact]
+    public void Render_RouteResourceBeforeTelemetryArrives_FiltersLogsWhenResourcesArrive()
+    {
+        SetupStructureLogsServices();
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        var uri = navigationManager.ToAbsoluteUri(DashboardUrls.StructuredLogsUrl(resource: "TestApp"));
+        navigationManager.NavigateTo(uri.OriginalString);
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<StructuredLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "TestApp");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var viewModel = Services.GetRequiredService<StructuredLogsViewModel>();
+        viewModel.StartIndex = 0;
+        viewModel.Count = 100;
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+
+        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "OtherApp", instanceId: "other-instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Other resource log")
+                        }
+                    }
+                }
+            }
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("TestApp", viewModel.ResourceKey?.Name);
+            Assert.Empty(viewModel.GetLogs().Items);
+        });
+
+        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "TestApp", instanceId: "app-instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Selected resource log")
+                        }
+                    }
+                }
+            }
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("TestApp", cut.Instance.PageViewModel.SelectedResource.Name);
+            Assert.Equal("TestApp", viewModel.ResourceKey?.Name);
+
+            var logs = viewModel.GetLogs();
+            var log = Assert.Single(logs.Items);
+            Assert.Equal("TestApp", log.ResourceView.ResourceKey.Name);
+            Assert.Equal(1, logs.TotalItemCount);
+        });
+    }
+
+    [Fact]
     public void Render_FiltersWithSpecialCharacters_SuccessfullyParsed()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
@@ -329,6 +330,99 @@ public partial class StructuredLogsTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task Render_RouteResourceBeforeTelemetryArrives_SerializesRouteResourceFilter()
+    {
+        SetupStructureLogsServices();
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: "TestApp"));
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<StructuredLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "TestApp");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+        var page = cut.Instance;
+
+        Assert.Equal("TestApp", page.ViewModel.ResourceKey?.Name);
+        Assert.Null(page.PageViewModel.SelectedResource.Id);
+
+        await cut.InvokeAsync(() => page.AfterViewModelChangedAsync(layout: null, waitToApplyMobileChange: true));
+
+        var state = page.ConvertViewModelToSerializable();
+        Assert.Equal("TestApp", state.SelectedResource);
+        Assert.EndsWith("/structuredlogs/resource/TestApp", navigationManager.Uri);
+    }
+
+    [Fact]
+    public async Task Render_RouteResourceAfterTelemetryArrives_AllSelectionClearsSerializedResource()
+    {
+        SetupStructureLogsServices();
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: "TestApp"));
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<StructuredLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "TestApp");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+        var page = cut.Instance;
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+
+        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "TestApp", instanceId: "app-instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "Selected resource log")
+                        }
+                    }
+                }
+            }
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("TestApp", page.ViewModel.ResourceKey?.Name);
+            Assert.NotNull(page.PageViewModel.SelectedResource.Id);
+        });
+
+        var allResourceLabel = Services.GetRequiredService<IStringLocalizer<Dashboard.Resources.ControlsStrings>>()[nameof(Dashboard.Resources.ControlsStrings.LabelAll)].Value;
+
+        await cut.InvokeAsync(() =>
+        {
+            var resourceSelect = cut.FindComponent<ResourceSelect>();
+            var innerSelect = resourceSelect.Find("fluent-select");
+            innerSelect.Change(allResourceLabel);
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            var state = page.ConvertViewModelToSerializable();
+            Assert.Null(state.SelectedResource);
+            Assert.EndsWith("/structuredlogs", navigationManager.Uri);
+        });
+    }
+
+    [Fact]
     public void Render_FiltersWithSpecialCharacters_SuccessfullyParsed()
     {
         // Arrange
@@ -422,6 +516,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
 
         JSInterop.SetupVoid("initializeContinuousScroll").SetVoidResult();
+        JSInterop.SetupVoid("resetContinuousScrollPosition").SetVoidResult();
         JSInterop.SetupVoid("focusElement", _ => true);
 
         FluentUISetupHelpers.AddCommonDashboardServices(this);

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -265,6 +265,23 @@ public sealed class ResourcesSelectHelpersTests
         Assert.Equal(OtlpResourceType.ResourceGrouping, app.Id!.Type);
     }
 
+    [Fact]
+    public void GetResource_DisplayNameWithShortGuid_GetInstance()
+    {
+        var instanceId1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var instanceId2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var appVMs = ResourcesSelectHelpers.CreateResources(new List<OtlpResource>
+        {
+            CreateOtlpResource(name: "app", instanceId: instanceId1.ToString()),
+            CreateOtlpResource(name: "app", instanceId: instanceId2.ToString())
+        });
+
+        var app = appVMs.GetResource(NullLogger.Instance, "app-11111111", canSelectGrouping: true, null!);
+
+        Assert.Equal($"app-{instanceId1}", app.Id!.InstanceId);
+        Assert.Equal(OtlpResourceType.Instance, app.Id!.Type);
+    }
+
     private static OtlpResource CreateOtlpResource(string name, string? instanceId)
     {
         var resource = new Resource();

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -282,6 +282,21 @@ public sealed class ResourcesSelectHelpersTests
         Assert.Equal(OtlpResourceType.Instance, app.Id!.Type);
     }
 
+    [Fact]
+    public void GetResource_DisplayNameCollisionWithReplicaSetName_ReturnsExactReplicaSet()
+    {
+        var appVMs = new List<SelectViewModel<ResourceTypeDetails>>
+        {
+            new() { Name = "app-11111111", Id = ResourceTypeDetails.CreateReplicaInstance("app-full-instance-id", "app") },
+            new() { Name = "app-11111111", Id = ResourceTypeDetails.CreateResourceGrouping("app-11111111", isReplicaSet: true) }
+        };
+
+        var app = appVMs.GetResource(NullLogger.Instance, "app-11111111", canSelectGrouping: true, null!);
+
+        Assert.Equal("app-11111111", app.Id!.ReplicaSetName);
+        Assert.Equal(OtlpResourceType.ResourceGrouping, app.Id!.Type);
+    }
+
     private static OtlpResource CreateOtlpResource(string name, string? instanceId)
     {
         var resource = new Resource();

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -283,6 +283,36 @@ public sealed class ResourcesSelectHelpersTests
     }
 
     [Fact]
+    public void GetResource_PriorReplicaDisplayNameWithSingleArrivedReplica_GetInstance()
+    {
+        var instanceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var appVMs = ResourcesSelectHelpers.CreateResources(new List<OtlpResource>
+        {
+            CreateOtlpResource(name: "app", instanceId: instanceId.ToString())
+        });
+
+        var app = appVMs.GetResource(NullLogger.Instance, "app-11111111", canSelectGrouping: true, null!);
+
+        Assert.Equal($"app-{instanceId}", app.Id!.InstanceId);
+        Assert.Equal(OtlpResourceType.Singleton, app.Id!.Type);
+    }
+
+    [Fact]
+    public void GetResource_PriorReplicaDisplayNameWithPartialSuffix_GetFallback()
+    {
+        var instanceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var fallback = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = "All" };
+        var appVMs = ResourcesSelectHelpers.CreateResources(new List<OtlpResource>
+        {
+            CreateOtlpResource(name: "app", instanceId: instanceId.ToString())
+        });
+
+        var app = appVMs.GetResource(NullLogger.Instance, "app-1", canSelectGrouping: true, fallback);
+
+        Assert.Same(fallback, app);
+    }
+
+    [Fact]
     public void GetResource_DisplayNameCollisionWithReplicaSetName_ReturnsExactReplicaSet()
     {
         var appVMs = new List<SelectViewModel<ResourceTypeDetails>>


### PR DESCRIPTION
## Description

Structured log resource filtering now survives AppHost reconnects and replica route names more reliably. Before this, restoring a structured logs URL after a reconnect could lose the intended resource filter before the dashboard had rebuilt the dropdown item, and replica/grouping selections could fail to map back to the route resource name.

This preserves the route resource key while telemetry catches up, refreshes the log subscription when resources are rebuilt, keeps serialized URL/session resource state stable until the user explicitly selects All, prefers exact route resource/group matches over display-name fallbacks, and lets resource dropdown matching use the display name before falling back when no exact route match exists.

Fixes #11119

### User-facing usage

If a structured logs URL includes a resource filter, for example:

```text
/structuredlogs/resource/api
```

the dashboard keeps that resource filter active across an AppHost restart/reconnect instead of temporarily falling back to all resources.

### Validation

```text
DOTNET_CLI_UI_LANGUAGE=en-US dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-class "*.ResourcesSelectHelpersTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
DOTNET_CLI_UI_LANGUAGE=en-US dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-class "*.StructuredLogsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
MSBUILDTERMINALLOGGER=false .dotnet/dotnet build src/Aspire.Dashboard/Aspire.Dashboard.csproj --no-restore /p:SkipNativeBuild=true
```

Results: 15 passed; 10 passed; Dashboard build clean.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

<!-- daily-work-queue:v1 repo=microsoft/aspire pr=18643 head=67e71db5008d58c7493716cd5385a18e687d6340 laneType=review-fix status=ci-green-tracking-resolved trackingThreadIds=PRRT_kwDOKYQzfc6OW38d,PRRT_kwDOKYQzfc6OW381 updatedAt=2026-07-04T13:16:30-06:00 -->
