### PR TITLE
Make bundled dotnet-inspect skill a thin bootstrapper that defers to the tool

### DIFF
--- a/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
+++ b/src/Aspire.Cli/Agents/CommonAgentApplicators.cs
@@ -68,123 +68,36 @@ internal static class CommonAgentApplicators
         """
         ---
         name: dotnet-inspect
-        description: "Query .NET APIs across NuGet packages, platform libraries, and local files. Search for types, list API surfaces, compare and diff versions, find extension methods and implementors. Use whenever you need to answer questions about .NET library contents."
+        description: Find evidence for .NET packages, platform libraries, assemblies, APIs, dependencies, SourceLink/source, and API version diffs.
         ---
 
         # dotnet-inspect
 
-        Query .NET library APIs — the same commands work across NuGet packages, platform libraries (System.*, Microsoft.AspNetCore.*), and local .dll/.nupkg files.
+        Use dotnet-inspect for evidence instead of guesses about .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/source, or version-to-version API changes.
 
-        ## Quick Decision Tree
-
-        - **Code broken?** → `diff --package Foo@old..new` first, then `member --oneline`
-        - **Need API surface?** → `member Type --package Foo --oneline` (token-efficient)
-        - **Need signatures?** → `member Type --package Foo -m Method` (default shows full signatures + docs)
-        - **Need source/IL?** → `member Type --package Foo -m Method -v:d` (adds Source, Lowered C#, IL)
-        - **Need constructors?** → `member 'Type<T>' --package Foo -m .ctor` (use `<T>` not `<>`)
-        - **Need all overloads?** → `member Type --package Foo --select` (shows `Name:N` indices)
-
-        ## When to Use This Skill
-
-        - **"What types are in this package?"** — `type` discovers types (terse), `find` searches by pattern
-        - **"What's the API surface?"** — `type` for discovery, `member` for detailed inspection (docs on)
-        - **"What changed between versions?"** — `diff` classifies breaking/additive changes
-        - **"This code uses an old API — fix it"** — `diff` the old..new version, then `member --oneline` to see the new API
-        - **"What extends this type?"** — `extensions` finds extension methods/properties
-        - **"What implements this interface?"** — `implements` finds concrete types
-        - **"What does this type depend on?"** — `depends` walks the type hierarchy upward
-        - **"What version/metadata does this have?"** — `package` and `library` inspect metadata
-        - **"Show me something cool"** — `demo` runs curated showcase queries
-
-        ## Key Patterns
-
-        Use `--oneline` as the default for scanning — it works on `type`, `member`, `find`, `diff`, and `implements`:
-
-        ```bash
-        dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json --oneline  # scan members
-        dnx dotnet-inspect -y -- type --package System.Text.Json --oneline                   # scan types
-        dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3 --oneline  # triage changes
-        ```
-
-        Use `--shape` to understand a type's hierarchy and surface at a glance:
-
-        ```bash
-        dnx dotnet-inspect -y -- type 'HashSet<T>' --platform System.Collections --shape
-        ```
-
-        Use `diff` first when fixing broken code — `--oneline` for triage, then full detail on specific types:
-
-        ```bash
-        dnx dotnet-inspect -y -- diff --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3 --oneline  # what changed?
-        dnx dotnet-inspect -y -- diff -t Command --package System.CommandLine@2.0.0-beta4.22272.1..2.0.3  # detail on Command
-        dnx dotnet-inspect -y -- member Command --package System.CommandLine@2.0.3 --oneline              # new API surface
-        ```
-
-        ## Search Scope
-
-        Search commands (`find`, `extensions`, `implements`, `depends`) use scope flags:
-
-        - **(no flags)** — platform frameworks + Microsoft.Extensions.AI
-        - **`--platform`** — all platform frameworks
-        - **`--extensions`** — curated Microsoft.Extensions.* packages
-        - **`--aspnetcore`** — curated Microsoft.AspNetCore.* packages
-        - **`--package Foo`** — specific NuGet package (combinable with scope flags)
-
-        `type`, `member`, `library`, `diff` accept `--platform <name>` as a string for a specific platform library.
-
-        ## Command Reference
-
-        | Command | Purpose |
-        | ------- | ------- |
-        | `type` | **Discover types** — terse output, no docs, use `--shape` for hierarchy |
-        | `member` | **Inspect members** — docs on by default, supports dotted syntax (`-m Type.Member`) |
-        | `find` | Search for types by glob pattern across any scope |
-        | `diff` | Compare API surfaces between versions — breaking/additive classification |
-        | `extensions` | Find extension methods/properties for a type |
-        | `implements` | Find types implementing an interface or extending a base class |
-        | `depends` | Walk the type dependency hierarchy upward (interfaces, base classes) |
-        | `package` | Package metadata, files, versions, dependencies, `search` for NuGet discovery |
-        | `library` | Library metadata, symbols, references, dependencies |
-        | `demo` | Run curated showcase queries — list, invoke, or feeling-lucky |
-
-        ## Output Limiting
-
-        **Do not pipe output through `head`, `tail`, or `Select-Object`.** The tool has built-in line limiting that preserves headers and formatting:
-
-        ```bash
-        dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json --oneline -10  # first 10 lines
-        dnx dotnet-inspect -y -- find "*Logger*" -n 5                                            # first 5 lines
-        dnx dotnet-inspect -y -- member JsonSerializer --package System.Text.Json -v:q -s Methods  # select specific section
-        ```
-
-        - **`-n N` or `-N`** — line limit, like `head`. Keeps headers, truncates cleanly.
-        - **`-s Section`** — show only a specific section (glob-capable). Use `-s` alone to list available sections.
-        - **`-v:q`** — quiet verbosity for compact summary output.
-
-        ## Key Syntax
-
-        - **Generic types** need quotes: `'Option<T>'`, `'IEnumerable<T>'`
-        - **Use `<T>` not `<>`** for generic types — `"Option<>"` resolves to the abstract base, `'Option<T>'` resolves to the concrete generic with constructors
-        - **`type` uses `-t`** for type filtering, **`member` uses `-m`** for member filtering (not `--filter`)
-        - **Dotted syntax** for `member`: `-m JsonSerializer.Deserialize`
-        - **Diff ranges** use `..`: `--package System.Text.Json@9.0.0..10.0.0`
-        - **Signatures** include `params` and default values from metadata
-        - **Derived types** only show their own members — query the base type too (e.g., `RootCommand` inherits `Add()` and `SetAction()` from `Command`)
-
-        ## Installation
-
-        Use `dnx` (like `npx`). Always use `-y` and `--` to prevent interactive prompts:
+        Invoke with `dnx` (like `npx`); always pass `-y` and `--` to avoid interactive prompts:
 
         ```bash
         dnx dotnet-inspect -y -- <command>
         ```
 
-        ## Full Documentation
-
-        For comprehensive syntax, edge cases, and the flag compatibility matrix:
+        This bundled skill is intentionally only a bootstrapper. For non-trivial work, first run the version-matched embedded guide. It always matches the installed tool, so prefer it whenever commands, output modes, section names, or workflow guidance differ:
 
         ```bash
-        dnx dotnet-inspect -y -- llmstxt
+        dnx dotnet-inspect -y -- skill
         ```
+
+        ## Seed commands
+
+        | Goal | Command |
+        | ---- | ------- |
+        | Find where an API lives | `find Pattern` |
+        | Inspect types or members | `type Type --package Foo`, then `member Type --package Foo` |
+        | Compare versions | `diff --package Foo@old..new --breaking` |
+        | Inspect package or library signals | `package Foo -S Signals` or `library Foo -S Signals` |
+        | Locate source or implementation | `source Type --package Foo` or `member Type Member:1 -S "Decompiled Source"` |
+        | Explore relationships | `depends Type`, `extensions Type`, `implements Interface` |
+
+        After `find`, reuse the package, library, or platform scope it reports. Quote generic type names such as `'List<T>'`; use `<T>`, not `<>`.
         """;
 }


### PR DESCRIPTION
The dotnet-inspect skill file is embedded in the aspire CLI as a full API guide (SkillSourceKind.Static), so it ships frozen per release and drifts from the tool. The current embedded copy already lags dotnet-inspect 0.16.0 in commands, flags (--breaking/--additive), output modes, and section names.

Replace the frozen full body with a thin bootstrapper: a few seed commands plus an explicit hand-off to the tool's own version-matched guide:

    dnx dotnet-inspect -y -- skill

Authoritative, always-current guidance then lives in the installed tool and can never go stale regardless of which aspire release wrote the file. This mirrors the dotnet-inspect marketplace skill (richlander/dotnet-skills), which is likewise an intentional bootstrapper.

This is very similar to what I do with my `plugin.json` skill: https://github.com/richlander/dotnet-skills/blob/main/skills/dotnet-inspect/SKILL.md

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
