### PR TITLE
Add polyglot code-generator signal to pr-docs-check catalog

### DIFF
--- a/.github/workflows/pr-docs-check/compute_signals.py
+++ b/.github/workflows/pr-docs-check/compute_signals.py
@@ -145,7 +145,7 @@ PATH_TRIGGERS: list[tuple[str, str, str]] = [
     # because nothing in the catalog matched these paths — the RPC payload
     # was byte-identical and the PR carried no breaking wording or label.)
     ("polyglot_code_generator_changed", "any",
-     r"^src/(Aspire\.Hosting\.CodeGeneration\.[^/]+|Shared/CodeGeneration)/.+$")
+     r"^src/(Aspire\.Hosting\.CodeGeneration\.[^/]+|Shared/CodeGeneration)/.+$"),
     # Files whose name ends in `Defaults.cs` or `Constants.cs`
     # typically hold shipping default values (timeouts, retry
     # counts, well-known property names, image tags, etc.).

--- a/.github/workflows/pr-docs-check/compute_signals.py
+++ b/.github/workflows/pr-docs-check/compute_signals.py
@@ -145,7 +145,7 @@ PATH_TRIGGERS: list[tuple[str, str, str]] = [
     # because nothing in the catalog matched these paths — the RPC payload
     # was byte-identical and the PR carried no breaking wording or label.)
     ("polyglot_code_generator_changed", "any",
-     r"^src/(Aspire\.Hosting\.CodeGeneration\.[^/]+|Shared/CodeGeneration)/.+\.cs$"),
+     r"^src/(Aspire\.Hosting\.CodeGeneration\.[^/]+|Shared/CodeGeneration)/.+$")
     # Files whose name ends in `Defaults.cs` or `Constants.cs`
     # typically hold shipping default values (timeouts, retry
     # counts, well-known property names, image tags, etc.).

--- a/.github/workflows/pr-docs-check/compute_signals.py
+++ b/.github/workflows/pr-docs-check/compute_signals.py
@@ -485,9 +485,27 @@ def compute_signals(pr: dict, files: list[dict]) -> dict:
             status = f.get("status") or ""
             if status_filter == "added" and status != "added":
                 continue
-            if regex.match(filename):
-                signals[signal_name] = True
-                record(signal_name, filename, f"path matched {path_regex}")
+            # GitHub reports a rename with the destination in `filename` and the
+            # source in `previous_filename` (status == "renamed"). Matching only
+            # `filename` misses *outbound* renames — a watched file moved to an
+            # untracked path — which would otherwise slip through as
+            # signal_count == 0 even though a status_filter of "any" is meant to
+            # include renames. Check the source path too so a generator source
+            # relocated out of the watched tree still gates. Inbound renames are
+            # already covered because the destination lands under `filename`.
+            # See https://docs.github.com/rest/pulls/pulls#list-pull-requests-files
+            candidate_paths = [filename]
+            if status == "renamed":
+                previous_filename = f.get("previous_filename") or ""
+                if previous_filename:
+                    candidate_paths.append(previous_filename)
+            for candidate in candidate_paths:
+                if regex.match(candidate):
+                    signals[signal_name] = True
+                    # Record the path that actually matched (the source for an
+                    # outbound rename) so the evidence points at the watched file.
+                    record(signal_name, candidate, f"path matched {path_regex}")
+                    break
 
     # ---- Group B: diff-content triggers ----
     #

--- a/.github/workflows/pr-docs-check/compute_signals.py
+++ b/.github/workflows/pr-docs-check/compute_signals.py
@@ -68,6 +68,7 @@ from typing import Callable, Pattern
 #   src/Aspire.Hosting.Redis/RedisContainerImageTags.cs   -> container_image_tags_file_changed
 #   src/Aspire.ProjectTemplates/templates/...             -> project_template_changed
 #   src/Aspire.Hosting.Analyzers/AppHostAnalyzer.cs       -> analyzer_source_changed
+#   src/Aspire.Hosting.CodeGeneration.Go/...              -> polyglot_code_generator_changed
 #   docs/list-of-diagnostics.md                           -> diagnostic_documentation_changed
 #   src/Aspire.Hosting/ApplicationModel/KnownDefaults.cs  -> defaults_or_constants_file_changed
 PATH_TRIGGERS: list[tuple[str, str, str]] = [
@@ -128,6 +129,23 @@ PATH_TRIGGERS: list[tuple[str, str, str]] = [
     # Roslyn analyzers — users see new build warnings/errors.
     ("analyzer_source_changed", "any",
      r"^src/Aspire\.(Hosting|AppHost)\.Analyzers/.+\.cs$"),
+    # Polyglot code generators. These emit the Go / TypeScript / Python /
+    # Rust / Java SDK source that AppHost authors write against, so the
+    # generated method and function signatures ARE the public API for
+    # polyglot AppHosts. Critically, no api/*.cs baseline tracks that
+    # generated output, so a signature-shape change (e.g. flattening a
+    # wrapper `options` DTO so it is passed directly) is a real — and
+    # potentially breaking — user-facing change that leaves no fingerprint
+    # on any of the C# API surfaces the other signals watch. It also need
+    # not touch the RPC payload at all, so the diff can look like a pure
+    # internal refactor. Watch both the per-language generator projects
+    # and the shared `src/Shared/CodeGeneration/` helpers they build on.
+    # (microsoft/aspire#18698: the Go options-DTO flattening breaking
+    # change classified as internal_refactor with signal_count == 0
+    # because nothing in the catalog matched these paths — the RPC payload
+    # was byte-identical and the PR carried no breaking wording or label.)
+    ("polyglot_code_generator_changed", "any",
+     r"^src/(Aspire\.Hosting\.CodeGeneration\.[^/]+|Shared/CodeGeneration)/.+\.cs$"),
     # Files whose name ends in `Defaults.cs` or `Constants.cs`
     # typically hold shipping default values (timeouts, retry
     # counts, well-known property names, image tags, etc.).

--- a/.github/workflows/pr-docs-check/test_compute_signals.py
+++ b/.github/workflows/pr-docs-check/test_compute_signals.py
@@ -31,11 +31,22 @@ def _pr(body: str = "", labels: list[str] | None = None, number: int = 1) -> dic
     }
 
 
-def _file(filename: str, status: str = "modified", patch: str | None = None) -> dict:
-    """Build a single 'files' entry. `patch` of None means GitHub omitted it."""
+def _file(
+    filename: str,
+    status: str = "modified",
+    patch: str | None = None,
+    previous_filename: str | None = None,
+) -> dict:
+    """Build a single 'files' entry. `patch` of None means GitHub omitted it.
+
+    `previous_filename` is set by GitHub only for renamed entries; pass it to
+    model a rename (also set status="renamed").
+    """
     out: dict = {"filename": filename, "status": status}
     if patch is not None:
         out["patch"] = patch
+    if previous_filename is not None:
+        out["previous_filename"] = previous_filename
     return out
 
 
@@ -312,6 +323,35 @@ class CatalogScenarioTests(unittest.TestCase):
         result = compute_signals.compute_signals(pr, files)
         self.assertEqual(result["recommendation"], "docs_required")
         self.assertTrue(result["signals"]["polyglot_code_generator_changed"])
+
+    def test_outbound_rename_of_generator_file_still_fires(self) -> None:
+        # GitHub reports a rename with the destination in `filename` and the
+        # source in `previous_filename` (status == "renamed"). Relocating a
+        # generator source OUT of the watched tree leaves only
+        # `previous_filename` under src/Aspire.Hosting.CodeGeneration.*, so the
+        # Group A loop matching `filename` alone would miss it and produce
+        # signal_count == 0 — despite the signal's "any" status filter being
+        # meant to include renames. The destination here is deliberately
+        # outside src/ (untracked by every signal) so this test isolates the
+        # source-path match: the polyglot signal must be the sole trigger, and
+        # its evidence must cite the watched source path, not the destination.
+        pr = _pr(body="Relocate the Go generator entry point.")
+        source = "src/Aspire.Hosting.CodeGeneration.Go/AtsGoCodeGenerator.cs"
+        files = [
+            _file(
+                "eng/codegen/AtsGoCodeGenerator.cs",
+                status="renamed",
+                previous_filename=source,
+            ),
+        ]
+        result = compute_signals.compute_signals(pr, files)
+        self.assertTrue(result["signals"]["polyglot_code_generator_changed"])
+        self.assertEqual(
+            result["triggered_signals"], ["polyglot_code_generator_changed"]
+        )
+        self.assertEqual(result["recommendation"], "docs_required")
+        evidence = result["evidence"]["polyglot_code_generator_changed"]
+        self.assertEqual(evidence[0]["file"], source)
 
 
 class DirectionAwareDiffScanTests(unittest.TestCase):

--- a/.github/workflows/pr-docs-check/test_compute_signals.py
+++ b/.github/workflows/pr-docs-check/test_compute_signals.py
@@ -256,6 +256,63 @@ class CatalogScenarioTests(unittest.TestCase):
         self.assertEqual(result["recommendation"], "docs_required")
         self.assertTrue(result["signals"]["defaults_or_constants_file_changed"])
 
+    def test_polyglot_code_generator_change(self) -> None:
+        # Reproduces microsoft/aspire#18698: the Go generator flattened a
+        # single optional `options` DTO so it is passed directly, changing
+        # the generated Go method signature (a user-facing, breaking
+        # surface for polyglot AppHost authors). The RPC payload was
+        # byte-identical and the PR body said as much, with only an area
+        # label — so Groups B/C/D all stayed silent. The new Group A path
+        # signal is what rescues the classification. The shared helper
+        # here is added as `internal`, so `new_public_type` must NOT fire;
+        # this proves the path signal alone is responsible.
+        pr = _pr(
+            body=(
+                "Flatten the single optional options DTO in the Go generator. "
+                "The RPC payload is unchanged — byte-identical to the previous "
+                "wrapped form."
+            ),
+            labels=["area-integrations"],
+        )
+        files = [
+            _file(
+                "src/Aspire.Hosting.CodeGeneration.Go/AtsGoCodeGenerator.cs",
+                patch="@@ +0,0 @@\n+        // emit the DTO type directly\n",
+            ),
+            _file(
+                "src/Shared/CodeGeneration/AtsOptionsFlattening.cs",
+                status="added",
+                patch=(
+                    "@@ +0,0 @@\n"
+                    "+internal static class AtsOptionsFlattening { }\n"
+                ),
+            ),
+        ]
+        result = compute_signals.compute_signals(pr, files)
+        self.assertEqual(result["recommendation"], "docs_required")
+        self.assertEqual(
+            result["triggered_signals"], ["polyglot_code_generator_changed"]
+        )
+        # The surfaces that genuinely stayed silent for this PR must stay
+        # silent — the point is that the path signal is the sole rescue.
+        self.assertFalse(result["signals"]["pr_label_breaking_change"])
+        self.assertFalse(result["signals"]["pr_body_has_breaking_change_marker"])
+        self.assertFalse(result["signals"]["new_public_type"])
+
+    def test_typescript_generator_change_also_fires(self) -> None:
+        # The signal covers every per-language generator, not just Go.
+        pr = _pr(body="Tweak TypeScript emitter output shape.")
+        files = [
+            _file(
+                "src/Aspire.Hosting.CodeGeneration.TypeScript/"
+                "AtsTypeScriptCodeGenerator.cs",
+                patch="@@ +0,0 @@\n+        // change the emitted call shape\n",
+            ),
+        ]
+        result = compute_signals.compute_signals(pr, files)
+        self.assertEqual(result["recommendation"], "docs_required")
+        self.assertTrue(result["signals"]["polyglot_code_generator_changed"])
+
 
 class DirectionAwareDiffScanTests(unittest.TestCase):
     """Tests covering direction-aware diff scanning.
@@ -388,6 +445,23 @@ class PathTriggerHygieneTests(unittest.TestCase):
         ]
         result = compute_signals.compute_signals(pr, files)
         self.assertFalse(result["signals"]["new_package_added"])
+        self.assertEqual(result["recommendation"], "docs_optional")
+
+    def test_codegen_tests_and_fixtures_do_not_trigger_polyglot_signal(self) -> None:
+        # The generator projects have sibling test projects and generated
+        # `apphost.*` fixtures under tests/. Both are advisory-only (tests
+        # never gate), so a change confined to them must NOT fire the
+        # polyglot code-generator path signal, which is scoped to `^src/`.
+        pr = _pr()
+        files = [
+            _file(
+                "tests/Aspire.Hosting.CodeGeneration.Go.Tests/"
+                "AtsGoCodeGeneratorTests.cs",
+            ),
+            _file("tests/PolyglotAppHosts/Aspire.Hosting/Go/apphost.go"),
+        ]
+        result = compute_signals.compute_signals(pr, files)
+        self.assertFalse(result["signals"]["polyglot_code_generator_changed"])
         self.assertEqual(result["recommendation"], "docs_optional")
 
 


### PR DESCRIPTION
Adds a path signal so changes under `src/Aspire.Hosting.CodeGeneration.*` and `src/Shared/CodeGeneration/` gate docs review. These paths generate the polyglot SDK source consumers write against, so a change there can be breaking even when the C# API and RPC payload are unchanged.

Closes the blind spot from microsoft/aspire#18698, which was misclassified as `internal_refactor` (`signal_count == 0`) because no signal covered generated polyglot output.