### PR TITLE
Revert ProjectLocator walk-stop behavior from #18683

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -636,47 +636,39 @@ internal sealed class ProjectLocator(
                 return null;
             }
 
-            if (aspireConfig is not null)
+            if (aspireConfig?.AppHost?.Path is { } configAppHostPath)
             {
-                // aspire.config.json exists at this level — this is the workspace root.
-                // If it specifies an appHost.path, resolve it; otherwise no AppHost is
-                // configured. Either way, do not walk further up.
-                if (aspireConfig.AppHost?.Path is { } configAppHostPath)
+                var configFilePath = Path.Combine(searchDirectory.FullName, AspireConfigFile.FileName);
+
+                // Validate before Path.Combine / new FileInfo, which throw ArgumentException
+                // ("Null character in path." / "Illegal characters in path.") on NUL bytes and
+                // other invalid characters that survive JSON parsing. Without this we surface
+                // as a generic "An unexpected error occurred" — see
+                // https://github.com/microsoft/aspire/issues/17624.
+                if (!IsValidConfiguredAppHostPath(configAppHostPath, configFilePath, fieldName: AspireConfigAppHostPathKey, silent: silent))
                 {
-                    var configFilePath = Path.Combine(searchDirectory.FullName, AspireConfigFile.FileName);
-
-                    // Validate before Path.Combine / new FileInfo, which throw ArgumentException
-                    // ("Null character in path." / "Illegal characters in path.") on NUL bytes and
-                    // other invalid characters that survive JSON parsing. Without this we surface
-                    // as a generic "An unexpected error occurred" — see
-                    // https://github.com/microsoft/aspire/issues/17624.
-                    if (!IsValidConfiguredAppHostPath(configAppHostPath, configFilePath, fieldName: AspireConfigAppHostPathKey, silent: silent))
-                    {
-                        return null;
-                    }
-
-                    var qualifiedPath = Path.IsPathRooted(configAppHostPath)
-                        ? configAppHostPath
-                        : Path.Combine(searchDirectory.FullName, configAppHostPath);
-                    qualifiedPath = PathNormalizer.NormalizePathForCurrentPlatform(qualifiedPath);
-                    var appHostFile = new FileInfo(qualifiedPath);
-
-                    if (appHostFile.Exists)
-                    {
-                        logger.LogInformation("Found AppHost path '{AppHostPath}' from config file in {Directory}", configAppHostPath, searchDirectory.FullName);
-                        return appHostFile;
-                    }
-                    else
-                    {
-                        if (!silent)
-                        {
-                            interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostWasSpecifiedButDoesntExist, configFilePath, qualifiedPath));
-                        }
-                        return null;
-                    }
+                    return null;
                 }
 
-                return null;
+                var qualifiedPath = Path.IsPathRooted(configAppHostPath)
+                    ? configAppHostPath
+                    : Path.Combine(searchDirectory.FullName, configAppHostPath);
+                qualifiedPath = PathNormalizer.NormalizePathForCurrentPlatform(qualifiedPath);
+                var appHostFile = new FileInfo(qualifiedPath);
+
+                if (appHostFile.Exists)
+                {
+                    logger.LogInformation("Found AppHost path '{AppHostPath}' from config file in {Directory}", configAppHostPath, searchDirectory.FullName);
+                    return appHostFile;
+                }
+                else
+                {
+                    if (!silent)
+                    {
+                        interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.AppHostWasSpecifiedButDoesntExist, configFilePath, qualifiedPath));
+                    }
+                    return null;
+                }
             }
 
             // TODO: Remove legacy .aspire/settings.json fallback once confident most users have migrated.
@@ -686,9 +678,6 @@ internal sealed class ProjectLocator(
 
             if (settingsFile.Exists)
             {
-                // .aspire/settings.json exists at this level — this is the workspace root.
-                // If it specifies an appHostPath, resolve it; otherwise no AppHost is
-                // configured. Either way, do not walk further up.
                 try
                 {
                     using var stream = settingsFile.OpenRead();
@@ -749,9 +738,6 @@ internal sealed class ProjectLocator(
                     ReportInvalidConfigurationFile(ex, message, silent);
                     return null;
                 }
-
-                // Settings file exists but has no appHostPath — no AppHost configured.
-                return null;
             }
 
             if (searchParentDirectories && searchDirectory.Parent is not null)

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -3029,69 +3029,6 @@ builder.Build().Run();");
         Assert.Equal(AppHostProjectCandidateStatus.Buildable, candidate.Status);
     }
 
-    [Fact]
-    public async Task GetAppHostFromSettings_StopsAtWorkspaceRootWhenLegacySettingsHasNoAppHostPath()
-    {
-        // Regression: previously, GetAppHostProjectFileFromSettingsAsync continued walking
-        // past .aspire/settings.json when it had no appHostPath, allowing stale config in
-        // parent directories to contaminate the result.
-        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-
-        // Plant a stale aspire.config.json in the parent directory with an appHost.path.
-        // The walk should NOT reach this because .aspire/settings.json in the workspace
-        // marks it as the workspace root.
-        var parentDir = workspace.WorkspaceRoot.Parent!;
-        var staleConfigPath = Path.Combine(parentDir.FullName, AspireConfigFile.FileName);
-        await File.WriteAllTextAsync(staleConfigPath, """{ "appHost": { "path": "Stale.csproj" } }""");
-
-        try
-        {
-            var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-            var projectLocator = CreateProjectLocator(executionContext);
-
-            var foundAppHost = await projectLocator.GetAppHostFromSettingsAsync(CancellationToken.None).DefaultTimeout();
-
-            // The workspace has .aspire/settings.json with no appHostPath — the walk
-            // should stop there and return null, not pick up the parent's stale config.
-            Assert.Null(foundAppHost);
-        }
-        finally
-        {
-            File.Delete(staleConfigPath);
-        }
-    }
-
-    [Fact]
-    public async Task GetAppHostFromSettings_StopsAtWorkspaceRootWhenAspireConfigJsonHasNoAppHostPath()
-    {
-        // Same regression scenario as above but with the modern aspire.config.json format.
-        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-
-        // Create aspire.config.json at workspace root with no appHost.path.
-        var workspaceConfigPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
-        await File.WriteAllTextAsync(workspaceConfigPath, """{ "channel": "daily" }""");
-
-        // Plant a stale aspire.config.json in the parent directory.
-        var parentDir = workspace.WorkspaceRoot.Parent!;
-        var staleConfigPath = Path.Combine(parentDir.FullName, AspireConfigFile.FileName);
-        await File.WriteAllTextAsync(staleConfigPath, """{ "appHost": { "path": "Stale.csproj" } }""");
-
-        try
-        {
-            var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
-            var projectLocator = CreateProjectLocator(executionContext);
-
-            var foundAppHost = await projectLocator.GetAppHostFromSettingsAsync(CancellationToken.None).DefaultTimeout();
-
-            // aspire.config.json exists at workspace root (no appHost.path) — stop there.
-            Assert.Null(foundAppHost);
-        }
-        finally
-        {
-            File.Delete(staleConfigPath);
-        }
-    }
-
     private static ProjectLocator CreateProjectLocator(
         CliExecutionContext executionContext,
         IInteractionService? interactionService = null,


### PR DESCRIPTION
## Description

Reverts the ProjectLocator "stop config walk at workspace root" behavior introduced in #18683.

The change removed:
- The outer `if (aspireConfig is not null)` wrapper that prevented the parent directory walk from continuing past `aspire.config.json` when it had no `appHost.path` configured
- The `return null;` after the `.aspire/settings.json` block that similarly stopped the walk
- Associated comments explaining the walk-stop behavior
- Two unit tests (`GetAppHostFromSettings_StopsAtWorkspaceRootWhenLegacySettingsHasNoAppHostPath` and `GetAppHostFromSettings_StopsAtWorkspaceRootWhenAspireConfigJsonHasNoAppHostPath`)

## Validation

All 4606 CLI tests pass (0 failures, 36 skipped for platform reasons).