### PR TITLE
[DO NOT MERGE] Mirror: validate reworked Radius deployment + KIND tests

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -316,6 +316,16 @@ jobs:
           # matches the Bicep types the publisher emits.
           RADIUS_VERSION: "0.59.0"
         run: |
+          # Pre-create the install dir (user-owned) BEFORE running install.sh. The
+          # Radius install.sh chooses whether to sudo by looking only at the install
+          # dir's immediate parent: for --install-dir "$HOME/.rad/bin" it inspects
+          # "$HOME/.rad", and on a fresh runner that does not exist yet, so it wrongly
+          # decides sudo is required and runs `sudo mkdir -p "$HOME/.rad/bin"`. That
+          # leaves "$HOME/.rad" owned by root, and the subsequent (non-sudo)
+          # `rad bicep download` then fails to create "$HOME/.rad/config.yaml.lock"
+          # with "permission denied". Creating the dir up front makes install.sh see a
+          # writable target and skip sudo entirely.
+          mkdir -p "$HOME/.rad/bin"
           # Fetch install.sh pinned to the same release tag (v$RADIUS_VERSION) we install, rather
           # than the moving `main` branch. This keeps the installer script content locked to the
           # pinned version so it cannot drift independently (supply-chain hardening).

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -316,7 +316,10 @@ jobs:
           # matches the Bicep types the publisher emits.
           RADIUS_VERSION: "0.59.0"
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" | \
+          # Fetch install.sh pinned to the same release tag (v$RADIUS_VERSION) we install, rather
+          # than the moving `main` branch. This keeps the installer script content locked to the
+          # pinned version so it cannot drift independently (supply-chain hardening).
+          curl -fsSL "https://raw.githubusercontent.com/radius-project/radius/v${RADIUS_VERSION}/deploy/install.sh" | \
             /bin/bash -s -- --version "$RADIUS_VERSION" --install-dir "$HOME/.rad/bin"
           echo "$HOME/.rad/bin" >> "$GITHUB_PATH"
           "$HOME/.rad/bin/rad" version --cli

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -302,6 +302,25 @@ jobs:
         with:
           version: v4.2.0
 
+      # Install the Radius (`rad`) CLI only for the Radius deployment scenario. `aspire deploy`
+      # against a Radius environment shells out to `rad deploy`, so the CLI must be on PATH.
+      # Gated to the single matrix class so the ~dozens of other split jobs neither pay the
+      # download cost nor fail if the install endpoint is unavailable. RADIUS_VERSION pins the
+      # control-plane version (`rad install kubernetes` in the test installs the matching plane),
+      # keeping CI deterministic across Radius releases.
+      - name: Setup Radius
+        if: ${{ contains(matrix.classname, 'RadiusStarterDeploymentTests') }}
+        env:
+          # Full release tag component; install.sh resolves this to tag v0.59.0. Keep aligned
+          # with RadiusBicepExtension.Version (major.minor 0.59) so the installed control plane
+          # matches the Bicep types the publisher emits.
+          RADIUS_VERSION: "0.59.0"
+        run: |
+          curl -fsSL "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" | \
+            /bin/bash -s -- --version "$RADIUS_VERSION" --install-dir "$HOME/.rad/bin"
+          echo "$HOME/.rad/bin" >> "$GITHUB_PATH"
+          "$HOME/.rad/bin/rad" version --cli
+
       - name: Run deployment test (${{ matrix.shortname }})
         id: run_tests
         env:

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
@@ -139,6 +139,83 @@ internal static class KubernetesDeployTestHelpers
     }
 
     /// <summary>
+    /// Installs the Radius <c>rad</c> CLI into ~/.local/bin (already added to PATH
+    /// by <see cref="InstallKindAndHelmAsync"/>) using the official install script,
+    /// pinned to <see cref="KubernetesE2EVersions.RadiusVersion"/>. Skips the
+    /// download when <c>rad</c> is already on PATH, and retries up to 3 times to
+    /// tolerate transient GitHub CDN failures (mirrors the KinD/Helm downloads).
+    /// </summary>
+    internal static async Task InstallRadCliAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter)
+    {
+        var radiusVersion = KubernetesE2EVersions.RadiusVersion;
+
+        await auto.TypeAsync("mkdir -p ~/.local/bin");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        // The install script is fetched from the matching release tag (which carries
+        // the leading `v`), while its `--version` flag expects the bare number. rad
+        // downloads its companion `bicep` to ~/.rad/bin on the first `rad deploy`.
+        await auto.TypeAsync($"command -v rad >/dev/null 2>&1 || {{ rm -f ~/.local/bin/rad; for i in 1 2 3; do curl -fsSL \"https://raw.githubusercontent.com/radius-project/radius/v{radiusVersion}/deploy/install.sh\" | /bin/bash -s -- --version {radiusVersion} --install-dir \"$HOME/.local/bin\" && test -x \"$HOME/.local/bin/rad\" && break; echo \"Retry $i: rad download failed, retrying in 5s...\"; rm -f ~/.local/bin/rad; sleep 5; done; test -x \"$HOME/.local/bin/rad\"; }}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync("export PATH=\"$HOME/.local/bin:$PATH\" && rad version");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+    }
+
+    /// <summary>
+    /// Installs the Radius control plane onto the KinD cluster and creates the
+    /// resource group, environment, and workspace that <c>rad deploy</c> (driven by
+    /// <c>aspire deploy</c>) resolves against. No Azure is involved.
+    /// </summary>
+    /// <remarks>
+    /// Two non-obvious behaviors this sequence works around, both confirmed against
+    /// rad 0.59.0:
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     <c>rad</c> ignores <c>KUBECONFIG</c> and targets the current-context of
+    ///     <c>~/.kube/config</c>. In this container <c>kind export kubeconfig
+    ///     --internal</c> has already set that to <c>kind-&lt;cluster&gt;</c>, but we
+    ///     still pass <c>--kubecontext</c>/<c>--context</c> explicitly so the
+    ///     control-plane install and workspace are pinned to the intended cluster.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <c>rad install kubernetes</c> does NOT create a default resource group,
+    ///     environment, or workspace, so <c>rad deploy</c> would otherwise fail to
+    ///     resolve a scope. We create <c>default</c>/<c>default</c> and a workspace
+    ///     bound to them explicitly.
+    ///   </description></item>
+    /// </list>
+    /// </remarks>
+    internal static async Task InstallRadiusControlPlaneAsync(
+        this Hex1bTerminalAutomator auto,
+        SequenceCounter counter,
+        string clusterName)
+    {
+        // Installing the control plane pulls several images and waits for the
+        // radius-system pods to become ready, so allow a generous budget.
+        await auto.TypeAsync($"rad install kubernetes --kubecontext kind-{clusterName}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(10));
+
+        await auto.TypeAsync("rad group create default");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync("rad env create default --group default");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.TypeAsync($"rad workspace create kubernetes radius-e2e --context kind-{clusterName} --group default --environment default --force");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+    }
+
+    /// <summary>
     /// Scaffolds an Aspire project using <c>aspire new</c> (Starter template, no Redis),
     /// then adds hosting/client packages and injects custom code into the existing source files.
     /// Asserts the "Using project templates version:" message appears with a prerelease suffix.

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesDeployTestHelpers.cs
@@ -184,10 +184,12 @@ internal static class KubernetesDeployTestHelpers
     ///     control-plane install and workspace are pinned to the intended cluster.
     ///   </description></item>
     ///   <item><description>
-    ///     <c>rad install kubernetes</c> does NOT create a default resource group,
-    ///     environment, or workspace, so <c>rad deploy</c> would otherwise fail to
-    ///     resolve a scope. We create <c>default</c>/<c>default</c> and a workspace
-    ///     bound to them explicitly.
+    ///     <c>rad install kubernetes</c> provisions the <c>default</c> resource group
+    ///     and environment, but does NOT persist a workspace, so <c>rad deploy</c>
+    ///     would otherwise fail to resolve a workspace scope. We create the workspace
+    ///     explicitly; the <c>rad group create</c>/<c>rad env create</c> calls below are
+    ///     defensive (idempotent) so the sequence still succeeds even if a future
+    ///     <c>rad</c> stops creating the group/environment during install.
     ///   </description></item>
     /// </list>
     /// </remarks>

--- a/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesE2EVersions.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Helpers/KubernetesE2EVersions.cs
@@ -30,4 +30,16 @@ internal static class KubernetesE2EVersions
     public static string HelmVersion => Environment.GetEnvironmentVariable("HELM_VERSION") ?? "v4.2.0";
 
     public static string KubectlVersion => Environment.GetEnvironmentVariable("KUBECTL_VERSION") ?? "v1.34.3";
+
+    /// <summary>
+    /// The Radius CLI / control-plane version installed for the KinD-based Radius
+    /// deploy E2E test. This must stay aligned with
+    /// <c>Aspire.Hosting.Radius.RadiusBicepExtension.Version</c> (currently
+    /// <c>0.59</c>): the generated <c>bicepconfig.json</c> pins the Radius Bicep
+    /// types to that version, and a mismatched <c>rad</c> CLI can fail to resolve
+    /// <c>br:biceptypes.azurecr.io/radius:&lt;version&gt;</c> during <c>rad deploy</c>.
+    /// Unlike the other versions, this default omits the leading <c>v</c> because
+    /// the Radius <c>install.sh</c> <c>--version</c> flag expects a bare number.
+    /// </summary>
+    public static string RadiusVersion => Environment.GetEnvironmentVariable("RADIUS_VERSION") ?? "0.59.0";
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/RadiusDeployTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/RadiusDeployTests.cs
@@ -149,10 +149,16 @@ public sealed class RadiusDeployTests(ITestOutputHelper output)
             // aspire deploy regenerates the artifacts and runs `rad deploy app.bicep`
             // against the radius-e2e workspace (pinned to this KinD cluster). A
             // container-only Radius app has no parameters to prompt for.
+            //
+            // Wait on this command's own sequence-numbered prompt with the full deploy
+            // budget rather than WaitForPipelineSuccessAsync: the latter scans the whole
+            // viewport and would match the stale "Pipeline succeeded" left by the earlier
+            // `aspire publish`, returning before this deploy finishes. The prompt wait is
+            // scoped to this command and still fails fast on a non-zero deploy via the ERR
+            // prompt.
             await auto.TypeAsync("aspire deploy");
             await auto.EnterAsync();
-            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(15));
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(15));
 
             // =================================================================
             // Phase 5: Verify the workload is scheduled and serving HTTP
@@ -187,10 +193,15 @@ public sealed class RadiusDeployTests(ITestOutputHelper output)
             await auto.WaitForSuccessPromptAsync(counter);
 
             // The aspnetapp sample serves HTTP 200 on `/`. Retry to absorb the brief
-            // window while the port-forward and container finish coming up.
+            // window while the port-forward and container finish coming up. The success
+            // marker is split in the shell source (VERIFY''_OK evaluates to VERIFY_OK) so
+            // the contiguous token appears only in curl's output on a 200, never in the
+            // echoed command line — otherwise WaitUntilTextAsync would match the command
+            // itself and return before curl succeeds. Mirrors BICEP_IMAGES''_OK in the
+            // AKS deployment test.
             await auto.TypeAsync("for i in $(seq 1 20); do " +
                 "code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/ 2>/dev/null); " +
-                "if [ \"$code\" = \"200\" ]; then echo \"VERIFY_OK: http=$code\"; break; fi; " +
+                "if [ \"$code\" = \"200\" ]; then echo VERIFY''_OK; break; fi; " +
                 "echo \"Attempt $i: got http=$code, retrying...\"; sleep 5; done");
             await auto.EnterAsync();
             await auto.WaitUntilTextAsync("VERIFY_OK", timeout: TimeSpan.FromMinutes(3));

--- a/tests/Aspire.Cli.EndToEnd.Tests/RadiusDeployTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/RadiusDeployTests.cs
@@ -17,8 +17,9 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// asserts the container is actually scheduled and serving HTTP.
 ///
 /// This gives per-PR, local coverage of the Radius deploy flow alongside the
-/// live Azure/AKS test (<c>Aspire.Deployment.EndToEnd.Tests</c>), which only
-/// runs on demand.
+/// live Azure/AKS test (<c>Aspire.Deployment.EndToEnd.Tests</c>), which runs on
+/// demand (<c>workflow_dispatch</c>) and nightly (the <c>deployment-tests.yml</c>
+/// schedule), not on every PR.
 ///
 /// A public image (<c>mcr.microsoft.com/dotnet/samples:aspnetapp</c>) is used
 /// so the KinD node pulls it directly from MCR. That intentionally avoids the
@@ -102,8 +103,10 @@ public sealed class RadiusDeployTests(ITestOutputHelper output)
             // Insert the Radius wiring before `builder.Build().Run();`. AddRadiusEnvironment,
             // WithNamespace, AddContainer, and WithHttpEndpoint are all non-[Experimental],
             // so no ASPIRERADIUS*/ASPIREPIPELINES* suppression is needed. WithHttpEndpoint's
-            // targetPort drives the container port that the Radius publisher emits (and thus
-            // the port of the Service the recipe creates).
+            // targetPort drives the container port the Radius publisher emits on the native
+            // Radius.Compute/containers workload. Radius does not synthesize a Kubernetes Service
+            // for that workload, so Phase 5 reaches it by port-forwarding straight to the
+            // Deployment rather than through a Service.
             var appHostFilePath = Path.Combine(
                 workspace.WorkspaceRoot.FullName,
                 ProjectName,

--- a/tests/Aspire.Cli.EndToEnd.Tests/RadiusDeployTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/RadiusDeployTests.cs
@@ -36,10 +36,15 @@ public sealed class RadiusDeployTests(ITestOutputHelper output)
 {
     private const string ProjectName = "AspireRadiusDeployTest";
 
-    // The container image is public and tagged (not :latest), so Kubernetes uses
-    // imagePullPolicy: IfNotPresent and the KinD node pulls it once from MCR.
-    private const string ContainerImage = "mcr.microsoft.com/dotnet/samples:aspnetapp";
-    private const int ContainerPort = 8080;
+    // A stable, digest-pinned public image. The `dotnet/samples` images are explicitly documented
+    // as unstable and can break at any time (dotnet/dotnet-docker#7191), so this test uses the same
+    // image + digest the deployment E2E suite standardized on (see
+    // tests/Aspire.Deployment.EndToEnd.Tests/AcaCompactNamingDeploymentTests.cs). Pinning by SHA256
+    // makes the pulled content immutable, so the KinD node pulls the exact bytes once from MCR.
+    private const string ContainerImage = "mcr.microsoft.com/azuredocs/aci-helloworld";
+    private const string ContainerImageTag = "latest";
+    private const string ContainerImageDigest = "456a1150aa41340a14c7be1342deda2cde9e6e7df9fde6b8a69de0ae04f92fad";
+    private const int ContainerPort = 80;
 
     [Fact]
     [CaptureWorkspaceOnFailure]
@@ -116,7 +121,8 @@ public sealed class RadiusDeployTests(ITestOutputHelper output)
             Assert.Contains(buildRunPattern, content);
             var radiusWiring = $$"""
                 builder.AddRadiusEnvironment("radius").WithNamespace("{{radiusNamespace}}");
-                builder.AddContainer("web", "{{ContainerImage}}")
+                builder.AddContainer("web", "{{ContainerImage}}", "{{ContainerImageTag}}")
+                    .WithImageSHA256("{{ContainerImageDigest}}")
                     .WithHttpEndpoint(targetPort: {{ContainerPort}});
                 """;
             content = content.Replace(buildRunPattern, radiusWiring + Environment.NewLine + Environment.NewLine + buildRunPattern);

--- a/tests/Aspire.Cli.EndToEnd.Tests/RadiusDeployTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/RadiusDeployTests.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end coverage for deploying an AppHost that targets a Radius compute
+/// environment (see <c>Aspire.Hosting.Radius</c>) all the way to running
+/// workloads — <b>without any Azure</b>. Where <see cref="RadiusPublishTests"/>
+/// stops at generating <c>app.bicep</c>, this test drives the full CLI path
+/// (<c>aspire publish</c> → <c>aspire deploy</c> → <c>rad deploy app.bicep</c>)
+/// against a local KinD cluster with the Radius control plane installed, then
+/// asserts the container is actually scheduled and serving HTTP.
+///
+/// This gives per-PR, local coverage of the Radius deploy flow alongside the
+/// live Azure/AKS test (<c>Aspire.Deployment.EndToEnd.Tests</c>), which only
+/// runs on demand.
+///
+/// A public image (<c>mcr.microsoft.com/dotnet/samples:aspnetapp</c>) is used
+/// so the KinD node pulls it directly from MCR. That intentionally avoids the
+/// build-and-push-to-localhost:5001 machinery the Kubernetes deploy tests need:
+/// no image build, no registry round-trip, and no reliance on the mounted host
+/// Docker daemon for image movement — the single biggest reliability win for a
+/// per-PR test. The KinD cluster is still created via
+/// <see cref="KubernetesDeployTestHelpers.CreateKindClusterWithRegistryAsync"/>
+/// (the registry sits idle) because that helper also performs the critical
+/// internal-kubeconfig networking fix that lets the helper container reach the
+/// cluster's API server.
+/// </summary>
+public sealed class RadiusDeployTests(ITestOutputHelper output)
+{
+    private const string ProjectName = "AspireRadiusDeployTest";
+
+    // The container image is public and tagged (not :latest), so Kubernetes uses
+    // imagePullPolicy: IfNotPresent and the KinD node pulls it once from MCR.
+    private const string ContainerImage = "mcr.microsoft.com/dotnet/samples:aspnetapp";
+    private const int ContainerPort = 8080;
+
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task DeployRadiusContainerToKind()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        using var workspace = TemporaryWorkspace.Create(output);
+
+        var clusterName = KubernetesDeployTestHelpers.GenerateUniqueClusterName();
+
+        // The Radius app namespace must be a valid RFC 1123 label (WithNamespace
+        // enforces this) and must pre-exist before deploy: the Radius.Core
+        // environment controller hard-fails if the target namespace is missing
+        // (the UDT environment model, unlike the legacy Applications.Core model,
+        // deliberately does not auto-create it).
+        var radiusNamespace = $"radius-{clusterName[..16]}";
+
+        output.WriteLine($"Cluster name: {clusterName}");
+        output.WriteLine($"Radius namespace: {radiusNamespace}");
+
+        // mountDockerSocket: true is required so KinD (and the Radius control-plane
+        // images it pulls) run against the host Docker daemon from inside the
+        // helper container.
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, mountDockerSocket: true, workspace: workspace);
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.VerifyPullRequestCliVersionAsync(counter);
+
+        try
+        {
+            // =================================================================
+            // Phase 1: Cluster + Radius control plane
+            // =================================================================
+            await auto.InstallKindAndHelmAsync(counter);
+            await auto.CreateKindClusterWithRegistryAsync(counter, clusterName);
+            await auto.InstallRadCliAsync(counter);
+            await auto.InstallRadiusControlPlaneAsync(counter, clusterName);
+
+            // =================================================================
+            // Phase 2: Scaffold the AppHost
+            // =================================================================
+
+            // Empty AppHost template (not Starter): the Radius publisher fails on
+            // ProjectResources with no attached image, so we add exactly one
+            // container. This mirrors RadiusPublishTests.
+            await auto.AspireNewCSharpEmptyAppHostAsync(ProjectName, counter);
+
+            await auto.TypeAsync($"cd {ProjectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync("aspire add Aspire.Hosting.Radius");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromSeconds(180));
+
+            // Insert the Radius wiring before `builder.Build().Run();`. AddRadiusEnvironment,
+            // WithNamespace, AddContainer, and WithHttpEndpoint are all non-[Experimental],
+            // so no ASPIRERADIUS*/ASPIREPIPELINES* suppression is needed. WithHttpEndpoint's
+            // targetPort drives the container port that the Radius publisher emits (and thus
+            // the port of the Service the recipe creates).
+            var appHostFilePath = Path.Combine(
+                workspace.WorkspaceRoot.FullName,
+                ProjectName,
+                "apphost.cs");
+            var content = File.ReadAllText(appHostFilePath);
+            const string buildRunPattern = "builder.Build().Run();";
+            Assert.Contains(buildRunPattern, content);
+            var radiusWiring = $$"""
+                builder.AddRadiusEnvironment("radius").WithNamespace("{{radiusNamespace}}");
+                builder.AddContainer("web", "{{ContainerImage}}")
+                    .WithHttpEndpoint(targetPort: {{ContainerPort}});
+                """;
+            content = content.Replace(buildRunPattern, radiusWiring + Environment.NewLine + Environment.NewLine + buildRunPattern);
+            File.WriteAllText(appHostFilePath, content);
+
+            // ASPIRE_PLAYGROUND=true takes precedence over --non-interactive and makes
+            // Spectre.Console attempt concurrent dynamic displays (see KubernetesPublishTests).
+            await auto.TypeAsync("unset ASPIRE_PLAYGROUND");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // =================================================================
+            // Phase 3: Publish and assert the generated Bicep shape
+            // =================================================================
+            await auto.TypeAsync("aspire publish -o radius-output --non-interactive");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            var appBicepPath = Path.Combine(workspace.WorkspaceRoot.FullName, ProjectName, "radius-output", "app.bicep");
+            Assert.True(File.Exists(appBicepPath), $"Expected generated Bicep at '{appBicepPath}'.");
+            var appBicep = File.ReadAllText(appBicepPath);
+            Assert.Contains("Radius.Core/environments", appBicep);
+            Assert.Contains("Radius.Compute/containers", appBicep);
+            Assert.Contains(ContainerImage, appBicep);
+
+            // =================================================================
+            // Phase 4: Create the app namespace, then deploy
+            // =================================================================
+            await auto.TypeAsync($"kubectl create namespace {radiusNamespace} --context kind-{clusterName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // aspire deploy regenerates the artifacts and runs `rad deploy app.bicep`
+            // against the radius-e2e workspace (pinned to this KinD cluster). A
+            // container-only Radius app has no parameters to prompt for.
+            await auto.TypeAsync("aspire deploy");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(15));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // =================================================================
+            // Phase 5: Verify the workload is scheduled and serving HTTP
+            // =================================================================
+
+            // Radius labels every workload it creates with radapp.io/application and
+            // radapp.io/resource; wait on the app label so we don't depend on the
+            // generated Deployment/pod name.
+            await auto.TypeAsync($"kubectl wait --for=condition=Ready pod -n {radiusNamespace} -l radapp.io/application=app --timeout=180s");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(4));
+
+            await auto.TypeAsync($"kubectl get pods,svc -n {radiusNamespace} -l radapp.io/application=app");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Resolve the Deployment by the radapp.io/resource label and port-forward to it
+            // directly. Radius does not synthesize a Kubernetes Service for a container workload
+            // (the HTTP endpoint is modeled at the Radius layer, not as a k8s Service), so there
+            // is no Service to target; only the Deployment/pods exist. Resolving by label avoids
+            // depending on the generated Deployment name.
+            await auto.TypeAsync($"RADIUS_DEPLOY=$(kubectl get deployment -n {radiusNamespace} -l radapp.io/resource=web -o jsonpath='{{.items[0].metadata.name}}') && echo \"Resolved deployment: $RADIUS_DEPLOY\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync($"kubectl port-forward -n {radiusNamespace} deployment/$RADIUS_DEPLOY 18080:{ContainerPort} &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync("sleep 3");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // The aspnetapp sample serves HTTP 200 on `/`. Retry to absorb the brief
+            // window while the port-forward and container finish coming up.
+            await auto.TypeAsync("for i in $(seq 1 20); do " +
+                "code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/ 2>/dev/null); " +
+                "if [ \"$code\" = \"200\" ]; then echo \"VERIFY_OK: http=$code\"; break; fi; " +
+                "echo \"Attempt $i: got http=$code, retrying...\"; sleep 5; done");
+            await auto.EnterAsync();
+            await auto.WaitUntilTextAsync("VERIFY_OK", timeout: TimeSpan.FromMinutes(3));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            await auto.TypeAsync("kill %1 2>/dev/null || true");
+            await auto.EnterAsync();
+            await auto.WaitForAnyPromptAsync(counter);
+
+            await auto.CleanupKubernetesDeploymentAsync(counter, clusterName);
+        }
+        finally
+        {
+            await KubernetesDeployTestHelpers.CleanupKindClusterOutOfBandAsync(clusterName, output);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -184,8 +184,15 @@ Radius-specific notes:
 - **Verifies the Radius.Core UDT app, not just Redis.** Graph validation uses
   `rad app graph -a app --preview` (the legacy `rad app graph` routes to Applications.Core, which
   the Redis-only legacy `app` satisfies on its own) and asserts the graph names both project
-  containers. The `webfrontend` probe requests `/weather` (not `/`) so it exercises the
-  `AddRedisOutputCache` path and the apiservice API client end-to-end.
+  containers. Each container is then probed on its own HTTP endpoint via `kubectl port-forward`:
+  `apiservice`'s `/weatherforecast` and `webfrontend`'s home page (`/`).
+- **Cross-container connectivity is not asserted (current Radius limitation).** The `webfrontend`
+  `/weather` page fans out to `apiservice` through the Redis output cache, but Radius 0.59 does not
+  synthesize a Kubernetes `Service` for a `Radius.Compute/containers` workload, so the
+  service-discovery hostname Aspire emits for `apiservice`
+  (`apiservice.<namespace>.svc.cluster.local`) does not resolve in-cluster (`rad app graph` shows
+  `webfrontend` wired only to the cache). The test therefore validates each container in isolation
+  rather than the `/weather` end-to-end path until that connectivity is supported.
 
 ## TypeScript deployment coverage
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -181,6 +181,11 @@ Radius-specific notes:
   resources yet (<https://github.com/microsoft/aspire/issues/16844>). The test builds/pushes the
   starter images to ACR and attaches them with `WithContainerImage` (Experimental
   `ASPIRERADIUS057`) so the generated `app.bicep` references pullable images.
+- **Verifies the Radius.Core UDT app, not just Redis.** Graph validation uses
+  `rad app graph -a app --preview` (the legacy `rad app graph` routes to Applications.Core, which
+  the Redis-only legacy `app` satisfies on its own) and asserts the graph names both project
+  containers. The `webfrontend` probe requests `/weather` (not `/`) so it exercises the
+  `AddRedisOutputCache` path and the apiservice API client end-to-end.
 
 ## TypeScript deployment coverage
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -158,10 +158,29 @@ Aspire.Deployment.EndToEnd.Tests/
 ├── AzureServiceBusDeploymentTests.cs      # Azure Service Bus resource
 ├── AzureStorageDeploymentTests.cs         # Azure Storage resource
 ├── PythonFastApiDeploymentTests.cs        # Python FastAPI to Azure Container Apps
+├── RadiusStarterDeploymentTests.cs        # Starter template to Radius on AKS (rad deploy)
 ├── TypeScriptAzureContainerAppJobDeploymentTests.cs # TypeScript AppHost ACA jobs
 ├── xunit.runner.json                  # Test runner config
 └── README.md                          # This file
 ```
+
+## Radius deployment coverage
+
+`RadiusStarterDeploymentTests.DeployStarterTemplateToRadiusOnAks` is the live counterpart to the
+`Aspire.Hosting.Radius` unit/snapshot tests. Those prove the Bicep serializer output; this test
+proves that `aspire publish` + `rad deploy app.bicep` produce a working deployment. It provisions an
+AKS cluster + ACR, installs the Radius control plane onto the cluster, deploys the starter app
+(`AddRadiusEnvironment`), and verifies the workloads become ready and serve HTTP traffic.
+
+Radius-specific notes:
+
+- **`rad` CLI prerequisite.** `aspire deploy` against a Radius environment shells out to `rad`. In
+  CI the gated **Setup Radius** step in `deployment-tests.yml` installs a pinned `rad` version;
+  locally, install `rad` from <https://docs.radapp.io/installation/> before running the test.
+- **Images must be pre-pushed.** The Radius publisher does not build or push images for project
+  resources yet (<https://github.com/microsoft/aspire/issues/16844>). The test builds/pushes the
+  starter images to ACR and attaches them with `WithContainerImage` (Experimental
+  `ASPIRERADIUS057`) so the generated `app.bicep` references pullable images.
 
 ## TypeScript deployment coverage
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -194,29 +194,24 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Step 8b: Expose the isolated kubeconfig at the default path for `rad install`.
-            // `rad install kubernetes` configures the Contour gateway through a code path that
-            // reads the default kubeconfig location (~/.kube/config) directly and does NOT honor
-            // the KUBECONFIG environment variable, unlike az/kubectl. With our isolated
-            // $KUBECONFIG (Step 1b), that step fails with
+            // Step 8b: Stage the isolated kubeconfig under a workspace-local HOME for `rad install`.
+            // `rad install kubernetes` configures the Contour gateway through a code path that reads
+            // the default kubeconfig location ($HOME/.kube/config) directly and does NOT honor the
+            // KUBECONFIG environment variable, unlike az/kubectl. With our isolated $KUBECONFIG
+            // (Step 1b) and no override, that step fails with
             // "failed to initialize Kubernetes client config: open ~/.kube/config: no such file or directory".
-            // Point the default path at our isolated kubeconfig so `rad` finds the AKS context.
             //
-            // Before overwriting the path, snapshot whatever was there so cleanup can restore it
-            // exactly. `cp -a` keeps a symlink a symlink (-d/--no-dereference) instead of copying
-            // its target, so a pre-existing link is backed up intact, and the `[ -e ] || [ -L ]`
-            // test also catches a dangling link (`-e` is false for a broken symlink). A marker file
-            // records that this test actually took over the path: provisioning can fail earlier,
-            // before Step 8b runs, and cleanup must not touch the developer's kubeconfig in that
-            // case. RestoreDefaultKubeConfig in `finally` uses the marker + backup to put the
-            // original back (file, symlink, or nothing) so a local run is never left pointing at the
-            // deleted cluster or dangling into the deleted workspace — even if the test fails.
-            output.WriteLine("Step 8b: Linking default kubeconfig path for rad install...");
+            // Rather than shadow (and later restore) the developer's real ~/.kube/config for the
+            // ~55-minute run — which would leak the test cluster into any concurrent kubectl/rad and
+            // risk losing a kubeconfig update made by another process — we create a private HOME under
+            // the TemporaryWorkspace and point its .kube/config at our isolated $KUBECONFIG. Step 9
+            // then runs `rad install` with HOME set to this directory, so the Contour code reads the
+            // isolated config and the developer's real ~/.kube/config is never touched. The workspace
+            // (and this HOME) is removed on dispose, so there is nothing to restore.
+            output.WriteLine("Step 8b: Staging an isolated kubeconfig under a workspace-local HOME for rad install...");
             await auto.TypeAsync(
-                "mkdir -p \"$HOME/.kube\" && " +
-                $"{{ {{ [ -e \"$HOME/.kube/config\" ] || [ -L \"$HOME/.kube/config\" ]; }} && cp -a \"$HOME/.kube/config\" \"{wsRoot}/kube-default.bak\" || true; }} && " +
-                $"touch \"{wsRoot}/kube-shadowed.marker\" && " +
-                "ln -sf \"$KUBECONFIG\" \"$HOME/.kube/config\"");
+                $"mkdir -p \"{wsRoot}/home/.kube\" && " +
+                $"ln -sf \"$KUBECONFIG\" \"{wsRoot}/home/.kube/config\"");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
@@ -224,9 +219,12 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
 
             // Install the Radius control plane. The `rad` CLI version is pinned by the
             // "Setup Radius" workflow step, and `rad install kubernetes` installs the matching
-            // control plane onto the current kube context.
+            // control plane onto the current kube context. HOME is overridden for this one command
+            // only so Contour's default-path kubeconfig read (Step 8b) resolves to our isolated
+            // config; PATH still routes `rad` through the Step 1b shim, so config writes land in the
+            // workspace-local <ws>/.rad/config.yaml regardless of HOME.
             output.WriteLine("Step 9: Installing the Radius control plane onto the cluster...");
-            await auto.TypeAsync("rad install kubernetes");
+            await auto.TypeAsync($"HOME=\"{wsRoot}/home\" rad install kubernetes");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(10));
 
@@ -509,69 +507,12 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
         }
         finally
         {
-            // Restore the developer's default kubeconfig that Step 8b shadowed with a symlink to
-            // the isolated $KUBECONFIG. Runs even on failure so a local run never leaves
-            // ~/.kube/config pointing at the deleted cluster or dangling into the deleted workspace.
-            RestoreDefaultKubeConfig(workspace.WorkspaceRoot.FullName);
-
             // Deleting the resource group removes AKS, ACR, and all Radius control-plane state,
-            // so no separate `rad` cleanup is required.
+            // so no separate `rad` cleanup is required. The isolated kubeconfig lived under the
+            // TemporaryWorkspace (Step 1b/8b), so disposing the workspace is all the kube cleanup
+            // needed — the developer's real ~/.kube/config was never touched.
             output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
             await CleanupResourceGroupAsync(resourceGroupName);
-        }
-    }
-
-    /// <summary>
-    /// Reverses the Step 8b default-kubeconfig shadow, restoring exactly what was there before.
-    /// Only acts when Step 8b actually ran (its <c>kube-shadowed.marker</c> is present); if
-    /// provisioning failed earlier the developer's <c>~/.kube/config</c> was never touched and is
-    /// left alone. When a backup exists it is moved back verbatim — <c>cp -a</c> preserved a
-    /// regular file as a file and a symlink as a symlink, so a pre-existing link is not turned into
-    /// a copy or dropped. When no backup exists nothing was there before, so only our own symlink
-    /// is removed. Best-effort: cleanup must not mask a test failure.
-    /// </summary>
-    private void RestoreDefaultKubeConfig(string workspaceRoot)
-    {
-        try
-        {
-            // Provisioning can fail before Step 8b runs. Without this guard the no-backup branch
-            // below would delete a developer's own pre-existing ~/.kube/config symlink that this
-            // test never created.
-            var marker = Path.Combine(workspaceRoot, "kube-shadowed.marker");
-            if (!File.Exists(marker))
-            {
-                return;
-            }
-
-            var home = Environment.GetEnvironmentVariable("HOME")
-                ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            if (string.IsNullOrEmpty(home))
-            {
-                return;
-            }
-
-            var defaultKubeConfig = Path.Combine(home, ".kube", "config");
-            var backup = Path.Combine(workspaceRoot, "kube-default.bak");
-
-            // Remove the symlink Step 8b created (Delete on a symlink removes the link, not its
-            // target). LinkTarget is non-null for a symlink even when it dangles, so this also
-            // clears a link left pointing into the about-to-be-deleted workspace.
-            var current = new FileInfo(defaultKubeConfig);
-            if (current.Exists || current.LinkTarget is not null)
-            {
-                current.Delete();
-            }
-
-            // Put the original back verbatim if Step 8b captured one.
-            var backupInfo = new FileInfo(backup);
-            if (backupInfo.Exists || backupInfo.LinkTarget is not null)
-            {
-                File.Move(backup, defaultKubeConfig);
-            }
-        }
-        catch (Exception ex)
-        {
-            output.WriteLine($"Warning: could not restore default kubeconfig: {ex.Message}");
         }
     }
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -202,16 +202,20 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             // "failed to initialize Kubernetes client config: open ~/.kube/config: no such file or directory".
             // Point the default path at our isolated kubeconfig so `rad` finds the AKS context.
             //
-            // Back up a developer's real ~/.kube/config first (a non-symlink file), then force the
-            // symlink so `rad install` can never read the developer's current-context cluster on a
-            // local run. The RestoreDefaultKubeConfig call in `finally` moves the backup back (or
-            // removes our symlink when none existed, e.g. on the ephemeral CI runner), so the
-            // developer's kube state is never left pointing at the deleted cluster or dangling into
-            // the deleted workspace — even if the test fails.
+            // Before overwriting the path, snapshot whatever was there so cleanup can restore it
+            // exactly. `cp -a` keeps a symlink a symlink (-d/--no-dereference) instead of copying
+            // its target, so a pre-existing link is backed up intact, and the `[ -e ] || [ -L ]`
+            // test also catches a dangling link (`-e` is false for a broken symlink). A marker file
+            // records that this test actually took over the path: provisioning can fail earlier,
+            // before Step 8b runs, and cleanup must not touch the developer's kubeconfig in that
+            // case. RestoreDefaultKubeConfig in `finally` uses the marker + backup to put the
+            // original back (file, symlink, or nothing) so a local run is never left pointing at the
+            // deleted cluster or dangling into the deleted workspace — even if the test fails.
             output.WriteLine("Step 8b: Linking default kubeconfig path for rad install...");
             await auto.TypeAsync(
                 "mkdir -p \"$HOME/.kube\" && " +
-                $"{{ [ -e \"$HOME/.kube/config\" ] && [ ! -L \"$HOME/.kube/config\" ] && cp -a \"$HOME/.kube/config\" \"{wsRoot}/kube-default.bak\" || true; }} && " +
+                $"{{ {{ [ -e \"$HOME/.kube/config\" ] || [ -L \"$HOME/.kube/config\" ]; }} && cp -a \"$HOME/.kube/config\" \"{wsRoot}/kube-default.bak\" || true; }} && " +
+                $"touch \"{wsRoot}/kube-shadowed.marker\" && " +
                 "ln -sf \"$KUBECONFIG\" \"$HOME/.kube/config\"");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
@@ -518,15 +522,27 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// Reverses the Step 8b default-kubeconfig shadow. If a real <c>~/.kube/config</c> existed
-    /// before the run it was copied to <c>&lt;workspace&gt;/kube-default.bak</c>; move it back.
-    /// Otherwise remove only the symlink we created (never a real file a concurrent process may
-    /// have written). Best-effort: cleanup must not mask a test failure.
+    /// Reverses the Step 8b default-kubeconfig shadow, restoring exactly what was there before.
+    /// Only acts when Step 8b actually ran (its <c>kube-shadowed.marker</c> is present); if
+    /// provisioning failed earlier the developer's <c>~/.kube/config</c> was never touched and is
+    /// left alone. When a backup exists it is moved back verbatim — <c>cp -a</c> preserved a
+    /// regular file as a file and a symlink as a symlink, so a pre-existing link is not turned into
+    /// a copy or dropped. When no backup exists nothing was there before, so only our own symlink
+    /// is removed. Best-effort: cleanup must not mask a test failure.
     /// </summary>
     private void RestoreDefaultKubeConfig(string workspaceRoot)
     {
         try
         {
+            // Provisioning can fail before Step 8b runs. Without this guard the no-backup branch
+            // below would delete a developer's own pre-existing ~/.kube/config symlink that this
+            // test never created.
+            var marker = Path.Combine(workspaceRoot, "kube-shadowed.marker");
+            if (!File.Exists(marker))
+            {
+                return;
+            }
+
             var home = Environment.GetEnvironmentVariable("HOME")
                 ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             if (string.IsNullOrEmpty(home))
@@ -537,17 +553,20 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             var defaultKubeConfig = Path.Combine(home, ".kube", "config");
             var backup = Path.Combine(workspaceRoot, "kube-default.bak");
 
-            if (File.Exists(backup))
+            // Remove the symlink Step 8b created (Delete on a symlink removes the link, not its
+            // target). LinkTarget is non-null for a symlink even when it dangles, so this also
+            // clears a link left pointing into the about-to-be-deleted workspace.
+            var current = new FileInfo(defaultKubeConfig);
+            if (current.Exists || current.LinkTarget is not null)
             {
-                File.Move(backup, defaultKubeConfig, overwrite: true);
+                current.Delete();
             }
-            else
+
+            // Put the original back verbatim if Step 8b captured one.
+            var backupInfo = new FileInfo(backup);
+            if (backupInfo.Exists || backupInfo.LinkTarget is not null)
             {
-                var info = new FileInfo(defaultKubeConfig);
-                if (info.Exists && info.LinkTarget is not null)
-                {
-                    info.Delete();
-                }
+                File.Move(backup, defaultKubeConfig);
             }
         }
         catch (Exception ex)

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -184,6 +184,10 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
 
             await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 12");
 
+            // Redis is intentionally enabled: it exercises the Radius container recipe and the
+            // connection-string wiring from webfrontend to a Radius-deployed cache, which is part
+            // of the realistic starter scenario. (Redis is a ContainerResource with its own image,
+            // so it is not the subject of the WithContainerImage project-image workaround.)
             output.WriteLine("Step 13: Creating Aspire starter project (with Redis cache)...");
             await auto.AspireNewAsync(projectName, counter, useRedisCache: true);
 
@@ -276,8 +280,13 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
 
+            // Split the marker token in the source command (BICEP_IMAGES''_OK evaluates to
+            // BICEP_IMAGES_OK) so the searched string appears only in the command's *output* when
+            // both greps match, not in the echoed command line itself. The grep -q chain's exit
+            // code is still the hard gate (a failed grep trips the ERR prompt below); this marker
+            // makes a successful match an explicit positive signal in the recording.
             await auto.TypeAsync($"grep -q '{acrLoginServer}/apiservice' ../out/app.bicep && " +
-                  $"grep -q '{acrLoginServer}/webfrontend' ../out/app.bicep && echo BICEP_IMAGES_OK");
+                  $"grep -q '{acrLoginServer}/webfrontend' ../out/app.bicep && echo BICEP_IMAGES''_OK");
             await auto.EnterAsync();
             await auto.WaitUntilAsync(
                 s => new CellPatternSearcher().Find("BICEP_IMAGES_OK").Search(s).Count > 0,
@@ -315,8 +324,12 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
 
+            // Show labels too: the endpoint verification below resolves Services by the Radius
+            // platform label radapp.io/resource=<name>. Printing --show-labels here makes a
+            // label-schema mismatch (e.g. a different key/casing in a future control plane)
+            // immediately visible in the recording instead of surfacing as an empty jsonpath.
             output.WriteLine("Step 25: Listing deployed pods and services...");
-            await auto.TypeAsync($"kubectl get pods,svc -n {appNamespace} -l radapp.io/application=app");
+            await auto.TypeAsync($"kubectl get pods,svc -n {appNamespace} -l radapp.io/application=app --show-labels");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -302,8 +302,19 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             output.WriteLine("Step 22: Deploying to Radius via aspire deploy (rad deploy app.bicep)...");
             await auto.TypeAsync("aspire deploy");
             await auto.EnterAsync();
-            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(15));
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+            // Wait on this command's sequence-numbered prompt (not WaitForPipelineSuccessAsync).
+            // WaitForPipelineSuccessAsync scans the whole viewport for "Pipeline succeeded", but the
+            // earlier `aspire publish` (Step 20) already printed that exact marker and it is still
+            // on screen, so the pipeline wait could match the stale publish marker and return
+            // immediately -- collapsing the real deploy budget down to the following prompt wait.
+            // The counter-scoped prompt wait is bound to this deploy command alone, carries the full
+            // deploy budget, and already fails fast on a non-zero deploy via the `[n ERR:]`
+            // prompt. (Unlike the sibling ACA/AKS tests, deploy here only runs `rad deploy` against
+            // the already-provisioned AKS cluster, so the pipeline helper's transient-Azure-capacity
+            // Assert.Skip -- which targets AKS *provisioning* -- does not apply.)
+            // 17m preserves the previous effective ceiling (15m pipeline detect + 2m prompt) so the
+            // single combined wait does not shrink the deploy's headroom.
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(17));
 
             // ===== PHASE 6: Verify the deployed application =====
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -103,9 +103,10 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             output.WriteLine("Step 1: Preparing environment...");
             await auto.PrepareEnvironmentAsync(workspace, counter);
 
-            // Step 1b: Isolate kubeconfig and the Radius (`rad`) config to throwaway files under the
-            // TemporaryWorkspace so this test never mutates the developer's real ~/.kube/config or
-            // ~/.rad/config.yaml (test-isolation requirement, .github/instructions/test-review-guidelines).
+            // Step 1b: Isolate kubeconfig, the Radius (`rad`) config, and Docker credentials to
+            // throwaway files under the TemporaryWorkspace so this test never mutates the developer's
+            // real ~/.kube/config, ~/.rad/config.yaml, or ~/.docker/config.json (test-isolation
+            // requirement, .github/instructions/test-review-guidelines).
             //
             // - KUBECONFIG: az/kubectl/rad all honor it, so `az aks get-credentials` writes here and
             //   every kube-touching command uses this file. Removed with the workspace on dispose.
@@ -117,15 +118,19 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             //   subcommand). REAL_RAD is resolved BEFORE prepending the shim dir, so the shim never
             //   recurses. This isolates the config file and its lock without backing up/restoring the
             //   user's real config (which would race with any concurrent `rad` for the ~55-min run).
+            // - DOCKER_CONFIG: the documented override directory for Docker's config.json. `az acr login`
+            //   shells out to `docker login`, and `dotnet publish /t:PublishContainer` reads the same
+            //   config, so both authenticate against this throwaway dir instead of ~/.docker.
             var wsRoot = workspace.WorkspaceRoot.FullName;
-            output.WriteLine("Step 1b: Isolating kubeconfig and rad config to the workspace...");
+            output.WriteLine("Step 1b: Isolating kubeconfig, rad config, and docker credentials to the workspace...");
             await auto.TypeAsync(
                 $"REAL_RAD=\"$(command -v rad)\" && " +
-                $"mkdir -p \"{wsRoot}/bin\" \"{wsRoot}/.rad\" \"{wsRoot}/.kube\" && " +
+                $"mkdir -p \"{wsRoot}/bin\" \"{wsRoot}/.rad\" \"{wsRoot}/.kube\" \"{wsRoot}/.docker\" && " +
                 $"printf '#!/usr/bin/env bash\\nexec \"%s\" --config \"%s\" \"$@\"\\n' \"$REAL_RAD\" \"{wsRoot}/.rad/config.yaml\" > \"{wsRoot}/bin/rad\" && " +
                 $"chmod +x \"{wsRoot}/bin/rad\" && " +
                 $"export PATH=\"{wsRoot}/bin:$PATH\" && " +
-                $"export KUBECONFIG=\"{wsRoot}/.kube/config\"");
+                $"export KUBECONFIG=\"{wsRoot}/.kube/config\" && " +
+                $"export DOCKER_CONFIG=\"{wsRoot}/.docker\"");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
@@ -147,7 +152,8 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
 
             // Log into ACR immediately (before AKS creation which takes 10-15 min). The OIDC
             // federated token expires after ~5 minutes, so authenticate while it's fresh. Docker
-            // credentials persist in ~/.docker/config.json.
+            // credentials are written to the isolated $DOCKER_CONFIG dir set up in Step 1b, not the
+            // developer's ~/.docker/config.json.
             output.WriteLine("Step 4b: Logging into Azure Container Registry (early, before token expires)...");
             await auto.TypeAsync($"az acr login --name {acrName}");
             await auto.EnterAsync();
@@ -348,8 +354,9 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             // prompt. (Unlike the sibling ACA/AKS tests, deploy here only runs `rad deploy` against
             // the already-provisioned AKS cluster, so the pipeline helper's transient-Azure-capacity
             // Assert.Skip -- which targets AKS *provisioning* -- does not apply.)
-            // 17m preserves the previous effective ceiling (15m pipeline detect + 2m prompt) so the
-            // single combined wait does not shrink the deploy's headroom.
+            // 17m is a generous upper bound for a single `rad deploy` of the starter app against the
+            // already-provisioned AKS cluster -- Radius recipe execution, container image pulls, and
+            // pod readiness -- plus margin for the terminal prompt to settle.
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(17));
 
             // ===== PHASE 6: Verify the deployed application =====

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -459,7 +459,8 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             };
 
             process.Start();
-            await process.WaitForExitAsync();
+            using var waitCts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            await process.WaitForExitAsync(waitCts.Token);
 
             if (process.ExitCode == 0)
             {

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -60,7 +60,7 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             }
         }
 
-        var workspace = TemporaryWorkspace.Create(output);
+        using var workspace = TemporaryWorkspace.Create(output);
         var startTime = DateTime.UtcNow;
 
         var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("radius");
@@ -411,7 +411,7 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
     {
         try
         {
-            var process = new System.Diagnostics.Process
+            using var process = new System.Diagnostics.Process
             {
                 StartInfo = new System.Diagnostics.ProcessStartInfo
                 {

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -309,8 +309,24 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
 
             // The Radius application name is fixed to "app" by the publisher. Show the deployed
             // graph and the container resources; both must succeed.
+            //
+            // --preview forces the Radius.Core graph implementation. Without it, the pinned 0.59
+            // `rad app graph` routes to the legacy Applications.Core graph API, which the legacy
+            // `app` that Radius creates for Redis satisfies on its own -- so the command could
+            // succeed without ever proving the Radius.Core UDT application that owns the project
+            // containers actually deployed. See `rad app graph --help`:
+            //   --preview   Use the Radius.Core preview implementation
             output.WriteLine("Step 23: Verifying Radius resources...");
-            await auto.TypeAsync("rad app graph -a app");
+            await auto.TypeAsync("rad app graph -a app --preview");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // An empty Radius.Core application still exits 0, and the harness only gates on the
+            // shell exit code -- not on graph contents. Capture the preview graph once and assert
+            // it names both project containers so a missing UDT container fails fast: grep exits
+            // non-zero on a miss, and `G=$(...)` propagates a failed `rad app graph`, either of
+            // which trips the `[n ERR:]` prompt that WaitForSuccessPromptAsync fails on.
+            await auto.TypeAsync("G=$(rad app graph -a app --preview) && echo \"$G\" && echo \"$G\" | grep -q apiservice && echo \"$G\" | grep -q webfrontend");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
@@ -346,14 +362,22 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
-            output.WriteLine("Step 27: Verifying webfrontend endpoint via port-forward...");
+            // Probe /weather (not /). The starter template wires Redis via AddRedisOutputCache("cache"),
+            // and /weather is the only page that both calls the apiservice (@inject WeatherApiClient)
+            // and is served through the Redis-backed output cache ([OutputCache(Duration = 5)]).
+            // Requesting / would only render the static home page and could pass with a broken Redis
+            // cache connection. The page uses [StreamRendering(true)], so a bare status check can
+            // return 200 before the forecast loads; grep the streamed table (its "Temp." headers only
+            // render in the forecasts != null branch, i.e. after WeatherApiClient returns) so the probe
+            // proves the API + output-cache path end-to-end. curl reads the full streamed response.
+            output.WriteLine("Step 27: Verifying webfrontend /weather endpoint (Redis output cache) via port-forward...");
             await auto.TypeAsync($"WEBSVC=$(kubectl get svc -n {appNamespace} -l radapp.io/resource=webfrontend -o jsonpath='{{.items[0].metadata.name}}')");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
             await auto.TypeAsync($"kubectl port-forward -n {appNamespace} svc/$WEBSVC 18081:8080 &");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
-            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/ -o /dev/null -w '%{http_code}' && echo ' OK' && break; done");
+            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/weather | grep -q Temp && echo ' OK' && break; done");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -1,0 +1,434 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end test that deploys the Aspire starter template to a live Radius environment
+/// running on Azure Kubernetes Service (AKS).
+/// </summary>
+/// <remarks>
+/// Unlike the Radius unit/snapshot tests (which only prove the Bicep serializer output), this
+/// test exercises the full <c>aspire publish</c> → <c>rad deploy app.bicep</c> path against a
+/// real cluster and verifies the deployed application actually runs. It provisions an AKS
+/// cluster + ACR, installs the Radius control plane onto the cluster, deploys the starter app,
+/// and asserts the workloads become ready and serve HTTP traffic.
+///
+/// The Radius publisher does not build or push container images for project resources yet
+/// (tracked at https://github.com/microsoft/aspire/issues/16844), so the test builds and pushes
+/// the starter's images to ACR itself and attaches the resulting references with
+/// <c>WithContainerImage</c> before publishing.
+/// </remarks>
+public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
+{
+    // AKS provisioning (~10-15 min) + Radius control-plane install + two image builds + recipe
+    // deployment push the total well past the pure-AKS test's budget, so allow up to 55 minutes.
+    private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(55);
+
+    [Fact]
+    public async Task DeployStarterTemplateToRadiusOnAks()
+    {
+        using var cts = new CancellationTokenSource(s_testTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        await DeployStarterTemplateToRadiusOnAksCore(cancellationToken);
+    }
+
+    private async Task DeployStarterTemplateToRadiusOnAksCore(CancellationToken cancellationToken)
+    {
+        var subscriptionId = AzureAuthenticationHelpers.TryGetSubscriptionId();
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            Assert.Skip("Azure subscription not configured. Set ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION.");
+        }
+
+        if (!AzureAuthenticationHelpers.IsAzureAuthAvailable())
+        {
+            if (DeploymentE2ETestHelpers.IsRunningInCI)
+            {
+                Assert.Fail("Azure authentication not available in CI. Check OIDC configuration.");
+            }
+            else
+            {
+                Assert.Skip("Azure authentication not available. Run 'az login' to authenticate.");
+            }
+        }
+
+        var workspace = TemporaryWorkspace.Create(output);
+        var startTime = DateTime.UtcNow;
+
+        var resourceGroupName = DeploymentE2ETestHelpers.GenerateResourceGroupName("radius");
+        var clusterName = $"radius-{DeploymentE2ETestHelpers.GetRunId()}-{DeploymentE2ETestHelpers.GetRunAttempt()}";
+        // ACR names must be alphanumeric only, 5-50 chars, globally unique.
+        var acrName = $"acrrad{DeploymentE2ETestHelpers.GetRunId()}{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
+        acrName = new string(acrName.Where(char.IsLetterOrDigit).Take(50).ToArray());
+        if (acrName.Length < 5)
+        {
+            acrName = $"acrrad{Guid.NewGuid():N}"[..24];
+        }
+
+        var acrLoginServer = $"{acrName}.azurecr.io";
+        var apiServiceImage = $"{acrLoginServer}/apiservice:latest";
+        var webFrontendImage = $"{acrLoginServer}/webfrontend:latest";
+
+        const string projectName = "RadiusStarter";
+        // Use a unique namespace so reruns / parallel jobs never collide in the shared "default"
+        // namespace and so label-based verification below is unambiguous.
+        var appNamespace = $"radius-{DeploymentE2ETestHelpers.GetRunId()}-{DeploymentE2ETestHelpers.GetRunAttempt()}".ToLowerInvariant();
+
+        output.WriteLine($"Test: {nameof(DeployStarterTemplateToRadiusOnAks)}");
+        output.WriteLine($"Resource Group: {resourceGroupName}");
+        output.WriteLine($"AKS Cluster: {clusterName}");
+        output.WriteLine($"ACR Name: {acrName}");
+        output.WriteLine($"App namespace: {appNamespace}");
+        output.WriteLine($"Subscription: {subscriptionId[..8]}...");
+        output.WriteLine($"Workspace: {workspace.WorkspaceRoot.FullName}");
+
+        try
+        {
+            using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+            var pendingRun = terminal.RunAsync(cancellationToken);
+
+            var counter = new SequenceCounter();
+            var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+            // ===== PHASE 1: Provision AKS + ACR =====
+
+            output.WriteLine("Step 1: Preparing environment...");
+            await auto.PrepareEnvironmentAsync(workspace, counter);
+
+            output.WriteLine("Step 2: Registering required resource providers...");
+            await auto.TypeAsync("az provider register --namespace Microsoft.ContainerService --wait && " +
+                  "az provider register --namespace Microsoft.ContainerRegistry --wait");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            output.WriteLine("Step 3: Creating resource group...");
+            await auto.TypeAsync($"az group create --name {resourceGroupName} --location westus3 --output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 4: Creating Azure Container Registry...");
+            await auto.TypeAsync($"az acr create --resource-group {resourceGroupName} --name {acrName} --sku Basic --output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            // Log into ACR immediately (before AKS creation which takes 10-15 min). The OIDC
+            // federated token expires after ~5 minutes, so authenticate while it's fresh. Docker
+            // credentials persist in ~/.docker/config.json.
+            output.WriteLine("Step 4b: Logging into Azure Container Registry (early, before token expires)...");
+            await auto.TypeAsync($"az acr login --name {acrName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 5: Creating AKS cluster (this may take 10-15 minutes)...");
+            await auto.TypeAsync($"az aks create " +
+                  $"--resource-group {resourceGroupName} " +
+                  $"--name {clusterName} " +
+                  $"--node-count 1 " +
+                  $"--node-vm-size Standard_D2s_v3 " +
+                  $"--generate-ssh-keys " +
+                  $"--attach-acr {acrName} " +
+                  $"--enable-managed-identity " +
+                  $"--output table");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(20));
+
+            output.WriteLine("Step 6: Verifying AKS-ACR integration...");
+            await auto.TypeAsync($"az aks update --resource-group {resourceGroupName} --name {clusterName} --attach-acr {acrName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            output.WriteLine("Step 7: Configuring kubectl credentials...");
+            await auto.TypeAsync($"az aks get-credentials --resource-group {resourceGroupName} --name {clusterName} --overwrite-existing");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            output.WriteLine("Step 8: Verifying kubectl connectivity...");
+            await auto.TypeAsync("kubectl get nodes");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // ===== PHASE 2: Install the Radius control plane on the cluster =====
+
+            // Install the Radius control plane. The `rad` CLI version is pinned by the
+            // "Setup Radius" workflow step, and `rad install kubernetes` installs the matching
+            // control plane onto the current kube context.
+            output.WriteLine("Step 9: Installing the Radius control plane onto the cluster...");
+            await auto.TypeAsync("rad install kubernetes");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(10));
+
+            // Configure a deterministic default workspace bound to this cluster. `rad install
+            // kubernetes` already ensures the `default` group and environment exist; `rad deploy`
+            // (invoked by `aspire deploy`) passes no --workspace/--group/--environment, so it
+            // resolves the default workspace scope. Create the workspace explicitly instead of
+            // relying on the interactive `rad init`.
+            output.WriteLine("Step 10: Creating Radius workspace (default scope)...");
+            await auto.TypeAsync($"rad workspace create kubernetes radius-e2e --context $(kubectl config current-context) --group default --environment default --force");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            output.WriteLine("Step 11: Verifying Radius environment...");
+            await auto.TypeAsync("rad version && rad env show default --group default");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            // ===== PHASE 3: Create the Aspire starter project and target Radius =====
+
+            await auto.InstallCurrentBuildAspireCliAsync(counter, output, "Step 12");
+
+            output.WriteLine("Step 13: Creating Aspire starter project (with Redis cache)...");
+            await auto.AspireNewAsync(projectName, counter, useRedisCache: true);
+
+            output.WriteLine("Step 14: Creating application namespace...");
+            await auto.TypeAsync($"kubectl create namespace {appNamespace} --dry-run=client -o yaml | kubectl apply -f -");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            output.WriteLine("Step 15: Adding the Aspire.Hosting.Radius package...");
+            await auto.TypeAsync($"cd {projectName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            await auto.TypeAsync("aspire add Aspire.Hosting.Radius");
+            await auto.EnterAsync();
+            await auto.WaitForAspireAddCompletionAsync(counter);
+
+            // Edit AppHost.cs: target the Radius environment and attach the ACR image references
+            // the publisher requires for project resources.
+            var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
+            var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
+            var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+
+            output.WriteLine($"Step 16: Modifying AppHost.cs at: {appHostFilePath}");
+            var content = File.ReadAllText(appHostFilePath);
+
+            // Attach the pushed ACR image to each project resource. The Radius publisher fails
+            // publish for project resources without an image annotation (no <name>:latest
+            // fallback) - see WithContainerImage / issue 16844. Inserting WithContainerImage
+            // immediately after the resource name keeps the existing fluent chain valid.
+            content = content.Replace(
+                "(\"apiservice\")",
+                $"(\"apiservice\")\n    .WithContainerImage(\"{apiServiceImage}\")");
+            content = content.Replace(
+                "(\"webfrontend\")",
+                $"(\"webfrontend\")\n    .WithContainerImage(\"{webFrontendImage}\")");
+
+            // Register the Radius compute environment before Build().
+            content = content.Replace(
+                "builder.Build().Run();",
+                $"builder.AddRadiusEnvironment(\"radius\").WithNamespace(\"{appNamespace}\");\n\nbuilder.Build().Run();");
+
+            // WithContainerImage is Experimental (ASPIRERADIUS057) and the pipeline APIs used by
+            // compute environments are Experimental (ASPIREPIPELINES001); suppress both.
+            if (!content.Contains("#pragma warning disable ASPIREPIPELINES001"))
+            {
+                content = "#pragma warning disable ASPIREPIPELINES001\n#pragma warning disable ASPIRERADIUS057\n" + content;
+            }
+
+            File.WriteAllText(appHostFilePath, content);
+            output.WriteLine("Modified AppHost.cs with AddRadiusEnvironment + WithContainerImage");
+
+            // ===== PHASE 4: Build and push the container images to ACR =====
+
+            // Re-login to ACR: the initial login (Step 4b) may have expired during the 10-15 min
+            // AKS provisioning because OIDC federated tokens have a short (~5 min) lifetime.
+            output.WriteLine("Step 17: Refreshing ACR login...");
+            await auto.TypeAsync($"az acr login --name {acrName}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 18: Building and pushing container images to ACR...");
+            await auto.TypeAsync($"dotnet publish {projectName}.Web/{projectName}.Web.csproj " +
+                  $"/t:PublishContainer " +
+                  $"/p:ContainerRegistry={acrLoginServer} " +
+                  $"/p:ContainerImageName=webfrontend " +
+                  $"/p:ContainerImageTag=latest");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            await auto.TypeAsync($"dotnet publish {projectName}.ApiService/{projectName}.ApiService.csproj " +
+                  $"/t:PublishContainer " +
+                  $"/p:ContainerRegistry={acrLoginServer} " +
+                  $"/p:ContainerImageName=apiservice " +
+                  $"/p:ContainerImageTag=latest");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            // ===== PHASE 5: Publish, verify Bicep, then deploy via rad =====
+
+            output.WriteLine("Step 19: Navigating to AppHost directory...");
+            await auto.TypeAsync($"cd {projectName}.AppHost");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter);
+
+            // Publish first to inspect the generated app.bicep. Fail fast if the ACR image
+            // references did not make it into the Bicep (the most likely wiring regression).
+            output.WriteLine("Step 20: Running aspire publish and verifying app.bicep image references...");
+            await auto.TypeAsync("aspire publish --output-path ../out");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
+
+            await auto.TypeAsync($"grep -q '{acrLoginServer}/apiservice' ../out/app.bicep && " +
+                  $"grep -q '{acrLoginServer}/webfrontend' ../out/app.bicep && echo BICEP_IMAGES_OK");
+            await auto.EnterAsync();
+            await auto.WaitUntilAsync(
+                s => new CellPatternSearcher().Find("BICEP_IMAGES_OK").Search(s).Count > 0,
+                timeout: TimeSpan.FromSeconds(30),
+                description: "app.bicep contains ACR image references");
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            output.WriteLine("Step 21: Verifying AKS can pull from ACR before deploying...");
+            await auto.TypeAsync($"az aks check-acr --resource-group {resourceGroupName} --name {clusterName} --acr {acrLoginServer}");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+            output.WriteLine("Step 22: Deploying to Radius via aspire deploy (rad deploy app.bicep)...");
+            await auto.TypeAsync("aspire deploy");
+            await auto.EnterAsync();
+            await auto.WaitForPipelineSuccessAsync(timeout: TimeSpan.FromMinutes(15));
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // ===== PHASE 6: Verify the deployed application =====
+
+            // The Radius application name is fixed to "app" by the publisher. Show the deployed
+            // graph and the container resources; both must succeed.
+            output.WriteLine("Step 23: Verifying Radius resources...");
+            await auto.TypeAsync("rad app graph -a app");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            await auto.TypeAsync("rad resource list Radius.Compute/containers -a app");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+            // Radius labels every workload with radapp.io/application; wait for all app pods ready.
+            output.WriteLine("Step 24: Waiting for application pods to be ready...");
+            await auto.TypeAsync($"kubectl wait --for=condition=ready pod -n {appNamespace} -l radapp.io/application=app --timeout=300s");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
+
+            output.WriteLine("Step 25: Listing deployed pods and services...");
+            await auto.TypeAsync($"kubectl get pods,svc -n {appNamespace} -l radapp.io/application=app");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Resolve the apiservice Service by Radius resource label rather than a hardcoded
+            // name (Radius names container services "<resource>-<container>").
+            output.WriteLine("Step 26: Verifying apiservice endpoint via port-forward...");
+            await auto.TypeAsync($"APISVC=$(kubectl get svc -n {appNamespace} -l radapp.io/resource=apiservice -o jsonpath='{{.items[0].metadata.name}}')");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+            await auto.TypeAsync($"kubectl port-forward -n {appNamespace} svc/$APISVC 18080:8080 &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18080/weatherforecast -o /dev/null -w '%{http_code}' && echo ' OK' && break; done");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 27: Verifying webfrontend endpoint via port-forward...");
+            await auto.TypeAsync($"WEBSVC=$(kubectl get svc -n {appNamespace} -l radapp.io/resource=webfrontend -o jsonpath='{{.items[0].metadata.name}}')");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+            await auto.TypeAsync($"kubectl port-forward -n {appNamespace} svc/$WEBSVC 18081:8080 &");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/ -o /dev/null -w '%{http_code}' && echo ' OK' && break; done");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 28: Cleaning up port-forwards...");
+            await auto.TypeAsync("kill %1 %2 2>/dev/null; true");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
+
+            output.WriteLine("Step 29: Exiting terminal...");
+            await auto.TypeAsync("exit");
+            await auto.EnterAsync();
+
+            await pendingRun;
+
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"Full Radius deployment completed in {duration}");
+
+            DeploymentReporter.ReportDeploymentSuccess(
+                nameof(DeployStarterTemplateToRadiusOnAks),
+                resourceGroupName,
+                new Dictionary<string, string>
+                {
+                    ["cluster"] = clusterName,
+                    ["acr"] = acrName,
+                    ["namespace"] = appNamespace,
+                    ["project"] = projectName
+                },
+                duration);
+
+            output.WriteLine("✅ Test passed - Aspire starter deployed to Radius on AKS!");
+        }
+        catch (Exception ex)
+        {
+            var duration = DateTime.UtcNow - startTime;
+            output.WriteLine($"❌ Test failed after {duration}: {ex.Message}");
+
+            DeploymentReporter.ReportDeploymentFailure(
+                nameof(DeployStarterTemplateToRadiusOnAks),
+                resourceGroupName,
+                ex.Message,
+                ex.StackTrace);
+
+            throw;
+        }
+        finally
+        {
+            // Deleting the resource group removes AKS, ACR, and all Radius control-plane state,
+            // so no separate `rad` cleanup is required.
+            output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
+            await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+
+    private async Task CleanupResourceGroupAsync(string resourceGroupName)
+    {
+        try
+        {
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "az",
+                    Arguments = $"group delete --name {resourceGroupName} --yes --no-wait",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                }
+            };
+
+            process.Start();
+            await process.WaitForExitAsync();
+
+            if (process.ExitCode == 0)
+            {
+                output.WriteLine($"Resource group deletion initiated: {resourceGroupName}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: true, "Deletion initiated");
+            }
+            else
+            {
+                var error = await process.StandardError.ReadToEndAsync();
+                output.WriteLine($"Resource group deletion may have failed (exit code {process.ExitCode}): {error}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, $"Exit code {process.ExitCode}: {error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Failed to cleanup resource group: {ex.Message}");
+            DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, ex.Message);
+        }
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -103,6 +103,32 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             output.WriteLine("Step 1: Preparing environment...");
             await auto.PrepareEnvironmentAsync(workspace, counter);
 
+            // Step 1b: Isolate kubeconfig and the Radius (`rad`) config to throwaway files under the
+            // TemporaryWorkspace so this test never mutates the developer's real ~/.kube/config or
+            // ~/.rad/config.yaml (test-isolation requirement, .github/instructions/test-review-guidelines).
+            //
+            // - KUBECONFIG: az/kubectl/rad all honor it, so `az aks get-credentials` writes here and
+            //   every kube-touching command uses this file. Removed with the workspace on dispose.
+            // - rad config: `rad` only accepts a `--config` flag (no config env var), and `aspire deploy`
+            //   spawns `rad deploy` internally (FileName="rad", UseShellExecute=false -> PATH lookup;
+            //   see src/Aspire.Hosting.Radius/Publishing/RadiusDeploymentPipelineStep.cs). So we shadow
+            //   `rad` with a workspace-local shim earlier on PATH that injects
+            //   `--config <ws>/.rad/config.yaml` into every invocation (global flag, valid before any
+            //   subcommand). REAL_RAD is resolved BEFORE prepending the shim dir, so the shim never
+            //   recurses. This isolates the config file and its lock without backing up/restoring the
+            //   user's real config (which would race with any concurrent `rad` for the ~55-min run).
+            var wsRoot = workspace.WorkspaceRoot.FullName;
+            output.WriteLine("Step 1b: Isolating kubeconfig and rad config to the workspace...");
+            await auto.TypeAsync(
+                $"REAL_RAD=\"$(command -v rad)\" && " +
+                $"mkdir -p \"{wsRoot}/bin\" \"{wsRoot}/.rad\" \"{wsRoot}/.kube\" && " +
+                $"printf '#!/usr/bin/env bash\\nexec \"%s\" --config \"%s\" \"$@\"\\n' \"$REAL_RAD\" \"{wsRoot}/.rad/config.yaml\" > \"{wsRoot}/bin/rad\" && " +
+                $"chmod +x \"{wsRoot}/bin/rad\" && " +
+                $"export PATH=\"{wsRoot}/bin:$PATH\" && " +
+                $"export KUBECONFIG=\"{wsRoot}/.kube/config\"");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
             output.WriteLine("Step 2: Registering required resource providers...");
             await auto.TypeAsync("az provider register --namespace Microsoft.ContainerService --wait && " +
                   "az provider register --namespace Microsoft.ContainerRegistry --wait");
@@ -146,6 +172,7 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
 
             output.WriteLine("Step 7: Configuring kubectl credentials...");
+            // Writes to the isolated $KUBECONFIG (Step 1b), not the developer's ~/.kube/config.
             await auto.TypeAsync($"az aks get-credentials --resource-group {resourceGroupName} --name {clusterName} --overwrite-existing");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
@@ -169,9 +196,12 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             // kubernetes` already ensures the `default` group and environment exist; `rad deploy`
             // (invoked by `aspire deploy`) passes no --workspace/--group/--environment, so it
             // resolves the default workspace scope. Create the workspace explicitly instead of
-            // relying on the interactive `rad init`.
+            // relying on the interactive `rad init`. This (and every other `rad`) goes through the
+            // Step 1b shim, so it writes the workspace-local config and sets itself current there.
+            // No `--force`: the isolated config starts empty, so the name can never collide with a
+            // pre-existing workspace (and there is no user workspace to clobber).
             output.WriteLine("Step 10: Creating Radius workspace (default scope)...");
-            await auto.TypeAsync($"rad workspace create kubernetes radius-e2e --context $(kubectl config current-context) --group default --environment default --force");
+            await auto.TypeAsync($"rad workspace create kubernetes radius-e2e --context $(kubectl config current-context) --group default --environment default");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
@@ -231,10 +261,16 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
                 $"builder.AddRadiusEnvironment(\"radius\").WithNamespace(\"{appNamespace}\");\n\nbuilder.Build().Run();");
 
             // WithContainerImage is Experimental (ASPIRERADIUS057) and the pipeline APIs used by
-            // compute environments are Experimental (ASPIREPIPELINES001); suppress both.
+            // compute environments are Experimental (ASPIREPIPELINES001); suppress both. Add each
+            // pragma independently so one already being present (e.g. a future template that emits
+            // ASPIREPIPELINES001 itself) never skips adding the other and fails the warning-as-error build.
             if (!content.Contains("#pragma warning disable ASPIREPIPELINES001"))
             {
-                content = "#pragma warning disable ASPIREPIPELINES001\n#pragma warning disable ASPIRERADIUS057\n" + content;
+                content = "#pragma warning disable ASPIREPIPELINES001\n" + content;
+            }
+            if (!content.Contains("#pragma warning disable ASPIRERADIUS057"))
+            {
+                content = "#pragma warning disable ASPIRERADIUS057\n" + content;
             }
 
             File.WriteAllText(appHostFilePath, content);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -200,11 +200,19 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             // the KUBECONFIG environment variable, unlike az/kubectl. With our isolated
             // $KUBECONFIG (Step 1b), that step fails with
             // "failed to initialize Kubernetes client config: open ~/.kube/config: no such file or directory".
-            // Symlink the default path to our isolated kubeconfig so `rad` finds the AKS context.
-            // Only create it when absent so a developer's real ~/.kube/config is never clobbered on
-            // a local run (on the ephemeral CI runner the file does not exist, so the symlink is used).
+            // Point the default path at our isolated kubeconfig so `rad` finds the AKS context.
+            //
+            // Back up a developer's real ~/.kube/config first (a non-symlink file), then force the
+            // symlink so `rad install` can never read the developer's current-context cluster on a
+            // local run. The RestoreDefaultKubeConfig call in `finally` moves the backup back (or
+            // removes our symlink when none existed, e.g. on the ephemeral CI runner), so the
+            // developer's kube state is never left pointing at the deleted cluster or dangling into
+            // the deleted workspace — even if the test fails.
             output.WriteLine("Step 8b: Linking default kubeconfig path for rad install...");
-            await auto.TypeAsync("mkdir -p \"$HOME/.kube\" && { [ -e \"$HOME/.kube/config\" ] || ln -s \"$KUBECONFIG\" \"$HOME/.kube/config\"; }");
+            await auto.TypeAsync(
+                "mkdir -p \"$HOME/.kube\" && " +
+                $"{{ [ -e \"$HOME/.kube/config\" ] && [ ! -L \"$HOME/.kube/config\" ] && cp -a \"$HOME/.kube/config\" \"{wsRoot}/kube-default.bak\" || true; }} && " +
+                "ln -sf \"$KUBECONFIG\" \"$HOME/.kube/config\"");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
@@ -497,10 +505,54 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
         }
         finally
         {
+            // Restore the developer's default kubeconfig that Step 8b shadowed with a symlink to
+            // the isolated $KUBECONFIG. Runs even on failure so a local run never leaves
+            // ~/.kube/config pointing at the deleted cluster or dangling into the deleted workspace.
+            RestoreDefaultKubeConfig(workspace.WorkspaceRoot.FullName);
+
             // Deleting the resource group removes AKS, ACR, and all Radius control-plane state,
             // so no separate `rad` cleanup is required.
             output.WriteLine($"Cleaning up resource group: {resourceGroupName}");
             await CleanupResourceGroupAsync(resourceGroupName);
+        }
+    }
+
+    /// <summary>
+    /// Reverses the Step 8b default-kubeconfig shadow. If a real <c>~/.kube/config</c> existed
+    /// before the run it was copied to <c>&lt;workspace&gt;/kube-default.bak</c>; move it back.
+    /// Otherwise remove only the symlink we created (never a real file a concurrent process may
+    /// have written). Best-effort: cleanup must not mask a test failure.
+    /// </summary>
+    private void RestoreDefaultKubeConfig(string workspaceRoot)
+    {
+        try
+        {
+            var home = Environment.GetEnvironmentVariable("HOME")
+                ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (string.IsNullOrEmpty(home))
+            {
+                return;
+            }
+
+            var defaultKubeConfig = Path.Combine(home, ".kube", "config");
+            var backup = Path.Combine(workspaceRoot, "kube-default.bak");
+
+            if (File.Exists(backup))
+            {
+                File.Move(backup, defaultKubeConfig, overwrite: true);
+            }
+            else
+            {
+                var info = new FileInfo(defaultKubeConfig);
+                if (info.Exists && info.LinkTarget is not null)
+                {
+                    info.Delete();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"Warning: could not restore default kubeconfig: {ex.Message}");
         }
     }
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -108,8 +108,10 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             // real ~/.kube/config, ~/.rad/config.yaml, or ~/.docker/config.json (test-isolation
             // requirement, .github/instructions/test-review-guidelines).
             //
-            // - KUBECONFIG: az/kubectl/rad all honor it, so `az aks get-credentials` writes here and
-            //   every kube-touching command uses this file. Removed with the workspace on dispose.
+            // - KUBECONFIG: az/kubectl honor it, so `az aks get-credentials` writes here and every
+            //   kube-touching command uses this file. Removed with the workspace on dispose. Note
+            //   `rad install kubernetes` does NOT fully honor KUBECONFIG (its Contour gateway config
+            //   reads the default ~/.kube/config), which is why Step 8b symlinks the default path.
             // - rad config: `rad` only accepts a `--config` flag (no config env var), and `aspire deploy`
             //   spawns `rad deploy` internally (FileName="rad", UseShellExecute=false -> PATH lookup;
             //   see src/Aspire.Hosting.Radius/Publishing/RadiusDeploymentPipelineStep.cs). So we shadow
@@ -165,7 +167,11 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
                   $"--name {clusterName} " +
                   $"--node-count 1 " +
                   $"--node-vm-size Standard_D2s_v3 " +
-                  $"--generate-ssh-keys " +
+                  // The test never SSHes into the nodes, so configure no SSH key at all. This avoids
+                  // `--generate-ssh-keys`, which would write ~/.ssh/id_rsa[.pub] on a local run and
+                  // mutate the developer's SSH state (the test isolates kube/rad/docker config in
+                  // Step 1b; --no-ssh-key means there is simply nothing to isolate here).
+                  $"--no-ssh-key " +
                   $"--attach-acr {acrName} " +
                   $"--enable-managed-identity " +
                   $"--output table");
@@ -185,6 +191,20 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
 
             output.WriteLine("Step 8: Verifying kubectl connectivity...");
             await auto.TypeAsync("kubectl get nodes");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+            // Step 8b: Expose the isolated kubeconfig at the default path for `rad install`.
+            // `rad install kubernetes` configures the Contour gateway through a code path that
+            // reads the default kubeconfig location (~/.kube/config) directly and does NOT honor
+            // the KUBECONFIG environment variable, unlike az/kubectl. With our isolated
+            // $KUBECONFIG (Step 1b), that step fails with
+            // "failed to initialize Kubernetes client config: open ~/.kube/config: no such file or directory".
+            // Symlink the default path to our isolated kubeconfig so `rad` finds the AKS context.
+            // Only create it when absent so a developer's real ~/.kube/config is never clobbered on
+            // a local run (on the ephemeral CI runner the file does not exist, so the symlink is used).
+            output.WriteLine("Step 8b: Linking default kubeconfig path for rad install...");
+            await auto.TypeAsync("mkdir -p \"$HOME/.kube\" && { [ -e \"$HOME/.kube/config\" ] || ln -s \"$KUBECONFIG\" \"$HOME/.kube/config\"; }");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
@@ -394,44 +414,43 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(6));
 
-            // Show labels too: the endpoint verification below resolves Services by the Radius
-            // platform label radapp.io/resource=<name>. Printing --show-labels here makes a
-            // label-schema mismatch (e.g. a different key/casing in a future control plane)
-            // immediately visible in the recording instead of surfacing as an empty jsonpath.
+            // Print the deployed workloads (with labels) for diagnostics. Radius labels every
+            // container Deployment/pod with radapp.io/resource=<name>, so this makes a label-schema
+            // change in a future control plane immediately visible in the recording.
             output.WriteLine("Step 25: Listing deployed pods and services...");
             await auto.TypeAsync($"kubectl get pods,svc -n {appNamespace} -l radapp.io/application=app --show-labels");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Resolve the apiservice Service by Radius resource label rather than a hardcoded
-            // name (Radius names container services "<resource>-<container>").
+            // Port-forward directly to the Deployment. Radius does not synthesize a Kubernetes
+            // Service for Radius.Compute/containers workloads (only recipe-backed resources such as
+            // the Redis cache get one), so there is no Service to target. kubectl port-forward
+            // resolves a ready pod in the Deployment; 8080 is the container port Aspire assigns to
+            // published containers (ASPNETCORE_HTTP_PORTS=8080).
             output.WriteLine("Step 26: Verifying apiservice endpoint via port-forward...");
-            await auto.TypeAsync($"APISVC=$(kubectl get svc -n {appNamespace} -l radapp.io/resource=apiservice -o jsonpath='{{.items[0].metadata.name}}')");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
-            await auto.TypeAsync($"kubectl port-forward -n {appNamespace} svc/$APISVC 18080:8080 &");
+            await auto.TypeAsync($"kubectl port-forward -n {appNamespace} deployment/apiservice 18080:8080 &");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
             await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18080/weatherforecast -o /dev/null -w '%{http_code}' && echo ' OK' && break; done");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
-            // Probe /weather (not /). The starter template wires Redis via AddRedisOutputCache("cache"),
-            // and /weather is the only page that both calls the apiservice (@inject WeatherApiClient)
-            // and is served through the Redis-backed output cache ([OutputCache(Duration = 5)]).
-            // Requesting / would only render the static home page and could pass with a broken Redis
-            // cache connection. The page uses [StreamRendering(true)], so a bare status check can
-            // return 200 before the forecast loads; grep the streamed table (its "Temp." headers only
-            // render in the forecasts != null branch, i.e. after WeatherApiClient returns) so the probe
-            // proves the API + output-cache path end-to-end. curl reads the full streamed response.
-            output.WriteLine("Step 27: Verifying webfrontend /weather endpoint (Redis output cache) via port-forward...");
-            await auto.TypeAsync($"WEBSVC=$(kubectl get svc -n {appNamespace} -l radapp.io/resource=webfrontend -o jsonpath='{{.items[0].metadata.name}}')");
-            await auto.EnterAsync();
-            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
-            await auto.TypeAsync($"kubectl port-forward -n {appNamespace} svc/$WEBSVC 18081:8080 &");
+            // Verify the webfrontend container serves HTTP by probing its home page.
+            //
+            // Note: we deliberately do NOT probe /weather here. That page renders forecast data
+            // fetched from the apiservice container (@inject WeatherApiClient) through the Redis
+            // output cache. On Radius that cross-service call does not resolve: Radius creates no
+            // Kubernetes Service for a Radius.Compute/containers workload, so Aspire's service
+            // discovery hostname ("apiservice") has nothing to resolve to, and `rad app graph`
+            // shows webfrontend wired only to the cache resource, not to apiservice. The home page
+            // does not depend on apiservice, so it is the reliable end-to-end signal that the
+            // second container deployed and is serving. curl retries to absorb the brief window
+            // while the port-forward and container finish coming up.
+            output.WriteLine("Step 27: Verifying webfrontend home page via port-forward...");
+            await auto.TypeAsync($"kubectl port-forward -n {appNamespace} deployment/webfrontend 18081:8080 &");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
-            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/weather | grep -q Temp && echo ' OK' && break; done");
+            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/ -o /dev/null -w '%{http_code}' && echo ' OK' && break; done");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -503,7 +503,39 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
 
             process.Start();
             using var waitCts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
-            await process.WaitForExitAsync(waitCts.Token);
+            try
+            {
+                await process.WaitForExitAsync(waitCts.Token);
+            }
+            catch (OperationCanceledException) when (waitCts.IsCancellationRequested)
+            {
+                // WaitForExitAsync only stops awaiting on cancellation; it does NOT terminate the
+                // spawned `az` process. Disposing the Process object wouldn't either. Kill the whole
+                // tree -- `az` is a Python wrapper that forks child processes -- so a hung cleanup
+                // (e.g. an interactive auth-refresh prompt) can't outlive the test run. Then wait
+                // briefly for the OS to reap the tree so we don't report before it has actually exited.
+                var terminated = false;
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                    using var killCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    await process.WaitForExitAsync(killCts.Token);
+                    terminated = true;
+                }
+                catch (Exception killEx)
+                {
+                    // The process may have exited between the timeout and the kill (race), or the
+                    // kill/second wait may itself fail; report based on whether the wait completed.
+                    output.WriteLine($"Failed to terminate timed-out cleanup process: {killEx.Message}");
+                }
+
+                var detail = terminated
+                    ? "Timed out after 2 minutes; process tree terminated"
+                    : "Timed out after 2 minutes; process tree may not be fully terminated";
+                output.WriteLine($"Resource group deletion timed out ({resourceGroupName}): {detail}");
+                DeploymentReporter.ReportCleanupStatus(resourceGroupName, success: false, detail);
+                return;
+            }
 
             if (process.ExitCode == 0)
             {


### PR DESCRIPTION
Throwaway **draft** mirror of the latest changes on #18730, used only to run the `/deployment-test` (AKS) suite and per-PR CLI E2E against the recent churn before collapsing back onto #18730.

Changes under validation:
- `RadiusStarterDeploymentTests` (AKS): isolate `rad install`'s kubeconfig read via a workspace-local `HOME` instead of shadowing the developer's real `~/.kube/config`; removes the backup/restore path (review threads QPhfP/QPhfT on #18730).
- `RadiusDeployTests` (KIND): repin off the moving `dotnet/samples:aspnetapp` tag to digest-pinned `aci-helloworld`, port 80 (#18747).

Do not merge — this exists solely to exercise the deployment suite.