### PR TITLE
Fix trace 'not contains' filter not excluding matching traces

### DIFF
--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -13,12 +13,10 @@ public abstract class TelemetryFilter : IEquatable<TelemetryFilter>
 {
     public bool Enabled { get; set; } = true;
 
-    /// <summary>
-    /// Returns true when this filter uses negative matching (e.g. NotEqual, NotContains).
-    /// Negative filters require ALL spans in a trace to satisfy the condition for the trace
-    /// to pass, rather than the default ANY-span semantics used by positive filters.
-    /// </summary>
-    public virtual bool IsNegativeFilter => false;
+    // Returns true when this filter uses negative matching (e.g. NotEqual, NotContains).
+    // Negative filters require ALL spans in a trace to satisfy the condition for the trace
+    // to pass, rather than the default ANY-span semantics used by positive filters.
+    internal virtual bool IsNegativeFilter => false;
 
     public abstract bool Equals(TelemetryFilter? other);
 
@@ -35,7 +33,7 @@ public class FieldTelemetryFilter : TelemetryFilter
     public FilterCondition Condition { get; set; }
     public string Value { get; set; } = default!;
 
-    public override bool IsNegativeFilter => Condition is FilterCondition.NotEqual or FilterCondition.NotContains;
+    internal override bool IsNegativeFilter => Condition is FilterCondition.NotEqual or FilterCondition.NotContains;
 
     private string DebuggerDisplayText => $"{Field} {ConditionToString(Condition, null)} {Value}";
 

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -13,6 +13,13 @@ public abstract class TelemetryFilter : IEquatable<TelemetryFilter>
 {
     public bool Enabled { get; set; } = true;
 
+    /// <summary>
+    /// Returns true when this filter uses negative matching (e.g. NotEqual, NotContains).
+    /// Negative filters require ALL spans in a trace to satisfy the condition for the trace
+    /// to pass, rather than the default ANY-span semantics used by positive filters.
+    /// </summary>
+    public virtual bool IsNegativeFilter => false;
+
     public abstract bool Equals(TelemetryFilter? other);
 
     public abstract IEnumerable<OtlpLogEntry> Apply(IEnumerable<OtlpLogEntry> input);
@@ -27,6 +34,8 @@ public class FieldTelemetryFilter : TelemetryFilter
     public string? FallbackField { get; set; }
     public FilterCondition Condition { get; set; }
     public string Value { get; set; } = default!;
+
+    public override bool IsNegativeFilter => Condition is FilterCondition.NotEqual or FilterCondition.NotContains;
 
     private string DebuggerDisplayText => $"{Field} {ConditionToString(Condition, null)} {Value}";
 

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -271,8 +271,13 @@ public class FieldTelemetryFilter : TelemetryFilter
         else
         {
             // And — both values must satisfy the not-equal/not-contains condition.
-            // When Value2 is null (most fields only have one value), Value1 alone is sufficient.
-            if (fieldValues.Value1 != null && IsMatch(fieldValues.Value1, Value, Condition, fieldType))
+            // When the field is absent (Value1 is null), the span trivially satisfies the
+            // negative condition — a span without the field cannot contain/equal the value.
+            if (fieldValues.Value1 is null)
+            {
+                return true;
+            }
+            if (IsMatch(fieldValues.Value1, Value, Condition, fieldType))
             {
                 if (fieldValues.Value2 is null || IsMatch(fieldValues.Value2, Value, Condition, fieldType))
                 {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -989,6 +989,8 @@ public sealed partial class TelemetryRepository : IDisposable
         var hasPositiveMatch = false;
         foreach (var span in trace.Spans)
         {
+            // Once a positive match has been found on an earlier span, skip re-evaluating
+            // positive filters on subsequent spans (only negative filters still need checking).
             var positiveMatch = !hasPositiveMatch;
             foreach (var filter in filters)
             {
@@ -1039,6 +1041,8 @@ public sealed partial class TelemetryRepository : IDisposable
         var hasPositiveMatch = false;
         foreach (var span in trace.Spans)
         {
+            // Once a positive match has been found on an earlier span, skip re-evaluating
+            // positive filters on subsequent spans (only negative filters still need checking).
             var positiveMatch = !hasPositiveMatch;
             foreach (var filter in optimizedFilters)
             {
@@ -1202,7 +1206,14 @@ public sealed partial class TelemetryRepository : IDisposable
             }
             else
             {
-                if (fieldValue.Value1 is not null && IsMatch(fieldValue.Value1))
+                // And — both values must satisfy the not-equal/not-contains condition.
+                // When the field is absent (Value1 is null), the span trivially satisfies the
+                // negative condition — a span without the field cannot contain/equal the value.
+                if (fieldValue.Value1 is null)
+                {
+                    return true;
+                }
+                if (IsMatch(fieldValue.Value1))
                 {
                     if (fieldValue.Value2 is null || IsMatch(fieldValue.Value2))
                     {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -981,10 +981,15 @@ public sealed partial class TelemetryRepository : IDisposable
             }
         }
 
-        // A trace matches when one of its spans matches all non-duration filters.
+        // Single pass over spans handles both filter polarities:
+        // - Negative filters (not-equal, not-contains) use ALL-span semantics: the trace is
+        //   excluded if ANY span violates the condition.
+        // - Positive filters use ANY-span semantics: the trace matches when at least one span
+        //   satisfies all positive filters.
+        var hasPositiveMatch = false;
         foreach (var span in trace.Spans)
         {
-            var match = true;
+            var positiveMatch = !hasPositiveMatch;
             foreach (var filter in filters)
             {
                 if (filter.IsTraceDurationFilter())
@@ -992,20 +997,29 @@ public sealed partial class TelemetryRepository : IDisposable
                     continue;
                 }
 
-                if (!filter.Apply(span))
+                if (filter.IsNegativeFilter)
                 {
-                    match = false;
-                    break;
+                    if (!filter.Apply(span))
+                    {
+                        return false;
+                    }
+                }
+                else if (positiveMatch)
+                {
+                    if (!filter.Apply(span))
+                    {
+                        positiveMatch = false;
+                    }
                 }
             }
 
-            if (match)
+            if (positiveMatch)
             {
-                return true;
+                hasPositiveMatch = true;
             }
         }
 
-        return false;
+        return hasPositiveMatch;
     }
 
     private static bool MatchesFilters(OtlpTrace trace, List<TraceFilter> optimizedFilters)
@@ -1019,10 +1033,13 @@ public sealed partial class TelemetryRepository : IDisposable
             }
         }
 
-        // A trace matches when one of its spans matches all non-duration filters.
+        // Single pass over spans handles both filter polarities:
+        // - Negative filters use ALL-span semantics (any violation excludes the trace).
+        // - Positive filters use ANY-span semantics (one span matching all suffices).
+        var hasPositiveMatch = false;
         foreach (var span in trace.Spans)
         {
-            var match = true;
+            var positiveMatch = !hasPositiveMatch;
             foreach (var filter in optimizedFilters)
             {
                 if (filter.IsDurationFilter)
@@ -1030,25 +1047,36 @@ public sealed partial class TelemetryRepository : IDisposable
                     continue;
                 }
 
-                if (!filter.Apply(span))
+                if (filter.IsNegativeFilter)
                 {
-                    match = false;
-                    break;
+                    if (!filter.Apply(span))
+                    {
+                        return false;
+                    }
+                }
+                else if (positiveMatch)
+                {
+                    if (!filter.Apply(span))
+                    {
+                        positiveMatch = false;
+                    }
                 }
             }
 
-            if (match)
+            if (positiveMatch)
             {
-                return true;
+                hasPositiveMatch = true;
             }
         }
 
-        return false;
+        return hasPositiveMatch;
     }
 
     private readonly record struct TraceFilter(TelemetryFilter Filter, DurationFilter? OptimizedDurationFilter, StringFilter? OptimizedStringFilter)
     {
         public bool IsOptimized => OptimizedDurationFilter is not null || OptimizedStringFilter is not null;
+
+        public bool IsNegativeFilter => Filter.IsNegativeFilter;
 
         public bool IsDurationFilter => OptimizedDurationFilter is not null || Filter.IsTraceDurationFilter();
 

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -2854,4 +2854,225 @@ public class TraceTests
         Assert.Equal(1, result.PagedResult.TotalItemCount);
         Assert.Contains("span1", result.PagedResult.Items[0].Name);
     }
+
+    [Fact]
+    public void GetTraces_NotContainsFilter_ExcludesTraceWhenAnySpanMatches()
+    {
+        // Verifies that a "not contains" filter on the trace Name field excludes the trace
+        // when ANY span's name contains the filtered text, even if other spans in the same
+        // trace do not contain it. This is the fix for https://github.com/microsoft/aspire/issues/18684.
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            // Root span whose name contains the filter text.
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(5)),
+                            // Child span whose name does NOT contain "1-1".
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        var resourceKey = new ResourceKey("service1", InstanceId: null);
+
+        // Filter: Name not contains "1-1" — the root span's name is "Test span. Id: 1-1" which
+        // contains "1-1", so the trace should be excluded even though the child span doesn't match.
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKeys = [resourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = KnownTraceFields.NameField,
+                    Condition = FilterCondition.NotContains,
+                    Value = "1-1"
+                }
+            ]
+        });
+
+        Assert.Empty(traces.PagedResult.Items);
+    }
+
+    [Fact]
+    public void GetTraces_NotContainsFilter_IncludesTraceWhenNoSpanMatches()
+    {
+        // Verifies that a "not contains" filter includes the trace when none of its spans'
+        // names contain the filtered text.
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(5)),
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        var resourceKey = new ResourceKey("service1", InstanceId: null);
+
+        // Filter: Name not contains "NONEXISTENT" — no span name contains this text,
+        // so the trace should be included.
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKeys = [resourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = KnownTraceFields.NameField,
+                    Condition = FilterCondition.NotContains,
+                    Value = "NONEXISTENT"
+                }
+            ]
+        });
+
+        Assert.Collection(traces.PagedResult.Items,
+            trace => AssertId("1", trace.TraceId));
+    }
+
+    [Fact]
+    public void GetTraces_NotEqualFilter_ExcludesTraceWhenAnySpanMatches()
+    {
+        // Verifies that a "not equal" filter excludes the trace when ANY span's field value
+        // equals the filtered text.
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(5)),
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        var resourceKey = new ResourceKey("service1", InstanceId: null);
+
+        // Filter: Name != "Test span. Id: 1-1" — the root span matches exactly, so the trace
+        // should be excluded even though the child span doesn't match.
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKeys = [resourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = KnownTraceFields.NameField,
+                    Condition = FilterCondition.NotEqual,
+                    Value = "Test span. Id: 1-1"
+                }
+            ]
+        });
+
+        Assert.Empty(traces.PagedResult.Items);
+    }
+
+    [Fact]
+    public void GetTraces_NotContainsWithPositiveFilter_CombinesCorrectly()
+    {
+        // Verifies that combining a positive filter with a negative filter works correctly:
+        // the trace must have at least one span matching the positive filter AND all spans
+        // must satisfy the negative filter.
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(5),
+                                attributes: [KeyValuePair.Create("env", "prod")]),
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3),
+                                parentSpanId: "1-1", attributes: [KeyValuePair.Create("env", "prod")])
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "2", spanId: "2-1", startTime: s_testTime.AddMinutes(10), endTime: s_testTime.AddMinutes(15),
+                                attributes: [KeyValuePair.Create("env", "staging")])
+                        }
+                    }
+                }
+            }
+        });
+
+        var resourceKey = new ResourceKey("service1", InstanceId: null);
+
+        // Positive: attribute env contains "prod"
+        // Negative: name not contains "1-1" (excludes trace 1 because root span name matches)
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKeys = [resourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters =
+            [
+                new FieldTelemetryFilter { Field = "env", Condition = FilterCondition.Contains, Value = "prod" },
+                new FieldTelemetryFilter { Field = KnownTraceFields.NameField, Condition = FilterCondition.NotContains, Value = "1-1" }
+            ]
+        });
+
+        // Trace 1 is excluded (root span name contains "1-1" even though env=prod matches).
+        // Trace 2 doesn't match the positive filter (env=staging, not prod).
+        Assert.Empty(traces.PagedResult.Items);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -3052,6 +3052,23 @@ public class TraceTests
                         }
                     }
                 }
+            },
+            // Trace 3: satisfies both conditions — env=prod and no span name contains "1-1".
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "3", spanId: "3-1", startTime: s_testTime.AddMinutes(20), endTime: s_testTime.AddMinutes(25),
+                                attributes: [KeyValuePair.Create("env", "prod")])
+                        }
+                    }
+                }
             }
         });
 
@@ -3073,7 +3090,9 @@ public class TraceTests
 
         // Trace 1 is excluded (root span name contains "1-1" even though env=prod matches).
         // Trace 2 doesn't match the positive filter (env=staging, not prod).
-        Assert.Empty(traces.PagedResult.Items);
+        // Trace 3 satisfies both: env=prod AND no span name contains "1-1".
+        Assert.Collection(traces.PagedResult.Items,
+            trace => AssertId("3", trace.TraceId));
     }
 
     [Fact]
@@ -3182,5 +3201,135 @@ public class TraceTests
         });
 
         Assert.Empty(traces.PagedResult.Items);
+    }
+
+    [Fact]
+    public void GetSpans_NotContainsFilter_AbsentAttributeIncludesSpan()
+    {
+        // Verifies that span-level negative filtering correctly includes spans that lack the
+        // filtered attribute. A span without the field trivially satisfies "not contains X".
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(5),
+                                attributes: [KeyValuePair.Create("http.method", "GET")]),
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3),
+                                parentSpanId: "1-1", attributes: [KeyValuePair.Create("http.method", "POST")]),
+                            // Span without http.method attribute — should still be included.
+                            CreateSpan(traceId: "1", spanId: "1-3", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(4),
+                                parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        // Filter: http.method not contains "GET"
+        // Span 1-1 has GET → excluded
+        // Span 1-2 has POST → included (POST doesn't contain GET)
+        // Span 1-3 has no http.method → included (absent field trivially satisfies "not contains")
+        var result = repository.GetSpans(new GetSpansRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = "http.method",
+                    Condition = FilterCondition.NotContains,
+                    Value = "GET"
+                }
+            ]
+        });
+
+        Assert.Equal(2, result.PagedResult.TotalItemCount);
+        Assert.Contains(result.PagedResult.Items, s => GetStringId(s.SpanId) == "1-2");
+        Assert.Contains(result.PagedResult.Items, s => GetStringId(s.SpanId) == "1-3");
+    }
+
+    [Fact]
+    public void GetTraces_NotEqualTimestampFilter_ExcludesTraceViaUnoptimizedPath()
+    {
+        // Verifies that the non-optimized MatchesFilters path (used for date/numeric fields)
+        // correctly applies ALL-span semantics for negative filters. A timestamp NotEqual
+        // filter excludes a trace when any span's timestamp matches the filter value.
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            // Span 1: starts at s_testTime (violates "timestamp != s_testTime")
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(5)),
+                            // Span 2: starts later (satisfies "timestamp != s_testTime")
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3),
+                                parentSpanId: "1-1")
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            // Trace 2: starts at a different time (satisfies the filter)
+                            CreateSpan(traceId: "2", spanId: "2-1", startTime: s_testTime.AddMinutes(10), endTime: s_testTime.AddMinutes(15))
+                        }
+                    }
+                }
+            }
+        });
+
+        var resourceKey = new ResourceKey("service1", InstanceId: null);
+
+        // Timestamp is a date field, so StringFilter.TryCreate returns false and
+        // CreateOptimizedTraceFilters falls through to the non-optimized path.
+        // Filter: Timestamp != "1970-01-01T00:00:00Z" — span 1-1 violates this (its timestamp
+        // equals the filter value), so trace 1 is excluded. Trace 2 passes.
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKeys = [resourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = KnownTraceFields.TimestampField,
+                    Condition = FilterCondition.NotEqual,
+                    Value = "1970-01-01T00:00:00Z"
+                }
+            ]
+        });
+
+        Assert.Collection(traces.PagedResult.Items,
+            trace => AssertId("2", trace.TraceId));
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -3075,4 +3075,112 @@ public class TraceTests
         // Trace 2 doesn't match the positive filter (env=staging, not prod).
         Assert.Empty(traces.PagedResult.Items);
     }
+
+    [Fact]
+    public void GetTraces_NotContainsFilter_AbsentAttributeDoesNotExcludeTrace()
+    {
+        // Verifies that a negative filter on an attribute field does NOT exclude a trace
+        // just because some spans lack the attribute. A span without the field trivially
+        // satisfies "not contains X" — it cannot contain the value.
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            // Span with http.method = POST (satisfies "not contains GET").
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(5),
+                                attributes: [KeyValuePair.Create("http.method", "POST")]),
+                            // Span without http.method attribute at all — should NOT cause exclusion.
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3),
+                                parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        var resourceKey = new ResourceKey("service1", InstanceId: null);
+
+        // Filter: http.method not contains "GET" — span 1-1 has POST (passes), span 1-2
+        // has no http.method (trivially passes). The trace should be included.
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKeys = [resourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = "http.method",
+                    Condition = FilterCondition.NotContains,
+                    Value = "GET"
+                }
+            ]
+        });
+
+        Assert.Collection(traces.PagedResult.Items,
+            trace => AssertId("1", trace.TraceId));
+    }
+
+    [Fact]
+    public void GetTraces_NotContainsFilter_AbsentAttributeWithViolatingSpanExcludes()
+    {
+        // Verifies that a trace is excluded when one span has the attribute and violates
+        // the negative condition, even though another span lacks the attribute entirely.
+        var repository = CreateRepository();
+
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "service1", instanceId: "inst1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            // Span with http.method = GET (violates "not contains GET").
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(5),
+                                attributes: [KeyValuePair.Create("http.method", "GET")]),
+                            // Span without http.method — trivially passes, but trace still excluded.
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3),
+                                parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        var resourceKey = new ResourceKey("service1", InstanceId: null);
+
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ResourceKeys = [resourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = "http.method",
+                    Condition = FilterCondition.NotContains,
+                    Value = "GET"
+                }
+            ]
+        });
+
+        Assert.Empty(traces.PagedResult.Items);
+    }
 }


### PR DESCRIPTION
## Description

The trace-level `MatchesFilters` logic used ANY-span semantics for all filters. For negative filters (`NotContains`, `NotEqual`), this meant a multi-span trace would pass the filter if any sibling span didn't match the negated value — even when another span in the same trace *did* match.

For example, with a filter "Name not contains GET (React StrictMode abort)":
- Span A (name = "GET (React StrictMode abort)"): violates the condition
- Span B (name = "HTTP GET /api/health"): satisfies the condition

Previously, since Span B passed, the trace was included — incorrectly.

**Fix:** Negative filters now use ALL-span semantics — the trace is excluded if ANY span violates the condition. Positive filters retain the existing ANY-span semantics. Both filter polarities are evaluated in a single pass over the trace's spans.

Fixes #18684

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No