### PR TITLE
Start versioned Native AOT dashboard backend

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -46,6 +46,7 @@
   </Folder>
   <Folder Name="/Hosting/">
     <Project Path="src/Aspire.Cli/Aspire.Cli.csproj" />
+    <Project Path="src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj" />
     <Project Path="src/Aspire.Dashboard/Aspire.Dashboard.csproj" />
     <Project Path="src/Aspire.Hosting.Analyzers/Aspire.Hosting.Analyzers.csproj" />
     <Project Path="src/Aspire.Hosting.Integration.Analyzers/Aspire.Hosting.Integration.Analyzers.csproj" />
@@ -499,6 +500,7 @@
     <Project Path="tests/Aspire.StackExchange.Redis.Tests/Aspire.StackExchange.Redis.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/Dashboard/">
+    <Project Path="tests/Aspire.Dashboard.Backend.Tests/Aspire.Dashboard.Backend.Tests.csproj" />
     <Project Path="tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj" />
     <Project Path="tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj" />
   </Folder>

--- a/src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj
+++ b/src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Dashboard.Backend.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj
+++ b/src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <!-- SignalR server trimming and Native AOT support starts in .NET 9. Use the repository's
+         highest supported TFM so the standalone backend remains warning-free under PublishAot. -->
+    <TargetFramework>net10.0</TargetFramework>
     <PublishAot>true</PublishAot>
     <IsAotCompatible>true</IsAotCompatible>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj
+++ b/src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj
@@ -11,4 +11,16 @@
     <InternalsVisibleTo Include="Aspire.Dashboard.Backend.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Protobuf Include="..\Aspire.Hosting\Dashboard\proto\dashboard_service.proto"
+              Link="ResourceService\dashboard_service.proto"
+              GrpcServices="Client" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Net.ClientFactory" />
+    <PackageReference Include="Grpc.Tools" VersionOverride="2.68.1" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.Dashboard.Backend/DashboardApiContract.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardApiContract.cs
@@ -10,6 +10,7 @@ internal static class DashboardApiContract
     public const string DiscoveryPath = "/api/dashboard";
     public const string VersionOneBasePath = "/api/dashboard/v1";
     public const string ConfigurationCapability = "configuration";
+    public const string ResourcesCapability = "resources";
 }
 
 internal sealed record DashboardApiDiscovery(
@@ -25,3 +26,67 @@ internal sealed record DashboardConfiguration(
     string ApplicationName,
     string DashboardVersion,
     string RuntimeVersion);
+
+internal sealed record DashboardResource(
+    string Name,
+    string ResourceType,
+    string DisplayName,
+    string Uid,
+    string? State,
+    string? StateStyle,
+    string? Health,
+    DateTime? CreatedAt,
+    DateTime? StartedAt,
+    DateTime? StoppedAt,
+    DashboardResourceUrl[] Urls,
+    DashboardResourceProperty[] Properties,
+    DashboardEnvironmentVariable[] Environment,
+    DashboardHealthReport[] HealthReports,
+    DashboardResourceCommand[] Commands,
+    DashboardResourceRelationship[] Relationships,
+    bool IsHidden,
+    bool SupportsDetailedTelemetry,
+    string? IconName,
+    string? IconVariant,
+    bool HasTerminal,
+    int? TerminalReplicaIndex);
+
+internal sealed record DashboardResourceUrl(
+    string? Name,
+    string Url,
+    bool IsInternal,
+    bool IsInactive,
+    string? DisplayName,
+    int SortOrder);
+
+internal sealed record DashboardResourceProperty(
+    string Name,
+    string? DisplayName,
+    string Value,
+    bool IsSensitive,
+    bool IsHighlighted,
+    int? SortOrder);
+
+internal sealed record DashboardEnvironmentVariable(
+    string Name,
+    string? Value,
+    bool IsFromSpec);
+
+internal sealed record DashboardHealthReport(
+    string? Status,
+    string Key,
+    string Description);
+
+internal sealed record DashboardResourceCommand(
+    string Name,
+    string DisplayName,
+    string? DisplayDescription,
+    string? ConfirmationMessage,
+    string? IconName,
+    string IconVariant,
+    bool IsHighlighted,
+    string State);
+
+internal sealed record DashboardResourceRelationship(
+    string ResourceName,
+    string Type);

--- a/src/Aspire.Dashboard.Backend/DashboardApiContract.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardApiContract.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Backend;
+
+internal static class DashboardApiContract
+{
+    public const string Product = "Aspire.Dashboard";
+    public const int CurrentVersion = 1;
+    public const string DiscoveryPath = "/api/dashboard";
+    public const string VersionOneBasePath = "/api/dashboard/v1";
+    public const string ConfigurationCapability = "configuration";
+}
+
+internal sealed record DashboardApiDiscovery(
+    string Product,
+    DashboardApiVersion[] Versions);
+
+internal sealed record DashboardApiVersion(
+    int Version,
+    string BasePath,
+    string[] Capabilities);
+
+internal sealed record DashboardConfiguration(
+    string ApplicationName,
+    string DashboardVersion,
+    string RuntimeVersion);

--- a/src/Aspire.Dashboard.Backend/DashboardApiContract.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardApiContract.cs
@@ -11,6 +11,8 @@ internal static class DashboardApiContract
     public const string VersionOneBasePath = "/api/dashboard/v1";
     public const string ConfigurationCapability = "configuration";
     public const string ResourcesCapability = "resources";
+    public const string ResourceStreamCapability = "resources-live";
+    public const string ResourceStreamPath = $"{VersionOneBasePath}/resources/live";
 }
 
 internal sealed record DashboardApiDiscovery(
@@ -90,3 +92,22 @@ internal sealed record DashboardResourceCommand(
 internal sealed record DashboardResourceRelationship(
     string ResourceName,
     string Type);
+
+internal sealed record DashboardResourcesEvent(
+    string Type,
+    DashboardResource[]? Resources,
+    DashboardResource[]? Upserts,
+    string[]? Deletes)
+{
+    public static DashboardResourcesEvent Snapshot(DashboardResource[] resources) => new(
+        "snapshot",
+        resources,
+        null,
+        null);
+
+    public static DashboardResourcesEvent Change(DashboardResource[] upserts, string[] deletes) => new(
+        "change",
+        null,
+        upserts,
+        deletes);
+}

--- a/src/Aspire.Dashboard.Backend/DashboardBackendApplication.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardBackendApplication.cs
@@ -24,6 +24,7 @@ internal static class DashboardBackendApplication
         configureBuilder?.Invoke(builder);
 
         var app = builder.Build();
+        app.UseDashboardDevelopmentAccessPolicy();
 
         app.MapGet(DashboardApiContract.DiscoveryPath, () =>
         {

--- a/src/Aspire.Dashboard.Backend/DashboardBackendApplication.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardBackendApplication.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Aspire.Dashboard.Backend;
@@ -13,7 +14,13 @@ internal static class DashboardBackendApplication
         var builder = WebApplication.CreateSlimBuilder(args);
         builder.Services.TryAddSingleton<DashboardResourceSnapshotService>();
         builder.Services.TryAddSingleton<IDashboardResourceSnapshotProvider>(services => services.GetRequiredService<DashboardResourceSnapshotService>());
+        builder.Services.TryAddSingleton<IDashboardResourceEventSource>(services => services.GetRequiredService<DashboardResourceSnapshotService>());
         builder.Services.AddHostedService(services => services.GetRequiredService<DashboardResourceSnapshotService>());
+        builder.Services.AddSignalR();
+        builder.Services.Configure<JsonHubProtocolOptions>(options =>
+        {
+            options.PayloadSerializerOptions.TypeInfoResolverChain.Insert(0, DashboardBackendJsonSerializerContext.Default);
+        });
         configureBuilder?.Invoke(builder);
 
         var app = builder.Build();
@@ -26,7 +33,11 @@ internal static class DashboardBackendApplication
                     new DashboardApiVersion(
                         DashboardApiContract.CurrentVersion,
                         DashboardApiContract.VersionOneBasePath,
-                        [DashboardApiContract.ConfigurationCapability, DashboardApiContract.ResourcesCapability])
+                        [
+                            DashboardApiContract.ConfigurationCapability,
+                            DashboardApiContract.ResourcesCapability,
+                            DashboardApiContract.ResourceStreamCapability
+                        ])
                 ]);
 
             return Results.Json(
@@ -63,6 +74,8 @@ internal static class DashboardBackendApplication
                 return Results.Text(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
             }
         });
+
+        app.MapHub<DashboardResourcesHub>(DashboardApiContract.ResourceStreamPath);
 
         return app;
     }

--- a/src/Aspire.Dashboard.Backend/DashboardBackendApplication.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardBackendApplication.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Aspire.Dashboard.Backend;
 
@@ -10,6 +11,9 @@ internal static class DashboardBackendApplication
     public static WebApplication Build(string[] args, Action<WebApplicationBuilder>? configureBuilder = null)
     {
         var builder = WebApplication.CreateSlimBuilder(args);
+        builder.Services.TryAddSingleton<DashboardResourceSnapshotService>();
+        builder.Services.TryAddSingleton<IDashboardResourceSnapshotProvider>(services => services.GetRequiredService<DashboardResourceSnapshotService>());
+        builder.Services.AddHostedService(services => services.GetRequiredService<DashboardResourceSnapshotService>());
         configureBuilder?.Invoke(builder);
 
         var app = builder.Build();
@@ -22,7 +26,7 @@ internal static class DashboardBackendApplication
                     new DashboardApiVersion(
                         DashboardApiContract.CurrentVersion,
                         DashboardApiContract.VersionOneBasePath,
-                        [DashboardApiContract.ConfigurationCapability])
+                        [DashboardApiContract.ConfigurationCapability, DashboardApiContract.ResourcesCapability])
                 ]);
 
             return Results.Json(
@@ -40,6 +44,24 @@ internal static class DashboardBackendApplication
             return Results.Json(
                 configuration,
                 DashboardBackendJsonSerializerContext.Default.DashboardConfiguration);
+        });
+
+        app.MapGet($"{DashboardApiContract.VersionOneBasePath}/resources", async (
+            IDashboardResourceSnapshotProvider resourceSnapshotProvider,
+            HttpContext context) =>
+        {
+            try
+            {
+                context.Response.Headers.CacheControl = "no-store";
+                var resources = await resourceSnapshotProvider.GetSnapshotAsync(context.RequestAborted).ConfigureAwait(false);
+                return Results.Json(
+                    resources,
+                    DashboardBackendJsonSerializerContext.Default.DashboardResourceArray);
+            }
+            catch (DashboardResourceServiceUnavailableException ex)
+            {
+                return Results.Text(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
         });
 
         return app;

--- a/src/Aspire.Dashboard.Backend/DashboardBackendApplication.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardBackendApplication.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Aspire.Dashboard.Backend;
+
+internal static class DashboardBackendApplication
+{
+    public static WebApplication Build(string[] args, Action<WebApplicationBuilder>? configureBuilder = null)
+    {
+        var builder = WebApplication.CreateSlimBuilder(args);
+        configureBuilder?.Invoke(builder);
+
+        var app = builder.Build();
+
+        app.MapGet(DashboardApiContract.DiscoveryPath, () =>
+        {
+            var discovery = new DashboardApiDiscovery(
+                DashboardApiContract.Product,
+                [
+                    new DashboardApiVersion(
+                        DashboardApiContract.CurrentVersion,
+                        DashboardApiContract.VersionOneBasePath,
+                        [DashboardApiContract.ConfigurationCapability])
+                ]);
+
+            return Results.Json(
+                discovery,
+                DashboardBackendJsonSerializerContext.Default.DashboardApiDiscovery);
+        });
+
+        app.MapGet($"{DashboardApiContract.VersionOneBasePath}/config", () =>
+        {
+            var configuration = new DashboardConfiguration(
+                builder.Configuration["DashboardBackend:ApplicationName"] ?? "Aspire",
+                builder.Configuration["DashboardBackend:Version"] ?? "0.0.0-dev",
+                RuntimeInformation.FrameworkDescription);
+
+            return Results.Json(
+                configuration,
+                DashboardBackendJsonSerializerContext.Default.DashboardConfiguration);
+        });
+
+        return app;
+    }
+}

--- a/src/Aspire.Dashboard.Backend/DashboardBackendJsonSerializerContext.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardBackendJsonSerializerContext.cs
@@ -11,4 +11,5 @@ namespace Aspire.Dashboard.Backend;
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(DashboardApiDiscovery))]
 [JsonSerializable(typeof(DashboardConfiguration))]
+[JsonSerializable(typeof(DashboardResource[]))]
 internal sealed partial class DashboardBackendJsonSerializerContext : JsonSerializerContext;

--- a/src/Aspire.Dashboard.Backend/DashboardBackendJsonSerializerContext.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardBackendJsonSerializerContext.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Aspire.Dashboard.Backend;
+
+// Every payload in the versioned React contract must be registered here. The standalone
+// backend is Native AOT, so accidentally adding a reflection-serialized endpoint must fail
+// during development instead of becoming a runtime-only failure in a published binary.
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(DashboardApiDiscovery))]
+[JsonSerializable(typeof(DashboardConfiguration))]
+internal sealed partial class DashboardBackendJsonSerializerContext : JsonSerializerContext;

--- a/src/Aspire.Dashboard.Backend/DashboardBackendJsonSerializerContext.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardBackendJsonSerializerContext.cs
@@ -12,4 +12,5 @@ namespace Aspire.Dashboard.Backend;
 [JsonSerializable(typeof(DashboardApiDiscovery))]
 [JsonSerializable(typeof(DashboardConfiguration))]
 [JsonSerializable(typeof(DashboardResource[]))]
+[JsonSerializable(typeof(DashboardResourcesEvent))]
 internal sealed partial class DashboardBackendJsonSerializerContext : JsonSerializerContext;

--- a/src/Aspire.Dashboard.Backend/DashboardDevelopmentAccessPolicy.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardDevelopmentAccessPolicy.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using Microsoft.Extensions.Primitives;
+
+namespace Aspire.Dashboard.Backend;
+
+internal static class DashboardDevelopmentAccessPolicy
+{
+    public static IApplicationBuilder UseDashboardDevelopmentAccessPolicy(this IApplicationBuilder app)
+    {
+        return app.Use(async (context, next) =>
+        {
+            // This migration host exposes the same raw resource values that the authenticated
+            // dashboard uses for explicit secret reveal. Until frontend authentication moves to
+            // this host, accept only local connections and browser origins so an accidental
+            // 0.0.0.0 binding or a hostile website cannot read the development API.
+            if (!IsLoopback(context.Connection.LocalIpAddress) || !IsAllowedOrigin(context.Request.Headers.Origin))
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return;
+            }
+
+            await next(context).ConfigureAwait(false);
+        });
+    }
+
+    internal static bool IsLoopback(IPAddress? address)
+    {
+        if (address is null)
+        {
+            // TestServer does not populate a socket address. Production Kestrel connections do.
+            return true;
+        }
+
+        return IPAddress.IsLoopback(address)
+            || (address.IsIPv4MappedToIPv6 && IPAddress.IsLoopback(address.MapToIPv4()));
+    }
+
+    internal static bool IsAllowedOrigin(StringValues values)
+    {
+        if (StringValues.IsNullOrEmpty(values))
+        {
+            // Non-browser clients and same-origin GET requests commonly omit Origin.
+            return true;
+        }
+
+        if (values.Count is not 1
+            || !Uri.TryCreate(values[0], UriKind.Absolute, out var origin)
+            || (origin.Scheme is not "http" && origin.Scheme is not "https"))
+        {
+            return false;
+        }
+
+        if (string.Equals(origin.Host, "localhost", StringComparison.OrdinalIgnoreCase)
+            || origin.Host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return IPAddress.TryParse(origin.DnsSafeHost, out var address) && IsLoopback(address);
+    }
+}

--- a/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
@@ -33,6 +33,7 @@ internal sealed class DashboardResourceSnapshotService(
     private const string LegacyResourceServiceEndpointKey = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL";
     private const string ResourceServiceAuthModeKey = "Dashboard:ResourceServiceClient:AuthMode";
     private const string ResourceServiceApiKeyKey = "Dashboard:ResourceServiceClient:ApiKey";
+    private const string InitialSnapshotTimeoutKey = "DashboardBackend:InitialSnapshotTimeout";
     private const string ApiKeyHeaderName = "x-resource-service-api-key";
     private const int ProducerDefinedPropertySortOrderStart = 7;
     private const int SubscriberBufferCapacity = 32;
@@ -51,11 +52,13 @@ internal sealed class DashboardResourceSnapshotService(
     private readonly Dictionary<string, DashboardResource> _resources = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<ChannelWriter<DashboardResourcesEvent>> _subscribers = [];
     private readonly object _lock = new();
-    private readonly TaskCompletionSource<bool> _initialSnapshot = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<bool> _initialStateAvailable = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private bool _hasInitialSnapshot;
+    private string? _initialFailure;
 
     public async ValueTask<DashboardResource[]> GetSnapshotAsync(CancellationToken cancellationToken)
     {
-        await _initialSnapshot.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await WaitForInitialSnapshotAsync(cancellationToken).ConfigureAwait(false);
         lock (_lock)
         {
             return CreateSnapshotLocked();
@@ -65,7 +68,7 @@ internal sealed class DashboardResourceSnapshotService(
     public async IAsyncEnumerable<DashboardResourcesEvent> WatchAsync(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await _initialSnapshot.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await WaitForInitialSnapshotAsync(cancellationToken).ConfigureAwait(false);
 
         var channel = Channel.CreateBounded<DashboardResourcesEvent>(new BoundedChannelOptions(SubscriberBufferCapacity)
         {
@@ -109,10 +112,11 @@ internal sealed class DashboardResourceSnapshotService(
         var endpoint = configuration[ResourceServiceEndpointKey] ?? configuration[LegacyResourceServiceEndpointKey];
         if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var resourceServiceUri))
         {
-            _initialSnapshot.TrySetException(new DashboardResourceServiceUnavailableException(
-                $"Configure {ResourceServiceEndpointKey} with the AppHost resource-service endpoint."));
+            ReportInitialFailure($"Configure {ResourceServiceEndpointKey} with the AppHost resource-service endpoint.");
             return;
         }
+
+        var initialSnapshotTimeout = GetInitialSnapshotTimeout();
 
         using var handler = new SocketsHttpHandler
         {
@@ -136,24 +140,48 @@ internal sealed class DashboardResourceSnapshotService(
         {
             try
             {
+                using var callCancellation = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                if (!reconnect)
+                {
+                    callCancellation.CancelAfter(initialSnapshotTimeout);
+                }
+
                 // The resource service sends one complete InitialData frame, followed by
                 // upsert/delete Changes frames for the lifetime of this streaming call.
                 using var call = client.WatchResources(
                     new WatchResourcesRequest { IsReconnect = reconnect },
                     headers,
-                    cancellationToken: stoppingToken);
-                await foreach (var update in call.ResponseStream.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+                    cancellationToken: callCancellation.Token);
+                await foreach (var update in call.ResponseStream.ReadAllAsync(callCancellation.Token).ConfigureAwait(false))
                 {
                     ApplyUpdate(update);
-                    reconnect = true;
+                    if (update.KindCase is WatchResourcesUpdate.KindOneofCase.InitialData)
+                    {
+                        reconnect = true;
+                        callCancellation.CancelAfter(Timeout.InfiniteTimeSpan);
+                    }
+                }
+
+                if (!reconnect)
+                {
+                    ReportInitialFailure("The AppHost resource stream ended before providing an initial snapshot. The AOT dashboard backend will keep retrying.");
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 return;
             }
+            catch (OperationCanceledException) when (!reconnect)
+            {
+                ReportInitialFailure($"The AppHost resource service did not provide an initial snapshot within {initialSnapshotTimeout}. The AOT dashboard backend will keep retrying.");
+            }
             catch (RpcException ex)
             {
+                if (!reconnect)
+                {
+                    ReportInitialFailure("The AppHost resource service is unavailable. The AOT dashboard backend will keep retrying.");
+                }
+
                 logger.LogWarning(ex, "The AppHost resource stream disconnected; retrying.");
             }
 
@@ -171,6 +199,17 @@ internal sealed class DashboardResourceSnapshotService(
 
             return metadata;
         }
+
+        TimeSpan GetInitialSnapshotTimeout()
+        {
+            return TimeSpan.TryParse(
+                configuration[InitialSnapshotTimeoutKey],
+                CultureInfo.InvariantCulture,
+                out var timeout)
+                && timeout > TimeSpan.Zero
+                    ? timeout
+                    : TimeSpan.FromSeconds(10);
+        }
     }
 
     internal void ApplyUpdate(WatchResourcesUpdate update)
@@ -185,7 +224,9 @@ internal sealed class DashboardResourceSnapshotService(
                     _resources[resource.Name] = Map(resource);
                 }
 
-                _initialSnapshot.TrySetResult(true);
+                _hasInitialSnapshot = true;
+                _initialFailure = null;
+                _initialStateAvailable.TrySetResult(true);
                 PublishLocked(DashboardResourcesEvent.Snapshot(CreateSnapshotLocked()));
                 return;
             }
@@ -214,6 +255,33 @@ internal sealed class DashboardResourceSnapshotService(
             }
 
             throw new FormatException($"Unexpected {nameof(WatchResourcesUpdate)} kind: {update.KindCase}.");
+        }
+    }
+
+    internal void ReportInitialFailure(string message)
+    {
+        lock (_lock)
+        {
+            if (_hasInitialSnapshot)
+            {
+                return;
+            }
+
+            _initialFailure = message;
+            _initialStateAvailable.TrySetResult(true);
+        }
+    }
+
+    private async ValueTask WaitForInitialSnapshotAsync(CancellationToken cancellationToken)
+    {
+        await _initialStateAvailable.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        lock (_lock)
+        {
+            if (!_hasInitialSnapshot)
+            {
+                throw new DashboardResourceServiceUnavailableException(
+                    _initialFailure ?? "The AppHost resource service has not provided an initial snapshot.");
+            }
         }
     }
 

--- a/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
@@ -1,0 +1,277 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.DashboardService.Proto.V1;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Grpc.Net.Client;
+using ProtoResource = Aspire.DashboardService.Proto.V1.Resource;
+
+namespace Aspire.Dashboard.Backend;
+
+internal interface IDashboardResourceSnapshotProvider
+{
+    ValueTask<DashboardResource[]> GetSnapshotAsync(CancellationToken cancellationToken);
+}
+
+internal sealed class DashboardResourceServiceUnavailableException(string message) : Exception(message);
+
+internal sealed class DashboardResourceSnapshotService(
+    IConfiguration configuration,
+    ILoggerFactory loggerFactory,
+    ILogger<DashboardResourceSnapshotService> logger) : BackgroundService, IDashboardResourceSnapshotProvider
+{
+    private const string ResourceServiceEndpointKey = "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL";
+    private const string LegacyResourceServiceEndpointKey = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL";
+    private const string ResourceServiceAuthModeKey = "Dashboard:ResourceServiceClient:AuthMode";
+    private const string ResourceServiceApiKeyKey = "Dashboard:ResourceServiceClient:ApiKey";
+    private const string ApiKeyHeaderName = "x-resource-service-api-key";
+
+    private readonly Dictionary<string, DashboardResource> _resources = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _lock = new();
+    private readonly TaskCompletionSource<bool> _initialSnapshot = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public async ValueTask<DashboardResource[]> GetSnapshotAsync(CancellationToken cancellationToken)
+    {
+        await _initialSnapshot.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        lock (_lock)
+        {
+            return [.. _resources.Values.OrderBy(resource => resource.DisplayName, StringComparer.OrdinalIgnoreCase).ThenBy(resource => resource.Name, StringComparer.OrdinalIgnoreCase)];
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var endpoint = configuration[ResourceServiceEndpointKey] ?? configuration[LegacyResourceServiceEndpointKey];
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var resourceServiceUri))
+        {
+            _initialSnapshot.TrySetException(new DashboardResourceServiceUnavailableException(
+                $"Configure {ResourceServiceEndpointKey} with the AppHost resource-service endpoint."));
+            return;
+        }
+
+        using var handler = new SocketsHttpHandler
+        {
+            EnableMultipleHttp2Connections = true,
+            KeepAlivePingDelay = TimeSpan.FromSeconds(20),
+            KeepAlivePingTimeout = TimeSpan.FromSeconds(10),
+            KeepAlivePingPolicy = HttpKeepAlivePingPolicy.WithActiveRequests
+        };
+        using var channel = GrpcChannel.ForAddress(resourceServiceUri, new GrpcChannelOptions
+        {
+            HttpHandler = handler,
+            LoggerFactory = loggerFactory,
+            ThrowOperationCanceledOnCancellation = true,
+            MaxReceiveMessageSize = 16 * 1024 * 1024
+        });
+        var client = new Aspire.DashboardService.Proto.V1.DashboardService.DashboardServiceClient(channel);
+        var headers = CreateHeaders();
+        var reconnect = false;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                // The resource service sends one complete InitialData frame, followed by
+                // upsert/delete Changes frames for the lifetime of this streaming call.
+                using var call = client.WatchResources(
+                    new WatchResourcesRequest { IsReconnect = reconnect },
+                    headers,
+                    cancellationToken: stoppingToken);
+                await foreach (var update in call.ResponseStream.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+                {
+                    ApplyUpdate(update);
+                    reconnect = true;
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (RpcException ex)
+            {
+                logger.LogWarning(ex, "The AppHost resource stream disconnected; retrying.");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken).ConfigureAwait(false);
+        }
+
+        Metadata CreateHeaders()
+        {
+            var metadata = new Metadata();
+            if (string.Equals(configuration[ResourceServiceAuthModeKey], "ApiKey", StringComparison.OrdinalIgnoreCase)
+                && configuration[ResourceServiceApiKeyKey] is { Length: > 0 } apiKey)
+            {
+                metadata.Add(ApiKeyHeaderName, apiKey);
+            }
+
+            return metadata;
+        }
+    }
+
+    private void ApplyUpdate(WatchResourcesUpdate update)
+    {
+        lock (_lock)
+        {
+            if (update.KindCase is WatchResourcesUpdate.KindOneofCase.InitialData)
+            {
+                _resources.Clear();
+                foreach (var resource in update.InitialData.Resources)
+                {
+                    _resources[resource.Name] = Map(resource);
+                }
+
+                _initialSnapshot.TrySetResult(true);
+                return;
+            }
+
+            if (update.KindCase is WatchResourcesUpdate.KindOneofCase.Changes)
+            {
+                foreach (var change in update.Changes.Value)
+                {
+                    if (change.KindCase is WatchResourcesChange.KindOneofCase.Upsert)
+                    {
+                        _resources[change.Upsert.Name] = Map(change.Upsert);
+                    }
+                    else if (change.KindCase is WatchResourcesChange.KindOneofCase.Delete)
+                    {
+                        _resources.Remove(change.Delete.ResourceName);
+                    }
+                }
+
+                return;
+            }
+
+            throw new FormatException($"Unexpected {nameof(WatchResourcesUpdate)} kind: {update.KindCase}.");
+        }
+    }
+
+    internal static DashboardResource Map(ProtoResource resource)
+    {
+        var properties = resource.Properties
+            .OrderBy(property => property.HasSortOrder ? property.SortOrder : int.MaxValue)
+            .ThenBy(property => property.Name, StringComparer.Ordinal)
+            .Select(MapProperty)
+            .ToArray();
+        var terminalReplicaIndex = TryGetPropertyString(resource, "terminal.replicaIndex", out var replicaIndexText)
+            && int.TryParse(replicaIndexText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var replicaIndex)
+            ? replicaIndex
+            : (int?)null;
+        var hasTerminal = resource.Properties.Any(property => string.Equals(property.Name, "terminal.enabled", StringComparison.OrdinalIgnoreCase))
+            && terminalReplicaIndex.HasValue;
+
+        return new DashboardResource(
+            resource.Name,
+            resource.ResourceType,
+            resource.DisplayName,
+            resource.Uid,
+            resource.HasState ? resource.State : null,
+            resource.HasStateStyle ? resource.StateStyle : null,
+            GetHealth(resource),
+            resource.CreatedAt?.ToDateTime(),
+            resource.StartedAt?.ToDateTime(),
+            resource.StoppedAt?.ToDateTime(),
+            [.. resource.Urls.Select(url => new DashboardResourceUrl(
+                url.HasEndpointName ? url.EndpointName : null,
+                url.FullUrl,
+                url.IsInternal,
+                url.IsInactive,
+                string.IsNullOrEmpty(url.DisplayProperties?.DisplayName) ? null : url.DisplayProperties.DisplayName,
+                url.DisplayProperties?.SortOrder ?? 0))],
+            properties,
+            [.. resource.Environment.Select(environment => new DashboardEnvironmentVariable(
+                environment.Name,
+                environment.HasValue ? environment.Value : null,
+                environment.IsFromSpec))],
+            [.. resource.HealthReports.OrderBy(report => report.Key, StringComparer.Ordinal).Select(report => new DashboardHealthReport(
+                report.HasStatus ? MapHealthStatus(report.Status) : null,
+                report.Key,
+                report.Description))],
+            [.. resource.Commands.Select(command => new DashboardResourceCommand(
+                command.Name,
+                command.DisplayName,
+                command.HasDisplayDescription ? command.DisplayDescription : null,
+                command.HasConfirmationMessage && !string.IsNullOrEmpty(command.ConfirmationMessage) ? command.ConfirmationMessage : null,
+                command.HasIconName && !string.IsNullOrEmpty(command.IconName) ? command.IconName : null,
+                MapIconVariant(command.IconVariant),
+                command.IsHighlighted,
+                MapCommandState(command.State)))],
+            [.. resource.Relationships.Select(relationship => new DashboardResourceRelationship(relationship.ResourceName, relationship.Type))],
+            resource.IsHidden || string.Equals(resource.State, "Hidden", StringComparison.OrdinalIgnoreCase),
+            resource.SupportsDetailedTelemetry,
+            resource.HasIconName ? resource.IconName : null,
+            resource.HasIconVariant ? MapIconVariant(resource.IconVariant) : null,
+            hasTerminal,
+            hasTerminal ? terminalReplicaIndex : null);
+    }
+
+    private static DashboardResourceProperty MapProperty(ResourceProperty property)
+    {
+        return new DashboardResourceProperty(
+            property.Name,
+            property.HasDisplayName ? property.DisplayName : null,
+            property.Value.KindCase is Value.KindOneofCase.StringValue ? property.Value.StringValue : property.Value.ToString(),
+            property.HasIsSensitive && property.IsSensitive,
+            property.IsHighlighted,
+            property.HasSortOrder ? property.SortOrder : null);
+    }
+
+    private static string? GetHealth(ProtoResource resource)
+    {
+        if (!string.Equals(resource.State, "Running", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        if (resource.HealthReports.Count is 0)
+        {
+            return "Healthy";
+        }
+
+        if (resource.HealthReports.Any(report => !report.HasStatus || report.Status is HealthStatus.Unhealthy))
+        {
+            return "Unhealthy";
+        }
+
+        return resource.HealthReports.Any(report => report.Status is HealthStatus.Degraded)
+            ? "Degraded"
+            : "Healthy";
+    }
+
+    private static bool TryGetPropertyString(ProtoResource resource, string name, out string? value)
+    {
+        var property = resource.Properties.FirstOrDefault(candidate => string.Equals(candidate.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (property?.Value.KindCase is Value.KindOneofCase.StringValue)
+        {
+            value = property.Value.StringValue;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static string MapHealthStatus(HealthStatus status) => status switch
+    {
+        HealthStatus.Healthy => "Healthy",
+        HealthStatus.Degraded => "Degraded",
+        HealthStatus.Unhealthy => "Unhealthy",
+        _ => throw new InvalidOperationException($"Unexpected {nameof(HealthStatus)} value: {status}.")
+    };
+
+    private static string MapIconVariant(IconVariant variant) => variant switch
+    {
+        IconVariant.Regular => "regular",
+        IconVariant.Filled => "filled",
+        _ => throw new InvalidOperationException($"Unexpected {nameof(IconVariant)} value: {variant}.")
+    };
+
+    private static string MapCommandState(ResourceCommandState state) => state switch
+    {
+        ResourceCommandState.Enabled => "enabled",
+        ResourceCommandState.Disabled => "disabled",
+        ResourceCommandState.Hidden => "hidden",
+        _ => throw new InvalidOperationException($"Unexpected {nameof(ResourceCommandState)} value: {state}.")
+    };
+}

--- a/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
@@ -27,6 +27,18 @@ internal sealed class DashboardResourceSnapshotService(
     private const string ResourceServiceAuthModeKey = "Dashboard:ResourceServiceClient:AuthMode";
     private const string ResourceServiceApiKeyKey = "Dashboard:ResourceServiceClient:ApiKey";
     private const string ApiKeyHeaderName = "x-resource-service-api-key";
+    private const int ProducerDefinedPropertySortOrderStart = 7;
+
+    private static readonly Dictionary<string, (string DisplayName, int SortOrder)> s_knownProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["resource.displayName"] = ("Display name", 0),
+        ["resource.state"] = ("State", 1),
+        ["resource.healthState"] = ("Health state", 2),
+        ["resource.startTime"] = ("Start time", 3),
+        ["resource.stopTime"] = ("Stop time", 4),
+        ["resource.exitCode"] = ("Exit code", 5),
+        ["resource.connectionString"] = ("Connection string", 6)
+    };
 
     private readonly Dictionary<string, DashboardResource> _resources = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _lock = new();
@@ -150,9 +162,9 @@ internal sealed class DashboardResourceSnapshotService(
     internal static DashboardResource Map(ProtoResource resource)
     {
         var properties = resource.Properties
-            .OrderBy(property => property.HasSortOrder ? property.SortOrder : int.MaxValue)
-            .ThenBy(property => property.Name, StringComparer.Ordinal)
             .Select(MapProperty)
+            .OrderBy(property => property.SortOrder)
+            .ThenBy(property => property.Name, StringComparer.Ordinal)
             .ToArray();
         var terminalReplicaIndex = TryGetPropertyString(resource, "terminal.replicaIndex", out var replicaIndexText)
             && int.TryParse(replicaIndexText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var replicaIndex)
@@ -172,13 +184,7 @@ internal sealed class DashboardResourceSnapshotService(
             resource.CreatedAt?.ToDateTime(),
             resource.StartedAt?.ToDateTime(),
             resource.StoppedAt?.ToDateTime(),
-            [.. resource.Urls.Select(url => new DashboardResourceUrl(
-                url.HasEndpointName ? url.EndpointName : null,
-                url.FullUrl,
-                url.IsInternal,
-                url.IsInactive,
-                string.IsNullOrEmpty(url.DisplayProperties?.DisplayName) ? null : url.DisplayProperties.DisplayName,
-                url.DisplayProperties?.SortOrder ?? 0))],
+            [.. resource.Urls.Select(MapUrl).OfType<DashboardResourceUrl>()],
             properties,
             [.. resource.Environment.Select(environment => new DashboardEnvironmentVariable(
                 environment.Name,
@@ -191,7 +197,7 @@ internal sealed class DashboardResourceSnapshotService(
             [.. resource.Commands.Select(command => new DashboardResourceCommand(
                 command.Name,
                 command.DisplayName,
-                command.HasDisplayDescription ? command.DisplayDescription : null,
+                command.HasDisplayDescription && !string.IsNullOrEmpty(command.DisplayDescription) ? command.DisplayDescription : null,
                 command.HasConfirmationMessage && !string.IsNullOrEmpty(command.ConfirmationMessage) ? command.ConfirmationMessage : null,
                 command.HasIconName && !string.IsNullOrEmpty(command.IconName) ? command.IconName : null,
                 MapIconVariant(command.IconVariant),
@@ -208,13 +214,47 @@ internal sealed class DashboardResourceSnapshotService(
 
     private static DashboardResourceProperty MapProperty(ResourceProperty property)
     {
+        var knownProperty = s_knownProperties.GetValueOrDefault(property.Name);
+        var sortOrder = knownProperty != default
+            ? knownProperty.SortOrder
+            : property.HasSortOrder ? ToProducerDefinedPropertySortOrder(property.SortOrder) : int.MaxValue;
+
         return new DashboardResourceProperty(
             property.Name,
-            property.HasDisplayName ? property.DisplayName : null,
+            property.HasDisplayName ? property.DisplayName : knownProperty.DisplayName,
             property.Value.KindCase is Value.KindOneofCase.StringValue ? property.Value.StringValue : property.Value.ToString(),
             property.HasIsSensitive && property.IsSensitive,
             property.IsHighlighted,
-            property.HasSortOrder ? property.SortOrder : null);
+            sortOrder);
+    }
+
+    private static DashboardResourceUrl? MapUrl(Url url)
+    {
+        // The legacy dashboard accepts only absolute URLs and renders them through Uri.ToString(),
+        // which canonicalizes an authority-only URL such as http://localhost:5000 with a trailing slash.
+        if (!Uri.TryCreate(url.FullUrl, UriKind.Absolute, out var parsedUrl))
+        {
+            return null;
+        }
+
+        return new DashboardResourceUrl(
+            url.HasEndpointName ? url.EndpointName : null,
+            parsedUrl.ToString(),
+            url.IsInternal,
+            url.IsInactive,
+            string.IsNullOrEmpty(url.DisplayProperties?.DisplayName) ? null : url.DisplayProperties.DisplayName,
+            url.DisplayProperties?.SortOrder ?? 0);
+    }
+
+    private static int ToProducerDefinedPropertySortOrder(int producerSortOrder)
+    {
+        if (producerSortOrder <= 0)
+        {
+            return ProducerDefinedPropertySortOrderStart;
+        }
+
+        var sortOrder = ProducerDefinedPropertySortOrderStart + (long)producerSortOrder;
+        return sortOrder > int.MaxValue ? int.MaxValue : (int)sortOrder;
     }
 
     private static string? GetHealth(ProtoResource resource)

--- a/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Aspire.DashboardService.Proto.V1;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -15,12 +17,17 @@ internal interface IDashboardResourceSnapshotProvider
     ValueTask<DashboardResource[]> GetSnapshotAsync(CancellationToken cancellationToken);
 }
 
+internal interface IDashboardResourceEventSource
+{
+    IAsyncEnumerable<DashboardResourcesEvent> WatchAsync(CancellationToken cancellationToken);
+}
+
 internal sealed class DashboardResourceServiceUnavailableException(string message) : Exception(message);
 
 internal sealed class DashboardResourceSnapshotService(
     IConfiguration configuration,
     ILoggerFactory loggerFactory,
-    ILogger<DashboardResourceSnapshotService> logger) : BackgroundService, IDashboardResourceSnapshotProvider
+    ILogger<DashboardResourceSnapshotService> logger) : BackgroundService, IDashboardResourceSnapshotProvider, IDashboardResourceEventSource
 {
     private const string ResourceServiceEndpointKey = "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL";
     private const string LegacyResourceServiceEndpointKey = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL";
@@ -28,6 +35,7 @@ internal sealed class DashboardResourceSnapshotService(
     private const string ResourceServiceApiKeyKey = "Dashboard:ResourceServiceClient:ApiKey";
     private const string ApiKeyHeaderName = "x-resource-service-api-key";
     private const int ProducerDefinedPropertySortOrderStart = 7;
+    private const int SubscriberBufferCapacity = 32;
 
     private static readonly Dictionary<string, (string DisplayName, int SortOrder)> s_knownProperties = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -41,6 +49,7 @@ internal sealed class DashboardResourceSnapshotService(
     };
 
     private readonly Dictionary<string, DashboardResource> _resources = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<ChannelWriter<DashboardResourcesEvent>> _subscribers = [];
     private readonly object _lock = new();
     private readonly TaskCompletionSource<bool> _initialSnapshot = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -49,7 +58,49 @@ internal sealed class DashboardResourceSnapshotService(
         await _initialSnapshot.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         lock (_lock)
         {
-            return [.. _resources.Values.OrderBy(resource => resource.DisplayName, StringComparer.OrdinalIgnoreCase).ThenBy(resource => resource.Name, StringComparer.OrdinalIgnoreCase)];
+            return CreateSnapshotLocked();
+        }
+    }
+
+    public async IAsyncEnumerable<DashboardResourcesEvent> WatchAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await _initialSnapshot.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        var channel = Channel.CreateBounded<DashboardResourcesEvent>(new BoundedChannelOptions(SubscriberBufferCapacity)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait
+        });
+
+        lock (_lock)
+        {
+            // Add the authoritative snapshot while holding the same lock used for upstream
+            // changes. Registering the subscriber before releasing the lock guarantees that
+            // no gRPC delta can overtake this first event.
+            if (!channel.Writer.TryWrite(DashboardResourcesEvent.Snapshot(CreateSnapshotLocked())))
+            {
+                throw new InvalidOperationException("The resource subscriber could not accept its initial snapshot.");
+            }
+
+            _subscribers.Add(channel.Writer);
+        }
+
+        try
+        {
+            await foreach (var resourceEvent in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return resourceEvent;
+            }
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                _subscribers.Remove(channel.Writer);
+                channel.Writer.TryComplete();
+            }
         }
     }
 
@@ -122,7 +173,7 @@ internal sealed class DashboardResourceSnapshotService(
         }
     }
 
-    private void ApplyUpdate(WatchResourcesUpdate update)
+    internal void ApplyUpdate(WatchResourcesUpdate update)
     {
         lock (_lock)
         {
@@ -135,27 +186,52 @@ internal sealed class DashboardResourceSnapshotService(
                 }
 
                 _initialSnapshot.TrySetResult(true);
+                PublishLocked(DashboardResourcesEvent.Snapshot(CreateSnapshotLocked()));
                 return;
             }
 
             if (update.KindCase is WatchResourcesUpdate.KindOneofCase.Changes)
             {
+                var upserts = new List<DashboardResource>();
+                var deletes = new List<string>();
                 foreach (var change in update.Changes.Value)
                 {
                     if (change.KindCase is WatchResourcesChange.KindOneofCase.Upsert)
                     {
-                        _resources[change.Upsert.Name] = Map(change.Upsert);
+                        var resource = Map(change.Upsert);
+                        _resources[resource.Name] = resource;
+                        upserts.Add(resource);
                     }
                     else if (change.KindCase is WatchResourcesChange.KindOneofCase.Delete)
                     {
                         _resources.Remove(change.Delete.ResourceName);
+                        deletes.Add(change.Delete.ResourceName);
                     }
                 }
 
+                PublishLocked(DashboardResourcesEvent.Change([.. upserts], [.. deletes]));
                 return;
             }
 
             throw new FormatException($"Unexpected {nameof(WatchResourcesUpdate)} kind: {update.KindCase}.");
+        }
+    }
+
+    private DashboardResource[] CreateSnapshotLocked() =>
+        [.. _resources.Values
+            .OrderBy(resource => resource.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(resource => resource.Name, StringComparer.OrdinalIgnoreCase)];
+
+    private void PublishLocked(DashboardResourcesEvent resourceEvent)
+    {
+        foreach (var subscriber in _subscribers.ToArray())
+        {
+            if (!subscriber.TryWrite(resourceEvent))
+            {
+                _subscribers.Remove(subscriber);
+                subscriber.TryComplete(new InvalidOperationException(
+                    "The resource subscriber was disconnected because it could not keep up with live changes."));
+            }
         }
     }
 

--- a/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardResourceSnapshotService.cs
@@ -171,9 +171,14 @@ internal sealed class DashboardResourceSnapshotService(
             {
                 return;
             }
-            catch (OperationCanceledException) when (!reconnect)
+            catch (OperationCanceledException ex)
             {
-                ReportInitialFailure($"The AppHost resource service did not provide an initial snapshot within {initialSnapshotTimeout}. The AOT dashboard backend will keep retrying.");
+                if (!reconnect)
+                {
+                    ReportInitialFailure($"The AppHost resource service did not provide an initial snapshot within {initialSnapshotTimeout}. The AOT dashboard backend will keep retrying.");
+                }
+
+                logger.LogWarning(ex, "The AppHost resource stream disconnected; retrying.");
             }
             catch (RpcException ex)
             {

--- a/src/Aspire.Dashboard.Backend/DashboardResourcesHub.cs
+++ b/src/Aspire.Dashboard.Backend/DashboardResourcesHub.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace Aspire.Dashboard.Backend;
+
+internal sealed class DashboardResourcesHub(IDashboardResourceEventSource resourceEventSource) : Hub
+{
+    public IAsyncEnumerable<DashboardResourcesEvent> WatchResources(CancellationToken cancellationToken)
+    {
+        return resourceEventSource.WatchAsync(cancellationToken);
+    }
+}

--- a/src/Aspire.Dashboard.Backend/Program.cs
+++ b/src/Aspire.Dashboard.Backend/Program.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Backend;
+
+var app = DashboardBackendApplication.Build(args);
+app.Run();

--- a/src/Aspire.Dashboard.Backend/README.md
+++ b/src/Aspire.Dashboard.Backend/README.md
@@ -4,11 +4,11 @@ This project is the separately runnable ASP.NET Core Native AOT backend for the 
 It is intentionally additive: `Aspire.Dashboard` remains the default Blazor dashboard and continues
 to host the existing `/api/deck` transport.
 
-The first migration slice implements only version discovery and the `configuration` capability.
-In side-by-side mode, React reads configuration from this host and delegates resources, telemetry,
-commands, interactions, authentication, and terminal traffic to the existing dashboard. A version
-must not advertise a capability until its complete black-box behavior passes the 157-feature parity
-inventory in `src/Aspire.Deck/ui/e2e/parity`.
+The backend currently implements version discovery plus the `configuration` and read-only
+`resources` snapshot capabilities. In side-by-side mode, React reads those capabilities from this
+host and delegates telemetry, commands, interactions, authentication, and terminal traffic to the
+existing dashboard. A version must not advertise a capability until its complete black-box behavior
+passes the 157-feature parity inventory in `src/Aspire.Deck/ui/e2e/parity`.
 
 ## Run
 
@@ -17,13 +17,20 @@ Bind this development-only slice to a loopback address:
 ```bash
 ASPNETCORE_URLS=http://127.0.0.1:18889 \
 DashboardBackend__ApplicationName=Stress \
+ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL=https://localhost:22000 \
+DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE=ApiKey \
+DASHBOARD__RESOURCESERVICECLIENT__APIKEY=<apphost-resource-service-key> \
   dotnet run --project src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj
 ```
+
+Use the same resource-service endpoint, authentication mode, and API key supplied to the existing
+dashboard process. `Unsecured` authentication requires no API-key setting.
 
 The host exposes:
 
 - `GET /api/dashboard` for version and capability discovery.
 - `GET /api/dashboard/v1/config` for the version 1 configuration capability.
+- `GET /api/dashboard/v1/resources` for the current AppHost resource snapshot.
 
 All JSON uses camel-case names and an explicit `JsonSerializerContext`. New contract payloads must
 be registered with source generation so Native AOT never depends on reflection serialization.

--- a/src/Aspire.Dashboard.Backend/README.md
+++ b/src/Aspire.Dashboard.Backend/README.md
@@ -31,6 +31,12 @@ DASHBOARD__RESOURCESERVICECLIENT__APIKEY=<apphost-resource-service-key> \
 Use the same resource-service endpoint, authentication mode, and API key supplied to the existing
 dashboard process. `Unsecured` authentication requires no API-key setting.
 
+The host enforces loopback connections and loopback browser origins because this first migration
+slice does not yet own dashboard authentication. If the resource service cannot provide its first
+snapshot within 10 seconds, resource requests return `503 Service Unavailable` while the host keeps
+retrying. Set `DashboardBackend__InitialSnapshotTimeout` to a positive `TimeSpan` value to change
+that startup timeout.
+
 The host exposes:
 
 - `GET /api/dashboard` for version and capability discovery.

--- a/src/Aspire.Dashboard.Backend/README.md
+++ b/src/Aspire.Dashboard.Backend/README.md
@@ -1,0 +1,29 @@
+# Aspire Dashboard backend
+
+This project is the separately runnable ASP.NET Core Native AOT backend for the React dashboard.
+It is intentionally additive: `Aspire.Dashboard` remains the default Blazor dashboard and continues
+to host the existing `/api/deck` transport.
+
+The first migration slice implements only version discovery and the `configuration` capability.
+In side-by-side mode, React reads configuration from this host and delegates resources, telemetry,
+commands, interactions, authentication, and terminal traffic to the existing dashboard. A version
+must not advertise a capability until its complete black-box behavior passes the 157-feature parity
+inventory in `src/Aspire.Deck/ui/e2e/parity`.
+
+## Run
+
+Bind this development-only slice to a loopback address:
+
+```bash
+ASPNETCORE_URLS=http://127.0.0.1:18889 \
+DashboardBackend__ApplicationName=Stress \
+  dotnet run --project src/Aspire.Dashboard.Backend/Aspire.Dashboard.Backend.csproj
+```
+
+The host exposes:
+
+- `GET /api/dashboard` for version and capability discovery.
+- `GET /api/dashboard/v1/config` for the version 1 configuration capability.
+
+All JSON uses camel-case names and an explicit `JsonSerializerContext`. New contract payloads must
+be registered with source generation so Native AOT never depends on reflection serialization.

--- a/src/Aspire.Dashboard.Backend/README.md
+++ b/src/Aspire.Dashboard.Backend/README.md
@@ -4,11 +4,16 @@ This project is the separately runnable ASP.NET Core Native AOT backend for the 
 It is intentionally additive: `Aspire.Dashboard` remains the default Blazor dashboard and continues
 to host the existing `/api/deck` transport.
 
-The backend currently implements version discovery plus the `configuration` and read-only
-`resources` snapshot capabilities. In side-by-side mode, React reads those capabilities from this
-host and delegates telemetry, commands, interactions, authentication, and terminal traffic to the
-existing dashboard. A version must not advertise a capability until its complete black-box behavior
-passes the 157-feature parity inventory in `src/Aspire.Deck/ui/e2e/parity`.
+The backend currently implements version discovery plus the `configuration`, read-only `resources`
+snapshot, and SignalR `resources-live` capabilities. In side-by-side mode, React reads those
+capabilities from this host and delegates telemetry, commands, interactions, authentication, and
+terminal traffic to the existing dashboard. A version must not advertise a capability until its
+complete black-box behavior passes the 157-feature parity inventory in
+`src/Aspire.Deck/ui/e2e/parity`.
+
+The host targets .NET 10 because SignalR server trimming and Native AOT support begins in .NET 9.
+This project remains separately selectable and does not change the target framework or runtime of
+the existing Blazor dashboard.
 
 ## Run
 
@@ -31,6 +36,9 @@ The host exposes:
 - `GET /api/dashboard` for version and capability discovery.
 - `GET /api/dashboard/v1/config` for the version 1 configuration capability.
 - `GET /api/dashboard/v1/resources` for the current AppHost resource snapshot.
+- `/api/dashboard/v1/resources/live` for the SignalR `WatchResources` server stream. Each
+  subscription receives an authoritative snapshot followed by incremental upserts and deletes.
 
-All JSON uses camel-case names and an explicit `JsonSerializerContext`. New contract payloads must
-be registered with source generation so Native AOT never depends on reflection serialization.
+All HTTP and SignalR JSON uses camel-case names and an explicit `JsonSerializerContext`. New
+contract payloads must be registered with source generation so Native AOT never depends on
+reflection serialization.

--- a/src/Aspire.Deck/CONTRACT.md
+++ b/src/Aspire.Deck/CONTRACT.md
@@ -27,18 +27,19 @@ The first discovery response is:
     {
       "version": 1,
       "basePath": "/api/dashboard/v1",
-      "capabilities": ["configuration", "resources"]
+      "capabilities": ["configuration", "resources", "resources-live"]
     }
   ]
 }
 ```
 
-Version 1 currently defines two capabilities:
+Version 1 currently defines three capabilities:
 
 | Capability | Route | Response |
 | --- | --- | --- |
 | `configuration` | `GET {basePath}/config` | `DashboardConfiguration` |
 | `resources` | `GET {basePath}/resources` | `Resource[]` |
+| `resources-live` | SignalR hub at `{basePath}/resources/live` | `ResourcesEvent` server stream |
 
 ```ts
 export interface DashboardConfiguration {
@@ -49,13 +50,22 @@ export interface DashboardConfiguration {
 ```
 
 The `resources` response uses the transport-neutral `Resource` shape documented below. It is a
-complete point-in-time snapshot, returned with `Cache-Control: no-store`. React polls this route for
-the first resource migration slice; commands and other resource operations remain on `/api/deck`.
+complete point-in-time snapshot, returned with `Cache-Control: no-store`. It remains the fallback
+when a compatible server does not advertise `resources-live`; commands and other resource
+operations remain on `/api/deck`.
+
+For `resources-live`, React connects with the SignalR JSON hub protocol and invokes the streaming
+hub method `WatchResources`. The first stream item is always an authoritative `snapshot`; later
+items are `change` events containing resource upserts and deleted resource names. Snapshot capture
+and subscriber registration are atomic, so an upstream gRPC change cannot overtake the first item.
+Every new or reconnected SignalR connection starts a new stream and receives a fresh snapshot before
+its changes. A slow subscriber is disconnected instead of receiving an unbounded backlog.
 
 The AOT backend must advertise only capabilities it implements end-to-end. During the side-by-side
 migration, React delegates every capability not advertised here to the existing `/api/deck`
 transport. All .NET request and response types in the versioned contract must be registered in a
-source-generated `JsonSerializerContext`; reflection serialization is not part of the contract.
+source-generated `JsonSerializerContext`, including SignalR hub payloads; reflection serialization
+is not part of the contract.
 
 ## Existing Deck transports
 

--- a/src/Aspire.Deck/CONTRACT.md
+++ b/src/Aspire.Deck/CONTRACT.md
@@ -27,17 +27,18 @@ The first discovery response is:
     {
       "version": 1,
       "basePath": "/api/dashboard/v1",
-      "capabilities": ["configuration"]
+      "capabilities": ["configuration", "resources"]
     }
   ]
 }
 ```
 
-Version 1 currently defines one capability:
+Version 1 currently defines two capabilities:
 
 | Capability | Route | Response |
 | --- | --- | --- |
 | `configuration` | `GET {basePath}/config` | `DashboardConfiguration` |
+| `resources` | `GET {basePath}/resources` | `Resource[]` |
 
 ```ts
 export interface DashboardConfiguration {
@@ -46,6 +47,10 @@ export interface DashboardConfiguration {
   runtimeVersion: string;
 }
 ```
+
+The `resources` response uses the transport-neutral `Resource` shape documented below. It is a
+complete point-in-time snapshot, returned with `Cache-Control: no-store`. React polls this route for
+the first resource migration slice; commands and other resource operations remain on `/api/deck`.
 
 The AOT backend must advertise only capabilities it implements end-to-end. During the side-by-side
 migration, React delegates every capability not advertised here to the existing `/api/deck`

--- a/src/Aspire.Deck/CONTRACT.md
+++ b/src/Aspire.Deck/CONTRACT.md
@@ -7,6 +7,53 @@ The backend exposes **commands** (request/response via `@tauri-apps/api/core` `i
 **events** (push via `@tauri-apps/api/event` `listen`). All payloads are JSON; field names are
 `camelCase`.
 
+## Versioned ASP.NET Core backend
+
+The React migration uses a separately runnable Native AOT backend at `/api/dashboard`. This
+contract grows capability-by-capability while the existing Blazor dashboard and its unversioned
+`/api/deck` transport remain available.
+
+React starts with `GET /api/dashboard` and intersects the returned versions with the versions it
+understands. It selects the highest compatible version and uses that entry's `basePath` for every
+capability advertised by the entry. A client must fail the new capability explicitly when there is
+no compatible version; it must not guess a route or silently reinterpret an incompatible payload.
+
+The first discovery response is:
+
+```json
+{
+  "product": "Aspire.Dashboard",
+  "versions": [
+    {
+      "version": 1,
+      "basePath": "/api/dashboard/v1",
+      "capabilities": ["configuration"]
+    }
+  ]
+}
+```
+
+Version 1 currently defines one capability:
+
+| Capability | Route | Response |
+| --- | --- | --- |
+| `configuration` | `GET {basePath}/config` | `DashboardConfiguration` |
+
+```ts
+export interface DashboardConfiguration {
+  applicationName: string;
+  dashboardVersion: string;
+  runtimeVersion: string;
+}
+```
+
+The AOT backend must advertise only capabilities it implements end-to-end. During the side-by-side
+migration, React delegates every capability not advertised here to the existing `/api/deck`
+transport. All .NET request and response types in the versioned contract must be registered in a
+source-generated `JsonSerializerContext`; reflection serialization is not part of the contract.
+
+## Existing Deck transports
+
 The ASP.NET Core dashboard backend exposes the same config, resource, command, and interaction
 shapes through `GET /api/deck/config`, `GET /api/deck/resources`,
 `POST /api/deck/commands/execute`, `GET /api/deck/interactions`, and

--- a/src/Aspire.Deck/ui/README.md
+++ b/src/Aspire.Deck/ui/README.md
@@ -178,6 +178,19 @@ ASPIRE_DASHBOARD_URL=https://Stress.dev.localhost:49985 \
   npm exec -- playwright test --config=playwright.stress.config.ts
 ```
 
+Run the same inventory through the side-by-side AOT topology after starting the AOT host:
+
+```bash
+ASPIRE_DASHBOARD_URL=https://Stress.dev.localhost:49985 \
+ASPIRE_DASHBOARD_AOT_URL=http://127.0.0.1:18889 \
+ASPIRE_DASHBOARD_BACKEND=aot \
+  npm exec -- playwright test --config=playwright.stress.config.ts
+```
+
+This verifies that version negotiation, the AOT SignalR resource stream, and the existing
+dashboard fallback for capabilities not yet migrated work together against the same 157-feature
+black-box compatibility inventory.
+
 The terminal playground has a separate live HMP suite. Start `playground/Terminals`, then run:
 
 ```bash

--- a/src/Aspire.Deck/ui/README.md
+++ b/src/Aspire.Deck/ui/README.md
@@ -143,9 +143,9 @@ ASPIRE_DASHBOARD_AOT_URL=http://127.0.0.1:18889 \
   npm run dev -- --host 127.0.0.1
 ```
 
-Open `http://127.0.0.1:1430/?backend=aot`. Version discovery and configuration use the new
-host; resources, telemetry, commands, interactions, authentication, and terminals remain on the
-existing dashboard until their versioned capabilities independently pass the parity inventory.
+Open `http://127.0.0.1:1430/?backend=aot`. Version discovery, configuration, and read-only resource
+snapshots use the new host; telemetry, commands, interactions, authentication, and terminals remain
+on the existing dashboard until their versioned capabilities independently pass the parity inventory.
 
 Open `http://localhost:1430/?view=toolkit` for the standalone toolkit playground. It exercises
 the shared controls without depending on the Deck backend or mock data layer, making it the

--- a/src/Aspire.Deck/ui/README.md
+++ b/src/Aspire.Deck/ui/README.md
@@ -10,6 +10,9 @@ the **same** code:
 - **ASP.NET dashboard** — `?backend=http` explicitly loads configuration and resources from
   the authenticated `/api/deck` endpoints. The adapter polls for resource changes and reports
   connection failures without falling back to mock data.
+- **Versioned ASP.NET backend** — `?backend=aot` negotiates the versioned `/api/dashboard`
+  contract with the separate Native AOT host. The first slice reads only configuration there;
+  every unported capability continues through the existing `/api/deck` backend.
 - **Tauri-embedded** — when running inside the Tauri shell, the data layer
   (`src/api/deck.ts`) calls the real backend via `invoke(...)` / `listen(...)` exactly as
   described in [`../CONTRACT.md`](../CONTRACT.md).
@@ -130,6 +133,19 @@ ASPIRE_DASHBOARD_URL=https://Stress.dev.localhost:49985 npm run dev -- --host 12
 Then open `http://127.0.0.1:1430/?backend=http`. The Vite proxy is enabled only
 when `ASPIRE_DASHBOARD_URL` is present, so standalone development continues to use
 the deterministic mock backend.
+
+To exercise the first side-by-side Native AOT slice, start the host documented in
+[`../../Aspire.Dashboard.Backend/README.md`](../../Aspire.Dashboard.Backend/README.md), then provide both backend URLs:
+
+```bash
+ASPIRE_DASHBOARD_URL=https://Stress.dev.localhost:49985 \
+ASPIRE_DASHBOARD_AOT_URL=http://127.0.0.1:18889 \
+  npm run dev -- --host 127.0.0.1
+```
+
+Open `http://127.0.0.1:1430/?backend=aot`. Version discovery and configuration use the new
+host; resources, telemetry, commands, interactions, authentication, and terminals remain on the
+existing dashboard until their versioned capabilities independently pass the parity inventory.
 
 Open `http://localhost:1430/?view=toolkit` for the standalone toolkit playground. It exercises
 the shared controls without depending on the Deck backend or mock data layer, making it the

--- a/src/Aspire.Deck/ui/README.md
+++ b/src/Aspire.Deck/ui/README.md
@@ -11,8 +11,9 @@ the **same** code:
   the authenticated `/api/deck` endpoints. The adapter polls for resource changes and reports
   connection failures without falling back to mock data.
 - **Versioned ASP.NET backend** — `?backend=aot` negotiates the versioned `/api/dashboard`
-  contract with the separate Native AOT host. The first slice reads only configuration there;
-  every unported capability continues through the existing `/api/deck` backend.
+  contract with the separate Native AOT host. Configuration and resources come from that host,
+  with resource snapshots and changes streamed over SignalR; every unported capability continues
+  through the existing `/api/deck` backend.
 - **Tauri-embedded** — when running inside the Tauri shell, the data layer
   (`src/api/deck.ts`) calls the real backend via `invoke(...)` / `listen(...)` exactly as
   described in [`../CONTRACT.md`](../CONTRACT.md).
@@ -143,9 +144,11 @@ ASPIRE_DASHBOARD_AOT_URL=http://127.0.0.1:18889 \
   npm run dev -- --host 127.0.0.1
 ```
 
-Open `http://127.0.0.1:1430/?backend=aot`. Version discovery, configuration, and read-only resource
-snapshots use the new host; telemetry, commands, interactions, authentication, and terminals remain
-on the existing dashboard until their versioned capabilities independently pass the parity inventory.
+Open `http://127.0.0.1:1430/?backend=aot`. Version discovery and configuration use the new host;
+resources arrive as an authoritative snapshot followed by live changes over SignalR. Telemetry,
+commands, interactions, authentication, and terminals remain on the existing dashboard until their
+versioned capabilities independently pass the parity inventory. The `resources` HTTP snapshot route
+remains a compatibility fallback for a version 1 host that does not advertise `resources-live`.
 
 Open `http://localhost:1430/?view=toolkit` for the standalone toolkit playground. It exercises
 the shared controls without depending on the Deck backend or mock data layer, making it the

--- a/src/Aspire.Deck/ui/README.md
+++ b/src/Aspire.Deck/ui/README.md
@@ -188,8 +188,9 @@ ASPIRE_DASHBOARD_BACKEND=aot \
 ```
 
 This verifies that version negotiation, the AOT SignalR resource stream, and the existing
-dashboard fallback for capabilities not yet migrated work together against the same 157-feature
-black-box compatibility inventory.
+dashboard fallback for capabilities not yet migrated work together across the 23 live Stress
+behaviors. Those scenarios provide live coverage evidence for the separate 157-feature parity
+ledger enforced by the default Playwright suite.
 
 The terminal playground has a separate live HMP suite. Start `playground/Terminals`, then run:
 

--- a/src/Aspire.Deck/ui/e2e/http-backend-features.ts
+++ b/src/Aspire.Deck/ui/e2e/http-backend-features.ts
@@ -1,5 +1,5 @@
 export const httpBackendFeatures = {
-  "AOT-CONTRACT-001": "AOT mode negotiates the highest supported contract version for configuration while unported capabilities stay on the existing backend.",
+  "AOT-CONTRACT-001": "AOT mode negotiates the highest supported contract version, uses its configuration and resource capabilities, and keeps unported capabilities on the existing backend.",
   "HTTP-SHELL-UNSECURED-001": "Backend security configuration renders a persistent, dismissible unsecured-endpoint warning.",
   "HTTP-MANAGE-DATA-001": "Manage Data inventories, selects, exports, imports, and removes dashboard data through the HTTP backend.",
   "HTTP-AUTH-001": "Frontend API authentication challenges transfer the React browser to the dashboard login flow.",

--- a/src/Aspire.Deck/ui/e2e/http-backend-features.ts
+++ b/src/Aspire.Deck/ui/e2e/http-backend-features.ts
@@ -1,5 +1,5 @@
 export const httpBackendFeatures = {
-  "AOT-CONTRACT-001": "AOT mode negotiates the highest supported contract version, uses its configuration and resource capabilities, and keeps unported capabilities on the existing backend.",
+  "AOT-CONTRACT-001": "AOT mode negotiates the highest supported contract version, streams resource snapshots and changes over SignalR when advertised, and keeps unported capabilities on the existing backend.",
   "HTTP-SHELL-UNSECURED-001": "Backend security configuration renders a persistent, dismissible unsecured-endpoint warning.",
   "HTTP-MANAGE-DATA-001": "Manage Data inventories, selects, exports, imports, and removes dashboard data through the HTTP backend.",
   "HTTP-AUTH-001": "Frontend API authentication challenges transfer the React browser to the dashboard login flow.",

--- a/src/Aspire.Deck/ui/e2e/http-backend-features.ts
+++ b/src/Aspire.Deck/ui/e2e/http-backend-features.ts
@@ -1,4 +1,5 @@
 export const httpBackendFeatures = {
+  "AOT-CONTRACT-001": "AOT mode negotiates the highest supported contract version for configuration while unported capabilities stay on the existing backend.",
   "HTTP-SHELL-UNSECURED-001": "Backend security configuration renders a persistent, dismissible unsecured-endpoint warning.",
   "HTTP-MANAGE-DATA-001": "Manage Data inventories, selects, exports, imports, and removes dashboard data through the HTTP backend.",
   "HTTP-AUTH-001": "Frontend API authentication challenges transfer the React browser to the dashboard login flow.",

--- a/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
+++ b/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
@@ -120,6 +120,53 @@ test.afterEach(async ({ page }) => {
   expect(telemetryFiltered, "Unexpected browser errors").toEqual([]);
 });
 
+test(`${features("AOT-CONTRACT-001")} negotiates configuration while retaining the existing resource backend`, async ({ page }) => {
+  let discoveryRequests = 0;
+  let aotConfigRequests = 0;
+  let legacyConfigRequests = 0;
+  let resourceRequests = 0;
+  await page.route("**/api/dashboard", async (route) => {
+    discoveryRequests++;
+    await route.fulfill({
+      json: {
+        product: "Aspire.Dashboard",
+        versions: [
+          { version: 99, basePath: "/api/dashboard/v99", capabilities: ["configuration"] },
+          { version: 1, basePath: "/api/dashboard/v1", capabilities: ["configuration"] },
+        ],
+      },
+    });
+  });
+  await page.route("**/api/dashboard/v1/config", async (route) => {
+    aotConfigRequests++;
+    await route.fulfill({
+      json: {
+        applicationName: "Stress AOT",
+        dashboardVersion: "13.5.0-aot",
+        runtimeVersion: ".NET 10.0.0",
+      },
+    });
+  });
+  await page.route("**/api/deck/config", async (route) => {
+    legacyConfigRequests++;
+    await route.fulfill({ json: config });
+  });
+  await page.route("**/api/deck/resources", async (route) => {
+    resourceRequests++;
+    await route.fulfill({ json: [resource] });
+  });
+
+  await page.goto("/?backend=aot");
+
+  await expect(page.getByRole("banner").locator(".topbar__app")).toHaveText("Stress AOT");
+  await expect(page.getByRole("navigation")).toContainText("Aspire Deck 13.5.0-aot");
+  await expect(page.getByRole("table").getByRole("row", { name: /stress-api/ })).toBeVisible();
+  expect(discoveryRequests).toBe(1);
+  expect(aotConfigRequests).toBe(1);
+  expect(legacyConfigRequests).toBeGreaterThan(0);
+  expect(resourceRequests).toBeGreaterThan(0);
+});
+
 test(`${features("HTTP-CONFIG-001", "HTTP-RESOURCES-001", "HTTP-MOCK-ISOLATION-001")} loads the dashboard from the HTTP backend`, async ({ page }, testInfo: TestInfo) => {
   let configRequests = 0;
   let resourceRequests = 0;

--- a/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
+++ b/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
@@ -9,7 +9,7 @@ const coveredFeatures = new Set<HttpBackendFeatureId>();
 const browserErrors = new WeakMap<Page, string[]>();
 const allowUnavailableResponses = new WeakSet<Page>();
 const allowInterceptedImportAbort = new WeakSet<Page>();
-const allowAuthenticationNavigation = new WeakSet<Page>();
+const allowNavigationAbort = new WeakSet<Page>();
 const allowMetricSeriesAbort = new WeakSet<Page>();
 
 function features(...ids: HttpBackendFeatureId[]): string {
@@ -106,7 +106,7 @@ test.afterEach(async ({ page }) => {
   const filtered = allowInterceptedImportAbort.has(page)
     ? unexpected.filter((error) => !error.includes("/api/deck/manage-data/import (net::ERR_ABORTED)"))
     : unexpected;
-  const navigationFiltered = allowAuthenticationNavigation.has(page)
+  const navigationFiltered = allowNavigationAbort.has(page)
     ? filtered.filter((error) =>
         error !== "console: Failed to load resource: the server responded with a status of 404 (Not Found)"
         && !(error.includes("/login?returnUrl=") && error.endsWith("(net::ERR_ABORTED)"))
@@ -369,7 +369,7 @@ test(`${features("HTTP-SHELL-UNSECURED-001")} warns about unsecured endpoints an
 
 test(`${features("HTTP-AUTH-001")} transfers an authentication challenge to the dashboard login flow`, async ({ page }) => {
   // Full-page login navigation intentionally cancels in-flight startup requests.
-  allowAuthenticationNavigation.add(page);
+  allowNavigationAbort.add(page);
   await page.route("**/api/deck/config", async (route) => route.fulfill({
     status: 302,
     headers: { Location: "/login?returnUrl=%2Fapi%2Fdeck%2Fconfig" },
@@ -391,7 +391,7 @@ test(`${features("HTTP-AUTH-001")} transfers an authentication challenge to the 
 });
 
 test(`${features("HTTP-USER-001")} shows the authenticated user and signs out`, async ({ page }) => {
-  allowAuthenticationNavigation.add(page);
+  allowNavigationAbort.add(page);
   await page.route("**/api/deck/config", async (route) => route.fulfill({
     json: {
       ...config,
@@ -431,6 +431,7 @@ test(`${features("HTTP-USER-001")} shows the authenticated user and signs out`, 
 });
 
 test(`${features("HTTP-LANGUAGE-001")} selects and applies a dashboard language`, async ({ page }) => {
+  allowNavigationAbort.add(page);
   let culture = "en";
   let requestedLanguage: string | null = null;
   await page.route("**/api/deck/config", async (route) => route.fulfill({

--- a/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
+++ b/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
@@ -297,10 +297,10 @@ test(`${features("AOT-CONTRACT-001")} streams AOT resource snapshots and changes
   await expect(resourceRow).toContainText("Stopped");
   await expect(page.getByTitle("Resources: Connected")).toBeVisible();
   // React strict mode can negotiate and tear down an initial connection while checking
-  // effect cleanup. At least one complete stream must win, and polling must remain unused.
+  // effect cleanup. Resource consumers still share one completed stream, and polling stays unused.
   expect(negotiateRequests).toBeGreaterThan(0);
-  expect(websocketConnections).toBeGreaterThan(0);
-  expect(streamInvocations).toBeGreaterThan(0);
+  expect(websocketConnections).toBe(1);
+  expect(streamInvocations).toBe(1);
   expect(resourceRequests).toBe(0);
 });
 

--- a/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
+++ b/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
@@ -120,7 +120,7 @@ test.afterEach(async ({ page }) => {
   expect(telemetryFiltered, "Unexpected browser errors").toEqual([]);
 });
 
-test(`${features("AOT-CONTRACT-001")} negotiates configuration while retaining the existing resource backend`, async ({ page }) => {
+test(`${features("AOT-CONTRACT-001")} falls back when the negotiated version does not advertise resources`, async ({ page }) => {
   let discoveryRequests = 0;
   let aotConfigRequests = 0;
   let legacyConfigRequests = 0;
@@ -163,8 +163,47 @@ test(`${features("AOT-CONTRACT-001")} negotiates configuration while retaining t
   await expect(page.getByRole("table").getByRole("row", { name: /stress-api/ })).toBeVisible();
   expect(discoveryRequests).toBe(1);
   expect(aotConfigRequests).toBe(1);
-  expect(legacyConfigRequests).toBeGreaterThan(0);
+  expect(legacyConfigRequests).toBe(0);
   expect(resourceRequests).toBeGreaterThan(0);
+});
+
+test(`${features("AOT-CONTRACT-001")} reads resources from the negotiated AOT capability`, async ({ page }) => {
+  let aotResourceRequests = 0;
+  let legacyResourceRequests = 0;
+  await page.route("**/api/dashboard", async (route) => {
+    await route.fulfill({
+      json: {
+        product: "Aspire.Dashboard",
+        versions: [
+          { version: 1, basePath: "/api/dashboard/v1", capabilities: ["configuration", "resources"] },
+        ],
+      },
+    });
+  });
+  await page.route("**/api/dashboard/v1/config", async (route) => {
+    await route.fulfill({
+      json: {
+        applicationName: "Stress AOT",
+        dashboardVersion: "13.5.0-aot",
+        runtimeVersion: ".NET 10.0.0",
+      },
+    });
+  });
+  await page.route("**/api/dashboard/v1/resources", async (route) => {
+    aotResourceRequests++;
+    await route.fulfill({ json: [resource] });
+  });
+  await page.route("**/api/deck/resources", async (route) => {
+    legacyResourceRequests++;
+    await route.fulfill({ json: [] });
+  });
+
+  await page.goto("/?backend=aot");
+
+  await expect(page.getByRole("table").getByRole("row", { name: /stress-api/ })).toBeVisible();
+  await expect(page.getByTitle("Resources: Connected")).toBeVisible();
+  expect(aotResourceRequests).toBeGreaterThan(0);
+  expect(legacyResourceRequests).toBe(0);
 });
 
 test(`${features("HTTP-CONFIG-001", "HTTP-RESOURCES-001", "HTTP-MOCK-ISOLATION-001")} loads the dashboard from the HTTP backend`, async ({ page }, testInfo: TestInfo) => {

--- a/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
+++ b/src/Aspire.Deck/ui/e2e/http-backend.spec.ts
@@ -206,6 +206,104 @@ test(`${features("AOT-CONTRACT-001")} reads resources from the negotiated AOT ca
   expect(legacyResourceRequests).toBe(0);
 });
 
+test(`${features("AOT-CONTRACT-001")} streams AOT resource snapshots and changes over SignalR`, async ({ page }) => {
+  let negotiateRequests = 0;
+  let websocketConnections = 0;
+  let streamInvocations = 0;
+  let resourceRequests = 0;
+  await page.route("**/api/dashboard", async (route) => {
+    await route.fulfill({
+      json: {
+        product: "Aspire.Dashboard",
+        versions: [
+          {
+            version: 1,
+            basePath: "/api/dashboard/v1",
+            capabilities: ["configuration", "resources", "resources-live"],
+          },
+        ],
+      },
+    });
+  });
+  await page.route("**/api/dashboard/v1/config", async (route) => {
+    await route.fulfill({
+      json: {
+        applicationName: "Stress AOT",
+        dashboardVersion: "13.5.0-aot",
+        runtimeVersion: ".NET 10.0.0",
+      },
+    });
+  });
+  await page.route("**/api/dashboard/v1/resources/live/negotiate?**", async (route) => {
+    negotiateRequests++;
+    await route.fulfill({
+      json: {
+        negotiateVersion: 1,
+        connectionId: "playwright-signalr-connection",
+        connectionToken: "playwright-signalr-token",
+        availableTransports: [
+          { transport: "WebSockets", transferFormats: ["Text", "Binary"] },
+        ],
+      },
+    });
+  });
+  await page.route("**/api/dashboard/v1/resources", async (route) => {
+    resourceRequests++;
+    await route.fulfill({ json: [] });
+  });
+  await page.routeWebSocket("**/api/dashboard/v1/resources/live?id=*", (webSocket) => {
+    websocketConnections++;
+    webSocket.onMessage((message) => {
+      // SignalR JSON messages are separated by ASCII record separators. The browser can
+      // coalesce the handshake and stream invocation, so handle every frame independently.
+      const frames = message.toString().split("\x1e").filter(Boolean);
+      for (const frame of frames) {
+        const payload = JSON.parse(frame) as {
+          protocol?: string;
+          type?: number;
+          invocationId?: string;
+          target?: string;
+        };
+        if (payload.protocol === "json") {
+          webSocket.send("{}\x1e");
+        } else if (payload.type === 4 && payload.target === "WatchResources") {
+          streamInvocations++;
+          webSocket.send(`${JSON.stringify({
+            type: 2,
+            invocationId: payload.invocationId,
+            item: { type: "snapshot", resources: [resource], upserts: null, deletes: null },
+          })}\x1e`);
+          setTimeout(() => {
+            webSocket.send(`${JSON.stringify({
+              type: 2,
+              invocationId: payload.invocationId,
+              item: {
+                type: "change",
+                resources: null,
+                upserts: [{ ...resource, state: "Stopped", stateStyle: "error" }],
+                deletes: [],
+              },
+            })}\x1e`);
+          }, 100);
+        }
+      }
+    });
+  });
+
+  await page.goto("/?backend=aot");
+
+  const resourceRow = page.getByRole("table").getByRole("row", { name: /stress-api/ });
+  await expect(resourceRow).toBeVisible();
+  await expect(resourceRow).toContainText("Stopped");
+  await expect(page.getByTitle("Resources: Connected")).toBeVisible();
+  // React strict mode can negotiate and tear down an initial connection while checking
+  // effect cleanup. At least one complete stream must win, and polling must remain unused.
+  expect(negotiateRequests).toBeGreaterThan(0);
+  expect(websocketConnections).toBeGreaterThan(0);
+  expect(streamInvocations).toBeGreaterThan(0);
+  expect(resourceRequests).toBe(0);
+});
+
 test(`${features("HTTP-CONFIG-001", "HTTP-RESOURCES-001", "HTTP-MOCK-ISOLATION-001")} loads the dashboard from the HTTP backend`, async ({ page }, testInfo: TestInfo) => {
   let configRequests = 0;
   let resourceRequests = 0;

--- a/src/Aspire.Deck/ui/e2e/live/stress.spec.ts
+++ b/src/Aspire.Deck/ui/e2e/live/stress.spec.ts
@@ -6,6 +6,8 @@ const browserErrors = new WeakMap<Page, string[]>();
 const allowConsoleStreamAbort = new WeakSet<Page>();
 const allowNavigationAbort = new WeakSet<Page>();
 const dashboardBrowserToken = process.env.ASPIRE_DASHBOARD_BROWSER_TOKEN;
+const dashboardBackend = process.env.ASPIRE_DASHBOARD_BACKEND === "aot" ? "aot" : "http";
+const backendQuery = `backend=${dashboardBackend}`;
 
 function features(...ids: StressFeatureId[]): string {
   for (const id of ids) {
@@ -101,7 +103,7 @@ test.beforeEach(async ({ page }) => {
   if (dashboardBrowserToken) {
     await page.goto(`/login?t=${encodeURIComponent(dashboardBrowserToken)}`);
   }
-  await page.goto("/?backend=http");
+  await page.goto(`/?${backendQuery}`);
   await expect(page.getByTitle("Resources: Connected")).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("main").locator(".page__title")).toHaveText("Resources");
 });
@@ -492,7 +494,7 @@ test(`${features("STRESS-NAVIGATION-001", "STRESS-EMPTY-METRICS-001")} reaches e
       await expect(metrics.locator(".page__subtitle")).toHaveText(/\d+ instruments/);
       await expect(metrics).not.toContainText("Loading…");
 
-      await page.goto("/metrics/resource/property-stress-resource?backend=http");
+      await page.goto(`/metrics/resource/property-stress-resource?${backendQuery}`);
       await expect(metrics.locator(".page__subtitle")).toHaveText("0 instruments");
       await expect(metrics.getByRole("heading", { name: "No meters for this resource" })).toBeVisible();
     }

--- a/src/Aspire.Deck/ui/package-lock.json
+++ b/src/Aspire.Deck/ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fluentui/react-components": "^9.74.3",
         "@fluentui/react-icons": "^2.0.332",
+        "@microsoft/signalr": "^10.0.0",
         "@tauri-apps/api": "^2.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2388,6 +2389,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@microsoft/signalr": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
+      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
@@ -2888,6 +2902,18 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
@@ -3067,6 +3093,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3178,6 +3232,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.48",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
@@ -3271,6 +3345,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3305,6 +3406,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.62.2",
@@ -3379,6 +3486,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3404,6 +3517,27 @@
         "keyborg": "^2.14.0",
         "tslib": "^2.8.1"
       }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -3431,6 +3565,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -3468,6 +3611,16 @@
       "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
       "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
       "license": "MIT"
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
@@ -3534,6 +3687,43 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/src/Aspire.Deck/ui/package.json
+++ b/src/Aspire.Deck/ui/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@fluentui/react-components": "^9.74.3",
     "@fluentui/react-icons": "^2.0.332",
+    "@microsoft/signalr": "^10.0.0",
     "@tauri-apps/api": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/Aspire.Deck/ui/playwright.stress.config.ts
+++ b/src/Aspire.Deck/ui/playwright.stress.config.ts
@@ -1,10 +1,26 @@
 import { defineConfig } from "@playwright/test";
 
 const dashboardUrl = process.env.ASPIRE_DASHBOARD_URL;
+const dashboardAotUrl = process.env.ASPIRE_DASHBOARD_AOT_URL;
+const dashboardBackend = process.env.ASPIRE_DASHBOARD_BACKEND ?? "http";
 const reuseExistingServer = process.env.ASPIRE_REUSE_EXISTING_SERVER === "true";
 
 if (!dashboardUrl) {
   throw new Error("ASPIRE_DASHBOARD_URL must point to a running Stress dashboard.");
+}
+if (dashboardBackend !== "http" && dashboardBackend !== "aot") {
+  throw new Error("ASPIRE_DASHBOARD_BACKEND must be either 'http' or 'aot'.");
+}
+if (dashboardBackend === "aot" && !dashboardAotUrl) {
+  throw new Error("ASPIRE_DASHBOARD_AOT_URL must point to the AOT backend when ASPIRE_DASHBOARD_BACKEND=aot.");
+}
+
+const webServerEnvironment: Record<string, string> = {
+  ASPIRE_DASHBOARD_URL: dashboardUrl,
+  ASPIRE_DASHBOARD_BACKEND: dashboardBackend,
+};
+if (dashboardAotUrl) {
+  webServerEnvironment.ASPIRE_DASHBOARD_AOT_URL = dashboardAotUrl;
 }
 
 export default defineConfig({
@@ -29,8 +45,8 @@ export default defineConfig({
   },
   webServer: {
     command: "npm run dev -- --host 127.0.0.1",
-    env: { ASPIRE_DASHBOARD_URL: dashboardUrl },
-    url: "http://127.0.0.1:1430/?backend=http",
+    env: webServerEnvironment,
+    url: `http://127.0.0.1:1430/?backend=${dashboardBackend}`,
     reuseExistingServer,
     timeout: 120_000,
   },

--- a/src/Aspire.Deck/ui/src/api/deck.ts
+++ b/src/Aspire.Deck/ui/src/api/deck.ts
@@ -149,6 +149,11 @@ export function listResources(): Promise<Resource[]> {
   if (isTauri()) {
     return invoke<Resource[]>("deck_list_resources");
   }
+  if (isAotBackend()) {
+    return nativeBackend.hasCapability("resources").then((supported) => (
+      supported ? nativeBackend.listResources() : httpBackend.listResources()
+    ));
+  }
   if (isHttpBackend()) {
     return httpBackend.listResources();
   }
@@ -177,7 +182,7 @@ export function listApphosts(): Promise<AppHostInfo[]> {
     return invoke<AppHostInfo[]>("deck_list_apphosts");
   }
   if (isAotBackend()) {
-    return httpBackend.listApphosts().then(applyAotApphostIdentity);
+    return httpBackend.listApphosts(nativeBackend.getConfig).then(applyAotApphostIdentity);
   }
   if (isHttpBackend()) {
     return httpBackend.listApphosts();
@@ -210,7 +215,7 @@ export function onApphosts(cb: (apphosts: AppHostInfo[]) => void): Unsubscribe {
           cb(identifiedApphosts);
         }
       }).catch(() => undefined);
-    });
+    }, nativeBackend.getConfig);
     return () => {
       cancelled = true;
       unsubscribe();
@@ -349,7 +354,11 @@ export function onResources(cb: (event: ResourcesEvent) => void): Unsubscribe {
     return unlisten;
   }
   if (isHttpBackend()) {
-    return httpBackend.onResources(cb);
+    return httpBackend.onResources(
+      cb,
+      isAotBackend() ? listResources : undefined,
+      isAotBackend() ? nativeBackend.getConfig : undefined,
+    );
   }
   return mockBackend.onResources(cb);
 }

--- a/src/Aspire.Deck/ui/src/api/deck.ts
+++ b/src/Aspire.Deck/ui/src/api/deck.ts
@@ -1,5 +1,6 @@
 // Transport-neutral data layer. Tauri dispatches to the Rust backend via
-// `invoke`/`listen`, explicit `?backend=http` mode calls the ASP.NET dashboard,
+// `invoke`/`listen`, explicit `?backend=http` mode calls the existing ASP.NET dashboard,
+// `?backend=aot` negotiates versioned capabilities with the Native AOT host,
 // and standalone browser development uses the in-process mock. Every transport
 // exposes the same function surface so feature code remains independent of it.
 //
@@ -10,6 +11,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { httpBackend } from "./http";
 import { mockBackend } from "./mock";
+import { nativeBackend } from "./native";
 import type {
   AppHostInfo,
   AssistantChatRequest,
@@ -42,7 +44,18 @@ export function isTauri(): boolean {
 }
 
 export function isHttpBackend(): boolean {
-  return typeof window !== "undefined" && new URLSearchParams(window.location.search).get("backend") === "http";
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const backend = new URLSearchParams(window.location.search).get("backend");
+  // AOT mode is a strangler path: capabilities not yet in the versioned contract
+  // deliberately continue through the existing HTTP backend until parity is proven.
+  return backend === "http" || backend === "aot";
+}
+
+export function isAotBackend(): boolean {
+  return typeof window !== "undefined" && new URLSearchParams(window.location.search).get("backend") === "aot";
 }
 
 // Bridges Tauri's promise-returning `listen` (which resolves to an unlisten fn)
@@ -66,6 +79,9 @@ function bridgeListen<T>(event: string, cb: (payload: T) => void): Unsubscribe {
 export function getConfig(): Promise<DeckConfig> {
   if (isTauri()) {
     return invoke<DeckConfig>("deck_get_config");
+  }
+  if (isAotBackend()) {
+    return nativeBackend.getConfig();
   }
   if (isHttpBackend()) {
     return httpBackend.getConfig();
@@ -149,9 +165,19 @@ export function listCanvases(): Promise<CanvasManifest[]> {
   return Promise.resolve(mockBackend.listCanvases());
 }
 
+async function applyAotApphostIdentity(apphosts: AppHostInfo[]): Promise<AppHostInfo[]> {
+  const config = await nativeBackend.getConfig();
+  return apphosts.map((apphost) => (
+    apphost.active ? { ...apphost, name: config.applicationName ?? apphost.name } : apphost
+  ));
+}
+
 export function listApphosts(): Promise<AppHostInfo[]> {
   if (isTauri()) {
     return invoke<AppHostInfo[]>("deck_list_apphosts");
+  }
+  if (isAotBackend()) {
+    return httpBackend.listApphosts().then(applyAotApphostIdentity);
   }
   if (isHttpBackend()) {
     return httpBackend.listApphosts();
@@ -175,6 +201,20 @@ export function onApphosts(cb: (apphosts: AppHostInfo[]) => void): Unsubscribe {
     const unlisten = bridgeListen<AppHostInfo[]>("deck://apphosts", cb);
     void listApphosts().then(cb);
     return unlisten;
+  }
+  if (isAotBackend()) {
+    let cancelled = false;
+    const unsubscribe = httpBackend.onApphosts((apphosts) => {
+      void applyAotApphostIdentity(apphosts).then((identifiedApphosts) => {
+        if (!cancelled) {
+          cb(identifiedApphosts);
+        }
+      }).catch(() => undefined);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }
   if (isHttpBackend()) {
     return httpBackend.onApphosts(cb);

--- a/src/Aspire.Deck/ui/src/api/deck.ts
+++ b/src/Aspire.Deck/ui/src/api/deck.ts
@@ -354,10 +354,37 @@ export function onResources(cb: (event: ResourcesEvent) => void): Unsubscribe {
     return unlisten;
   }
   if (isHttpBackend()) {
+    if (isAotBackend()) {
+      let cancelled = false;
+      let unsubscribe: Unsubscribe | null = null;
+      void nativeBackend.hasCapability("resources-live").then((supported) => {
+        if (cancelled) {
+          return;
+        }
+
+        unsubscribe = supported
+          ? nativeBackend.subscribeResources(
+              cb,
+              (status) => httpBackend.reportResourceConnection(status, nativeBackend.getConfig),
+              (retry) => httpBackend.registerResourceRetry(retry),
+            )
+          : httpBackend.onResources(cb, listResources, nativeBackend.getConfig);
+      }).catch((error: unknown) => {
+        httpBackend.reportResourceConnection({
+          target: "resourceService",
+          state: "error",
+          message: error instanceof Error ? error.message : String(error),
+        }, nativeBackend.getConfig);
+      });
+
+      return () => {
+        cancelled = true;
+        unsubscribe?.();
+      };
+    }
+
     return httpBackend.onResources(
       cb,
-      isAotBackend() ? listResources : undefined,
-      isAotBackend() ? nativeBackend.getConfig : undefined,
     );
   }
   return mockBackend.onResources(cb);

--- a/src/Aspire.Deck/ui/src/api/http.ts
+++ b/src/Aspire.Deck/ui/src/api/http.ts
@@ -230,12 +230,15 @@ function toApphost(config: DeckConfig): AppHostInfo {
   };
 }
 
-function setResourceConnection(status: ConnectionStatus): void {
+function setResourceConnection(
+  status: ConnectionStatus,
+  loadConfig: () => Promise<DeckConfig> = getConfig,
+): void {
   connectionStatuses.resourceService = status;
   for (const listener of connectionListeners) {
     listener(status);
   }
-  void getConfig().then((config) => {
+  void loadConfig().then((config) => {
     const apphosts = [toApphost(config)];
     for (const listener of apphostListeners) {
       listener(apphosts);
@@ -243,7 +246,11 @@ function setResourceConnection(status: ConnectionStatus): void {
   }).catch(() => undefined);
 }
 
-function onResources(callback: (event: ResourcesEvent) => void): Unsubscribe {
+function onResources(
+  callback: (event: ResourcesEvent) => void,
+  getResources: () => Promise<Resource[]> = listResources,
+  loadConfig: () => Promise<DeckConfig> = getConfig,
+): Unsubscribe {
   let cancelled = false;
   let timer: number | undefined;
   let polling = false;
@@ -254,10 +261,10 @@ function onResources(callback: (event: ResourcesEvent) => void): Unsubscribe {
     }
     polling = true;
     try {
-      const resources = await listResources();
+      const resources = await getResources();
       if (!cancelled) {
         callback({ type: "snapshot", resources });
-        setResourceConnection({ target: "resourceService", state: "connected" });
+        setResourceConnection({ target: "resourceService", state: "connected" }, loadConfig);
       }
     } catch (error) {
       if (!cancelled) {
@@ -265,7 +272,7 @@ function onResources(callback: (event: ResourcesEvent) => void): Unsubscribe {
           target: "resourceService",
           state: "error",
           message: error instanceof Error ? error.message : String(error),
-        });
+        }, loadConfig);
       }
     } finally {
       polling = false;
@@ -280,7 +287,7 @@ function onResources(callback: (event: ResourcesEvent) => void): Unsubscribe {
       window.clearTimeout(timer);
       timer = undefined;
     }
-    setResourceConnection({ target: "resourceService", state: "connecting" });
+    setResourceConnection({ target: "resourceService", state: "connecting" }, loadConfig);
     void poll();
   };
   retryResourceConnection = retry;
@@ -304,18 +311,21 @@ function onConnection(callback: (status: ConnectionStatus) => void): Unsubscribe
   return () => connectionListeners.delete(callback);
 }
 
-function listApphosts(): Promise<AppHostInfo[]> {
-  return getConfig().then((config) => [toApphost(config)]);
+function listApphosts(loadConfig: () => Promise<DeckConfig> = getConfig): Promise<AppHostInfo[]> {
+  return loadConfig().then((config) => [toApphost(config)]);
 }
 
-function onApphosts(callback: (apphosts: AppHostInfo[]) => void): Unsubscribe {
+function onApphosts(
+  callback: (apphosts: AppHostInfo[]) => void,
+  loadConfig: () => Promise<DeckConfig> = getConfig,
+): Unsubscribe {
   apphostListeners.add(callback);
-  void listApphosts().then(callback).catch((error) => {
+  void listApphosts(loadConfig).then(callback).catch((error) => {
     setResourceConnection({
       target: "resourceService",
       state: "error",
       message: error instanceof Error ? error.message : String(error),
-    });
+    }, loadConfig);
   });
   return () => apphostListeners.delete(callback);
 }

--- a/src/Aspire.Deck/ui/src/api/http.ts
+++ b/src/Aspire.Deck/ui/src/api/http.ts
@@ -657,6 +657,15 @@ export const httpBackend = {
   retryConnection(): void {
     retryResourceConnection?.();
   },
+  reportResourceConnection(
+    status: ConnectionStatus,
+    loadConfig: () => Promise<DeckConfig> = getConfig,
+  ): void {
+    setResourceConnection(status, loadConfig);
+  },
+  registerResourceRetry(retry: (() => void) | null): void {
+    retryResourceConnection = retry;
+  },
   getManageData,
   exportManageData,
   importManageData,

--- a/src/Aspire.Deck/ui/src/api/native.ts
+++ b/src/Aspire.Deck/ui/src/api/native.ts
@@ -1,15 +1,25 @@
+import {
+  HubConnectionBuilder,
+  HubConnectionState,
+  LogLevel,
+  type HubConnection,
+  type ISubscription,
+} from "@microsoft/signalr";
 import type {
+  ConnectionStatus,
   DashboardApiDiscovery,
   DashboardApiVersion,
   DashboardConfiguration,
   DeckConfig,
   Resource,
+  ResourcesEvent,
 } from "./types";
 
 const dashboardProduct = "Aspire.Dashboard";
 const discoveryPath = "/api/dashboard";
 const configurationCapability = "configuration";
 const resourcesCapability = "resources";
+const resourceStreamCapability = "resources-live";
 const supportedVersions = new Set([1]);
 
 let negotiatedVersion: Promise<DashboardApiVersion> | null = null;
@@ -140,8 +150,172 @@ async function listResources(): Promise<Resource[]> {
   return payload as Resource[];
 }
 
+function isResourcesEvent(value: unknown): value is ResourcesEvent {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<ResourcesEvent>;
+  return candidate.type === "snapshot"
+    ? Array.isArray(candidate.resources)
+    : candidate.type === "change"
+      && Array.isArray(candidate.upserts)
+      && Array.isArray(candidate.deletes);
+}
+
+function subscribeResources(
+  callback: (event: ResourcesEvent) => void,
+  reportConnection: (status: ConnectionStatus) => void,
+  registerRetry: (retry: (() => void) | null) => void,
+): () => void {
+  let cancelled = false;
+  let starting = false;
+  let retryTimer: number | undefined;
+  let connection: HubConnection | null = null;
+  let streamSubscription: ISubscription<ResourcesEvent> | null = null;
+
+  const reportError = (error: unknown): void => {
+    reportConnection({
+      target: "resourceService",
+      state: "error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  };
+
+  const stopForStreamError = (error: unknown): void => {
+    if (cancelled) {
+      return;
+    }
+
+    reportError(error);
+    if (connection?.state === HubConnectionState.Connected) {
+      void connection.stop();
+    }
+  };
+
+  const beginStream = (): void => {
+    if (cancelled || connection?.state !== HubConnectionState.Connected) {
+      return;
+    }
+
+    streamSubscription?.dispose();
+    let receivedSnapshot = false;
+    streamSubscription = connection.stream<ResourcesEvent>("WatchResources").subscribe({
+      next: (event) => {
+        if (!isResourcesEvent(event)) {
+          stopForStreamError(new Error("Dashboard resource stream returned an incompatible event."));
+          return;
+        }
+        if (!receivedSnapshot && event.type !== "snapshot") {
+          stopForStreamError(new Error("Dashboard resource stream sent a change before its initial snapshot."));
+          return;
+        }
+
+        receivedSnapshot = true;
+        callback(event);
+        reportConnection({ target: "resourceService", state: "connected" });
+      },
+      error: (error) => {
+        streamSubscription = null;
+        if (connection?.state === HubConnectionState.Connected) {
+          stopForStreamError(error);
+        }
+      },
+      complete: () => {
+        streamSubscription = null;
+        if (connection?.state === HubConnectionState.Connected) {
+          stopForStreamError(new Error("Dashboard resource stream ended unexpectedly."));
+        }
+      },
+    });
+  };
+
+  const scheduleStart = (): void => {
+    if (cancelled || retryTimer !== undefined) {
+      return;
+    }
+
+    retryTimer = window.setTimeout(() => {
+      retryTimer = undefined;
+      void start();
+    }, 1_000);
+  };
+
+  const start = async (): Promise<void> => {
+    if (cancelled || starting || (connection !== null && connection.state !== HubConnectionState.Disconnected)) {
+      return;
+    }
+
+    starting = true;
+    reportConnection({ target: "resourceService", state: "connecting" });
+    try {
+      if (connection === null) {
+        const version = await getNegotiatedVersion();
+        if (!version.capabilities.includes(resourceStreamCapability)) {
+          throw new Error("Dashboard API version 1 does not advertise the live resources capability.");
+        }
+
+        connection = new HubConnectionBuilder()
+          .withUrl(`${version.basePath}/resources/live`, { withCredentials: true })
+          .withAutomaticReconnect([0, 1_000, 2_000, 5_000])
+          .configureLogging(LogLevel.None)
+          .build();
+        connection.onreconnecting((error) => {
+          streamSubscription = null;
+          reportConnection({
+            target: "resourceService",
+            state: "connecting",
+            message: error?.message,
+          });
+        });
+        connection.onreconnected(() => beginStream());
+        connection.onclose((error) => {
+          streamSubscription = null;
+          if (!cancelled) {
+            if (error !== undefined) {
+              reportError(error);
+            }
+            scheduleStart();
+          }
+        });
+      }
+
+      await connection.start();
+      beginStream();
+    } catch (error) {
+      if (!cancelled) {
+        reportError(error);
+        scheduleStart();
+      }
+    } finally {
+      starting = false;
+    }
+  };
+
+  const retry = (): void => {
+    if (retryTimer !== undefined) {
+      window.clearTimeout(retryTimer);
+      retryTimer = undefined;
+    }
+    void start();
+  };
+
+  registerRetry(retry);
+  void start();
+  return () => {
+    cancelled = true;
+    registerRetry(null);
+    if (retryTimer !== undefined) {
+      window.clearTimeout(retryTimer);
+    }
+    streamSubscription?.dispose();
+    void connection?.stop();
+  };
+}
+
 export const nativeBackend = {
   getConfig,
   hasCapability,
   listResources,
+  subscribeResources,
 };

--- a/src/Aspire.Deck/ui/src/api/native.ts
+++ b/src/Aspire.Deck/ui/src/api/native.ts
@@ -3,11 +3,13 @@ import type {
   DashboardApiVersion,
   DashboardConfiguration,
   DeckConfig,
+  Resource,
 } from "./types";
 
 const dashboardProduct = "Aspire.Dashboard";
 const discoveryPath = "/api/dashboard";
 const configurationCapability = "configuration";
+const resourcesCapability = "resources";
 const supportedVersions = new Set([1]);
 
 let negotiatedVersion: Promise<DashboardApiVersion> | null = null;
@@ -120,6 +122,26 @@ function getConfig(): Promise<DeckConfig> {
   return configuration;
 }
 
+async function hasCapability(capability: string): Promise<boolean> {
+  return (await getNegotiatedVersion()).capabilities.includes(capability);
+}
+
+async function listResources(): Promise<Resource[]> {
+  const version = await getNegotiatedVersion();
+  if (!version.capabilities.includes(resourcesCapability)) {
+    throw new Error("Dashboard API version 1 does not advertise the resources capability.");
+  }
+
+  const payload = await requestJson(`${version.basePath}/resources`);
+  if (!Array.isArray(payload)) {
+    throw new Error("Dashboard API resources returned an incompatible payload.");
+  }
+
+  return payload as Resource[];
+}
+
 export const nativeBackend = {
   getConfig,
+  hasCapability,
+  listResources,
 };

--- a/src/Aspire.Deck/ui/src/api/native.ts
+++ b/src/Aspire.Deck/ui/src/api/native.ts
@@ -1,0 +1,125 @@
+import type {
+  DashboardApiDiscovery,
+  DashboardApiVersion,
+  DashboardConfiguration,
+  DeckConfig,
+} from "./types";
+
+const dashboardProduct = "Aspire.Dashboard";
+const discoveryPath = "/api/dashboard";
+const configurationCapability = "configuration";
+const supportedVersions = new Set([1]);
+
+let negotiatedVersion: Promise<DashboardApiVersion> | null = null;
+let configuration: Promise<DeckConfig> | null = null;
+
+async function requestJson(path: string): Promise<unknown> {
+  const response = await fetch(path, {
+    cache: "no-store",
+    credentials: "same-origin",
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`Dashboard API request failed with ${response.status} ${response.statusText}.`);
+  }
+
+  return await response.json() as unknown;
+}
+
+function isVersion(value: unknown): value is DashboardApiVersion {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<DashboardApiVersion>;
+  return Number.isInteger(candidate.version)
+    && typeof candidate.basePath === "string"
+    && Array.isArray(candidate.capabilities)
+    && candidate.capabilities.every((capability) => typeof capability === "string");
+}
+
+function validateBasePath(basePath: string): string {
+  const url = new URL(basePath, window.location.origin);
+  if (url.origin !== window.location.origin
+      || !url.pathname.startsWith(`${discoveryPath}/`)
+      || url.search !== ""
+      || url.hash !== "") {
+    throw new Error(`Dashboard API returned an invalid version base path: ${basePath}.`);
+  }
+
+  return url.pathname.replace(/\/$/, "");
+}
+
+async function negotiateVersion(): Promise<DashboardApiVersion> {
+  const payload = await requestJson(discoveryPath) as Partial<DashboardApiDiscovery>;
+  if (payload.product !== dashboardProduct || !Array.isArray(payload.versions)) {
+    throw new Error("Dashboard API discovery returned an incompatible product or payload.");
+  }
+
+  const version = payload.versions
+    .filter(isVersion)
+    .filter((candidate) => supportedVersions.has(candidate.version))
+    .filter((candidate) => candidate.capabilities.includes(configurationCapability))
+    .sort((left, right) => right.version - left.version)[0];
+  if (version === undefined) {
+    const advertised = payload.versions
+      .filter(isVersion)
+      .map((candidate) => candidate.version)
+      .sort((left, right) => right - left)
+      .join(", ") || "none";
+    throw new Error(`Dashboard API has no compatible configuration version (server: ${advertised}; client: 1).`);
+  }
+
+  return { ...version, basePath: validateBasePath(version.basePath) };
+}
+
+function getNegotiatedVersion(): Promise<DashboardApiVersion> {
+  if (negotiatedVersion === null) {
+    const request = negotiateVersion();
+    negotiatedVersion = request;
+    void request.catch(() => {
+      if (negotiatedVersion === request) {
+        negotiatedVersion = null;
+      }
+    });
+  }
+
+  return negotiatedVersion;
+}
+
+async function loadConfig(): Promise<DeckConfig> {
+  const version = await getNegotiatedVersion();
+  const payload = await requestJson(`${version.basePath}/config`) as Partial<DashboardConfiguration>;
+  if (typeof payload.applicationName !== "string"
+      || typeof payload.dashboardVersion !== "string"
+      || typeof payload.runtimeVersion !== "string") {
+    throw new Error("Dashboard API configuration returned an incompatible payload.");
+  }
+
+  return {
+    applicationName: payload.applicationName,
+    resourceServiceUrl: null,
+    otlpGrpcUrl: null,
+    otlpHttpUrl: null,
+    version: payload.dashboardVersion,
+    runtimeVersion: payload.runtimeVersion,
+  };
+}
+
+function getConfig(): Promise<DeckConfig> {
+  if (configuration === null) {
+    const request = loadConfig();
+    configuration = request;
+    void request.catch(() => {
+      if (configuration === request) {
+        configuration = null;
+      }
+    });
+  }
+
+  return configuration;
+}
+
+export const nativeBackend = {
+  getConfig,
+};

--- a/src/Aspire.Deck/ui/src/api/types.ts
+++ b/src/Aspire.Deck/ui/src/api/types.ts
@@ -19,6 +19,25 @@ export interface DeckConfig {
   isAssistantEnabled?: boolean;
 }
 
+// Versioned ASP.NET backend discovery types. Keep these aligned with the
+// versioned contract in ../../CONTRACT.md rather than the legacy /api/deck shapes.
+export interface DashboardApiDiscovery {
+  product: string;
+  versions: DashboardApiVersion[];
+}
+
+export interface DashboardApiVersion {
+  version: number;
+  basePath: string;
+  capabilities: string[];
+}
+
+export interface DashboardConfiguration {
+  applicationName: string;
+  dashboardVersion: string;
+  runtimeVersion: string;
+}
+
 export interface DeckUser {
   name: string;
   username: string | null;

--- a/src/Aspire.Deck/ui/src/lib/useDeckEvent.ts
+++ b/src/Aspire.Deck/ui/src/lib/useDeckEvent.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   onApphosts,
   onConnection,
@@ -25,38 +25,89 @@ const INITIAL_CONNECTION: ConnectionMap = {
   otlpHttp: "connecting",
 };
 
-// Subscribes to live resource events and maintains a name-keyed map, applying
-// snapshots and incremental change deltas from the backend.
-export function useResources(): { resources: Resource[]; ready: boolean } {
-  const [resources, setResources] = useState<Resource[]>([]);
-  const [ready, setReady] = useState(false);
-  const mapRef = useRef<Map<string, Resource>>(new Map());
+interface ResourceStoreSnapshot {
+  resources: Resource[];
+  ready: boolean;
+}
+
+const resourceMap = new Map<string, Resource>();
+const resourceListeners = new Set<() => void>();
+let resourceSubscription: (() => void) | null = null;
+let resourceSubscriptionTimer: number | undefined;
+let resourceSnapshot: ResourceStoreSnapshot = { resources: [], ready: false };
+
+function applyResourceEvent(event: ResourcesEvent): void {
+  if (event.type === "snapshot") {
+    resourceMap.clear();
+    for (const resource of event.resources ?? []) {
+      resourceMap.set(resource.name, resource);
+    }
+  } else {
+    for (const resource of event.upserts ?? []) {
+      resourceMap.set(resource.name, resource);
+    }
+    for (const name of event.deletes ?? []) {
+      resourceMap.delete(name);
+    }
+  }
+
+  resourceSnapshot = { resources: Array.from(resourceMap.values()), ready: true };
+  for (const listener of resourceListeners) {
+    listener();
+  }
+}
+
+function subscribeResourceStore(listener: () => void): () => void {
+  resourceListeners.add(listener);
+  // Several mounted pages consume the resource inventory at once. Keep one backend
+  // subscription so HTTP polling and SignalR connections are not multiplied per hook.
+  // Deferring its creation also lets React Strict Mode finish its synthetic unmount/remount
+  // without starting a request that it immediately has to abort.
+  if (resourceSubscription === null && resourceSubscriptionTimer === undefined) {
+    resourceSubscriptionTimer = window.setTimeout(() => {
+      resourceSubscriptionTimer = undefined;
+      if (resourceListeners.size > 0 && resourceSubscription === null) {
+        resourceSubscription = onResources(applyResourceEvent);
+      }
+    });
+  }
+
+  return () => {
+    resourceListeners.delete(listener);
+    if (resourceListeners.size === 0) {
+      if (resourceSubscriptionTimer !== undefined) {
+        window.clearTimeout(resourceSubscriptionTimer);
+        resourceSubscriptionTimer = undefined;
+      }
+      resourceSubscription?.();
+      resourceSubscription = null;
+      resourceMap.clear();
+      resourceSnapshot = { resources: [], ready: false };
+    }
+  };
+}
+
+function getResourceSnapshot(): ResourceStoreSnapshot {
+  return resourceSnapshot;
+}
+
+// Shares one live backend subscription while retaining hook-local snapshots. Priming each
+// consumer on the next task preserves the existing effect ordering for pages that open
+// additional streams after the resource inventory becomes available.
+export function useResources(): ResourceStoreSnapshot {
+  const [snapshot, setSnapshot] = useState<ResourceStoreSnapshot>({ resources: [], ready: false });
 
   useEffect(() => {
-    const apply = (event: ResourcesEvent): void => {
-      const map = mapRef.current;
-      if (event.type === "snapshot") {
-        map.clear();
-        for (const resource of event.resources ?? []) {
-          map.set(resource.name, resource);
-        }
-      } else {
-        for (const resource of event.upserts ?? []) {
-          map.set(resource.name, resource);
-        }
-        for (const name of event.deletes ?? []) {
-          map.delete(name);
-        }
-      }
-      setResources(Array.from(map.values()));
-      setReady(true);
+    const update = (): void => setSnapshot(getResourceSnapshot());
+    const unsubscribe = subscribeResourceStore(update);
+    const primeTimer = window.setTimeout(update);
+    return () => {
+      window.clearTimeout(primeTimer);
+      unsubscribe();
     };
-
-    const unsubscribe = onResources(apply);
-    return unsubscribe;
   }, []);
 
-  return { resources, ready };
+  return snapshot;
 }
 
 export function useConnection(): ConnectionMap {

--- a/src/Aspire.Deck/ui/vite.config.ts
+++ b/src/Aspire.Deck/ui/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 
 const dashboardUrl = process.env.ASPIRE_DASHBOARD_URL;
+const aotDashboardUrl = process.env.ASPIRE_DASHBOARD_AOT_URL;
 
 // Vite stamps `crossorigin` on the entry <script>/<link> tags. Under Tauri's custom
 // asset protocol (notably macOS WKWebView), a `crossorigin` request is treated as a
@@ -29,6 +30,13 @@ export default defineConfig({
     strictPort: true,
     proxy: dashboardUrl
       ? {
+          // The versioned AOT backend is independently selectable. All capabilities
+          // it has not advertised remain on the existing dashboard proxy below.
+          "/api/dashboard": {
+            target: aotDashboardUrl ?? dashboardUrl,
+            changeOrigin: true,
+            secure: false,
+          },
           "/api/deck": {
             target: dashboardUrl,
             changeOrigin: true,

--- a/src/Aspire.Deck/ui/vite.config.ts
+++ b/src/Aspire.Deck/ui/vite.config.ts
@@ -36,6 +36,8 @@ export default defineConfig({
             target: aotDashboardUrl ?? dashboardUrl,
             changeOrigin: true,
             secure: false,
+            ws: true,
+            rewriteWsOrigin: true,
           },
           "/api/deck": {
             target: dashboardUrl,

--- a/tests/Aspire.Dashboard.Backend.Tests/Aspire.Dashboard.Backend.Tests.csproj
+++ b/tests/Aspire.Dashboard.Backend.Tests/Aspire.Dashboard.Backend.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Dashboard.Backend\Aspire.Dashboard.Backend.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Dashboard.Backend.Tests/Aspire.Dashboard.Backend.Tests.csproj
+++ b/tests/Aspire.Dashboard.Backend.Tests/Aspire.Dashboard.Backend.Tests.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <!-- Must match the Native AOT backend, which targets net10.0 for SignalR AOT support. -->
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
   </ItemGroup>

--- a/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
+++ b/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
@@ -1,17 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using System.Text.Json;
+using Aspire.DashboardService.Proto.V1;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using ProtoResource = Aspire.DashboardService.Proto.V1.Resource;
 
 namespace Aspire.Dashboard.Backend.Tests;
 
 public class DashboardBackendApplicationTests
 {
     [Fact]
-    public async Task Discovery_AdvertisesOnlyVersionedConfigurationCapability()
+    public async Task Discovery_AdvertisesImplementedVersionedCapabilities()
     {
         await using var app = DashboardBackendApplication.Build([], builder => builder.WebHost.UseTestServer());
         await app.StartAsync(TestContext.Current.CancellationToken);
@@ -21,7 +26,7 @@ public class DashboardBackendApplicationTests
 
         response.EnsureSuccessStatusCode();
         Assert.Equal(
-            "{\"product\":\"Aspire.Dashboard\",\"versions\":[{\"version\":1,\"basePath\":\"/api/dashboard/v1\",\"capabilities\":[\"configuration\"]}]}",
+            "{\"product\":\"Aspire.Dashboard\",\"versions\":[{\"version\":1,\"basePath\":\"/api/dashboard/v1\",\"capabilities\":[\"configuration\",\"resources\"]}]}",
             await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 
@@ -49,5 +54,135 @@ public class DashboardBackendApplicationTests
         Assert.Equal("13.5.0-aot", root.GetProperty("dashboardVersion").GetString());
         Assert.StartsWith(".NET", root.GetProperty("runtimeVersion").GetString(), StringComparison.Ordinal);
         Assert.Equal(3, root.EnumerateObject().Count());
+    }
+
+    [Fact]
+    public async Task GetResources_ReturnsSourceGeneratedSnapshotFromVersionOneRoute()
+    {
+        DashboardResource[] resources =
+        [
+            new DashboardResource(
+                "api-abc123",
+                "Project",
+                "api",
+                "resource-1",
+                "Running",
+                "success",
+                "Healthy",
+                DateTime.Parse("2026-07-13T12:00:00Z"),
+                DateTime.Parse("2026-07-13T12:00:01Z"),
+                null,
+                [new("http", "https://api.example.test", false, false, "API", 1)],
+                [new("project.path", "Project path", "/src/api.csproj", false, true, 10)],
+                [new("ASPNETCORE_ENVIRONMENT", "Development", true)],
+                [new("Healthy", "ready", "Ready")],
+                [new("restart", "Restart", "Restart API", null, "ArrowCounterclockwise", "regular", true, "enabled")],
+                [new("postgres", "Reference")],
+                false,
+                true,
+                "Code",
+                "filled",
+                false,
+                null)
+        ];
+
+        await using var app = DashboardBackendApplication.Build([], builder =>
+        {
+            builder.WebHost.UseTestServer();
+            builder.Services.AddSingleton<IDashboardResourceSnapshotProvider>(new TestResourceSnapshotProvider(resources));
+        });
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/api/dashboard/v1/resources", TestContext.Current.CancellationToken);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal("no-store", response.Headers.CacheControl?.ToString());
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStreamAsync(TestContext.Current.CancellationToken));
+        var resource = Assert.Single(document.RootElement.EnumerateArray());
+        Assert.Equal("api-abc123", resource.GetProperty("name").GetString());
+        Assert.Equal("https://api.example.test", resource.GetProperty("urls")[0].GetProperty("url").GetString());
+        Assert.Equal("/src/api.csproj", resource.GetProperty("properties")[0].GetProperty("value").GetString());
+        Assert.Equal("enabled", resource.GetProperty("commands")[0].GetProperty("state").GetString());
+        Assert.Equal(22, resource.EnumerateObject().Count());
+    }
+
+    [Fact]
+    public async Task GetResources_ReturnsServiceUnavailableWithoutResourceServiceConfiguration()
+    {
+        await using var app = DashboardBackendApplication.Build([], builder => builder.WebHost.UseTestServer());
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/api/dashboard/v1/resources", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Contains("ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResourceMapper_ProjectsResourceServiceContractWithoutDashboardDependencies()
+    {
+        var resource = new ProtoResource
+        {
+            Name = "worker-xyz",
+            ResourceType = "Executable",
+            DisplayName = "worker",
+            Uid = "resource-2",
+            State = "Running",
+            StateStyle = "success",
+            CreatedAt = Timestamp.FromDateTime(DateTime.Parse("2026-07-13T12:00:00Z").ToUniversalTime()),
+            StartedAt = Timestamp.FromDateTime(DateTime.Parse("2026-07-13T12:00:01Z").ToUniversalTime()),
+            SupportsDetailedTelemetry = true,
+            IconName = "WindowConsole",
+            IconVariant = IconVariant.Filled
+        };
+        resource.Urls.Add(new Url
+        {
+            EndpointName = "http",
+            FullUrl = "http://localhost:5000",
+            DisplayProperties = new UrlDisplayProperties { DisplayName = "HTTP", SortOrder = 2 }
+        });
+        resource.Properties.Add(new ResourceProperty
+        {
+            Name = "terminal.enabled",
+            Value = Value.ForString("true")
+        });
+        resource.Properties.Add(new ResourceProperty
+        {
+            Name = "terminal.replicaIndex",
+            Value = Value.ForString("3")
+        });
+        resource.HealthReports.Add(new HealthReport
+        {
+            Key = "live",
+            Status = HealthStatus.Degraded,
+            Description = "Slow"
+        });
+        resource.Commands.Add(new ResourceCommand
+        {
+            Name = "restart",
+            DisplayName = "Restart",
+            IconVariant = IconVariant.Regular,
+            State = ResourceCommandState.Disabled
+        });
+
+        var result = DashboardResourceSnapshotService.Map(resource);
+
+        Assert.Equal("worker", result.DisplayName);
+        Assert.Equal("Degraded", result.Health);
+        Assert.True(result.HasTerminal);
+        Assert.Equal(3, result.TerminalReplicaIndex);
+        Assert.Equal("filled", result.IconVariant);
+        Assert.Equal("disabled", Assert.Single(result.Commands).State);
+        Assert.Equal("HTTP", Assert.Single(result.Urls).DisplayName);
+    }
+
+    private sealed class TestResourceSnapshotProvider(DashboardResource[] resources) : IDashboardResourceSnapshotProvider
+    {
+        public ValueTask<DashboardResource[]> GetSnapshotAsync(CancellationToken cancellationToken)
+        {
+            return ValueTask.FromResult(resources);
+        }
     }
 }

--- a/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
+++ b/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Aspire.DashboardService.Proto.V1;
@@ -169,6 +170,60 @@ public class DashboardBackendApplicationTests
 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
         Assert.Contains("ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetResources_ReturnsServiceUnavailableWhenConfiguredResourceServiceCannotConnect()
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        var endpoint = (IPEndPoint)socket.LocalEndPoint!;
+
+        await using var app = DashboardBackendApplication.Build([], builder =>
+        {
+            builder.WebHost.UseTestServer();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"] = $"http://127.0.0.1:{endpoint.Port}",
+                ["DashboardBackend:InitialSnapshotTimeout"] = "00:00:01"
+            });
+        });
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/api/dashboard/v1/resources", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Contains("will keep retrying", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResourceSnapshot_RecoversAfterInitialConnectionFailure()
+    {
+        var service = new DashboardResourceSnapshotService(
+            new ConfigurationBuilder().Build(),
+            NullLoggerFactory.Instance,
+            NullLogger<DashboardResourceSnapshotService>.Instance);
+        service.ReportInitialFailure("Unavailable");
+
+        var exception = await Assert.ThrowsAsync<DashboardResourceServiceUnavailableException>(async () =>
+            await service.GetSnapshotAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("Unavailable", exception.Message);
+
+        var initialUpdate = new WatchResourcesUpdate
+        {
+            InitialData = new InitialResourceData()
+        };
+        initialUpdate.InitialData.Resources.Add(new ProtoResource
+        {
+            Name = "api",
+            DisplayName = "API",
+            ResourceType = "Project",
+            Uid = "resource-1"
+        });
+        service.ApplyUpdate(initialUpdate);
+
+        Assert.Equal("api", Assert.Single(await service.GetSnapshotAsync(TestContext.Current.CancellationToken)).Name);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
+++ b/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Aspire.DashboardService.Proto.V1;
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using ProtoResource = Aspire.DashboardService.Proto.V1.Resource;
 
@@ -26,7 +30,7 @@ public class DashboardBackendApplicationTests
 
         response.EnsureSuccessStatusCode();
         Assert.Equal(
-            "{\"product\":\"Aspire.Dashboard\",\"versions\":[{\"version\":1,\"basePath\":\"/api/dashboard/v1\",\"capabilities\":[\"configuration\",\"resources\"]}]}",
+            "{\"product\":\"Aspire.Dashboard\",\"versions\":[{\"version\":1,\"basePath\":\"/api/dashboard/v1\",\"capabilities\":[\"configuration\",\"resources\",\"resources-live\"]}]}",
             await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 
@@ -206,11 +210,148 @@ public class DashboardBackendApplicationTests
             property => Assert.Equal("terminal.replicaIndex", property.Name));
     }
 
+    [Fact]
+    public async Task ResourceEventSource_SendsSnapshotBeforeIncrementalChanges()
+    {
+        var service = new DashboardResourceSnapshotService(
+            new ConfigurationBuilder().Build(),
+            NullLoggerFactory.Instance,
+            NullLogger<DashboardResourceSnapshotService>.Instance);
+        var initialResource = new ProtoResource
+        {
+            Name = "api",
+            DisplayName = "API",
+            ResourceType = "Project",
+            Uid = "resource-1",
+            State = "Starting"
+        };
+        var initialUpdate = new WatchResourcesUpdate
+        {
+            InitialData = new InitialResourceData()
+        };
+        initialUpdate.InitialData.Resources.Add(initialResource);
+        service.ApplyUpdate(initialUpdate);
+
+        await using var events = service
+            .WatchAsync(TestContext.Current.CancellationToken)
+            .GetAsyncEnumerator(TestContext.Current.CancellationToken);
+
+        Assert.True(await events.MoveNextAsync());
+        var snapshot = events.Current;
+        Assert.Equal("snapshot", snapshot.Type);
+        Assert.Equal("Starting", Assert.Single(snapshot.Resources!).State);
+        Assert.Null(snapshot.Upserts);
+        Assert.Null(snapshot.Deletes);
+
+        var updatedResource = initialResource.Clone();
+        updatedResource.State = "Running";
+        var changes = new WatchResourcesUpdate
+        {
+            Changes = new WatchResourcesChanges()
+        };
+        changes.Changes.Value.Add(new WatchResourcesChange { Upsert = updatedResource });
+        changes.Changes.Value.Add(new WatchResourcesChange
+        {
+            Delete = new ResourceDeletion { ResourceName = "worker", ResourceType = "Project" }
+        });
+        service.ApplyUpdate(changes);
+
+        Assert.True(await events.MoveNextAsync());
+        var change = events.Current;
+        Assert.Equal("change", change.Type);
+        Assert.Equal("Running", Assert.Single(change.Upserts!).State);
+        Assert.Equal("worker", Assert.Single(change.Deletes!));
+        Assert.Null(change.Resources);
+    }
+
+    [Fact]
+    public async Task ResourceHub_StreamsSourceGeneratedSnapshotAndChanges()
+    {
+        DashboardResource[] resources =
+        [
+            new DashboardResource(
+                "api",
+                "Project",
+                "API",
+                "resource-1",
+                "Running",
+                "success",
+                "Healthy",
+                null,
+                null,
+                null,
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                false,
+                true,
+                "Code",
+                "regular",
+                false,
+                null)
+        ];
+        DashboardResourcesEvent[] resourceEvents =
+        [
+            DashboardResourcesEvent.Snapshot(resources),
+            DashboardResourcesEvent.Change(resources, ["worker"])
+        ];
+
+        await using var app = DashboardBackendApplication.Build([], builder =>
+        {
+            builder.WebHost.UseTestServer();
+            builder.Services.AddSingleton<IDashboardResourceEventSource>(new TestResourceEventSource(resourceEvents));
+        });
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        await using var connection = new HubConnectionBuilder()
+            .WithUrl($"http://localhost{DashboardApiContract.ResourceStreamPath}", options =>
+            {
+                options.HttpMessageHandlerFactory = _ => app.GetTestServer().CreateHandler();
+                options.Transports = HttpTransportType.LongPolling;
+            })
+            .AddJsonProtocol(options =>
+            {
+                options.PayloadSerializerOptions.TypeInfoResolverChain.Insert(0, DashboardBackendJsonSerializerContext.Default);
+            })
+            .Build();
+        await connection.StartAsync(TestContext.Current.CancellationToken);
+
+        await using var events = connection
+            .StreamAsync<DashboardResourcesEvent>(nameof(DashboardResourcesHub.WatchResources), TestContext.Current.CancellationToken)
+            .GetAsyncEnumerator(TestContext.Current.CancellationToken);
+
+        Assert.True(await events.MoveNextAsync());
+        Assert.Equal("snapshot", events.Current.Type);
+        Assert.Equal("api", Assert.Single(events.Current.Resources!).Name);
+
+        Assert.True(await events.MoveNextAsync());
+        Assert.Equal("change", events.Current.Type);
+        Assert.Equal("api", Assert.Single(events.Current.Upserts!).Name);
+        Assert.Equal("worker", Assert.Single(events.Current.Deletes!));
+    }
+
     private sealed class TestResourceSnapshotProvider(DashboardResource[] resources) : IDashboardResourceSnapshotProvider
     {
         public ValueTask<DashboardResource[]> GetSnapshotAsync(CancellationToken cancellationToken)
         {
             return ValueTask.FromResult(resources);
+        }
+    }
+
+    private sealed class TestResourceEventSource(DashboardResourcesEvent[] events) : IDashboardResourceEventSource
+    {
+        public async IAsyncEnumerable<DashboardResourcesEvent> WatchAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var resourceEvent in events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return resourceEvent;
+                await Task.Yield();
+            }
         }
     }
 }

--- a/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
+++ b/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
@@ -34,6 +34,53 @@ public class DashboardBackendApplicationTests
             await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("null")]
+    [InlineData("file://")]
+    public async Task DevelopmentAccessPolicy_RejectsNonLoopbackBrowserOrigins(string origin)
+    {
+        await using var app = DashboardBackendApplication.Build([], builder => builder.WebHost.UseTestServer());
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var client = app.GetTestClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, DashboardApiContract.DiscoveryPath);
+        request.Headers.TryAddWithoutValidation("Origin", origin);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:1430")]
+    [InlineData("https://Stress.dev.localhost:49985")]
+    [InlineData("http://127.0.0.1:1430")]
+    [InlineData("http://[::1]:1430")]
+    public async Task DevelopmentAccessPolicy_AllowsLoopbackBrowserOrigins(string origin)
+    {
+        await using var app = DashboardBackendApplication.Build([], builder => builder.WebHost.UseTestServer());
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var client = app.GetTestClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, DashboardApiContract.DiscoveryPath);
+        request.Headers.TryAddWithoutValidation("Origin", origin);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1", true)]
+    [InlineData("127.42.0.1", true)]
+    [InlineData("::1", true)]
+    [InlineData("::ffff:127.0.0.1", true)]
+    [InlineData("192.168.1.10", false)]
+    [InlineData("2001:db8::1", false)]
+    public void DevelopmentAccessPolicy_RestrictsConnectionsToLoopback(string address, bool expected)
+    {
+        Assert.Equal(expected, DashboardDevelopmentAccessPolicy.IsLoopback(IPAddress.Parse(address)));
+    }
+
     [Fact]
     public async Task GetConfiguration_ReturnsConfiguredIdentityFromVersionOneRoute()
     {

--- a/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
+++ b/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
@@ -153,6 +153,18 @@ public class DashboardBackendApplicationTests
             Name = "terminal.replicaIndex",
             Value = Value.ForString("3")
         });
+        resource.Properties.Add(new ResourceProperty
+        {
+            Name = "resource.state",
+            Value = Value.ForString("Running")
+        });
+        resource.Properties.Add(new ResourceProperty
+        {
+            Name = "executable.pid",
+            DisplayName = "Process ID",
+            Value = Value.ForString("123"),
+            SortOrder = 2
+        });
         resource.HealthReports.Add(new HealthReport
         {
             Key = "live",
@@ -176,6 +188,22 @@ public class DashboardBackendApplicationTests
         Assert.Equal("filled", result.IconVariant);
         Assert.Equal("disabled", Assert.Single(result.Commands).State);
         Assert.Equal("HTTP", Assert.Single(result.Urls).DisplayName);
+        Assert.Equal("http://localhost:5000/", Assert.Single(result.Urls).Url);
+        Assert.Collection(
+            result.Properties,
+            property =>
+            {
+                Assert.Equal("resource.state", property.Name);
+                Assert.Equal("State", property.DisplayName);
+                Assert.Equal(1, property.SortOrder);
+            },
+            property =>
+            {
+                Assert.Equal("executable.pid", property.Name);
+                Assert.Equal(9, property.SortOrder);
+            },
+            property => Assert.Equal("terminal.enabled", property.Name),
+            property => Assert.Equal("terminal.replicaIndex", property.Name));
     }
 
     private sealed class TestResourceSnapshotProvider(DashboardResource[] resources) : IDashboardResourceSnapshotProvider

--- a/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
+++ b/tests/Aspire.Dashboard.Backend.Tests/DashboardBackendApplicationTests.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Aspire.Dashboard.Backend.Tests;
+
+public class DashboardBackendApplicationTests
+{
+    [Fact]
+    public async Task Discovery_AdvertisesOnlyVersionedConfigurationCapability()
+    {
+        await using var app = DashboardBackendApplication.Build([], builder => builder.WebHost.UseTestServer());
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/api/dashboard", TestContext.Current.CancellationToken);
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(
+            "{\"product\":\"Aspire.Dashboard\",\"versions\":[{\"version\":1,\"basePath\":\"/api/dashboard/v1\",\"capabilities\":[\"configuration\"]}]}",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetConfiguration_ReturnsConfiguredIdentityFromVersionOneRoute()
+    {
+        await using var app = DashboardBackendApplication.Build([], builder =>
+        {
+            builder.WebHost.UseTestServer();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DashboardBackend:ApplicationName"] = "Stress AppHost",
+                ["DashboardBackend:Version"] = "13.5.0-aot"
+            });
+        });
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/api/dashboard/v1/config", TestContext.Current.CancellationToken);
+
+        response.EnsureSuccessStatusCode();
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStreamAsync(TestContext.Current.CancellationToken));
+        var root = document.RootElement;
+        Assert.Equal("Stress AppHost", root.GetProperty("applicationName").GetString());
+        Assert.Equal("13.5.0-aot", root.GetProperty("dashboardVersion").GetString());
+        Assert.StartsWith(".NET", root.GetProperty("runtimeVersion").GetString(), StringComparison.Ordinal);
+        Assert.Equal(3, root.EnumerateObject().Count());
+    }
+}


### PR DESCRIPTION
## Description

Starts the next dashboard migration phase without replacing the existing Blazor dashboard or its backend.

This adds a separately runnable ASP.NET Core Native AOT host with:

- `GET /api/dashboard` discovery for explicit version and capability negotiation.
- Version 1 `configuration`, `resources`, and `resources-live` capabilities.
- A read-only resource snapshot maintained from the existing AppHost dashboard service.
- A SignalR `WatchResources` server stream that sends an atomic authoritative snapshot followed by incremental upserts and deletes.
- Source-generated JSON serialization for every HTTP and SignalR contract payload.
- Loopback connection and browser-origin enforcement while frontend authentication remains on the existing dashboard.
- Bounded initial resource-service startup: callers receive `503 Service Unavailable` while the host keeps retrying and can recover in place.
- A documented strangler boundary: capabilities are advertised only after they work end to end.

Deck can select the slice with `?backend=aot`. React negotiates and reads configuration from the new host, then consumes live resource updates through SignalR with automatic reconnection and a fresh snapshot on each stream. A compatible host that does not advertise `resources-live` continues to use the versioned HTTP resource snapshot. Telemetry, commands, interactions, authentication, and terminal traffic continue through the existing `/api/deck` backend. The existing `?backend=http` path and Blazor dashboard remain intact.

The standalone host and its tests target .NET 10 because SignalR server trimming and Native AOT support begins in .NET 9. This does not change the target framework or runtime of the existing dashboard.

This remains an intentionally narrow, independently useful slice. Follow-up changes can move capabilities one at a time behind the versioned contract and the 157-feature parity inventory.

## Validation

- Restored the repository with `./restore.sh` before building.
- Passed 22/22 `Aspire.Dashboard.Backend.Tests`, including access-policy, unavailable-resource-service, recovery, snapshot-before-delta, and real SignalR client/server-stream coverage.
- Published the final host with Native AOT for `osx-arm64` with no AOT or trimming warnings.
- Passed the Deck TypeScript/Vite production build.
- Passed 105/105 default Playwright scenarios, including the parity-ledger assertion at exactly 157 features.
- Passed 29/29 HTTP/AOT adapter scenarios. The SignalR case requires exactly one WebSocket resource stream, verifies a snapshot and subsequent change, and asserts the HTTP polling route is unused.
- Passed all 23 live Stress behaviors in 11/11 Playwright scenarios against the final published Native AOT executable. This exercised AOT version negotiation and SignalR resources alongside the existing dashboard fallback for commands, parameters, console, structured logs, traces, metrics, navigation, and responsive layout.
- Ran the 157-feature legacy black-box inventory against Stress. Every feature group passed in its intended fixture phase. The cold fixture preserves the unresolved-parameter assertions; after parameter initialization and `aspire wait`, the telemetry groups pass. The secure launch profile was required for the legacy `Dashboard (https)` assertion.
- Compared the live AOT and legacy resource payloads against Stress before this transport change: all 294 resources matched exactly, with no missing resources or field differences.
- Verified the SignalR transport side by side against Stress using the built-in browser and the published Native AOT executable:
  - React negotiated the AOT contract, opened one HTTP 101 WebSocket, rendered 30 visible Stress resources, and reported no browser errors.
  - Stopping `empty-0000` changed the filtered row from `Running · Healthy` to `Finished` within 500 ms without HTTP polling; restarting it restored `Running · Healthy`.
  - Stopping and restarting the AOT host showed the retained resource snapshot with an error/reconnect state, then recovered automatically.
  - The original Blazor dashboard remained runnable in a separate tab, rendered the same 30 visible Stress resources, and reported no browser errors.

The original package-file restriction was superseded by the explicit decision to use SignalR. `package.json` and `package-lock.json` change only to add the official `@microsoft/signalr` browser client. No changes were made to `global.json` or `NuGet.config`.

## Screenshots / recordings

There is no visual design change in this slice.

## Security considerations

The first migration slice does not yet own dashboard frontend authentication. Because the resource contract includes sensitive values used by explicit secret reveal, the AOT host rejects non-loopback connections and non-loopback browser origins. Its AppHost resource-service client supports the existing API-key and unsecured-development modes. Authentication, authorization, and sensitive or mutating capabilities remain on the existing backend until they are migrated and reviewed independently.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
