### PR TITLE
Reset stale mis-localized "Table" chart tab string (#18708)

### DIFF
--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Prostředky</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Ressourcen</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Recursos</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Ressources</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Risorse</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">リソース</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">리소스</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Zasoby</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Recursos</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Ресурсы</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">Kaynaklar</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">资源</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">資源</target>
+        <target state="new">Table</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">


### PR DESCRIPTION
Fixes #18708

In Aspire 13.5 several dashboard strings render in English in non-English locales — a regression from 13.4.6. This is a **localization-data (`.xlf`) issue, not a code bug**: `Resources.razor` and the action menu already reference the correct localizer keys. Recent PRs renamed keys in `ControlsStrings.resx`, which orphaned the existing translations.

## Why most of this needs no code change

When a resx key is renamed, XliffTasks emits the new trans-unit as `state="new"` with the English text as a placeholder target. The **OneLocBuild** pipeline automatically sends every `state="new"` unit to translators and commits the real translations back — so these strings get localized without any manual editing:

- `ResourcesContainerTableTab`, `ResourcesContainerParametersTab`, `ResourcesContainerGraphTab`, `ResourcesContainerGraphAccessibleLabel` (renamed by #18312)
- `ViewJson` (renamed from `ExportJson`, source changed "Export JSON" → "View JSON", by #18107)

They render in English today only because the renames are recent and haven't been through a loc run yet. Per repo policy we do **not** hand-edit `.xlf` targets — the loc pipeline owns that.

## The one thing that does need fixing: `ChartContainerTableTab`

PR #18312 **repurposed** `ChartContainerTableTab`: its source text changed from "Resources" to **"Table"**. Unlike a rename, a source-text change makes XliffTasks set `state="needs-review-translation"` and **keep the old target**. So the metrics-chart "Table" tab rendered the *old* translation of "Resources" (e.g. `资源`, `Ressourcen`, `Recursos`) — an actively **wrong** label in every non-English locale, and one that `UpdateXlf` will not self-correct.

This PR resets that stale target in all 13 `ControlsStrings.<lang>.xlf` files to the English source with `state="new"`:

```diff
       <trans-unit id="ChartContainerTableTab">
         <source>Table</source>
-        <target state="needs-review-translation">资源</target>
+        <target state="new">Table</target>
```

That removes the incorrect label now and lets the loc pipeline translate it correctly (to "Table", not "Resources") on the next run.

## Validation

- `dotnet build /t:UpdateXlf` produces **no** additional changes — the `.xlf` files are in canonical tooling state.
- `dotnet build src/Aspire.Dashboard` succeeds with 0 warnings / 0 errors.
- UTF-8 + BOM and CRLF encoding preserved in all edited files.