### PR TITLE
Add App Service delegated subnet support

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AspireSiteContainer.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AspireSiteContainer.cs
@@ -83,3 +83,59 @@ internal sealed class AspireWebSite : WebSite
         }
     }
 }
+
+/// <summary>
+/// A derived <see cref="global::Azure.Provisioning.AppService.SiteNetworkConfig"/> that emits the required
+/// singleton resource name.
+/// </summary>
+internal sealed class AspireSiteNetworkConfig : global::Azure.Provisioning.AppService.SiteNetworkConfig
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="AspireSiteNetworkConfig"/>.
+    /// </summary>
+    /// <param name="bicepIdentifier">The Bicep identifier name of the resource.</param>
+    public AspireSiteNetworkConfig(string bicepIdentifier)
+        : base(bicepIdentifier)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override IEnumerable<BicepStatement> Compile()
+    {
+        foreach (var statement in base.Compile())
+        {
+            if (statement is ResourceStatement resourceStatement &&
+                resourceStatement.Body is ObjectExpression body &&
+                !body.Properties.Any(static property => property.Name is "name"))
+            {
+                // Workaround for https://github.com/Azure/azure-sdk-for-net/issues/54629.
+                // SiteNetworkConfig models its fixed "virtualNetwork" name as an output, so the
+                // generated resource omits the required Bicep property. Bicep requires a name even
+                // for this singleton child and otherwise reports BCP035. Emit the fixed App Service
+                // child name explicitly until the Azure.Provisioning.AppService version consumed by
+                // Aspire emits the default name as a resource property.
+                var resourceWithName = new ResourceStatement(
+                    resourceStatement.Name,
+                    resourceStatement.Type,
+                    new ObjectExpression(
+                    [
+                        new PropertyExpression("name", new StringLiteralExpression("virtualNetwork")),
+                        .. body.Properties
+                    ]))
+                {
+                    Existing = resourceStatement.Existing
+                };
+
+                foreach (var decorator in resourceStatement.Decorators)
+                {
+                    resourceWithName.Decorators.Add(decorator);
+                }
+
+                yield return resourceWithName;
+                continue;
+            }
+
+            yield return statement;
+        }
+    }
+}

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -226,6 +226,10 @@ public static partial class AzureAppServiceEnvironmentExtensions
             {
                 // Add aspire dashboard website
                 var website = AzureAppServiceEnvironmentUtility.AddDashboard(infra, managedIdentityClientIdOutputValue, plan.Id);
+                if (resource.GetDelegatedSubnetId(infra) is { } delegatedSubnetId)
+                {
+                    website.VirtualNetworkSubnetId = delegatedSubnetId;
+                }
 
                 infra.Add(new ProvisioningOutput("AZURE_APP_SERVICE_DASHBOARD_URI", typeof(string))
                 {

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -3,12 +3,14 @@
 
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREAZURE001
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.AppService;
+using Azure.Core;
 using Aspire.Hosting.Pipelines;
 using Azure.Provisioning;
 using Azure.Provisioning.AppService;
@@ -27,9 +29,13 @@ namespace Aspire.Hosting.Azure;
 public class AzureAppServiceEnvironmentResource :
     AzureProvisioningResource,
     IAzureComputeEnvironmentResource,
-    IAzureContainerRegistry
+    IAzureContainerRegistry,
+    IAzureDelegatedSubnetResource
 #pragma warning restore CS0618 // Type or member is obsolete
 {
+    /// <inheritdoc />
+    string IAzureDelegatedSubnetResource.DelegatedSubnetServiceName => "Microsoft.Web/serverFarms";
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureAppServiceEnvironmentResource"/> class.
     /// </summary>
@@ -364,6 +370,19 @@ public class AzureAppServiceEnvironmentResource :
     internal BicepOutputReference WebSiteSuffix => new("webSiteSuffix", this);
 
     /// <summary>
+    /// Gets the delegated subnet ID configured for this environment, if any.
+    /// </summary>
+    internal BicepValue<ResourceIdentifier>? GetDelegatedSubnetId(AzureResourceInfrastructure infra)
+    {
+        if (this.TryGetLastAnnotation<DelegatedSubnetAnnotation>(out var subnetAnnotation))
+        {
+            return subnetAnnotation.SubnetId.AsProvisioningParameter(infra);
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// When true, HTTP endpoints are not upgraded to HTTPS. Default is false (HTTP→HTTPS upgrade is enabled).
     /// </summary>
     internal bool PreserveHttpEndpoints { get; set; }
@@ -476,6 +495,7 @@ public class AzureAppServiceEnvironmentResource :
             return azureRegistry;
         }
     }
+    #pragma warning restore ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 #pragma warning disable CS0618 // Type or member is obsolete
     ReferenceExpression IAzureContainerRegistry.ManagedIdentityId => ReferenceExpression.Create($"{ContainerRegistryManagedIdentityId}");

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -3,7 +3,6 @@
 
 #pragma warning disable ASPIREPIPELINES001
 #pragma warning disable ASPIREAZURE001
-#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -26,12 +25,14 @@ namespace Aspire.Hosting.Azure;
 /// Represents an Azure App Service Environment resource.
 /// </summary>
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 public class AzureAppServiceEnvironmentResource :
     AzureProvisioningResource,
     IAzureComputeEnvironmentResource,
     IAzureContainerRegistry,
     IAzureDelegatedSubnetResource
 #pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore ASPIREAZURE003
 {
     /// <inheritdoc />
     string IAzureDelegatedSubnetResource.DelegatedSubnetServiceName => "Microsoft.Web/serverFarms";
@@ -372,6 +373,7 @@ public class AzureAppServiceEnvironmentResource :
     /// <summary>
     /// Gets the delegated subnet ID configured for this environment, if any.
     /// </summary>
+#pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     internal BicepValue<ResourceIdentifier>? GetDelegatedSubnetId(AzureResourceInfrastructure infra)
     {
         if (this.TryGetLastAnnotation<DelegatedSubnetAnnotation>(out var subnetAnnotation))
@@ -381,6 +383,7 @@ public class AzureAppServiceEnvironmentResource :
 
         return null;
     }
+#pragma warning restore ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     /// When true, HTTP endpoints are not upgraded to HTTPS. Default is false (HTTP→HTTPS upgrade is enabled).
@@ -495,7 +498,6 @@ public class AzureAppServiceEnvironmentResource :
             return azureRegistry;
         }
     }
-    #pragma warning restore ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 #pragma warning disable CS0618 // Type or member is obsolete
     ReferenceExpression IAzureContainerRegistry.ManagedIdentityId => ReferenceExpression.Create($"{ContainerRegistryManagedIdentityId}");

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -360,6 +360,7 @@ internal sealed class AzureAppServiceWebsiteContext(
     /// <param name="isSlot">Indicates whether this is a deployment slot.</param>
     /// <param name="parentWebSite">The parent website when creating a slot.</param>
     /// <param name="deploymentSlot">The deployment slot name. When not null and isSlot is false, adds @onlyIfNotExists() decorator to the main site.</param>
+    /// <param name="virtualNetworkSubnetId">The optional subnet ID for regional virtual network integration.</param>
     /// <returns>A dynamic object representing either a WebSite or WebSiteSlot.</returns>
     private object CreateAndConfigureWebSite(
     AzureResourceInfrastructure infra,
@@ -371,7 +372,8 @@ internal sealed class AzureAppServiceWebsiteContext(
     HashSet<string> slotConfigNames,
     bool isSlot = false,
     WebSite? parentWebSite = null,
-    BicepValue<string>? deploymentSlot = null)
+    BicepValue<string>? deploymentSlot = null,
+    BicepValue<ResourceIdentifier>? virtualNetworkSubnetId = null)
     {
         object webSite;
         object mainContainer;
@@ -454,6 +456,18 @@ internal sealed class AzureAppServiceWebsiteContext(
 
             webSite = site;
             mainContainer = siteContainer;
+        }
+
+        if (virtualNetworkSubnetId is { } subnetId)
+        {
+            if (webSite is WebSite site)
+            {
+                site.VirtualNetworkSubnetId = subnetId;
+            }
+            else if (webSite is WebSiteSlot slot)
+            {
+                slot.VirtualNetworkSubnetId = subnetId;
+            }
         }
 
         // There should be a single valid target port
@@ -694,6 +708,7 @@ internal sealed class AzureAppServiceWebsiteContext(
         var acrMidParameter = environmentContext.Environment.ContainerRegistryManagedIdentityId.AsProvisioningParameter(infra);
         var acrClientIdParameter = environmentContext.Environment.ContainerRegistryClientId.AsProvisioningParameter(infra);
         var containerImage = AllocateParameter(new ContainerImageReference(Resource));
+        var virtualNetworkSubnetId = environmentContext.Environment.GetDelegatedSubnetId(infra);
 
         // Create parent WebSite from existing
         WebSite? parentWebSite = null;
@@ -716,7 +731,8 @@ internal sealed class AzureAppServiceWebsiteContext(
             stickyConfigNames,
             isSlot: deploymentSlot is not null,
             parentWebSite: parentWebSite,
-            deploymentSlot: deploymentSlot);
+            deploymentSlot: deploymentSlot,
+            virtualNetworkSubnetId: virtualNetworkSubnetId);
 
         // Allow users to customize the web app here
         if (deploymentSlot is not null)
@@ -761,6 +777,7 @@ internal sealed class AzureAppServiceWebsiteContext(
         var acrMidParameter = environmentContext.Environment.ContainerRegistryManagedIdentityId.AsProvisioningParameter(infra);
         var acrClientIdParameter = environmentContext.Environment.ContainerRegistryClientId.AsProvisioningParameter(infra);
         var containerImage = AllocateParameter(new ContainerImageReference(Resource));
+        var virtualNetworkSubnetId = environmentContext.Environment.GetDelegatedSubnetId(infra);
         HashSet<string> stickyConfigNames = new();
 
         // Main site - @onlyIfNotExists() is automatically added because deploymentSlot is not null and isSlot is false
@@ -773,7 +790,8 @@ internal sealed class AzureAppServiceWebsiteContext(
             containerImage,
             stickyConfigNames,
             isSlot: false,
-            deploymentSlot: deploymentSlot);
+            deploymentSlot: deploymentSlot,
+            virtualNetworkSubnetId: virtualNetworkSubnetId);
 
         // Slot - no @onlyIfNotExists() needed, slot is always deployed to
         var webSiteSlot = (WebSiteSlot)CreateAndConfigureWebSite(
@@ -786,7 +804,8 @@ internal sealed class AzureAppServiceWebsiteContext(
             stickyConfigNames,
             isSlot: true,
             parentWebSite: (WebSite)webSite,
-            deploymentSlot: deploymentSlot);
+            deploymentSlot: deploymentSlot,
+            virtualNetworkSubnetId: virtualNetworkSubnetId);
 
         // Allow users to customize the website
         if (resource.TryGetAnnotationsOfType<AzureAppServiceWebsiteCustomizationAnnotation>(out var customizeWebSiteAnnotations))
@@ -806,7 +825,39 @@ internal sealed class AzureAppServiceWebsiteContext(
             }
         }
 
+        AddWebSiteNetworkConfig(infra, webSite);
         AddStickySlotSettings(webSite, stickyConfigNames);
+    }
+
+    private static void AddWebSiteNetworkConfig(AzureResourceInfrastructure infra, WebSite webSite)
+    {
+        if (webSite.VirtualNetworkSubnetId.IsEmpty)
+        {
+            return;
+        }
+
+        // App Service supports regional VNet integration through both the site's
+        // properties.virtualNetworkSubnetId property and the singleton
+        // Microsoft.Web/sites/networkConfig child named "virtualNetwork":
+        // https://learn.microsoft.com/azure/templates/microsoft.web/sites/networkconfig
+        //
+        // The site property is sufficient when provisioning a new site, and it is also applied to the
+        // slot. The production site requires the child resource as well when a deployment slot exists.
+        // In that path, the production site is emitted with @onlyIfNotExists() so that deploying a slot
+        // cannot reset production configuration. That intentionally prevents changes to the parent,
+        // including a newly configured virtualNetworkSubnetId, from updating an existing production site.
+        //
+        // The networkConfig child remains updateable independently of its parent, so it safely applies
+        // VNet integration during that upgrade without weakening the production-site safeguard. Create
+        // it after customization callbacks so an explicit user-provided VirtualNetworkSubnetId remains
+        // authoritative for both representations. AspireSiteNetworkConfig exists because the current
+        // Azure.Provisioning SiteNetworkConfig generator omits the required fixed child name; it restores
+        // name: 'virtualNetwork' while retaining the generated resource's type and decorators.
+        infra.Add(new AspireSiteNetworkConfig("webappNetworkConfig")
+        {
+            Parent = webSite,
+            SubnetResourceId = webSite.VirtualNetworkSubnetId
+        });
     }
 
     private BicepValue<string> GetEndpointValue(EndpointMapping mapping, EndpointProperty property)

--- a/src/Aspire.Hosting.Azure.AppService/README.md
+++ b/src/Aspire.Hosting.Azure.AppService/README.md
@@ -106,6 +106,16 @@ var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("env")
 #pragma warning restore ASPIREAZURE003
 ```
 
+**TypeScript**
+
+```typescript
+const vnet = await builder.addAzureVirtualNetwork("vnet");
+const subnet = await vnet.addSubnet("app-service-subnet", "10.0.0.0/24");
+
+const appServiceEnvironment = await builder.addAzureAppServiceEnvironment("env")
+    .withDelegatedSubnet(subnet);
+```
+
 `WithDelegatedSubnet` delegates the subnet to `Microsoft.Web/serverFarms` and configures every generated
 website, deployment slot, and the default Aspire Dashboard to use it for regional virtual network integration.
 The subnet must meet the [Azure App Service regional virtual network integration requirements](https://learn.microsoft.com/azure/app-service/overview-vnet-integration).

--- a/src/Aspire.Hosting.Azure.AppService/README.md
+++ b/src/Aspire.Hosting.Azure.AppService/README.md
@@ -86,6 +86,34 @@ var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("env")
     .WithDashboard(enable: false);
 ```
 
+### Configuring regional virtual network integration
+
+To configure regional virtual network integration for the websites in an Azure App Service environment, add the `Aspire.Hosting.Azure.Network` integration:
+
+```bash
+aspire add Aspire.Hosting.Azure.Network
+```
+
+Then create a subnet and apply it to the environment:
+
+```csharp
+#pragma warning disable ASPIREAZURE003 // Azure Virtual Network APIs are experimental.
+var vnet = builder.AddAzureVirtualNetwork("vnet");
+var subnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24");
+
+var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("env")
+    .WithDelegatedSubnet(subnet);
+#pragma warning restore ASPIREAZURE003
+```
+
+`WithDelegatedSubnet` delegates the subnet to `Microsoft.Web/serverFarms` and configures every generated
+website, deployment slot, and the default Aspire Dashboard to use it for regional virtual network integration.
+The subnet must meet the [Azure App Service regional virtual network integration requirements](https://learn.microsoft.com/azure/app-service/overview-vnet-integration).
+
+Regional virtual network integration affects outbound traffic only. It does not make website or dashboard ingress
+private, and it does not enable Route All. Configure private endpoints or access restrictions and Route All
+separately when those behaviors are required.
+
 ### Enabling Application Insights
 
 Application Insights can be enabled for the App Service Environment using the `WithAzureApplicationInsights` extension method. A different location can be specified for Application Insights using the optional location parameter:

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -284,7 +284,7 @@ public static class AzureVirtualNetworkExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="subnet">The subnet to associate with the resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the resource is already associated with a different delegated subnet.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the resource is already associated with a different delegated subnet or the subnet is delegated to a different service.</exception>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
     /// This method automatically configures the subnet with the appropriate service delegation
@@ -319,6 +319,18 @@ public static class AzureVirtualNetworkExtensions
         {
             throw new InvalidOperationException(
                 $"The resource '{target.Name}' is already associated with a different delegated subnet. A resource can use only one delegated subnet.");
+        }
+
+        var conflictingDelegation = subnet.Resource.Annotations
+            .OfType<AzureSubnetServiceDelegationAnnotation>()
+            .FirstOrDefault(annotation => !string.Equals(
+                annotation.ServiceName,
+                target.DelegatedSubnetServiceName,
+                StringComparison.Ordinal));
+        if (conflictingDelegation is not null)
+        {
+            throw new InvalidOperationException(
+                $"The subnet '{subnet.Resource.Name}' is already delegated to '{conflictingDelegation.ServiceName}' and cannot also be delegated to '{target.DelegatedSubnetServiceName}'.");
         }
 
         builder.WithAnnotation(

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -287,7 +287,8 @@ public static class AzureVirtualNetworkExtensions
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
     /// This method automatically configures the subnet with the appropriate service delegation
-    /// for the target resource type (e.g., "Microsoft.App/environments" for Azure Container Apps).
+    /// for the target resource type (for example, "Microsoft.App/environments" for Azure Container Apps
+    /// and "Microsoft.Web/serverFarms" for Azure App Service).
     /// </remarks>
     /// <example>
     /// This example configures an Azure Container App Environment to use a subnet:

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -326,7 +326,7 @@ public static class AzureVirtualNetworkExtensions
             .FirstOrDefault(annotation => !string.Equals(
                 annotation.ServiceName,
                 target.DelegatedSubnetServiceName,
-                StringComparison.Ordinal));
+                StringComparison.OrdinalIgnoreCase));
         if (conflictingDelegation is not null)
         {
             throw new InvalidOperationException(

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -289,6 +289,7 @@ public static class AzureVirtualNetworkExtensions
     /// This method automatically configures the subnet with the appropriate service delegation
     /// for the target resource type (for example, "Microsoft.App/environments" for Azure Container Apps
     /// and "Microsoft.Web/serverFarms" for Azure App Service).
+    /// Calling this method again for the same resource replaces its previous subnet association.
     /// </remarks>
     /// <example>
     /// This example configures an Azure Container App Environment to use a subnet:
@@ -311,14 +312,48 @@ public static class AzureVirtualNetworkExtensions
 
         var target = builder.Resource;
 
-        // Store the subnet ID reference on the target resource via annotation
+        var subnetId = ReferenceExpression.Create($"{subnet.Resource.Id}");
+        var previousSubnetId = target.TryGetLastAnnotation<DelegatedSubnetAnnotation>(out var previousAnnotation)
+            ? previousAnnotation.SubnetId
+            : null;
+
+        // A resource can use only one delegated subnet, so a later call supersedes an earlier one.
         builder.WithAnnotation(
-            new DelegatedSubnetAnnotation(ReferenceExpression.Create($"{subnet.Resource.Id}")));
+            new DelegatedSubnetAnnotation(subnetId),
+            ResourceAnnotationMutationBehavior.Replace);
+
+        if (previousSubnetId is not null && previousSubnetId.ValueExpression != subnetId.ValueExpression)
+        {
+            var isPreviousSubnetStillInUse = builder.ApplicationBuilder.Resources
+                .SelectMany(resource => resource.Annotations.OfType<DelegatedSubnetAnnotation>())
+                .Any(annotation => annotation.SubnetId.ValueExpression == previousSubnetId.ValueExpression);
+
+            if (!isPreviousSubnetStillInUse)
+            {
+                var previousSubnet = builder.ApplicationBuilder.Resources
+                    .OfType<AzureSubnetResource>()
+                    .SingleOrDefault(candidate => ReferenceExpression.Create($"{candidate.Id}").ValueExpression == previousSubnetId.ValueExpression);
+
+                if (previousSubnet is not null)
+                {
+                    // Avoid provisioning an unused delegation after replacing the target's subnet.
+                    foreach (var delegation in previousSubnet.Annotations
+                        .OfType<AzureSubnetServiceDelegationAnnotation>()
+                        .Where(annotation => string.Equals(annotation.ServiceName, target.DelegatedSubnetServiceName, StringComparison.Ordinal))
+                        .ToList())
+                    {
+                        previousSubnet.Annotations.Remove(delegation);
+                    }
+                }
+            }
+        }
 
         // Add service delegation annotation to the subnet
-        subnet.WithAnnotation(new AzureSubnetServiceDelegationAnnotation(
-            target.DelegatedSubnetServiceName,
-            target.DelegatedSubnetServiceName));
+        subnet.WithAnnotation(
+            new AzureSubnetServiceDelegationAnnotation(
+                target.DelegatedSubnetServiceName,
+                target.DelegatedSubnetServiceName),
+            ResourceAnnotationMutationBehavior.Replace);
 
         return builder;
     }

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -284,12 +284,13 @@ public static class AzureVirtualNetworkExtensions
     /// <param name="builder">The resource builder.</param>
     /// <param name="subnet">The subnet to associate with the resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the resource is already associated with a different delegated subnet.</exception>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
     /// This method automatically configures the subnet with the appropriate service delegation
     /// for the target resource type (for example, "Microsoft.App/environments" for Azure Container Apps
     /// and "Microsoft.Web/serverFarms" for Azure App Service).
-    /// Calling this method again for the same resource replaces its previous subnet association.
+    /// A resource can only be associated with one delegated subnet. Repeating the call with the same subnet is idempotent.
     /// </remarks>
     /// <example>
     /// This example configures an Azure Container App Environment to use a subnet:
@@ -313,42 +314,19 @@ public static class AzureVirtualNetworkExtensions
         var target = builder.Resource;
 
         var subnetId = ReferenceExpression.Create($"{subnet.Resource.Id}");
-        var previousSubnetId = target.TryGetLastAnnotation<DelegatedSubnetAnnotation>(out var previousAnnotation)
-            ? previousAnnotation.SubnetId
-            : null;
+        if (target.TryGetLastAnnotation<DelegatedSubnetAnnotation>(out var previousAnnotation) &&
+            previousAnnotation.SubnetId.ValueExpression != subnetId.ValueExpression)
+        {
+            throw new InvalidOperationException(
+                $"The resource '{target.Name}' is already associated with a different delegated subnet. A resource can use only one delegated subnet.");
+        }
 
-        // A resource can use only one delegated subnet, so a later call supersedes an earlier one.
         builder.WithAnnotation(
             new DelegatedSubnetAnnotation(subnetId),
             ResourceAnnotationMutationBehavior.Replace);
 
-        if (previousSubnetId is not null && previousSubnetId.ValueExpression != subnetId.ValueExpression)
-        {
-            var isPreviousSubnetStillInUse = builder.ApplicationBuilder.Resources
-                .SelectMany(resource => resource.Annotations.OfType<DelegatedSubnetAnnotation>())
-                .Any(annotation => annotation.SubnetId.ValueExpression == previousSubnetId.ValueExpression);
-
-            if (!isPreviousSubnetStillInUse)
-            {
-                var previousSubnet = builder.ApplicationBuilder.Resources
-                    .OfType<AzureSubnetResource>()
-                    .SingleOrDefault(candidate => ReferenceExpression.Create($"{candidate.Id}").ValueExpression == previousSubnetId.ValueExpression);
-
-                if (previousSubnet is not null)
-                {
-                    // Avoid provisioning an unused delegation after replacing the target's subnet.
-                    foreach (var delegation in previousSubnet.Annotations
-                        .OfType<AzureSubnetServiceDelegationAnnotation>()
-                        .Where(annotation => string.Equals(annotation.ServiceName, target.DelegatedSubnetServiceName, StringComparison.Ordinal))
-                        .ToList())
-                    {
-                        previousSubnet.Annotations.Remove(delegation);
-                    }
-                }
-            }
-        }
-
-        // Add service delegation annotation to the subnet
+        // The subnet provisioner emits a single delegation, so replacing prevents duplicate annotations
+        // when the same subnet is configured repeatedly.
         subnet.WithAnnotation(
             new AzureSubnetServiceDelegationAnnotation(
                 target.DelegatedSubnetServiceName,

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -286,12 +286,12 @@ builder.AddAzureAppServiceEnvironment("infra")
             "webapp_count=0 && slot_count=0 && " +
             "for webapp in $webapps; do " +
             "webapp_count=$((webapp_count + 1)); " +
-            "subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query \"virtualNetworkSubnetId\" -o tsv 2>/dev/null); " +
+            "if ! subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query \"virtualNetworkSubnetId\" -o tsv); then echo \"ERROR: Failed to query VNet integration for $webapp\"; exit 1; fi; " +
             "if [ -n \"$subnet_id\" ]; then echo \"ERROR: $webapp unexpectedly has VNet integration\"; exit 1; fi; " +
             "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
             "for slot in $slots; do " +
             "slot_count=$((slot_count + 1)); " +
-            "subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query \"virtualNetworkSubnetId\" -o tsv 2>/dev/null); " +
+            "if ! subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query \"virtualNetworkSubnetId\" -o tsv); then echo \"ERROR: Failed to query VNet integration for $webapp/$slot\"; exit 1; fi; " +
             "if [ -n \"$subnet_id\" ]; then echo \"ERROR: $webapp/$slot unexpectedly has VNet integration\"; exit 1; fi; " +
             "done; " +
             "done && " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -246,10 +246,8 @@ builder.AddAzureAppServiceEnvironment("infra")
         }
         finally
         {
-            // Clean up the resource group we created
             output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
-            TriggerCleanupResourceGroup(resourceGroupName, output);
-            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+            await TriggerCleanupResourceGroupAsync(resourceGroupName, output);
         }
     }
 
@@ -412,15 +410,9 @@ builder.AddAzureAppServiceEnvironment("infra")
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
     }
 
-    /// <summary>
-    /// Triggers cleanup of a specific resource group.
-    /// This is fire-and-forget - the hourly cleanup workflow handles any missed resources.
-    /// </summary>
-    private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)
+    private static async Task TriggerCleanupResourceGroupAsync(string resourceGroupName, ITestOutputHelper output)
     {
-        // Fire and forget - trigger deletion of the specific resource group created by this test
-        // The cleanup workflow will handle any that don't get deleted
-        var process = new System.Diagnostics.Process
+        using var process = new System.Diagnostics.Process
         {
             StartInfo = new System.Diagnostics.ProcessStartInfo
             {
@@ -433,14 +425,30 @@ builder.AddAzureAppServiceEnvironment("infra")
             }
         };
 
-        try
+        if (!process.Start())
         {
-            process.Start();
-            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+            const string message = "Azure CLI did not start the resource group deletion request.";
+            output.WriteLine(message);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, message);
+            return;
         }
-        catch (Exception ex)
+
+        // Read both streams concurrently to avoid deadlock when a pipe buffer fills.
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        await Task.WhenAll(process.WaitForExitAsync(), standardOutputTask, standardErrorTask);
+
+        if (process.ExitCode == 0)
         {
-            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+            output.WriteLine($"Resource group deletion initiated: {resourceGroupName}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Deletion initiated");
+            return;
         }
+
+        var standardError = await standardErrorTask;
+        var standardOutput = await standardOutputTask;
+        var error = string.IsNullOrWhiteSpace(standardError) ? standardOutput : standardError;
+        output.WriteLine($"Resource group deletion may have failed (exit code {process.ExitCode}): {error}");
+        DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, $"Exit code {process.ExitCode}: {error}");
     }
 }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -200,20 +200,22 @@ builder.AddAzureAppServiceEnvironment("infra")
                   "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
                   "webapps=$(az webapp list -g \"$RG_NAME\" --query \"[].name\" -o tsv 2>/dev/null) && " +
                   "if [ -z \"$webapps\" ]; then echo \"❌ No App Service sites found\"; exit 1; fi && " +
-                  "urls='' && " +
+                  "urls='' && staging_endpoint_count=0 && dashboard_endpoint_count=0 && " +
                   "for webapp in $webapps; do " +
                   "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
                   "if [ -n \"$slots\" ]; then " +
                   "for slot in $slots; do " +
                   "url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query defaultHostName -o tsv 2>/dev/null); " +
-                  "if [ -n \"$url\" ]; then urls=\"$urls $url\"; fi; " +
+                  "if [ -z \"$url\" ]; then echo \"❌ Missing hostname for staging slot $webapp/$slot\"; exit 1; fi; " +
+                  "urls=\"$urls $url\"; staging_endpoint_count=$((staging_endpoint_count + 1)); " +
                   "done; " +
                   "else " +
                   "url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query defaultHostName -o tsv 2>/dev/null); " +
-                  "if [ -n \"$url\" ]; then urls=\"$urls $url\"; fi; " +
+                  "if [ -z \"$url\" ]; then echo \"❌ Missing hostname for dashboard $webapp\"; exit 1; fi; " +
+                  "urls=\"$urls $url\"; dashboard_endpoint_count=$((dashboard_endpoint_count + 1)); " +
                   "fi; " +
                   "done && " +
-                  "if [ -z \"$urls\" ]; then echo \"❌ No App Service endpoints found\"; exit 1; fi && " +
+                  "if [ \"$staging_endpoint_count\" -ne 1 ] || [ \"$dashboard_endpoint_count\" -ne 1 ]; then echo \"❌ Expected one staging slot endpoint and one dashboard endpoint\"; exit 1; fi && " +
                   "failed=0 && " +
                   "for url in $urls; do " +
                   "echo \"Checking https://$url...\"; " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -189,47 +189,16 @@ builder.AddAzureAppServiceEnvironment("infra")
             await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
-            // Step 14: Extract deployment URLs and verify endpoints with retry
+            // Step 14: Extract deployment URLs and verify endpoints with retry.
             // The workload is deployed to its staging slot, so the production site's empty
             // hostname is not a liveness target. Sites without slots, such as the dashboard,
             // are reached through their production hostname.
-            // Retry each endpoint for up to 3 minutes (18 attempts * 10 seconds)
+            // Verify both endpoints concurrently for up to six minutes. Each attempt has a
+            // 10-second curl cap and waits 10 seconds before the next attempt.
             output.WriteLine("Step 14: Verifying deployed endpoints...");
-            await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
-                  "echo \"Resource group: $RG_NAME\" && " +
-                  "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
-                  "webapps=$(az webapp list -g \"$RG_NAME\" --query \"[].name\" -o tsv 2>/dev/null) && " +
-                  "if [ -z \"$webapps\" ]; then echo \"❌ No App Service sites found\"; exit 1; fi && " +
-                  "urls='' && staging_endpoint_count=0 && dashboard_endpoint_count=0 && " +
-                  "for webapp in $webapps; do " +
-                  "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
-                  "if [ -n \"$slots\" ]; then " +
-                  "for slot in $slots; do " +
-                  "if ! url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query defaultHostName -o tsv); then echo \"❌ Failed to query hostname for staging slot $webapp/$slot\"; exit 1; fi; " +
-                  "if [ -z \"$url\" ]; then echo \"❌ Missing hostname for staging slot $webapp/$slot\"; exit 1; fi; " +
-                  "urls=\"$urls $url\"; staging_endpoint_count=$((staging_endpoint_count + 1)); " +
-                  "done; " +
-                  "else " +
-                  "if ! url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query defaultHostName -o tsv); then echo \"❌ Failed to query hostname for dashboard $webapp\"; exit 1; fi; " +
-                  "if [ -z \"$url\" ]; then echo \"❌ Missing hostname for dashboard $webapp\"; exit 1; fi; " +
-                  "urls=\"$urls $url\"; dashboard_endpoint_count=$((dashboard_endpoint_count + 1)); " +
-                  "fi; " +
-                  "done && " +
-                  "if [ \"$staging_endpoint_count\" -ne 1 ] || [ \"$dashboard_endpoint_count\" -ne 1 ]; then echo \"❌ Expected one staging slot endpoint and one dashboard endpoint\"; exit 1; fi && " +
-                  "failed=0 && " +
-                  "for url in $urls; do " +
-                  "echo \"Checking https://$url...\"; " +
-                  "success=0; " +
-                  "for i in $(seq 1 18); do " +
-                  "STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://$url\" --max-time 30 2>/dev/null); " +
-                  "if [ \"$STATUS\" = \"200\" ] || [ \"$STATUS\" = \"302\" ]; then echo \"  ✅ $STATUS (attempt $i)\"; success=1; break; fi; " +
-                  "echo \"  Attempt $i: $STATUS, retrying in 10s...\"; sleep 10; " +
-                  "done; " +
-                  "if [ \"$success\" -eq 0 ]; then echo \"  ❌ Failed after 18 attempts\"; failed=1; fi; " +
-                  "done && " +
-                  "if [ \"$failed\" -ne 0 ]; then echo \"❌ One or more endpoint checks failed\"; exit 1; fi");
+            await auto.TypeAsync(BuildEndpointVerificationCommand(resourceGroupName));
             await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(7));
 
             // Step 15: Verify that the production site, staging slot, and dashboard use the delegated subnet.
             output.WriteLine("Step 15: Verifying regional VNet integration...");
@@ -273,6 +242,103 @@ builder.AddAzureAppServiceEnvironment("infra")
             TriggerCleanupResourceGroup(resourceGroupName, output);
             DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
         }
+    }
+
+    private static string BuildEndpointVerificationCommand(string resourceGroupName)
+    {
+        var script = $$"""
+            set -uo pipefail
+
+            fail() {
+                echo "ERROR: $1"
+                exit 1
+            }
+
+            resource_group={{AspireCliShellCommandHelpers.QuoteBashArg(resourceGroupName)}}
+
+            az group show -n "$resource_group" >/dev/null ||
+                fail "Resource group was not found"
+
+            webapps=$(az webapp list -g "$resource_group" --query "[].name" -o tsv) ||
+                fail "Failed to query App Service sites"
+            [ -n "$webapps" ] || fail "No App Service sites found"
+
+            urls=""
+            staging_endpoint_count=0
+            dashboard_endpoint_count=0
+            for webapp in $webapps
+            do
+                slots=$(az webapp deployment slot list -g "$resource_group" -n "$webapp" --query "[].name" -o tsv) ||
+                    fail "Failed to query deployment slots for $webapp"
+                if [ -n "$slots" ]
+                then
+                    for slot in $slots
+                    do
+                        url=$(az webapp show -g "$resource_group" -n "$webapp" --slot "$slot" --query defaultHostName -o tsv) ||
+                            fail "Failed to query hostname for staging slot $webapp/$slot"
+                        [ -n "$url" ] || fail "Missing hostname for staging slot $webapp/$slot"
+                        urls="$urls $url"
+                        staging_endpoint_count=$((staging_endpoint_count + 1))
+                    done
+                else
+                    url=$(az webapp show -g "$resource_group" -n "$webapp" --query defaultHostName -o tsv) ||
+                        fail "Failed to query hostname for dashboard $webapp"
+                    [ -n "$url" ] || fail "Missing hostname for dashboard $webapp"
+                    urls="$urls $url"
+                    dashboard_endpoint_count=$((dashboard_endpoint_count + 1))
+                fi
+            done
+
+            [ "$staging_endpoint_count" -eq 1 ] &&
+                [ "$dashboard_endpoint_count" -eq 1 ] ||
+                fail "Expected one staging slot endpoint and one dashboard endpoint"
+
+            verify_endpoint() {
+                local url="$1"
+                local status
+
+                echo "Checking https://$url..."
+                for attempt in $(seq 1 18)
+                do
+                    status=$(curl -s -o /dev/null -w "%{http_code}" "https://$url" --max-time 10 2>/dev/null) ||
+                        status=""
+                    if [ "$status" = "200" ] || [ "$status" = "302" ]
+                    then
+                        echo "  $status (attempt $attempt)"
+                        return 0
+                    fi
+
+                    echo "  Attempt $attempt: $status, retrying in 10 seconds..."
+                    if [ "$attempt" -lt 18 ]
+                    then
+                        sleep 10
+                    fi
+                done
+
+                echo "  Failed after 18 attempts"
+                return 1
+            }
+
+            pids=()
+            for url in $urls
+            do
+                verify_endpoint "$url" &
+                pids+=("$!")
+            done
+
+            failed=0
+            for pid in "${pids[@]}"
+            do
+                if ! wait "$pid"
+                then
+                    failed=1
+                fi
+            done
+
+            [ "$failed" -eq 0 ] || fail "One or more endpoint checks failed"
+            """;
+
+        return $"bash -c {AspireCliShellCommandHelpers.QuoteBashArg(script)}";
     }
 
     private static async Task VerifyNoVnetIntegrationAsync(

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -12,22 +12,23 @@ namespace Aspire.Deployment.EndToEnd.Tests;
 /// </summary>
 public sealed class AppServiceReactDeploymentTests(ITestOutputHelper output)
 {
-    // Timeout set to 40 minutes to allow for Azure App Service provisioning.
-    // Full deployments can take up to 30 minutes if Azure infrastructure is backed up.
-    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
+    // This test deploys both the initial slot-enabled site and its VNet-integration upgrade.
+    // Two 30-minute provisioning operations plus bounded verification waits leave time for
+    // template creation, package installation, and the commands between deployments.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(85);
 
     [Fact]
-    public async Task DeployReactTemplateToAzureAppService()
+    public async Task DeployReactTemplateToAzureAppServiceWithDelegatedSubnet()
     {
         using var cts = new CancellationTokenSource(s_testTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cts.Token, TestContext.Current.CancellationToken);
         var cancellationToken = linkedCts.Token;
 
-        await DeployReactTemplateToAzureAppServiceCore(cancellationToken);
+        await DeployReactTemplateToAzureAppServiceWithDelegatedSubnetCore(cancellationToken);
     }
 
-    private async Task DeployReactTemplateToAzureAppServiceCore(CancellationToken cancellationToken)
+    private async Task DeployReactTemplateToAzureAppServiceWithDelegatedSubnetCore(CancellationToken cancellationToken)
     {
         // Validate prerequisites
         var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
@@ -52,11 +53,11 @@ public sealed class AppServiceReactDeploymentTests(ITestOutputHelper output)
         var startTime = DateTime.UtcNow;
         var deploymentUrls = new Dictionary<string, string>();
         // Generate a unique resource group name with pattern: e2e-[testcasename]-[runid]-[attempt]
-        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("appservice");
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("appservice-vnet");
         // Project name can be simpler since resource group is explicitly set
         var projectName = "ReactAppSvc";
 
-        output.WriteLine($"Test: {nameof(DeployReactTemplateToAzureAppService)}");
+        output.WriteLine($"Test: {nameof(DeployReactTemplateToAzureAppServiceWithDelegatedSubnet)}");
         output.WriteLine($"Project Name: {projectName}");
         output.WriteLine($"Resource Group: {resourceGroupName}");
         output.WriteLine($"Subscription: {subscriptionId[..8]}...");
@@ -97,36 +98,58 @@ public sealed class AppServiceReactDeploymentTests(ITestOutputHelper output)
             // aspire add may show a version selection prompt
             await auto.WaitForAspireAddCompletionAsync(counter);
 
-            // Step 6: Modify AppHost.cs to add Azure App Service Environment
+            // Step 6: Add Azure Virtual Network hosting package
+            output.WriteLine("Step 6: Adding Azure Virtual Network hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Network");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Step 7: Configure the first deployment with a staging slot but without VNet integration.
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
             var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
             var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
 
             output.WriteLine($"Looking for AppHost.cs at: {appHostFilePath}");
 
-            var content = File.ReadAllText(appHostFilePath);
-
-            // Insert the Azure App Service Environment before builder.Build().Run();
-            var buildRunPattern = "builder.Build().Run();";
-            var replacement = """
-// Add Azure App Service Environment for deployment
-builder.AddAzureAppServiceEnvironment("infra");
-
-builder.Build().Run();
+            const string buildRunPattern = "builder.Build().Run();";
+            const string initialEnvironmentConfiguration = """
+builder.AddAzureAppServiceEnvironment("infra")
+    .WithDeploymentSlot("stage");
+""";
+            const string upgradedEnvironmentConfiguration = """
+#pragma warning disable ASPIREAZURE003 // Azure Virtual Network APIs are experimental.
+var vnet = builder.AddAzureVirtualNetwork("vnet");
+var subnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24");
+builder.AddAzureAppServiceEnvironment("infra")
+    .WithDelegatedSubnet(subnet)
+    .WithDeploymentSlot("stage");
+#pragma warning restore ASPIREAZURE003
 """;
 
-            content = content.Replace(buildRunPattern, replacement);
+            var content = File.ReadAllText(appHostFilePath);
+            var initialAppHostConfiguration = $"""
+// Add Azure App Service Environment with a staging slot for deployment.
+{initialEnvironmentConfiguration}
+
+{buildRunPattern}
+""";
+            if (!content.Contains(buildRunPattern, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Could not find '{buildRunPattern}' in the generated AppHost.");
+            }
+
+            content = content.Replace(buildRunPattern, initialAppHostConfiguration, StringComparison.Ordinal);
             File.WriteAllText(appHostFilePath, content);
 
             output.WriteLine($"Modified AppHost.cs at: {appHostFilePath}");
 
-            // Step 7: Navigate to AppHost project directory
-            output.WriteLine("Step 6: Navigating to AppHost directory...");
+            // Step 8: Navigate to AppHost project directory
+            output.WriteLine("Step 8: Navigating to AppHost directory...");
             await auto.TypeAsync($"cd {projectName}.AppHost");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 
-            // Step 8: Set environment variables for deployment
+            // Step 9: Set environment variables for deployment
             // - Unset ASPIRE_PLAYGROUND to avoid conflicts
             // - Set Azure location
             // - Set AZURE__RESOURCEGROUP to use our unique resource group name
@@ -134,24 +157,62 @@ builder.Build().Run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 
-            // Step 9: Deploy to Azure App Service using aspire deploy
-            // Use --clear-cache to ensure fresh deployment without cached location from previous runs
-            output.WriteLine("Step 7: Starting Azure App Service deployment...");
+            // Step 10: Deploy the site and slot without VNet integration.
+            output.WriteLine("Step 10: Starting the initial Azure App Service deployment...");
             await auto.TypeAsync("aspire deploy --clear-cache");
             await auto.EnterAsync();
-            // Wait for pipeline to complete successfully (App Service can take longer)
-            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(35));
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
-            // Step 10: Extract deployment URLs and verify endpoints with retry
-            // For App Service, we use az webapp list instead of az containerapp list
+            // The protected production-site path is only exercised when VNet integration is added
+            // after the slot-enabled site already exists.
+            output.WriteLine("Step 11: Verifying the initial deployment has no VNet integration...");
+            await VerifyNoVnetIntegrationAsync(auto, counter, resourceGroupName);
+
+            // Step 12: Add the delegated subnet before redeploying to the same resource group.
+            content = File.ReadAllText(appHostFilePath);
+            var upgradedContent = content.Replace(
+                initialEnvironmentConfiguration,
+                upgradedEnvironmentConfiguration,
+                StringComparison.Ordinal);
+            if (upgradedContent == content)
+            {
+                throw new InvalidOperationException("Could not add regional VNet integration to the generated AppHost.");
+            }
+
+            File.WriteAllText(appHostFilePath, upgradedContent);
+
+            // Step 13: Upgrade the existing production site, staging slot, and dashboard.
+            output.WriteLine("Step 13: Upgrading the deployment with regional VNet integration...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Step 14: Extract deployment URLs and verify endpoints with retry
+            // The workload is deployed to its staging slot, so the production site's empty
+            // hostname is not a liveness target. Sites without slots, such as the dashboard,
+            // are reached through their production hostname.
             // Retry each endpoint for up to 3 minutes (18 attempts * 10 seconds)
-            output.WriteLine("Step 8: Verifying deployed endpoints...");
+            output.WriteLine("Step 14: Verifying deployed endpoints...");
             await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
                   "echo \"Resource group: $RG_NAME\" && " +
                   "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
-                  // Get App Service hostnames (defaultHostName for each web app)
-                  "urls=$(az webapp list -g \"$RG_NAME\" --query \"[].defaultHostName\" -o tsv 2>/dev/null) && " +
+                  "webapps=$(az webapp list -g \"$RG_NAME\" --query \"[].name\" -o tsv 2>/dev/null) && " +
+                  "if [ -z \"$webapps\" ]; then echo \"❌ No App Service sites found\"; exit 1; fi && " +
+                  "urls='' && " +
+                  "for webapp in $webapps; do " +
+                  "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
+                  "if [ -n \"$slots\" ]; then " +
+                  "for slot in $slots; do " +
+                  "url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query defaultHostName -o tsv 2>/dev/null); " +
+                  "if [ -n \"$url\" ]; then urls=\"$urls $url\"; fi; " +
+                  "done; " +
+                  "else " +
+                  "url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query defaultHostName -o tsv 2>/dev/null); " +
+                  "if [ -n \"$url\" ]; then urls=\"$urls $url\"; fi; " +
+                  "fi; " +
+                  "done && " +
                   "if [ -z \"$urls\" ]; then echo \"❌ No App Service endpoints found\"; exit 1; fi && " +
                   "failed=0 && " +
                   "for url in $urls; do " +
@@ -168,7 +229,11 @@ builder.Build().Run();
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
 
-            // Step 11: Exit terminal
+            // Step 15: Verify that the production site, staging slot, and dashboard use the delegated subnet.
+            output.WriteLine("Step 15: Verifying regional VNet integration...");
+            await VerifyVnetIntegrationAsync(auto, counter, resourceGroupName);
+
+            // Step 16: Exit terminal
             await auto.TypeAsync("exit");
             await auto.EnterAsync();
 
@@ -179,7 +244,7 @@ builder.Build().Run();
 
             // Report success
             DeploymentReporter.ReportDeploymentSuccess(
-                nameof(DeployReactTemplateToAzureAppService),
+                nameof(DeployReactTemplateToAzureAppServiceWithDelegatedSubnet),
                 resourceGroupName,
                 deploymentUrls,
                 duration);
@@ -192,7 +257,7 @@ builder.Build().Run();
             output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
 
             DeploymentReporter.ReportDeploymentFailure(
-                nameof(DeployReactTemplateToAzureAppService),
+                nameof(DeployReactTemplateToAzureAppServiceWithDelegatedSubnet),
                 resourceGroupName,
                 ex.Message,
                 ex.StackTrace);
@@ -206,6 +271,68 @@ builder.Build().Run();
             TriggerCleanupResourceGroup(resourceGroupName, output);
             DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
         }
+    }
+
+    private static async Task VerifyNoVnetIntegrationAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string resourceGroupName)
+    {
+        await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
+            "webapps=$(az webapp list -g \"$RG_NAME\" --query \"[].name\" -o tsv 2>/dev/null) && " +
+            "if [ -z \"$webapps\" ]; then echo \"ERROR: No App Service sites found\"; exit 1; fi && " +
+            "webapp_count=0 && slot_count=0 && " +
+            "for webapp in $webapps; do " +
+            "webapp_count=$((webapp_count + 1)); " +
+            "subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query \"virtualNetworkSubnetId\" -o tsv 2>/dev/null); " +
+            "if [ -n \"$subnet_id\" ]; then echo \"ERROR: $webapp unexpectedly has VNet integration\"; exit 1; fi; " +
+            "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
+            "for slot in $slots; do " +
+            "slot_count=$((slot_count + 1)); " +
+            "subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query \"virtualNetworkSubnetId\" -o tsv 2>/dev/null); " +
+            "if [ -n \"$subnet_id\" ]; then echo \"ERROR: $webapp/$slot unexpectedly has VNet integration\"; exit 1; fi; " +
+            "done; " +
+            "done && " +
+            "if [ \"$webapp_count\" -ne 2 ] || [ \"$slot_count\" -ne 1 ]; then echo \"ERROR: Expected two sites and one staging slot\"; exit 1; fi && " +
+            "echo \"Verified no VNet integration on the initial deployment\"");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+    }
+
+    private static async Task VerifyVnetIntegrationAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string resourceGroupName)
+    {
+        await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
+            "vnet_name=$(az network vnet list -g \"$RG_NAME\" --query \"[?subnets[?name == 'app-service-subnet']].name | [0]\" -o tsv 2>/dev/null) && " +
+            "expected_subnet_id=$(az network vnet subnet show -g \"$RG_NAME\" --vnet-name \"$vnet_name\" --name app-service-subnet --query \"id\" -o tsv 2>/dev/null) && " +
+            "if [ -z \"$expected_subnet_id\" ]; then echo \"ERROR: Delegated subnet not found\"; exit 1; fi && " +
+            "delegation=$(az network vnet subnet show --ids \"$expected_subnet_id\" --query \"delegations[?serviceName == 'Microsoft.Web/serverFarms'].serviceName | [0]\" -o tsv 2>/dev/null) && " +
+            "if [ \"$delegation\" != \"Microsoft.Web/serverFarms\" ]; then echo \"ERROR: Subnet is not delegated to Microsoft.Web/serverFarms\"; exit 1; fi && " +
+            "webapps=$(az webapp list -g \"$RG_NAME\" --query \"[].name\" -o tsv 2>/dev/null) && " +
+            "if [ -z \"$webapps\" ]; then echo \"ERROR: No App Service sites found\"; exit 1; fi && " +
+            // Keep the interactive shell alive after successful verification so Hex1b can observe its prompt.
+            "integration_verified=0 && " +
+            "for attempt in $(seq 1 12); do " +
+            "all_integrated=1; webapp_count=0; slot_count=0; " +
+            "for webapp in $webapps; do " +
+            "webapp_count=$((webapp_count + 1)); " +
+            "subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query \"virtualNetworkSubnetId\" -o tsv 2>/dev/null); " +
+            "if [ \"$subnet_id\" != \"$expected_subnet_id\" ]; then all_integrated=0; fi; " +
+            "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
+            "for slot in $slots; do " +
+            "slot_count=$((slot_count + 1)); " +
+            "subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query \"virtualNetworkSubnetId\" -o tsv 2>/dev/null); " +
+            "if [ \"$subnet_id\" != \"$expected_subnet_id\" ]; then all_integrated=0; fi; " +
+            "done; " +
+            "done; " +
+            "if [ \"$all_integrated\" -eq 1 ] && [ \"$webapp_count\" -eq 2 ] && [ \"$slot_count\" -eq 1 ]; then echo \"Verified VNet integration on production, staging, and dashboard\"; integration_verified=1; break; fi; " +
+            "echo \"Waiting for VNet integration (attempt $attempt)...\"; sleep 10; " +
+            "done && " +
+            "if [ \"$integration_verified\" -ne 1 ]; then echo \"ERROR: VNet integration was not configured on every site and slot\"; exit 1; fi");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
     }
 
     /// <summary>

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -354,7 +354,7 @@ builder.AddAzureAppServiceEnvironment("infra")
             "webapp_count=$((webapp_count + 1)); " +
             "if ! subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query \"virtualNetworkSubnetId\" -o tsv); then echo \"ERROR: Failed to query VNet integration for $webapp\"; exit 1; fi; " +
             "if [ -n \"$subnet_id\" ]; then echo \"ERROR: $webapp unexpectedly has VNet integration\"; exit 1; fi; " +
-            "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
+            "if ! slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); then echo \"ERROR: Failed to query deployment slots for $webapp\"; exit 1; fi; " +
             "for slot in $slots; do " +
             "slot_count=$((slot_count + 1)); " +
             "if ! subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query \"virtualNetworkSubnetId\" -o tsv); then echo \"ERROR: Failed to query VNet integration for $webapp/$slot\"; exit 1; fi; " +
@@ -388,7 +388,7 @@ builder.AddAzureAppServiceEnvironment("infra")
             "webapp_count=$((webapp_count + 1)); " +
             "subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query \"virtualNetworkSubnetId\" -o tsv 2>/dev/null); " +
             "if [ \"$subnet_id\" != \"$expected_subnet_id\" ]; then all_integrated=0; fi; " +
-            "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
+            "if ! slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); then echo \"ERROR: Failed to query deployment slots for $webapp\"; all_integrated=0; continue; fi; " +
             "for slot in $slots; do " +
             "slot_count=$((slot_count + 1)); " +
             "subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query \"virtualNetworkSubnetId\" -o tsv 2>/dev/null); " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -205,12 +205,12 @@ builder.AddAzureAppServiceEnvironment("infra")
                   "slots=$(az webapp deployment slot list -g \"$RG_NAME\" -n \"$webapp\" --query \"[].name\" -o tsv 2>/dev/null); " +
                   "if [ -n \"$slots\" ]; then " +
                   "for slot in $slots; do " +
-                  "url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query defaultHostName -o tsv 2>/dev/null); " +
+                  "if ! url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --slot \"$slot\" --query defaultHostName -o tsv); then echo \"❌ Failed to query hostname for staging slot $webapp/$slot\"; exit 1; fi; " +
                   "if [ -z \"$url\" ]; then echo \"❌ Missing hostname for staging slot $webapp/$slot\"; exit 1; fi; " +
                   "urls=\"$urls $url\"; staging_endpoint_count=$((staging_endpoint_count + 1)); " +
                   "done; " +
                   "else " +
-                  "url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query defaultHostName -o tsv 2>/dev/null); " +
+                  "if ! url=$(az webapp show -g \"$RG_NAME\" -n \"$webapp\" --query defaultHostName -o tsv); then echo \"❌ Failed to query hostname for dashboard $webapp\"; exit 1; fi; " +
                   "if [ -z \"$url\" ]; then echo \"❌ Missing hostname for dashboard $webapp\"; exit 1; fi; " +
                   "urls=\"$urls $url\"; dashboard_endpoint_count=$((dashboard_endpoint_count + 1)); " +
                   "fi; " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -49,7 +49,7 @@ public sealed class AppServiceReactDeploymentTests(ITestOutputHelper output)
             }
         }
 
-        var workspace = TemporaryWorkspace.Create(output);
+        using var workspace = TemporaryWorkspace.Create(output);
         var startTime = DateTime.UtcNow;
         var deploymentUrls = new Dictionary<string, string>();
         // Generate a unique resource group name with pattern: e2e-[testcasename]-[runid]-[attempt]

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -182,6 +182,15 @@ builder.AddAzureAppServiceEnvironment("infra")
 
             File.WriteAllText(appHostFilePath, upgradedContent);
 
+            // Clear the terminal before redeploying. WaitForPipelineSuccessAsync matches the
+            // "pipeline succeeded" banner anywhere on the visible screen, and the first deploy's
+            // banner is still shown. Without clearing, the second deploy's wait matches that stale
+            // banner immediately (instead of waiting for the redeploy to finish), which forces the
+            // subsequent success-prompt wait to absorb the entire second deployment and time out.
+            await auto.TypeAsync("clear");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
             // Step 13: Upgrade the existing production site, staging slot, and dashboard.
             output.WriteLine("Step 13: Upgrading the deployment with regional VNet integration...");
             await auto.TypeAsync("aspire deploy --clear-cache");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceReactDeploymentTests.cs
@@ -346,7 +346,7 @@ builder.AddAzureAppServiceEnvironment("infra")
         SequenceCounter counter,
         string resourceGroupName)
     {
-        await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
+        await auto.TypeAsync($"RG_NAME={AspireCliShellCommandHelpers.QuoteBashArg(resourceGroupName)} && " +
             "webapps=$(az webapp list -g \"$RG_NAME\" --query \"[].name\" -o tsv 2>/dev/null) && " +
             "if [ -z \"$webapps\" ]; then echo \"ERROR: No App Service sites found\"; exit 1; fi && " +
             "webapp_count=0 && slot_count=0 && " +
@@ -372,7 +372,7 @@ builder.AddAzureAppServiceEnvironment("infra")
         SequenceCounter counter,
         string resourceGroupName)
     {
-        await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
+        await auto.TypeAsync($"RG_NAME={AspireCliShellCommandHelpers.QuoteBashArg(resourceGroupName)} && " +
             "vnet_name=$(az network vnet list -g \"$RG_NAME\" --query \"[?subnets[?name == 'app-service-subnet']].name | [0]\" -o tsv 2>/dev/null) && " +
             "expected_subnet_id=$(az network vnet subnet show -g \"$RG_NAME\" --vnet-name \"$vnet_name\" --name app-service-subnet --query \"id\" -o tsv 2>/dev/null) && " +
             "if [ -z \"$expected_subnet_id\" ]; then echo \"ERROR: Delegated subnet not found\"; exit 1; fi && " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
@@ -1,0 +1,335 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end tests for an Azure App Service workload that accesses Azure Blob Storage through a private endpoint.
+/// </summary>
+public sealed class AppServiceStoragePrivateEndpointDeploymentTests(ITestOutputHelper output)
+{
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(55);
+
+    [Fact]
+    public async Task DeployReactTemplateWithAppServiceVnetAndStoragePrivateEndpoint()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+
+        await DeployReactTemplateWithAppServiceVnetAndStoragePrivateEndpointCore(linkedCts.Token);
+    }
+
+    private async Task DeployReactTemplateWithAppServiceVnetAndStoragePrivateEndpointCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("appservice-blob-pe");
+        const string projectName = "AppServiceBlobPe";
+
+        output.WriteLine($"Test: {nameof(DeployReactTemplateWithAppServiceVnetAndStoragePrivateEndpoint)}");
+        output.WriteLine($"Project Name: {projectName}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 2");
+
+            output.WriteLine("Step 3: Creating React + ASP.NET Core project...");
+            await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.JsReact, useRedisCache: false);
+
+            output.WriteLine("Step 4: Navigating to project directory...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 5a: Adding Azure App Service hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.AppService");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            output.WriteLine("Step 5b: Adding Azure Virtual Network hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Network");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            output.WriteLine("Step 5c: Adding Azure Storage hosting package...");
+            await auto.TypeAsync("aspire add Aspire.Hosting.Azure.Storage");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            output.WriteLine("Step 6: Adding Blob Storage client package to Server project...");
+            await auto.TypeAsync($"dotnet add {projectName}.Server package Aspire.Azure.Storage.Blobs --prerelease");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(120));
+
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostFilePath = Path.Combine(projectDir, $"{projectName}.AppHost", "AppHost.cs");
+            var serverProgramPath = Path.Combine(projectDir, $"{projectName}.Server", "Program.cs");
+
+            output.WriteLine("Step 7: Configuring App Service VNet integration and Storage private endpoint...");
+            var appHostContent = File.ReadAllText(appHostFilePath);
+            const string builderCreation = "var builder = DistributedApplication.CreateBuilder(args);";
+            const string infrastructure = """
+var builder = DistributedApplication.CreateBuilder(args);
+
+#pragma warning disable ASPIREAZURE003 // Azure Virtual Network APIs are experimental.
+
+var vnet = builder.AddAzureVirtualNetwork("vnet", "10.0.0.0/16");
+var appServiceSubnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24");
+var privateEndpointSubnet = vnet.AddSubnet("private-endpoint-subnet", "10.0.1.0/24");
+
+var storage = builder.AddAzureStorage("storage");
+var blobs = storage.AddBlobs("blobs");
+privateEndpointSubnet.AddPrivateEndpoint(blobs);
+
+builder.AddAzureAppServiceEnvironment("infra")
+    .WithDelegatedSubnet(appServiceSubnet);
+
+#pragma warning restore ASPIREAZURE003
+""";
+            if (!appHostContent.Contains(builderCreation, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Could not find '{builderCreation}' in the generated AppHost.");
+            }
+
+            appHostContent = appHostContent.Replace(builderCreation, infrastructure, StringComparison.Ordinal);
+
+            const string healthCheck = ".WithHttpHealthCheck(\"/health\")";
+            const string healthCheckWithStorage = """
+.WithHttpHealthCheck("/health")
+    .WithReference(blobs)
+""";
+            if (!appHostContent.Contains(healthCheck, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Could not find '{healthCheck}' in the generated AppHost.");
+            }
+
+            appHostContent = appHostContent.Replace(healthCheck, healthCheckWithStorage, StringComparison.Ordinal);
+            File.WriteAllText(appHostFilePath, appHostContent);
+
+            output.WriteLine("Step 8: Adding an application-level Blob Storage and DNS verification endpoint...");
+            var serverProgramContent = File.ReadAllText(serverProgramPath);
+            serverProgramContent = "using System.Net;\nusing Azure.Storage.Blobs;\n" + serverProgramContent;
+
+            const string serviceDefaults = "builder.AddServiceDefaults();";
+            const string serviceDefaultsWithBlobClient = """
+builder.AddServiceDefaults();
+builder.AddAzureBlobServiceClient("blobs");
+""";
+            if (!serverProgramContent.Contains(serviceDefaults, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Could not find '{serviceDefaults}' in the generated Server project.");
+            }
+
+            serverProgramContent = serverProgramContent.Replace(
+                serviceDefaults,
+                serviceDefaultsWithBlobClient,
+                StringComparison.Ordinal);
+
+            const string defaultEndpoints = "app.MapDefaultEndpoints();";
+            const string storageProbe = """
+// Use the normal Blob endpoint so private DNS resolution, rather than a special connection string,
+// determines whether App Service reaches Storage through the private endpoint.
+app.MapGet("/api/verify-blobs", async (BlobServiceClient blobServiceClient, CancellationToken cancellationToken) =>
+{
+    var containerClient = blobServiceClient.GetBlobContainerClient("private-link-test");
+    await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+    var blobName = $"test-{Guid.NewGuid():N}.txt";
+    var blobClient = containerClient.GetBlobClient(blobName);
+    var expectedContent = $"Hello from the App Service private-link test at {DateTime.UtcNow:O}";
+
+    await blobClient.UploadAsync(BinaryData.FromString(expectedContent), overwrite: true, cancellationToken: cancellationToken);
+    var downloadedContent = await blobClient.DownloadContentAsync(cancellationToken);
+    await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+
+    var resolvedAddresses = await Dns.GetHostAddressesAsync(blobServiceClient.Uri.Host, cancellationToken);
+    return Results.Ok(new
+    {
+        status = "ok",
+        contentMatches = expectedContent == downloadedContent.Value.Content.ToString(),
+        resolvedAddresses = resolvedAddresses.Select(address => address.ToString()).ToArray()
+    });
+});
+
+app.MapDefaultEndpoints();
+""";
+            if (!serverProgramContent.Contains(defaultEndpoints, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Could not find '{defaultEndpoints}' in the generated Server project.");
+            }
+
+            serverProgramContent = serverProgramContent.Replace(defaultEndpoints, storageProbe, StringComparison.Ordinal);
+            File.WriteAllText(serverProgramPath, serverProgramContent);
+
+            output.WriteLine("Step 9: Navigating to AppHost project directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 10: Configuring the Azure deployment...");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            output.WriteLine("Step 11: Deploying to Azure...");
+            await auto.TypeAsync("aspire deploy --clear-cache");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(35));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            output.WriteLine("Step 12: Verifying the deployed network infrastructure...");
+            await VerifyNetworkInfrastructureAsync(auto, counter, resourceGroupName);
+
+            output.WriteLine("Step 13: Verifying Blob access and private DNS from App Service...");
+            await VerifyBlobConnectivityAsync(auto, counter, resourceGroupName);
+
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployReactTemplateWithAppServiceVnetAndStoragePrivateEndpoint),
+                resourceGroupName,
+                new Dictionary<string, string>(),
+                duration);
+        }
+        catch (Exception ex)
+        {
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployReactTemplateWithAppServiceVnetAndStoragePrivateEndpoint),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+            throw;
+        }
+        finally
+        {
+            output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
+            TriggerCleanupResourceGroup(resourceGroupName, output);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+        }
+    }
+
+    private static async Task VerifyNetworkInfrastructureAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string resourceGroupName)
+    {
+        await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
+            "if ! vnet_name=$(az network vnet list -g \"$RG_NAME\" --query \"[?subnets[?name == 'app-service-subnet']].name | [0]\" -o tsv); then echo \"ERROR: Failed to query virtual network\"; exit 1; fi; " +
+            "if [ -z \"$vnet_name\" ]; then echo \"ERROR: Virtual network was not found\"; exit 1; fi && " +
+            "if ! app_service_subnet_id=$(az network vnet subnet show -g \"$RG_NAME\" --vnet-name \"$vnet_name\" --name app-service-subnet --query id -o tsv); then echo \"ERROR: Failed to query App Service subnet\"; exit 1; fi; " +
+            "if ! private_endpoint_subnet_id=$(az network vnet subnet show -g \"$RG_NAME\" --vnet-name \"$vnet_name\" --name private-endpoint-subnet --query id -o tsv); then echo \"ERROR: Failed to query private endpoint subnet\"; exit 1; fi; " +
+            "if [ -z \"$app_service_subnet_id\" ] || [ -z \"$private_endpoint_subnet_id\" ] || [ \"$app_service_subnet_id\" = \"$private_endpoint_subnet_id\" ]; then echo \"ERROR: Expected distinct App Service and private endpoint subnets\"; exit 1; fi && " +
+            "if ! delegation=$(az network vnet subnet show --ids \"$app_service_subnet_id\" --query \"delegations[?serviceName == 'Microsoft.Web/serverFarms'].serviceName | [0]\" -o tsv); then echo \"ERROR: Failed to query App Service subnet delegation\"; exit 1; fi; " +
+            "if [ \"$delegation\" != \"Microsoft.Web/serverFarms\" ]; then echo \"ERROR: App Service subnet is not delegated to Microsoft.Web/serverFarms\"; exit 1; fi && " +
+            "if ! private_endpoint_delegation=$(az network vnet subnet show --ids \"$private_endpoint_subnet_id\" --query \"delegations[0].serviceName\" -o tsv); then echo \"ERROR: Failed to query private endpoint subnet delegation\"; exit 1; fi; " +
+            "if [ -n \"$private_endpoint_delegation\" ]; then echo \"ERROR: Private endpoint subnet must not be delegated\"; exit 1; fi && " +
+            "if ! server_app_name=$(az webapp list -g \"$RG_NAME\" --query \"[?contains(name, 'server')].name | [0]\" -o tsv); then echo \"ERROR: Failed to query App Service workload\"; exit 1; fi; " +
+            "if [ -z \"$server_app_name\" ]; then echo \"ERROR: Server App Service workload was not found\"; exit 1; fi && " +
+            "if ! server_subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$server_app_name\" --query virtualNetworkSubnetId -o tsv); then echo \"ERROR: Failed to query App Service VNet integration\"; exit 1; fi; " +
+            "if [ \"$server_subnet_id\" != \"$app_service_subnet_id\" ]; then echo \"ERROR: App Service workload is not integrated with the delegated subnet\"; exit 1; fi && " +
+            "if ! storage_name=$(az storage account list -g \"$RG_NAME\" --query \"[0].name\" -o tsv); then echo \"ERROR: Failed to query Storage account\"; exit 1; fi; " +
+            "if [ -z \"$storage_name\" ]; then echo \"ERROR: Storage account was not found\"; exit 1; fi && " +
+            "if ! public_network_access=$(az storage account show -g \"$RG_NAME\" -n \"$storage_name\" --query publicNetworkAccess -o tsv); then echo \"ERROR: Failed to query Storage public network access\"; exit 1; fi; " +
+            "if [ \"$public_network_access\" != \"Disabled\" ]; then echo \"ERROR: Storage public network access must be disabled\"; exit 1; fi && " +
+            "if ! private_endpoint_count=$(az network private-endpoint list -g \"$RG_NAME\" --query \"length([])\" -o tsv); then echo \"ERROR: Failed to query private endpoints\"; exit 1; fi; " +
+            "if [ \"$private_endpoint_count\" != \"1\" ]; then echo \"ERROR: Expected exactly one private endpoint\"; exit 1; fi && " +
+            "if ! private_endpoint_id=$(az network private-endpoint list -g \"$RG_NAME\" --query \"[0].id\" -o tsv); then echo \"ERROR: Failed to query private endpoint ID\"; exit 1; fi; " +
+            "if ! private_endpoint_nic_id=$(az network private-endpoint show --ids \"$private_endpoint_id\" --query \"networkInterfaces[0].id\" -o tsv); then echo \"ERROR: Failed to query private endpoint NIC\"; exit 1; fi; " +
+            "if ! private_endpoint_ip=$(az network nic show --ids \"$private_endpoint_nic_id\" --query \"ipConfigurations[0].privateIPAddress\" -o tsv); then echo \"ERROR: Failed to query private endpoint IP\"; exit 1; fi; " +
+            "if [ -z \"$private_endpoint_ip\" ]; then echo \"ERROR: Private endpoint IP was not found\"; exit 1; fi && " +
+            "if ! az network private-dns zone show -g \"$RG_NAME\" -n privatelink.blob.core.windows.net &>/dev/null; then echo \"ERROR: Blob private DNS zone was not found\"; exit 1; fi && " +
+            "if ! dns_record_ip=$(az network private-dns record-set a show -g \"$RG_NAME\" -z privatelink.blob.core.windows.net -n \"$storage_name\" --query \"aRecords[0].ipv4Address\" -o tsv); then echo \"ERROR: Failed to query Blob private DNS record\"; exit 1; fi; " +
+            "if [ \"$dns_record_ip\" != \"$private_endpoint_ip\" ]; then echo \"ERROR: Blob private DNS record does not point to the private endpoint\"; exit 1; fi && " +
+            "echo \"Verified App Service VNet integration, Blob private endpoint, and private DNS infrastructure\"");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
+    }
+
+    private static async Task VerifyBlobConnectivityAsync(
+        Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string resourceGroupName)
+    {
+        await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
+            "if ! server_app_name=$(az webapp list -g \"$RG_NAME\" --query \"[?contains(name, 'server')].name | [0]\" -o tsv); then echo \"ERROR: Failed to query App Service workload\"; exit 1; fi; " +
+            "if [ -z \"$server_app_name\" ]; then echo \"ERROR: Server App Service workload was not found\"; exit 1; fi && " +
+            "if ! server_host_name=$(az webapp show -g \"$RG_NAME\" -n \"$server_app_name\" --query defaultHostName -o tsv); then echo \"ERROR: Failed to query App Service hostname\"; exit 1; fi; " +
+            "if [ -z \"$server_host_name\" ]; then echo \"ERROR: App Service hostname was not found\"; exit 1; fi && " +
+            "if ! private_endpoint_id=$(az network private-endpoint list -g \"$RG_NAME\" --query \"[0].id\" -o tsv); then echo \"ERROR: Failed to query private endpoint ID\"; exit 1; fi; " +
+            "if ! private_endpoint_nic_id=$(az network private-endpoint show --ids \"$private_endpoint_id\" --query \"networkInterfaces[0].id\" -o tsv); then echo \"ERROR: Failed to query private endpoint NIC\"; exit 1; fi; " +
+            "if ! private_endpoint_ip=$(az network nic show --ids \"$private_endpoint_nic_id\" --query \"ipConfigurations[0].privateIPAddress\" -o tsv); then echo \"ERROR: Failed to query private endpoint IP\"; exit 1; fi; " +
+            "probe_succeeded=0 && " +
+            "for attempt in $(seq 1 18); do " +
+            "probe_result=$(curl -sS \"https://$server_host_name/api/verify-blobs\" --max-time 60 2>&1) || probe_result=\"\"; " +
+            "if echo \"$probe_result\" | grep -q '\"status\":\"ok\"' && echo \"$probe_result\" | grep -q '\"contentMatches\":true' && echo \"$probe_result\" | grep -Fq \"$private_endpoint_ip\"; then echo \"Verified Blob access through private endpoint on attempt $attempt\"; probe_succeeded=1; break; fi; " +
+            "echo \"Blob probe attempt $attempt did not succeed; retrying in 10 seconds...\"; sleep 10; " +
+            "done && " +
+            "if [ \"$probe_succeeded\" -ne 1 ]; then echo \"ERROR: Blob probe did not report private endpoint connectivity\"; exit 1; fi");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(8));
+    }
+
+    private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)
+    {
+        var process = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        try
+        {
+            process.Start();
+            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
@@ -364,7 +364,7 @@ app.MapDefaultEndpoints();
                 probe_result=$(curl -sS "https://$server_host_name/api/verify-blobs" --max-time 10 2>&1) || probe_result=""
                 if echo "$probe_result" | grep -q '"status":"ok"' &&
                    echo "$probe_result" | grep -q '"contentMatches":true' &&
-                   echo "$probe_result" | grep -Fq "$private_endpoint_ip"
+                   echo "$probe_result" | grep -Fq "\"$private_endpoint_ip\""
                 then
                     echo "Verified Blob access through private endpoint on attempt $attempt"
                     exit 0

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
@@ -247,8 +247,7 @@ app.MapDefaultEndpoints();
         finally
         {
             output.WriteLine($"Triggering cleanup of resource group: {resourceGroupName}");
-            TriggerCleanupResourceGroup(resourceGroupName, output);
-            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Cleanup triggered (fire-and-forget)");
+            await TriggerCleanupResourceGroupAsync(resourceGroupName, output);
         }
     }
 
@@ -383,9 +382,9 @@ app.MapDefaultEndpoints();
         return $"bash -c {AspireCliShellCommandHelpers.QuoteBashArg(script)}";
     }
 
-    private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)
+    private static async Task TriggerCleanupResourceGroupAsync(string resourceGroupName, ITestOutputHelper output)
     {
-        var process = new System.Diagnostics.Process
+        using var process = new System.Diagnostics.Process
         {
             StartInfo = new System.Diagnostics.ProcessStartInfo
             {
@@ -398,14 +397,30 @@ app.MapDefaultEndpoints();
             }
         };
 
-        try
+        if (!process.Start())
         {
-            process.Start();
-            output.WriteLine($"Cleanup triggered for resource group: {resourceGroupName}");
+            const string message = "Azure CLI did not start the resource group deletion request.";
+            output.WriteLine(message);
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, message);
+            return;
         }
-        catch (Exception ex)
+
+        // Read both streams concurrently to avoid deadlock when a pipe buffer fills.
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        await Task.WhenAll(process.WaitForExitAsync(), standardOutputTask, standardErrorTask);
+
+        if (process.ExitCode == 0)
         {
-            output.WriteLine($"Failed to trigger cleanup: {ex.Message}");
+            output.WriteLine($"Resource group deletion initiated: {resourceGroupName}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Deletion initiated");
+            return;
         }
+
+        var standardError = await standardErrorTask;
+        var standardOutput = await standardOutputTask;
+        var error = string.IsNullOrWhiteSpace(standardError) ? standardOutput : standardError;
+        output.WriteLine($"Resource group deletion may have failed (exit code {process.ExitCode}): {error}");
+        DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, $"Exit code {process.ExitCode}: {error}");
     }
 }

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
@@ -213,10 +213,16 @@ app.MapDefaultEndpoints();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
             output.WriteLine("Step 12: Verifying the deployed network infrastructure...");
-            await VerifyNetworkInfrastructureAsync(auto, counter, resourceGroupName);
+            await auto.RunCommandAsync(
+                BuildNetworkInfrastructureVerificationCommand(resourceGroupName),
+                counter,
+                TimeSpan.FromMinutes(4));
 
             output.WriteLine("Step 13: Verifying Blob access and private DNS from App Service...");
-            await VerifyBlobConnectivityAsync(auto, counter, resourceGroupName);
+            await auto.RunCommandAsync(
+                BuildBlobConnectivityVerificationCommand(resourceGroupName),
+                counter,
+                TimeSpan.FromMinutes(8));
 
             await auto.TypeAsync("exit");
             await auto.EnterAsync();
@@ -246,65 +252,135 @@ app.MapDefaultEndpoints();
         }
     }
 
-    private static async Task VerifyNetworkInfrastructureAsync(
-        Hex1bTerminalAutomator auto,
-        SequenceCounter counter,
-        string resourceGroupName)
+    private static string BuildNetworkInfrastructureVerificationCommand(string resourceGroupName)
     {
-        await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
-            "if ! vnet_name=$(az network vnet list -g \"$RG_NAME\" --query \"[?subnets[?name == 'app-service-subnet']].name | [0]\" -o tsv); then echo \"ERROR: Failed to query virtual network\"; exit 1; fi; " +
-            "if [ -z \"$vnet_name\" ]; then echo \"ERROR: Virtual network was not found\"; exit 1; fi && " +
-            "if ! app_service_subnet_id=$(az network vnet subnet show -g \"$RG_NAME\" --vnet-name \"$vnet_name\" --name app-service-subnet --query id -o tsv); then echo \"ERROR: Failed to query App Service subnet\"; exit 1; fi; " +
-            "if ! private_endpoint_subnet_id=$(az network vnet subnet show -g \"$RG_NAME\" --vnet-name \"$vnet_name\" --name private-endpoint-subnet --query id -o tsv); then echo \"ERROR: Failed to query private endpoint subnet\"; exit 1; fi; " +
-            "if [ -z \"$app_service_subnet_id\" ] || [ -z \"$private_endpoint_subnet_id\" ] || [ \"$app_service_subnet_id\" = \"$private_endpoint_subnet_id\" ]; then echo \"ERROR: Expected distinct App Service and private endpoint subnets\"; exit 1; fi && " +
-            "if ! delegation=$(az network vnet subnet show --ids \"$app_service_subnet_id\" --query \"delegations[?serviceName == 'Microsoft.Web/serverFarms'].serviceName | [0]\" -o tsv); then echo \"ERROR: Failed to query App Service subnet delegation\"; exit 1; fi; " +
-            "if [ \"$delegation\" != \"Microsoft.Web/serverFarms\" ]; then echo \"ERROR: App Service subnet is not delegated to Microsoft.Web/serverFarms\"; exit 1; fi && " +
-            "if ! private_endpoint_delegation=$(az network vnet subnet show --ids \"$private_endpoint_subnet_id\" --query \"delegations[0].serviceName\" -o tsv); then echo \"ERROR: Failed to query private endpoint subnet delegation\"; exit 1; fi; " +
-            "if [ -n \"$private_endpoint_delegation\" ]; then echo \"ERROR: Private endpoint subnet must not be delegated\"; exit 1; fi && " +
-            "if ! server_app_name=$(az webapp list -g \"$RG_NAME\" --query \"[?contains(name, 'server')].name | [0]\" -o tsv); then echo \"ERROR: Failed to query App Service workload\"; exit 1; fi; " +
-            "if [ -z \"$server_app_name\" ]; then echo \"ERROR: Server App Service workload was not found\"; exit 1; fi && " +
-            "if ! server_subnet_id=$(az webapp show -g \"$RG_NAME\" -n \"$server_app_name\" --query virtualNetworkSubnetId -o tsv); then echo \"ERROR: Failed to query App Service VNet integration\"; exit 1; fi; " +
-            "if [ \"$server_subnet_id\" != \"$app_service_subnet_id\" ]; then echo \"ERROR: App Service workload is not integrated with the delegated subnet\"; exit 1; fi && " +
-            "if ! storage_name=$(az storage account list -g \"$RG_NAME\" --query \"[0].name\" -o tsv); then echo \"ERROR: Failed to query Storage account\"; exit 1; fi; " +
-            "if [ -z \"$storage_name\" ]; then echo \"ERROR: Storage account was not found\"; exit 1; fi && " +
-            "if ! public_network_access=$(az storage account show -g \"$RG_NAME\" -n \"$storage_name\" --query publicNetworkAccess -o tsv); then echo \"ERROR: Failed to query Storage public network access\"; exit 1; fi; " +
-            "if [ \"$public_network_access\" != \"Disabled\" ]; then echo \"ERROR: Storage public network access must be disabled\"; exit 1; fi && " +
-            "if ! private_endpoint_count=$(az network private-endpoint list -g \"$RG_NAME\" --query \"length([])\" -o tsv); then echo \"ERROR: Failed to query private endpoints\"; exit 1; fi; " +
-            "if [ \"$private_endpoint_count\" != \"1\" ]; then echo \"ERROR: Expected exactly one private endpoint\"; exit 1; fi && " +
-            "if ! private_endpoint_id=$(az network private-endpoint list -g \"$RG_NAME\" --query \"[0].id\" -o tsv); then echo \"ERROR: Failed to query private endpoint ID\"; exit 1; fi; " +
-            "if ! private_endpoint_nic_id=$(az network private-endpoint show --ids \"$private_endpoint_id\" --query \"networkInterfaces[0].id\" -o tsv); then echo \"ERROR: Failed to query private endpoint NIC\"; exit 1; fi; " +
-            "if ! private_endpoint_ip=$(az network nic show --ids \"$private_endpoint_nic_id\" --query \"ipConfigurations[0].privateIPAddress\" -o tsv); then echo \"ERROR: Failed to query private endpoint IP\"; exit 1; fi; " +
-            "if [ -z \"$private_endpoint_ip\" ]; then echo \"ERROR: Private endpoint IP was not found\"; exit 1; fi && " +
-            "if ! az network private-dns zone show -g \"$RG_NAME\" -n privatelink.blob.core.windows.net &>/dev/null; then echo \"ERROR: Blob private DNS zone was not found\"; exit 1; fi && " +
-            "if ! dns_record_ip=$(az network private-dns record-set a show -g \"$RG_NAME\" -z privatelink.blob.core.windows.net -n \"$storage_name\" --query \"aRecords[0].ipv4Address\" -o tsv); then echo \"ERROR: Failed to query Blob private DNS record\"; exit 1; fi; " +
-            "if [ \"$dns_record_ip\" != \"$private_endpoint_ip\" ]; then echo \"ERROR: Blob private DNS record does not point to the private endpoint\"; exit 1; fi && " +
-            "echo \"Verified App Service VNet integration, Blob private endpoint, and private DNS infrastructure\"");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
+        return BuildBashCommand($$"""
+            set -euo pipefail
+
+            fail() {
+                echo "ERROR: $1"
+                exit 1
+            }
+
+            require_value() {
+                [ -n "$1" ] || fail "$2"
+            }
+
+            require_equal() {
+                [ "$1" = "$2" ] || fail "$3"
+            }
+
+            resource_group={{AspireCliShellCommandHelpers.QuoteBashArg(resourceGroupName)}}
+
+            vnet_name=$(az network vnet list -g "$resource_group" --query "[?subnets[?name == 'app-service-subnet']].name | [0]" -o tsv) ||
+                fail "Failed to query virtual network"
+            require_value "$vnet_name" "Virtual network was not found"
+
+            app_service_subnet_id=$(az network vnet subnet show -g "$resource_group" --vnet-name "$vnet_name" --name app-service-subnet --query id -o tsv) ||
+                fail "Failed to query App Service subnet"
+            private_endpoint_subnet_id=$(az network vnet subnet show -g "$resource_group" --vnet-name "$vnet_name" --name private-endpoint-subnet --query id -o tsv) ||
+                fail "Failed to query private endpoint subnet"
+            require_value "$app_service_subnet_id" "App Service subnet was not found"
+            require_value "$private_endpoint_subnet_id" "Private endpoint subnet was not found"
+            [ "$app_service_subnet_id" != "$private_endpoint_subnet_id" ] ||
+                fail "Expected distinct App Service and private endpoint subnets"
+
+            delegation=$(az network vnet subnet show --ids "$app_service_subnet_id" --query "delegations[?serviceName == 'Microsoft.Web/serverFarms'].serviceName | [0]" -o tsv) ||
+                fail "Failed to query App Service subnet delegation"
+            require_equal "$delegation" "Microsoft.Web/serverFarms" "App Service subnet is not delegated to Microsoft.Web/serverFarms"
+
+            private_endpoint_delegation=$(az network vnet subnet show --ids "$private_endpoint_subnet_id" --query "delegations[0].serviceName" -o tsv) ||
+                fail "Failed to query private endpoint subnet delegation"
+            [ -z "$private_endpoint_delegation" ] ||
+                fail "Private endpoint subnet must not be delegated"
+
+            server_app_name=$(az webapp list -g "$resource_group" --query "[?contains(name, 'server')].name | [0]" -o tsv) ||
+                fail "Failed to query App Service workload"
+            require_value "$server_app_name" "Server App Service workload was not found"
+            server_subnet_id=$(az webapp show -g "$resource_group" -n "$server_app_name" --query virtualNetworkSubnetId -o tsv) ||
+                fail "Failed to query App Service VNet integration"
+            require_equal "$server_subnet_id" "$app_service_subnet_id" "App Service workload is not integrated with the delegated subnet"
+
+            storage_name=$(az storage account list -g "$resource_group" --query "[0].name" -o tsv) ||
+                fail "Failed to query Storage account"
+            require_value "$storage_name" "Storage account was not found"
+            public_network_access=$(az storage account show -g "$resource_group" -n "$storage_name" --query publicNetworkAccess -o tsv) ||
+                fail "Failed to query Storage public network access"
+            require_equal "$public_network_access" "Disabled" "Storage public network access must be disabled"
+
+            private_endpoint_count=$(az network private-endpoint list -g "$resource_group" --query "length([])" -o tsv) ||
+                fail "Failed to query private endpoints"
+            require_equal "$private_endpoint_count" "1" "Expected exactly one private endpoint"
+            private_endpoint_id=$(az network private-endpoint list -g "$resource_group" --query "[0].id" -o tsv) ||
+                fail "Failed to query private endpoint ID"
+            private_endpoint_nic_id=$(az network private-endpoint show --ids "$private_endpoint_id" --query "networkInterfaces[0].id" -o tsv) ||
+                fail "Failed to query private endpoint NIC"
+            private_endpoint_ip=$(az network nic show --ids "$private_endpoint_nic_id" --query "ipConfigurations[0].privateIPAddress" -o tsv) ||
+                fail "Failed to query private endpoint IP"
+            require_value "$private_endpoint_ip" "Private endpoint IP was not found"
+
+            az network private-dns zone show -g "$resource_group" -n privatelink.blob.core.windows.net >/dev/null ||
+                fail "Blob private DNS zone was not found"
+            dns_record_ip=$(az network private-dns record-set a show -g "$resource_group" -z privatelink.blob.core.windows.net -n "$storage_name" --query "aRecords[0].ipv4Address" -o tsv) ||
+                fail "Failed to query Blob private DNS record"
+            require_equal "$dns_record_ip" "$private_endpoint_ip" "Blob private DNS record does not point to the private endpoint"
+
+            echo "Verified App Service VNet integration, Blob private endpoint, and private DNS infrastructure"
+            """);
     }
 
-    private static async Task VerifyBlobConnectivityAsync(
-        Hex1bTerminalAutomator auto,
-        SequenceCounter counter,
-        string resourceGroupName)
+    private static string BuildBlobConnectivityVerificationCommand(string resourceGroupName)
     {
-        await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
-            "if ! server_app_name=$(az webapp list -g \"$RG_NAME\" --query \"[?contains(name, 'server')].name | [0]\" -o tsv); then echo \"ERROR: Failed to query App Service workload\"; exit 1; fi; " +
-            "if [ -z \"$server_app_name\" ]; then echo \"ERROR: Server App Service workload was not found\"; exit 1; fi && " +
-            "if ! server_host_name=$(az webapp show -g \"$RG_NAME\" -n \"$server_app_name\" --query defaultHostName -o tsv); then echo \"ERROR: Failed to query App Service hostname\"; exit 1; fi; " +
-            "if [ -z \"$server_host_name\" ]; then echo \"ERROR: App Service hostname was not found\"; exit 1; fi && " +
-            "if ! private_endpoint_id=$(az network private-endpoint list -g \"$RG_NAME\" --query \"[0].id\" -o tsv); then echo \"ERROR: Failed to query private endpoint ID\"; exit 1; fi; " +
-            "if ! private_endpoint_nic_id=$(az network private-endpoint show --ids \"$private_endpoint_id\" --query \"networkInterfaces[0].id\" -o tsv); then echo \"ERROR: Failed to query private endpoint NIC\"; exit 1; fi; " +
-            "if ! private_endpoint_ip=$(az network nic show --ids \"$private_endpoint_nic_id\" --query \"ipConfigurations[0].privateIPAddress\" -o tsv); then echo \"ERROR: Failed to query private endpoint IP\"; exit 1; fi; " +
-            "probe_succeeded=0 && " +
-            "for attempt in $(seq 1 18); do " +
-            "probe_result=$(curl -sS \"https://$server_host_name/api/verify-blobs\" --max-time 60 2>&1) || probe_result=\"\"; " +
-            "if echo \"$probe_result\" | grep -q '\"status\":\"ok\"' && echo \"$probe_result\" | grep -q '\"contentMatches\":true' && echo \"$probe_result\" | grep -Fq \"$private_endpoint_ip\"; then echo \"Verified Blob access through private endpoint on attempt $attempt\"; probe_succeeded=1; break; fi; " +
-            "echo \"Blob probe attempt $attempt did not succeed; retrying in 10 seconds...\"; sleep 10; " +
-            "done && " +
-            "if [ \"$probe_succeeded\" -ne 1 ]; then echo \"ERROR: Blob probe did not report private endpoint connectivity\"; exit 1; fi");
-        await auto.EnterAsync();
-        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(8));
+        return BuildBashCommand($$"""
+            set -euo pipefail
+
+            fail() {
+                echo "ERROR: $1"
+                exit 1
+            }
+
+            require_value() {
+                [ -n "$1" ] || fail "$2"
+            }
+
+            resource_group={{AspireCliShellCommandHelpers.QuoteBashArg(resourceGroupName)}}
+
+            server_app_name=$(az webapp list -g "$resource_group" --query "[?contains(name, 'server')].name | [0]" -o tsv) ||
+                fail "Failed to query App Service workload"
+            require_value "$server_app_name" "Server App Service workload was not found"
+            server_host_name=$(az webapp show -g "$resource_group" -n "$server_app_name" --query defaultHostName -o tsv) ||
+                fail "Failed to query App Service hostname"
+            require_value "$server_host_name" "App Service hostname was not found"
+
+            private_endpoint_id=$(az network private-endpoint list -g "$resource_group" --query "[0].id" -o tsv) ||
+                fail "Failed to query private endpoint ID"
+            private_endpoint_nic_id=$(az network private-endpoint show --ids "$private_endpoint_id" --query "networkInterfaces[0].id" -o tsv) ||
+                fail "Failed to query private endpoint NIC"
+            private_endpoint_ip=$(az network nic show --ids "$private_endpoint_nic_id" --query "ipConfigurations[0].privateIPAddress" -o tsv) ||
+                fail "Failed to query private endpoint IP"
+
+            for attempt in $(seq 1 18)
+            do
+                probe_result=$(curl -sS "https://$server_host_name/api/verify-blobs" --max-time 60 2>&1) || probe_result=""
+                if echo "$probe_result" | grep -q '"status":"ok"' &&
+                   echo "$probe_result" | grep -q '"contentMatches":true' &&
+                   echo "$probe_result" | grep -Fq "$private_endpoint_ip"
+                then
+                    echo "Verified Blob access through private endpoint on attempt $attempt"
+                    exit 0
+                fi
+
+                echo "Blob probe attempt $attempt did not succeed; retrying in 10 seconds..."
+                sleep 10
+            done
+
+            fail "Blob probe did not report private endpoint connectivity"
+            """);
+    }
+
+    private static string BuildBashCommand(string script)
+    {
+        return $"bash -c {AspireCliShellCommandHelpers.QuoteBashArg(script)}";
     }
 
     private static void TriggerCleanupResourceGroup(string resourceGroupName, ITestOutputHelper output)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
@@ -44,7 +44,7 @@ public sealed class AppServiceStoragePrivateEndpointDeploymentTests(ITestOutputH
             }
         }
 
-        var workspace = TemporaryWorkspace.Create(output);
+        using var workspace = TemporaryWorkspace.Create(output);
         var startTime = DateTime.UtcNow;
         var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("appservice-blob-pe");
         const string projectName = "AppServiceBlobPe";
@@ -361,7 +361,7 @@ app.MapDefaultEndpoints();
 
             for attempt in $(seq 1 18)
             do
-                probe_result=$(curl -sS "https://$server_host_name/api/verify-blobs" --max-time 60 2>&1) || probe_result=""
+                probe_result=$(curl -sS "https://$server_host_name/api/verify-blobs" --max-time 10 2>&1) || probe_result=""
                 if echo "$probe_result" | grep -q '"status":"ok"' &&
                    echo "$probe_result" | grep -q '"contentMatches":true' &&
                    echo "$probe_result" | grep -Fq "$private_endpoint_ip"

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AppServiceStoragePrivateEndpointDeploymentTests.cs
@@ -357,6 +357,7 @@ app.MapDefaultEndpoints();
                 fail "Failed to query private endpoint NIC"
             private_endpoint_ip=$(az network nic show --ids "$private_endpoint_nic_id" --query "ipConfigurations[0].privateIPAddress" -o tsv) ||
                 fail "Failed to query private endpoint IP"
+            require_value "$private_endpoint_ip" "Private endpoint IP was not found"
 
             for attempt in $(seq 1 18)
             do

--- a/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/Aspire.Deployment.EndToEnd.Tests.csproj
@@ -40,9 +40,9 @@
     <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
     <TestArchiveTestsDir>$(TestArchiveTestsDirForDeploymentEndToEndTests)</TestArchiveTestsDir>
 
-    <!-- Extended test session settings for deployment tests -->
-    <TestSessionTimeout>60m</TestSessionTimeout>
-    <TestHangTimeout>45m</TestHangTimeout>
+    <!-- The App Service VNet-integration upgrade test performs two full deployments. -->
+    <TestSessionTimeout>100m</TestSessionTimeout>
+    <TestHangTimeout>90m</TestHangTimeout>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -120,6 +120,46 @@ public class AzureAppServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AddAppServiceWithDelegatedSubnetWithoutDeploymentSlot()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("vnet");
+        var subnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24");
+        builder.AddAzureAppServiceEnvironment("env")
+            .WithDelegatedSubnet(subnet);
+
+        var project = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appServiceEnvironment = Assert.Single(model.Resources.OfType<AzureAppServiceEnvironmentResource>());
+        var target = project.Resource.GetDeploymentTargetAnnotation();
+        Assert.NotNull(target);
+        var website = Assert.IsAssignableFrom<AzureProvisioningResource>(target.DeploymentTarget);
+
+        var (_, virtualNetworkBicep) = await GetManifestWithBicep(vnet.Resource);
+        var (_, environmentBicep) = await GetManifestWithBicep(appServiceEnvironment);
+        var (_, websiteBicep) = await GetManifestWithBicep(website);
+
+        await Verify($"""
+            // Virtual network
+            {virtualNetworkBicep}
+
+            // App Service environment
+            {environmentBicep}
+
+            // App Service website
+            {websiteBicep}
+            """, "bicep");
+    }
+
+    [Fact]
     public async Task PublishAsAzureAppServiceWebsite_CanOverrideEnvironmentDelegatedSubnet()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIRECOMPUTE002
 #pragma warning disable ASPIREPIPELINES001
+#pragma warning disable ASPIREAZURE003
 
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
@@ -75,6 +76,78 @@ public class AzureAppServiceTests(ITestOutputHelper outputHelper)
 
         await Verify(manifest.ToString(), "json")
               .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task AddAppServiceWithDelegatedSubnet()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("vnet");
+        var subnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24");
+        builder.AddAzureAppServiceEnvironment("env")
+            .WithDelegatedSubnet(subnet)
+            .WithDeploymentSlot("stage");
+
+        var project = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appServiceEnvironment = Assert.Single(model.Resources.OfType<AzureAppServiceEnvironmentResource>());
+        var target = project.Resource.GetDeploymentTargetAnnotation();
+        Assert.NotNull(target);
+        var website = Assert.IsAssignableFrom<AzureProvisioningResource>(target.DeploymentTarget);
+
+        var (_, virtualNetworkBicep) = await GetManifestWithBicep(vnet.Resource);
+        var (_, environmentBicep) = await GetManifestWithBicep(appServiceEnvironment);
+        var (_, websiteBicep) = await GetManifestWithBicep(website);
+
+        await Verify($"""
+            // Virtual network
+            {virtualNetworkBicep}
+
+            // App Service environment
+            {environmentBicep}
+
+            // App Service website
+            {websiteBicep}
+            """, "bicep");
+    }
+
+    [Fact]
+    public async Task PublishAsAzureAppServiceWebsite_CanOverrideEnvironmentDelegatedSubnet()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("vnet");
+        var subnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24");
+        builder.AddAzureAppServiceEnvironment("env")
+            .WithDelegatedSubnet(subnet)
+            .WithDeploymentSlot("stage");
+
+        var project = builder.AddProject<Project>("api", launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints()
+            .PublishAsAzureAppServiceWebsite(
+                configure: (_, website) => website.VirtualNetworkSubnetId = new global::Azure.Core.ResourceIdentifier("/subscriptions/subscription/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/website-subnet"),
+                configureSlot: (_, slot) => slot.VirtualNetworkSubnetId = new global::Azure.Core.ResourceIdentifier("/subscriptions/subscription/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/slot-subnet"));
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var target = project.Resource.GetDeploymentTargetAnnotation();
+        Assert.NotNull(target);
+        var website = Assert.IsAssignableFrom<AzureProvisioningResource>(target.DeploymentTarget);
+
+        var (_, bicep) = await GetManifestWithBicep(website);
+
+        await Verify(bicep, "bicep");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
@@ -180,7 +180,26 @@ public class AzureVirtualNetworkExtensionsTests
     }
 
     [Fact]
-    public void WithDelegatedSubnet_ReplacesExistingSubnet()
+    public void WithDelegatedSubnet_SameSubnetCanBeConfiguredMoreThanOnce()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("myvnet");
+        var subnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24");
+
+        var environment = builder.AddAzureAppServiceEnvironment("env")
+            .WithDelegatedSubnet(subnet)
+            .WithDelegatedSubnet(subnet);
+
+        var subnetAnnotation = Assert.Single(environment.Resource.Annotations.OfType<DelegatedSubnetAnnotation>());
+        Assert.Equal("{myvnet.outputs.app_service_subnet_Id}", subnetAnnotation.SubnetId.ValueExpression);
+
+        var delegationAnnotation = Assert.Single(subnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
+        Assert.Equal("Microsoft.Web/serverFarms", delegationAnnotation.ServiceName);
+    }
+
+    [Fact]
+    public void WithDelegatedSubnet_DifferentSubnetThrows()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
@@ -189,15 +208,16 @@ public class AzureVirtualNetworkExtensionsTests
         var secondSubnet = vnet.AddSubnet("second-subnet", "10.0.1.0/24");
 
         var environment = builder.AddAzureAppServiceEnvironment("env")
-            .WithDelegatedSubnet(firstSubnet)
-            .WithDelegatedSubnet(secondSubnet);
+            .WithDelegatedSubnet(firstSubnet);
 
-        var subnetAnnotation = Assert.Single(environment.Resource.Annotations.OfType<DelegatedSubnetAnnotation>());
-        Assert.Equal("{myvnet.outputs.second_subnet_Id}", subnetAnnotation.SubnetId.ValueExpression);
-        Assert.Empty(firstSubnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
+        var exception = Assert.Throws<InvalidOperationException>(() => environment.WithDelegatedSubnet(secondSubnet));
 
-        var delegationAnnotation = Assert.Single(secondSubnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
-        Assert.Equal("Microsoft.Web/serverFarms", delegationAnnotation.ServiceName);
+        Assert.Equal(
+            "The resource 'env' is already associated with a different delegated subnet. A resource can use only one delegated subnet.",
+            exception.Message);
+        Assert.Single(environment.Resource.Annotations.OfType<DelegatedSubnetAnnotation>());
+        Assert.Single(firstSubnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
+        Assert.Empty(secondSubnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
@@ -221,6 +221,29 @@ public class AzureVirtualNetworkExtensionsTests
     }
 
     [Fact]
+    public void WithDelegatedSubnet_DifferentServiceDelegationThrows()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("myvnet");
+        var subnet = vnet.AddSubnet("shared-subnet", "10.0.0.0/24");
+        builder.AddAzureContainerAppEnvironment("container-apps")
+            .WithDelegatedSubnet(subnet);
+
+        var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("app-service");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => appServiceEnvironment.WithDelegatedSubnet(subnet));
+
+        Assert.Equal(
+            "The subnet 'shared-subnet' is already delegated to 'Microsoft.App/environments' and cannot also be delegated to 'Microsoft.Web/serverFarms'.",
+            exception.Message);
+        Assert.Empty(appServiceEnvironment.Resource.Annotations.OfType<DelegatedSubnetAnnotation>());
+
+        var delegation = Assert.Single(subnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
+        Assert.Equal("Microsoft.App/environments", delegation.ServiceName);
+    }
+
+    [Fact]
     public void AddSubnet_WithParameterResource_CreatesSubnetResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
@@ -160,6 +160,26 @@ public class AzureVirtualNetworkExtensionsTests
     }
 
     [Fact]
+    public void WithDelegatedSubnet_AddsAnnotationsToAppServiceEnvironment()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("myvnet");
+        var subnet = vnet.AddSubnet("mysubnet", "10.0.0.0/23");
+
+        var environment = builder.AddAzureAppServiceEnvironment("env")
+            .WithDelegatedSubnet(subnet);
+
+        var subnetAnnotation = environment.Resource.Annotations.OfType<DelegatedSubnetAnnotation>().SingleOrDefault();
+        Assert.NotNull(subnetAnnotation);
+        Assert.Equal("{myvnet.outputs.mysubnet_Id}", subnetAnnotation.SubnetId.ValueExpression);
+
+        var delegationAnnotation = subnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>().SingleOrDefault();
+        Assert.NotNull(delegationAnnotation);
+        Assert.Equal("Microsoft.Web/serverFarms", delegationAnnotation.ServiceName);
+    }
+
+    [Fact]
     public void AddSubnet_WithParameterResource_CreatesSubnetResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
@@ -180,6 +180,27 @@ public class AzureVirtualNetworkExtensionsTests
     }
 
     [Fact]
+    public void WithDelegatedSubnet_ReplacesExistingSubnet()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("myvnet");
+        var firstSubnet = vnet.AddSubnet("first-subnet", "10.0.0.0/24");
+        var secondSubnet = vnet.AddSubnet("second-subnet", "10.0.1.0/24");
+
+        var environment = builder.AddAzureAppServiceEnvironment("env")
+            .WithDelegatedSubnet(firstSubnet)
+            .WithDelegatedSubnet(secondSubnet);
+
+        var subnetAnnotation = Assert.Single(environment.Resource.Annotations.OfType<DelegatedSubnetAnnotation>());
+        Assert.Equal("{myvnet.outputs.second_subnet_Id}", subnetAnnotation.SubnetId.ValueExpression);
+        Assert.Empty(firstSubnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
+
+        var delegationAnnotation = Assert.Single(secondSubnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
+        Assert.Equal("Microsoft.Web/serverFarms", delegationAnnotation.ServiceName);
+    }
+
+    [Fact]
     public void AddSubnet_WithParameterResource_CreatesSubnetResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureVirtualNetworkExtensionsTests.cs
@@ -199,6 +199,23 @@ public class AzureVirtualNetworkExtensionsTests
     }
 
     [Fact]
+    public void WithDelegatedSubnet_CaseInsensitiveServiceDelegationIsAllowed()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var vnet = builder.AddAzureVirtualNetwork("myvnet");
+        var subnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24")
+            .WithAnnotation(new AzureSubnetServiceDelegationAnnotation("AppServiceDelegation", "microsoft.web/serverfarms"));
+
+        var environment = builder.AddAzureAppServiceEnvironment("env")
+            .WithDelegatedSubnet(subnet);
+
+        Assert.Single(environment.Resource.Annotations.OfType<DelegatedSubnetAnnotation>());
+        var delegationAnnotation = Assert.Single(subnet.Resource.Annotations.OfType<AzureSubnetServiceDelegationAnnotation>());
+        Assert.Equal("Microsoft.Web/serverFarms", delegationAnnotation.ServiceName);
+    }
+
+    [Fact]
     public void WithDelegatedSubnet_DifferentSubnetThrows()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDelegatedSubnet.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDelegatedSubnet.verified.bicep
@@ -1,0 +1,414 @@
+﻿// Virtual network
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource vnet 'Microsoft.Network/virtualNetworks@2025-05-01' = {
+  name: take('vnet-${uniqueString(resourceGroup().id)}', 64)
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+  }
+  location: location
+  tags: {
+    'aspire-resource-name': 'vnet'
+  }
+}
+
+resource app_service_subnet 'Microsoft.Network/virtualNetworks/subnets@2025-05-01' = {
+  name: 'app-service-subnet'
+  properties: {
+    addressPrefix: '10.0.0.0/24'
+    delegations: [
+      {
+        properties: {
+          serviceName: 'Microsoft.Web/serverFarms'
+        }
+        name: 'Microsoft.Web/serverFarms'
+      }
+    ]
+  }
+  parent: vnet
+}
+
+output app_service_subnet_Id string = app_service_subnet.id
+
+output id string = vnet.id
+
+output name string = vnet.name
+
+// App Service environment
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param userPrincipalId string = ''
+
+param tags object = { }
+
+param env_acr_outputs_name string
+
+param vnet_outputs_app_service_subnet_id string
+
+resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('env_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+  tags: tags
+}
+
+resource env_acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: env_acr_outputs_name
+}
+
+resource env_acr_env_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(env_acr.id, env_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: env_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: env_acr
+}
+
+resource env_asplan 'Microsoft.Web/serverfarms@2025-03-01' = {
+  name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    perSiteScaling: true
+    reserved: true
+  }
+  kind: 'Linux'
+  sku: {
+    name: 'P0V3'
+    tier: 'Premium'
+  }
+}
+
+resource env_contributor_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('env_contributor_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+}
+
+resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, env_contributor_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7'))
+  properties: {
+    principalId: env_contributor_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
+  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_asplan.id
+    siteConfig: {
+      numberOfWorkers: 1
+      linuxFxVersion: 'ASPIREDASHBOARD|1.0'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_mi.properties.clientId
+      appSettings: [
+        {
+          name: 'DASHBOARD__FRONTEND__AUTHMODE'
+          value: 'Unsecured'
+        }
+        {
+          name: 'DASHBOARD__OTLP__AUTHMODE'
+          value: 'Unsecured'
+        }
+        {
+          name: 'DASHBOARD__OTLP__SUPPRESSUNSECUREDTELEMETRYMESSAGE'
+          value: 'true'
+        }
+        {
+          name: 'DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE'
+          value: 'Unsecured'
+        }
+        {
+          name: 'DASHBOARD__UI__DISABLEIMPORT'
+          value: 'true'
+        }
+        {
+          name: 'WEBSITES_PORT'
+          value: '5000'
+        }
+        {
+          name: 'HTTP20_ONLY_PORT'
+          value: '4317'
+        }
+        {
+          name: 'WEBSITE_START_SCM_WITH_PRELOAD'
+          value: 'true'
+        }
+        {
+          name: 'AZURE_CLIENT_ID'
+          value: env_contributor_mi.properties.clientId
+        }
+        {
+          name: 'ALLOWED_MANAGED_IDENTITIES'
+          value: env_mi.properties.clientId
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+      ]
+      alwaysOn: true
+      http20Enabled: true
+      http20ProxyFlag: 1
+    }
+    virtualNetworkSubnetId: vnet_outputs_app_service_subnet_id
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_contributor_mi.id}': { }
+    }
+  }
+  kind: 'app,linux,aspiredashboard'
+}
+
+output name string = env_asplan.name
+
+output planId string = env_asplan.id
+
+output webSiteSuffix string = uniqueString(resourceGroup().id)
+
+output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env_mi.id
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID string = env_mi.properties.clientId
+
+output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi.id
+
+output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
+
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+
+// App Service website
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_planid string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param env_outputs_azure_container_registry_managed_identity_client_id string
+
+param api_containerimage string
+
+param vnet_outputs_app_service_subnet_id string
+
+param api_containerport string
+
+param env_outputs_azure_app_service_dashboard_uri string
+
+param env_outputs_azure_website_contributor_managed_identity_id string
+
+param env_outputs_azure_website_contributor_managed_identity_principal_id string
+
+@onlyIfNotExists()
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: api_containerimage
+    isMain: true
+    targetPort: api_containerport
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+@onlyIfNotExists()
+resource webapp 'Microsoft.Web/sites@2025-03-01' = {
+  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: api_containerport
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'api'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+    virtualNetworkSubnetId: vnet_outputs_app_service_subnet_id
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}
+
+resource mainContainerSlot 'Microsoft.Web/sites/slots/sitecontainers@2025-03-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: api_containerimage
+    isMain: true
+    targetPort: api_containerport
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webappslot
+}
+
+resource webappslot 'Microsoft.Web/sites/slots@2025-03-01' = {
+  name: 'stage'
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: api_containerport
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'api-stage'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+    virtualNetworkSubnetId: vnet_outputs_app_service_subnet_id
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+  parent: webapp
+}
+
+resource api_website_slot_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webappslot.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webappslot
+}
+
+resource webappNetworkConfig 'Microsoft.Web/sites/networkConfig@2025-03-01' = {
+  name: 'virtualNetwork'
+  properties: {
+    subnetResourceId: vnet_outputs_app_service_subnet_id
+  }
+  parent: webapp
+}
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDelegatedSubnetWithoutDeploymentSlot.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDelegatedSubnetWithoutDeploymentSlot.verified.bicep
@@ -1,0 +1,314 @@
+﻿// Virtual network
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+resource vnet 'Microsoft.Network/virtualNetworks@2025-05-01' = {
+  name: take('vnet-${uniqueString(resourceGroup().id)}', 64)
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+  }
+  location: location
+  tags: {
+    'aspire-resource-name': 'vnet'
+  }
+}
+
+resource app_service_subnet 'Microsoft.Network/virtualNetworks/subnets@2025-05-01' = {
+  name: 'app-service-subnet'
+  properties: {
+    addressPrefix: '10.0.0.0/24'
+    delegations: [
+      {
+        properties: {
+          serviceName: 'Microsoft.Web/serverFarms'
+        }
+        name: 'Microsoft.Web/serverFarms'
+      }
+    ]
+  }
+  parent: vnet
+}
+
+output app_service_subnet_Id string = app_service_subnet.id
+
+output id string = vnet.id
+
+output name string = vnet.name
+
+// App Service environment
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param userPrincipalId string = ''
+
+param tags object = { }
+
+param env_acr_outputs_name string
+
+param vnet_outputs_app_service_subnet_id string
+
+resource env_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('env_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+  tags: tags
+}
+
+resource env_acr 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = {
+  name: env_acr_outputs_name
+}
+
+resource env_acr_env_mi_AcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(env_acr.id, env_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  properties: {
+    principalId: env_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: env_acr
+}
+
+resource env_asplan 'Microsoft.Web/serverfarms@2025-03-01' = {
+  name: take('envasplan-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    perSiteScaling: true
+    reserved: true
+  }
+  kind: 'Linux'
+  sku: {
+    name: 'P0V3'
+    tier: 'Premium'
+  }
+}
+
+resource env_contributor_mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('env_contributor_mi-${uniqueString(resourceGroup().id)}', 128)
+  location: location
+}
+
+resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, env_contributor_mi.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7'))
+  properties: {
+    principalId: env_contributor_mi.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
+  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_asplan.id
+    siteConfig: {
+      numberOfWorkers: 1
+      linuxFxVersion: 'ASPIREDASHBOARD|1.0'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_mi.properties.clientId
+      appSettings: [
+        {
+          name: 'DASHBOARD__FRONTEND__AUTHMODE'
+          value: 'Unsecured'
+        }
+        {
+          name: 'DASHBOARD__OTLP__AUTHMODE'
+          value: 'Unsecured'
+        }
+        {
+          name: 'DASHBOARD__OTLP__SUPPRESSUNSECUREDTELEMETRYMESSAGE'
+          value: 'true'
+        }
+        {
+          name: 'DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE'
+          value: 'Unsecured'
+        }
+        {
+          name: 'DASHBOARD__UI__DISABLEIMPORT'
+          value: 'true'
+        }
+        {
+          name: 'WEBSITES_PORT'
+          value: '5000'
+        }
+        {
+          name: 'HTTP20_ONLY_PORT'
+          value: '4317'
+        }
+        {
+          name: 'WEBSITE_START_SCM_WITH_PRELOAD'
+          value: 'true'
+        }
+        {
+          name: 'AZURE_CLIENT_ID'
+          value: env_contributor_mi.properties.clientId
+        }
+        {
+          name: 'ALLOWED_MANAGED_IDENTITIES'
+          value: env_mi.properties.clientId
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+      ]
+      alwaysOn: true
+      http20Enabled: true
+      http20ProxyFlag: 1
+    }
+    virtualNetworkSubnetId: vnet_outputs_app_service_subnet_id
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_contributor_mi.id}': { }
+    }
+  }
+  kind: 'app,linux,aspiredashboard'
+}
+
+output name string = env_asplan.name
+
+output planId string = env_asplan.id
+
+output webSiteSuffix string = uniqueString(resourceGroup().id)
+
+output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = env_mi.id
+
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_CLIENT_ID string = env_mi.properties.clientId
+
+output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi.id
+
+output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
+
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+
+// App Service website
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_planid string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param env_outputs_azure_container_registry_managed_identity_client_id string
+
+param api_containerimage string
+
+param vnet_outputs_app_service_subnet_id string
+
+param api_containerport string
+
+param env_outputs_azure_app_service_dashboard_uri string
+
+param env_outputs_azure_website_contributor_managed_identity_id string
+
+param env_outputs_azure_website_contributor_managed_identity_principal_id string
+
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: api_containerimage
+    isMain: true
+    targetPort: api_containerport
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+resource webapp 'Microsoft.Web/sites@2025-03-01' = {
+  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: api_containerport
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'api'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+    virtualNetworkSubnetId: vnet_outputs_app_service_subnet_id
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.PublishAsAzureAppServiceWebsite_CanOverrideEnvironmentDelegatedSubnet.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.PublishAsAzureAppServiceWebsite_CanOverrideEnvironmentDelegatedSubnet.verified.bicep
@@ -1,0 +1,221 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param env_outputs_azure_container_registry_endpoint string
+
+param env_outputs_planid string
+
+param env_outputs_azure_container_registry_managed_identity_id string
+
+param env_outputs_azure_container_registry_managed_identity_client_id string
+
+param api_containerimage string
+
+param vnet_outputs_app_service_subnet_id string
+
+param api_containerport string
+
+param env_outputs_azure_app_service_dashboard_uri string
+
+param env_outputs_azure_website_contributor_managed_identity_id string
+
+param env_outputs_azure_website_contributor_managed_identity_principal_id string
+
+@onlyIfNotExists()
+resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: api_containerimage
+    isMain: true
+    targetPort: api_containerport
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webapp
+}
+
+@onlyIfNotExists()
+resource webapp 'Microsoft.Web/sites@2025-03-01' = {
+  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: api_containerport
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'api'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+    virtualNetworkSubnetId: '/subscriptions/subscription/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/website-subnet'
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}
+
+resource api_website_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webapp.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webapp
+}
+
+resource mainContainerSlot 'Microsoft.Web/sites/slots/sitecontainers@2025-03-01' = {
+  name: 'main'
+  properties: {
+    authType: 'UserAssigned'
+    image: api_containerimage
+    isMain: true
+    targetPort: api_containerport
+    userManagedIdentityClientId: env_outputs_azure_container_registry_managed_identity_client_id
+  }
+  parent: webappslot
+}
+
+resource webappslot 'Microsoft.Web/sites/slots@2025-03-01' = {
+  name: 'stage'
+  location: location
+  properties: {
+    serverFarmId: env_outputs_planid
+    siteConfig: {
+      numberOfWorkers: 30
+      linuxFxVersion: 'SITECONTAINERS'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: env_outputs_azure_container_registry_managed_identity_client_id
+      appSettings: [
+        {
+          name: 'WEBSITES_PORT'
+          value: api_containerport
+        }
+        {
+          name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+          value: 'in_memory'
+        }
+        {
+          name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+          value: 'true'
+        }
+        {
+          name: 'HTTP_PORTS'
+          value: api_containerport
+        }
+        {
+          name: 'ASPIRE_ENVIRONMENT_NAME'
+          value: 'env'
+        }
+        {
+          name: 'OTEL_SERVICE_NAME'
+          value: 'api-stage'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+          value: 'grpc'
+        }
+        {
+          name: 'OTEL_EXPORTER_OTLP_ENDPOINT'
+          value: 'http://localhost:6001'
+        }
+        {
+          name: 'WEBSITE_ENABLE_ASPIRE_OTEL_SIDECAR'
+          value: 'true'
+        }
+        {
+          name: 'OTEL_COLLECTOR_URL'
+          value: env_outputs_azure_app_service_dashboard_uri
+        }
+        {
+          name: 'OTEL_CLIENT_ID'
+          value: env_outputs_azure_container_registry_managed_identity_client_id
+        }
+      ]
+    }
+    virtualNetworkSubnetId: '/subscriptions/subscription/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/slot-subnet'
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${env_outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+  parent: webapp
+}
+
+resource api_website_slot_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(webappslot.id, env_outputs_azure_website_contributor_managed_identity_id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772'))
+  properties: {
+    principalId: env_outputs_azure_website_contributor_managed_identity_principal_id
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')
+    principalType: 'ServicePrincipal'
+  }
+  scope: webappslot
+}
+
+resource webappNetworkConfig 'Microsoft.Web/sites/networkConfig@2025-03-01' = {
+  name: 'virtualNetwork'
+  properties: {
+    subnetResourceId: '/subscriptions/subscription/resourceGroups/resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/website-subnet'
+  }
+  parent: webapp
+}
+
+resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
+  name: 'slotConfigNames'
+  properties: {
+    appSettingNames: [
+      'OTEL_SERVICE_NAME'
+    ]
+  }
+  parent: webapp
+}

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppService/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppService/TypeScript/apphost.mts
@@ -4,8 +4,11 @@ const builder = await createBuilder();
 
 const deploymentSlot = await builder.addParameter('deploymentSlot');
 const existingApplicationInsights = await builder.addAzureApplicationInsights('existingApplicationInsights');
+const vnet = await builder.addAzureVirtualNetwork('vnet');
+const subnet = await vnet.addSubnet('app-service-subnet', '10.0.0.0/24');
 
 const environment = await builder.addAzureAppServiceEnvironment('appservice-environment')
+    .withDelegatedSubnet(subnet)
     .withDashboard()
     .withDashboard({ enable: false })
     .withAzureApplicationInsights()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppService/TypeScript/aspire.config.json
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Azure.AppService/TypeScript/aspire.config.json
@@ -4,6 +4,7 @@
     "language": "typescript/nodejs"
   },
   "packages": {
-    "Aspire.Hosting.Azure.AppService": ""
+    "Aspire.Hosting.Azure.AppService": "",
+    "Aspire.Hosting.Azure.Network": ""
   }
 }


### PR DESCRIPTION
## Description

Adds regional virtual network integration for Azure App Service environments, addressing the App Service configuration gap reported in [discussion #18734](https://github.com/microsoft/aspire/discussions/18734). AppHost authors can now apply an Azure delegated subnet to an App Service environment, and Aspire configures workload sites, deployment slots, and the default dashboard consistently.

### User-facing usage

```csharp
#pragma warning disable ASPIREAZURE003 // Azure Virtual Network APIs are experimental.
var vnet = builder.AddAzureVirtualNetwork("vnet");
var subnet = vnet.AddSubnet("app-service-subnet", "10.0.0.0/24");

var appServiceEnvironment = builder.AddAzureAppServiceEnvironment("env")
    .WithDelegatedSubnet(subnet);
#pragma warning restore ASPIREAZURE003
```

The subnet is delegated to `Microsoft.Web/serverFarms`. This is regional VNet integration for outbound traffic only: it does not make site or dashboard ingress private and does not enable Route All.

### Implementation details

Slot-enabled deployments preserve the production `Microsoft.Web/sites` resource with `@onlyIfNotExists()`. The change emits the required `Microsoft.Web/sites/networkConfig` child named `virtualNetwork` so an existing production site can be upgraded safely without bypassing that guard. A narrow custom Azure.Provisioning resource is used until the upstream library can generate the required fixed child resource name.

### Validation

- `dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.AzureAppServiceTests" --filter-class "*.AzureVirtualNetworkExtensionsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (84 passed)
- `dotnet test --project tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (99 passed)
- The App Service TypeScript fixture restored the locally built App Service and Network SDK packages and type-checked the generated `.withDelegatedSubnet(subnet)` call.
- Live Azure E2E ran the slot-enabled initial deployment, upgraded the same resource group with a delegated subnet, verified public staging-slot and dashboard endpoints, and confirmed the expected subnet on the production site, staging slot, and dashboard.

N/A - prompted by [discussion #18734](https://github.com/microsoft/aspire/discussions/18734).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No