### PR TITLE
Enable basic debugging scenarios with the new DotnetProjectResource

### DIFF
--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -295,6 +295,21 @@ predicate; fallback: a dedicated prepare path or a distinct launch type). Preser
 **Verify:** F5/debug of a `DotnetProjectResource` (no watch) from a C# app host and the Aspire VS Code extension;
 debug behavior matches `AddProject`. *Depends on: 1.* **(R1)**
 
+**Status: ⚠️ Implementation complete; manual F5 verification not recorded.** DCP now treats an
+`ExecutableResource` carrying `IProjectMetadata` and `"project"` debug support as a project launch.
+`DotnetProjectResource` therefore gets launch-profile and Debug/NoDebug handling, is classified/rendered as a
+project, and passes only application arguments to the IDE. Project launches and other debug integrations that
+rewrite arguments deliberately have no Process fallback; persistent resources and IDEs without `"project"`
+support keep the normal process launch.
+
+The VS Code project debugger was extended for file-based `.cs` resources. It resolves the program through
+`dotnet run-api`, retains the built-DLL host prefix when `dotnet` is the launcher, and keeps the selected or
+disabled launch profile authoritative for application arguments, working directory, and environment while
+preserving required `DOTNET_ROOT*` host variables.
+
+Automated coverage exercises the DCP, package, snapshot, and extension behavior above. The C# app-host + VS Code
+F5 check in **Verify** remains unconfirmed. *(Watch-mode debugging remains out of scope; see Session 9.)*
+
 ### Session 3 — Core run sub-mode state (minimal, no mechanics)
 Add `IsWatch`/`RunSubMode` to `DistributedApplicationExecutionContext(+Options)`; populate from a CLI config
 key in `DistributedApplicationBuilder` (mirror `Publishing:Publisher`). No watch logic in core. **Verify:**
@@ -360,7 +375,8 @@ limitations (no watch-debug, no partial runs yet), `ASPIREDOTNETPROJECT001`. *De
                       ▲           ▲
                       └─ (4,5) ───┘
 ```
-Session 1 (✅ complete) is the root. Sessions 1b (✅ complete), 2, 4, 5 parallelize after 1; session 3 is independent.
+Session 1 (✅ complete) is the root. Sessions 1b (✅ complete) and 2 (✅ complete) are done; sessions 4, 5
+parallelize after 1; session 3 is independent.
 Service watch (6) needs 3+4+5; CLI `--watch` (7) needs 6+3; app-host watch (8) needs 7+4; tests/docs (9) last.
 Session 1b (the playground dogfood harness) is extended by session 9.
 

--- a/extension/loc/xlf/aspire-vscode.xlf
+++ b/extension/loc/xlf/aspire-vscode.xlf
@@ -379,6 +379,9 @@
     <trans-unit id="configuration.aspire.dashboardBrowser.debugEdge">
       <source xml:lang="en">Launch Microsoft Edge as a debug session (auto-closes when debugging ends).</source>
     </trans-unit>
+    <trans-unit id="aspire-vscode.strings.executableLaunchProfileMissingExecutablePath">
+      <source xml:lang="en">Launch profile &apos;{0}&apos; uses commandName &apos;Executable&apos; but does not specify an executablePath. Add an executablePath to the launch profile.</source>
+    </trans-unit>
     <trans-unit id="extension.debug.defaultConfiguration.description">
       <source xml:lang="en">Launch the effective Aspire AppHost in your workspace</source>
     </trans-unit>
@@ -684,6 +687,9 @@
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.resourceCommandOutputOpenFailed">
       <source xml:lang="en">The command completed, but its output could not be opened: {0}</source>
+    </trans-unit>
+    <trans-unit id="aspire-vscode.strings.dotNetRunFileBasedExecutableProfileFallback">
+      <source xml:lang="en">The default launch profile &apos;{0}&apos; is an Executable profile, so dotnet run-api does not return the file-based app {1}; launching it with dotnet run without debugger attach. Breakpoints will not be hit for this resource.</source>
     </trans-unit>
     <trans-unit id="aspire-vscode.strings.dashboardLaunchNoneDescription">
       <source xml:lang="en">The dashboard URL is still printed in the terminal and available from the Aspire panel.</source>

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -155,6 +155,8 @@
   "aspire-vscode.strings.buildFailedForProjectWithError": "Build failed for project {0} with error: {1}.",
   "aspire-vscode.strings.failedToInspectRuntimeConfig": "Failed to inspect runtimeconfig for {0}: {1}",
   "aspire-vscode.strings.dotNetRunFallbackDisablesDebugger": "Project output {0} is not directly runnable; launching {1} with dotnet run without debugger attach. Breakpoints will not be hit for this resource.",
+  "aspire-vscode.strings.dotNetRunFileBasedExecutableProfileFallback": "The default launch profile '{0}' is an Executable profile, so dotnet run-api does not return the file-based app {1}; launching it with dotnet run without debugger attach. Breakpoints will not be hit for this resource.",
+  "aspire-vscode.strings.executableLaunchProfileMissingExecutablePath": "Launch profile '{0}' uses commandName 'Executable' but does not specify an executablePath. Add an executablePath to the launch profile.",
   "aspire-vscode.strings.lookingForDevkitBuildTask": "C# Dev Kit is installed, looking for C# Dev Kit build task...",
   "aspire-vscode.strings.csharpDevKitNotInstalled": "C# Dev Kit is not installed, building using dotnet CLI...",
   "aspire-vscode.strings.cliNotAvailable": "Aspire CLI is not available on PATH. Please install it and restart VS Code.",

--- a/extension/src/debugger/languages/dotnet.ts
+++ b/extension/src/debugger/languages/dotnet.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { extensionLogOutputChannel } from '../../utils/logging';
-import { noCsharpBuildTask, buildFailedWithExitCode, noOutputFromMsbuild, failedToGetTargetPath, invalidLaunchConfiguration, buildFailedForProjectWithError, processExitedWithCode, lookingForDevkitBuildTask, csharpDevKitNotInstalled, failedToInspectRuntimeConfig, dotNetRunFallbackDisablesDebugger } from '../../loc/strings';
+import { noCsharpBuildTask, buildFailedWithExitCode, noOutputFromMsbuild, failedToGetTargetPath, invalidLaunchConfiguration, buildFailedForProjectWithError, processExitedWithCode, lookingForDevkitBuildTask, csharpDevKitNotInstalled, failedToInspectRuntimeConfig, dotNetRunFallbackDisablesDebugger, dotNetRunFileBasedExecutableProfileFallback, executableLaunchProfileMissingExecutablePath } from '../../loc/strings';
 import { ChildProcessWithoutNullStreams, execFile, spawn } from 'child_process';
 import * as util from 'util';
 import * as path from 'path';
@@ -13,11 +13,13 @@ import { ResourceDebuggerExtension } from '../debuggerExtensions';
 import {
     readLaunchSettings,
     determineBaseLaunchProfile,
+    determineDefaultLaunchProfile,
     mergeEnvironmentVariables,
     determineArguments,
     determineWorkingDirectory,
     determineServerReadyAction,
     LaunchProfileCommandName,
+    LaunchProfile,
     expandEnvironmentVariables
 } from '../launchProfiles';
 import { AspireDebugSession } from '../AspireDebugSession';
@@ -175,6 +177,7 @@ export function isFileBasedApp(projectPath: string): boolean {
 
 interface RunApiOutput {
     executablePath: string;
+    commandLineArguments: string;
     env?: { [key: string]: string };
 }
 
@@ -189,8 +192,78 @@ function getRunApiConfigFromOutput(runApiOutput: string): RunApiOutput {
 
     return {
         executablePath: parsed.ExecutablePath,
+        commandLineArguments: parsed.CommandLineArguments,
         env: parsed.EnvironmentVariables
     };
+}
+
+function isDotnetLauncher(executablePath: string): boolean {
+    // If the command is "dotnet", but with a full path, it is not the SDK-injected dotnet launcher,
+    // but a user program that just happens to be named "dotnet".
+    if (path.dirname(executablePath) !== '.') {
+        return false;
+    }
+
+    const executableName = path.basename(executablePath).toLowerCase();
+    return executableName === 'dotnet' || executableName === 'dotnet.exe';
+}
+
+// DOTNET_ROOT and its architecture-specific variants (e.g. DOTNET_ROOT_X64, DOTNET_ROOT_ARM64) that the SDK
+// injects so a launched program can locate the .NET runtime.
+const dotnetRootEnvironmentVariablePattern = new RegExp(
+    '^DOTNET_ROOT(_[A-Z0-9]+)?$',
+    process.platform === 'win32' ? 'i' : undefined);
+
+// Returns .NET host environment variables from the given environment, minus any in the excluded set.
+function pickRuntimeHostEnvironment(
+    env: { [key: string]: string } | undefined,
+    excluded: Set<string>
+): { [key: string]: string } | undefined {
+    if (!env) {
+        return undefined;
+    }
+
+    const runtimeHostEnv: { [key: string]: string } = {};
+    for (const [name, value] of Object.entries(env)) {
+        if (!dotnetRootEnvironmentVariablePattern.test(name)) {
+            continue;
+        }
+
+        if (excluded.has(name.toUpperCase())) {
+            continue;
+        }
+
+        runtimeHostEnv[name] = value;
+    }
+
+    return Object.keys(runtimeHostEnv).length > 0 ? runtimeHostEnv : undefined;
+}
+
+function collectProfileDotnetHostEnvVarNames(profile: LaunchProfile | null | undefined): Set<string> {
+    const names = new Set<string>();
+    for (const name of Object.keys(profile?.environmentVariables ?? {})) {
+        if (dotnetRootEnvironmentVariablePattern.test(name)) {
+            names.add(name.toUpperCase());
+        }
+    }
+
+    return names;
+}
+
+// Combine the SDK host arguments from `dotnet run-api` (the built app DLL that is passed to the `dotnet`
+// launcher) with the user/launch-profile application arguments that were already resolved onto the debug
+// configuration. `hostArguments` is present only when the program is the `dotnet` launcher; 
+// for an apphost-executable build it is undefined and only the application arguments remain.
+// The host arguments must come first because they identify what to run; the user application arguments
+// follow and are passed to the app. The result is kept as a single command-line string so the quoting the
+// SDK already applied to CommandLineArguments is preserved.
+function combineRunApiArguments(hostArguments: string | undefined, applicationArguments: string | string[] | undefined): string | string[] | undefined {
+    const applicationArgumentsText = Array.isArray(applicationArguments) ? applicationArguments.join(' ') : applicationArguments;
+    const combined = [hostArguments, applicationArgumentsText]
+        .filter((part): part is string => part !== undefined && part.length > 0)
+        .join(' ');
+
+    return combined.length > 0 ? combined : undefined;
 }
 
 function createErrorWithStreamedDebugConsoleOutput(message: string): Error {
@@ -233,12 +306,17 @@ function quoteCommandLineArgument(argument: string): string {
     return `"${argument.replace(/"/g, '\\"')}"`;
 }
 
-function createDotNetRunBaseArguments(projectPath: string): string[] {
-    return ['run', '--project', projectPath, '--no-launch-profile'];
+function createDotNetRunBaseArguments(projectPath: string, fileBased: boolean): string[] {
+    // File-based apps (.cs) launch with `dotnet run --file <app.cs> --no-cache`; project files launch with
+    // `dotnet run --project <proj>`. This mirrors how the hosting side builds the non-debug `dotnet run`
+    // command line in DotnetProjectHostingExtensions.
+    return fileBased
+        ? ['run', '--file', projectPath, '--no-cache', '--no-launch-profile']
+        : ['run', '--project', projectPath, '--no-launch-profile'];
 }
 
-function createDotNetRunArguments(projectPath: string, baseProfileArgs: string | undefined, runSessionArgs: string[] | undefined): string[] | string {
-    const dotnetRunArgs = createDotNetRunBaseArguments(projectPath);
+function createDotNetRunArguments(projectPath: string, baseProfileArgs: string | undefined, runSessionArgs: string[] | undefined, fileBased: boolean = false): string[] | string {
+    const dotnetRunArgs = createDotNetRunBaseArguments(projectPath, fileBased);
     if (runSessionArgs !== undefined) {
         if (runSessionArgs.length > 0) {
             dotnetRunArgs.push('--', ...runSessionArgs);
@@ -251,8 +329,9 @@ function createDotNetRunArguments(projectPath: string, baseProfileArgs: string |
         // launchSettings.json stores application arguments as a command-line string, for example:
         //   --path "value with spaces" --flag
         // Preserve that string instead of reparsing it here so debugger command-line parsing
-        // handles escaping consistently with normal project launches.
-        return `run --project ${quoteCommandLineArgument(projectPath)} --no-launch-profile -- ${baseProfileArgs}`;
+        // handles escaping consistently with normal project launches. Only the path token needs quoting.
+        const quotedRunArgs = createDotNetRunBaseArguments(quoteCommandLineArgument(projectPath), fileBased);
+        return `${quotedRunArgs.join(' ')} -- ${baseProfileArgs}`;
     }
 
     return dotnetRunArgs;
@@ -260,13 +339,16 @@ function createDotNetRunArguments(projectPath: string, baseProfileArgs: string |
 
 function configureDotNetRunDebugConfiguration(
     debugConfiguration: AspireResourceExtendedDebugConfiguration,
-    projectPath: string,
     args: string[] | string,
     baseProfileEnvironmentVariables: { [key: string]: string } | undefined,
     runSessionEnvironmentVariables: EnvVar[]): void {
     debugConfiguration.program = 'dotnet';
     debugConfiguration.args = args;
-    debugConfiguration.cwd = path.dirname(projectPath);
+    // Intentionally do NOT set cwd here. The caller already resolved debugConfiguration.cwd from the
+    // selected launch profile via determineWorkingDirectory (which falls back to the project directory
+    // when the profile sets no workingDirectory). Because this fallback launches with --no-launch-profile,
+    // `dotnet run` will not re-apply the profile's workingDirectory itself, so overwriting cwd here would
+    // silently discard a custom profile workingDirectory and launch the app from the wrong directory.
     debugConfiguration.executablePath = undefined;
     debugConfiguration.noDebug = true;
     debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(
@@ -340,7 +422,16 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
                 env.push({ name: "ASPIRE_DASHBOARD_AI_DISABLED", value: "true" });
             }
 
-            if (baseProfile?.commandName?.toLowerCase() === LaunchProfileCommandName.executable && baseProfile.executablePath) {
+            // An Executable-command launch profile must specify an executablePath. The .NET SDK's
+            // ExecutableProvider requires it, so `dotnet run` / `dotnet run-api` fail with a configuration
+            // error when it is missing. Without this guard the extension would instead fall through the
+            // `&& executablePath` check below and silently launch the project output (or file-based app),
+            // running a different program than the SDK would. Surface the same configuration error instead.
+            if (baseProfile?.commandName === LaunchProfileCommandName.executable && !baseProfile.executablePath) {
+                throw new Error(executableLaunchProfileMissingExecutablePath(profileName ?? ''));
+            }
+
+            if (baseProfile?.commandName === LaunchProfileCommandName.executable && baseProfile.executablePath) {
                 const dotNetService: IDotNetService = dotNetServiceProducer(launchOptions.debugSession);
 
                 // For Executable command profiles (e.g., class library integrations), the launch profile
@@ -378,7 +469,7 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
                         vscode.window.showInformationMessage(fallbackMessage);
                     }
 
-                    configureDotNetRunDebugConfiguration(debugConfiguration, projectPath, createDotNetRunArguments(projectPath, baseProfile?.commandLineArgs, args), baseProfile?.environmentVariables, env);
+                    configureDotNetRunDebugConfiguration(debugConfiguration, createDotNetRunArguments(projectPath, baseProfile?.commandLineArgs, args), baseProfile?.environmentVariables, env);
                 } else {
                     debugConfiguration.program = outputPath;
                     debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(
@@ -391,22 +482,70 @@ export function createProjectDebuggerExtension(dotNetServiceProducer: (debugSess
             else {
                 const dotNetService: IDotNetService = dotNetServiceProducer(launchOptions.debugSession);
 
-                // For file-based apps, get the dotnet run-api output first to determine the executable path
-                const runApiOutput = await dotNetService.getDotNetRunApiOutput(projectPath);
-                const runApiConfig = getRunApiConfigFromOutput(runApiOutput);
+                // `dotnet run-api` always applies the SDK *default* (first supported) launch profile and offers
+                // no way to request a specific profile or --no-launch-profile. When that default profile is an
+                // 'Executable' profile, run-api reports THAT profile's external command (e.g. `dotnet --version`)
+                // instead of the file-based app, so its ExecutablePath / CommandLineArguments / environment
+                // describe the wrong program. This branch is only reached when the selected base profile is not an
+                // Executable profile (profiles disabled, or a later 'Project' profile explicitly selected), so
+                // blindly trusting run-api's program here would launch the wrong thing.
+                const { profile: runApiDefaultProfile, profileName: runApiDefaultProfileName } = determineDefaultLaunchProfile(launchSettings);
 
-                // There may be an older cached version of the file-based app, so we
-                // should force a build.
-                await dotNetService.buildDotNetProject(projectPath);
+                if (runApiDefaultProfile?.commandName === LaunchProfileCommandName.executable) {
+                    // Do not trust run-api's program. Launch the file-based app ourselves with
+                    // `dotnet run --file <app.cs> --no-launch-profile` (no debugger attach), applying the selected
+                    // profile's arguments and environment. This mirrors the dotnet-run fallback used when project
+                    // build output is not directly runnable.
+                    const fallbackMessage = dotNetRunFileBasedExecutableProfileFallback(runApiDefaultProfileName ?? '', projectPath);
+                    extensionLogOutputChannel.warn(fallbackMessage);
+                    if (launchOptions.debug) {
+                        vscode.window.showInformationMessage(fallbackMessage);
+                    }
 
-                debugConfiguration.program = runApiConfig.executablePath;
+                    // There may be an older cached version of the file-based app, so force a build.
+                    await dotNetService.buildDotNetProject(projectPath);
 
-                debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(
-                    baseProfile?.environmentVariables,
-                    debugConfiguration.env,
-                    env,
-                    runApiConfig.env
-                ));
+                    configureDotNetRunDebugConfiguration(
+                        debugConfiguration,
+                        createDotNetRunArguments(projectPath, baseProfile?.commandLineArgs, args, /* fileBased */ true),
+                        baseProfile?.environmentVariables,
+                        env);
+                }
+                else {
+                    // The default profile is a 'Project' profile (or there is none), so run-api's program is the
+                    // file-based app itself and can be trusted.
+                    const runApiOutput = await dotNetService.getDotNetRunApiOutput(projectPath);
+                    const runApiConfig = getRunApiConfigFromOutput(runApiOutput);
+
+                    // There may be an older cached version of the file-based app, so force a build.
+                    await dotNetService.buildDotNetProject(projectPath);
+
+                    debugConfiguration.program = runApiConfig.executablePath;
+
+                    const hostArguments = isDotnetLauncher(runApiConfig.executablePath) ? runApiConfig.commandLineArguments : undefined;
+                    debugConfiguration.args = combineRunApiArguments(hostArguments, debugConfiguration.args);
+
+                    // Intentionally do NOT consume run-api's WorkingDirectory: it carries the SDK default profile's
+                    // working directory, whereas cwd was already resolved from the (possibly different) selected
+                    // launch profile via determineWorkingDirectory.
+                    //
+                    // From run-api's environment we keep ONLY the SDK-injected runtime host-resolution variables
+                    // (DOTNET_ROOT*) so the launched program can locate the .NET runtime.
+                    // BUT
+                    // If the default launch profile, or the selected launch profile sets any of these variables,
+                    // we must not override them with the run-api values.
+                    const profileDefinedRuntimeHostNames = new Set<string>([
+                        ...collectProfileDotnetHostEnvVarNames(runApiDefaultProfile),
+                        ...collectProfileDotnetHostEnvVarNames(baseProfile)
+                    ]);
+
+                    debugConfiguration.env = Object.fromEntries(mergeEnvironmentVariables(
+                        baseProfile?.environmentVariables,
+                        debugConfiguration.env,
+                        env,
+                        pickRuntimeHostEnvironment(runApiConfig.env, profileDefinedRuntimeHostNames)
+                    ));
+                }
             }
 
             // Set DOTNET_LAUNCH_PROFILE

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -127,11 +127,6 @@ export async function readLaunchSettings(projectPath: string): Promise<LaunchSet
             // (LaunchSettings.TryFindLaunchSettingsFile): for a file-based app the SDK looks next to the
             // entry-point `.cs` file and prefers `Properties/launchSettings.json`, only falling back to
             // `<app>.run.json` when the former is absent. If both exist, `<app>.run.json` is ignored.
-            // The extension MUST resolve the same file the SDK does: createProjectDebuggerExtension uses
-            // determineDefaultLaunchProfile to decide whether `dotnet run-api`'s reported program can be
-            // trusted, so reading a different (or no) file would make that guard disagree with the profile
-            // run-api actually applied and launch the file-based app with the wrong program.
-            // https://github.com/dotnet/sdk/blob/main/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
             const dir = path.dirname(projectPath);
             const propertiesLaunchSettingsPath = path.join(dir, 'Properties', 'launchSettings.json');
             const fileNameWithoutExt = path.basename(projectPath, path.extname(projectPath));

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { ExecutableLaunchConfiguration, EnvVar, ProjectLaunchConfiguration } from '../dcp/types';
 import { extensionLogOutputChannel } from '../utils/logging';
 import { isFileBasedApp } from './languages/dotnet';
-import { stripComments } from 'jsonc-parser';
+import { stripComments, parseTree, findNodeAtLocation } from 'jsonc-parser';
 import { aspireConfigFileName, AspireConfigProfile } from '../utils/cliTypes';
 
 /*
@@ -43,20 +43,76 @@ export function expandEnvironmentVariables(value: string): string {
 }
 
 /**
- * Well-known launch profile command names (lowercased for case-insensitive comparison).
+ * Well-known launch profile command names, using the exact casing the .NET SDK uses.
+ *
+ * The SDK's provider table (`LaunchSettings.s_providers`) is an ordinal, case-sensitive dictionary keyed
+ * by these exact strings, so command-name comparisons must match that casing rather than lowercasing.
+ * A profile such as `commandName: "executable"` is therefore NOT a supported provider and `dotnet run` /
+ * `dotnet run-api` skips it. See
+ * https://github.com/dotnet/sdk/blob/main/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
  */
 export const LaunchProfileCommandName = {
-    project: 'project',
-    executable: 'executable',
+    project: 'Project',
+    executable: 'Executable',
 } as const;
+
+// Command names that `dotnet run` / `dotnet run-api` recognize when picking the *default* launch profile.
+// The SDK selects the first profile whose commandName maps to a supported provider, and its provider table
+// currently contains both 'Project' and 'Executable'. Keep this in sync with the SDK's provider table:
+// https://github.com/dotnet/sdk/blob/main/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
+const defaultLaunchProfileCommandNames: ReadonlySet<string> = new Set([
+    LaunchProfileCommandName.project,
+    LaunchProfileCommandName.executable,
+]);
 
 export interface LaunchSettings {
     profiles: { [key: string]: LaunchProfile };
+    // The profile names in launchSettings.json *source order*. JavaScript objects enumerate
+    // integer-like keys (e.g. "10", "2") in ascending numeric order rather than insertion order, so
+    // `Object.keys(profiles)` cannot be trusted to reflect the order profiles appear in the file. The
+    // .NET SDK selects the default launch profile using `JsonElement.EnumerateObject()`, which walks
+    // the file in source order, so we must preserve that order here to pick the same default profile.
+    // Populated by readLaunchSettings; may be absent for LaunchSettings constructed by other means.
+    profileOrder?: readonly string[];
 }
 
 export interface LaunchProfileResult {
     profile: LaunchProfile | null;
     profileName: string | null;
+}
+
+/**
+ * Extracts the profile names from launchSettings.json (or aspire.config.json) content in *source
+ * order* using a JSONC syntax tree, rather than relying on parsed-object key enumeration.
+ *
+ * This is necessary because integer-like profile names (e.g. "10", "2") are reordered by JavaScript
+ * object key enumeration (numeric keys first, in ascending order), which does not match the file
+ * order the .NET SDK uses when selecting the default launch profile. Walking the parse tree preserves
+ * the exact order the properties appear in the file.
+ *
+ * Returns undefined when the content has no `profiles` object so callers can fall back to key order.
+ */
+function extractProfileOrder(content: string): string[] | undefined {
+    const root = parseTree(content);
+    if (!root) {
+        return undefined;
+    }
+
+    const profilesNode = findNodeAtLocation(root, ['profiles']);
+    if (profilesNode?.type !== 'object' || !profilesNode.children) {
+        return undefined;
+    }
+
+    const order: string[] = [];
+    for (const propertyNode of profilesNode.children) {
+        // Each object member is a 'property' node whose first child is the key (a string node).
+        const keyNode = propertyNode.children?.[0];
+        if (typeof keyNode?.value === 'string') {
+            order.push(keyNode.value);
+        }
+    }
+
+    return order;
 }
 
 /**
@@ -79,6 +135,8 @@ export async function readLaunchSettings(projectPath: string): Promise<LaunchSet
             // We need to strip comments from the JSON file before parsing
             content = stripComments(content);
             const launchSettings = JSON.parse(content) as LaunchSettings;
+            // Capture the profile order from the file so the default-profile selection matches the SDK.
+            launchSettings.profileOrder = extractProfileOrder(content);
 
             extensionLogOutputChannel.debug(`Successfully read launch settings from: ${launchSettingsPath}`);
             return launchSettings;
@@ -106,7 +164,7 @@ export async function readLaunchSettings(projectPath: string): Promise<LaunchSet
                 }
 
                 extensionLogOutputChannel.debug(`Successfully read launch profiles from: ${aspireConfigPath}`);
-                return { profiles };
+                return { profiles, profileOrder: extractProfileOrder(content) };
             }
         }
 
@@ -149,17 +207,51 @@ export function determineBaseLaunchProfile(
         }
     }
 
-    // If launch_profile is absent, choose the first one with commandName='Project'
-    for (const [name, profile] of Object.entries(launchSettings.profiles)) {
-        if (profile.commandName?.toLowerCase() === LaunchProfileCommandName.project) {
-            extensionLogOutputChannel.debug(`Using default launch profile: ${name}`);
-            return { profile, profileName: name };
-        }
+    // If launch_profile is absent, fall back to the profile that `dotnet run` applies by default.
+    const defaultProfile = determineDefaultLaunchProfile(launchSettings);
+    if (defaultProfile.profile) {
+        extensionLogOutputChannel.debug(`Using default launch profile: ${defaultProfile.profileName}`);
+        return defaultProfile;
     }
 
     // TODO: If launch_profile is absent, check for a ServiceDefaults project in the workspace
     // and look for a launch profile with that ServiceDefaults project name in the current project's launch settings
     extensionLogOutputChannel.debug('No base launch profile determined');
+    return { profile: null, profileName: null };
+}
+
+/**
+ * Determines the launch profile that `dotnet run` / `dotnet run-api` applies by default: the first
+ * profile whose commandName maps to a supported provider (currently 'Project' or 'Executable').
+ *
+ * This is NOT necessarily the first 'Project' profile. The SDK picks the first *supported* profile, so an
+ * 'Executable' profile that appears earlier wins over a later 'Project' profile. See
+ * {@link defaultLaunchProfileCommandNames}.
+ *
+ * `dotnet run-api` always applies this default profile because the extension invokes it without
+ * selecting a profile, so run-api applies it regardless of which profile the extension itself resolves
+ * via {@link determineBaseLaunchProfile} (or of `disable_launch_profile`). Callers use it to recognize
+ * environment values that run-api copied from that default profile.
+ */
+export function determineDefaultLaunchProfile(launchSettings: LaunchSettings | null): LaunchProfileResult {
+    if (!launchSettings?.profiles) {
+        return { profile: null, profileName: null };
+    }
+
+    // Enumerate profiles in file source order to match the SDK's `JsonElement.EnumerateObject()`.
+    // profileOrder (populated by readLaunchSettings) preserves that order even for integer-like
+    // profile names; fall back to Object.keys for LaunchSettings constructed without it.
+    const profileNames = launchSettings.profileOrder ?? Object.keys(launchSettings.profiles);
+
+    for (const name of profileNames) {
+        const profile = launchSettings.profiles[name];
+        // Match the SDK's exact, case-sensitive provider lookup: a profile whose commandName differs only
+        // in casing (e.g. "executable") is not a supported provider, so `dotnet run-api` would skip it too.
+        if (profile?.commandName && defaultLaunchProfileCommandNames.has(profile.commandName)) {
+            return { profile, profileName: name };
+        }
+    }
+
     return { profile: null, profileName: null };
 }
 

--- a/extension/src/debugger/launchProfiles.ts
+++ b/extension/src/debugger/launchProfiles.ts
@@ -123,8 +123,29 @@ export async function readLaunchSettings(projectPath: string): Promise<LaunchSet
         let launchSettingsPath: string;
 
         if (isFileBasedApp(projectPath)) {
+            // Mirror the .NET SDK's launch-settings discovery for `dotnet run` / `dotnet run-api`
+            // (LaunchSettings.TryFindLaunchSettingsFile): for a file-based app the SDK looks next to the
+            // entry-point `.cs` file and prefers `Properties/launchSettings.json`, only falling back to
+            // `<app>.run.json` when the former is absent. If both exist, `<app>.run.json` is ignored.
+            // The extension MUST resolve the same file the SDK does: createProjectDebuggerExtension uses
+            // determineDefaultLaunchProfile to decide whether `dotnet run-api`'s reported program can be
+            // trusted, so reading a different (or no) file would make that guard disagree with the profile
+            // run-api actually applied and launch the file-based app with the wrong program.
+            // https://github.com/dotnet/sdk/blob/main/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
+            const dir = path.dirname(projectPath);
+            const propertiesLaunchSettingsPath = path.join(dir, 'Properties', 'launchSettings.json');
             const fileNameWithoutExt = path.basename(projectPath, path.extname(projectPath));
-            launchSettingsPath = path.join(path.dirname(projectPath), `${fileNameWithoutExt}.run.json`);
+            const runJsonPath = path.join(dir, `${fileNameWithoutExt}.run.json`);
+
+            if (fs.existsSync(propertiesLaunchSettingsPath)) {
+                if (fs.existsSync(runJsonPath)) {
+                    extensionLogOutputChannel.warn(`Both '${propertiesLaunchSettingsPath}' and '${runJsonPath}' exist; using '${propertiesLaunchSettingsPath}' to match 'dotnet run'. '${runJsonPath}' is ignored.`);
+                }
+
+                launchSettingsPath = propertiesLaunchSettingsPath;
+            } else {
+                launchSettingsPath = runJsonPath;
+            }
         } else {
             const projectDir = path.dirname(projectPath);
             launchSettingsPath = path.join(projectDir, 'Properties', 'launchSettings.json');

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -169,6 +169,8 @@ export const testRunSessionManagerNotInitialized = vscode.l10n.t('Test run sessi
 export const buildFailedForProjectWithError = (project: string, error: string) => vscode.l10n.t('Build failed for project {0} with error: {1}.', project, error);
 export const failedToInspectRuntimeConfig = (outputPath: string, error: string) => vscode.l10n.t('Failed to inspect runtimeconfig for {0}: {1}', outputPath, error);
 export const dotNetRunFallbackDisablesDebugger = (outputPath: string, projectPath: string) => vscode.l10n.t('Project output {0} is not directly runnable; launching {1} with dotnet run without debugger attach. Breakpoints will not be hit for this resource.', outputPath, projectPath);
+export const dotNetRunFileBasedExecutableProfileFallback = (profileName: string, projectPath: string) => vscode.l10n.t('The default launch profile \'{0}\' is an Executable profile, so dotnet run-api does not return the file-based app {1}; launching it with dotnet run without debugger attach. Breakpoints will not be hit for this resource.', profileName, projectPath);
+export const executableLaunchProfileMissingExecutablePath = (profileName: string) => vscode.l10n.t('Launch profile \'{0}\' uses commandName \'Executable\' but does not specify an executablePath. Add an executablePath to the launch profile.', profileName);
 export const lookingForDevkitBuildTask = vscode.l10n.t('C# Dev Kit is installed, looking for C# Dev Kit build task...');
 export const csharpDevKitNotInstalled = vscode.l10n.t('C# Dev Kit is not installed, building using dotnet CLI...');
 export const dismissLabel = vscode.l10n.t('Dismiss');

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -13,6 +13,10 @@ class TestDotNetService {
 
     public buildDotNetProjectStub: sinon.SinonStub;
 
+    // `dotnet run-api` output returned for file-based (.cs) apps. Tests override this with a serialized
+    // RunCommand payload; the default empty string mirrors the not-configured case.
+    public runApiOutput: string = '';
+
     constructor(outputPath: string, rejectBuild: Error | null, hasDevKit: boolean) {
         this._getDotNetTargetPathStub = sinon.stub();
         this._getDotNetTargetPathStub.resolves(outputPath);
@@ -40,7 +44,7 @@ class TestDotNetService {
     }
 
     getDotNetRunApiOutput(projectPath: string): Promise<string> {
-        return Promise.resolve('');
+        return Promise.resolve(this.runApiOutput);
     }
 }
 
@@ -268,6 +272,813 @@ suite('Dotnet Debugger Extension Tests', () => {
         assert.strictEqual(dotNetService.buildDotNetProjectStub.notCalled, true);
     });
 
+    test('advertises the coreclr project debugger and extracts project_path for .csproj and file-based .cs', () => {
+        // A DotnetProjectResource (AddDotnetProject) advertises the same "project" launch capability as
+        // AddProject and emits a ProjectLaunchConfiguration carrying project_path (a .csproj or a file-based
+        // .cs). The extension's .NET debugger keys purely off that "project" type + project_path, so it must
+        // resolve the same coreclr debugger and project file regardless of which resource produced the config.
+        assert.strictEqual(projectDebuggerExtension.resourceType, 'project');
+        assert.strictEqual(projectDebuggerExtension.debugAdapter, 'coreclr');
+        assert.deepStrictEqual(projectDebuggerExtension.getSupportedFileTypes(), ['.cs', '.csproj']);
+
+        const csprojConfig: ProjectLaunchConfiguration = { type: 'project', project_path: '/tmp/Worker.csproj' };
+        const fileBasedConfig: ProjectLaunchConfiguration = { type: 'project', project_path: '/tmp/app.cs' };
+        assert.strictEqual(projectDebuggerExtension.getProjectFile(csprojConfig), '/tmp/Worker.csproj');
+        assert.strictEqual(projectDebuggerExtension.getProjectFile(fileBasedConfig), '/tmp/app.cs');
+    });
+
+    test('file-based .cs project launches the dotnet run-api executable under coreclr', async () => {
+        // A file-based DotnetProjectResource emits a "project" launch config whose project_path is a .cs file.
+        // Unlike a .csproj (launched from its build output), a .cs app has no build output path, so the
+        // extension resolves the runnable program via `dotnet run-api`. This proves the file-based half of the
+        // AddDotnetProject debug contract: project_path (.cs) -> run-api ExecutablePath, launched under coreclr.
+        const executablePath = '/tmp/obj/Debug/net10.0/app';
+        const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+        dotNetService.runApiOutput = JSON.stringify({
+            $type: 'RunCommand',
+            Version: 1,
+            ExecutablePath: executablePath,
+            CommandLineArguments: '',
+            WorkingDirectory: '',
+            EnvironmentVariables: { RUNAPI_ENV: 'from-run-api' }
+        });
+
+        const launchConfig: ProjectLaunchConfiguration = {
+            type: 'project',
+            project_path: '/tmp/app.cs'
+        };
+
+        const debugConfig: AspireResourceExtendedDebugConfiguration = {
+            runId: '1',
+            debugSessionId: '1',
+            type: 'coreclr',
+            name: 'Test Debug Config',
+            request: 'launch'
+        };
+
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+        assert.strictEqual(extension.debugAdapter, 'coreclr');
+        assert.strictEqual(debugConfig.program, executablePath);
+        assert.strictEqual(debugConfig.args, undefined);
+        // cwd defaults to the file's directory; run-api's WorkingDirectory (empty here) is not consumed.
+        assert.strictEqual(debugConfig.cwd, '/tmp');
+        // run-api's profile-derived EnvironmentVariables are dropped (only DOTNET_ROOT* would be kept), so
+        // RUNAPI_ENV must not appear.
+        assert.deepStrictEqual(debugConfig.env, {});
+        assert.strictEqual(dotNetService.buildDotNetProjectStub.called, true);
+    });
+
+    test('file-based .cs project preserves run-api DOTNET_ROOT host variables but drops profile env', async () => {
+        // `dotnet run-api` returns the SDK default launch profile's environment variables mixed with the runtime
+        // host-resolution variables the SDK injects (DOTNET_ROOT / DOTNET_ROOT_<ARCH>). The profile-derived values
+        // (DOTNET_LAUNCH_PROFILE, ASPNETCORE_URLS, and the profile's own env) must be dropped because the user may
+        // have selected a different profile that is resolved separately, but the DOTNET_ROOT* variables must be
+        // preserved or an apphost-executable build can resolve the wrong runtime or fail to start.
+        const executablePath = '/tmp/obj/Debug/net10.0/app';
+        const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+        dotNetService.runApiOutput = JSON.stringify({
+            $type: 'RunCommand',
+            Version: 1,
+            ExecutablePath: executablePath,
+            CommandLineArguments: '',
+            WorkingDirectory: '',
+            EnvironmentVariables: {
+                DOTNET_ROOT: '/usr/share/dotnet',
+                DOTNET_ROOT_X64: '/usr/share/dotnet/x64',
+                DOTNET_LAUNCH_PROFILE: 'default',
+                ASPNETCORE_URLS: 'http://localhost:5000',
+                RUNAPI_ENV: 'from-run-api'
+            }
+        });
+
+        const launchConfig: ProjectLaunchConfiguration = {
+            type: 'project',
+            project_path: '/tmp/app.cs'
+        };
+
+        const debugConfig: AspireResourceExtendedDebugConfiguration = {
+            runId: '1',
+            debugSessionId: '1',
+            type: 'coreclr',
+            name: 'Test Debug Config',
+            request: 'launch'
+        };
+
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+        assert.strictEqual(debugConfig.program, executablePath);
+        // Only the DOTNET_ROOT* runtime host-resolution variables survive; every profile-derived value is dropped.
+        assert.deepStrictEqual(debugConfig.env, {
+            DOTNET_ROOT: '/usr/share/dotnet',
+            DOTNET_ROOT_X64: '/usr/share/dotnet/x64'
+        });
+    });
+
+    test('file-based .cs project launched via the dotnet launcher keeps the run-api host DLL and user args', async () => {
+        // When the SDK resolves a file-based app to the `dotnet` launcher, run-api returns ExecutablePath=dotnet
+        // and CommandLineArguments carrying the built app DLL. The extension must launch that program with the
+        // DLL host argument first, then the user application arguments supplied by DCP. Dropping CommandLineArguments
+        // would launch the 'dotnet' launcher with nothing to run. The working directory and environment come from
+        // the launch profile (here, its defaults) — not from run-api, whose values reflect the SDK default profile.
+        const dllPath = '/tmp/obj/Debug/net10.0/app.dll';
+        const workingDirectory = '/tmp/obj/Debug/net10.0';
+        const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+        dotNetService.runApiOutput = JSON.stringify({
+            $type: 'RunCommand',
+            Version: 1,
+            ExecutablePath: 'dotnet',
+            CommandLineArguments: dllPath,
+            WorkingDirectory: workingDirectory,
+            EnvironmentVariables: { RUNAPI_ENV: 'from-run-api' }
+        });
+
+        const launchConfig: ProjectLaunchConfiguration = {
+            type: 'project',
+            project_path: '/tmp/app.cs'
+        };
+
+        const debugConfig: AspireResourceExtendedDebugConfiguration = {
+            runId: '1',
+            debugSessionId: '1',
+            type: 'coreclr',
+            name: 'Test Debug Config',
+            request: 'launch'
+        };
+
+        const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+        await extension.createDebugSessionConfigurationCallback!(launchConfig, ['--message', 'hello'], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+        assert.strictEqual(debugConfig.program, 'dotnet');
+        assert.strictEqual(debugConfig.args, `${dllPath} --message hello`);
+        // cwd comes from the launch profile default (the file's directory), not run-api's WorkingDirectory.
+        assert.strictEqual(debugConfig.cwd, '/tmp');
+        // run-api's profile-derived EnvironmentVariables are dropped (only DOTNET_ROOT* would be kept), so
+        // RUNAPI_ENV must not appear.
+        assert.deepStrictEqual(debugConfig.env, {});
+        assert.strictEqual(dotNetService.buildDotNetProjectStub.called, true);
+    });
+
+    test('file-based .cs applies the launch profile working directory', async () => {
+        // A file-based app can carry a `<name>.run.json` launch profile. When that profile sets an explicit
+        // workingDirectory the extension must resolve and apply it, mirroring how launch profiles set the
+        // working directory for .csproj projects. run-api's own WorkingDirectory is never consumed.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            const profileWorkingDirectory = path.join(tempRoot, 'from-profile');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    app: {
+                        commandName: 'Project',
+                        workingDirectory: profileWorkingDirectory
+                    }
+                }
+            }));
+
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: 'dotnet',
+                CommandLineArguments: '',
+                WorkingDirectory: path.join(tempRoot, 'from-run-api'),
+                EnvironmentVariables: {}
+            });
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.cwd, profileWorkingDirectory);
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based .cs apphost-executable build does not duplicate launch profile arguments from run-api', async () => {
+        // For an apphost-executable build, `dotnet run-api` returns the app's own executable as ExecutablePath
+        // and — because it always applies the SDK default launch profile — echoes that profile's arguments back
+        // in CommandLineArguments. The extension resolves the same profile arguments itself, so it must NOT also
+        // prepend run-api's CommandLineArguments or the arguments would appear twice.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-dup-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    app: {
+                        commandName: 'Project',
+                        commandLineArgs: '--from-profile'
+                    }
+                }
+            }));
+
+            const executablePath = path.join(tempRoot, 'obj', 'Debug', 'net10.0', 'app');
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: executablePath,
+                CommandLineArguments: '--from-profile',
+                WorkingDirectory: '',
+                EnvironmentVariables: {}
+            });
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            // No run session arguments (undefined) so the launch profile's arguments are the ones used.
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.program, executablePath);
+            assert.strictEqual(debugConfig.args, '--from-profile');
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based .cs with disable_launch_profile ignores run-api profile arguments, working directory, and profile environment but keeps DOTNET_ROOT', async () => {
+        // With disable_launch_profile the extension selects no launch profile, but `dotnet run-api` still applies
+        // the SDK default profile and returns its arguments, working directory, and environment. The profile
+        // values may not leak into the debug configuration: args come only from the run session, cwd defaults to
+        // the file's directory, and no profile env is applied. The runtime host-resolution variables (DOTNET_ROOT*)
+        // are NOT profile-derived, so they must still be preserved even when the profile is disabled.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-disabled-profile-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    app: {
+                        commandName: 'Project',
+                        commandLineArgs: '--from-disabled-profile',
+                        workingDirectory: path.join(tempRoot, 'from-disabled-profile'),
+                        environmentVariables: {
+                            DISABLED_PROFILE_ENV: 'should-not-appear'
+                        }
+                    }
+                }
+            }));
+
+            const executablePath = path.join(tempRoot, 'obj', 'Debug', 'net10.0', 'app');
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: executablePath,
+                CommandLineArguments: '--from-disabled-profile',
+                WorkingDirectory: path.join(tempRoot, 'from-run-api'),
+                EnvironmentVariables: { DISABLED_PROFILE_ENV: 'should-not-appear', DOTNET_ROOT: '/usr/share/dotnet' }
+            });
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath,
+                disable_launch_profile: true
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.program, executablePath);
+            assert.strictEqual(debugConfig.args, undefined);
+            assert.strictEqual(debugConfig.cwd, tempRoot);
+            // The profile env (DISABLED_PROFILE_ENV) is dropped; the runtime host variable DOTNET_ROOT is preserved.
+            assert.deepStrictEqual(debugConfig.env, { DOTNET_ROOT: '/usr/share/dotnet' });
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based dotnet.cs apphost named dotnet is not mistaken for the launcher', async () => {
+        // A file-based app whose entry file is `dotnet.cs` builds an apphost whose AssemblyName — and therefore
+        // executable file name — is `dotnet`/`dotnet.exe`, the same name as the launcher but at a full build-output
+        // path. run-api returns that full path as ExecutablePath and echoes the SDK default profile's arguments
+        // in CommandLineArguments. Because the program is an apphost (a rooted path), not the launcher (a bare
+        // command name), the extension must NOT treat CommandLineArguments as host arguments — it resolves the
+        // profile arguments itself, so prepending run-api's would duplicate them.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-launchername-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'dotnet.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'dotnet.run.json'), JSON.stringify({
+                profiles: {
+                    dotnet: {
+                        commandName: 'Project',
+                        commandLineArgs: '--from-profile'
+                    }
+                }
+            }));
+
+            // The apphost executable derives its name from the .cs file, so it is `dotnet` / `dotnet.exe`.
+            const executablePath = path.join(tempRoot, 'obj', 'Debug', 'net10.0', process.platform === 'win32' ? 'dotnet.exe' : 'dotnet');
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: executablePath,
+                CommandLineArguments: '--from-profile',
+                WorkingDirectory: '',
+                EnvironmentVariables: {}
+            });
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            // No run session arguments (undefined) so the launch profile's arguments are the ones used.
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.program, executablePath);
+            // The apphost's own name is `dotnet`, but it is a full path, so it is not the launcher: the profile
+            // arguments appear exactly once and are not prefixed with run-api's CommandLineArguments.
+            assert.strictEqual(debugConfig.args, '--from-profile');
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based .cs drops a DOTNET_ROOT defined by the launch profile but keeps the SDK-injected host variable', async () => {
+        // `dotnet run-api` applies the SDK default launch profile, whose environmentVariables can define
+        // DOTNET_ROOT and then overwrite the SDK-injected value in run-api's output. A profile-derived
+        // DOTNET_ROOT must not be treated as an SDK runtime host variable: with the profile disabled (as here)
+        // it would otherwise leak and could launch against the wrong runtime. The architecture-specific
+        // DOTNET_ROOT_X64 is NOT defined by any profile, so it is a genuine SDK host-resolution variable and
+        // must be preserved.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-root-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    app: {
+                        commandName: 'Project',
+                        environmentVariables: {
+                            DOTNET_ROOT: '/profile/dotnet'
+                        }
+                    }
+                }
+            }));
+
+            const executablePath = path.join(tempRoot, 'obj', 'Debug', 'net10.0', 'app');
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: executablePath,
+                CommandLineArguments: '',
+                WorkingDirectory: '',
+                // run-api echoes the profile's DOTNET_ROOT (overwriting the SDK value) alongside the
+                // SDK-injected arch-specific DOTNET_ROOT_X64 that no profile defines.
+                EnvironmentVariables: { DOTNET_ROOT: '/profile/dotnet', DOTNET_ROOT_X64: '/usr/share/dotnet/x64' }
+            });
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath,
+                disable_launch_profile: true
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.program, executablePath);
+            // DOTNET_ROOT is defined by the (disabled) profile, so run-api's value is dropped; the SDK-injected
+            // DOTNET_ROOT_X64 survives.
+            assert.deepStrictEqual(debugConfig.env, { DOTNET_ROOT_X64: '/usr/share/dotnet/x64' });
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based .cs falls back to dotnet run (no debugger) when the default profile is an Executable profile and launch profile is disabled', async () => {
+        // `dotnet run-api` always applies the first *supported* profile and offers no way to request a
+        // no-profile command. Here an 'Executable' profile appears BEFORE a 'Project' profile, so run-api would
+        // report the Executable profile's external command (e.g. `some-external-tool --version`), NOT the .cs app.
+        // With the launch profile disabled the extension must not trust run-api's program; it launches the app
+        // itself via `dotnet run --file <app.cs> --no-cache --no-launch-profile` with the debugger detached.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-exec-default-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    // First supported profile: run-api applies this Executable profile and reports its external
+                    // command, not the .cs app.
+                    runExe: {
+                        commandName: 'Executable',
+                        executablePath: 'some-external-tool',
+                        commandLineArgs: '--version'
+                    },
+                    // A later 'Project' profile that is not selected here.
+                    app: {
+                        commandName: 'Project'
+                    }
+                }
+            }));
+
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            // The realistic run-api output for an Executable default profile is the external command. If the
+            // extension (incorrectly) trusted run-api, it would launch this program. It must not.
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: 'some-external-tool',
+                CommandLineArguments: '--version',
+                WorkingDirectory: '',
+                EnvironmentVariables: {}
+            });
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath,
+                disable_launch_profile: true
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            // The extension launches the app itself instead of the Executable profile's external command.
+            assert.strictEqual(debugConfig.program, 'dotnet');
+            assert.deepStrictEqual(debugConfig.args, ['run', '--file', projectPath, '--no-cache', '--no-launch-profile']);
+            assert.strictEqual(debugConfig.noDebug, true);
+            assert.strictEqual(debugConfig.cwd, tempRoot);
+            assert.deepStrictEqual(debugConfig.env, {});
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based .cs falls back to dotnet run applying the selected Project profile when the default profile is Executable', async () => {
+        // The default (first) profile is an 'Executable' profile that `dotnet run-api` would apply, but the user
+        // explicitly selected a later 'Project' profile. run-api still reports the Executable profile's external
+        // command, so the extension launches the app itself via `dotnet run --file ... --no-launch-profile`
+        // (no debugger attach) while applying the selected profile's arguments and environment.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-exec-default-select-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    runExe: {
+                        commandName: 'Executable',
+                        executablePath: 'some-external-tool',
+                        commandLineArgs: '--version'
+                    },
+                    app: {
+                        commandName: 'Project',
+                        commandLineArgs: '--from-profile',
+                        environmentVariables: {
+                            APP_ENV: 'from-project-profile'
+                        }
+                    }
+                }
+            }));
+
+            const { extension } = createDebuggerExtension('unused-build-output', null, true, true);
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath,
+                launch_profile: 'app'
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            // No run session args (undefined): the selected profile's commandLineArgs are appended after `--`.
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.program, 'dotnet');
+            // The selected 'app' profile's arguments are preserved verbatim after `--`; only the path is quoted.
+            assert.strictEqual(debugConfig.args, `run --file "${projectPath}" --no-cache --no-launch-profile -- --from-profile`);
+            assert.strictEqual(debugConfig.noDebug, true);
+            assert.strictEqual(debugConfig.cwd, tempRoot);
+            assert.deepStrictEqual(debugConfig.env, { APP_ENV: 'from-project-profile' });
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based .cs dotnet run fallback preserves the selected Project profile working directory', async () => {
+        // Same fallback as above (an Executable default profile forces `dotnet run --file ... --no-launch-profile`),
+        // but the selected Project profile sets a custom workingDirectory. Because --no-launch-profile stops
+        // `dotnet run` from applying the profile's workingDirectory itself, the extension must keep the cwd it
+        // resolved from the selected profile; the fallback must NOT reset it to the .cs file's own directory.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-exec-default-wd-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    runExe: {
+                        commandName: 'Executable',
+                        executablePath: 'some-external-tool',
+                        commandLineArgs: '--version'
+                    },
+                    app: {
+                        commandName: 'Project',
+                        workingDirectory: 'custom',
+                        commandLineArgs: '--from-profile',
+                        environmentVariables: {
+                            APP_ENV: 'from-project-profile'
+                        }
+                    }
+                }
+            }));
+
+            const { extension } = createDebuggerExtension('unused-build-output', null, true, true);
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath,
+                launch_profile: 'app'
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.program, 'dotnet');
+            assert.strictEqual(debugConfig.args, `run --file "${projectPath}" --no-cache --no-launch-profile -- --from-profile`);
+            assert.strictEqual(debugConfig.noDebug, true);
+            // The selected profile's relative workingDirectory is resolved against the .cs file's directory and
+            // preserved through the fallback (it must NOT be reset to the file's own directory).
+            assert.strictEqual(debugConfig.cwd, path.join(tempRoot, 'custom'));
+            assert.deepStrictEqual(debugConfig.env, { APP_ENV: 'from-project-profile' });
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based .cs uses the selected profile DOTNET_ROOT rather than the default profile value from run-api', async () => {
+        // `dotnet run-api` always applies the SDK *default* (first) profile, so its DOTNET_ROOT reflects that
+        // profile. When the extension selects a *different* profile, run-api's default-profile DOTNET_ROOT must
+        // not override the selected profile's own DOTNET_ROOT. The selected profile's value wins, and the
+        // SDK-injected DOTNET_ROOT_X64 (defined by no profile) is still preserved from run-api.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-root-select-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    app: {
+                        commandName: 'Project',
+                        environmentVariables: {
+                            DOTNET_ROOT: '/default/dotnet'
+                        }
+                    },
+                    other: {
+                        commandName: 'Project',
+                        environmentVariables: {
+                            DOTNET_ROOT: '/selected/dotnet'
+                        }
+                    }
+                }
+            }));
+
+            const executablePath = path.join(tempRoot, 'obj', 'Debug', 'net10.0', 'app');
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: executablePath,
+                CommandLineArguments: '',
+                WorkingDirectory: '',
+                // run-api applied the default profile 'app', so it returns that profile's DOTNET_ROOT.
+                EnvironmentVariables: { DOTNET_ROOT: '/default/dotnet', DOTNET_ROOT_X64: '/usr/share/dotnet/x64' }
+            });
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath,
+                launch_profile: 'other'
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.program, executablePath);
+            // The selected profile's DOTNET_ROOT wins over run-api's default-profile value; DOTNET_ROOT_X64
+            // (SDK-injected, defined by no profile) is preserved.
+            assert.deepStrictEqual(debugConfig.env, { DOTNET_ROOT: '/selected/dotnet', DOTNET_ROOT_X64: '/usr/share/dotnet/x64' });
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    test('file-based .cs preserves a genuine SDK DOTNET_ROOT even when an unrelated profile defines that name', async () => {
+        // `dotnet run-api` only ever applies the SDK default (first 'Project') profile, so only that profile —
+        // and the profile the extension selected — can legitimately shadow a DOTNET_ROOT* value. A DOTNET_ROOT*
+        // defined by some *other*, unselected profile must NOT cause run-api's genuine SDK-injected value of the
+        // same name to be discarded. Here the default/selected profile 'app' defines no DOTNET_ROOT*, while an
+        // unrelated profile 'other' defines DOTNET_ROOT_X64; run-api reports a real SDK DOTNET_ROOT_X64, which
+        // must be preserved so the file-based app can locate the runtime.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-root-unrelated-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(tempRoot, { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            fs.writeFileSync(path.join(tempRoot, 'app.run.json'), JSON.stringify({
+                profiles: {
+                    // The default (first 'Project') profile the extension selects and run-api applies. It does
+                    // not define any DOTNET_ROOT*.
+                    app: {
+                        commandName: 'Project'
+                    },
+                    // An unrelated profile that is never selected. Its DOTNET_ROOT_X64 must not affect the result.
+                    other: {
+                        commandName: 'Project',
+                        environmentVariables: {
+                            DOTNET_ROOT_X64: '/unrelated/dotnet/x64'
+                        }
+                    }
+                }
+            }));
+
+            const executablePath = path.join(tempRoot, 'obj', 'Debug', 'net10.0', 'app');
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: executablePath,
+                CommandLineArguments: '',
+                WorkingDirectory: '',
+                // The genuine SDK-injected host variable. Neither the selected nor the run-api default profile
+                // defines it.
+                EnvironmentVariables: { DOTNET_ROOT_X64: '/usr/share/dotnet/x64' }
+            });
+
+            // No launch_profile: the extension uses the default profile 'app', which run-api also applied.
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            assert.strictEqual(debugConfig.program, executablePath);
+            // The unrelated 'other' profile's DOTNET_ROOT_X64 must not poison the exclusion set, so run-api's
+            // genuine SDK-injected DOTNET_ROOT_X64 survives.
+            assert.deepStrictEqual(debugConfig.env, { DOTNET_ROOT_X64: '/usr/share/dotnet/x64' });
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
     test('does not use dotnet run when ordinary project launch configuration requests NoDebug', async () => {
         const outputPath = '/tmp/bin/Debug/net10.0/Worker.dll';
         const { extension } = createDebuggerExtension(outputPath, null, true, true);
@@ -446,7 +1257,10 @@ suite('Dotnet Debugger Extension Tests', () => {
 
             await extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
 
-            assert.strictEqual(debugConfig.cwd, projectDir);
+            // The dotnet CLI fallback ignores the profile's executablePath (that setting only applies to
+            // 'Executable' command profiles), but it still honors the profile's workingDirectory: it is resolved
+            // into cwd up front and must survive the fallback so the app runs from the configured directory.
+            assert.strictEqual(debugConfig.cwd, path.join(projectDir, 'custom'));
             assert.strictEqual(debugConfig.executablePath, undefined);
         } finally {
             fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -693,6 +1507,118 @@ suite('Dotnet Debugger Extension Tests', () => {
 
         // cleanup
         fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('fails project launch when the selected Executable launch profile has no executablePath', async () => {
+        // An Executable-command profile requires an executablePath. The .NET SDK's ExecutableProvider errors
+        // when it is missing, so the extension must surface a configuration error rather than silently falling
+        // through and launching the project output.
+        const fs = require('fs');
+        const os = require('os');
+        const path = require('path');
+
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+        try {
+            const projectDir = path.join(tempDir, 'MyClassLibFunction');
+            const propertiesDir = path.join(projectDir, 'Properties');
+            fs.mkdirSync(propertiesDir, { recursive: true });
+
+            const projectPath = path.join(projectDir, 'MyClassLibFunction.csproj');
+            fs.writeFileSync(projectPath, '<Project></Project>');
+
+            const launchSettings = {
+                profiles: {
+                    'Aspire_my-function': {
+                        commandName: 'Executable',
+                        commandLineArgs: 'exec RuntimeSupport.dll'
+                    }
+                }
+            };
+            fs.writeFileSync(path.join(propertiesDir, 'launchSettings.json'), JSON.stringify(launchSettings, null, 2));
+
+            const outputPath = path.join(projectDir, 'bin', 'Debug', 'net10.0', 'MyClassLibFunction.dll');
+            const { extension, dotNetService } = createDebuggerExtension(outputPath, null, true, true);
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath,
+                launch_profile: 'Aspire_my-function'
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await assert.rejects(
+                extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig),
+                /Launch profile 'Aspire_my-function' uses commandName 'Executable' but does not specify an executablePath/);
+
+            // The invalid profile must be rejected before any build/launch work happens.
+            assert.strictEqual(dotNetService.buildDotNetProjectStub.called, false);
+        } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test('fails project launch when the default Executable launch profile has no executablePath', async () => {
+        // With no explicit launch_profile, the extension resolves the SDK default (first supported) profile.
+        // When that default is an Executable profile without an executablePath, `dotnet run` would error, so
+        // the extension must surface the same configuration error instead of launching the project output.
+        const fs = require('fs');
+        const os = require('os');
+        const path = require('path');
+
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aspire-test-'));
+        try {
+            const projectDir = path.join(tempDir, 'MyClassLibFunction');
+            const propertiesDir = path.join(projectDir, 'Properties');
+            fs.mkdirSync(propertiesDir, { recursive: true });
+
+            const projectPath = path.join(projectDir, 'MyClassLibFunction.csproj');
+            fs.writeFileSync(projectPath, '<Project></Project>');
+
+            const launchSettings = {
+                profiles: {
+                    'RunExe': {
+                        commandName: 'Executable',
+                        commandLineArgs: 'exec RuntimeSupport.dll'
+                    }
+                }
+            };
+            fs.writeFileSync(path.join(propertiesDir, 'launchSettings.json'), JSON.stringify(launchSettings, null, 2));
+
+            const outputPath = path.join(projectDir, 'bin', 'Debug', 'net10.0', 'MyClassLibFunction.dll');
+            const { extension, dotNetService } = createDebuggerExtension(outputPath, null, true, true);
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await assert.rejects(
+                extension.createDebugSessionConfigurationCallback!(launchConfig, undefined, [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig),
+                /Launch profile 'RunExe' uses commandName 'Executable' but does not specify an executablePath/);
+
+            assert.strictEqual(dotNetService.buildDotNetProjectStub.called, false);
+        } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
     });
 
     test('expands environment variables in Executable profile executablePath and commandLineArgs', async () => {

--- a/extension/src/test/dotnetDebugger.test.ts
+++ b/extension/src/test/dotnetDebugger.test.ts
@@ -809,6 +809,72 @@ suite('Dotnet Debugger Extension Tests', () => {
         }
     });
 
+    test('file-based .cs reads Properties/launchSettings.json (not just <app>.run.json) to detect an Executable default profile', async () => {
+        // Regression test for the launch-settings search order. For a file-based app the .NET SDK prefers
+        // Properties/launchSettings.json over <app>.run.json when locating launch settings, so `dotnet run-api`
+        // applies the default profile from THAT file. The extension previously read only <app>.run.json for
+        // file-based apps, so it missed an Executable default profile living in Properties/launchSettings.json
+        // and wrongly trusted run-api's external command. It must now read the same file the SDK does, detect
+        // the Executable default, and launch the .cs app itself via `dotnet run --file ... --no-launch-profile`.
+        const fs = require('fs');
+        const path = require('path');
+
+        const tempRoot = path.join(process.cwd(), '.test-temp', `dotnet-runapi-exec-props-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(path.join(tempRoot, 'Properties'), { recursive: true });
+
+        try {
+            const projectPath = path.join(tempRoot, 'app.cs');
+            fs.writeFileSync(projectPath, '// file-based app');
+            // The Executable default profile lives ONLY in Properties/launchSettings.json (there is no
+            // <app>.run.json). run-api applies it and reports the external command below.
+            fs.writeFileSync(path.join(tempRoot, 'Properties', 'launchSettings.json'), JSON.stringify({
+                profiles: {
+                    runExe: {
+                        commandName: 'Executable',
+                        executablePath: 'some-external-tool',
+                        commandLineArgs: '--version'
+                    }
+                }
+            }));
+
+            const { extension, dotNetService } = createDebuggerExtension('unused-build-output', null, true, true);
+            dotNetService.runApiOutput = JSON.stringify({
+                $type: 'RunCommand',
+                Version: 1,
+                ExecutablePath: 'some-external-tool',
+                CommandLineArguments: '--version',
+                WorkingDirectory: '',
+                EnvironmentVariables: {}
+            });
+
+            const launchConfig: ProjectLaunchConfiguration = {
+                type: 'project',
+                project_path: projectPath,
+                disable_launch_profile: true
+            };
+
+            const debugConfig: AspireResourceExtendedDebugConfiguration = {
+                runId: '1',
+                debugSessionId: '1',
+                type: 'coreclr',
+                name: 'Test Debug Config',
+                request: 'launch'
+            };
+
+            const fakeAspireDebugSession = sinon.createStubInstance(AspireDebugSession);
+
+            await extension.createDebugSessionConfigurationCallback!(launchConfig, [], [], { debug: true, runId: '1', debugSessionId: '1', isApphost: false, debugSession: fakeAspireDebugSession }, debugConfig);
+
+            // The extension launches the .cs app itself instead of the Executable profile's external command.
+            assert.strictEqual(debugConfig.program, 'dotnet');
+            assert.deepStrictEqual(debugConfig.args, ['run', '--file', projectPath, '--no-cache', '--no-launch-profile']);
+            assert.strictEqual(debugConfig.noDebug, true);
+            assert.strictEqual(debugConfig.cwd, tempRoot);
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
     test('file-based .cs falls back to dotnet run applying the selected Project profile when the default profile is Executable', async () => {
         // The default (first) profile is an 'Executable' profile that `dotnet run-api` would apply, but the user
         // explicitly selected a later 'Project' profile. run-api still reports the Executable profile's external

--- a/extension/src/test/launchProfiles.test.ts
+++ b/extension/src/test/launchProfiles.test.ts
@@ -967,6 +967,71 @@ suite('Launch Profile Tests', () => {
             assert.strictEqual(defaultProfile.profileName, '10');
             assert.strictEqual(defaultProfile.profile?.commandName, 'Executable');
         });
+
+        test('prefers Properties/launchSettings.json over <app>.run.json for file-based app (matches dotnet run)', async () => {
+            // The .NET SDK resolves launch settings for a file-based app by preferring
+            // Properties/launchSettings.json over <app>.run.json (LaunchSettings.TryFindLaunchSettingsFile).
+            // The extension must read the same file, otherwise determineDefaultLaunchProfile disagrees with
+            // the profile `dotnet run-api` actually applied and createProjectDebuggerExtension can launch the
+            // file-based app with the wrong (Executable-profile) program.
+            const fileBasedAppPath = path.join(tempDir, 'TestProject', 'apphost.cs');
+            fs.writeFileSync(fileBasedAppPath, '// test file-based app');
+
+            // Properties/launchSettings.json: the default profile is an Executable profile — exactly the
+            // case the run-api trust guard depends on detecting.
+            fs.writeFileSync(launchSettingsPath, JSON.stringify({
+                profiles: {
+                    fromProperties: {
+                        commandName: 'Executable',
+                        executablePath: 'some-external-tool',
+                        commandLineArgs: '--version'
+                    }
+                }
+            }, null, 2));
+
+            // <app>.run.json exists too, but must be ignored because launchSettings.json wins.
+            const runJsonPath = path.join(tempDir, 'TestProject', 'apphost.run.json');
+            fs.writeFileSync(runJsonPath, JSON.stringify({
+                profiles: {
+                    fromRunJson: {
+                        commandName: 'Project',
+                        applicationUrl: 'https://localhost:7000'
+                    }
+                }
+            }, null, 2));
+
+            const result = await readLaunchSettings(fileBasedAppPath);
+
+            assert.notStrictEqual(result, null);
+            assert.deepStrictEqual(Object.keys(result!.profiles), ['fromProperties']);
+
+            const defaultProfile = determineDefaultLaunchProfile(result);
+            assert.strictEqual(defaultProfile.profileName, 'fromProperties');
+            assert.strictEqual(defaultProfile.profile?.commandName, 'Executable');
+        });
+
+        test('falls back to <app>.run.json when Properties/launchSettings.json is absent for file-based app', async () => {
+            const fileBasedAppPath = path.join(tempDir, 'TestProject', 'apphost.cs');
+            fs.writeFileSync(fileBasedAppPath, '// test file-based app');
+
+            // No Properties/launchSettings.json is written, so the SDK (and the extension) fall back to
+            // <app>.run.json.
+            const runJsonPath = path.join(tempDir, 'TestProject', 'apphost.run.json');
+            fs.writeFileSync(runJsonPath, JSON.stringify({
+                profiles: {
+                    fromRunJson: {
+                        commandName: 'Project',
+                        applicationUrl: 'https://localhost:7000'
+                    }
+                }
+            }, null, 2));
+
+            const result = await readLaunchSettings(fileBasedAppPath);
+
+            assert.notStrictEqual(result, null);
+            assert.deepStrictEqual(Object.keys(result!.profiles), ['fromRunJson']);
+            assert.strictEqual(result!.profiles['fromRunJson'].applicationUrl, 'https://localhost:7000');
+        });
     });
 
     suite('expandEnvironmentVariables', () => {

--- a/extension/src/test/launchProfiles.test.ts
+++ b/extension/src/test/launchProfiles.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import {
     determineBaseLaunchProfile,
+    determineDefaultLaunchProfile,
     mergeEnvironmentVariables,
     determineArguments,
     determineWorkingDirectory,
@@ -138,6 +139,122 @@ suite('Launch Profile Tests', () => {
 
             assert.strictEqual(result.profileName, 'IISExpress');
             assert.strictEqual(result.profile?.commandName, 'IISExpress');
+        });
+    });
+
+    suite('determineDefaultLaunchProfile', () => {
+        test('returns null for null launch settings', () => {
+            const result = determineDefaultLaunchProfile(null);
+
+            assert.strictEqual(result.profile, null);
+            assert.strictEqual(result.profileName, null);
+        });
+
+        test('returns the first Project profile when it appears before other supported profiles', () => {
+            const launchSettings: LaunchSettings = {
+                profiles: {
+                    'Development': { commandName: 'Project' },
+                    'Run': { commandName: 'Executable' }
+                }
+            };
+
+            const result = determineDefaultLaunchProfile(launchSettings);
+
+            assert.strictEqual(result.profileName, 'Development');
+            assert.strictEqual(result.profile?.commandName, 'Project');
+        });
+
+        test('returns an earlier Executable profile instead of a later Project profile', () => {
+            // The SDK selects the first *supported* profile, and 'Executable' is supported alongside 'Project'.
+            // An 'Executable' profile that appears first must win over a later 'Project' profile, matching what
+            // `dotnet run-api` actually applies.
+            const launchSettings: LaunchSettings = {
+                profiles: {
+                    'RunExe': {
+                        commandName: 'Executable',
+                        environmentVariables: {
+                            DOTNET_ROOT: '/exec/dotnet'
+                        }
+                    },
+                    'Development': {
+                        commandName: 'Project',
+                        environmentVariables: {
+                            ASPNETCORE_ENVIRONMENT: 'Development'
+                        }
+                    }
+                }
+            };
+
+            const result = determineDefaultLaunchProfile(launchSettings);
+
+            assert.strictEqual(result.profileName, 'RunExe');
+            assert.strictEqual(result.profile?.commandName, 'Executable');
+            assert.strictEqual(result.profile?.environmentVariables?.DOTNET_ROOT, '/exec/dotnet');
+        });
+
+        test('skips unsupported command names and returns the first supported profile', () => {
+            const launchSettings: LaunchSettings = {
+                profiles: {
+                    'IISExpress': { commandName: 'IISExpress' },
+                    'RunExe': { commandName: 'Executable' },
+                    'Development': { commandName: 'Project' }
+                }
+            };
+
+            const result = determineDefaultLaunchProfile(launchSettings);
+
+            assert.strictEqual(result.profileName, 'RunExe');
+            assert.strictEqual(result.profile?.commandName, 'Executable');
+        });
+
+        test('matches command names case-sensitively (skips a lowercased "executable")', () => {
+            // The SDK's provider table (LaunchSettings.s_providers) is ordinal/case-sensitive, so
+            // `dotnet run-api` treats a profile whose commandName is "executable" (wrong casing) as
+            // unsupported and skips it when picking the default profile. The extension must match.
+            const launchSettings: LaunchSettings = {
+                profiles: {
+                    'Run': { commandName: 'executable' }
+                }
+            };
+
+            const result = determineDefaultLaunchProfile(launchSettings);
+
+            assert.strictEqual(result.profile, null);
+            assert.strictEqual(result.profileName, null);
+        });
+
+        test('returns null when no profile has a supported command name', () => {
+            const launchSettings: LaunchSettings = {
+                profiles: {
+                    'IISExpress': { commandName: 'IISExpress' }
+                }
+            };
+
+            const result = determineDefaultLaunchProfile(launchSettings);
+
+            assert.strictEqual(result.profile, null);
+            assert.strictEqual(result.profileName, null);
+        });
+
+        test('honors profileOrder for integer-like names instead of numeric key order', () => {
+            // The file lists the Executable profile "10" before the Project profile "2", so the SDK
+            // picks "10". JavaScript object key enumeration would instead reorder these integer-like
+            // keys to ["2", "10"] and pick "2"; profileOrder must override that to match the SDK.
+            const launchSettings: LaunchSettings = {
+                profiles: {
+                    '10': { commandName: 'Executable' },
+                    '2': { commandName: 'Project' }
+                },
+                profileOrder: ['10', '2']
+            };
+
+            // Sanity check: without profileOrder, key enumeration would visit "2" (Project) first.
+            assert.deepStrictEqual(Object.keys(launchSettings.profiles), ['2', '10']);
+
+            const result = determineDefaultLaunchProfile(launchSettings);
+
+            assert.strictEqual(result.profileName, '10');
+            assert.strictEqual(result.profile?.commandName, 'Executable');
         });
     });
 
@@ -815,6 +932,40 @@ suite('Launch Profile Tests', () => {
             assert.notStrictEqual(result, null);
             assert.strictEqual(result!.profiles['https'].applicationUrl, 'https://localhost:5001');
             assert.strictEqual(result!.profiles['https'].environmentVariables!.ASPNETCORE_ENVIRONMENT, 'Development');
+        });
+
+        test('preserves file order for integer-like profile names when selecting the default profile', async () => {
+            // The Executable profile "10" appears before the Project profile "2" in the file. The .NET
+            // SDK selects the first supported profile in file order ("10"), but JavaScript object key
+            // enumeration would reorder these integer-like keys to ["2", "10"] and pick "2".
+            // readLaunchSettings must capture the source order so the extension matches `dotnet run-api`.
+            const launchSettings = `{
+  "profiles": {
+    "10": {
+      "commandName": "Executable",
+      "environmentVariables": {
+        "DOTNET_ROOT": "/exec/dotnet"
+      }
+    },
+    "2": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}`;
+
+            fs.writeFileSync(launchSettingsPath, launchSettings);
+
+            const result = await readLaunchSettings(projectPath);
+
+            assert.notStrictEqual(result, null);
+            assert.deepStrictEqual(result!.profileOrder, ['10', '2']);
+
+            const defaultProfile = determineDefaultLaunchProfile(result);
+            assert.strictEqual(defaultProfile.profileName, '10');
+            assert.strictEqual(defaultProfile.profile?.commandName, 'Executable');
         });
     });
 

--- a/src/Aspire.Hosting.Dotnet/DotnetProjectHostingExtensions.cs
+++ b/src/Aspire.Hosting.Dotnet/DotnetProjectHostingExtensions.cs
@@ -126,13 +126,21 @@ public static class DotnetProjectHostingExtensions
                               .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = projectMetadata.ProjectPath, Mode = mode }, "project")
                               .WithProjectDefaults(options);
 
-        // Build the `dotnet run` command line. This mirrors the ExecutionType.Process path in
-        // Dcp/ExecutableCreator.PrepareProjectExecutables() so a non-debug launch of a DotnetProjectResource
-        // (now an ExecutableResource, not a ProjectResource) matches how AddProject launches today:
-        //   dotnet run --project <proj> [--no-build] [--configuration <cfg>] --no-launch-profile
+        // Build the `dotnet run` command line for a non-debug launch of a DotnetProjectResource:
+        //   dotnet run --project <proj> [--no-build] [--configuration <cfg>] --no-launch-profile OR
         //   dotnet run --file <app.cs> --no-cache [--no-build] [--configuration <cfg>] --no-launch-profile
         resource.WithArgs(ctx =>
         {
+            // Mirrors the fallback rule in Dcp/ExecutableCreator: 
+            // a Process fallback is offered for the plain executable UNLESS 
+            // the launch configuration is "project", OR the configuration rewrites the arguments for debugging. 
+            // For any other active annotation a fallback IS offered and we need to construct the args here.
+            if (ctx.Resource.SupportsDebugging(builder.Configuration, out var debugAnnotation)
+                && (debugAnnotation.LaunchConfigurationType is "project" || debugAnnotation.RewritesArgumentsForDebugging))
+            {
+                return;
+            }
+
             IProjectMetadata metadata = projectMetadata;
 
             ctx.Args.Add("run");

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1759,6 +1759,7 @@ public static class ResourceExtensions
         ContainerResource => KnownResourceTypes.Container,
         ContainerExecutableResource => KnownResourceTypes.ContainerExec,
         DotnetToolResource => KnownResourceTypes.Tool,
+        ExecutableResource when resource.HasAnnotationOfType<IProjectMetadata>() => KnownResourceTypes.Project,
         ExecutableResource => KnownResourceTypes.Executable,
         ParameterResource => KnownResourceTypes.Parameter,
         ConnectionStringResource => KnownResourceTypes.ConnectionString,

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -377,7 +377,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         return resource switch
         {
             Container => KnownResourceTypes.Container,
-            Executable => appModelResource is ProjectResource ? KnownResourceTypes.Project : KnownResourceTypes.Executable,
+            Executable => appModelResource.GetResourceType(),
             ContainerExec => KnownResourceTypes.ContainerExec,
             _ => throw new InvalidOperationException($"Unknown resource type {resource.GetType().Name}")
         };

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -161,23 +161,50 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         // Invoke the debug configuration callback now that endpoints are allocated.
         // This allows launch configurations to access endpoint URLs that were not
         // available during PrepareExecutables().
-        // "project" launch types configure their launch configs in PrepareProjectExecutables() directly;
-        // all other types (plain executables and project subtypes like azure-functions) are handled here.
+        // "project" launch types on ProjectResources configure their launch configs in
+        // PrepareProjectExecutables() directly. Plain executables that carry IProjectMetadata and a
+        // "project" SupportsDebuggingAnnotation (e.g. DotnetProjectResource) are prepared as plain executables, 
+        // so their "project" launch configuration is applied here for IDE/F5 parity with AddProject. 
+        // All other types (plain executables and project subtypes like azure-functions) are also handled here.
         if (!er.ModelResource.HasAnnotationOfType<ForceProcessExecutionAnnotation>()
-            && er.ModelResource.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation)
-            && supportsDebuggingAnnotation.LaunchConfigurationType is not "project")
+            && er.ModelResource.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation))
         {
-            var mode = _configuration[KnownConfigNames.DebugSessionRunMode] ?? ExecutableLaunchMode.NoDebug;
-            try
+            if (supportsDebuggingAnnotation.LaunchConfigurationType is "project")
             {
-                // Clear any existing launch configurations (needed for restart scenarios).
-                exe.Annotate(Executable.LaunchConfigurationsAnnotation, string.Empty);
-                supportsDebuggingAnnotation.LaunchConfigurationAnnotator(exe, mode);
+                // ProjectResources already applied the "project" launch config in PrepareProjectExecutables().
+                // Only plain executables carrying project metadata need it applied here.
+                if (er.ModelResource is not ProjectResource)
+                {
+                    if (er.ModelResource.TryGetLastAnnotation<IProjectMetadata>(out var plainProjectMetadata))
+                    {
+                        // Clear and re-apply the launch configuration to ensure proper restart behavior.
+                        ApplyProjectLaunchConfiguration(exe, er.ModelResource, plainProjectMetadata, supportsDebuggingAnnotation);
+                    }
+                    else
+                    {
+                        throw new FailedToApplyEnvironmentException(
+                            $"Resource '{er.ModelResource.Name}' declares \"project\" debug launch support (WithDebugSupport) but has no project metadata. " +
+                            $"The \"project\" launch configuration type is reserved for .NET project resources; use a resource that carries {nameof(IProjectMetadata)} or a different launch configuration type.");
+                    }
+                }
             }
-            catch (Exception ex)
+            else
             {
-                _logger.LogWarning(ex, "Failed to apply launch configuration for resource '{ResourceName}'. Falling back to process execution.", er.ModelResource.Name);
-                exe.Spec.ExecutionType = ExecutionType.Process;
+                // We have non-project Executable that supports debugging; need to annotate it properly.
+
+                var mode = _configuration[KnownConfigNames.DebugSessionRunMode] ?? ExecutableLaunchMode.NoDebug;
+                try
+                {
+                    // Clear any existing launch configurations (needed for restart scenarios).
+                    exe.Annotate(Executable.LaunchConfigurationsAnnotation, string.Empty);
+                    supportsDebuggingAnnotation.LaunchConfigurationAnnotator(exe, mode);
+                }
+                // Only fall back to Process when Spec.Args still forms a runnable command.
+                catch (Exception ex) when (!supportsDebuggingAnnotation.RewritesArgumentsForDebugging)
+                {
+                    _logger.LogWarning(ex, "Failed to apply launch configuration for resource '{ResourceName}'. Falling back to process execution.", er.ModelResource.Name);
+                    exe.Spec.ExecutionType = ExecutionType.Process;
+                }
             }
         }
 
@@ -406,12 +433,20 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
 
             if (!persistent
                 && !executable.HasAnnotationOfType<ForceProcessExecutionAnnotation>()
-                && executable.SupportsDebugging(_configuration, out _))
+                && executable.SupportsDebugging(_configuration, out var supportsDebuggingAnnotation))
             {
                 // Just mark as IDE execution here - the actual launch configuration callback
                 // will be invoked in CreateExecutableAsync after endpoints are allocated.
                 exe.Spec.ExecutionType = ExecutionType.IDE;
-                exe.Spec.FallbackExecutionTypes = [ExecutionType.Process];
+
+                // A Process fallback is only meaningful when the fallback can actually launch the resource.
+                // This means the DCP Executable Spec has "real" command and args that can be executed "as is".
+                // In case of "project" launch configuration type, or when RewritesArgumentsForDebugging is true, 
+                // that is not the case, so we do not add the fallback. 
+                if (supportsDebuggingAnnotation.LaunchConfigurationType is not "project" && !supportsDebuggingAnnotation.RewritesArgumentsForDebugging)
+                {
+                    exe.Spec.FallbackExecutionTypes = [ExecutionType.Process];
+                }
             }
             else
             {
@@ -761,7 +796,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         return true;
     }
 
-    private void ApplyProjectLaunchConfiguration(Executable exe, ProjectResource project, IProjectMetadata projectMetadata, SupportsDebuggingAnnotation? supportsDebuggingAnnotation = null)
+    private void ApplyProjectLaunchConfiguration(Executable exe, IResource project, IProjectMetadata projectMetadata, SupportsDebuggingAnnotation? supportsDebuggingAnnotation = null)
     {
         if (supportsDebuggingAnnotation?.LaunchConfigurationType is "project")
         {
@@ -782,7 +817,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         exe.SetProjectLaunchConfiguration(CreateProjectLaunchConfiguration(project, projectMetadata));
     }
 
-    private ProjectLaunchConfiguration CreateProjectLaunchConfiguration(ProjectResource project, IProjectMetadata projectMetadata)
+    private ProjectLaunchConfiguration CreateProjectLaunchConfiguration(IResource project, IProjectMetadata projectMetadata)
     {
         var projectLaunchConfiguration = new ProjectLaunchConfiguration();
         projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
@@ -793,7 +828,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         return projectLaunchConfiguration;
     }
 
-    private static void ApplyProjectLaunchConfigurationDefaults(ProjectLaunchConfiguration projectLaunchConfiguration, ProjectResource project, IProjectMetadata projectMetadata)
+    private static void ApplyProjectLaunchConfigurationDefaults(ProjectLaunchConfiguration projectLaunchConfiguration, IResource project, IProjectMetadata projectMetadata)
     {
         if (string.IsNullOrEmpty(projectLaunchConfiguration.ProjectPath))
         {

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -281,7 +281,15 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                 if (!persistent && !forceProcessExecution && project.SupportsDebugging(_configuration, out supportsDebuggingAnnotation))
                 {
                     exe.Spec.ExecutionType = ExecutionType.IDE;
-                    exe.Spec.FallbackExecutionTypes = [ExecutionType.Process];
+
+                    // A Process fallback runs the DCP Executable Spec's command and args "as is". When the debug
+                    // support rewrites the resource's arguments for debugging (an argsCallback on an
+                    // IResourceWithArgs, supplied via the generic WithDebugSupport), those args are valid only for
+                    // IDE launch, so a Process fallback would run a broken command. Skip the fallback in that case.
+                    if (!supportsDebuggingAnnotation.RewritesArgumentsForDebugging)
+                    {
+                        exe.Spec.FallbackExecutionTypes = [ExecutionType.Process];
+                    }
 
                     if (supportsDebuggingAnnotation.LaunchConfigurationType is "project")
                     {

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -142,6 +142,12 @@ internal class ResourceSnapshotBuilder
                 projectPath = projectResource.GetProjectMetadata().ProjectPath;
                 launchProfileName = projectResource.GetEffectiveLaunchProfile()?.Name;
             }
+            else if (appModelResource.TryGetLastAnnotation<IProjectMetadata>(out var projectMetadata))
+            {
+                // New-style, annotation-based C# service (DotnetProjectResource)
+                projectPath = projectMetadata.ProjectPath;
+                launchProfileName = appModelResource.GetEffectiveLaunchProfile()?.Name;
+            }
         }
 
         var state = executable.AppModelInitialState is "Hidden" ? "Hidden" : executable.Status?.State;

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -172,6 +172,9 @@ internal sealed class ApplicationOrchestrator
         {
             case KnownResourceTypes.Project:
             case KnownResourceTypes.Executable:
+            // A Tool (e.g. DotnetToolResource) is realized as a DCP Executable and only differs from a plain
+            // executable in how the dashboard renders it, so it needs the same Starting-state transition and initial health reports.
+            case KnownResourceTypes.Tool:
                 await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
                 {
                     State = KnownResourceStates.Starting,

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3023,7 +3023,7 @@ public static class ResourceBuilderExtensions
 #pragma warning restore CS0618
     }
 
-    #pragma warning disable ASPIREPROCESSCOMMAND001 // Process command APIs are experimental.
+#pragma warning disable ASPIREPROCESSCOMMAND001 // Process command APIs are experimental.
 
     /// <summary>
     /// Adds a command to the resource that starts a local process when invoked.
@@ -3513,7 +3513,7 @@ public static class ResourceBuilderExtensions
             : CommandResults.Failure(message, resultData);
     }
 
-    #pragma warning restore ASPIREPROCESSCOMMAND001
+#pragma warning restore ASPIREPROCESSCOMMAND001
 
     /// <summary>
     /// Adds a command to the resource that when invoked sends an HTTP request to the specified endpoint and path.
@@ -4767,18 +4767,27 @@ public static class ResourceBuilderExtensions
             return builder;
         }
 
-        if (builder is IResourceBuilder<IResourceWithArgs> resourceWithArgs)
+        var supportsDebuggingAnnotation = SupportsDebuggingAnnotation.Create(
+            launchConfigurationType,
+            launchConfigurationProducer,
+            rewritesArgumentsForDebugging: argsCallback is not null && builder is IResourceBuilder<IResourceWithArgs>
+        );
+
+        if (argsCallback is not null && builder is IResourceBuilder<IResourceWithArgs> resourceWithArgs)
         {
-            resourceWithArgs.WithArgs(async ctx =>
+            resourceWithArgs.WithArgs(ctx =>
             {
-                if (resourceWithArgs.Resource.SupportsDebugging(builder.ApplicationBuilder.Configuration, out _) && argsCallback is not null)
+                // Make sure that we do not call the callback if we aren't the active (last) SupportsDebuggingAnnotation, 
+                // because the callback may be specific to the launch configuration type.
+                if (resourceWithArgs.Resource.SupportsDebugging(builder.ApplicationBuilder.Configuration, out var activeAnnotation)
+                    && ReferenceEquals(activeAnnotation, supportsDebuggingAnnotation))
                 {
                     argsCallback(ctx);
                 }
             });
         }
 
-        return builder.WithAnnotation(SupportsDebuggingAnnotation.Create(launchConfigurationType, launchConfigurationProducer));
+        return builder.WithAnnotation(supportsDebuggingAnnotation);
     }
 
     /// <summary>
@@ -5091,7 +5100,7 @@ public static class ResourceBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIREPIPELINES003", UrlFormat = "https://aka.ms/aspire/diagnostics#{0}")]
-[AspireExport]
+    [AspireExport]
     public static IResourceBuilder<T> WithImagePushOptions<T>(
         this IResourceBuilder<T> builder,
         Func<ContainerImagePushOptionsCallbackContext, Task> callback)

--- a/src/Aspire.Hosting/SupportsDebuggingAnnotation.cs
+++ b/src/Aspire.Hosting/SupportsDebuggingAnnotation.cs
@@ -14,20 +14,43 @@ namespace Aspire.Hosting.ApplicationModel;
 [Experimental("ASPIREEXTENSION001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 internal sealed class SupportsDebuggingAnnotation : IResourceAnnotation
 {
-    private SupportsDebuggingAnnotation(string launchConfigurationType, Action<Executable, string> launchConfigurationAnnotator)
+    private SupportsDebuggingAnnotation(string launchConfigurationType, Action<Executable, string> launchConfigurationAnnotator, bool rewritesArgumentsForDebugging)
     {
         LaunchConfigurationType = launchConfigurationType;
         LaunchConfigurationAnnotator = launchConfigurationAnnotator;
+        RewritesArgumentsForDebugging = rewritesArgumentsForDebugging;
     }
 
     public string LaunchConfigurationType { get; }
     public Action<Executable, string> LaunchConfigurationAnnotator { get; }
 
-    internal static SupportsDebuggingAnnotation Create<T>(string launchConfigurationType, Func<string, T> launchProfileProducer)
+    /// <summary>
+    /// Indicates that the debug support rewrites the resource's command-line arguments while a debug
+    /// session is active (via the <c>argsCallback</c> passed to <c>WithDebugSupport</c>).
+    /// </summary>
+    /// <remarks>
+    /// Integrations such as Go and Python strip the process entrypoint tokens 
+    /// (e.g. <c>go run &lt;pkg&gt;</c>, <c>python -m &lt;mod&gt;</c>)
+    /// so the IDE debugger can own them, which leaves the executable's <c>Spec.Args</c> valid 
+    /// only for IDE execution. When this is <see langword="true"/>, a Process fallback 
+    /// (either the DCP-level <c>FallbackExecutionTypes</c> or the in-process fallback when the launch configuration fails) 
+    /// would attempt to run <c>ExecutablePath + Args</c> with the entrypoint stripped — a broken command — 
+    /// so a process fallback must NOT be offered.
+    /// <para>
+    /// This is set based purely on the presence of an <c>argsCallback</c> in <c>WithDebugSupport</c>,
+    /// not on whether that callback actually rewrites anything for a given resource configuration. This is a
+    /// deliberate, conservative rule: a resource that supplies an args callback forgoes the process fallback
+    /// even when the callback happens to be a no-op (e.g. a Python "Executable" entrypoint), keeping the rule
+    /// simple and predictable.
+    /// </para>
+    /// </remarks>
+    public bool RewritesArgumentsForDebugging { get; }
+
+    internal static SupportsDebuggingAnnotation Create<T>(string launchConfigurationType, Func<string, T> launchProfileProducer, bool rewritesArgumentsForDebugging = false)
     {
         return new SupportsDebuggingAnnotation(launchConfigurationType, (exe, mode) =>
         {
             exe.AnnotateAsObjectList(Executable.LaunchConfigurationsAnnotation, launchProfileProducer(mode));
-        });
+        }, rewritesArgumentsForDebugging);
     }
 }

--- a/src/Aspire.Hosting/Utils/ExtensionUtils.cs
+++ b/src/Aspire.Hosting/Utils/ExtensionUtils.cs
@@ -20,7 +20,8 @@ internal static class ExtensionUtils
 
         if (!builder.TryGetLastAnnotation(out supportsDebuggingAnnotation)
             || string.IsNullOrEmpty(configuration[DcpExecutor.DebugSessionPortVar])
-            || builder.HasAnnotationOfType<ForceProcessExecutionAnnotation>())
+            || builder.HasAnnotationOfType<ForceProcessExecutionAnnotation>()
+            || builder.HasPersistentLifetime())
         {
             return false;
         }

--- a/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
@@ -3,8 +3,11 @@
 
 #pragma warning disable ASPIREDOTNETPROJECT001
 #pragma warning disable ASPIREEXTENSION001
+#pragma warning disable ASPIREPERSISTENCE001
 
+using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
@@ -134,5 +137,223 @@ public class DotnetProjectResourceTests(ITestOutputHelper outputHelper)
         var restartCommand = resource.Annotations.OfType<ResourceCommandAnnotation>().Single(a => a.Name == KnownResourceCommands.RestartCommand);
 
         Assert.Equal(CommandStrings.RestartProjectDescription, restartCommand.DisplayDescription);
+    }
+
+    [Fact]
+    public void AddDotnetProject_DebugAnnotator_ProducesProjectLaunchConfiguration()
+    {
+        // The "project" SupportsDebuggingAnnotation must produce a ProjectLaunchConfiguration carrying the
+        // project path so the IDE (and DCP) can launch/debug it exactly like AddProject.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var projectPath = Path.Combine(builder.AppHostDirectory, "MyService", "MyService.csproj");
+        var app = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true);
+
+        Assert.True(app.Resource.TryGetLastAnnotation<SupportsDebuggingAnnotation>(out var supportsDebugging));
+        Assert.Equal("project", supportsDebugging.LaunchConfigurationType);
+
+        var exe = Executable.Create("svc", "dotnet");
+        supportsDebugging.LaunchConfigurationAnnotator(exe, ExecutableLaunchMode.Debug);
+
+        Assert.True(exe.TryGetProjectLaunchConfiguration(out var launchConfig));
+        Assert.Equal("project", launchConfig.Type);
+        Assert.Equal(ExecutableLaunchMode.Debug, launchConfig.Mode);
+        Assert.Equal(projectPath, launchConfig.ProjectPath);
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_InDebugSession_OmitsDotnetRunScaffolding()
+    {
+        // When the active IDE advertises support for the "project" launch configuration, the IDE owns the
+        // launch (via project_path + launch profile). Emitting `dotnet run …` here would be handed to the IDE
+        // as the debugged program's invocation args, so only the user's own args should remain.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["project"]
+        });
+
+        var projectPath = Path.Combine(builder.AppHostDirectory, "MyService", "MyService.csproj");
+        var app = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true)
+                         .WithArgs("--config", "prod.yaml");
+
+        using var application = builder.Build();
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        Assert.Collection(args,
+            arg => Assert.Equal("--config", arg),
+            arg => Assert.Equal("prod.yaml", arg));
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_InDebugSession_KeepsDotnetRunArgs_WhenProjectLaunchUnsupported()
+    {
+        // When the IDE does NOT advertise "project" support, the resource runs as a plain process, so the full
+        // `dotnet run --project …` command must be preserved.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["python"]
+        });
+
+        var projectPath = Path.Combine(builder.AppHostDirectory, "MyService", "MyService.csproj");
+        var app = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true)
+                         .WithArgs("--config", "prod.yaml");
+
+        using var application = builder.Build();
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        // run --project <path> [--configuration <cfg>] --no-launch-profile --config prod.yaml
+        // (--configuration is only present when the app host assembly declares a build configuration)
+        Assert.Equal("run", args[0]);
+        Assert.Equal("--project", args[1]);
+        Assert.Equal(projectPath, args[2]);
+        Assert.Contains("--no-launch-profile", args);
+        Assert.Equal("--config", args[^2]);
+        Assert.Equal("prod.yaml", args[^1]);
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_InDebugSession_KeepsDotnetRunArgs_WhenActiveCustomDebugSupportOffersProcessFallback()
+    {
+        // SupportsDebugging() consults only the LAST SupportsDebuggingAnnotation. When a caller stacks a
+        // custom, non-"project" WithDebugSupport that does NOT rewrite args, ExecutableCreator offers a
+        // Process fallback built from Spec.Args. The `dotnet run …` scaffolding must therefore be preserved
+        // so that fallback launches the app instead of a bare `dotnet`.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["custom"]
+        });
+
+        var projectPath = Path.Combine(builder.AppHostDirectory, "MyService", "MyService.csproj");
+        var app = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true)
+                         .WithArgs("--config", "prod.yaml")
+                         .WithDebugSupport(_ => new ExecutableLaunchConfiguration("custom"), "custom");
+
+        using var application = builder.Build();
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        // run --project <path> [--configuration <cfg>] --no-launch-profile --config prod.yaml
+        Assert.Equal("run", args[0]);
+        Assert.Equal("--project", args[1]);
+        Assert.Equal(projectPath, args[2]);
+        Assert.Contains("--no-launch-profile", args);
+        Assert.Equal("--config", args[^2]);
+        Assert.Equal("prod.yaml", args[^1]);
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_InDebugSession_OmitsDotnetRunScaffolding_WhenActiveCustomDebugSupportRewritesArgs()
+    {
+        // A stacked custom WithDebugSupport with an argsCallback rewrites the arguments for debugging
+        // (RewritesArgumentsForDebugging == true), so no Process fallback is offered and that callback owns
+        // Spec.Args. The `dotnet run …` scaffolding must be omitted; re-emitting it would pollute the args
+        // the custom callback rewrites.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["custom"]
+        });
+
+        var projectPath = Path.Combine(builder.AppHostDirectory, "MyService", "MyService.csproj");
+        var app = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true)
+                         .WithArgs("--config", "prod.yaml")
+                         .WithDebugSupport(_ => new ExecutableLaunchConfiguration("custom"), "custom", ctx => ctx.Args.Add("rewritten-arg"));
+
+        using var application = builder.Build();
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        // Only the user args plus the custom callback's rewrite remain; no `dotnet run …` scaffolding.
+        Assert.Collection(args,
+            arg => Assert.Equal("--config", arg),
+            arg => Assert.Equal("prod.yaml", arg),
+            arg => Assert.Equal("rewritten-arg", arg));
+    }
+
+    [Theory]
+    [InlineData(PersistenceMode.Persistent)]
+    [InlineData(PersistenceMode.ParentProcess)]
+    [InlineData(PersistenceMode.Resource)]
+    public async Task AddDotnetProject_InDebugSession_EffectivePersistentLifetimeKeepsDotnetRunProjectArgs(PersistenceMode persistenceMode)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["project"]
+        });
+
+        var projectPath = Path.Combine(builder.AppHostDirectory, "MyService", "MyService.csproj");
+        var app = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true)
+                         .WithArgs("--config", "prod.yaml");
+
+        switch (persistenceMode)
+        {
+            case PersistenceMode.Persistent:
+                app.WithPersistentLifetime();
+                break;
+            case PersistenceMode.ParentProcess:
+                app.WithParentProcessLifetime(Environment.ProcessId);
+                break;
+            case PersistenceMode.Resource:
+                var source = builder.AddContainer("source", "image").WithPersistentLifetime();
+                app.WithLifetimeOf(source);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(persistenceMode), persistenceMode, null);
+        }
+
+        using var application = builder.Build();
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        Assert.Equal("run", args[0]);
+        Assert.Equal("--project", args[1]);
+        Assert.Equal(projectPath, args[2]);
+        Assert.Contains("--no-launch-profile", args);
+        Assert.Equal("--config", args[^2]);
+        Assert.Equal("prod.yaml", args[^1]);
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_FileBasedApp_InDebugSession_PersistentLifetimeKeepsDotnetRunFileArgs()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["project"]
+        });
+
+        var appPath = Path.Combine(builder.AppHostDirectory, "service.cs");
+        var app = builder.AddDotnetProject("svc", appPath, o => o.ExcludeLaunchProfile = true)
+                         .WithArgs("--flag")
+                         .WithPersistentLifetime();
+
+        using var application = builder.Build();
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        Assert.Equal("run", args[0]);
+        Assert.Equal("--file", args[1]);
+        Assert.Equal(appPath, args[2]);
+        Assert.Equal("--no-cache", args[3]);
+        Assert.Contains("--no-launch-profile", args);
+        Assert.Equal("--flag", args[^1]);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3224,6 +3224,82 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ProjectResource_WithArgumentRewritingDebugSupport_DoesNotOfferProcessFallback_InDebugSession()
+    {
+        // A ProjectResource can, via the generic WithDebugSupport(argsCallback: ...), rewrite its arguments
+        // for debugging (ProjectResource implements IResourceWithArgs). Those args are valid only for IDE
+        // launch, so DCP must NOT advertise a Process fallback that would later run a broken command. This
+        // mirrors the guard already applied to plain executables in PreparePlainExecutables.
+        var builder = DistributedApplication.CreateBuilder();
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+
+        // Replace the default "project" debug support with a custom launch type that also rewrites arguments.
+        var defaultAnnotation = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (defaultAnnotation is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(defaultAnnotation);
+        }
+
+        projectBuilder.WithDebugSupport(
+            mode => new ExecutableLaunchConfiguration("test") { Mode = mode },
+            "test",
+            argsCallback: _ => { /* rewrites arguments for debugging */ });
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var kubernetes = new TestKubernetesService();
+        var configBuilder = new ConfigurationBuilder();
+        configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["test"] })
+        });
+        var configuration = configBuilder.Build();
+
+        var executor = CreateAppExecutor(model, configuration: configuration, kubernetesService: kubernetes);
+
+        await executor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetes, "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.Null(exe.Spec.FallbackExecutionTypes);
+    }
+
+    [Fact]
+    public async Task ProjectResource_WithoutArgumentRewriting_OffersProcessFallback_InDebugSession()
+    {
+        // The common case: a default AddProject ("project" launch type, no argument rewriting) keeps the
+        // Process fallback so an IDE launch rejection can still start the project. Guards against the
+        // RewritesArgumentsForDebugging guard accidentally dropping the fallback for ordinary projects.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddProject<Projects.ServiceA>("proj", launchProfileName: null);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var kubernetes = new TestKubernetesService();
+        var configBuilder = new ConfigurationBuilder();
+        configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [KnownConfigNames.DashboardOtlpGrpcEndpointUrl] = "http://localhost",
+            ["AppHost:BrowserToken"] = "token",
+            ["AppHost:OtlpApiKey"] = "otlp-key",
+            [DcpExecutor.DebugSessionPortVar] = "12345"
+        });
+        var configuration = configBuilder.Build();
+
+        var executor = CreateAppExecutor(model, configuration: configuration, kubernetesService: kubernetes);
+
+        await executor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetes, "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.NotNull(exe.Spec.FallbackExecutionTypes);
+        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes));
+    }
+
+    [Fact]
     public async Task PersistentDcpResourcesDoNotIncludeMonitorProcessByDefault()
     {
         var builder = DistributedApplication.CreateBuilder();

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3173,6 +3173,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         var debuggableExe = Assert.Single(dcpExes, e => e.AppModelResourceName == "TestExecutable");
         Assert.Equal(ExecutionType.IDE, debuggableExe.Spec.ExecutionType);
+        // A non-"project" debuggable executable runs its own ExecutablePath + Spec.Args directly, so DCP can
+        // fall back to Process execution when the IDE can't launch it. (A "project" launch, by contrast, gets no
+        // Process fallback because DCP cannot reconstruct `dotnet run` from the launch config's project_path.)
+        Assert.NotNull(debuggableExe.Spec.FallbackExecutionTypes);
+        Assert.Equal(ExecutionType.Process, Assert.Single(debuggableExe.Spec.FallbackExecutionTypes));
         Assert.True(debuggableExe.TryGetAnnotationAsObjectList<ExecutableLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs1));
         var config1 = Assert.Single(launchConfigs1);
         Assert.Equal(ExecutableLaunchMode.Debug, config1.Mode);
@@ -4942,6 +4947,377 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes));
     }
 
+    [Fact]
+    public async Task DotnetProjectExecutable_InDebugSession_GetsIdeExecutionWithProjectLaunchConfig()
+    {
+        // A plain ExecutableResource that carries IProjectMetadata + a "project" SupportsDebuggingAnnotation
+        // (e.g. DotnetProjectResource, which launches `dotnet run --project`) must be launched/debugged like
+        // AddProject: IDE execution with a ProjectLaunchConfiguration (project_path + launch profile) so F5 works.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var resource = new TestDotnetProjectExecutableResource("test-working-directory");
+        builder.AddResource(resource)
+            .WithAnnotation(new TestProjectWithLaunchSettings())
+            .WithAnnotation(new LaunchProfileAnnotation("http"))
+            .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = "TestProjectWithLaunchSettings", Mode = mode }, "project");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["project"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetesService, "TestDotnetProject");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        // A "project" launch must NOT advertise a Process fallback: DCP's process runner executes
+        // Spec.ExecutablePath + Spec.Args and cannot reconstruct `dotnet run --project <path>` from the launch
+        // config's project_path, so a fallback would only run a bare `dotnet` and fail. IDEs that cannot launch
+        // the resource fail fast instead of silently mis-launching.
+        Assert.Null(exe.Spec.FallbackExecutionTypes);
+
+        Assert.True(exe.TryGetProjectLaunchConfiguration(out var plc));
+        Assert.Equal("TestProjectWithLaunchSettings", plc.ProjectPath);
+        Assert.Equal("http", plc.LaunchProfile);
+        Assert.Equal(ExecutableLaunchMode.NoDebug, plc.Mode);
+    }
+
+    [Fact]
+    public void GetResourceType_DcpExecutable_DelegatesToAppModelClassifier()
+    {
+        // Regression guard for the DCP resource-type classifier. A DotnetProjectResource is an ExecutableResource
+        // that carries IProjectMetadata, so DCP realizes it as an Executable (not a Container). The dashboard
+        // snapshot classifies it as "Project" (via ResourceExtensions.GetResourceType); DcpExecutor.GetResourceType
+        // must agree, otherwise the same resource reports "Executable" in DCP create/start/watch events and
+        // profiling telemetry while showing "Project" everywhere else. A plain ExecutableResource must still
+        // classify as "Executable".
+        var dcpExecutable = Executable.Create("test-exe", "dotnet");
+
+        var dotnetProject = new TestDotnetProjectExecutableResource("test-working-directory");
+        dotnetProject.Annotations.Add(new TestProjectWithLaunchSettings());
+        Assert.Equal(KnownResourceTypes.Project, DcpExecutor.GetResourceType(dcpExecutable, dotnetProject));
+
+        var plainExecutable = new TestExecutableResource("test-working-directory");
+        Assert.Equal(KnownResourceTypes.Executable, DcpExecutor.GetResourceType(dcpExecutable, plainExecutable));
+
+        // A DotnetToolResource is also realized as a DCP Executable but the app-model classifier reports "Tool"
+        // so the dashboard can render it distinctly. ApplicationOrchestrator.OnResourceStarting handles "Tool" like an
+        // executable so the resource still transitions to the Starting state.
+#pragma warning disable ASPIREDOTNETTOOL // DotnetToolResource is experimental.
+        var dotnetTool = new DotnetToolResource("test-tool", "SomePackage.Id");
+#pragma warning restore ASPIREDOTNETTOOL
+        Assert.Equal(KnownResourceTypes.Tool, DcpExecutor.GetResourceType(dcpExecutable, dotnetTool));
+    }
+
+    [Fact]
+    public async Task DotnetProjectExecutable_ProjectLaunchUnsupported_RunsInProcess()
+    {
+        // When the IDE does not advertise "project" support, the resource should run as a plain process with
+        // no ProjectLaunchConfiguration applied.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var resource = new TestDotnetProjectExecutableResource("test-working-directory");
+        builder.AddResource(resource)
+            .WithAnnotation(new TestProjectWithLaunchSettings())
+            .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = "TestProjectWithLaunchSettings", Mode = mode }, "project");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["python"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetesService, "TestDotnetProject");
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+        Assert.False(exe.TryGetProjectLaunchConfiguration(out _));
+    }
+
+    [Fact]
+    public async Task DotnetProjectExecutable_PersistentLifetime_InDebugSession_RunsInProcessWithoutProjectLaunchConfig()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var resource = new TestDotnetProjectExecutableResource("test-working-directory");
+        builder.AddResource(resource)
+            .WithAnnotation(new TestProjectWithLaunchSettings())
+            .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = "TestProjectWithLaunchSettings", Mode = mode }, "project")
+            .WithPersistentLifetime();
+
+        var configDict = new Dictionary<string, string?>
+        {
+            ["AppHost:Sha256"] = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["project"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetesService, "TestDotnetProject");
+        Assert.True(exe.Spec.Persistent);
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+        Assert.False(exe.TryGetProjectLaunchConfiguration(out _));
+    }
+
+    [Fact]
+    public async Task DotnetProjectExecutable_ProjectLaunchConfigurationFailure_FailsWithoutProcessFallback()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var resource = new TestDotnetProjectExecutableResource("test-working-directory");
+        builder.AddResource(resource)
+            .WithAnnotation(new TestProjectWithLaunchSettings())
+            .WithDebugSupport(CreateProjectLaunchConfiguration, "project");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["project"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var resourceLoggerService = new ResourceLoggerService();
+        var failedResources = new List<IResource>();
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceFailedToStartContext>(context =>
+        {
+            failedResources.Add(context.Resource);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            kubernetesService: kubernetesService,
+            configuration: configuration,
+            resourceLoggerService: resourceLoggerService,
+            events: events);
+
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Empty(kubernetesService.CreatedResources.OfType<Executable>());
+        Assert.Same(resource, Assert.Single(failedResources));
+
+        var logLines = new List<LogLine>();
+        await foreach (var lines in resourceLoggerService.GetAllAsync(resource).DefaultTimeout())
+        {
+            logLines.AddRange(lines);
+        }
+
+        Assert.Contains(logLines, line => line.Content.Contains("Project launch configuration failed.", StringComparison.Ordinal));
+
+        static ProjectLaunchConfiguration CreateProjectLaunchConfiguration(string mode)
+        {
+            throw new InvalidOperationException("Project launch configuration failed.");
+        }
+    }
+
+    [Fact]
+    public async Task PlainExecutable_ExtensionMode_ArgsRewritingDebugSupport_OmitsProcessFallback()
+    {
+        // A non-"project" debuggable executable whose WithDebugSupport supplies an argsCallback (e.g. Go/Python,
+        // which strip the process entrypoint so the IDE debugger owns it) is left with Spec.Args holding only the
+        // application arguments. A Process fallback would then run `ExecutablePath <app-args>` — the wrong command —
+        // so no Process fallback must be advertised for it.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var debuggableExecutable = new TestExecutableResource("test-working-directory");
+        builder.AddResource(debuggableExecutable)
+            .WithArgs("run", "app-arg")
+            .WithDebugSupport(
+                mode => new ExecutableLaunchConfiguration("test") { Mode = mode },
+                "test",
+                argsCallback: static ctx =>
+                {
+                    // Mimic Go/Python stripping the process entrypoint token, leaving only the application args.
+                    if (ctx.Args.Count > 0)
+                    {
+                        ctx.Args.RemoveAt(0);
+                    }
+                });
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["test"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234",
+            [KnownConfigNames.DebugSessionRunMode] = "Debug"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetesService, "TestExecutable");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        // Because the debug support registered an argsCallback (RewritesArgumentsForDebugging), Spec.Args can be
+        // rewritten to an IDE-only shape, so no Process fallback is advertised even though the launch type is not
+        // "project".
+        Assert.Null(exe.Spec.FallbackExecutionTypes);
+    }
+
+    [Fact]
+    public async Task PlainExecutable_ExtensionMode_ArgsRewritingDebugSupport_LaunchConfigFailure_FailsWithoutProcessFallback()
+    {
+        // When the launch configuration producer throws for an args-rewriting debug resource, Spec.Args has already
+        // had its entrypoint stripped for the IDE, so a Process fallback would launch a broken command. The failure
+        // must propagate (the resource fails to start) instead of silently falling back to Process execution.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var resource = new TestExecutableResource("test-working-directory");
+        builder.AddResource(resource)
+            .WithArgs("run", "app-arg")
+            .WithDebugSupport(
+                ThrowingLaunchConfiguration,
+                "test",
+                argsCallback: static ctx =>
+                {
+                    if (ctx.Args.Count > 0)
+                    {
+                        ctx.Args.RemoveAt(0);
+                    }
+                });
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["test"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        var failedResources = new List<IResource>();
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceFailedToStartContext>(context =>
+        {
+            failedResources.Add(context.Resource);
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration, events: events);
+
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Empty(kubernetesService.CreatedResources.OfType<Executable>());
+        Assert.Same(resource, Assert.Single(failedResources));
+
+        static ExecutableLaunchConfiguration ThrowingLaunchConfiguration(string mode)
+        {
+            throw new InvalidOperationException("Launch configuration failed.");
+        }
+    }
+
+    [Fact]
+    public async Task PlainExecutable_ProjectDebugSupportWithoutProjectMetadata_FailsToStart()
+    {
+        // "project" is a reserved launch configuration type for .NET project resources: it needs IProjectMetadata
+        // to build the launch configuration and gets no Process fallback. A plain executable that declares
+        // "project" debug support without project metadata can neither be launched by the IDE (no launch config is
+        // applied) nor fall back to Process, so it must fail fast with an actionable message instead of silently
+        // getting stuck.
+        var builder = DistributedApplication.CreateBuilder();
+
+        var resource = new TestExecutableResource("test-working-directory");
+        builder.AddResource(resource)
+            .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = "/test/path", Mode = mode }, "project");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["project"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        var failedResources = new List<(IResource Resource, string? ErrorMessage)>();
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceFailedToStartContext>(context =>
+        {
+            failedResources.Add((context.Resource, context.ErrorMessage));
+            return Task.CompletedTask;
+        });
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration, events: events);
+
+        await appExecutor.RunApplicationAsync();
+
+        Assert.Empty(kubernetesService.CreatedResources.OfType<Executable>());
+        var failure = Assert.Single(failedResources);
+        Assert.Same(resource, failure.Resource);
+        Assert.NotNull(failure.ErrorMessage);
+        Assert.Contains("project metadata", failure.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData(ExecutableLaunchMode.Debug, ExecutableLaunchMode.Debug)]
+    [InlineData(ExecutableLaunchMode.NoDebug, ExecutableLaunchMode.NoDebug)]
+    public async Task DotnetProjectExecutable_RespectsDebugSessionRunMode(string runMode, string expectedMode)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var resource = new TestDotnetProjectExecutableResource("test-working-directory");
+        builder.AddResource(resource)
+            .WithAnnotation(new TestProjectWithLaunchSettings())
+            .WithAnnotation(new LaunchProfileAnnotation("http"))
+            .WithDebugSupport(mode => new ProjectLaunchConfiguration { ProjectPath = "TestProjectWithLaunchSettings", Mode = mode }, "project");
+
+        var configDict = new Dictionary<string, string?>
+        {
+            [DcpExecutor.DebugSessionPortVar] = "12345",
+            [KnownConfigNames.DebugSessionRunMode] = runMode,
+            [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["test"], SupportedLaunchConfigurations = ["project"] }),
+            [KnownConfigNames.ExtensionEndpoint] = "http://localhost:1234"
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetesService, "TestDotnetProject");
+        Assert.True(exe.TryGetProjectLaunchConfiguration(out var plc));
+        Assert.Equal(expectedMode, plc.Mode);
+    }
+
     [Theory]
     [InlineData(true, null, "aspire.dev.internal")]
     [InlineData(false, null, "host.docker.internal")]
@@ -6373,6 +6749,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
     private sealed class TestExecutableResource(string directory) : ExecutableResource("TestExecutable", "test", directory);
     private sealed class TestOtherExecutableResource(string directory) : ExecutableResource("TestOtherExecutable", "test-other", directory);
+
+    // Models a DotnetProjectResource: a plain ExecutableResource (launches `dotnet`) that carries
+    // IProjectMetadata and a "project" SupportsDebuggingAnnotation. Used to verify the DCP project-launch
+    // generalization without taking a dependency on Aspire.Hosting.Dotnet.
+    private sealed class TestDotnetProjectExecutableResource(string directory) : ExecutableResource("TestDotnetProject", "dotnet", directory);
 
     private sealed class TestHostEnvironment : IHostEnvironment
     {

--- a/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ResourceSnapshotBuilderTests.cs
@@ -85,6 +85,38 @@ public class ResourceSnapshotBuilderTests
     }
 
     [Fact]
+    public void ExecutableWithProjectMetadataSnapshotAddsProjectPropertiesAndPreservesCustomResourceType()
+    {
+        // A plain ExecutableResource that carries IProjectMetadata (e.g. DotnetProjectResource, an
+        // ExecutableResource launched via `dotnet run --project`) should render like a project in the
+        // dashboard — with the project path + launch profile — for parity with AddProject.
+        var resource = new TestDotnetProjectResource("proj");
+        resource.Annotations.Add(new TestProjectMetadata());
+        resource.Annotations.Add(new LaunchProfileAnnotation("https"));
+
+        var executable = Executable.Create("proj", "dotnet");
+        executable.Annotate(DcpCustomResource.ResourceNameAnnotation, resource.Name);
+        executable.Spec.WorkingDirectory = "/app";
+        executable.Status = new ExecutableStatus
+        {
+            EffectiveArgs = ["run"],
+            ProcessId = 1234
+        };
+
+        var snapshotBuilder = CreateSnapshotBuilder(new Dictionary<string, IResource>
+        {
+            [resource.Name] = resource
+        });
+        var projectSnapshot = snapshotBuilder.ToSnapshot(executable, CreatePreviousSnapshot(KnownResourceTypes.Project));
+
+        AssertHighlightedProperty(projectSnapshot, KnownProperties.Project.Path, "Project path", isSensitive: false, sortOrder: 0);
+        AssertHighlightedProperty(projectSnapshot, KnownProperties.Project.LaunchProfile, "Launch profile", isSensitive: false, sortOrder: 1);
+
+        var customSnapshot = snapshotBuilder.ToSnapshot(executable, CreatePreviousSnapshot("custom-type"));
+        Assert.Equal("custom-type", customSnapshot.ResourceType);
+    }
+
+    [Fact]
     public void ExecutableSnapshotPreservesLaunchArgumentSensitivityWhenUsingEffectiveArgs()
     {
         var executable = CreateExecutable(
@@ -195,11 +227,11 @@ public class ResourceSnapshotBuilderTests
         return new(new DcpResourceState(applicationModel ?? new Dictionary<string, IResource>(), []));
     }
 
-    private static CustomResourceSnapshot CreatePreviousSnapshot()
+    private static CustomResourceSnapshot CreatePreviousSnapshot(string resourceType = "resource")
     {
         return new()
         {
-            ResourceType = "resource",
+            ResourceType = resourceType,
             Properties = []
         };
     }
@@ -248,4 +280,6 @@ public class ResourceSnapshotBuilderTests
             }
         };
     }
+
+    private sealed class TestDotnetProjectResource(string name) : ExecutableResource(name, "dotnet", "/app");
 }

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceBuilderExtensionTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceBuilderExtensionTests.cs
@@ -5,7 +5,9 @@
 #pragma warning disable ASPIREPERSISTENCE001 // Resource lifetime APIs are experimental.
 #pragma warning disable IDE0005 // Using directive is unnecessary.
 
+using System.Text.Json;
 using Aspire.Hosting.Dcp.Model;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Tests;
@@ -113,4 +115,103 @@ public class ExecutableResourceBuilderExtensionTests
         var annotation = executable.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().SingleOrDefault();
         Assert.Null(annotation);
     }
+
+    [Fact]
+    public async Task WithDebugSupportArgsCallbackRunsWhenItsAnnotationIsActive()
+    {
+        // A single WithDebugSupport call whose annotation is active (last) must run its
+        // argument-rewriting callback. This verifies the normal single-integration path
+        // independently of the multiple-annotation behavior below.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["go"]
+        });
+
+        var executable = builder.AddExecutable("myexe", "command", "workingdirectory")
+            .WithArgs("base-arg")
+            .WithDebugSupport(_ => new ExecutableLaunchConfiguration("go"), "go", ctx => ctx.Args.Add("rewritten-arg"));
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(executable.Resource);
+
+        Assert.Collection(args,
+            arg => Assert.Equal("base-arg", arg),
+            arg => Assert.Equal("rewritten-arg", arg));
+    }
+
+    [Fact]
+    public async Task WithDebugSupportArgsCallbackDoesNotRunWhenLaterDebugSupportSupersedesIt()
+    {
+        // WithDebugSupport is append-only and SupportsDebugging() only consults the LAST
+        // SupportsDebuggingAnnotation. A resource can gain debug support from more than one caller: e.g. a
+        // Go/Python integration that rewrites the entrypoint args (rewritesArgumentsForDebugging: true),
+        // followed by a second WithDebugSupport that does not. Once the later annotation supersedes the
+        // first, the first call's arg-rewriting callback must NOT fire; otherwise it would strip/append
+        // args while the active annotation reports RewritesArgumentsForDebugging == false and
+        // ExecutableCreator would offer a Process fallback built from the mangled arguments.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["go", "project"]
+        });
+
+        var executable = builder.AddExecutable("myexe", "command", "workingdirectory")
+            .WithArgs("base-arg")
+            .WithDebugSupport(_ => new ExecutableLaunchConfiguration("go"), "go", ctx => ctx.Args.Add("rewritten-arg"))
+            .WithDebugSupport(_ => new ExecutableLaunchConfiguration("project"), "project");
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(executable.Resource);
+
+        Assert.Collection(args,
+            arg => Assert.Equal("base-arg", arg));
+    }
+
+    [Fact]
+    public void WithDebugSupportReportsRewritesArgumentsWhenResourceSupportsArgs()
+    {
+        // A resource that carries command-line arguments (IResourceWithArgs) actually gets the
+        // arg-rewriting callback attached, so the annotation must advertise that it rewrites args.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var executable = builder.AddExecutable("myexe", "command", "workingdirectory")
+            .WithDebugSupport(_ => new ExecutableLaunchConfiguration("go"), "go", ctx => ctx.Args.Add("rewritten-arg"));
+
+        var annotation = executable.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().Single();
+        Assert.True(annotation.RewritesArgumentsForDebugging);
+    }
+
+    [Fact]
+    public void WithDebugSupportDoesNotReportRewritesArgumentsWhenResourceHasNoArgs()
+    {
+        // If a caller supplies an argsCallback for a resource that is not IResourceWithArgs, the callback
+        // is never registered and the arguments are left unchanged. The annotation must therefore report
+        // RewritesArgumentsForDebugging == false so ExecutableCreator still offers the Process fallbacks.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var resource = builder.AddResource(new DebuggableResourceWithoutArgs("noargs"))
+            .WithDebugSupport(_ => new ExecutableLaunchConfiguration("go"), "go", ctx => ctx.Args.Add("rewritten-arg"));
+
+        var annotation = resource.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().Single();
+        Assert.False(annotation.RewritesArgumentsForDebugging);
+    }
+
+    [Fact]
+    public void WithDebugSupportDoesNotReportRewritesArgumentsWhenNoArgsCallbackProvided()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+
+        var executable = builder.AddExecutable("myexe", "command", "workingdirectory")
+            .WithDebugSupport(_ => new ExecutableLaunchConfiguration("go"), "go");
+
+        var annotation = executable.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().Single();
+        Assert.False(annotation.RewritesArgumentsForDebugging);
+    }
+
+    private sealed class DebuggableResourceWithoutArgs(string name) : Resource(name);
 }

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -549,6 +549,29 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         Assert.Null(snapshotEvent.Snapshot.State?.Style);
     }
 
+    [Fact]
+    public async Task OnResourceStarting_ToolResourceType_TransitionsToStarting()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var resource = builder.AddResource(new CustomResource("tool"));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourceStartingContext(CancellationToken.None, KnownResourceTypes.Tool, resource.Resource, "tool-dcp"));
+
+        Assert.True(resourceNotificationService.TryGetCurrentState("tool-dcp", out var snapshotEvent));
+        Assert.Equal(KnownResourceStates.Starting, snapshotEvent.Snapshot.State?.Text);
+    }
+
     private ApplicationOrchestrator CreateOrchestrator(
         DistributedApplicationModel distributedAppModel,
         ResourceNotificationService notificationService,

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREPIPELINES003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
+using Aspire.Dashboard.Model;
 using Aspire.Hosting.Ats;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -13,6 +14,26 @@ namespace Aspire.Hosting.Tests;
 [Trait("Partition", "2")]
 public class ResourceExtensionsTests
 {
+    [Fact]
+    public void GetResourceTypeReturnsProjectForExecutableResourceWithProjectMetadata()
+    {
+        // An annotation-based project (e.g. DotnetProjectResource) derives from ExecutableResource but
+        // carries IProjectMetadata, so it must be classified as a project. This is what seeds the initial
+        // CustomResourceSnapshot.ResourceType with "Project" instead of "Executable".
+        var resource = new ExecutableResource("proj", "dotnet", "/app");
+        resource.Annotations.Add(new TestProjectMetadata());
+
+        Assert.Equal(KnownResourceTypes.Project, resource.GetResourceType());
+    }
+
+    [Fact]
+    public void GetResourceTypeReturnsExecutableForExecutableResourceWithoutProjectMetadata()
+    {
+        var resource = new ExecutableResource("exe", "dotnet", "/app");
+
+        Assert.Equal(KnownResourceTypes.Executable, resource.GetResourceType());
+    }
+
     [Fact]
     public void TryGetAnnotationsOfTypeReturnsFalseWhenNoAnnotations()
     {
@@ -568,6 +589,11 @@ public class ResourceExtensionsTests
     private sealed class AnotherDummyAnnotation : IResourceAnnotation
     {
 
+    }
+
+    private sealed class TestProjectMetadata : IProjectMetadata
+    {
+        public string ProjectPath => "/app/project.csproj";
     }
 
     private sealed class TestContainerFilesResource(string name) : ContainerResource(name), IResourceWithContainerFiles


### PR DESCRIPTION
## Description

With this change applications using the experimental DotnetProjectResource can be debugged.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
