### PR TITLE
Prevent asciinema upload hang from wedging deployment-tests reporting job

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -410,6 +410,15 @@ jobs:
       pull-requests: write
       actions: read
     steps:
+      - name: Record job start time
+        shell: bash
+        # Anchor the upload budget (below) to job start rather than to the start of the
+        # upload block. timeout-minutes is measured from job start, and the preceding
+        # artifact download / extraction / pip install steps also consume that budget,
+        # so deriving the upload deadline from here guarantees posting time is reserved
+        # regardless of how long those earlier steps take.
+        run: echo "JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Get job results and download recording artifacts
         id: get_results
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -579,14 +588,22 @@ jobs:
             MAX_UPLOAD_RETRIES=5
             RETRY_BASE_DELAY_SECONDS=30
 
-            # Global budget for ALL uploads combined. The job has timeout-minutes: 20,
-            # and a single recording's worst case (5 x 120s timeout + 30+60+90+120s
-            # backoff = 15m) could otherwise consume the whole cap before the results
-            # comment is posted — worse with multiple recordings. Cap total upload time
-            # so the remainder of the job budget is always reserved for comment posting;
-            # any recordings still pending when the deadline passes are marked FAILED.
-            GLOBAL_UPLOAD_BUDGET_SECONDS=720
-            UPLOAD_DEADLINE=$(( $(date +%s) + GLOBAL_UPLOAD_BUDGET_SECONDS ))
+            # Global budget for ALL uploads combined, anchored to the job start so the
+            # time already spent downloading/extracting artifacts and installing asciinema
+            # counts against it. The job has timeout-minutes: 20; we cut uploads off 15
+            # minutes into the job, always reserving ~5 minutes to post the results comment.
+            # Without this, a single recording's worst case (5 x 120s timeout + 30+60+90+120s
+            # backoff = 15m) — worse with multiple recordings — could consume the whole cap
+            # before the comment is posted. Any recordings still pending at the deadline are
+            # marked FAILED. If earlier steps already blew the 15m mark, the deadline is
+            # already in the past and every upload is skipped so posting still happens.
+            UPLOAD_CUTOFF_SECONDS_INTO_JOB=900
+            if [ -n "${JOB_START_EPOCH:-}" ]; then
+              UPLOAD_DEADLINE=$(( JOB_START_EPOCH + UPLOAD_CUTOFF_SECONDS_INTO_JOB ))
+            else
+              # Fallback if the job-start timestamp is unavailable for any reason.
+              UPLOAD_DEADLINE=$(( $(date +%s) + 720 ))
+            fi
 
             UPLOAD_COUNT=0
             for castfile in "$RECORDINGS_DIR"/*.cast; do

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -401,6 +401,10 @@ jobs:
     name: Post PR Comment
     needs: [deploy-test]
     runs-on: ubuntu-latest
+    # Backstop so this reporting job can never hold the concurrency slot for hours.
+    # A hung asciinema upload once wedged this job past an hour, and because the
+    # workflow uses cancel-in-progress concurrency, that blocked newer queued runs.
+    timeout-minutes: 20
     if: ${{ always() && inputs.pr_number != '' }}
     permissions:
       pull-requests: write
@@ -584,7 +588,13 @@ jobs:
                 # Upload to asciinema with retry logic for transient failures
                 ASCIINEMA_URL=""
                 for attempt in $(seq 1 "$MAX_UPLOAD_RETRIES"); do
-                  UPLOAD_OUTPUT=$(asciinema upload "$castfile" 2>&1) || true
+                  # Wrap in `timeout` because `asciinema upload` has no built-in network
+                  # timeout and can hang indefinitely on a read from asciinema.org. A real
+                  # run once wedged here for over an hour, holding the cancel-in-progress
+                  # concurrency slot and blocking newer queued deployment runs. `timeout`
+                  # exits 124 on a hang, which `|| true` treats like any other failed
+                  # attempt so the retry loop advances (and eventually records FAILED).
+                  UPLOAD_OUTPUT=$(timeout 120 asciinema upload "$castfile" 2>&1) || true
                   ASCIINEMA_URL=$(echo "$UPLOAD_OUTPUT" | grep -oP 'https://asciinema\.org/a/[a-zA-Z0-9_-]+' | head -1) || true
                   if [ -n "$ASCIINEMA_URL" ]; then
                     break

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -579,10 +579,28 @@ jobs:
             MAX_UPLOAD_RETRIES=5
             RETRY_BASE_DELAY_SECONDS=30
 
+            # Global budget for ALL uploads combined. The job has timeout-minutes: 20,
+            # and a single recording's worst case (5 x 120s timeout + 30+60+90+120s
+            # backoff = 15m) could otherwise consume the whole cap before the results
+            # comment is posted — worse with multiple recordings. Cap total upload time
+            # so the remainder of the job budget is always reserved for comment posting;
+            # any recordings still pending when the deadline passes are marked FAILED.
+            GLOBAL_UPLOAD_BUDGET_SECONDS=720
+            UPLOAD_DEADLINE=$(( $(date +%s) + GLOBAL_UPLOAD_BUDGET_SECONDS ))
+
             UPLOAD_COUNT=0
             for castfile in "$RECORDINGS_DIR"/*.cast; do
               if [ -f "$castfile" ]; then
                 filename=$(basename "$castfile" .cast)
+
+                # Stop uploading once the global budget is exhausted so we always
+                # leave time to post the results comment within the job timeout.
+                if [ "$(date +%s)" -ge "$UPLOAD_DEADLINE" ]; then
+                  RECORDING_URLS["$filename"]="FAILED"
+                  echo "Skipping upload of $castfile: global upload budget exhausted"
+                  continue
+                fi
+
                 echo "Uploading $castfile..."
 
                 # Upload to asciinema with retry logic for transient failures
@@ -599,7 +617,9 @@ jobs:
                   if [ -n "$ASCIINEMA_URL" ]; then
                     break
                   fi
-                  if [ "$attempt" -lt "$MAX_UPLOAD_RETRIES" ]; then
+                  # Don't sleep/retry past the global deadline — bail out so remaining
+                  # recordings and the comment step still fit inside the job timeout.
+                  if [ "$attempt" -lt "$MAX_UPLOAD_RETRIES" ] && [ "$(date +%s)" -lt "$UPLOAD_DEADLINE" ]; then
                     DELAY=$((attempt * RETRY_BASE_DELAY_SECONDS))
                     echo "Upload attempt $attempt failed, retrying in ${DELAY}s..."
                     sleep "$DELAY"

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -606,6 +606,14 @@ jobs:
                 # Upload to asciinema with retry logic for transient failures
                 ASCIINEMA_URL=""
                 for attempt in $(seq 1 "$MAX_UPLOAD_RETRIES"); do
+                  # Stop retrying this recording once the global budget is exhausted.
+                  # Checking at the top (not just before the sleep) prevents a recording
+                  # that started near the deadline from running all remaining `timeout 120`
+                  # attempts back-to-back and blowing past the job timeout.
+                  if [ "$(date +%s)" -ge "$UPLOAD_DEADLINE" ]; then
+                    echo "Global upload budget exhausted; abandoning retries for $castfile"
+                    break
+                  fi
                   # Wrap in `timeout` because `asciinema upload` has no built-in network
                   # timeout and can hang indefinitely on a read from asciinema.org. A real
                   # run once wedged here for over an hour, holding the cancel-in-progress
@@ -617,12 +625,18 @@ jobs:
                   if [ -n "$ASCIINEMA_URL" ]; then
                     break
                   fi
-                  # Don't sleep/retry past the global deadline — bail out so remaining
-                  # recordings and the comment step still fit inside the job timeout.
-                  if [ "$attempt" -lt "$MAX_UPLOAD_RETRIES" ] && [ "$(date +%s)" -lt "$UPLOAD_DEADLINE" ]; then
+                  if [ "$attempt" -lt "$MAX_UPLOAD_RETRIES" ]; then
                     DELAY=$((attempt * RETRY_BASE_DELAY_SECONDS))
-                    echo "Upload attempt $attempt failed, retrying in ${DELAY}s..."
-                    sleep "$DELAY"
+                    # Never sleep past the global deadline, so the backoff itself can't
+                    # eat into the time reserved for posting the results comment.
+                    REMAINING=$((UPLOAD_DEADLINE - $(date +%s)))
+                    if [ "$REMAINING" -lt "$DELAY" ]; then
+                      DELAY="$REMAINING"
+                    fi
+                    if [ "$DELAY" -gt 0 ]; then
+                      echo "Upload attempt $attempt failed, retrying in ${DELAY}s..."
+                      sleep "$DELAY"
+                    fi
                   fi
                 done
 

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -410,15 +410,6 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Record job start time
-        shell: bash
-        # Anchor the upload budget (below) to job start rather than to the start of the
-        # upload block. timeout-minutes is measured from job start, and the preceding
-        # artifact download / extraction / pip install steps also consume that budget,
-        # so deriving the upload deadline from here guarantees posting time is reserved
-        # regardless of how long those earlier steps take.
-        run: echo "JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
-
       - name: Get job results and download recording artifacts
         id: get_results
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -588,49 +579,15 @@ jobs:
             MAX_UPLOAD_RETRIES=5
             RETRY_BASE_DELAY_SECONDS=30
 
-            # Global budget for ALL uploads combined, anchored to the job start so the
-            # time already spent downloading/extracting artifacts and installing asciinema
-            # counts against it. The job has timeout-minutes: 20; we cut uploads off 15
-            # minutes into the job, always reserving ~5 minutes to post the results comment.
-            # Without this, a single recording's worst case (5 x 120s timeout + 30+60+90+120s
-            # backoff = 15m) — worse with multiple recordings — could consume the whole cap
-            # before the comment is posted. Any recordings still pending at the deadline are
-            # marked FAILED. If earlier steps already blew the 15m mark, the deadline is
-            # already in the past and every upload is skipped so posting still happens.
-            UPLOAD_CUTOFF_SECONDS_INTO_JOB=900
-            if [ -n "${JOB_START_EPOCH:-}" ]; then
-              UPLOAD_DEADLINE=$(( JOB_START_EPOCH + UPLOAD_CUTOFF_SECONDS_INTO_JOB ))
-            else
-              # Fallback if the job-start timestamp is unavailable for any reason.
-              UPLOAD_DEADLINE=$(( $(date +%s) + 720 ))
-            fi
-
             UPLOAD_COUNT=0
             for castfile in "$RECORDINGS_DIR"/*.cast; do
               if [ -f "$castfile" ]; then
                 filename=$(basename "$castfile" .cast)
-
-                # Stop uploading once the global budget is exhausted so we always
-                # leave time to post the results comment within the job timeout.
-                if [ "$(date +%s)" -ge "$UPLOAD_DEADLINE" ]; then
-                  RECORDING_URLS["$filename"]="FAILED"
-                  echo "Skipping upload of $castfile: global upload budget exhausted"
-                  continue
-                fi
-
                 echo "Uploading $castfile..."
 
                 # Upload to asciinema with retry logic for transient failures
                 ASCIINEMA_URL=""
                 for attempt in $(seq 1 "$MAX_UPLOAD_RETRIES"); do
-                  # Stop retrying this recording once the global budget is exhausted.
-                  # Checking at the top (not just before the sleep) prevents a recording
-                  # that started near the deadline from running all remaining `timeout 120`
-                  # attempts back-to-back and blowing past the job timeout.
-                  if [ "$(date +%s)" -ge "$UPLOAD_DEADLINE" ]; then
-                    echo "Global upload budget exhausted; abandoning retries for $castfile"
-                    break
-                  fi
                   # Wrap in `timeout` because `asciinema upload` has no built-in network
                   # timeout and can hang indefinitely on a read from asciinema.org. A real
                   # run once wedged here for over an hour, holding the cancel-in-progress
@@ -644,16 +601,8 @@ jobs:
                   fi
                   if [ "$attempt" -lt "$MAX_UPLOAD_RETRIES" ]; then
                     DELAY=$((attempt * RETRY_BASE_DELAY_SECONDS))
-                    # Never sleep past the global deadline, so the backoff itself can't
-                    # eat into the time reserved for posting the results comment.
-                    REMAINING=$((UPLOAD_DEADLINE - $(date +%s)))
-                    if [ "$REMAINING" -lt "$DELAY" ]; then
-                      DELAY="$REMAINING"
-                    fi
-                    if [ "$DELAY" -gt 0 ]; then
-                      echo "Upload attempt $attempt failed, retrying in ${DELAY}s..."
-                      sleep "$DELAY"
-                    fi
+                    echo "Upload attempt $attempt failed, retrying in ${DELAY}s..."
+                    sleep "$DELAY"
                   fi
                 done
 


### PR DESCRIPTION
## Description

The `Post PR Comment` job (`post_pr_comment`) in `.github/workflows/deployment-tests.yml` uploads terminal recordings to asciinema.org before posting the results comment. `asciinema upload` has no built-in network timeout and can hang indefinitely on a read. We observed a real run where all deploy jobs finished but this job got wedged for over an hour on the "Upload recordings to asciinema and post comment" step; two `gh run cancel` requests did not terminate it. Because the workflow uses `concurrency: cancel-in-progress: true`, the hung run held the concurrency slot and blocked a newer queued deployment run from starting.

Two minimal, surgical fixes:

1. **Wrap `asciinema upload` in `timeout 120`.** The existing `|| true` only handled a non-zero exit, not a hang, so the retry loop never advanced. `timeout` exits 124 on a hang, which `|| true` treats like any other failed attempt — the loop retries and, after `MAX_UPLOAD_RETRIES`, records `FAILED` and moves on. A comment explains why the wrapper is there so it isn't removed later.
2. **Add `timeout-minutes: 20` to the `post_pr_comment` job**, which previously had no timeout and defaulted to GitHub's 6-hour limit. This is a hard backstop so the reporting job can never hold the concurrency slot for hours.

Together these guarantee the job can never run more than 20 minutes or hold the concurrency slot indefinitely, which fully resolves the reported wedge.

> Note: an earlier revision added an upload-time budget (global deadline anchored to job start, capped backoff, etc.) to also guarantee the results comment posts during a sustained asciinema.org outage. That addressed a secondary edge case rather than the reported bug and was reverted to keep the change minimal and surgical.

CI-config only; no unit tests exist for this workflow. YAML validity verified with `yaml.safe_load`.

Fixes # (N/A)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No