### PR TITLE
Add WithUniqueResourceNaming to opt into collision-free managed environment names

### DIFF
--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -228,6 +228,8 @@ public class AzureContainerAppEnvironmentResource :
 
     internal bool UseCompactResourceNaming { get; set; }
 
+    internal bool UseSingletonResourceNaming { get; set; }
+
     /// <summary>
     /// Gets or sets a value indicating whether the Aspire dashboard should be included in the container app environment.
     /// Default is true.

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -51,7 +51,12 @@ public class AzureContainerAppEnvironmentResource :
                 Name = $"prepare-azure-container-apps-{name}",
                 Description = $"Prepares Azure Container Apps deployment targets for {name}.",
                 Action = ctx => PrepareDeploymentTargetsAsync(ctx),
-                DependsOnSteps = [AzureEnvironmentResource.PrepareResourcesStepName, WellKnownPipelineSteps.ValidateComputeEnvironments],
+                DependsOnSteps =
+                [
+                    AzureEnvironmentResource.PrepareResourcesStepName,
+                    WellKnownPipelineSteps.ValidateComputeEnvironments,
+                    AzureContainerAppExtensions.ValidateContainerAppsStepName
+                ],
                 RequiredBySteps = [WellKnownPipelineSteps.BeforeStart]
             };
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -228,7 +228,7 @@ public class AzureContainerAppEnvironmentResource :
 
     internal bool UseCompactResourceNaming { get; set; }
 
-    internal bool UseSingletonResourceNaming { get; set; }
+    internal bool UseUniqueResourceNaming { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the Aspire dashboard should be included in the container app environment.

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs
@@ -48,14 +48,13 @@ public class AzureContainerAppEnvironmentResource :
             // BeforeStartEvent subscribers (and downstream code) can observe the deployment targets.
             var prepareStep = new PipelineStep
             {
-                Name = $"prepare-azure-container-apps-{name}",
+                Name = $"{AzureContainerAppExtensions.PrepareContainerAppsStepNamePrefix}{name}",
                 Description = $"Prepares Azure Container Apps deployment targets for {name}.",
                 Action = ctx => PrepareDeploymentTargetsAsync(ctx),
                 DependsOnSteps =
                 [
                     AzureEnvironmentResource.PrepareResourcesStepName,
-                    WellKnownPipelineSteps.ValidateComputeEnvironments,
-                    AzureContainerAppExtensions.ValidateContainerAppsStepName
+                    WellKnownPipelineSteps.ValidateComputeEnvironments
                 ],
                 RequiredBySteps = [WellKnownPipelineSteps.BeforeStart]
             };

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -73,7 +73,10 @@ public static class AzureContainerAppExtensions
                         return Task.CompletedTask;
                     }
 
-                    var environments = ctx.Model.Resources.OfType<AzureContainerAppEnvironmentResource>().ToList();
+                    var environments = ctx.Model.Resources
+                        .OfType<AzureContainerAppEnvironmentResource>()
+                        .Where(environment => !environment.IsExcludedFromPublish())
+                        .ToList();
                     if (environments.Count == 0)
                     {
                         foreach (var r in ctx.Model.GetComputeResources())
@@ -94,7 +97,8 @@ public static class AzureContainerAppExtensions
                             _ = environment.GetBicepTemplateString();
                         }
 
-                        marker.ValidateManagedEnvironmentNames();
+                        marker.ValidateManagedEnvironmentNames(
+                            environments.Select(environment => environment.Name).ToHashSet(StringComparer.Ordinal));
                     }
 
                     return Task.CompletedTask;
@@ -154,15 +158,17 @@ public static class AzureContainerAppExtensions
             }
         }
 
-        public void ValidateManagedEnvironmentNames()
+        public void ValidateManagedEnvironmentNames(IReadOnlySet<string> includedEnvironmentNames)
         {
             (string Expression, KeyValuePair<string, ManagedEnvironmentNamingMode>[] Environments)[] collisions;
 
             lock (_lock)
             {
                 collisions = _environmentsByManagedEnvironmentName
-                    .Where(pair => pair.Value.Count > 1)
-                    .Select(pair => (pair.Key, pair.Value.ToArray()))
+                    .Select(pair => (
+                        Expression: pair.Key,
+                        Environments: pair.Value.Where(environment => includedEnvironmentNames.Contains(environment.Key)).ToArray()))
+                    .Where(pair => pair.Environments.Length > 1)
                     .ToArray();
             }
 
@@ -507,10 +513,13 @@ public static class AzureContainerAppExtensions
                 laWorkspace.Name = BicepFunction.Interpolate($"law-{resourceToken}");
                 var managedEnvironmentName = BicepFunction.Interpolate($"cae-{resourceToken}");
                 containerAppEnvironment.Name = managedEnvironmentName;
-                marker.RecordManagedEnvironmentName(
-                    appEnvResource.Name,
-                    managedEnvironmentName,
-                    ManagedEnvironmentNamingMode.Azd);
+                if (!appEnvResource.IsExcludedFromPublish())
+                {
+                    marker.RecordManagedEnvironmentName(
+                        appEnvResource.Name,
+                        managedEnvironmentName,
+                        ManagedEnvironmentNamingMode.Azd);
+                }
 
 #pragma warning disable IDE0031 // Use null propagation (IDE0031)
                 if (storageVolume is not null)
@@ -552,7 +561,7 @@ public static class AzureContainerAppExtensions
             // them, so the digit-preserving name is opt-in via WithUniqueResourceNaming(). The fallback resolver
             // also records the actual generated expression so publish can reject colliding legacy names with
             // actionable guidance instead of allowing a broken deployment.
-            if (!appEnvResource.UseAzdNamingConvention)
+            if (!appEnvResource.UseAzdNamingConvention && !appEnvResource.IsExcludedFromPublish())
             {
                 AddManagedEnvironmentNameResolver(appEnvResource, containerAppEnvironment, marker);
             }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -410,6 +410,25 @@ public static class AzureContainerAppExtensions
                 }
             }
 
+            // When not using azd naming, the managed environment name would otherwise be left to
+            // Azure.Provisioning's default. That default only permits lowercase letters
+            // (ContainerAppManagedEnvironment inherits ResourceNameRequirements(1, 24,
+            // ResourceNameCharacters.LowercaseLetters)), so digits are stripped from the bicep
+            // identifier: environments named e.g. "cae1"/"cae2" in the same resource group both
+            // resolve to take('cae${uniqueString(resourceGroup().id)}', 24) and collapse onto a
+            // single physical environment, where concurrent container-app writes race with
+            // ManagedEnvironmentOperationInProgress. Set the name explicitly, preserving digits,
+            // so multiple environments in one resource group get distinct names. Opt out with
+            // WithSingletonResourceNaming() to keep the pre-fix name for already-deployed environments.
+            // See https://github.com/microsoft/aspire/issues/18722.
+            if (!appEnvResource.UseAzdNamingConvention && !appEnvResource.UseSingletonResourceNaming)
+            {
+                containerAppEnvironment.Name = BicepFunction.Take(
+                    BicepFunction.Interpolate(
+                        $"{GetManagedEnvironmentNamePrefix(appEnvResource)}{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"),
+                    24);
+            }
+
             // Exposed so that callers reference the LA workspace in other bicep modules
             infra.Add(new ProvisioningOutput("AZURE_LOG_ANALYTICS_WORKSPACE_NAME", typeof(string))
             {
@@ -437,6 +456,23 @@ public static class AzureContainerAppExtensions
             : builder.AddResource(containerAppEnvResource);
 
         return appEnvBuilder;
+    }
+
+    /// <summary>
+    /// Builds the prefix used for the managed environment's <c>name</c> in the default (non-azd) naming path.
+    /// </summary>
+    /// <remarks>
+    /// Azure.Provisioning's default name for a managed environment is
+    /// <c>take('{sanitizedBicepIdentifier}{uniqueString(resourceGroup().id)}', 24)</c>, but its sanitizer only
+    /// keeps lowercase letters (<c>ResourceNameCharacters.LowercaseLetters</c>),
+    /// which drops digits and causes environments named e.g. <c>cae1</c>/<c>cae2</c> to collapse to the same
+    /// <c>cae…</c> name in a shared resource group. We reproduce that prefix but keep digits (managed environment
+    /// names permit lowercase alphanumerics), so distinct resource names produce distinct environment names.
+    /// </remarks>
+    private static string GetManagedEnvironmentNamePrefix(AzureContainerAppEnvironmentResource appEnvResource)
+    {
+        var identifier = appEnvResource.GetBicepIdentifier();
+        return new string(identifier.ToLowerInvariant().Where(char.IsLetterOrDigit).ToArray());
     }
 
     /// <summary>
@@ -647,6 +683,39 @@ public static class AzureContainerAppExtensions
     public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithCompactResourceNaming(this IResourceBuilder<AzureContainerAppEnvironmentResource> builder)
     {
         builder.Resource.UseCompactResourceNaming = true;
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the container app environment to use the managed environment name that Aspire generated
+    /// before resource names were incorporated into the name calculation. This naming is appropriate when a
+    /// single container app environment is deployed to a resource group.
+    /// </summary>
+    /// <param name="builder">The <see cref="AzureContainerAppEnvironmentResource"/> to configure.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// By default, the managed environment's <c>name</c> now incorporates the resource name so that multiple
+    /// <see cref="AddAzureContainerAppEnvironment"/> resources in the same resource group produce distinct
+    /// environment names (see <see href="https://github.com/microsoft/aspire/issues/18722"/>).
+    /// </para>
+    /// <para>
+    /// The previous behavior relied on Azure.Provisioning's default name, whose sanitizer keeps only lowercase
+    /// letters — dropping any trailing digit and yielding <c>take('cae{uniqueString(resourceGroup().id)}', 24)</c>
+    /// regardless of the resource name. Applications that deployed a single environment before this change should
+    /// call this method to keep their already-deployed environment name and avoid Azure recreating the environment
+    /// on the next deployment.
+    /// </para>
+    /// <para>
+    /// This option has no effect when <see cref="WithAzdResourceNaming"/> is also used, since azd naming sets the
+    /// environment name explicitly.
+    /// </para>
+    /// </remarks>
+    [AspireExport]
+    [Experimental("ASPIREACANAMING001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithSingletonResourceNaming(this IResourceBuilder<AzureContainerAppEnvironmentResource> builder)
+    {
+        builder.Resource.UseSingletonResourceNaming = true;
         return builder;
     }
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -421,6 +421,13 @@ public static class AzureContainerAppExtensions
             // so multiple environments in one resource group get distinct names. Opt out with
             // WithSingletonResourceNaming() to keep the pre-fix name for already-deployed environments.
             // See https://github.com/microsoft/aspire/issues/18722.
+            //
+            // Note: uniqueString(resourceGroup().id) is identical for every environment in the same
+            // resource group, so the ONLY differentiator between environments is the name prefix. Because
+            // the whole value is truncated to 24 chars (the managed environment name limit), two
+            // environments whose sanitized names match in their first 24 characters would still collide.
+            // That is a narrow edge case (long, similar names), but it's the same truncation-collision
+            // class already seen for storage account names in #14427.
             if (!appEnvResource.UseAzdNamingConvention && !appEnvResource.UseSingletonResourceNaming)
             {
                 containerAppEnvironment.Name = BicepFunction.Take(

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -467,7 +467,7 @@ public static class AzureContainerAppExtensions
     /// </remarks>
     private static void AddManagedEnvironmentNameFallbackResolver(AzureContainerAppEnvironmentResource appEnvResource)
     {
-        var options = appEnvResource.ProvisioningBuildOptions ??= new ProvisioningBuildOptions();
+        var options = appEnvResource.ProvisioningBuildOptions ?? new ProvisioningBuildOptions();
         var bicepIdentifier = appEnvResource.GetBicepIdentifier();
 
         if (options.InfrastructureResolvers.OfType<ManagedEnvironmentNameResolver>()
@@ -475,6 +475,13 @@ public static class AzureContainerAppExtensions
         {
             return;
         }
+
+        // AzureResourcePreparer assigns the same ProvisioningBuildOptions instance to every provisioning resource.
+        // Deployment builds independent resource templates concurrently, so mutating that shared resolver list here
+        // would race with other builds that are enumerating it. Copy the caller-configured options first, then add
+        // the managed-environment fallback only to this resource's build options.
+        options = CloneProvisioningBuildOptions(options);
+        appEnvResource.ProvisioningBuildOptions = options;
 
         var resolver = new ManagedEnvironmentNameResolver(bicepIdentifier);
 
@@ -499,6 +506,22 @@ public static class AzureContainerAppExtensions
         {
             options.InfrastructureResolvers.Add(resolver);
         }
+    }
+
+    private static ProvisioningBuildOptions CloneProvisioningBuildOptions(ProvisioningBuildOptions options)
+    {
+        var clone = new ProvisioningBuildOptions
+        {
+            Random = options.Random
+        };
+
+        clone.InfrastructureResolvers.Clear();
+        foreach (var infrastructureResolver in options.InfrastructureResolvers)
+        {
+            clone.InfrastructureResolvers.Add(infrastructureResolver);
+        }
+
+        return clone;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -411,7 +411,18 @@ public static class AzureContainerAppExtensions
                 }
             }
 
-            if (!appEnvResource.UseAzdNamingConvention && !appEnvResource.UseSingletonResourceNaming)
+            // By default the managed environment name is left to Azure.Provisioning, whose sanitizer keeps
+            // only lowercase letters (ContainerAppManagedEnvironment inherits ResourceNameRequirements(1, 24,
+            // ResourceNameCharacters.LowercaseLetters)). That drops digits from the bicep identifier, so
+            // environments named e.g. "cae1"/"cae2" in the same resource group both resolve to
+            // take('cae${uniqueString(resourceGroup().id)}', 24) and collapse onto a single physical
+            // environment, where concurrent container-app writes race with ManagedEnvironmentOperationInProgress
+            // (see https://github.com/microsoft/aspire/issues/18722).
+            //
+            // Changing this by default would rename already-deployed environments and cause Azure to recreate
+            // them, so the digit-preserving name is opt-in via WithUniqueResourceNaming(). Applications that put
+            // multiple environments in one resource group opt in to get distinct names.
+            if (!appEnvResource.UseAzdNamingConvention && appEnvResource.UseUniqueResourceNaming)
             {
                 AddManagedEnvironmentNameFallbackResolver(appEnvResource);
             }
@@ -446,7 +457,8 @@ public static class AzureContainerAppExtensions
     }
 
     /// <summary>
-    /// Adds the fallback resolver used for the managed environment's <c>name</c> in the default (non-azd) naming path.
+    /// Adds the fallback resolver used for the managed environment's <c>name</c> when
+    /// <see cref="WithUniqueResourceNaming"/> is applied (and azd naming is not in effect).
     /// </summary>
     /// <remarks>
     /// Azure.Provisioning's default name resolver only assigns names while the <c>Name</c> property is unset.
@@ -701,36 +713,39 @@ public static class AzureContainerAppExtensions
     }
 
     /// <summary>
-    /// Configures the container app environment to use the managed environment name that Aspire generated
-    /// before resource names were incorporated into the name calculation. This naming is appropriate when a
-    /// single container app environment is deployed to a resource group.
+    /// Configures the container app environment to incorporate its resource name into the generated managed
+    /// environment <c>name</c>, so that multiple environments in the same resource group get distinct names.
     /// </summary>
     /// <param name="builder">The <see cref="AzureContainerAppEnvironmentResource"/> to configure.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
     /// <para>
-    /// By default, the managed environment's <c>name</c> now incorporates the resource name so that multiple
-    /// <see cref="AddAzureContainerAppEnvironment"/> resources in the same resource group produce distinct
-    /// environment names (see <see href="https://github.com/microsoft/aspire/issues/18722"/>).
+    /// By default the managed environment relies on Azure.Provisioning's name, whose sanitizer keeps only
+    /// lowercase letters — dropping any trailing digit and yielding
+    /// <c>take('cae{uniqueString(resourceGroup().id)}', 24)</c> regardless of the resource name. When two
+    /// <see cref="AddAzureContainerAppEnvironment"/> resources (e.g. <c>cae1</c> and <c>cae2</c>) share a
+    /// resource group, that default collapses both onto a single physical environment and concurrent
+    /// container-app writes race with <c>ManagedEnvironmentOperationInProgress</c>
+    /// (see <see href="https://github.com/microsoft/aspire/issues/18722"/>).
     /// </para>
     /// <para>
-    /// The previous behavior relied on Azure.Provisioning's default name, whose sanitizer keeps only lowercase
-    /// letters — dropping any trailing digit and yielding <c>take('cae{uniqueString(resourceGroup().id)}', 24)</c>
-    /// regardless of the resource name. Applications that deployed a single environment before this change should
-    /// call this method to keep their already-deployed environment name and avoid Azure recreating the environment
-    /// on the next deployment.
+    /// Applying this method keeps the resource name's digits so each environment gets a distinct
+    /// <c>name</c>. This is opt-in because enabling it changes the environment <c>name</c> for an
+    /// already-deployed single environment, which would cause Azure to recreate it. Apply it only to the
+    /// environments that need distinct names (typically when deploying more than one environment to a single
+    /// resource group), or to new deployments.
     /// </para>
     /// <para>
-    /// This option has no effect when <see cref="WithAzdResourceNaming"/> is also used, since azd naming sets the
-    /// environment name explicitly.
+    /// This option has no effect when <see cref="WithAzdResourceNaming"/> is also used, since azd naming sets
+    /// the environment name explicitly.
     /// </para>
     /// </remarks>
     [AspireExport]
     [Experimental("ASPIREACANAMING001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithSingletonResourceNaming(this IResourceBuilder<AzureContainerAppEnvironmentResource> builder)
+    public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithUniqueResourceNaming(this IResourceBuilder<AzureContainerAppEnvironmentResource> builder)
     {
-        builder.Resource.UseSingletonResourceNaming = true;
+        builder.Resource.UseUniqueResourceNaming = true;
         return builder;
     }
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -764,8 +764,10 @@ public static class AzureContainerAppExtensions
     /// deploying more than one environment to a single resource group), or to new deployments.
     /// </para>
     /// <para>
-    /// This option has no effect when <see cref="WithAzdResourceNaming"/> is also used, since azd naming sets
-    /// the environment name explicitly.
+    /// This option acts as a fallback after name resolvers configured through
+    /// <see cref="AzureProvisioningOptions.ProvisioningBuildOptions"/>. A configured resolver can therefore
+    /// override the generated name. This option also has no effect when <see cref="WithAzdResourceNaming"/> is
+    /// used, since azd naming sets the environment name explicitly.
     /// </para>
     /// </remarks>
     [AspireExport]

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -424,7 +424,7 @@ public static class AzureContainerAppExtensions
             // multiple environments in one resource group opt in to get distinct names.
             if (!appEnvResource.UseAzdNamingConvention && appEnvResource.UseUniqueResourceNaming)
             {
-                AddManagedEnvironmentNameFallbackResolver(appEnvResource);
+                AddManagedEnvironmentNameFallbackResolver(appEnvResource, containerAppEnvironment);
             }
 
             // Exposed so that callers reference the LA workspace in other bicep modules
@@ -465,13 +465,12 @@ public static class AzureContainerAppExtensions
     /// Registering a resolver rather than assigning <c>Name</c> here preserves any caller-supplied resolvers in
     /// <see cref="ProvisioningBuildOptions.InfrastructureResolvers"/> while still fixing the default fallback.
     /// </remarks>
-    private static void AddManagedEnvironmentNameFallbackResolver(AzureContainerAppEnvironmentResource appEnvResource)
+    private static void AddManagedEnvironmentNameFallbackResolver(AzureContainerAppEnvironmentResource appEnvResource, ContainerAppManagedEnvironment managedEnvironment)
     {
         var options = appEnvResource.ProvisioningBuildOptions ?? new ProvisioningBuildOptions();
-        var bicepIdentifier = appEnvResource.GetBicepIdentifier();
 
         if (options.InfrastructureResolvers.OfType<ManagedEnvironmentNameResolver>()
-            .Any(resolver => resolver.BicepIdentifier == bicepIdentifier))
+            .Any(resolver => ReferenceEquals(resolver.ManagedEnvironment, managedEnvironment)))
         {
             return;
         }
@@ -483,7 +482,7 @@ public static class AzureContainerAppExtensions
         options = CloneProvisioningBuildOptions(options);
         appEnvResource.ProvisioningBuildOptions = options;
 
-        var resolver = new ManagedEnvironmentNameResolver(bicepIdentifier);
+        var resolver = new ManagedEnvironmentNameResolver(managedEnvironment);
 
         // Put Aspire's resolver after caller-configured resolvers but before Azure.Provisioning's default dynamic
         // resolver. This preserves explicit policies such as AspireV8ResourceNamePropertyResolver while preventing
@@ -886,7 +885,7 @@ public static class AzureContainerAppExtensions
         return builder;
     }
 
-    private sealed class ManagedEnvironmentNameResolver(string bicepIdentifier) : DynamicResourceNamePropertyResolver
+    private sealed class ManagedEnvironmentNameResolver(ContainerAppManagedEnvironment managedEnvironment) : DynamicResourceNamePropertyResolver
     {
         // Azure Container Apps managed environment names allow lowercase letters, digits, and hyphens, up to
         // 32 characters, must start with a letter, and must end with an alphanumeric character
@@ -903,14 +902,15 @@ public static class AzureContainerAppExtensions
             maxLength: 32,
             validCharacters: ResourceNameCharacters.LowercaseLetters | ResourceNameCharacters.Numbers | ResourceNameCharacters.Hyphen);
 
-        public string BicepIdentifier { get; } = bicepIdentifier;
+        public ContainerAppManagedEnvironment ManagedEnvironment { get; } = managedEnvironment;
 
         public override BicepValue<string>? ResolveName(ProvisioningBuildOptions options, ProvisionableResource resource, ResourceNameRequirements requirements)
         {
-            // Only take over naming for the specific environment this resolver was created for. Every other
-            // resource (including managed environments that did not opt in) returns null so it falls through to
-            // the rest of the resolver chain unchanged.
-            if (resource is not ContainerAppManagedEnvironment || resource.BicepIdentifier != BicepIdentifier)
+            // Scope strictly to the environment instance this resolver was created for, by reference identity.
+            // Bicep identifiers are only unique within a single module, so matching on the identifier could rename
+            // an unrelated ContainerAppManagedEnvironment that happens to share the same name in another module.
+            // Every other resource returns null so it falls through to the rest of the resolver chain unchanged.
+            if (!ReferenceEquals(resource, ManagedEnvironment))
             {
                 return null;
             }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -20,6 +20,7 @@ using Azure.Provisioning.Primitives;
 using Azure.Provisioning.Roles;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using FileShare = Azure.Provisioning.Storage.FileShare;
 
 namespace Aspire.Hosting;
@@ -104,9 +105,18 @@ public static class AzureContainerAppExtensions
             builder.Pipeline.AddPipelineConfiguration(context =>
             {
                 var validationStep = context.Steps.Single(step => step.Name == ValidateContainerAppsStepName);
+                var configuredBuildOptions = context.Services
+                    .GetRequiredService<IOptions<AzureProvisioningOptions>>()
+                    .Value
+                    .ProvisioningBuildOptions;
 
                 foreach (var environment in context.Model.Resources.OfType<AzureContainerAppEnvironmentResource>())
                 {
+                    // Pipeline-level configuration runs before AzureBicepResource forces template generation.
+                    // Assign configured resolvers now so the collision tracker records the final fallback name,
+                    // rather than a stale legacy expression generated before azure-prepare-resources executes.
+                    environment.ProvisioningBuildOptions ??= configuredBuildOptions;
+
                     var prepareStep = context.GetSteps(environment)
                         .SingleOrDefault(step => step.Name == $"{PrepareContainerAppsStepNamePrefix}{environment.Name}");
 
@@ -831,6 +841,7 @@ public static class AzureContainerAppExtensions
     /// <param name="builder">The <see cref="AzureContainerAppEnvironmentResource"/> to configure.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is null.</exception>
     /// <remarks>
     /// <para>
     /// By default the managed environment relies on Azure.Provisioning's name, whose sanitizer keeps only
@@ -861,10 +872,20 @@ public static class AzureContainerAppExtensions
     /// used, since azd naming sets the environment name explicitly.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// var env1 = builder.AddAzureContainerAppEnvironment("cae1")
+    ///     .WithUniqueResourceNaming();
+    /// var env2 = builder.AddAzureContainerAppEnvironment("cae2")
+    ///     .WithUniqueResourceNaming();
+    /// </code>
+    /// </example>
     [AspireExport]
     [Experimental("ASPIREACANAMING002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithUniqueResourceNaming(this IResourceBuilder<AzureContainerAppEnvironmentResource> builder)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+
         builder.Resource.UseUniqueResourceNaming = true;
         return builder;
     }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -29,6 +29,7 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class AzureContainerAppExtensions
 {
+    internal const string PrepareContainerAppsStepNamePrefix = "prepare-azure-container-apps-";
     internal const string ValidateContainerAppsStepName = "validate-azure-container-apps";
 
     /// <summary>
@@ -99,6 +100,21 @@ public static class AzureContainerAppExtensions
                 },
                 dependsOn: AzureEnvironmentResource.PrepareResourcesStepName,
                 requiredBy: WellKnownPipelineSteps.BeforeStart);
+
+            builder.Pipeline.AddPipelineConfiguration(context =>
+            {
+                var validationStep = context.Steps.Single(step => step.Name == ValidateContainerAppsStepName);
+
+                foreach (var environment in context.Model.Resources.OfType<AzureContainerAppEnvironmentResource>())
+                {
+                    var prepareStep = context.GetSteps(environment)
+                        .SingleOrDefault(step => step.Name == $"{PrepareContainerAppsStepNamePrefix}{environment.Name}");
+
+                    prepareStep?.DependsOn(validationStep);
+                }
+
+                return Task.CompletedTask;
+            });
         }
 
         return builder;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -470,15 +470,15 @@ public static class AzureContainerAppExtensions
         var options = appEnvResource.ProvisioningBuildOptions ??= new ProvisioningBuildOptions();
         var bicepIdentifier = appEnvResource.GetBicepIdentifier();
 
-        if (options.InfrastructureResolvers.OfType<DigitPreservingManagedEnvironmentNameResolver>()
+        if (options.InfrastructureResolvers.OfType<ManagedEnvironmentNameResolver>()
             .Any(resolver => resolver.BicepIdentifier == bicepIdentifier))
         {
             return;
         }
 
-        var resolver = new DigitPreservingManagedEnvironmentNameResolver(bicepIdentifier);
+        var resolver = new ManagedEnvironmentNameResolver(bicepIdentifier);
 
-        // Put Aspire's fallback after caller-configured resolvers but before Azure.Provisioning's default dynamic
+        // Put Aspire's resolver after caller-configured resolvers but before Azure.Provisioning's default dynamic
         // resolver. This preserves explicit policies such as AspireV8ResourceNamePropertyResolver while preventing
         // the built-in lowercase-letters-only fallback from collapsing "cae1" and "cae2" to the same name.
         var defaultDynamicResolverIndex = -1;
@@ -730,11 +730,14 @@ public static class AzureContainerAppExtensions
     /// (see <see href="https://github.com/microsoft/aspire/issues/18722"/>).
     /// </para>
     /// <para>
-    /// Applying this method keeps the resource name's digits so each environment gets a distinct
-    /// <c>name</c>. This is opt-in because enabling it changes the environment <c>name</c> for an
-    /// already-deployed single environment, which would cause Azure to recreate it. Apply it only to the
-    /// environments that need distinct names (typically when deploying more than one environment to a single
-    /// resource group), or to new deployments.
+    /// Applying this method computes the managed environment <c>name</c> with the same algorithm Azure.Provisioning
+    /// uses for every other Azure resource type (sanitized resource name, then a
+    /// <c>uniqueString(resourceGroup().id)</c> suffix, truncated to the maximum length), but with the character
+    /// requirements Azure Container Apps actually allows — lowercase letters, digits, and hyphens up to 32
+    /// characters. Preserving the digits gives each environment a distinct <c>name</c>. This is opt-in because
+    /// enabling it changes the environment <c>name</c> for an already-deployed single environment, which would
+    /// cause Azure to recreate it. Apply it only to the environments that need distinct names (typically when
+    /// deploying more than one environment to a single resource group), or to new deployments.
     /// </para>
     /// <para>
     /// This option has no effect when <see cref="WithAzdResourceNaming"/> is also used, since azd naming sets
@@ -860,24 +863,40 @@ public static class AzureContainerAppExtensions
         return builder;
     }
 
-    private sealed class DigitPreservingManagedEnvironmentNameResolver(string bicepIdentifier) : ResourceNamePropertyResolver
+    private sealed class ManagedEnvironmentNameResolver(string bicepIdentifier) : DynamicResourceNamePropertyResolver
     {
+        // Azure Container Apps managed environment names allow lowercase letters, digits, and hyphens, up to
+        // 32 characters, must start with a letter, and must end with an alphanumeric character
+        // (^[a-z][a-z0-9-]{0,31}[a-z0-9]$):
+        // https://learn.microsoft.com/azure/templates/microsoft.app/managedenvironments
+        //
+        // Azure.Provisioning.AppContainers does not override GetResourceNameRequirements for
+        // ContainerAppManagedEnvironment, so it inherits ProvisionableResource's conservative default of
+        // (1, 24, LowercaseLetters). That default silently drops the digits Aspire relies on to keep sibling
+        // environment names distinct, so "cae1"/"cae2" both sanitize to "cae" and collide in a shared resource
+        // group (https://github.com/microsoft/aspire/issues/18722).
+        private static readonly ResourceNameRequirements s_requirements = new(
+            minLength: 1,
+            maxLength: 32,
+            validCharacters: ResourceNameCharacters.LowercaseLetters | ResourceNameCharacters.Numbers | ResourceNameCharacters.Hyphen);
+
         public string BicepIdentifier { get; } = bicepIdentifier;
 
         public override BicepValue<string>? ResolveName(ProvisioningBuildOptions options, ProvisionableResource resource, ResourceNameRequirements requirements)
         {
+            // Only take over naming for the specific environment this resolver was created for. Every other
+            // resource (including managed environments that did not opt in) returns null so it falls through to
+            // the rest of the resolver chain unchanged.
             if (resource is not ContainerAppManagedEnvironment || resource.BicepIdentifier != BicepIdentifier)
             {
                 return null;
             }
 
-            // uniqueString(resourceGroup().id) is identical for every environment in the same resource group, so
-            // the prefix is the only differentiator. Keep digits that Azure.Provisioning's default requirements
-            // currently drop, otherwise "cae1" and "cae2" both become "cae" and deploy to the same environment.
-            var prefix = new string(resource.BicepIdentifier.ToLowerInvariant().Where(char.IsLetterOrDigit).ToArray());
-            return BicepFunction.Take(
-                BicepFunction.Interpolate($"{prefix}{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"),
-                24);
+            // Delegate to the standard dynamic naming algorithm, only substituting the requirements that
+            // Azure.Provisioning failed to declare. This keeps the generated name computed exactly like every
+            // other Azure resource type (sanitized prefix + separator + uniqueString(resourceGroup().id) suffix,
+            // truncated to the max length) while preserving the digits and hyphens that distinguish environments.
+            return base.ResolveName(options, resource, s_requirements);
         }
     }
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -769,7 +769,7 @@ public static class AzureContainerAppExtensions
     /// </para>
     /// </remarks>
     [AspireExport]
-    [Experimental("ASPIREACANAMING001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    [Experimental("ASPIREACANAMING002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static IResourceBuilder<AzureContainerAppEnvironmentResource> WithUniqueResourceNaming(this IResourceBuilder<AzureContainerAppEnvironmentResource> builder)
     {
         builder.Resource.UseUniqueResourceNaming = true;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -15,6 +15,7 @@ using Azure.Provisioning.AppContainers;
 using Azure.Provisioning.ContainerRegistry;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.OperationalInsights;
+using Azure.Provisioning.Primitives;
 using Azure.Provisioning.Roles;
 using Azure.Provisioning.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -410,30 +411,9 @@ public static class AzureContainerAppExtensions
                 }
             }
 
-            // When not using azd naming, the managed environment name would otherwise be left to
-            // Azure.Provisioning's default. That default only permits lowercase letters
-            // (ContainerAppManagedEnvironment inherits ResourceNameRequirements(1, 24,
-            // ResourceNameCharacters.LowercaseLetters)), so digits are stripped from the bicep
-            // identifier: environments named e.g. "cae1"/"cae2" in the same resource group both
-            // resolve to take('cae${uniqueString(resourceGroup().id)}', 24) and collapse onto a
-            // single physical environment, where concurrent container-app writes race with
-            // ManagedEnvironmentOperationInProgress. Set the name explicitly, preserving digits,
-            // so multiple environments in one resource group get distinct names. Opt out with
-            // WithSingletonResourceNaming() to keep the pre-fix name for already-deployed environments.
-            // See https://github.com/microsoft/aspire/issues/18722.
-            //
-            // Note: uniqueString(resourceGroup().id) is identical for every environment in the same
-            // resource group, so the ONLY differentiator between environments is the name prefix. Because
-            // the whole value is truncated to 24 chars (the managed environment name limit), two
-            // environments whose sanitized names match in their first 24 characters would still collide.
-            // That is a narrow edge case (long, similar names), but it's the same truncation-collision
-            // class already seen for storage account names in #14427.
             if (!appEnvResource.UseAzdNamingConvention && !appEnvResource.UseSingletonResourceNaming)
             {
-                containerAppEnvironment.Name = BicepFunction.Take(
-                    BicepFunction.Interpolate(
-                        $"{GetManagedEnvironmentNamePrefix(appEnvResource)}{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"),
-                    24);
+                AddManagedEnvironmentNameFallbackResolver(appEnvResource);
             }
 
             // Exposed so that callers reference the LA workspace in other bicep modules
@@ -466,20 +446,47 @@ public static class AzureContainerAppExtensions
     }
 
     /// <summary>
-    /// Builds the prefix used for the managed environment's <c>name</c> in the default (non-azd) naming path.
+    /// Adds the fallback resolver used for the managed environment's <c>name</c> in the default (non-azd) naming path.
     /// </summary>
     /// <remarks>
-    /// Azure.Provisioning's default name for a managed environment is
-    /// <c>take('{sanitizedBicepIdentifier}{uniqueString(resourceGroup().id)}', 24)</c>, but its sanitizer only
-    /// keeps lowercase letters (<c>ResourceNameCharacters.LowercaseLetters</c>),
-    /// which drops digits and causes environments named e.g. <c>cae1</c>/<c>cae2</c> to collapse to the same
-    /// <c>cae…</c> name in a shared resource group. We reproduce that prefix but keep digits (managed environment
-    /// names permit lowercase alphanumerics), so distinct resource names produce distinct environment names.
+    /// Azure.Provisioning's default name resolver only assigns names while the <c>Name</c> property is unset.
+    /// Registering a resolver rather than assigning <c>Name</c> here preserves any caller-supplied resolvers in
+    /// <see cref="ProvisioningBuildOptions.InfrastructureResolvers"/> while still fixing the default fallback.
     /// </remarks>
-    private static string GetManagedEnvironmentNamePrefix(AzureContainerAppEnvironmentResource appEnvResource)
+    private static void AddManagedEnvironmentNameFallbackResolver(AzureContainerAppEnvironmentResource appEnvResource)
     {
-        var identifier = appEnvResource.GetBicepIdentifier();
-        return new string(identifier.ToLowerInvariant().Where(char.IsLetterOrDigit).ToArray());
+        var options = appEnvResource.ProvisioningBuildOptions ??= new ProvisioningBuildOptions();
+        var bicepIdentifier = appEnvResource.GetBicepIdentifier();
+
+        if (options.InfrastructureResolvers.OfType<DigitPreservingManagedEnvironmentNameResolver>()
+            .Any(resolver => resolver.BicepIdentifier == bicepIdentifier))
+        {
+            return;
+        }
+
+        var resolver = new DigitPreservingManagedEnvironmentNameResolver(bicepIdentifier);
+
+        // Put Aspire's fallback after caller-configured resolvers but before Azure.Provisioning's default dynamic
+        // resolver. This preserves explicit policies such as AspireV8ResourceNamePropertyResolver while preventing
+        // the built-in lowercase-letters-only fallback from collapsing "cae1" and "cae2" to the same name.
+        var defaultDynamicResolverIndex = -1;
+        for (var i = 0; i < options.InfrastructureResolvers.Count; i++)
+        {
+            if (options.InfrastructureResolvers[i].GetType() == typeof(DynamicResourceNamePropertyResolver))
+            {
+                defaultDynamicResolverIndex = i;
+                break;
+            }
+        }
+
+        if (defaultDynamicResolverIndex >= 0)
+        {
+            options.InfrastructureResolvers.Insert(defaultDynamicResolverIndex, resolver);
+        }
+        else
+        {
+            options.InfrastructureResolvers.Add(resolver);
+        }
     }
 
     /// <summary>
@@ -836,6 +843,27 @@ public static class AzureContainerAppExtensions
         builder.WithAnnotation(new AzureContainerAppEnvironmentAcrPullIdentityAnnotation(identityBuilder.Resource));
 
         return builder;
+    }
+
+    private sealed class DigitPreservingManagedEnvironmentNameResolver(string bicepIdentifier) : ResourceNamePropertyResolver
+    {
+        public string BicepIdentifier { get; } = bicepIdentifier;
+
+        public override BicepValue<string>? ResolveName(ProvisioningBuildOptions options, ProvisionableResource resource, ResourceNameRequirements requirements)
+        {
+            if (resource is not ContainerAppManagedEnvironment || resource.BicepIdentifier != BicepIdentifier)
+            {
+                return null;
+            }
+
+            // uniqueString(resourceGroup().id) is identical for every environment in the same resource group, so
+            // the prefix is the only differentiator. Keep digits that Azure.Provisioning's default requirements
+            // currently drop, otherwise "cae1" and "cae2" both become "cae" and deploy to the same environment.
+            var prefix = new string(resource.BicepIdentifier.ToLowerInvariant().Where(char.IsLetterOrDigit).ToArray());
+            return BicepFunction.Take(
+                BicepFunction.Interpolate($"{prefix}{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"),
+                24);
+        }
     }
 
     private static AzureContainerRegistryResource CreateDefaultAzureContainerRegistry(IDistributedApplicationBuilder builder, string name, AzureContainerAppEnvironmentResource containerAppEnvironment)

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREPIPELINES001
+#pragma warning disable ASPIREAZURE001
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Diagnostics;
@@ -28,6 +29,8 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class AzureContainerAppExtensions
 {
+    internal const string ValidateContainerAppsStepName = "validate-azure-container-apps";
+
     /// <summary>
     /// Adds the necessary infrastructure for Azure Container Apps to the distributed application builder.
     /// </summary>
@@ -56,10 +59,11 @@ public static class AzureContainerAppExtensions
         // no AzureContainerAppEnvironmentResource instances in the model.
         if (builder.Services.All(d => d.ServiceType != typeof(ContainerAppsPipelineStepMarker)))
         {
-            builder.Services.AddSingleton<ContainerAppsPipelineStepMarker>();
+            var marker = new ContainerAppsPipelineStepMarker();
+            builder.Services.AddSingleton(marker);
 
             builder.Pipeline.AddStep(
-                name: ContainerAppsPipelineStepMarker.StepName,
+                name: ValidateContainerAppsStepName,
                 action: ctx =>
                 {
                     if (!ctx.ExecutionContext.IsPublishMode)
@@ -67,7 +71,8 @@ public static class AzureContainerAppExtensions
                         return Task.CompletedTask;
                     }
 
-                    if (!ctx.Model.Resources.OfType<AzureContainerAppEnvironmentResource>().Any())
+                    var environments = ctx.Model.Resources.OfType<AzureContainerAppEnvironmentResource>().ToList();
+                    if (environments.Count == 0)
                     {
                         foreach (var r in ctx.Model.GetComputeResources())
                         {
@@ -78,9 +83,21 @@ public static class AzureContainerAppExtensions
                             }
                         }
                     }
+                    else
+                    {
+                        // Name resolvers run while each environment's Bicep module is generated. Force evaluation
+                        // here so the shared tracker sees every legacy fallback before deployment targets are prepared.
+                        foreach (var environment in environments)
+                        {
+                            _ = environment.GetBicepTemplateString();
+                        }
+
+                        marker.ValidateManagedEnvironmentNames();
+                    }
 
                     return Task.CompletedTask;
                 },
+                dependsOn: AzureEnvironmentResource.PrepareResourcesStepName,
                 requiredBy: WellKnownPipelineSteps.BeforeStart);
         }
 
@@ -89,7 +106,50 @@ public static class AzureContainerAppExtensions
 
     private sealed class ContainerAppsPipelineStepMarker
     {
-        public const string StepName = "validate-azure-container-apps";
+        private readonly object _lock = new();
+        private readonly Dictionary<string, HashSet<string>> _environmentsByManagedEnvironmentName = new(StringComparer.Ordinal);
+
+        public void RecordManagedEnvironmentName(string environmentName, BicepValue<string> managedEnvironmentName)
+        {
+            var expression = managedEnvironmentName.ToString();
+
+            lock (_lock)
+            {
+                if (!_environmentsByManagedEnvironmentName.TryGetValue(expression, out var environmentNames))
+                {
+                    environmentNames = new HashSet<string>(StringComparer.Ordinal);
+                    _environmentsByManagedEnvironmentName.Add(expression, environmentNames);
+                }
+
+                environmentNames.Add(environmentName);
+            }
+        }
+
+        public void ValidateManagedEnvironmentNames()
+        {
+            KeyValuePair<string, HashSet<string>>[] collisions;
+
+            lock (_lock)
+            {
+                collisions = _environmentsByManagedEnvironmentName
+                    .Where(pair => pair.Value.Count > 1)
+                    .ToArray();
+            }
+
+            if (collisions.Length == 0)
+            {
+                return;
+            }
+
+            var collisionDetails = string.Join(
+                "; ",
+                collisions.Select(pair =>
+                    $"'{string.Join("', '", pair.Value.Order(StringComparer.Ordinal))}' resolve to {pair.Key}"));
+
+            throw new InvalidOperationException(
+                $"Azure Container App environments {collisionDetails}. Multiple environments with the same managed environment name cannot be deployed to one resource group. " +
+                $"Call '{nameof(WithUniqueResourceNaming)}()' on one or more of the colliding environment resources.");
+        }
     }
 
     /// <summary>
@@ -104,7 +164,13 @@ public static class AzureContainerAppExtensions
     {
         builder.AddAzureContainerAppsInfrastructureCore();
 
-        var containerAppEnvResource = new AzureContainerAppEnvironmentResource(name, static infra =>
+        var marker = builder.Services
+            .Where(descriptor => descriptor.ServiceType == typeof(ContainerAppsPipelineStepMarker))
+            .Select(descriptor => descriptor.ImplementationInstance)
+            .OfType<ContainerAppsPipelineStepMarker>()
+            .Single();
+
+        var containerAppEnvResource = new AzureContainerAppEnvironmentResource(name, infra =>
         {
             var appEnvResource = (AzureContainerAppEnvironmentResource)infra.AspireResource;
 
@@ -420,11 +486,12 @@ public static class AzureContainerAppExtensions
             // (see https://github.com/microsoft/aspire/issues/18722).
             //
             // Changing this by default would rename already-deployed environments and cause Azure to recreate
-            // them, so the digit-preserving name is opt-in via WithUniqueResourceNaming(). Applications that put
-            // multiple environments in one resource group opt in to get distinct names.
-            if (!appEnvResource.UseAzdNamingConvention && appEnvResource.UseUniqueResourceNaming)
+            // them, so the digit-preserving name is opt-in via WithUniqueResourceNaming(). The fallback resolver
+            // also records the actual generated expression so publish can reject colliding legacy names with
+            // actionable guidance instead of allowing a broken deployment.
+            if (!appEnvResource.UseAzdNamingConvention)
             {
-                AddManagedEnvironmentNameFallbackResolver(appEnvResource, containerAppEnvironment);
+                AddManagedEnvironmentNameResolver(appEnvResource, containerAppEnvironment, marker);
             }
 
             // Exposed so that callers reference the LA workspace in other bicep modules
@@ -465,7 +532,10 @@ public static class AzureContainerAppExtensions
     /// Registering a resolver rather than assigning <c>Name</c> here preserves any caller-supplied resolvers in
     /// <see cref="ProvisioningBuildOptions.InfrastructureResolvers"/> while still fixing the default fallback.
     /// </remarks>
-    private static void AddManagedEnvironmentNameFallbackResolver(AzureContainerAppEnvironmentResource appEnvResource, ContainerAppManagedEnvironment managedEnvironment)
+    private static void AddManagedEnvironmentNameResolver(
+        AzureContainerAppEnvironmentResource appEnvResource,
+        ContainerAppManagedEnvironment managedEnvironment,
+        ContainerAppsPipelineStepMarker marker)
     {
         var options = appEnvResource.ProvisioningBuildOptions ?? new ProvisioningBuildOptions();
 
@@ -482,7 +552,11 @@ public static class AzureContainerAppExtensions
         options = CloneProvisioningBuildOptions(options);
         appEnvResource.ProvisioningBuildOptions = options;
 
-        var resolver = new ManagedEnvironmentNameResolver(managedEnvironment);
+        var resolver = new ManagedEnvironmentNameResolver(
+            managedEnvironment,
+            appEnvResource.Name,
+            appEnvResource.UseUniqueResourceNaming,
+            marker);
 
         // Put Aspire's resolver after caller-configured resolvers but before Azure.Provisioning's default dynamic
         // resolver. This preserves explicit policies such as AspireV8ResourceNamePropertyResolver while preventing
@@ -747,8 +821,9 @@ public static class AzureContainerAppExtensions
     /// lowercase letters. For example, two <see cref="AddAzureContainerAppEnvironment"/> resources named
     /// <c>cae1</c> and <c>cae2</c> both drop their trailing digit and yield
     /// <c>take('cae${uniqueString(resourceGroup().id)}', 24)</c>. When they share a resource group,
-    /// that default collapses both onto a single physical environment and concurrent
-    /// container-app writes race with <c>ManagedEnvironmentOperationInProgress</c>
+    /// that default would collapse both onto a single physical environment and concurrent
+    /// container-app writes would race with <c>ManagedEnvironmentOperationInProgress</c>. Publish and deploy
+    /// detect this collision and fail with guidance to apply this method instead
     /// (see <see href="https://github.com/microsoft/aspire/issues/18722"/>).
     /// </para>
     /// <para>
@@ -889,7 +964,11 @@ public static class AzureContainerAppExtensions
         return builder;
     }
 
-    private sealed class ManagedEnvironmentNameResolver(ContainerAppManagedEnvironment managedEnvironment) : DynamicResourceNamePropertyResolver
+    private sealed class ManagedEnvironmentNameResolver(
+        ContainerAppManagedEnvironment managedEnvironment,
+        string environmentName,
+        bool useUniqueResourceNaming,
+        ContainerAppsPipelineStepMarker marker) : DynamicResourceNamePropertyResolver
     {
         // Azure Container Apps managed environment names allow lowercase letters, digits, and hyphens and are
         // 2-60 characters long. These are the managed-environment limits, not the 2-32 character container-app
@@ -919,13 +998,21 @@ public static class AzureContainerAppExtensions
                 return null;
             }
 
-            // Delegate to the standard dynamic naming algorithm, only substituting the requirements that
-            // Azure.Provisioning failed to declare. This keeps the generated name computed exactly like every
-            // other Azure resource type (sanitized prefix + separator + uniqueString(resourceGroup().id) suffix,
-            // truncated to the max length) while preserving the digits that distinguish environments. Allowing
-            // hyphens keeps the standard prefix/suffix separator; hyphens from the resource name are normalized to
-            // underscores in the Bicep identifier and then removed from the sanitized prefix (e.g. "my-cae" -> "mycae").
-            return base.ResolveName(options, resource, s_requirements);
+            // Delegate to the standard dynamic naming algorithm. The opt-in substitutes the requirements that
+            // Azure.Provisioning failed to declare; otherwise the supplied requirements preserve the legacy output
+            // byte-for-byte. Recording the returned expression here means caller-configured resolvers still take
+            // precedence and only names produced by this fallback participate in collision validation.
+            var resolvedName = base.ResolveName(
+                options,
+                resource,
+                useUniqueResourceNaming ? s_requirements : requirements);
+
+            if (resolvedName is not null)
+            {
+                marker.RecordManagedEnvironmentName(environmentName, resolvedName);
+            }
+
+            return resolvedName;
         }
     }
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -755,9 +755,9 @@ public static class AzureContainerAppExtensions
     /// Applying this method computes the managed environment <c>name</c> with the same algorithm Azure.Provisioning
     /// uses for every other Azure resource type (sanitized resource name, then a hyphen separator and a
     /// <c>uniqueString(resourceGroup().id)</c> suffix, truncated to the maximum length), but with the character
-    /// requirements Azure Container Apps actually allows — lowercase letters, digits, and hyphens up to 32
-    /// characters. For example, <c>cae1</c> produces
-    /// <c>take('cae1-${uniqueString(resourceGroup().id)}', 32)</c>, while <c>prod1</c> uses a <c>prod1</c>
+    /// requirements Azure Container Apps managed environments actually allow — lowercase letters, digits, and
+    /// hyphens, with a 60-character maximum. For example, <c>cae1</c> produces
+    /// <c>take('cae1-${uniqueString(resourceGroup().id)}', 60)</c>, while <c>prod1</c> uses a <c>prod1</c>
     /// prefix. Preserving the digits gives each environment a distinct <c>name</c>. This is opt-in because
     /// enabling it changes the environment <c>name</c> for an already-deployed single environment, which would
     /// cause Azure to recreate it. Apply it only to the environments that need distinct names (typically when
@@ -889,10 +889,10 @@ public static class AzureContainerAppExtensions
 
     private sealed class ManagedEnvironmentNameResolver(ContainerAppManagedEnvironment managedEnvironment) : DynamicResourceNamePropertyResolver
     {
-        // Azure Container Apps managed environment names allow lowercase letters, digits, and hyphens, up to
-        // 32 characters, must start with a letter, and must end with an alphanumeric character
-        // (^[a-z][a-z0-9-]{0,31}[a-z0-9]$):
-        // https://learn.microsoft.com/azure/templates/microsoft.app/managedenvironments
+        // Azure Container Apps managed environment names allow lowercase letters, digits, and hyphens and are
+        // 2-60 characters long. These are the managed-environment limits, not the 2-32 character container-app
+        // limits:
+        // https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ContainerApp.EnvNaming/
         //
         // Azure.Provisioning.AppContainers does not override GetResourceNameRequirements for
         // ContainerAppManagedEnvironment, so it inherits ProvisionableResource's conservative default of
@@ -900,8 +900,8 @@ public static class AzureContainerAppExtensions
         // environment names distinct, so "cae1"/"cae2" both sanitize to "cae" and collide in a shared resource
         // group (https://github.com/microsoft/aspire/issues/18722).
         private static readonly ResourceNameRequirements s_requirements = new(
-            minLength: 1,
-            maxLength: 32,
+            minLength: 2,
+            maxLength: 60,
             validCharacters: ResourceNameCharacters.LowercaseLetters | ResourceNameCharacters.Numbers | ResourceNameCharacters.Hyphen);
 
         public ContainerAppManagedEnvironment ManagedEnvironment { get; } = managedEnvironment;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -918,7 +918,9 @@ public static class AzureContainerAppExtensions
             // Delegate to the standard dynamic naming algorithm, only substituting the requirements that
             // Azure.Provisioning failed to declare. This keeps the generated name computed exactly like every
             // other Azure resource type (sanitized prefix + separator + uniqueString(resourceGroup().id) suffix,
-            // truncated to the max length) while preserving the digits and hyphens that distinguish environments.
+            // truncated to the max length) while preserving the digits that distinguish environments. Allowing
+            // hyphens keeps the standard prefix/suffix separator; hyphens from the resource name are normalized to
+            // underscores in the Bicep identifier and then removed from the sanitized prefix (e.g. "my-cae" -> "mycae").
             return base.ResolveName(options, resource, s_requirements);
         }
     }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -744,19 +744,21 @@ public static class AzureContainerAppExtensions
     /// <remarks>
     /// <para>
     /// By default the managed environment relies on Azure.Provisioning's name, whose sanitizer keeps only
-    /// lowercase letters — dropping any trailing digit and yielding
-    /// <c>take('cae{uniqueString(resourceGroup().id)}', 24)</c> regardless of the resource name. When two
-    /// <see cref="AddAzureContainerAppEnvironment"/> resources (e.g. <c>cae1</c> and <c>cae2</c>) share a
-    /// resource group, that default collapses both onto a single physical environment and concurrent
+    /// lowercase letters. For example, two <see cref="AddAzureContainerAppEnvironment"/> resources named
+    /// <c>cae1</c> and <c>cae2</c> both drop their trailing digit and yield
+    /// <c>take('cae${uniqueString(resourceGroup().id)}', 24)</c>. When they share a resource group,
+    /// that default collapses both onto a single physical environment and concurrent
     /// container-app writes race with <c>ManagedEnvironmentOperationInProgress</c>
     /// (see <see href="https://github.com/microsoft/aspire/issues/18722"/>).
     /// </para>
     /// <para>
     /// Applying this method computes the managed environment <c>name</c> with the same algorithm Azure.Provisioning
-    /// uses for every other Azure resource type (sanitized resource name, then a
+    /// uses for every other Azure resource type (sanitized resource name, then a hyphen separator and a
     /// <c>uniqueString(resourceGroup().id)</c> suffix, truncated to the maximum length), but with the character
     /// requirements Azure Container Apps actually allows — lowercase letters, digits, and hyphens up to 32
-    /// characters. Preserving the digits gives each environment a distinct <c>name</c>. This is opt-in because
+    /// characters. For example, <c>cae1</c> produces
+    /// <c>take('cae1-${uniqueString(resourceGroup().id)}', 32)</c>, while <c>prod1</c> uses a <c>prod1</c>
+    /// prefix. Preserving the digits gives each environment a distinct <c>name</c>. This is opt-in because
     /// enabling it changes the environment <c>name</c> for an already-deployed single environment, which would
     /// cause Azure to recreate it. Apply it only to the environments that need distinct names (typically when
     /// deploying more than one environment to a single resource group), or to new deployments.

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -133,9 +133,12 @@ public static class AzureContainerAppExtensions
     private sealed class ContainerAppsPipelineStepMarker
     {
         private readonly object _lock = new();
-        private readonly Dictionary<string, HashSet<string>> _environmentsByManagedEnvironmentName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Dictionary<string, ManagedEnvironmentNamingMode>> _environmentsByManagedEnvironmentName = new(StringComparer.Ordinal);
 
-        public void RecordManagedEnvironmentName(string environmentName, BicepValue<string> managedEnvironmentName)
+        public void RecordManagedEnvironmentName(
+            string environmentName,
+            BicepValue<string> managedEnvironmentName,
+            ManagedEnvironmentNamingMode namingMode)
         {
             var expression = managedEnvironmentName.ToString();
 
@@ -143,22 +146,23 @@ public static class AzureContainerAppExtensions
             {
                 if (!_environmentsByManagedEnvironmentName.TryGetValue(expression, out var environmentNames))
                 {
-                    environmentNames = new HashSet<string>(StringComparer.Ordinal);
+                    environmentNames = new Dictionary<string, ManagedEnvironmentNamingMode>(StringComparer.Ordinal);
                     _environmentsByManagedEnvironmentName.Add(expression, environmentNames);
                 }
 
-                environmentNames.Add(environmentName);
+                environmentNames[environmentName] = namingMode;
             }
         }
 
         public void ValidateManagedEnvironmentNames()
         {
-            KeyValuePair<string, HashSet<string>>[] collisions;
+            (string Expression, KeyValuePair<string, ManagedEnvironmentNamingMode>[] Environments)[] collisions;
 
             lock (_lock)
             {
                 collisions = _environmentsByManagedEnvironmentName
                     .Where(pair => pair.Value.Count > 1)
+                    .Select(pair => (pair.Key, pair.Value.ToArray()))
                     .ToArray();
             }
 
@@ -170,12 +174,40 @@ public static class AzureContainerAppExtensions
             var collisionDetails = string.Join(
                 "; ",
                 collisions.Select(pair =>
-                    $"'{string.Join("', '", pair.Value.Order(StringComparer.Ordinal))}' resolve to {pair.Key}"));
+                    $"'{string.Join("', '", pair.Environments.Select(environment => environment.Key).Order(StringComparer.Ordinal))}' resolve to {pair.Expression}"));
+
+            var namingModes = collisions
+                .SelectMany(collision => collision.Environments)
+                .Select(environment => environment.Value)
+                .ToHashSet();
+            var guidance = new List<string>();
+
+            if (namingModes.Contains(ManagedEnvironmentNamingMode.Legacy))
+            {
+                guidance.Add($"For environments using the default naming convention, call '{nameof(WithUniqueResourceNaming)}()'.");
+            }
+
+            if (namingModes.Contains(ManagedEnvironmentNamingMode.Unique))
+            {
+                guidance.Add($"For environments already using '{nameof(WithUniqueResourceNaming)}()', rename one or more resources or configure an explicit name resolver.");
+            }
+
+            if (namingModes.Contains(ManagedEnvironmentNamingMode.Azd))
+            {
+                guidance.Add($"For environments using '{nameof(WithAzdResourceNaming)}()', remove it or configure distinct managed environment names explicitly.");
+            }
 
             throw new DistributedApplicationException(
                 $"Azure Container App environments {collisionDetails}. Multiple environments with the same managed environment name cannot be deployed to one resource group. " +
-                $"Call '{nameof(WithUniqueResourceNaming)}()' on one or more of the colliding environment resources.");
+                string.Join(" ", guidance));
         }
+    }
+
+    private enum ManagedEnvironmentNamingMode
+    {
+        Legacy,
+        Unique,
+        Azd
     }
 
     /// <summary>
@@ -473,7 +505,12 @@ public static class AzureContainerAppExtensions
                     new StringLiteralExpression("-"),
                     new StringLiteralExpression(""));
                 laWorkspace.Name = BicepFunction.Interpolate($"law-{resourceToken}");
-                containerAppEnvironment.Name = BicepFunction.Interpolate($"cae-{resourceToken}");
+                var managedEnvironmentName = BicepFunction.Interpolate($"cae-{resourceToken}");
+                containerAppEnvironment.Name = managedEnvironmentName;
+                marker.RecordManagedEnvironmentName(
+                    appEnvResource.Name,
+                    managedEnvironmentName,
+                    ManagedEnvironmentNamingMode.Azd);
 
 #pragma warning disable IDE0031 // Use null propagation (IDE0031)
                 if (storageVolume is not null)
@@ -550,8 +587,8 @@ public static class AzureContainerAppExtensions
     }
 
     /// <summary>
-    /// Adds the fallback resolver used for the managed environment's <c>name</c> when
-    /// <see cref="WithUniqueResourceNaming"/> is applied (and azd naming is not in effect).
+    /// Adds the fallback resolver used to track generated managed environment names when azd naming is not in
+    /// effect, substituting the corrected name requirements when <see cref="WithUniqueResourceNaming"/> is applied.
     /// </summary>
     /// <remarks>
     /// Azure.Provisioning's default name resolver only assigns names while the <c>Name</c> property is unset.
@@ -1046,7 +1083,10 @@ public static class AzureContainerAppExtensions
 
             if (resolvedName is not null)
             {
-                marker.RecordManagedEnvironmentName(environmentName, resolvedName);
+                marker.RecordManagedEnvironmentName(
+                    environmentName,
+                    resolvedName,
+                    useUniqueResourceNaming ? ManagedEnvironmentNamingMode.Unique : ManagedEnvironmentNamingMode.Legacy);
             }
 
             return resolvedName;

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -700,6 +700,7 @@ public static class AzureContainerAppExtensions
     /// </summary>
     /// <param name="builder">The <see cref="AzureContainerAppEnvironmentResource"/> to configure.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
     /// <para>
     /// By default, the managed environment's <c>name</c> now incorporates the resource name so that multiple

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -136,8 +136,9 @@ public static class AzureContainerAppExtensions
 
     private sealed class ContainerAppsPipelineStepMarker
     {
+        private const string ResourceGroupTokenPlaceholder = "\u001f\u001f\u001f\u001f\u001f\u001f\u001f\u001f\u001f\u001f\u001f\u001f\u001f";
         private readonly object _lock = new();
-        private readonly Dictionary<string, Dictionary<string, ManagedEnvironmentNamingMode>> _environmentsByManagedEnvironmentName = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, Dictionary<string, ManagedEnvironmentName>> _environmentsByManagedEnvironmentName = new(StringComparer.Ordinal);
 
         public void RecordManagedEnvironmentName(
             string environmentName,
@@ -145,30 +146,29 @@ public static class AzureContainerAppExtensions
             ManagedEnvironmentNamingMode namingMode)
         {
             var expression = managedEnvironmentName.ToString();
+            var effectiveNameKey = GetEffectiveNameKey(expression);
 
             lock (_lock)
             {
-                if (!_environmentsByManagedEnvironmentName.TryGetValue(expression, out var environmentNames))
+                if (!_environmentsByManagedEnvironmentName.TryGetValue(effectiveNameKey, out var environmentNames))
                 {
-                    environmentNames = new Dictionary<string, ManagedEnvironmentNamingMode>(StringComparer.Ordinal);
-                    _environmentsByManagedEnvironmentName.Add(expression, environmentNames);
+                    environmentNames = new Dictionary<string, ManagedEnvironmentName>(StringComparer.Ordinal);
+                    _environmentsByManagedEnvironmentName.Add(effectiveNameKey, environmentNames);
                 }
 
-                environmentNames[environmentName] = namingMode;
+                environmentNames[environmentName] = new ManagedEnvironmentName(expression, namingMode);
             }
         }
 
         public void ValidateManagedEnvironmentNames(IReadOnlySet<string> includedEnvironmentNames)
         {
-            (string Expression, KeyValuePair<string, ManagedEnvironmentNamingMode>[] Environments)[] collisions;
+            KeyValuePair<string, ManagedEnvironmentName>[][] collisions;
 
             lock (_lock)
             {
                 collisions = _environmentsByManagedEnvironmentName
-                    .Select(pair => (
-                        Expression: pair.Key,
-                        Environments: pair.Value.Where(environment => includedEnvironmentNames.Contains(environment.Key)).ToArray()))
-                    .Where(pair => pair.Environments.Length > 1)
+                    .Select(pair => pair.Value.Where(environment => includedEnvironmentNames.Contains(environment.Key)).ToArray())
+                    .Where(environments => environments.Length > 1)
                     .ToArray();
             }
 
@@ -179,12 +179,15 @@ public static class AzureContainerAppExtensions
 
             var collisionDetails = string.Join(
                 "; ",
-                collisions.Select(pair =>
-                    $"'{string.Join("', '", pair.Environments.Select(environment => environment.Key).Order(StringComparer.Ordinal))}' resolve to {pair.Expression}"));
+                collisions.SelectMany(environments =>
+                    environments
+                        .GroupBy(environment => environment.Value.Expression, StringComparer.Ordinal)
+                        .Select(group =>
+                            $"'{string.Join("', '", group.Select(environment => environment.Key).Order(StringComparer.Ordinal))}' resolve to {group.Key}")));
 
             var namingModes = collisions
-                .SelectMany(collision => collision.Environments)
-                .Select(environment => environment.Value)
+                .SelectMany(environments => environments)
+                .Select(environment => environment.Value.NamingMode)
                 .ToHashSet();
             var guidance = new List<string>();
 
@@ -207,6 +210,42 @@ public static class AzureContainerAppExtensions
                 $"Azure Container App environments {collisionDetails}. Multiple environments with the same managed environment name cannot be deployed to one resource group. " +
                 string.Join(" ", guidance));
         }
+
+        private static string GetEffectiveNameKey(string expression)
+        {
+            // Normalize the two generated Bicep shapes that use the same 13-character resource-group token:
+            //   take('cae-${uniqueString(resourceGroup().id)}', 60)
+            //   'cae-${resourceToken}'
+            // Evaluating take after substitution catches syntactically different expressions that deploy the
+            // same physical name. Unknown shapes retain their expression as the key.
+            var normalizedExpression = expression
+                .Replace("${uniqueString(resourceGroup().id)}", ResourceGroupTokenPlaceholder, StringComparison.Ordinal)
+                .Replace("${resourceToken}", ResourceGroupTokenPlaceholder, StringComparison.Ordinal);
+
+            const string TakePrefix = "take('";
+            const string TakeSeparator = "', ";
+            if (normalizedExpression.StartsWith(TakePrefix, StringComparison.Ordinal) &&
+                normalizedExpression.EndsWith(')'))
+            {
+                var separatorIndex = normalizedExpression.LastIndexOf(TakeSeparator, StringComparison.Ordinal);
+                var lengthStart = separatorIndex + TakeSeparator.Length;
+                if (separatorIndex >= TakePrefix.Length &&
+                    int.TryParse(
+                        normalizedExpression.AsSpan(lengthStart, normalizedExpression.Length - lengthStart - 1),
+                        out var maxLength))
+                {
+                    var value = normalizedExpression[TakePrefix.Length..separatorIndex];
+                    return value[..Math.Min(value.Length, maxLength)];
+                }
+            }
+
+            if (normalizedExpression is ['\'', .., '\''])
+            {
+                return normalizedExpression[1..^1];
+            }
+
+            return normalizedExpression;
+        }
     }
 
     private enum ManagedEnvironmentNamingMode
@@ -215,6 +254,8 @@ public static class AzureContainerAppExtensions
         Unique,
         Azd
     }
+
+    private readonly record struct ManagedEnvironmentName(string Expression, ManagedEnvironmentNamingMode NamingMode);
 
     /// <summary>
     /// Adds a container app environment resource to the distributed application builder.

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -146,7 +146,7 @@ public static class AzureContainerAppExtensions
                 collisions.Select(pair =>
                     $"'{string.Join("', '", pair.Value.Order(StringComparer.Ordinal))}' resolve to {pair.Key}"));
 
-            throw new InvalidOperationException(
+            throw new DistributedApplicationException(
                 $"Azure Container App environments {collisionDetails}. Multiple environments with the same managed environment name cannot be deployed to one resource group. " +
                 $"Call '{nameof(WithUniqueResourceNaming)}()' on one or more of the colliding environment resources.");
         }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -278,7 +278,7 @@ builder.Build().Run();
             content = content.Replace(buildRunPattern, replacement, StringComparison.Ordinal);
 
             // WithUniqueResourceNaming is experimental, so suppress the diagnostic in the generated AppHost.
-            content = "#pragma warning disable ASPIREACANAMING001\n" + content;
+            content = "#pragma warning disable ASPIREACANAMING002\n" + content;
 
             File.WriteAllText(appHostFilePath, content);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -219,7 +219,7 @@ builder.Build().Run();
             }
         }
 
-        var workspace = TemporaryWorkspace.Create(output);
+        using var workspace = TemporaryWorkspace.Create(output);
         var startTime = DateTime.UtcNow;
         var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aca-multi-env");
 
@@ -271,7 +271,11 @@ builder.AddContainer("api2", "mcr.microsoft.com/azuredocs/aci-helloworld", "late
 builder.Build().Run();
 """;
 
-            content = content.Replace(buildRunPattern, replacement);
+            // Fail loudly if the AppHost template no longer contains the expected entry point, otherwise the
+            // Replace below would silently no-op and the test would deploy an unmodified AppHost, appearing to
+            // pass without ever exercising the multi-environment scenario.
+            Assert.Contains(buildRunPattern, content, StringComparison.Ordinal);
+            content = content.Replace(buildRunPattern, replacement, StringComparison.Ordinal);
 
             // WithUniqueResourceNaming is experimental, so suppress the diagnostic in the generated AppHost.
             content = "#pragma warning disable ASPIREACANAMING001\n" + content;

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -31,6 +31,20 @@ public sealed class AcaCompactNamingDeploymentTests(ITestOutputHelper output)
         await DeployWithCompactNamingFixesStorageCollisionCore(linkedCts.Token);
     }
 
+    /// <summary>
+    /// Verifies that deploying two ACA environments in the same resource group creates
+    /// two distinct managed environments.
+    /// </summary>
+    [Fact]
+    public async Task DeployWithMultipleContainerAppEnvironmentsCreatesDistinctManagedEnvironments()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+
+        await DeployWithMultipleContainerAppEnvironmentsCreatesDistinctManagedEnvironmentsCore(linkedCts.Token);
+    }
+
     private async Task DeployWithCompactNamingFixesStorageCollisionCore(CancellationToken cancellationToken)
     {
         var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
@@ -172,6 +186,140 @@ builder.Build().Run();
 
             DeploymentReporter.ReportDeploymentFailure(
                 nameof(DeployWithCompactNamingFixesStorageCollision),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+
+    private async Task DeployWithMultipleContainerAppEnvironmentsCreatesDistinctManagedEnvironmentsCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("aca-multi-env");
+
+        output.WriteLine($"Test: {nameof(DeployWithMultipleContainerAppEnvironmentsCreatesDistinctManagedEnvironments)}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+            output.WriteLine("Step 3: Creating single-file AppHost...");
+            await auto.AspireInitAsync(counter);
+
+            output.WriteLine("Step 4: Adding Azure Container Apps package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppContainers");
+            await auto.EnterAsync();
+
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            var appHostFilePath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.cs");
+            var content = File.ReadAllText(appHostFilePath);
+
+            var buildRunPattern = "builder.Build().Run();";
+            var replacement = """
+var cae1 = builder.AddAzureContainerAppEnvironment("cae1");
+var cae2 = builder.AddAzureContainerAppEnvironment("cae2");
+
+builder.AddContainer("api1", "mcr.microsoft.com/azuredocs/aci-helloworld", "latest")
+       .WithImageSHA256("456a1150aa41340a14c7be1342deda2cde9e6e7df9fde6b8a69de0ae04f92fad")
+       .WithComputeEnvironment(cae1);
+
+builder.AddContainer("api2", "mcr.microsoft.com/azuredocs/aci-helloworld", "latest")
+       .WithImageSHA256("456a1150aa41340a14c7be1342deda2cde9e6e7df9fde6b8a69de0ae04f92fad")
+       .WithComputeEnvironment(cae2);
+
+builder.Build().Run();
+""";
+
+            content = content.Replace(buildRunPattern, replacement);
+            File.WriteAllText(appHostFilePath, content);
+
+            output.WriteLine("Modified apphost.cs with two Azure Container App environments");
+
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 7: Deploying two Azure Container App environments...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            output.WriteLine("Step 8: Verifying managed environments...");
+            await auto.TypeAsync(
+                $"RG_NAME=\"{resourceGroupName}\" && " +
+                "ENV_NAMES=$(az containerapp env list -g \"$RG_NAME\" --query \"[].name\" -o tsv) && " +
+                "echo \"Managed environments:\" && printf '%s\\n' \"$ENV_NAMES\" && " +
+                "ENV_COUNT=$(printf '%s\\n' \"$ENV_NAMES\" | sed '/^$/d' | wc -l | tr -d ' ') && " +
+                "UNIQUE_ENV_COUNT=$(printf '%s\\n' \"$ENV_NAMES\" | sed '/^$/d' | sort -u | wc -l | tr -d ' ') && " +
+                "echo \"Count: $ENV_COUNT, unique count: $UNIQUE_ENV_COUNT\" && " +
+                "if [ \"$ENV_COUNT\" -ne 2 ]; then echo \"❌ Expected 2 managed environments\"; exit 1; fi && " +
+                "if [ \"$UNIQUE_ENV_COUNT\" -ne 2 ]; then echo \"❌ Expected 2 distinct managed environment names\"; exit 1; fi");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            output.WriteLine("Step 9: Destroying Azure deployment...");
+            await auto.AspireDestroyAsync(counter);
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"✅ Test completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployWithMultipleContainerAppEnvironmentsCreatesDistinctManagedEnvironments),
+                resourceGroupName,
+                new Dictionary<string, string>(),
+                duration);
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"❌ Test failed: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployWithMultipleContainerAppEnvironmentsCreatesDistinctManagedEnvironments),
                 resourceGroupName,
                 ex.Message,
                 ex.StackTrace);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs
@@ -255,8 +255,10 @@ builder.Build().Run();
 
             var buildRunPattern = "builder.Build().Run();";
             var replacement = """
-var cae1 = builder.AddAzureContainerAppEnvironment("cae1");
-var cae2 = builder.AddAzureContainerAppEnvironment("cae2");
+var cae1 = builder.AddAzureContainerAppEnvironment("cae1")
+                  .WithUniqueResourceNaming();
+var cae2 = builder.AddAzureContainerAppEnvironment("cae2")
+                  .WithUniqueResourceNaming();
 
 builder.AddContainer("api1", "mcr.microsoft.com/azuredocs/aci-helloworld", "latest")
        .WithImageSHA256("456a1150aa41340a14c7be1342deda2cde9e6e7df9fde6b8a69de0ae04f92fad")
@@ -270,6 +272,10 @@ builder.Build().Run();
 """;
 
             content = content.Replace(buildRunPattern, replacement);
+
+            // WithUniqueResourceNaming is experimental, so suppress the diagnostic in the generated AppHost.
+            content = "#pragma warning disable ASPIREACANAMING001\n" + content;
+
             File.WriteAllText(appHostFilePath, content);
 
             output.WriteLine("Modified apphost.cs with two Azure Container App environments");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -902,6 +902,12 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         }
     }
 
+    private sealed class CustomManagedEnvironmentNameResolver : ResourceNamePropertyResolver
+    {
+        public override BicepValue<string>? ResolveName(ProvisioningBuildOptions options, ProvisionableResource resource, ResourceNameRequirements requirements)
+            => resource is ContainerAppManagedEnvironment ? new BicepValue<string>("customcae") : null;
+    }
+
     [Fact]
     public async Task ExternalEndpointBecomesIngress()
     {
@@ -1959,6 +1965,33 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         var name = GetManagedEnvironmentNameExpression(bicep);
 
         Assert.Equal("take('cae${uniqueString(resourceGroup().id)}', 24)", name);
+    }
+
+    [Fact]
+    public async Task ConfiguredNameResolverWinsOverManagedEnvironmentNameFallback()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.Services.Configure<AzureProvisioningOptions>(options =>
+            options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new CustomManagedEnvironmentNameResolver()));
+
+        var env = builder.AddAzureContainerAppEnvironment("cae1");
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var envResource = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
+
+        var (_, bicep) = await GetManifestWithBicep(envResource);
+
+        var name = GetManagedEnvironmentNameExpression(bicep);
+
+        Assert.Equal("'customcae'", name);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2016,6 +2016,18 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DirectlyAddedAzureContainerAppEnvironmentDoesNotRequireContainerAppsValidationStep()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddAzureProvisioning();
+        builder.AddResource(new AzureContainerAppEnvironmentResource("env", _ => { }));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+    }
+
+    [Fact]
     public async Task WithUniqueResourceNamingPreservesDigitsInManagedEnvironmentName()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1906,8 +1906,14 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         var envResources = model.Resources.OfType<AzureContainerAppEnvironmentResource>().ToList();
         Assert.Equal(2, envResources.Count);
 
-        var (_, bicep1) = await GetManifestWithBicep(envResources[0]);
-        var (_, bicep2) = await GetManifestWithBicep(envResources[1]);
+        // Look up each environment by resource name rather than relying on the enumeration
+        // order of model.Resources, which isn't guaranteed and would make the assertions below
+        // flip (and fail) even when the naming behavior is correct.
+        var env1Resource = Assert.Single(envResources, r => r.Name == "cae1");
+        var env2Resource = Assert.Single(envResources, r => r.Name == "cae2");
+
+        var (_, bicep1) = await GetManifestWithBicep(env1Resource);
+        var (_, bicep2) = await GetManifestWithBicep(env2Resource);
 
         var name1 = GetManagedEnvironmentNameExpression(bicep1);
         var name2 = GetManagedEnvironmentNameExpression(bicep2);
@@ -1953,6 +1959,48 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         var name = GetManagedEnvironmentNameExpression(bicep);
 
         Assert.Equal("take('cae${uniqueString(resourceGroup().id)}', 24)", name);
+    }
+
+    [Fact]
+    public async Task WithCompactResourceNamingGeneratesDistinctManagedEnvironmentNames()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Compact naming doesn't set the managed environment name itself, so it flows through the
+        // same default-naming path as the plain case. Two compact environments in one resource
+        // group must still get distinct, digit-preserving names to avoid the collision in #18722.
+        var env1 = builder.AddAzureContainerAppEnvironment("cae1")
+            .WithCompactResourceNaming();
+        var env2 = builder.AddAzureContainerAppEnvironment("cae2")
+            .WithCompactResourceNaming();
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env1);
+
+        builder.AddContainer("api2", "myimage")
+            .WithComputeEnvironment(env2);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var envResources = model.Resources.OfType<AzureContainerAppEnvironmentResource>().ToList();
+        Assert.Equal(2, envResources.Count);
+
+        var env1Resource = Assert.Single(envResources, r => r.Name == "cae1");
+        var env2Resource = Assert.Single(envResources, r => r.Name == "cae2");
+
+        var (_, bicep1) = await GetManifestWithBicep(env1Resource);
+        var (_, bicep2) = await GetManifestWithBicep(env2Resource);
+
+        var name1 = GetManagedEnvironmentNameExpression(bicep1);
+        var name2 = GetManagedEnvironmentNameExpression(bicep2);
+
+        Assert.NotEqual(name1, name2);
+        Assert.Equal("take('cae1${uniqueString(resourceGroup().id)}', 24)", name1);
+        Assert.Equal("take('cae2${uniqueString(resourceGroup().id)}', 24)", name2);
     }
 
     private static string GetManagedEnvironmentNameExpression(string bicep)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2016,6 +2016,28 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ExcludedAzureContainerAppEnvironmentDoesNotParticipateInCollisionValidation()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: "publish-manifest");
+
+        var includedEnvironment = builder.AddAzureContainerAppEnvironment("cae1");
+        builder.AddAzureContainerAppEnvironment("cae2")
+            .ExcludeFromManifest();
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(includedEnvironment);
+
+        using var app = builder.Build();
+
+        await app.RunAsync();
+    }
+
+    [Fact]
     public async Task DirectlyAddedAzureContainerAppEnvironmentDoesNotRequireContainerAppsValidationStep()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1935,10 +1935,11 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         // https://github.com/microsoft/aspire/issues/18722.
         Assert.NotEqual(name1, name2);
 
-        // The generated name incorporates the resource name (keeping its trailing digit)
-        // so the two environments are distinguishable.
-        Assert.Equal("take('cae1${uniqueString(resourceGroup().id)}', 24)", name1);
-        Assert.Equal("take('cae2${uniqueString(resourceGroup().id)}', 24)", name2);
+        // The generated name is computed with the same algorithm as every other Azure resource type
+        // (sanitized resource name + '-' separator + uniqueString(resourceGroup().id) suffix, truncated to the
+        // 32-character managed environment limit), keeping the trailing digit so the two environments differ.
+        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 32)", name1);
+        Assert.Equal("take('cae2-${uniqueString(resourceGroup().id)}', 32)", name2);
     }
 
     [Fact]
@@ -2008,7 +2009,37 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         var name = GetManagedEnvironmentNameExpression(bicep);
 
-        Assert.Equal("take('cae1${uniqueString(resourceGroup().id)}', 24)", name);
+        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 32)", name);
+    }
+
+    [Fact]
+    public async Task WithUniqueResourceNamingComputesNameLikeStandardAzureResourceNaming()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // A hyphenated resource name normalizes to a bicep identifier with an underscore ("my_cae"). The managed
+        // environment character set doesn't allow underscores, so the sanitizer drops it exactly like it does for
+        // every other Azure resource type. This documents that WithUniqueResourceNaming is consistent with the
+        // standard naming algorithm rather than inventing a bespoke scheme.
+        var env = builder.AddAzureContainerAppEnvironment("my-cae")
+            .WithUniqueResourceNaming();
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var envResource = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
+
+        var (_, bicep) = await GetManifestWithBicep(envResource);
+
+        var name = GetManagedEnvironmentNameExpression(bicep);
+
+        Assert.Equal("take('mycae-${uniqueString(resourceGroup().id)}', 32)", name);
     }
 
     [Fact]
@@ -2079,15 +2110,15 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         var name2 = GetManagedEnvironmentNameExpression(bicep2);
 
         Assert.NotEqual(name1, name2);
-        Assert.Equal("take('cae1${uniqueString(resourceGroup().id)}', 24)", name1);
-        Assert.Equal("take('cae2${uniqueString(resourceGroup().id)}', 24)", name2);
+        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 32)", name1);
+        Assert.Equal("take('cae2-${uniqueString(resourceGroup().id)}', 32)", name2);
     }
 
     private static string GetManagedEnvironmentNameExpression(string bicep)
     {
         // Extract the 'name:' line for the managed environment resource, e.g.:
         //   resource cae1 'Microsoft.App/managedEnvironments@2025-07-01' = {
-        //     name: take('cae1${uniqueString(resourceGroup().id)}', 24)
+        //     name: take('cae1-${uniqueString(resourceGroup().id)}', 32)
         var match = System.Text.RegularExpressions.Regex.Match(
             bicep,
             @"'Microsoft\.App/managedEnvironments@[^']+'\s*=\s*\{\s*\r?\n\s*name:\s*(?<name>.+)");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2220,6 +2220,34 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task MixedAzdAndUniqueNamingDetectsEquivalentPhysicalNames()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: "publish-manifest");
+
+        var azdEnvironment = builder.AddAzureContainerAppEnvironment("azd")
+            .WithAzdResourceNaming();
+        var uniqueEnvironment = builder.AddAzureContainerAppEnvironment("cae")
+            .WithUniqueResourceNaming();
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(azdEnvironment);
+        builder.AddContainer("api2", "myimage")
+            .WithComputeEnvironment(uniqueEnvironment);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => app.RunAsync());
+
+        Assert.Contains("'azd' resolve to 'cae-${resourceToken}'", exception.Message);
+        Assert.Contains("'cae' resolve to take('cae-${uniqueString(resourceGroup().id)}', 60)", exception.Message);
+    }
+
+    [Fact]
     public void WithUniqueResourceNamingThrowsWhenBuilderIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => AzureContainerAppExtensions.WithUniqueResourceNaming(null!));

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1872,8 +1872,10 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path, step: "publish-manifest");
 
-        var env1 = builder.AddAzureContainerAppEnvironment("env1");
-        var env2 = builder.AddAzureContainerAppEnvironment("env2");
+        var env1 = builder.AddAzureContainerAppEnvironment("env1")
+            .WithUniqueResourceNaming();
+        var env2 = builder.AddAzureContainerAppEnvironment("env2")
+            .WithUniqueResourceNaming();
 
         builder.AddContainer("api1", "myimage")
             .WithComputeEnvironment(env1);
@@ -1965,8 +1967,6 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        await ExecuteBeforeStartHooksAsync(app, default);
-
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var envResources = model.Resources.OfType<AzureContainerAppEnvironmentResource>().ToList();
@@ -1983,6 +1983,37 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("take('cae${uniqueString(resourceGroup().id)}', 24)", name1);
         Assert.Equal(name1, name2);
+    }
+
+    [Fact]
+    public async Task MultipleAzureContainerAppEnvironmentsWithCollidingLegacyNamesFailPublish()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: "publish-manifest");
+
+        var env1 = builder.AddAzureContainerAppEnvironment("cae1");
+        var env2 = builder.AddAzureContainerAppEnvironment("cae2");
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env1);
+
+        builder.AddContainer("api2", "myimage")
+            .WithComputeEnvironment(env2);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => app.RunAsync());
+        var validationException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+
+        Assert.Equal(
+            "Azure Container App environments 'cae1', 'cae2' resolve to take('cae${uniqueString(resourceGroup().id)}', 24). " +
+            "Multiple environments with the same managed environment name cannot be deployed to one resource group. " +
+            "Call 'WithUniqueResourceNaming()' on one or more of the colliding environment resources.",
+            validationException.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -903,10 +903,10 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         }
     }
 
-    private sealed class CustomManagedEnvironmentNameResolver : ResourceNamePropertyResolver
+    private sealed class BicepIdentifierManagedEnvironmentNameResolver : ResourceNamePropertyResolver
     {
         public override BicepValue<string>? ResolveName(ProvisioningBuildOptions options, ProvisionableResource resource, ResourceNameRequirements requirements)
-            => resource is ContainerAppManagedEnvironment ? new BicepValue<string>("customcae") : null;
+            => resource is ContainerAppManagedEnvironment ? new BicepValue<string>(resource.BicepIdentifier) : null;
     }
 
     [Fact]
@@ -2091,7 +2091,7 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         builder.Services.Configure<AzureProvisioningOptions>(options =>
-            options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new CustomManagedEnvironmentNameResolver()));
+            options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new BicepIdentifierManagedEnvironmentNameResolver()));
 
         var env = builder.AddAzureContainerAppEnvironment("cae1")
             .WithUniqueResourceNaming();
@@ -2110,7 +2110,39 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         var name = GetManagedEnvironmentNameExpression(bicep);
 
-        Assert.Equal("'customcae'", name);
+        Assert.Equal("'cae1'", name);
+    }
+
+    [Fact]
+    public async Task ConfiguredNameResolverPreventsFalseLegacyCollision()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: "publish-manifest");
+
+        builder.Services.Configure<AzureProvisioningOptions>(options =>
+            options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new BicepIdentifierManagedEnvironmentNameResolver()));
+
+        var env1 = builder.AddAzureContainerAppEnvironment("cae1");
+        var env2 = builder.AddAzureContainerAppEnvironment("cae2");
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env1);
+        builder.AddContainer("api2", "myimage")
+            .WithComputeEnvironment(env2);
+
+        using var app = builder.Build();
+
+        await app.RunAsync();
+    }
+
+    [Fact]
+    public void WithUniqueResourceNamingThrowsWhenBuilderIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => AzureContainerAppExtensions.WithUniqueResourceNaming(null!));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -6,6 +6,7 @@
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREACANAMING001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable ASPIREACANAMING002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1883,6 +1883,93 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task MultipleAzureContainerAppEnvironmentsGenerateDistinctManagedEnvironmentNames()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Two environments in the same AppHost (and therefore the same resource group).
+        var env1 = builder.AddAzureContainerAppEnvironment("cae1");
+        var env2 = builder.AddAzureContainerAppEnvironment("cae2");
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env1);
+
+        builder.AddContainer("api2", "myimage")
+            .WithComputeEnvironment(env2);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var envResources = model.Resources.OfType<AzureContainerAppEnvironmentResource>().ToList();
+        Assert.Equal(2, envResources.Count);
+
+        var (_, bicep1) = await GetManifestWithBicep(envResources[0]);
+        var (_, bicep2) = await GetManifestWithBicep(envResources[1]);
+
+        var name1 = GetManagedEnvironmentNameExpression(bicep1);
+        var name2 = GetManagedEnvironmentNameExpression(bicep2);
+
+        // Both environments deploy to the same resource group, so their generated
+        // 'name:' expressions must differ. When they don't, the two symbolic
+        // environments collapse onto a single physical Azure Container Apps
+        // environment and concurrent container-app writes race with
+        // ManagedEnvironmentOperationInProgress. See
+        // https://github.com/microsoft/aspire/issues/18722.
+        Assert.NotEqual(name1, name2);
+
+        // The generated name incorporates the resource name (keeping its trailing digit)
+        // so the two environments are distinguishable.
+        Assert.Equal("take('cae1${uniqueString(resourceGroup().id)}', 24)", name1);
+        Assert.Equal("take('cae2${uniqueString(resourceGroup().id)}', 24)", name2);
+    }
+
+    [Fact]
+    public async Task WithSingletonResourceNamingPreservesPreFixManagedEnvironmentName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Opting into singleton naming keeps Azure.Provisioning's default (lowercase-letters-only)
+        // name so an already-deployed environment is not recreated. The trailing digit is dropped,
+        // reproducing the pre-fix name.
+        var env = builder.AddAzureContainerAppEnvironment("cae1")
+            .WithSingletonResourceNaming();
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var envResource = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
+
+        var (_, bicep) = await GetManifestWithBicep(envResource);
+
+        var name = GetManagedEnvironmentNameExpression(bicep);
+
+        Assert.Equal("take('cae${uniqueString(resourceGroup().id)}', 24)", name);
+    }
+
+    private static string GetManagedEnvironmentNameExpression(string bicep)
+    {
+        // Extract the 'name:' line for the managed environment resource, e.g.:
+        //   resource cae1 'Microsoft.App/managedEnvironments@2025-07-01' = {
+        //     name: take('cae1${uniqueString(resourceGroup().id)}', 24)
+        var match = System.Text.RegularExpressions.Regex.Match(
+            bicep,
+            @"'Microsoft\.App/managedEnvironments@[^']+'\s*=\s*\{\s*\r?\n\s*name:\s*(?<name>.+)");
+
+        Assert.True(match.Success, $"Could not find managed environment name in bicep:\n{bicep}");
+
+        return match.Groups["name"].Value.Trim();
+    }
+
+    [Fact]
     public async Task PublishAsContainerAppJobInfluencesContainerAppDefinition()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1893,9 +1893,12 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        // Two environments in the same AppHost (and therefore the same resource group).
-        var env1 = builder.AddAzureContainerAppEnvironment("cae1");
-        var env2 = builder.AddAzureContainerAppEnvironment("cae2");
+        // Two environments in the same AppHost (and therefore the same resource group). Opting into
+        // unique naming keeps each resource name's digits so the environments get distinct names.
+        var env1 = builder.AddAzureContainerAppEnvironment("cae1")
+            .WithUniqueResourceNaming();
+        var env2 = builder.AddAzureContainerAppEnvironment("cae2")
+            .WithUniqueResourceNaming();
 
         builder.AddContainer("api1", "myimage")
             .WithComputeEnvironment(env1);
@@ -1939,15 +1942,56 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task WithSingletonResourceNamingPreservesPreFixManagedEnvironmentName()
+    public async Task MultipleAzureContainerAppEnvironmentsShareManagedEnvironmentNameByDefault()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        // Opting into singleton naming keeps Azure.Provisioning's default (lowercase-letters-only)
-        // name so an already-deployed environment is not recreated. The trailing digit is dropped,
-        // reproducing the pre-fix name.
+        // Without opting into unique naming, both environments fall through to Azure.Provisioning's default
+        // name, whose sanitizer keeps only lowercase letters and drops the trailing digit. This preserves the
+        // pre-existing (colliding) behavior so already-deployed environments are not renamed. Deploying more
+        // than one environment to a single resource group in this mode collapses them onto one physical
+        // environment (the reason WithUniqueResourceNaming exists). See
+        // https://github.com/microsoft/aspire/issues/18722.
+        var env1 = builder.AddAzureContainerAppEnvironment("cae1");
+        var env2 = builder.AddAzureContainerAppEnvironment("cae2");
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env1);
+
+        builder.AddContainer("api2", "myimage")
+            .WithComputeEnvironment(env2);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var envResources = model.Resources.OfType<AzureContainerAppEnvironmentResource>().ToList();
+        Assert.Equal(2, envResources.Count);
+
+        var env1Resource = Assert.Single(envResources, r => r.Name == "cae1");
+        var env2Resource = Assert.Single(envResources, r => r.Name == "cae2");
+
+        var (_, bicep1) = await GetManifestWithBicep(env1Resource);
+        var (_, bicep2) = await GetManifestWithBicep(env2Resource);
+
+        var name1 = GetManagedEnvironmentNameExpression(bicep1);
+        var name2 = GetManagedEnvironmentNameExpression(bicep2);
+
+        Assert.Equal("take('cae${uniqueString(resourceGroup().id)}', 24)", name1);
+        Assert.Equal(name1, name2);
+    }
+
+    [Fact]
+    public async Task WithUniqueResourceNamingPreservesDigitsInManagedEnvironmentName()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        // Opting into unique naming keeps the resource name's trailing digit, so the environment name is
+        // distinct from other digit-suffixed environments in the same resource group.
         var env = builder.AddAzureContainerAppEnvironment("cae1")
-            .WithSingletonResourceNaming();
+            .WithUniqueResourceNaming();
 
         builder.AddContainer("api1", "myimage")
             .WithComputeEnvironment(env);
@@ -1964,7 +2008,7 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         var name = GetManagedEnvironmentNameExpression(bicep);
 
-        Assert.Equal("take('cae${uniqueString(resourceGroup().id)}', 24)", name);
+        Assert.Equal("take('cae1${uniqueString(resourceGroup().id)}', 24)", name);
     }
 
     [Fact]
@@ -1975,7 +2019,8 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         builder.Services.Configure<AzureProvisioningOptions>(options =>
             options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new CustomManagedEnvironmentNameResolver()));
 
-        var env = builder.AddAzureContainerAppEnvironment("cae1");
+        var env = builder.AddAzureContainerAppEnvironment("cae1")
+            .WithUniqueResourceNaming();
 
         builder.AddContainer("api1", "myimage")
             .WithComputeEnvironment(env);
@@ -1999,13 +2044,15 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
-        // Compact naming doesn't set the managed environment name itself, so it flows through the
-        // same default-naming path as the plain case. Two compact environments in one resource
-        // group must still get distinct, digit-preserving names to avoid the collision in #18722.
+        // Compact naming doesn't set the managed environment name itself. Combined with unique naming, two
+        // compact environments in one resource group must still get distinct, digit-preserving names to avoid
+        // the collision in #18722.
         var env1 = builder.AddAzureContainerAppEnvironment("cae1")
-            .WithCompactResourceNaming();
+            .WithCompactResourceNaming()
+            .WithUniqueResourceNaming();
         var env2 = builder.AddAzureContainerAppEnvironment("cae2")
-            .WithCompactResourceNaming();
+            .WithCompactResourceNaming()
+            .WithUniqueResourceNaming();
 
         builder.AddContainer("api1", "myimage")
             .WithComputeEnvironment(env1);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1938,9 +1938,9 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         // The generated name is computed with the same algorithm as every other Azure resource type
         // (sanitized resource name + '-' separator + uniqueString(resourceGroup().id) suffix, truncated to the
-        // 32-character managed environment limit), keeping the trailing digit so the two environments differ.
-        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 32)", name1);
-        Assert.Equal("take('cae2-${uniqueString(resourceGroup().id)}', 32)", name2);
+        // 60-character managed environment limit), keeping the trailing digit so the two environments differ.
+        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 60)", name1);
+        Assert.Equal("take('cae2-${uniqueString(resourceGroup().id)}', 60)", name2);
     }
 
     [Fact]
@@ -2010,7 +2010,7 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         var name = GetManagedEnvironmentNameExpression(bicep);
 
-        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 32)", name);
+        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 60)", name);
     }
 
     [Fact]
@@ -2040,7 +2040,7 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         var name = GetManagedEnvironmentNameExpression(bicep);
 
-        Assert.Equal("take('mycae-${uniqueString(resourceGroup().id)}', 32)", name);
+        Assert.Equal("take('mycae-${uniqueString(resourceGroup().id)}', 60)", name);
     }
 
     [Fact]
@@ -2111,15 +2111,15 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         var name2 = GetManagedEnvironmentNameExpression(bicep2);
 
         Assert.NotEqual(name1, name2);
-        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 32)", name1);
-        Assert.Equal("take('cae2-${uniqueString(resourceGroup().id)}', 32)", name2);
+        Assert.Equal("take('cae1-${uniqueString(resourceGroup().id)}', 60)", name1);
+        Assert.Equal("take('cae2-${uniqueString(resourceGroup().id)}', 60)", name2);
     }
 
     private static string GetManagedEnvironmentNameExpression(string bicep)
     {
         // Extract the 'name:' line for the managed environment resource, e.g.:
         //   resource cae1 'Microsoft.App/managedEnvironments@2025-07-01' = {
-        //     name: take('cae1-${uniqueString(resourceGroup().id)}', 32)
+        //     name: take('cae1-${uniqueString(resourceGroup().id)}', 60)
         var match = System.Text.RegularExpressions.Regex.Match(
             bicep,
             @"'Microsoft\.App/managedEnvironments@[^']+'\s*=\s*\{\s*\r?\n\s*name:\s*(?<name>.+)");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2006,14 +2006,13 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
 
         using var app = builder.Build();
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => app.RunAsync());
-        var validationException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => app.RunAsync());
 
         Assert.Equal(
             "Azure Container App environments 'cae1', 'cae2' resolve to take('cae${uniqueString(resourceGroup().id)}', 24). " +
             "Multiple environments with the same managed environment name cannot be deployed to one resource group. " +
             "Call 'WithUniqueResourceNaming()' on one or more of the colliding environment resources.",
-            validationException.Message);
+            exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -2011,7 +2011,7 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         Assert.Equal(
             "Azure Container App environments 'cae1', 'cae2' resolve to take('cae${uniqueString(resourceGroup().id)}', 24). " +
             "Multiple environments with the same managed environment name cannot be deployed to one resource group. " +
-            "Call 'WithUniqueResourceNaming()' on one or more of the colliding environment resources.",
+            "For environments using the default naming convention, call 'WithUniqueResourceNaming()'.",
             exception.Message);
     }
 
@@ -2106,7 +2106,7 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var envResource = Assert.Single(model.Resources.OfType<AzureContainerAppEnvironmentResource>());
 
-        var (_, bicep) = await GetManifestWithBicep(envResource);
+        var bicep = envResource.GetBicepTemplateString();
 
         var name = GetManagedEnvironmentNameExpression(bicep);
 
@@ -2137,6 +2137,64 @@ public class AzureContainerAppsTests(ITestOutputHelper outputHelper)
         using var app = builder.Build();
 
         await app.RunAsync();
+    }
+
+    [Fact]
+    public async Task UniqueNamingCollisionSuggestsRenamingOrExplicitResolver()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: "publish-manifest");
+
+        var env1 = builder.AddAzureContainerAppEnvironment("cae-1")
+            .WithUniqueResourceNaming();
+        var env2 = builder.AddAzureContainerAppEnvironment("cae1")
+            .WithUniqueResourceNaming();
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env1);
+        builder.AddContainer("api2", "myimage")
+            .WithComputeEnvironment(env2);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => app.RunAsync());
+
+        Assert.Contains(
+            "For environments already using 'WithUniqueResourceNaming()', rename one or more resources or configure an explicit name resolver.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task AzdNamingCollisionSuggestsRemovingAzdNamingOrExplicitNames()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: "publish-manifest");
+
+        var env1 = builder.AddAzureContainerAppEnvironment("cae1")
+            .WithAzdResourceNaming();
+        var env2 = builder.AddAzureContainerAppEnvironment("cae2")
+            .WithAzdResourceNaming();
+
+        builder.AddContainer("api1", "myimage")
+            .WithComputeEnvironment(env1);
+        builder.AddContainer("api2", "myimage")
+            .WithComputeEnvironment(env2);
+
+        using var app = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() => app.RunAsync());
+
+        Assert.Contains(
+            "For environments using 'WithAzdResourceNaming()', remove it or configure distinct managed environment names explicitly.",
+            exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithFoundryAndAzureContainerApps_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithFoundryAndAzureContainerApps_CreatesCorrectDependencies.verified.txt
@@ -15,10 +15,10 @@ This shows the order in which steps would execute, respecting all dependencies.
 Steps with no dependencies run first, followed by steps that depend on them.
 
   1. azure-prepare-resources
-  2. validate-compute-environments
-  3. prepare-azure-container-apps-aca-env
-  4. prepare-foundry-project-foundry-project
-  5. validate-azure-container-apps
+  2. validate-azure-container-apps
+  3. validate-compute-environments
+  4. prepare-azure-container-apps-aca-env
+  5. prepare-foundry-project-foundry-project
   6. before-start
   7. process-parameters
   8. build-prereq
@@ -153,7 +153,7 @@ Step: login-to-acr-foundry-project-acr
 
 Step: prepare-azure-container-apps-aca-env
     Description: Prepares Azure Container Apps deployment targets for aca-env.
-    Dependencies: ✓ azure-prepare-resources, ✓ validate-compute-environments
+    Dependencies: ✓ azure-prepare-resources, ✓ validate-azure-container-apps, ✓ validate-compute-environments
     Resource: aca-env (AzureContainerAppEnvironmentResource)
 
 Step: prepare-foundry-project-foundry-project
@@ -255,7 +255,7 @@ Step: push-prereq
     Dependencies: ✓ login-to-acr-aca-env-acr, ✓ login-to-acr-foundry-project-acr
 
 Step: validate-azure-container-apps
-    Dependencies: none
+    Dependencies: ✓ azure-prepare-resources
 
 Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
@@ -291,9 +291,10 @@ If targeting 'before-start':
   Direct dependencies: azure-prepare-resources, prepare-azure-container-apps-aca-env, prepare-foundry-project-foundry-project, validate-azure-container-apps, validate-compute-environments
   Total steps: 6
   Execution order:
-    [0] azure-prepare-resources | validate-azure-container-apps | validate-compute-environments (parallel)
-    [1] prepare-azure-container-apps-aca-env | prepare-foundry-project-foundry-project (parallel)
-    [2] before-start
+    [0] azure-prepare-resources | validate-compute-environments (parallel)
+    [1] prepare-foundry-project-foundry-project | validate-azure-container-apps (parallel)
+    [2] prepare-azure-container-apps-aca-env
+    [3] before-start
 
 If targeting 'build':
   Direct dependencies: build-agent, build-api
@@ -464,11 +465,12 @@ If targeting 'login-to-acr-foundry-project-acr':
     [5] login-to-acr-foundry-project-acr
 
 If targeting 'prepare-azure-container-apps-aca-env':
-  Direct dependencies: azure-prepare-resources, validate-compute-environments
-  Total steps: 3
+  Direct dependencies: azure-prepare-resources, validate-azure-container-apps, validate-compute-environments
+  Total steps: 4
   Execution order:
     [0] azure-prepare-resources | validate-compute-environments (parallel)
-    [1] prepare-azure-container-apps-aca-env
+    [1] validate-azure-container-apps
+    [2] prepare-azure-container-apps-aca-env
 
 If targeting 'prepare-foundry-project-foundry-project':
   Direct dependencies: azure-prepare-resources, validate-compute-environments
@@ -678,10 +680,11 @@ If targeting 'push-prereq':
     [6] push-prereq
 
 If targeting 'validate-azure-container-apps':
-  Direct dependencies: none
-  Total steps: 1
+  Direct dependencies: azure-prepare-resources
+  Total steps: 2
   Execution order:
-    [0] validate-azure-container-apps
+    [0] azure-prepare-resources
+    [1] validate-azure-container-apps
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithMultipleComputeEnvironments_Works_step=diagnostics.verified.txt
@@ -17,9 +17,9 @@ Steps with no dependencies run first, followed by steps that depend on them.
   1. azure-prepare-resources
   2. validate-compute-environments
   3. prepare-azure-app-service-aas-env
-  4. prepare-azure-container-apps-aca-env
-  5. validate-azure-app-service
-  6. validate-azure-container-apps
+  4. validate-azure-container-apps
+  5. prepare-azure-container-apps-aca-env
+  6. validate-azure-app-service
   7. before-start
   8. process-parameters
   9. build-prereq
@@ -167,7 +167,7 @@ Step: prepare-azure-app-service-aas-env
 
 Step: prepare-azure-container-apps-aca-env
     Description: Prepares Azure Container Apps deployment targets for aca-env.
-    Dependencies: ✓ azure-prepare-resources, ✓ validate-compute-environments
+    Dependencies: ✓ azure-prepare-resources, ✓ validate-azure-container-apps, ✓ validate-compute-environments
     Resource: aca-env (AzureContainerAppEnvironmentResource)
 
 Step: print-api-service-summary
@@ -302,7 +302,7 @@ Step: validate-azure-app-service
     Dependencies: none
 
 Step: validate-azure-container-apps
-    Dependencies: none
+    Dependencies: ✓ azure-prepare-resources
 
 Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
@@ -338,9 +338,10 @@ If targeting 'before-start':
   Direct dependencies: azure-prepare-resources, prepare-azure-app-service-aas-env, prepare-azure-container-apps-aca-env, validate-azure-app-service, validate-azure-container-apps, validate-compute-environments
   Total steps: 7
   Execution order:
-    [0] azure-prepare-resources | validate-azure-app-service | validate-azure-container-apps | validate-compute-environments (parallel)
-    [1] prepare-azure-app-service-aas-env | prepare-azure-container-apps-aca-env (parallel)
-    [2] before-start
+    [0] azure-prepare-resources | validate-azure-app-service | validate-compute-environments (parallel)
+    [1] prepare-azure-app-service-aas-env | validate-azure-container-apps (parallel)
+    [2] prepare-azure-container-apps-aca-env
+    [3] before-start
 
 If targeting 'build':
   Direct dependencies: build-api-service, build-python-app
@@ -516,11 +517,12 @@ If targeting 'prepare-azure-app-service-aas-env':
     [1] prepare-azure-app-service-aas-env
 
 If targeting 'prepare-azure-container-apps-aca-env':
-  Direct dependencies: azure-prepare-resources, validate-compute-environments
-  Total steps: 3
+  Direct dependencies: azure-prepare-resources, validate-azure-container-apps, validate-compute-environments
+  Total steps: 4
   Execution order:
     [0] azure-prepare-resources | validate-compute-environments (parallel)
-    [1] prepare-azure-container-apps-aca-env
+    [1] validate-azure-container-apps
+    [2] prepare-azure-container-apps-aca-env
 
 If targeting 'print-api-service-summary':
   Direct dependencies: provision-api-service-website
@@ -807,10 +809,11 @@ If targeting 'validate-azure-app-service':
     [0] validate-azure-app-service
 
 If targeting 'validate-azure-container-apps':
-  Direct dependencies: none
-  Total steps: 1
+  Direct dependencies: azure-prepare-resources
+  Total steps: 2
   Execution order:
-    [0] validate-azure-container-apps
+    [0] azure-prepare-resources
+    [1] validate-azure-container-apps
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureDeployerTests.DeployAsync_WithPrivateEndpoints_CreatesCorrectDependencies.verified.txt
@@ -15,9 +15,9 @@ This shows the order in which steps would execute, respecting all dependencies.
 Steps with no dependencies run first, followed by steps that depend on them.
 
   1. azure-prepare-resources
-  2. validate-compute-environments
-  3. prepare-azure-container-apps-env
-  4. validate-azure-container-apps
+  2. validate-azure-container-apps
+  3. validate-compute-environments
+  4. prepare-azure-container-apps-env
   5. before-start
   6. process-parameters
   7. build-prereq
@@ -140,7 +140,7 @@ Step: login-to-acr-env-acr
 
 Step: prepare-azure-container-apps-env
     Description: Prepares Azure Container Apps deployment targets for env.
-    Dependencies: ✓ azure-prepare-resources, ✓ validate-compute-environments
+    Dependencies: ✓ azure-prepare-resources, ✓ validate-azure-container-apps, ✓ validate-compute-environments
     Resource: env (AzureContainerAppEnvironmentResource)
 
 Step: print-api-summary
@@ -310,7 +310,7 @@ Step: push-prereq
     Dependencies: ✓ login-to-acr-env-acr
 
 Step: validate-azure-container-apps
-    Dependencies: none
+    Dependencies: ✓ azure-prepare-resources
 
 Step: validate-azure-login
     Description: Validates Azure CLI authentication before deployment.
@@ -346,9 +346,10 @@ If targeting 'before-start':
   Direct dependencies: azure-prepare-resources, prepare-azure-container-apps-env, validate-azure-container-apps, validate-compute-environments
   Total steps: 5
   Execution order:
-    [0] azure-prepare-resources | validate-azure-container-apps | validate-compute-environments (parallel)
-    [1] prepare-azure-container-apps-env
-    [2] before-start
+    [0] azure-prepare-resources | validate-compute-environments (parallel)
+    [1] validate-azure-container-apps
+    [2] prepare-azure-container-apps-env
+    [3] before-start
 
 If targeting 'build':
   Direct dependencies: build-api
@@ -470,11 +471,12 @@ If targeting 'login-to-acr-env-acr':
     [5] login-to-acr-env-acr
 
 If targeting 'prepare-azure-container-apps-env':
-  Direct dependencies: azure-prepare-resources, validate-compute-environments
-  Total steps: 3
+  Direct dependencies: azure-prepare-resources, validate-azure-container-apps, validate-compute-environments
+  Total steps: 4
   Execution order:
     [0] azure-prepare-resources | validate-compute-environments (parallel)
-    [1] prepare-azure-container-apps-env
+    [1] validate-azure-container-apps
+    [2] prepare-azure-container-apps-env
 
 If targeting 'print-api-summary':
   Direct dependencies: provision-api-containerapp
@@ -821,10 +823,11 @@ If targeting 'push-prereq':
     [6] push-prereq
 
 If targeting 'validate-azure-container-apps':
-  Direct dependencies: none
-  Total steps: 1
+  Direct dependencies: azure-prepare-resources
+  Total steps: 2
   Execution order:
-    [0] validate-azure-container-apps
+    [0] azure-prepare-resources
+    [1] validate-azure-container-apps
 
 If targeting 'validate-azure-login':
   Direct dependencies: deploy-prereq


### PR DESCRIPTION
## Description

Multiple `AddAzureContainerAppEnvironment(...)` resources deployed to the same resource group generate **identical** managed-environment names, collapsing onto a single physical Azure environment and racing with `ManagedEnvironmentOperationInProgress`.

Root cause: `ContainerAppManagedEnvironment` inherits Azure.Provisioning's `ResourceNameRequirements(1, 24, LowercaseLetters)`, whose sanitizer **strips digits**. So environments named e.g. `cae1`/`cae2` both resolve to `take('cae${uniqueString(resourceGroup().id)}', 24)` - the same name in a shared resource group.

### Approach: explicit migration with fail-fast validation

Changing the managed environment name by default would rename already-deployed environments and force Azure to recreate them, which is far too dangerous to ship as a default. The generated managed-environment name therefore remains unchanged unless callers explicitly opt in, mirroring how `WithCompactResourceNaming` shipped:

- **Legacy generated names remain unchanged** - single-environment apps and existing physical resource names are unaffected.
- **Colliding legacy names now fail fast during publish/deploy** - instead of emitting a deployment known to collapse multiple logical environments onto one Azure resource, validation identifies the colliding resources and directs the caller to `WithUniqueResourceNaming()`.
- **`WithUniqueResourceNaming()`** is a new per-environment extension method that opts into digit-preserving managed environment names, so distinct resource names produce distinct environment names. Apply it to each `AddAzureContainerAppEnvironment(...)` that needs to coexist with others in the same resource group.

The method is marked `[Experimental("ASPIREACANAMING002")]`. It is implemented as a scoped fallback `ResourceNamePropertyResolver`, so any name resolver explicitly configured by the caller (e.g. `AspireV8ResourceNamePropertyResolver`) still takes precedence.

Fixes #18722

## Validation

Unit tests assert that legacy Bicep names remain unchanged, `WithUniqueResourceNaming()` produces distinct digit-preserving names, and publish fails with actionable guidance when legacy names collide. The fix was also validated with **real `aspire deploy` runs against live Azure** for both single-CAE and multi-CAE scenarios - see the detailed testing report in the PR comments. A deployment E2E test deploys two environments into one resource group and asserts Azure contains two distinct managed environments.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No