### PR TITLE
Fix VS Code extension ignoring non-zero debuggee exit code

### DIFF
--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -29,6 +29,8 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
             }
             const debugSessionId = configuration.debugSessionId;
 
+            let debuggeeExitCode: number | undefined;
+
             return {
                 onWillReceiveMessage: message => {
                     // Detect restart requests on app host debug sessions.
@@ -87,18 +89,24 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
 
                         dcpServer.sendNotification(processNotification);
                     }
+
+                    if (message.type === 'event' && message.event === 'exited' && typeof message.body?.exitCode === 'number') {
+                        debuggeeExitCode = message.body.exitCode;
+                    }
                 },
                 onExit(code: number | undefined) {
+                    let exitCode = debuggeeExitCode ?? code;
+
                     // Exit code 143 should be treated as normal exit (SIGTERM) on macOS and Linux
-                    if ((process.platform === 'darwin' || process.platform === 'linux') && code === 143) {
-                        code = 0;
+                    if ((process.platform === 'darwin' || process.platform === 'linux') && exitCode === 143) {
+                        exitCode = 0;
                     }
 
                     const notification: SessionTerminatedNotification = {
                         notification_type: 'sessionTerminated',
                         session_id: configuration.runId,
                         dcp_id: debugSessionId,
-                        exit_code: code ?? 0
+                        exit_code: exitCode ?? 0
                     };
 
                     dcpServer.sendNotification(notification);

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -71,13 +71,15 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
 
                     // Listen for process event with isRestart (if supported by adapter)
                     if (message.type === 'event' && message.event === 'process') {
+                        // A new debuggee process invalidates any exit code captured from a prior run.
+                        // Reset before the PID guard: `systemProcessId` is optional in DAP, so a
+                        // restart reported without it must still clear the stale exit code.
+                        debuggeeExitCode = undefined;
+
                         if (typeof message.body?.systemProcessId !== 'number') {
                             extensionLogOutputChannel.warn(`Debug session ${session.id} does not have a valid system process ID.`);
                             return;
                         }
-
-                        // A new debuggee process invalidates any exit code captured from a prior run.
-                        debuggeeExitCode = undefined;
 
                         if (!dcpServer) {
                             extensionLogOutputChannel.warn(dcpServerNotInitialized);

--- a/extension/src/debugger/adapterTracker.ts
+++ b/extension/src/debugger/adapterTracker.ts
@@ -76,6 +76,9 @@ export function createDebugAdapterTracker(dcpServer: AspireDcpServer, debugAdapt
                             return;
                         }
 
+                        // A new debuggee process invalidates any exit code captured from a prior run.
+                        debuggeeExitCode = undefined;
+
                         if (!dcpServer) {
                             extensionLogOutputChannel.warn(dcpServerNotInitialized);
                             return;

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -188,6 +188,128 @@ suite('Debug Adapter Tracker Tests', () => {
         disposable.dispose();
     });
 
+    test('exited event exit code takes precedence over adapter onExit code', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        // Debuggee reports non-zero exit via the DAP `exited` event...
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'exited',
+            body: { exitCode: 1 }
+        });
+
+        // ...but the debug adapter itself exits cleanly with 0.
+        tracker.onExit(0);
+
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+        const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+        assert.strictEqual(notification.notification_type, 'sessionTerminated');
+        assert.strictEqual(notification.exit_code, 1, 'The debuggee exit code from the exited event should be reported');
+
+        disposable.dispose();
+    });
+
+    test('falls back to adapter onExit code when no exited event is observed', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        // No `exited` event; only the adapter exit code is available.
+        tracker.onExit(3);
+
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+        const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+        assert.strictEqual(notification.exit_code, 3);
+
+        disposable.dispose();
+    });
+
+    test('exited event exit code of 0 is used even when adapter exit code differs', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'exited',
+            body: { exitCode: 0 }
+        });
+        tracker.onExit(1);
+
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+        const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+        assert.strictEqual(notification.exit_code, 0, 'A zero exited-event code must not be overridden by the adapter code');
+
+        disposable.dispose();
+    });
+
+    test('exited event exit code 143 on Linux is converted to 0', async () => {
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', {
+            value: 'linux',
+            configurable: true
+        });
+
+        try {
+            const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+            const factory = registerFactoryStub.lastCall.args[1];
+            const tracker = factory.createDebugAdapterTracker(debugSession);
+
+            // SIGTERM-terminated debuggee reports 143 via the exited event.
+            tracker.onDidSendMessage({
+                type: 'event',
+                event: 'exited',
+                body: { exitCode: 143 }
+            });
+            tracker.onExit(0);
+
+            assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+            const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+            assert.strictEqual(notification.exit_code, 0, 'Exit code 143 from the exited event should be converted to 0 on Linux');
+
+            disposable.dispose();
+        } finally {
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+                configurable: true
+            });
+        }
+    });
+
+    test('exited event exit code 143 on Windows is NOT converted', async () => {
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', {
+            value: 'win32',
+            configurable: true
+        });
+
+        try {
+            const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+            const factory = registerFactoryStub.lastCall.args[1];
+            const tracker = factory.createDebugAdapterTracker(debugSession);
+
+            tracker.onDidSendMessage({
+                type: 'event',
+                event: 'exited',
+                body: { exitCode: 143 }
+            });
+            tracker.onExit(0);
+
+            assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+            const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+            assert.strictEqual(notification.exit_code, 143, 'Exit code 143 from the exited event should NOT be converted to 0 on Windows');
+
+            disposable.dispose();
+        } finally {
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+                configurable: true
+            });
+        }
+    });
+
     test('non-telemetry output events are sent as service logs', async () => {
         const disposable = createDebugAdapterTracker(dcpServer as any, 'node');
         const factory = registerFactoryStub.lastCall.args[1];

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -226,6 +226,27 @@ suite('Debug Adapter Tracker Tests', () => {
         disposable.dispose();
     });
 
+    test('falls back to adapter onExit code when exited event has a non-number exit code', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        // Malformed `exited` event without a numeric exitCode; the guard should
+        // ignore it and leave the adapter exit code to be used.
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'exited',
+            body: {}
+        });
+        tracker.onExit(2);
+
+        assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
+        const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
+        assert.strictEqual(notification.exit_code, 2);
+
+        disposable.dispose();
+    });
+
     test('exited event exit code of 0 is used even when adapter exit code differs', async () => {
         const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
         const factory = registerFactoryStub.lastCall.args[1];

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -279,12 +279,14 @@ suite('Debug Adapter Tracker Tests', () => {
             const tracker = factory.createDebugAdapterTracker(debugSession);
 
             // SIGTERM-terminated debuggee reports 143 via the exited event.
+            // The adapter code is a distinct sentinel so the asserted 0 can only
+            // come from converting the exited-event 143, not the adapter code.
             tracker.onDidSendMessage({
                 type: 'event',
                 event: 'exited',
                 body: { exitCode: 143 }
             });
-            tracker.onExit(0);
+            tracker.onExit(7);
 
             assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
             const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;
@@ -311,12 +313,15 @@ suite('Debug Adapter Tracker Tests', () => {
             const factory = registerFactoryStub.lastCall.args[1];
             const tracker = factory.createDebugAdapterTracker(debugSession);
 
+            // Windows never converts 143, so the exited-event code must survive as-is.
+            // The adapter code is a distinct sentinel so the asserted 143 can only
+            // come from the exited event, not the adapter code.
             tracker.onDidSendMessage({
                 type: 'event',
                 event: 'exited',
                 body: { exitCode: 143 }
             });
-            tracker.onExit(0);
+            tracker.onExit(7);
 
             assert.strictEqual(dcpServer.sendNotification.calledOnce, true);
             const notification = dcpServer.sendNotification.firstCall.args[0] as SessionTerminatedNotification;

--- a/extension/src/test/adapterTracker.test.ts
+++ b/extension/src/test/adapterTracker.test.ts
@@ -266,6 +266,56 @@ suite('Debug Adapter Tracker Tests', () => {
         disposable.dispose();
     });
 
+    test('process event resets a captured exit code so a clean restart reports 0', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        // A prior run exited non-zero, then the debuggee restarts (process event with a
+        // valid PID) and exits cleanly. The stale 1 must not leak into the new run.
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'exited',
+            body: { exitCode: 1 }
+        });
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'process',
+            body: { systemProcessId: 4242 }
+        });
+        tracker.onExit(0);
+
+        const terminated = findSessionTerminated(dcpServer);
+        assert.strictEqual(terminated.exit_code, 0, 'The process event should clear the captured exit code from the prior run');
+
+        disposable.dispose();
+    });
+
+    test('process event without a system process ID still resets a captured exit code', async () => {
+        const disposable = createDebugAdapterTracker(dcpServer as any, 'coreclr');
+        const factory = registerFactoryStub.lastCall.args[1];
+        const tracker = factory.createDebugAdapterTracker(debugSession);
+
+        // `systemProcessId` is optional in DAP. Even when the restart is reported without
+        // it, the captured exit code must still be cleared for the new run.
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'exited',
+            body: { exitCode: 1 }
+        });
+        tracker.onDidSendMessage({
+            type: 'event',
+            event: 'process',
+            body: {}
+        });
+        tracker.onExit(0);
+
+        const terminated = findSessionTerminated(dcpServer);
+        assert.strictEqual(terminated.exit_code, 0, 'A PID-less process event must still clear the captured exit code');
+
+        disposable.dispose();
+    });
+
     test('exited event exit code 143 on Linux is converted to 0', async () => {
         const originalPlatform = process.platform;
         Object.defineProperty(process, 'platform', {
@@ -487,3 +537,14 @@ suite('Debug Adapter Tracker Tests', () => {
         disposable.dispose();
     });
 });
+
+// Returns the single sessionTerminated notification sent during a test. A restart
+// sequence also emits a processRestarted notification, so we can't rely on firstCall.
+function findSessionTerminated(dcpServer: sinon.SinonStubbedInstance<AspireDcpServer>): SessionTerminatedNotification {
+    const terminated = dcpServer.sendNotification.getCalls()
+        .map(call => call.args[0])
+        .find((notification): notification is SessionTerminatedNotification => notification.notification_type === 'sessionTerminated');
+
+    assert.ok(terminated, 'Expected a sessionTerminated notification to be sent');
+    return terminated;
+}


### PR DESCRIPTION
## Description

Fixes #18687

The VS Code extension's debug adapter tracker reported the debug **adapter's** (vsdbg) exit code via `SessionTerminatedNotification`. For a clean debugging session that value is always `0` — even when the debuggee itself crashed. As a result, DCP treated a non-zero exit as success, so `.WaitFor()` dependents started despite their dependency failing. This worked correctly in the CLI but not in the VS Code extension.

## Fix

Capture the debuggee's actual exit code from the DAP `exited` event (`body.exitCode`) and prefer it over the adapter's `onExit` code in the notification sent to DCP. Falls back to the adapter code for adapters that don't emit the event, and preserves the existing `143` (SIGTERM) → `0` normalization on macOS/Linux applied to the chosen exit code.

## Testing

Added regression tests in `adapterTracker.test.ts`, including the exact bug scenario — debuggee `exited` event = `1` while the adapter exits cleanly (`onExit(0)`), asserting DCP receives `exit_code: 1`. Verified before/after: reverting the source (keeping the tests) reproduces the failure (`exit_code` reported as `0`), and the fix makes all 17 tests pass. `compile-tests` and `lint` are clean.

## Demo
#### Repro
https://github.com/user-attachments/assets/64ff3c38-c530-4a85-99dc-429f93714265

#### Fix
https://github.com/user-attachments/assets/2742159e-168a-4dbd-be3c-619d56efcb5e
