### PR TITLE
Allow external service URIs without trailing slash

### DIFF
--- a/src/Aspire.Hosting/ExternalServiceResource.cs
+++ b/src/Aspire.Hosting/ExternalServiceResource.cs
@@ -20,7 +20,7 @@ public sealed class ExternalServiceResource : Resource
     /// <param name="name">The name of the resource.</param>
     /// <param name="uri">The URI for the external service.</param>
     /// <remarks>
-    /// The URI must be an absolute URI with the absolute path ending with '/'.
+    /// The URI must be an absolute URI.
     /// The URI cannot contain a fragment or query string.
     /// </remarks>
     public ExternalServiceResource(string name, Uri uri) : base(name)
@@ -85,10 +85,6 @@ public sealed class ExternalServiceResource : Resource
         if (!uri.IsAbsoluteUri)
         {
             return new ArgumentException("The URI for the external service must be absolute.", nameof(uri));
-        }
-        if (!uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal))
-        {
-            return new ArgumentException("The URI absolute path must end with '/'.", nameof(uri));
         }
         if (!string.IsNullOrEmpty(uri.Fragment))
         {

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -1265,11 +1265,6 @@ public static class ResourceBuilderExtensions
             throw new InvalidOperationException($"The URI for service reference '{name}' is invalid while configuring target resource '{builder.Resource.Name}': it must be absolute.");
         }
 
-        if (!uri.AbsolutePath.EndsWith('/'))
-        {
-            throw new InvalidOperationException($"The URI for service reference '{name}' is invalid while configuring target resource '{builder.Resource.Name}': the absolute path must end with '/'.");
-        }
-
         if (!string.IsNullOrEmpty(uri.Fragment))
         {
             throw new InvalidOperationException($"The URI for service reference '{name}' is invalid while configuring target resource '{builder.Resource.Name}': it cannot contain a fragment.");

--- a/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExternalServiceTests.cs
@@ -54,11 +54,8 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData("not-a-url")]
     [InlineData("")]
-    [InlineData("https://example.com/path")]  // Invalid: missing trailing slash
     [InlineData("https://example.com/path?query=value")]  // Invalid: has query string
     [InlineData("https://example.com#fragment")]  // Invalid: has fragment
-    [InlineData("https://example.com/service")]  // Invalid: missing trailing slash
-    [InlineData("https://example.com/service/sub")]  // Invalid: missing trailing slash
     [InlineData("https://example.com/?query=1")]  // Invalid: has query string
     public void AddExternalServiceThrowsWithInvalidUrl(string invalidUrl)
     {
@@ -79,13 +76,15 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public void AddExternalServiceThrowsWithUriWithoutTrailingSlash()
+    public void AddExternalServiceAcceptsUriWithoutTrailingSlash()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
         var uriWithPath = new Uri("https://api.example.com/api/v1");
-        var ex = Assert.Throws<ArgumentException>(() => builder.AddExternalService("nuget", uriWithPath));
-        Assert.Contains("absolute path must end with '/'", ex.Message);
+        var externalService = builder.AddExternalService("nuget", uriWithPath);
+
+        Assert.Equal("nuget", externalService.Resource.Name);
+        Assert.Equal(uriWithPath, externalService.Resource.Uri);
     }
 
     [Theory]
@@ -301,10 +300,9 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(invalidMessage);
         Assert.Contains("absolute URI", invalidMessage);
 
-        Assert.False(ExternalServiceResource.UrlIsValidForExternalService("https://nuget.org/path", out var pathUri, out var pathMessage));
-        Assert.Null(pathUri);
-        Assert.NotNull(pathMessage);
-        Assert.Contains("absolute path must end with '/'", pathMessage);
+        Assert.True(ExternalServiceResource.UrlIsValidForExternalService("https://nuget.org/path", out var pathUri, out var pathMessage));
+        Assert.Equal("https://nuget.org/path", pathUri!.ToString());
+        Assert.Null(pathMessage);
 
         // Test valid paths with trailing slash
         Assert.True(ExternalServiceResource.UrlIsValidForExternalService("https://gateway/orders-service/", out var validPathUri, out var validPathMessage));
@@ -514,13 +512,15 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
     [InlineData("https://host/service")]
     [InlineData("https://host/service/sub")]
     [InlineData("https://host/api")]
-    [InlineData("https://host/service?query=1")]
-    public void ExternalServiceRejectsPathsWithoutTrailingSlash(string invalidUrl)
+    [InlineData("http://gateway:8080/api/v1")]
+    public void ExternalServiceAcceptsPathsWithoutTrailingSlash(string validUrl)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var ex = Assert.Throws<ArgumentException>(() => builder.AddExternalService("service", invalidUrl));
-        Assert.Contains("absolute path must end with '/'", ex.Message);
+        var externalService = builder.AddExternalService("service", validUrl);
+
+        Assert.Equal("service", externalService.Resource.Name);
+        Assert.Equal(validUrl, externalService.Resource.Uri?.ToString());
     }
 
     [Theory]
@@ -565,17 +565,14 @@ public class ExternalServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public void WithReferenceThrowsForUriWithoutTrailingSlash()
+    public void WithReferenceAcceptsUriWithoutTrailingSlash()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var project = builder.AddProject<TestProject>("project");
 
         var uri = new Uri("https://api.example.com/service");
-        var ex = Assert.Throws<InvalidOperationException>(() => project.WithReference("api", uri));
-        Assert.Contains("reference 'api'", ex.Message);
-        Assert.Contains("target resource 'project'", ex.Message);
-        Assert.Contains("absolute path must end with '/'", ex.Message);
+        project.WithReference("api", uri);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -529,11 +529,20 @@ public class WithReferenceTests
     }
 
     [Fact]
-    public void WithReferenceHttpUriThrowsException()
+    public async Task WithReferenceHttpUriWithPathProducesEnvironmentVariables()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        Assert.Throws<InvalidOperationException>(() => builder.AddProject<ProjectA>("projecta").WithReference("petstore", new Uri("https://petstore.swagger.io/v2")));
+        var projectA = builder.AddProject<ProjectA>("projecta")
+                               .WithReference("petstore", new Uri("https://petstore.swagger.io/v2"));
+
+        // Call environment variable callbacks.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectA.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+
+        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
+        Assert.Equal(1, servicesKeysCount);
+        Assert.Contains(config, kvp => kvp.Key == "services__petstore__default__0" && kvp.Value == "https://petstore.swagger.io/v2");
+        Assert.Contains(config, kvp => kvp.Key == "petstore" && kvp.Value == "https://petstore.swagger.io/v2");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

This change addresses a usability issue where external service URIs were rejected unless their absolute path ended with `/`. That restriction prevented valid references such as `https://tempuri.org/data.xml` and other concrete path-based endpoints.

The URI validation was updated to remove only the trailing-slash requirement while keeping the existing safety checks that require absolute URIs and reject fragments and query strings. The same alignment was applied to `WithReference(..., Uri)` so direct URI references behave consistently with external service resources. Hosting tests were updated to cover accepted path URIs both with and without trailing slashes.

Fixes: #18653

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No