### PR TITLE
Add preview Aspire.Mcp.Client integration

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -26,6 +26,7 @@
     <Project Path="src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj" />
     <Project Path="src/Components/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.csproj" />
     <Project Path="src/Components/Aspire.Milvus.Client/Aspire.Milvus.Client.csproj" />
+    <Project Path="src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj" />
     <Project Path="src/Components/Aspire.MongoDB.Driver.v2/Aspire.MongoDB.Driver.v2.csproj" />
     <Project Path="src/Components/Aspire.MongoDB.Driver/Aspire.MongoDB.Driver.csproj" />
     <Project Path="src/Components/Aspire.MongoDB.EntityFrameworkCore/Aspire.MongoDB.EntityFrameworkCore.csproj" Id="61b0efc4-439c-4d09-a336-b4c5763c6bd7" />
@@ -489,6 +490,7 @@
     <Project Path="tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj" />
     <Project Path="tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests/Aspire.Microsoft.Extensions.Configuration.AzureAppConfiguration.Tests.csproj" />
     <Project Path="tests/Aspire.Milvus.Client.Tests/Aspire.Milvus.Client.Tests.csproj" />
+    <Project Path="tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj" />
     <Project Path="tests/Aspire.MongoDB.Driver.Tests/Aspire.MongoDB.Driver.Tests.csproj" />
     <Project Path="tests/Aspire.MongoDB.Driver.v2.Tests/Aspire.MongoDB.Driver.v2.Tests.csproj" />
     <Project Path="tests/Aspire.MongoDB.EntityFrameworkCore.Tests/Aspire.MongoDB.EntityFrameworkCore.Tests.csproj" Id="79ef6bd3-8f2b-4b42-8993-6707fd8be598" />

--- a/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
+++ b/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
   </ItemGroup>
 

--- a/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
+++ b/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <PackageTags>$(ComponentCommonPackageTags) ai mcp model-context-protocol</PackageTags>
+    <Description>A Model Context Protocol client that integrates with Aspire service discovery.</Description>
+    <!-- In preview until the public API and MCP client lifecycle are validated. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
+++ b/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
@@ -10,9 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
+++ b/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
+++ b/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />

--- a/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
+++ b/src/Components/Aspire.Mcp.Client/Aspire.Mcp.Client.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientBuilder.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientBuilder.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol.Authentication;
+using ModelContextProtocol.Client;
+
+namespace Aspire.Mcp.Client;
+
+/// <summary>
+/// Provides a builder for configuring MCP client registrations in Aspire.
+/// </summary>
+public sealed class AspireMcpClientBuilder
+{
+    private readonly string _httpClientName;
+    private readonly Action<Action<McpClientOptions>> _addClientOptionsAction;
+    private readonly Action<Action<HttpClientTransportOptions>> _addTransportOptionsAction;
+    private readonly Action<ClientOAuthOptions> _setOAuthOptions;
+    private readonly Action<Func<IServiceProvider, HttpRequestMessage, CancellationToken, ValueTask<string?>>> _setBearerTokenProvider;
+
+    internal AspireMcpClientBuilder(
+        IHostApplicationBuilder hostBuilder,
+        string connectionName,
+        object? serviceKey,
+        McpClientSettings settings,
+        string httpClientName,
+        Action<Action<McpClientOptions>> addClientOptionsAction,
+        Action<Action<HttpClientTransportOptions>> addTransportOptionsAction,
+        Action<ClientOAuthOptions> setOAuthOptions,
+        Action<Func<IServiceProvider, HttpRequestMessage, CancellationToken, ValueTask<string?>>> setBearerTokenProvider)
+    {
+        HostBuilder = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
+        ConnectionName = connectionName ?? throw new ArgumentNullException(nameof(connectionName));
+        ServiceKey = serviceKey;
+        Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _httpClientName = httpClientName ?? throw new ArgumentNullException(nameof(httpClientName));
+        _addClientOptionsAction = addClientOptionsAction ?? throw new ArgumentNullException(nameof(addClientOptionsAction));
+        _addTransportOptionsAction = addTransportOptionsAction ?? throw new ArgumentNullException(nameof(addTransportOptionsAction));
+        _setOAuthOptions = setOAuthOptions ?? throw new ArgumentNullException(nameof(setOAuthOptions));
+        _setBearerTokenProvider = setBearerTokenProvider ?? throw new ArgumentNullException(nameof(setBearerTokenProvider));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="IHostApplicationBuilder"/> with which services are being registered.
+    /// </summary>
+    public IHostApplicationBuilder HostBuilder { get; }
+
+    /// <summary>
+    /// Gets the service-discovery connection name used by this MCP client registration.
+    /// </summary>
+    public string ConnectionName { get; }
+
+    /// <summary>
+    /// Gets the service key used to register the client, when using keyed registration.
+    /// </summary>
+    public object? ServiceKey { get; }
+
+    /// <summary>
+    /// Gets the Aspire settings used by the registration.
+    /// </summary>
+    public McpClientSettings Settings { get; }
+
+    /// <summary>
+    /// Configures <see cref="McpClientOptions"/> used for MCP client creation.
+    /// </summary>
+    public AspireMcpClientBuilder ConfigureClientOptions(Action<McpClientOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        _addClientOptionsAction(configure);
+        return this;
+    }
+
+    /// <summary>
+    /// Configures <see cref="HttpClientTransportOptions"/> used by the MCP transport.
+    /// </summary>
+    public AspireMcpClientBuilder ConfigureTransportOptions(Action<HttpClientTransportOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        _addTransportOptionsAction(configure);
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the underlying named <see cref="HttpClient"/> used by this MCP registration.
+    /// </summary>
+    public AspireMcpClientBuilder ConfigureHttpClient(Action<IHttpClientBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        configure(HostBuilder.Services.AddHttpClient(_httpClientName));
+        return this;
+    }
+
+    /// <summary>
+    /// Enables MCP OAuth authentication for this registration.
+    /// </summary>
+    public AspireMcpClientBuilder UseOAuth(Action<ClientOAuthOptions> configureOAuth)
+    {
+        ArgumentNullException.ThrowIfNull(configureOAuth);
+        var options = new ClientOAuthOptions
+        {
+            RedirectUri = new Uri("http://localhost"),
+        };
+        configureOAuth(options);
+        _setOAuthOptions(options);
+        return this;
+    }
+
+    /// <summary>
+    /// Configures a bearer token provider invoked for each MCP transport request.
+    /// </summary>
+    public AspireMcpClientBuilder UseBearerTokenProvider(Func<IServiceProvider, HttpRequestMessage, CancellationToken, ValueTask<string?>> tokenProvider)
+    {
+        ArgumentNullException.ThrowIfNull(tokenProvider);
+        _setBearerTokenProvider(tokenProvider);
+        return this;
+    }
+}

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientBuilder.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientBuilder.cs
@@ -22,7 +22,7 @@ public sealed class AspireMcpClientBuilder
     internal AspireMcpClientBuilder(
         IHostApplicationBuilder hostBuilder,
         string connectionName,
-        object? serviceKey,
+        string? serviceKey,
         McpClientSettings settings,
         string httpClientName,
         Action<Action<McpClientOptions>> addClientOptionsAction,
@@ -54,7 +54,7 @@ public sealed class AspireMcpClientBuilder
     /// <summary>
     /// Gets the service key used to register the client, when using keyed registration.
     /// </summary>
-    public object? ServiceKey { get; }
+    public string? ServiceKey { get; }
 
     /// <summary>
     /// Gets the Aspire settings used by the registration.

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -355,9 +355,13 @@ public static class AspireMcpClientExtensions
             HttpClientTransport? transport = null;
             try
             {
-                var resolvedEndpoint = await ResolveEndpointAsync(endpoint, serviceEndpointResolver, _creationCancellation.Token).ConfigureAwait(false);
-                var transportOptions = new HttpClientTransportOptions { Endpoint = resolvedEndpoint };
+                var defaultTransportEndpoint = CreateInitialTransportEndpoint(endpoint);
+                var transportOptions = new HttpClientTransportOptions { Endpoint = defaultTransportEndpoint };
                 configureTransportOptions?.Invoke(transportOptions);
+                var endpointToResolve = endpoint.Scheme is "https+http" && Equals(transportOptions.Endpoint, defaultTransportEndpoint)
+                    ? endpoint
+                    : transportOptions.Endpoint;
+                transportOptions.Endpoint = await ResolveEndpointAsync(endpointToResolve, serviceEndpointResolver, _creationCancellation.Token).ConfigureAwait(false);
                 McpClientSettings.ValidateEndpoint(transportOptions.Endpoint);
                 var clientOptions = new McpClientOptions();
                 configureClientOptions?.Invoke(clientOptions);
@@ -383,6 +387,13 @@ public static class AspireMcpClientExtensions
                 }
                 throw;
             }
+        }
+
+        private static Uri CreateInitialTransportEndpoint(Uri endpoint)
+        {
+            return endpoint.Scheme is "https+http"
+                ? CreateResolvedEndpointUri(endpoint, endpoint.Host, endpoint.Port)
+                : endpoint;
         }
 
         private async Task<Uri> ResolveEndpointAsync(Uri endpoint, ServiceEndpointResolver? serviceEndpointResolver, CancellationToken cancellationToken)

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -216,6 +216,7 @@ public static class AspireMcpClientExtensions
         var registrationKey = new object();
         builder.Services.AddHttpClient();
         builder.Services.AddKeyedSingleton<McpClientRegistration>(registrationKey, (serviceProvider, _) => new McpClientRegistration(
+            connectionName,
             endpoint,
             configureClientOptions,
             configureTransportOptions,
@@ -269,6 +270,7 @@ public static class AspireMcpClientExtensions
         private int _disposed;
 
         public McpClientRegistration(
+            string connectionName,
             Uri endpoint,
             Action<McpClientOptions>? configureClientOptions,
             Action<HttpClientTransportOptions>? configureTransportOptions,
@@ -276,7 +278,7 @@ public static class AspireMcpClientExtensions
             ILoggerFactory loggerFactory,
             ServiceEndpointResolver? serviceEndpointResolver)
         {
-            _createClient = () => CreateClientAsync(endpoint, configureClientOptions, configureTransportOptions, httpClientFactory, loggerFactory, serviceEndpointResolver);
+            _createClient = () => CreateClientAsync(connectionName, endpoint, configureClientOptions, configureTransportOptions, httpClientFactory, loggerFactory, serviceEndpointResolver);
         }
 
         public McpClient GetClient()
@@ -344,6 +346,7 @@ public static class AspireMcpClientExtensions
             }
 
         private async Task<DisposableMcpClient> CreateClientAsync(
+            string connectionName,
             Uri endpoint,
             Action<McpClientOptions>? configureClientOptions,
             Action<HttpClientTransportOptions>? configureTransportOptions,
@@ -356,8 +359,13 @@ public static class AspireMcpClientExtensions
             try
             {
                 var defaultTransportEndpoint = CreateInitialTransportEndpoint(endpoint);
-                var transportOptions = new HttpClientTransportOptions { Endpoint = defaultTransportEndpoint };
+                var transportOptions = new HttpClientTransportOptions
+                {
+                    Endpoint = defaultTransportEndpoint,
+                    Name = connectionName,
+                };
                 configureTransportOptions?.Invoke(transportOptions);
+                transportOptions.Name ??= connectionName;
                 var endpointToResolve = endpoint.Scheme is "https+http" && Equals(transportOptions.Endpoint, defaultTransportEndpoint)
                     ? endpoint
                     : transportOptions.Endpoint;

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -246,16 +246,16 @@ public static class AspireMcpClientExtensions
             IHttpClientFactory httpClientFactory,
             ILoggerFactory loggerFactory)
         {
-            var httpClient = httpClientFactory.CreateClient();
             var transportOptions = new HttpClientTransportOptions { Endpoint = endpoint };
             configureTransportOptions?.Invoke(transportOptions);
+            var clientOptions = new McpClientOptions();
+            configureClientOptions?.Invoke(clientOptions);
+            var httpClient = httpClientFactory.CreateClient();
             var transport = new HttpClientTransport(
                 transportOptions,
                 httpClient,
                 loggerFactory,
                 ownsHttpClient: true);
-            var clientOptions = new McpClientOptions();
-            configureClientOptions?.Invoke(clientOptions);
 
             try
             {

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -39,7 +39,7 @@ public static class AspireMcpClientExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
     public static IHostApplicationBuilder AddMcpClient(this IHostApplicationBuilder builder, string connectionName)
-        => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions: null, configureTransportOptions: null);
+        => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions: null, configureTransportOptions: null, configureSettings: null);
 
     /// <summary>
     /// Registers an <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
@@ -48,6 +48,7 @@ public static class AspireMcpClientExtensions
     /// <param name="connectionName">The service-discovery name of the MCP server.</param>
     /// <param name="configureClientOptions">An optional delegate to configure <see cref="McpClientOptions"/> before the client is created.</param>
     /// <param name="configureTransportOptions">An optional delegate to configure <see cref="HttpClientTransportOptions"/> before the transport is created.</param>
+    /// <param name="configureSettings">An optional delegate to configure <see cref="McpClientSettings"/> after configuration binding.</param>
     /// <remarks>
     /// The server is resolved at <c>https://{connectionName}/mcp</c> by default. When service discovery only provides
     /// HTTP endpoints, the client uses <c>http://{connectionName}/mcp</c> instead. Use <c>WithReference</c> in the
@@ -75,8 +76,9 @@ public static class AspireMcpClientExtensions
         this IHostApplicationBuilder builder,
         string connectionName,
         Action<McpClientOptions>? configureClientOptions = null,
-        Action<HttpClientTransportOptions>? configureTransportOptions = null)
-        => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions, configureTransportOptions);
+        Action<HttpClientTransportOptions>? configureTransportOptions = null,
+        Action<McpClientSettings>? configureSettings = null)
+        => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions, configureTransportOptions, configureSettings);
 
     /// <summary>
     /// Registers a keyed <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
@@ -102,7 +104,7 @@ public static class AspireMcpClientExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        return AddMcpClientCore(builder, name, name, configureClientOptions: null, configureTransportOptions: null);
+        return AddMcpClientCore(builder, name, name, configureClientOptions: null, configureTransportOptions: null, configureSettings: null);
     }
 
     /// <summary>
@@ -112,6 +114,7 @@ public static class AspireMcpClientExtensions
     /// <param name="name">The service-discovery name of the MCP server and the service key of the client.</param>
     /// <param name="configureClientOptions">An optional delegate to configure <see cref="McpClientOptions"/> before the client is created.</param>
     /// <param name="configureTransportOptions">An optional delegate to configure <see cref="HttpClientTransportOptions"/> before the transport is created.</param>
+    /// <param name="configureSettings">An optional delegate to configure <see cref="McpClientSettings"/> after configuration binding.</param>
     /// <remarks>
     /// The server is resolved at <c>https://{name}/mcp</c> by default. When service discovery only provides HTTP
     /// endpoints, the client uses <c>http://{name}/mcp</c> instead. Use <c>WithReference</c> in the AppHost to provide
@@ -139,12 +142,13 @@ public static class AspireMcpClientExtensions
         this IHostApplicationBuilder builder,
         string name,
         Action<McpClientOptions>? configureClientOptions = null,
-        Action<HttpClientTransportOptions>? configureTransportOptions = null)
+        Action<HttpClientTransportOptions>? configureTransportOptions = null,
+        Action<McpClientSettings>? configureSettings = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        return AddMcpClientCore(builder, name, name, configureClientOptions, configureTransportOptions);
+        return AddMcpClientCore(builder, name, name, configureClientOptions, configureTransportOptions, configureSettings);
     }
 
     private static IHostApplicationBuilder AddMcpClientCore(
@@ -152,7 +156,8 @@ public static class AspireMcpClientExtensions
         string connectionName,
         object? serviceKey,
         Action<McpClientOptions>? configureClientOptions,
-        Action<HttpClientTransportOptions>? configureTransportOptions)
+        Action<HttpClientTransportOptions>? configureTransportOptions,
+        Action<McpClientSettings>? configureSettings)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(connectionName);
@@ -167,6 +172,8 @@ public static class AspireMcpClientExtensions
         {
             settings.ParseConnectionString(connectionString);
         }
+
+        configureSettings?.Invoke(settings);
 
         var endpoint = settings.Endpoint ?? CreateServiceDiscoveryEndpoint(builder.Configuration, connectionName);
         var registrationKey = new object();
@@ -340,19 +347,20 @@ public static class AspireMcpClientExtensions
 
     private sealed class McpClientHealthCheck(IServiceProvider serviceProvider, object? serviceKey) : IHealthCheck
     {
-        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                _ = serviceKey is null
+                var client = serviceKey is null
                     ? serviceProvider.GetRequiredService<McpClient>()
                     : serviceProvider.GetRequiredKeyedService<McpClient>(serviceKey);
 
-                return Task.FromResult(HealthCheckResult.Healthy());
+                await client.PingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                return HealthCheckResult.Healthy();
             }
             catch (Exception ex)
             {
-                return Task.FromResult(HealthCheckResult.Unhealthy("MCP client initialization failed.", ex));
+                return HealthCheckResult.Unhealthy("MCP client health check failed.", ex);
             }
         }
     }

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -237,25 +237,34 @@ public static class AspireMcpClientExtensions
             var transport = new HttpClientTransport(
                 transportOptions,
                 httpClient,
-                loggerFactory);
+                loggerFactory,
+                ownsHttpClient: true);
             var clientOptions = new McpClientOptions();
             configureClientOptions?.Invoke(clientOptions);
 
-            var client = await McpClient.CreateAsync(transport, clientOptions, cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
-            if (Volatile.Read(ref _disposed) is not 0)
+            try
             {
-                await client.DisposeAsync().ConfigureAwait(false);
-                throw new ObjectDisposedException(nameof(McpClientRegistration));
-            }
+                var client = await McpClient.CreateAsync(transport, clientOptions, cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
+                if (Volatile.Read(ref _disposed) is not 0)
+                {
+                    await client.DisposeAsync().ConfigureAwait(false);
+                    throw new ObjectDisposedException(nameof(McpClientRegistration));
+                }
 
-            return new DisposableMcpClient(client);
+                return new DisposableMcpClient(client, transport);
+            }
+            catch
+            {
+                await transport.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
         }
     }
 
     // The DI container disposes singleton factory results directly. Wrapping the async-only client
     // gives the host a synchronous disposal path while preserving the client API surface.
 #pragma warning disable MCPEXP002 // McpClient constructor is required to provide a wrapper that supports IDisposable.
-    private sealed class DisposableMcpClient(McpClient innerClient) : McpClient, IDisposable
+    private sealed class DisposableMcpClient(McpClient innerClient, HttpClientTransport transport) : McpClient, IDisposable
 #pragma warning restore MCPEXP002
     {
         private int _disposed;
@@ -285,7 +294,14 @@ public static class AspireMcpClientExtensions
         {
             if (Interlocked.Exchange(ref _disposed, 1) is 0)
             {
-                innerClient.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                try
+                {
+                    innerClient.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+                finally
+                {
+                    transport.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
             }
         }
 
@@ -293,10 +309,22 @@ public static class AspireMcpClientExtensions
         {
             if (Interlocked.Exchange(ref _disposed, 1) is 0)
             {
-                return innerClient.DisposeAsync();
+                return DisposeAsyncCore();
             }
 
             return ValueTask.CompletedTask;
+        }
+
+        private async ValueTask DisposeAsyncCore()
+        {
+            try
+            {
+                await innerClient.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                await transport.DisposeAsync().ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -203,6 +203,7 @@ public static class AspireMcpClientExtensions
         }
 
         var endpoint = settings.Endpoint ?? CreateServiceDiscoveryEndpoint(builder.Configuration, connectionName);
+        McpClientSettings.ValidateEndpoint(endpoint);
         var registrationKey = new object();
         builder.Services.AddHttpClient();
         builder.Services.AddKeyedSingleton<McpClientRegistration>(registrationKey, (serviceProvider, _) => new McpClientRegistration(
@@ -278,6 +279,7 @@ public static class AspireMcpClientExtensions
             {
                 lock (_lock)
                 {
+                    ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
                     client ??= _client ??= new ReconnectableMcpClient(_createClient, _creationCancellation.Cancel);
                 }
             }
@@ -290,7 +292,13 @@ public static class AspireMcpClientExtensions
             if (Interlocked.Exchange(ref _disposed, 1) is 0)
             {
                 _creationCancellation.Cancel();
-                Volatile.Read(ref _client)?.Dispose();
+                ReconnectableMcpClient? client;
+                lock (_lock)
+                {
+                    client = _client;
+                }
+
+                client?.Dispose();
                 _creationCancellation.Dispose();
             }
         }
@@ -300,7 +308,12 @@ public static class AspireMcpClientExtensions
                 if (Interlocked.Exchange(ref _disposed, 1) is 0)
                 {
                     _creationCancellation.Cancel();
-                    var client = Volatile.Read(ref _client);
+                    ReconnectableMcpClient? client;
+                    lock (_lock)
+                    {
+                        client = _client;
+                    }
+
                     if (client is not null)
                     {
                         await client.DisposeAsync().ConfigureAwait(false);
@@ -530,6 +543,11 @@ public static class AspireMcpClientExtensions
                 return false;
             }
 
+            if (task.IsFaulted)
+            {
+                return true;
+            }
+
             if (exception is HttpRequestException or IOException or System.Net.Sockets.SocketException)
             {
                 return true;
@@ -546,6 +564,7 @@ public static class AspireMcpClientExtensions
 
         private void Invalidate(Task<DisposableMcpClient> task)
         {
+            Task? cleanupTask = null;
             lock (_lock)
             {
                 if (!ReferenceEquals(_client, task))
@@ -553,27 +572,23 @@ public static class AspireMcpClientExtensions
                     return;
                 }
 
+                if (task.IsCompletedSuccessfully)
+                {
+                    cleanupTask = DisposeClientAsync(task);
+                    _cleanupTasks.Add(cleanupTask);
+                }
+
                 _client = null;
             }
 
-            if (task.IsCompletedSuccessfully)
+            if (cleanupTask is not null)
             {
-                TrackCleanup(DisposeClientAsync(task));
+                _ = cleanupTask.ContinueWith(
+                    _ => RemoveCleanup(cleanupTask),
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
             }
-        }
-
-        private void TrackCleanup(Task cleanupTask)
-        {
-            lock (_lock)
-            {
-                _cleanupTasks.Add(cleanupTask);
-            }
-
-            _ = cleanupTask.ContinueWith(
-                _ => RemoveCleanup(cleanupTask),
-                CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
         }
 
         private void RemoveCleanup(Task cleanupTask)

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
@@ -19,8 +20,9 @@ public static class AspireMcpClientExtensions
     /// <param name="builder">The application builder to add services to.</param>
     /// <param name="connectionName">The service-discovery name of the MCP server.</param>
     /// <remarks>
-    /// The server is resolved at <c>https://{connectionName}/mcp</c>. Use <c>WithReference</c> in the AppHost to
-    /// provide the server endpoint to this application.
+    /// The server is resolved at <c>https://{connectionName}/mcp</c> by default. When service discovery only provides
+    /// HTTP endpoints, the client uses <c>http://{connectionName}/mcp</c> instead. Use <c>WithReference</c> in the
+    /// AppHost to provide the server endpoint to this application.
     /// </remarks>
     /// <example>
     /// This example registers an unkeyed MCP client for an MCP server named <c>mcp-server</c>:
@@ -42,8 +44,9 @@ public static class AspireMcpClientExtensions
     /// <param name="configureClientOptions">An optional delegate to configure <see cref="McpClientOptions"/> before the client is created.</param>
     /// <param name="configureTransportOptions">An optional delegate to configure <see cref="HttpClientTransportOptions"/> before the transport is created.</param>
     /// <remarks>
-    /// The server is resolved at <c>https://{connectionName}/mcp</c>. Use <c>WithReference</c> in the AppHost to
-    /// provide the server endpoint to this application.
+    /// The server is resolved at <c>https://{connectionName}/mcp</c> by default. When service discovery only provides
+    /// HTTP endpoints, the client uses <c>http://{connectionName}/mcp</c> instead. Use <c>WithReference</c> in the
+    /// AppHost to provide the server endpoint to this application.
     /// </remarks>
     /// <example>
     /// This example configures an unkeyed MCP client registration:
@@ -76,8 +79,9 @@ public static class AspireMcpClientExtensions
     /// <param name="builder">The application builder to add services to.</param>
     /// <param name="name">The service-discovery name of the MCP server and the service key of the client.</param>
     /// <remarks>
-    /// The server is resolved at <c>https://{name}/mcp</c>. Use <c>WithReference</c> in the AppHost to provide the
-    /// server endpoint to this application.
+    /// The server is resolved at <c>https://{name}/mcp</c> by default. When service discovery only provides HTTP
+    /// endpoints, the client uses <c>http://{name}/mcp</c> instead. Use <c>WithReference</c> in the AppHost to provide
+    /// the server endpoint to this application.
     /// </remarks>
     /// <example>
     /// This example registers a keyed MCP client where the key and service-discovery name are both <c>mcp-server</c>:
@@ -104,8 +108,9 @@ public static class AspireMcpClientExtensions
     /// <param name="configureClientOptions">An optional delegate to configure <see cref="McpClientOptions"/> before the client is created.</param>
     /// <param name="configureTransportOptions">An optional delegate to configure <see cref="HttpClientTransportOptions"/> before the transport is created.</param>
     /// <remarks>
-    /// The server is resolved at <c>https://{name}/mcp</c>. Use <c>WithReference</c> in the AppHost to provide the
-    /// server endpoint to this application.
+    /// The server is resolved at <c>https://{name}/mcp</c> by default. When service discovery only provides HTTP
+    /// endpoints, the client uses <c>http://{name}/mcp</c> instead. Use <c>WithReference</c> in the AppHost to provide
+    /// the server endpoint to this application.
     /// </remarks>
     /// <example>
     /// This example configures a keyed MCP client registration:
@@ -147,7 +152,7 @@ public static class AspireMcpClientExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
-        var endpoint = new Uri($"https://{connectionName}/mcp", UriKind.Absolute);
+        var endpoint = CreateEndpoint(builder.Configuration, connectionName);
         var registrationKey = new object();
         builder.Services.AddHttpClient();
         builder.Services.AddKeyedSingleton<McpClientRegistration>(registrationKey, (serviceProvider, _) => new McpClientRegistration(
@@ -170,6 +175,18 @@ public static class AspireMcpClientExtensions
 
         return builder;
     }
+
+    private static Uri CreateEndpoint(IConfiguration configuration, string connectionName)
+    {
+        var servicesSection = configuration.GetSection("services").GetSection(connectionName);
+        var hasHttpsEndpoint = HasServiceDiscoveryEndpoint(servicesSection, "https");
+        var hasHttpEndpoint = HasServiceDiscoveryEndpoint(servicesSection, "http");
+        var scheme = !hasHttpsEndpoint && hasHttpEndpoint ? "http" : "https";
+        return new Uri($"{scheme}://{connectionName}/mcp", UriKind.Absolute);
+    }
+
+    private static bool HasServiceDiscoveryEndpoint(IConfigurationSection serviceSection, string scheme)
+        => serviceSection.GetSection(scheme).GetChildren().Any();
 
     private sealed class McpClientRegistration : IDisposable
     {

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -47,9 +47,9 @@ public static class AspireMcpClientExtensions
     /// </summary>
     /// <param name="builder">The application builder to add services to.</param>
     /// <param name="connectionName">The service-discovery name of the MCP server.</param>
+    /// <param name="configureSettings">An optional delegate to configure <see cref="McpClientSettings"/> after configuration binding.</param>
     /// <param name="configureClientOptions">An optional delegate to configure <see cref="McpClientOptions"/> before the client is created.</param>
     /// <param name="configureTransportOptions">An optional delegate to configure <see cref="HttpClientTransportOptions"/> before the transport is created.</param>
-    /// <param name="configureSettings">An optional delegate to configure <see cref="McpClientSettings"/> after configuration binding.</param>
     /// <remarks>
     /// The server is resolved at <c>https://{connectionName}/mcp</c> by default. When service discovery only provides
     /// HTTP endpoints, the client uses <c>http://{connectionName}/mcp</c> instead. Use <c>WithReference</c> in the
@@ -60,13 +60,17 @@ public static class AspireMcpClientExtensions
     /// <code>
     /// builder.AddMcpClient(
     ///     "mcp-server",
+    ///     settings =>
+    ///     {
+    ///         // Configure Aspire settings.
+    ///     },
     ///     clientOptions =>
     ///     {
     ///         // Configure client options.
     ///     },
     ///     transportOptions =>
     ///     {
-    ///         transportOptions.Endpoint = new Uri("https://mcp-server/mcp");
+    ///         // Configure transport options.
     ///     });
     /// </code>
     /// </example>
@@ -77,9 +81,9 @@ public static class AspireMcpClientExtensions
     public static IHostApplicationBuilder AddMcpClient(
         this IHostApplicationBuilder builder,
         string connectionName,
+        Action<McpClientSettings>? configureSettings = null,
         Action<McpClientOptions>? configureClientOptions = null,
-        Action<HttpClientTransportOptions>? configureTransportOptions = null,
-        Action<McpClientSettings>? configureSettings = null)
+        Action<HttpClientTransportOptions>? configureTransportOptions = null)
         => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions, configureTransportOptions, configureSettings);
 
     /// <summary>
@@ -115,9 +119,9 @@ public static class AspireMcpClientExtensions
     /// </summary>
     /// <param name="builder">The application builder to add services to.</param>
     /// <param name="name">The service-discovery name of the MCP server and the service key of the client.</param>
+    /// <param name="configureSettings">An optional delegate to configure <see cref="McpClientSettings"/> after configuration binding.</param>
     /// <param name="configureClientOptions">An optional delegate to configure <see cref="McpClientOptions"/> before the client is created.</param>
     /// <param name="configureTransportOptions">An optional delegate to configure <see cref="HttpClientTransportOptions"/> before the transport is created.</param>
-    /// <param name="configureSettings">An optional delegate to configure <see cref="McpClientSettings"/> after configuration binding.</param>
     /// <remarks>
     /// The server is resolved at <c>https://{name}/mcp</c> by default. When service discovery only provides HTTP
     /// endpoints, the client uses <c>http://{name}/mcp</c> instead. Use <c>WithReference</c> in the AppHost to provide
@@ -128,13 +132,17 @@ public static class AspireMcpClientExtensions
     /// <code>
     /// builder.AddKeyedMcpClient(
     ///     "mcp-server",
+    ///     settings =>
+    ///     {
+    ///         // Configure Aspire settings.
+    ///     },
     ///     clientOptions =>
     ///     {
     ///         // Configure client options.
     ///     },
     ///     transportOptions =>
     ///     {
-    ///         transportOptions.Endpoint = new Uri("https://mcp-server/mcp");
+    ///         // Configure transport options.
     ///     });
     /// </code>
     /// </example>
@@ -145,9 +153,9 @@ public static class AspireMcpClientExtensions
     public static IHostApplicationBuilder AddKeyedMcpClient(
         this IHostApplicationBuilder builder,
         string name,
+        Action<McpClientSettings>? configureSettings = null,
         Action<McpClientOptions>? configureClientOptions = null,
-        Action<HttpClientTransportOptions>? configureTransportOptions = null,
-        Action<McpClientSettings>? configureSettings = null)
+        Action<HttpClientTransportOptions>? configureTransportOptions = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
@@ -181,6 +189,8 @@ public static class AspireMcpClientExtensions
             }
             catch (FormatException ex)
             {
+                // A malformed connection string must not be masked by an endpoint inherited from configuration.
+                settings.Endpoint = null;
                 connectionStringException = ex;
             }
         }
@@ -242,12 +252,12 @@ public static class AspireMcpClientExtensions
         return new Uri($"{scheme}://{connectionName}/mcp", UriKind.Absolute);
     }
 
-    private sealed class McpClientRegistration : IDisposable
+    private sealed class McpClientRegistration : IDisposable, IAsyncDisposable
     {
-        private readonly object _clientLock = new();
         private readonly Func<Task<DisposableMcpClient>> _createClient;
         private readonly CancellationTokenSource _creationCancellation = new();
-        private Task<DisposableMcpClient>? _client;
+        private ReconnectableMcpClient? _client;
+        private readonly object _lock = new();
         private int _disposed;
 
         public McpClientRegistration(
@@ -257,57 +267,48 @@ public static class AspireMcpClientExtensions
             IHttpClientFactory httpClientFactory,
             ILoggerFactory loggerFactory)
         {
-            _createClient = () => CreateClientAsync(
-                endpoint,
-                configureClientOptions,
-                configureTransportOptions,
-                httpClientFactory,
-                loggerFactory);
+            _createClient = () => CreateClientAsync(endpoint, configureClientOptions, configureTransportOptions, httpClientFactory, loggerFactory);
         }
 
         public McpClient GetClient()
         {
             ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
-
-            var clientTask = Volatile.Read(ref _client);
-            if (clientTask is null)
+            var client = Volatile.Read(ref _client);
+            if (client is null)
             {
-                lock (_clientLock)
+                lock (_lock)
                 {
-                    clientTask ??= _client ??= _createClient();
+                    client ??= _client ??= new ReconnectableMcpClient(_createClient);
                 }
             }
-
-            try
-            {
-                return clientTask.GetAwaiter().GetResult();
-            }
-            catch
-            {
-                if (clientTask.IsFaulted || clientTask.IsCanceled)
-                {
-                    lock (_clientLock)
-                    {
-                        if (ReferenceEquals(_client, clientTask))
-                        {
-                            _client = null;
-                        }
-                    }
-                }
-
-                throw;
-            }
+            client.Initialize();
+            return client;
         }
 
         public void Dispose()
         {
-            if (Interlocked.Exchange(ref _disposed, 1) is not 0)
+            if (Interlocked.Exchange(ref _disposed, 1) is 0)
             {
-                return;
+                _creationCancellation.Cancel();
+                Volatile.Read(ref _client)?.Dispose();
+                _creationCancellation.Dispose();
             }
-
-            _creationCancellation.Cancel();
         }
+
+        public async ValueTask DisposeAsync()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) is 0)
+                {
+                    _creationCancellation.Cancel();
+                    var client = Volatile.Read(ref _client);
+                    if (client is not null)
+                    {
+                        client.Dispose();
+                        await client.DisposeAsync().ConfigureAwait(false);
+                    }
+                    _creationCancellation.Dispose();
+                }
+            }
 
         private async Task<DisposableMcpClient> CreateClientAsync(
             Uri endpoint,
@@ -318,7 +319,6 @@ public static class AspireMcpClientExtensions
         {
             HttpClient? httpClient = null;
             HttpClientTransport? transport = null;
-
             try
             {
                 var transportOptions = new HttpClientTransportOptions { Endpoint = endpoint };
@@ -326,23 +326,13 @@ public static class AspireMcpClientExtensions
                 var clientOptions = new McpClientOptions();
                 configureClientOptions?.Invoke(clientOptions);
                 httpClient = httpClientFactory.CreateClient(string.Empty);
-                transport = new HttpClientTransport(
-                    transportOptions,
-                    httpClient,
-                    loggerFactory,
-                    ownsHttpClient: true);
-
-                var client = await McpClient.CreateAsync(
-                    transport,
-                    clientOptions,
-                    loggerFactory: loggerFactory,
-                    cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
+                transport = new HttpClientTransport(transportOptions, httpClient, loggerFactory, ownsHttpClient: true);
+                var client = await McpClient.CreateAsync(transport, clientOptions, loggerFactory: loggerFactory, cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
                 if (Volatile.Read(ref _disposed) is not 0)
                 {
                     await client.DisposeAsync().ConfigureAwait(false);
                     throw new ObjectDisposedException(nameof(McpClientRegistration));
                 }
-
                 return new DisposableMcpClient(client, transport);
             }
             catch
@@ -355,8 +345,176 @@ public static class AspireMcpClientExtensions
                 {
                     httpClient?.Dispose();
                 }
-
                 throw;
+            }
+        }
+    }
+
+    // Keep the injected McpClient stable while replacing its private session after completion or failure.
+#pragma warning disable MCPEXP002
+    private sealed class ReconnectableMcpClient(Func<Task<DisposableMcpClient>> createClient) : McpClient, IDisposable
+#pragma warning restore MCPEXP002
+    {
+        private readonly object _lock = new();
+        private readonly SemaphoreSlim _operationLock = new(1, 1);
+        private readonly List<Task> _retiredClients = [];
+        private Task<DisposableMcpClient>? _client;
+        private int _disposed;
+
+        public override ServerCapabilities ServerCapabilities => GetClient().ServerCapabilities;
+        public override Implementation ServerInfo => GetClient().ServerInfo;
+        public override string ServerInstructions => GetClient().ServerInstructions!;
+        public override Task<ClientCompletionDetails> Completion => GetClient().Completion;
+        public override string SessionId => GetClient().SessionId!;
+        public override string NegotiatedProtocolVersion => GetClient().NegotiatedProtocolVersion!;
+        public override Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken = default) => ExecuteAsync(client => client.SendRequestAsync(request, cancellationToken));
+        public override Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default) => ExecuteAsync(client => client.SendMessageAsync(message, cancellationToken));
+        public override IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler) => GetClient().RegisterNotificationHandler(method, handler);
+
+        public void Initialize() => _ = GetClient();
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) is 0)
+            {
+                var client = Interlocked.Exchange(ref _client, null);
+                if (client?.IsCompletedSuccessfully is true)
+                {
+                    DisposeClientAsync(client).GetAwaiter().GetResult();
+                }
+                DisposeRetiredClientsAsync().GetAwaiter().GetResult();
+                _operationLock.Dispose();
+            }
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+
+        private McpClient GetClient()
+        {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
+            var clientTask = Volatile.Read(ref _client);
+            if (clientTask is null)
+            {
+                lock (_lock)
+                {
+                    clientTask ??= _client ??= createClient();
+                    _ = ObserveCompletionAsync(clientTask);
+                }
+            }
+            try
+            {
+                return clientTask.GetAwaiter().GetResult();
+            }
+            catch
+            {
+                Invalidate(clientTask);
+                throw;
+            }
+        }
+
+        private async Task<T> ExecuteAsync<T>(Func<McpClient, Task<T>> operation)
+        {
+            await _operationLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                for (var attempt = 0; ; attempt++)
+                {
+                    var task = Volatile.Read(ref _client);
+                    try
+                    {
+                        return await operation(GetClient()).ConfigureAwait(false);
+                    }
+                    catch when (attempt is 0 && task is not null)
+                    {
+                        Invalidate(task);
+                    }
+                }
+            }
+            finally
+            {
+                _operationLock.Release();
+            }
+        }
+
+        private async Task ExecuteAsync(Func<McpClient, Task> operation)
+        {
+            await _operationLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                for (var attempt = 0; ; attempt++)
+                {
+                    var task = Volatile.Read(ref _client);
+                    try
+                    {
+                        await operation(GetClient()).ConfigureAwait(false);
+                        return;
+                    }
+                    catch when (attempt is 0 && task is not null)
+                    {
+                        Invalidate(task);
+                    }
+                }
+            }
+            finally
+            {
+                _operationLock.Release();
+            }
+        }
+
+        private async Task ObserveCompletionAsync(Task<DisposableMcpClient> task)
+        {
+            try
+            {
+                await (await task.ConfigureAwait(false)).Completion.ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+            Invalidate(task);
+        }
+
+        private void Invalidate(Task<DisposableMcpClient> task)
+        {
+            lock (_lock)
+            {
+                if (!ReferenceEquals(_client, task))
+                {
+                    return;
+                }
+                _client = null;
+            }
+            if (task.IsCompletedSuccessfully)
+            {
+                lock (_lock)
+                {
+                    _retiredClients.Add(DisposeClientAsync(task));
+                }
+            }
+        }
+
+        private async Task DisposeRetiredClientsAsync()
+        {
+            Task[] tasks;
+            lock (_lock)
+            {
+                tasks = [.. _retiredClients];
+                _retiredClients.Clear();
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+
+        private static async Task DisposeClientAsync(Task<DisposableMcpClient> task)
+        {
+            try
+            {
+                await (await task.ConfigureAwait(false)).DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
             }
         }
     }

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -22,6 +22,12 @@ public static class AspireMcpClientExtensions
     /// The server is resolved at <c>https://{connectionName}/mcp</c>. Use <c>WithReference</c> in the AppHost to
     /// provide the server endpoint to this application.
     /// </remarks>
+    /// <example>
+    /// This example registers an unkeyed MCP client for an MCP server named <c>mcp-server</c>:
+    /// <code>
+    /// builder.AddMcpClient("mcp-server");
+    /// </code>
+    /// </example>
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
@@ -39,6 +45,21 @@ public static class AspireMcpClientExtensions
     /// The server is resolved at <c>https://{connectionName}/mcp</c>. Use <c>WithReference</c> in the AppHost to
     /// provide the server endpoint to this application.
     /// </remarks>
+    /// <example>
+    /// This example configures an unkeyed MCP client registration:
+    /// <code>
+    /// builder.AddMcpClient(
+    ///     "mcp-server",
+    ///     clientOptions =>
+    ///     {
+    ///         // Configure client options.
+    ///     },
+    ///     transportOptions =>
+    ///     {
+    ///         transportOptions.Endpoint = new Uri("https://mcp-server/mcp");
+    ///     });
+    /// </code>
+    /// </example>
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
@@ -58,6 +79,12 @@ public static class AspireMcpClientExtensions
     /// The server is resolved at <c>https://{name}/mcp</c>. Use <c>WithReference</c> in the AppHost to provide the
     /// server endpoint to this application.
     /// </remarks>
+    /// <example>
+    /// This example registers a keyed MCP client where the key and service-discovery name are both <c>mcp-server</c>:
+    /// <code>
+    /// builder.AddKeyedMcpClient("mcp-server");
+    /// </code>
+    /// </example>
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="name"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty.</exception>
@@ -80,6 +107,21 @@ public static class AspireMcpClientExtensions
     /// The server is resolved at <c>https://{name}/mcp</c>. Use <c>WithReference</c> in the AppHost to provide the
     /// server endpoint to this application.
     /// </remarks>
+    /// <example>
+    /// This example configures a keyed MCP client registration:
+    /// <code>
+    /// builder.AddKeyedMcpClient(
+    ///     "mcp-server",
+    ///     clientOptions =>
+    ///     {
+    ///         // Configure client options.
+    ///     },
+    ///     transportOptions =>
+    ///     {
+    ///         transportOptions.Endpoint = new Uri("https://mcp-server/mcp");
+    ///     });
+    /// </code>
+    /// </example>
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="name"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty.</exception>

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -25,7 +25,28 @@ public static class AspireMcpClientExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
     public static IHostApplicationBuilder AddMcpClient(this IHostApplicationBuilder builder, string connectionName)
-        => AddMcpClientCore(builder, connectionName, serviceKey: null);
+        => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions: null, configureTransportOptions: null);
+
+    /// <summary>
+    /// Registers an <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
+    /// </summary>
+    /// <param name="builder">The application builder to add services to.</param>
+    /// <param name="connectionName">The service-discovery name of the MCP server.</param>
+    /// <param name="configureClientOptions">An optional delegate to configure <see cref="McpClientOptions"/> before the client is created.</param>
+    /// <param name="configureTransportOptions">An optional delegate to configure <see cref="HttpClientTransportOptions"/> before the transport is created.</param>
+    /// <remarks>
+    /// The server is resolved at <c>https://{connectionName}/mcp</c>. Use <c>WithReference</c> in the AppHost to
+    /// provide the server endpoint to this application.
+    /// </remarks>
+    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
+    public static IHostApplicationBuilder AddMcpClient(
+        this IHostApplicationBuilder builder,
+        string connectionName,
+        Action<McpClientOptions>? configureClientOptions,
+        Action<HttpClientTransportOptions>? configureTransportOptions)
+        => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions, configureTransportOptions);
 
     /// <summary>
     /// Registers a keyed <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
@@ -44,10 +65,41 @@ public static class AspireMcpClientExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        return AddMcpClientCore(builder, name, name);
+        return AddMcpClientCore(builder, name, name, configureClientOptions: null, configureTransportOptions: null);
     }
 
-    private static IHostApplicationBuilder AddMcpClientCore(IHostApplicationBuilder builder, string connectionName, object? serviceKey)
+    /// <summary>
+    /// Registers a keyed <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
+    /// </summary>
+    /// <param name="builder">The application builder to add services to.</param>
+    /// <param name="name">The service-discovery name of the MCP server and the service key of the client.</param>
+    /// <param name="configureClientOptions">An optional delegate to configure <see cref="McpClientOptions"/> before the client is created.</param>
+    /// <param name="configureTransportOptions">An optional delegate to configure <see cref="HttpClientTransportOptions"/> before the transport is created.</param>
+    /// <remarks>
+    /// The server is resolved at <c>https://{name}/mcp</c>. Use <c>WithReference</c> in the AppHost to provide the
+    /// server endpoint to this application.
+    /// </remarks>
+    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="name"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty.</exception>
+    public static IHostApplicationBuilder AddKeyedMcpClient(
+        this IHostApplicationBuilder builder,
+        string name,
+        Action<McpClientOptions>? configureClientOptions,
+        Action<HttpClientTransportOptions>? configureTransportOptions)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        return AddMcpClientCore(builder, name, name, configureClientOptions, configureTransportOptions);
+    }
+
+    private static IHostApplicationBuilder AddMcpClientCore(
+        IHostApplicationBuilder builder,
+        string connectionName,
+        object? serviceKey,
+        Action<McpClientOptions>? configureClientOptions,
+        Action<HttpClientTransportOptions>? configureTransportOptions)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(connectionName);
@@ -57,6 +109,8 @@ public static class AspireMcpClientExtensions
         builder.Services.AddHttpClient();
         builder.Services.AddKeyedSingleton<McpClientRegistration>(registrationKey, (serviceProvider, _) => new McpClientRegistration(
             endpoint,
+            configureClientOptions,
+            configureTransportOptions,
             serviceProvider.GetRequiredService<IHttpClientFactory>(),
             serviceProvider.GetRequiredService<ILoggerFactory>()));
 
@@ -78,9 +132,14 @@ public static class AspireMcpClientExtensions
     {
         private readonly Lazy<Task<McpClient>> _client;
 
-        public McpClientRegistration(Uri endpoint, IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
+        public McpClientRegistration(
+            Uri endpoint,
+            Action<McpClientOptions>? configureClientOptions,
+            Action<HttpClientTransportOptions>? configureTransportOptions,
+            IHttpClientFactory httpClientFactory,
+            ILoggerFactory loggerFactory)
         {
-            _client = new(() => CreateClientAsync(endpoint, httpClientFactory, loggerFactory));
+            _client = new(() => CreateClientAsync(endpoint, configureClientOptions, configureTransportOptions, httpClientFactory, loggerFactory));
         }
 
         public McpClient GetClient()
@@ -106,16 +165,22 @@ public static class AspireMcpClientExtensions
 
         private static async Task<McpClient> CreateClientAsync(
             Uri endpoint,
+            Action<McpClientOptions>? configureClientOptions,
+            Action<HttpClientTransportOptions>? configureTransportOptions,
             IHttpClientFactory httpClientFactory,
             ILoggerFactory loggerFactory)
         {
             var httpClient = httpClientFactory.CreateClient();
+            var transportOptions = new HttpClientTransportOptions { Endpoint = endpoint };
+            configureTransportOptions?.Invoke(transportOptions);
             var transport = new HttpClientTransport(
-                new HttpClientTransportOptions { Endpoint = endpoint },
+                transportOptions,
                 httpClient,
                 loggerFactory);
+            var clientOptions = new McpClientOptions();
+            configureClientOptions?.Invoke(clientOptions);
 
-            return await McpClient.CreateAsync(transport).ConfigureAwait(false);
+            return await McpClient.CreateAsync(transport, clientOptions).ConfigureAwait(false);
         }
     }
 }

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -130,8 +130,12 @@ public static class AspireMcpClientExtensions
     }
 
     private sealed class McpClientRegistration
+        : IDisposable
+        , IAsyncDisposable
     {
         private readonly Lazy<Task<DisposableMcpClient>> _client;
+        private readonly CancellationTokenSource _creationCancellation = new();
+        private int _disposed;
 
         public McpClientRegistration(
             Uri endpoint,
@@ -145,10 +149,82 @@ public static class AspireMcpClientExtensions
 
         public McpClient GetClient()
         {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
             return _client.Value.GetAwaiter().GetResult();
         }
 
-        private static async Task<DisposableMcpClient> CreateClientAsync(
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) is not 0)
+            {
+                return;
+            }
+
+            _creationCancellation.Cancel();
+            if (!_client.IsValueCreated)
+            {
+                _creationCancellation.Dispose();
+                return;
+            }
+
+            try
+            {
+                _client.Value.GetAwaiter().GetResult().Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception)
+            {
+                // Client creation can fail independently of host shutdown; disposal still needs to
+                // observe and drain the in-flight task without surfacing teardown-time failures.
+            }
+            finally
+            {
+                _creationCancellation.Dispose();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) is not 0)
+            {
+                return;
+            }
+
+            _creationCancellation.Cancel();
+            if (!_client.IsValueCreated)
+            {
+                _creationCancellation.Dispose();
+                return;
+            }
+
+            try
+            {
+                var client = await _client.Value.ConfigureAwait(false);
+                await client.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception)
+            {
+                // Client creation can fail independently of host shutdown; disposal still needs to
+                // observe and drain the in-flight task without surfacing teardown-time failures.
+            }
+            finally
+            {
+                _creationCancellation.Dispose();
+            }
+        }
+
+        private async Task<DisposableMcpClient> CreateClientAsync(
             Uri endpoint,
             Action<McpClientOptions>? configureClientOptions,
             Action<HttpClientTransportOptions>? configureTransportOptions,
@@ -165,7 +241,13 @@ public static class AspireMcpClientExtensions
             var clientOptions = new McpClientOptions();
             configureClientOptions?.Invoke(clientOptions);
 
-            var client = await McpClient.CreateAsync(transport, clientOptions).ConfigureAwait(false);
+            var client = await McpClient.CreateAsync(transport, clientOptions, cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
+            if (Volatile.Read(ref _disposed) is not 0)
+            {
+                await client.DisposeAsync().ConfigureAwait(false);
+                throw new ObjectDisposedException(nameof(McpClientRegistration));
+            }
+
             return new DisposableMcpClient(client);
         }
     }

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Client;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Provides extension methods for registering <see cref="McpClient"/> instances.
+/// </summary>
+public static class AspireMcpClientExtensions
+{
+    /// <summary>
+    /// Registers an <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
+    /// </summary>
+    /// <param name="builder">The application builder to add services to.</param>
+    /// <param name="connectionName">The service-discovery name of the MCP server.</param>
+    /// <remarks>
+    /// The server is resolved at <c>https://{connectionName}/mcp</c>. Use <c>WithReference</c> in the AppHost to
+    /// provide the server endpoint to this application.
+    /// </remarks>
+    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
+    public static IHostApplicationBuilder AddMcpClient(this IHostApplicationBuilder builder, string connectionName)
+        => AddMcpClientCore(builder, connectionName, serviceKey: null);
+
+    /// <summary>
+    /// Registers a keyed <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
+    /// </summary>
+    /// <param name="builder">The application builder to add services to.</param>
+    /// <param name="name">The service-discovery name of the MCP server and the service key of the client.</param>
+    /// <remarks>
+    /// The server is resolved at <c>https://{name}/mcp</c>. Use <c>WithReference</c> in the AppHost to provide the
+    /// server endpoint to this application.
+    /// </remarks>
+    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="name"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty.</exception>
+    public static IHostApplicationBuilder AddKeyedMcpClient(this IHostApplicationBuilder builder, string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        return AddMcpClientCore(builder, name, name);
+    }
+
+    private static IHostApplicationBuilder AddMcpClientCore(IHostApplicationBuilder builder, string connectionName, object? serviceKey)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
+        var endpoint = new Uri($"https://{connectionName}/mcp", UriKind.Absolute);
+        var registrationKey = new object();
+        builder.Services.AddHttpClient();
+        builder.Services.AddKeyedSingleton<McpClientRegistration>(registrationKey, (serviceProvider, _) => new McpClientRegistration(
+            endpoint,
+            serviceProvider.GetRequiredService<IHttpClientFactory>(),
+            serviceProvider.GetRequiredService<ILoggerFactory>()));
+
+        if (serviceKey is null)
+        {
+            builder.Services.AddSingleton(serviceProvider =>
+                serviceProvider.GetRequiredKeyedService<McpClientRegistration>(registrationKey).GetClient());
+        }
+        else
+        {
+            builder.Services.AddKeyedSingleton<McpClient>(serviceKey, (serviceProvider, _) =>
+                serviceProvider.GetRequiredKeyedService<McpClientRegistration>(registrationKey).GetClient());
+        }
+
+        return builder;
+    }
+
+    private sealed class McpClientRegistration : IAsyncDisposable, IDisposable
+    {
+        private readonly Lazy<Task<McpClient>> _client;
+
+        public McpClientRegistration(Uri endpoint, IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
+        {
+            _client = new(() => CreateClientAsync(endpoint, httpClientFactory, loggerFactory));
+        }
+
+        public McpClient GetClient()
+        {
+            return _client.Value.GetAwaiter().GetResult();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_client.IsValueCreated && _client.Value.IsCompletedSuccessfully)
+            {
+                await _client.Value.Result.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_client.IsValueCreated && _client.Value.IsCompletedSuccessfully)
+            {
+                _client.Value.Result.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+        }
+
+        private static async Task<McpClient> CreateClientAsync(
+            Uri endpoint,
+            IHttpClientFactory httpClientFactory,
+            ILoggerFactory loggerFactory)
+        {
+            var httpClient = httpClientFactory.CreateClient();
+            var transport = new HttpClientTransport(
+                new HttpClientTransportOptions { Endpoint = endpoint },
+                httpClient,
+                loggerFactory);
+
+            return await McpClient.CreateAsync(transport).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -131,8 +131,10 @@ public static class AspireMcpClientExtensions
 
     private sealed class McpClientRegistration : IDisposable
     {
-        private readonly Lazy<Task<DisposableMcpClient>> _client;
+        private readonly object _clientLock = new();
+        private readonly Func<Task<DisposableMcpClient>> _createClient;
         private readonly CancellationTokenSource _creationCancellation = new();
+        private Task<DisposableMcpClient>? _client;
         private int _disposed;
 
         public McpClientRegistration(
@@ -142,13 +144,46 @@ public static class AspireMcpClientExtensions
             IHttpClientFactory httpClientFactory,
             ILoggerFactory loggerFactory)
         {
-            _client = new(() => CreateClientAsync(endpoint, configureClientOptions, configureTransportOptions, httpClientFactory, loggerFactory));
+            _createClient = () => CreateClientAsync(
+                endpoint,
+                configureClientOptions,
+                configureTransportOptions,
+                httpClientFactory,
+                loggerFactory);
         }
 
         public McpClient GetClient()
         {
             ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
-            return _client.Value.GetAwaiter().GetResult();
+
+            var clientTask = Volatile.Read(ref _client);
+            if (clientTask is null)
+            {
+                lock (_clientLock)
+                {
+                    clientTask ??= _client ??= _createClient();
+                }
+            }
+
+            try
+            {
+                return clientTask.GetAwaiter().GetResult();
+            }
+            catch
+            {
+                if (clientTask.IsFaulted || clientTask.IsCanceled)
+                {
+                    lock (_clientLock)
+                    {
+                        if (ReferenceEquals(_client, clientTask))
+                        {
+                            _client = null;
+                        }
+                    }
+                }
+
+                throw;
+            }
         }
 
         public void Dispose()

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ServiceDiscovery;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
+using System.Net;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -264,6 +265,7 @@ public static class AspireMcpClientExtensions
         private readonly CancellationTokenSource _creationCancellation = new();
         private ReconnectableMcpClient? _client;
         private readonly object _lock = new();
+        private int _endpointIndex = -1;
         private int _disposed;
 
         public McpClientRegistration(
@@ -383,7 +385,7 @@ public static class AspireMcpClientExtensions
             }
         }
 
-        private static async Task<Uri> ResolveEndpointAsync(Uri endpoint, ServiceEndpointResolver? serviceEndpointResolver, CancellationToken cancellationToken)
+        private async Task<Uri> ResolveEndpointAsync(Uri endpoint, ServiceEndpointResolver? serviceEndpointResolver, CancellationToken cancellationToken)
         {
             if (endpoint.Scheme is not "https+http")
             {
@@ -396,23 +398,70 @@ public static class AspireMcpClientExtensions
             }
 
             var endpointSource = await serviceEndpointResolver.GetEndpointsAsync(endpoint.GetLeftPart(UriPartial.Authority), cancellationToken).ConfigureAwait(false);
-            var resolvedUri = endpointSource.Endpoints
-                .Select(static serviceEndpoint => serviceEndpoint.EndPoint)
-                .OfType<UriEndPoint>()
-                .Select(static uriEndpoint => uriEndpoint.Uri)
+            var resolvedUris = endpointSource.Endpoints
+                .Select(serviceEndpoint => CreateResolvedEndpointUri(serviceEndpoint, endpoint))
+                .OfType<Uri>()
                 .Where(static uri => uri.Scheme is "http" or "https")
-                .OrderByDescending(static uri => uri.Scheme is "https")
-                .FirstOrDefault();
+                .GroupBy(static uri => uri.Scheme is "https" ? 0 : 1)
+                .OrderBy(static group => group.Key)
+                .FirstOrDefault()
+                ?.ToArray();
 
-            if (resolvedUri is null)
+            if (resolvedUris is null || resolvedUris.Length == 0)
             {
                 throw new InvalidOperationException($"No HTTP or HTTPS endpoint was found for MCP service '{endpoint.Host}'.");
             }
 
+            return resolvedUris[GetNextEndpointIndex(resolvedUris.Length)];
+        }
+
+        private static Uri? CreateResolvedEndpointUri(ServiceEndpoint serviceEndpoint, Uri endpoint)
+        {
+            return serviceEndpoint.EndPoint switch
+            {
+                UriEndPoint uriEndPoint => CreateResolvedEndpointUri(uriEndPoint.Uri, endpoint),
+                DnsEndPoint dnsEndPoint => CreateResolvedEndpointUri(endpoint, dnsEndPoint.Host, dnsEndPoint.Port),
+                IPEndPoint ipEndPoint => CreateResolvedEndpointUri(endpoint, serviceEndpoint.Features.Get<IHostNameFeature>()?.HostName ?? ipEndPoint.Address.ToString(), ipEndPoint.Port),
+                _ => null,
+            };
+        }
+
+        private static Uri CreateResolvedEndpointUri(Uri resolvedUri, Uri endpoint)
+        {
             return new UriBuilder(resolvedUri)
             {
                 Path = endpoint.AbsolutePath,
             }.Uri;
+        }
+
+        private static Uri CreateResolvedEndpointUri(Uri endpoint, string host, int port)
+        {
+            var builder = new UriBuilder(GetFirstScheme(endpoint), host)
+            {
+                Path = endpoint.AbsolutePath,
+            };
+
+            if (port > 0)
+            {
+                builder.Port = port;
+            }
+
+            return builder.Uri;
+        }
+
+        private static string GetFirstScheme(Uri endpoint)
+        {
+            var scheme = endpoint.Scheme;
+            var separatorIndex = scheme.IndexOf('+', StringComparison.Ordinal);
+
+            return separatorIndex < 0 ? scheme : scheme[..separatorIndex];
+        }
+
+        private int GetNextEndpointIndex(int endpointCount)
+        {
+            var index = Interlocked.Increment(ref _endpointIndex);
+
+            return (int)((uint)index % (uint)endpointCount);
         }
     }
 

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -278,7 +278,7 @@ public static class AspireMcpClientExtensions
             {
                 lock (_lock)
                 {
-                    client ??= _client ??= new ReconnectableMcpClient(_createClient);
+                    client ??= _client ??= new ReconnectableMcpClient(_createClient, _creationCancellation.Cancel);
                 }
             }
             client.Initialize();
@@ -303,7 +303,6 @@ public static class AspireMcpClientExtensions
                     var client = Volatile.Read(ref _client);
                     if (client is not null)
                     {
-                        client.Dispose();
                         await client.DisposeAsync().ConfigureAwait(false);
                     }
                     _creationCancellation.Dispose();
@@ -352,7 +351,9 @@ public static class AspireMcpClientExtensions
 
     // Keep the injected McpClient stable while replacing its private session after a terminal failure.
 #pragma warning disable MCPEXP002
-    private sealed class ReconnectableMcpClient(Func<Task<DisposableMcpClient>> createClient) : McpClient, IDisposable
+    private sealed class ReconnectableMcpClient(
+        Func<Task<DisposableMcpClient>> createClient,
+        Action cancelClientCreation) : McpClient, IDisposable
 #pragma warning restore MCPEXP002
     {
         private readonly object _lock = new();
@@ -399,6 +400,8 @@ public static class AspireMcpClientExtensions
         {
             if (Interlocked.Exchange(ref _disposed, 1) is 0)
             {
+                cancelClientCreation();
+
                 Task<DisposableMcpClient>? client;
                 lock (_lock)
                 {
@@ -421,6 +424,8 @@ public static class AspireMcpClientExtensions
         {
             if (Interlocked.Exchange(ref _disposed, 1) is 0)
             {
+                cancelClientCreation();
+
                 Task<DisposableMcpClient>? client;
                 lock (_lock)
                 {

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -356,6 +356,7 @@ public static class AspireMcpClientExtensions
                 var resolvedEndpoint = await ResolveEndpointAsync(endpoint, serviceEndpointResolver, _creationCancellation.Token).ConfigureAwait(false);
                 var transportOptions = new HttpClientTransportOptions { Endpoint = resolvedEndpoint };
                 configureTransportOptions?.Invoke(transportOptions);
+                McpClientSettings.ValidateEndpoint(transportOptions.Endpoint);
                 var clientOptions = new McpClientOptions();
                 configureClientOptions?.Invoke(clientOptions);
                 httpClient = httpClientFactory.CreateClient(string.Empty);

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 
@@ -202,8 +203,15 @@ public static class AspireMcpClientExtensions
             throw connectionStringException;
         }
 
-        var endpoint = settings.Endpoint ?? CreateServiceDiscoveryEndpoint(builder.Configuration, connectionName);
-        McpClientSettings.ValidateEndpoint(endpoint);
+        var endpoint = settings.Endpoint;
+        if (endpoint is null)
+        {
+            endpoint = CreateServiceDiscoveryEndpoint(connectionName);
+        }
+        else
+        {
+            McpClientSettings.ValidateEndpoint(endpoint);
+        }
         var registrationKey = new object();
         builder.Services.AddHttpClient();
         builder.Services.AddKeyedSingleton<McpClientRegistration>(registrationKey, (serviceProvider, _) => new McpClientRegistration(
@@ -211,7 +219,8 @@ public static class AspireMcpClientExtensions
             configureClientOptions,
             configureTransportOptions,
             serviceProvider.GetRequiredService<IHttpClientFactory>(),
-            serviceProvider.GetRequiredService<ILoggerFactory>()));
+            serviceProvider.GetRequiredService<ILoggerFactory>(),
+            serviceProvider.GetService<ServiceEndpointResolver>()));
 
         if (serviceKey is null)
         {
@@ -239,18 +248,14 @@ public static class AspireMcpClientExtensions
         return builder;
     }
 
-    private static Uri CreateServiceDiscoveryEndpoint(IConfiguration configuration, string connectionName)
+    private static Uri CreateServiceDiscoveryEndpoint(string connectionName)
     {
         if (connectionName.IndexOfAny(['/', '\\', '?', '#', '@', ':']) >= 0)
         {
             throw new ArgumentException($"'{connectionName}' is not a valid MCP service-discovery connection name.", nameof(connectionName));
         }
 
-        var servicesSection = configuration.GetSection("services").GetSection(connectionName);
-        var hasHttpsEndpoint = servicesSection.GetSection("https").GetChildren().Any();
-        var hasHttpEndpoint = servicesSection.GetSection("http").GetChildren().Any();
-        var scheme = !hasHttpsEndpoint && hasHttpEndpoint ? "http" : "https";
-        return new Uri($"{scheme}://{connectionName}/mcp", UriKind.Absolute);
+        return new Uri($"https+http://{connectionName}/mcp", UriKind.Absolute);
     }
 
     private sealed class McpClientRegistration : IDisposable, IAsyncDisposable
@@ -266,9 +271,10 @@ public static class AspireMcpClientExtensions
             Action<McpClientOptions>? configureClientOptions,
             Action<HttpClientTransportOptions>? configureTransportOptions,
             IHttpClientFactory httpClientFactory,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            ServiceEndpointResolver? serviceEndpointResolver)
         {
-            _createClient = () => CreateClientAsync(endpoint, configureClientOptions, configureTransportOptions, httpClientFactory, loggerFactory);
+            _createClient = () => CreateClientAsync(endpoint, configureClientOptions, configureTransportOptions, httpClientFactory, loggerFactory, serviceEndpointResolver);
         }
 
         public McpClient GetClient()
@@ -340,13 +346,15 @@ public static class AspireMcpClientExtensions
             Action<McpClientOptions>? configureClientOptions,
             Action<HttpClientTransportOptions>? configureTransportOptions,
             IHttpClientFactory httpClientFactory,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            ServiceEndpointResolver? serviceEndpointResolver)
         {
             HttpClient? httpClient = null;
             HttpClientTransport? transport = null;
             try
             {
-                var transportOptions = new HttpClientTransportOptions { Endpoint = endpoint };
+                var resolvedEndpoint = await ResolveEndpointAsync(endpoint, serviceEndpointResolver, _creationCancellation.Token).ConfigureAwait(false);
+                var transportOptions = new HttpClientTransportOptions { Endpoint = resolvedEndpoint };
                 configureTransportOptions?.Invoke(transportOptions);
                 var clientOptions = new McpClientOptions();
                 configureClientOptions?.Invoke(clientOptions);
@@ -372,6 +380,38 @@ public static class AspireMcpClientExtensions
                 }
                 throw;
             }
+        }
+
+        private static async Task<Uri> ResolveEndpointAsync(Uri endpoint, ServiceEndpointResolver? serviceEndpointResolver, CancellationToken cancellationToken)
+        {
+            if (endpoint.Scheme is not "https+http")
+            {
+                return endpoint;
+            }
+
+            if (serviceEndpointResolver is null)
+            {
+                return new UriBuilder(Uri.UriSchemeHttps, endpoint.Host, endpoint.Port, endpoint.AbsolutePath).Uri;
+            }
+
+            var endpointSource = await serviceEndpointResolver.GetEndpointsAsync(endpoint.GetLeftPart(UriPartial.Authority), cancellationToken).ConfigureAwait(false);
+            var resolvedUri = endpointSource.Endpoints
+                .Select(static serviceEndpoint => serviceEndpoint.EndPoint)
+                .OfType<UriEndPoint>()
+                .Select(static uriEndpoint => uriEndpoint.Uri)
+                .Where(static uri => uri.Scheme is "http" or "https")
+                .OrderByDescending(static uri => uri.Scheme is "https")
+                .FirstOrDefault();
+
+            if (resolvedUri is null)
+            {
+                throw new InvalidOperationException($"No HTTP or HTTPS endpoint was found for MCP service '{endpoint.Host}'.");
+            }
+
+            return new UriBuilder(resolvedUri)
+            {
+                Path = endpoint.AbsolutePath,
+            }.Uri;
         }
     }
 

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -230,7 +230,7 @@ public static class AspireMcpClientExtensions
 
             builder.TryAddHealthCheck(new HealthCheckRegistration(
                 healthCheckName,
-                sp => new McpClientHealthCheck(sp, serviceKey),
+                sp => new McpClientHealthCheck(sp, registrationKey),
                 failureStatus: default,
                 tags: default,
                 timeout: default));
@@ -273,6 +273,20 @@ public static class AspireMcpClientExtensions
 
         public McpClient GetClient()
         {
+            var client = GetOrCreateClient();
+            client.Initialize();
+            return client;
+        }
+
+        public async Task<McpClient> GetClientAsync(CancellationToken cancellationToken)
+        {
+            var client = GetOrCreateClient();
+            await client.InitializeAsync(cancellationToken).ConfigureAwait(false);
+            return client;
+        }
+
+        private ReconnectableMcpClient GetOrCreateClient()
+        {
             ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
             var client = Volatile.Read(ref _client);
             if (client is null)
@@ -283,7 +297,6 @@ public static class AspireMcpClientExtensions
                     client ??= _client ??= new ReconnectableMcpClient(_createClient, _creationCancellation.Cancel);
                 }
             }
-            client.Initialize();
             return client;
         }
 
@@ -409,6 +422,21 @@ public static class AspireMcpClientExtensions
 
         public void Initialize() => _ = GetClient();
 
+        public async Task InitializeAsync(CancellationToken cancellationToken)
+        {
+            var task = GetClientTask();
+            try
+            {
+                var client = await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                RegisterNotificationHandlers(task, client);
+            }
+            catch (Exception ex) when (IsTerminalFailure(task, ex))
+            {
+                Invalidate(task);
+                throw;
+            }
+        }
+
         public void Dispose()
         {
             if (Interlocked.Exchange(ref _disposed, 1) is 0)
@@ -455,7 +483,21 @@ public static class AspireMcpClientExtensions
             }
         }
 
-        private McpClient GetClient() => GetClientTask().GetAwaiter().GetResult();
+        private McpClient GetClient()
+        {
+            var task = GetClientTask();
+            try
+            {
+                var client = task.GetAwaiter().GetResult();
+                RegisterNotificationHandlers(task, client);
+                return client;
+            }
+            catch (Exception ex) when (IsTerminalFailure(task, ex))
+            {
+                Invalidate(task);
+                throw;
+            }
+        }
 
         private Task<DisposableMcpClient> GetClientTask()
         {
@@ -670,15 +712,14 @@ public static class AspireMcpClientExtensions
         }
     }
 
-    private sealed class McpClientHealthCheck(IServiceProvider serviceProvider, object? serviceKey) : IHealthCheck
+    private sealed class McpClientHealthCheck(IServiceProvider serviceProvider, object registrationKey) : IHealthCheck
     {
         public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             try
             {
-                var client = serviceKey is null
-                    ? serviceProvider.GetRequiredService<McpClient>()
-                    : serviceProvider.GetRequiredKeyedService<McpClient>(serviceKey);
+                var registration = serviceProvider.GetRequiredKeyedService<McpClientRegistration>(registrationKey);
+                var client = await registration.GetClientAsync(cancellationToken).ConfigureAwait(false);
 
                 await client.PingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
                 return HealthCheckResult.Healthy();

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -129,9 +129,7 @@ public static class AspireMcpClientExtensions
         return builder;
     }
 
-    private sealed class McpClientRegistration
-        : IDisposable
-        , IAsyncDisposable
+    private sealed class McpClientRegistration : IDisposable
     {
         private readonly Lazy<Task<DisposableMcpClient>> _client;
         private readonly CancellationTokenSource _creationCancellation = new();
@@ -161,67 +159,7 @@ public static class AspireMcpClientExtensions
             }
 
             _creationCancellation.Cancel();
-            if (!_client.IsValueCreated)
-            {
-                _creationCancellation.Dispose();
-                return;
-            }
-
-            try
-            {
-                _client.Value.GetAwaiter().GetResult().Dispose();
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception)
-            {
-                // Client creation can fail independently of host shutdown; disposal still needs to
-                // observe and drain the in-flight task without surfacing teardown-time failures.
-            }
-            finally
-            {
-                _creationCancellation.Dispose();
-            }
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            if (Interlocked.Exchange(ref _disposed, 1) is not 0)
-            {
-                return;
-            }
-
-            _creationCancellation.Cancel();
-            if (!_client.IsValueCreated)
-            {
-                _creationCancellation.Dispose();
-                return;
-            }
-
-            try
-            {
-                var client = await _client.Value.ConfigureAwait(false);
-                await client.DisposeAsync().ConfigureAwait(false);
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception)
-            {
-                // Client creation can fail independently of host shutdown; disposal still needs to
-                // observe and drain the in-flight task without surfacing teardown-time failures.
-            }
-            finally
-            {
-                _creationCancellation.Dispose();
-            }
+            _creationCancellation.Dispose();
         }
 
         private async Task<DisposableMcpClient> CreateClientAsync(

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -182,7 +182,11 @@ public static class AspireMcpClientExtensions
 
             try
             {
-                var client = await McpClient.CreateAsync(transport, clientOptions, cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
+                var client = await McpClient.CreateAsync(
+                    transport,
+                    clientOptions,
+                    loggerFactory: loggerFactory,
+                    cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
                 if (Volatile.Read(ref _disposed) is not 0)
                 {
                     await client.DisposeAsync().ConfigureAwait(false);

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -350,14 +350,14 @@ public static class AspireMcpClientExtensions
         }
     }
 
-    // Keep the injected McpClient stable while replacing its private session after completion or failure.
+    // Keep the injected McpClient stable while replacing its private session after a terminal failure.
 #pragma warning disable MCPEXP002
     private sealed class ReconnectableMcpClient(Func<Task<DisposableMcpClient>> createClient) : McpClient, IDisposable
 #pragma warning restore MCPEXP002
     {
         private readonly object _lock = new();
-        private readonly SemaphoreSlim _operationLock = new(1, 1);
-        private readonly List<Task> _retiredClients = [];
+        private readonly HashSet<NotificationRegistration> _notificationRegistrations = [];
+        private readonly HashSet<Task> _cleanupTasks = [];
         private Task<DisposableMcpClient>? _client;
         private int _disposed;
 
@@ -367,9 +367,31 @@ public static class AspireMcpClientExtensions
         public override Task<ClientCompletionDetails> Completion => GetClient().Completion;
         public override string SessionId => GetClient().SessionId!;
         public override string NegotiatedProtocolVersion => GetClient().NegotiatedProtocolVersion!;
-        public override Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken = default) => ExecuteAsync(client => client.SendRequestAsync(request, cancellationToken));
-        public override Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default) => ExecuteAsync(client => client.SendMessageAsync(message, cancellationToken));
-        public override IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler) => GetClient().RegisterNotificationHandler(method, handler);
+
+        public override Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken = default)
+            => ExecuteAsync((client, token) => client.SendRequestAsync(request, token), cancellationToken);
+
+        public override Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
+            => ExecuteAsync((client, token) => client.SendMessageAsync(message, token), cancellationToken);
+
+        public override IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler)
+        {
+            var registration = new NotificationRegistration(this, method, handler);
+            while (true)
+            {
+                var task = GetClientTask();
+                var client = task.GetAwaiter().GetResult();
+                lock (_lock)
+                {
+                    if (ReferenceEquals(_client, task))
+                    {
+                        _notificationRegistrations.Add(registration);
+                        registration.Register(task, client);
+                        return registration;
+                    }
+                }
+            }
+        }
 
         public void Initialize() => _ = GetClient();
 
@@ -377,23 +399,47 @@ public static class AspireMcpClientExtensions
         {
             if (Interlocked.Exchange(ref _disposed, 1) is 0)
             {
-                var client = Interlocked.Exchange(ref _client, null);
-                if (client?.IsCompletedSuccessfully is true)
+                Task<DisposableMcpClient>? client;
+                lock (_lock)
+                {
+                    client = _client;
+                    _client = null;
+                }
+
+                if (client is not null)
                 {
                     DisposeClientAsync(client).GetAwaiter().GetResult();
                 }
-                DisposeRetiredClientsAsync().GetAwaiter().GetResult();
-                _operationLock.Dispose();
+
+                WaitForCleanupAsync().GetAwaiter().GetResult();
             }
         }
 
-        public override ValueTask DisposeAsync()
+        public override ValueTask DisposeAsync() => new(DisposeAsyncCore());
+
+        private async Task DisposeAsyncCore()
         {
-            Dispose();
-            return ValueTask.CompletedTask;
+            if (Interlocked.Exchange(ref _disposed, 1) is 0)
+            {
+                Task<DisposableMcpClient>? client;
+                lock (_lock)
+                {
+                    client = _client;
+                    _client = null;
+                }
+
+                if (client is not null)
+                {
+                    await DisposeClientAsync(client).ConfigureAwait(false);
+                }
+
+                await WaitForCleanupAsync().ConfigureAwait(false);
+            }
         }
 
-        private McpClient GetClient()
+        private McpClient GetClient() => GetClientTask().GetAwaiter().GetResult();
+
+        private Task<DisposableMcpClient> GetClientTask()
         {
             ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
             var clientTask = Volatile.Read(ref _client);
@@ -401,67 +447,47 @@ public static class AspireMcpClientExtensions
             {
                 lock (_lock)
                 {
+                    ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) is not 0, this);
                     clientTask ??= _client ??= createClient();
-                    _ = ObserveCompletionAsync(clientTask);
+                    if (ReferenceEquals(_client, clientTask))
+                    {
+                        _ = ObserveCompletionAsync(clientTask);
+                    }
                 }
             }
+
+            return clientTask;
+        }
+
+        private async Task<T> ExecuteAsync<T>(Func<McpClient, CancellationToken, Task<T>> operation, CancellationToken cancellationToken)
+        {
+            var task = GetClientTask();
             try
             {
-                return clientTask.GetAwaiter().GetResult();
+                var client = await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                RegisterNotificationHandlers(task, client);
+                return await operation(client, cancellationToken).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex) when (IsTerminalFailure(task, ex))
             {
-                Invalidate(clientTask);
+                Invalidate(task);
                 throw;
             }
         }
 
-        private async Task<T> ExecuteAsync<T>(Func<McpClient, Task<T>> operation)
+        private async Task ExecuteAsync(Func<McpClient, CancellationToken, Task> operation, CancellationToken cancellationToken)
         {
-            await _operationLock.WaitAsync().ConfigureAwait(false);
+            var task = GetClientTask();
             try
             {
-                for (var attempt = 0; ; attempt++)
-                {
-                    var task = Volatile.Read(ref _client);
-                    try
-                    {
-                        return await operation(GetClient()).ConfigureAwait(false);
-                    }
-                    catch when (attempt is 0 && task is not null)
-                    {
-                        Invalidate(task);
-                    }
-                }
+                var client = await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                RegisterNotificationHandlers(task, client);
+                await operation(client, cancellationToken).ConfigureAwait(false);
             }
-            finally
+            catch (Exception ex) when (IsTerminalFailure(task, ex))
             {
-                _operationLock.Release();
-            }
-        }
-
-        private async Task ExecuteAsync(Func<McpClient, Task> operation)
-        {
-            await _operationLock.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                for (var attempt = 0; ; attempt++)
-                {
-                    var task = Volatile.Read(ref _client);
-                    try
-                    {
-                        await operation(GetClient()).ConfigureAwait(false);
-                        return;
-                    }
-                    catch when (attempt is 0 && task is not null)
-                    {
-                        Invalidate(task);
-                    }
-                }
-            }
-            finally
-            {
-                _operationLock.Release();
+                Invalidate(task);
+                throw;
             }
         }
 
@@ -474,7 +500,43 @@ public static class AspireMcpClientExtensions
             catch
             {
             }
+
             Invalidate(task);
+        }
+
+        private void RegisterNotificationHandlers(Task<DisposableMcpClient> task, DisposableMcpClient client)
+        {
+            lock (_lock)
+            {
+                if (ReferenceEquals(_client, task))
+                {
+                    foreach (var registration in _notificationRegistrations)
+                    {
+                        registration.Register(task, client);
+                    }
+                }
+            }
+        }
+
+        private static bool IsTerminalFailure(Task<DisposableMcpClient> task, Exception exception)
+        {
+            if (exception is OperationCanceledException)
+            {
+                return false;
+            }
+
+            if (exception is HttpRequestException or IOException or System.Net.Sockets.SocketException)
+            {
+                return true;
+            }
+
+            if (!task.IsCompletedSuccessfully)
+            {
+                return false;
+            }
+
+            var completion = task.Result.Completion;
+            return completion.IsCompletedSuccessfully && completion.Result.Exception is not null;
         }
 
         private void Invalidate(Task<DisposableMcpClient> task)
@@ -485,26 +547,55 @@ public static class AspireMcpClientExtensions
                 {
                     return;
                 }
+
                 _client = null;
             }
+
             if (task.IsCompletedSuccessfully)
             {
-                lock (_lock)
-                {
-                    _retiredClients.Add(DisposeClientAsync(task));
-                }
+                TrackCleanup(DisposeClientAsync(task));
             }
         }
 
-        private async Task DisposeRetiredClientsAsync()
+        private void TrackCleanup(Task cleanupTask)
         {
-            Task[] tasks;
             lock (_lock)
             {
-                tasks = [.. _retiredClients];
-                _retiredClients.Clear();
+                _cleanupTasks.Add(cleanupTask);
             }
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            _ = cleanupTask.ContinueWith(
+                _ => RemoveCleanup(cleanupTask),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        private void RemoveCleanup(Task cleanupTask)
+        {
+            lock (_lock)
+            {
+                _cleanupTasks.Remove(cleanupTask);
+            }
+        }
+
+        private async Task WaitForCleanupAsync()
+        {
+            while (true)
+            {
+                Task[] tasks;
+                lock (_lock)
+                {
+                    tasks = [.. _cleanupTasks];
+                }
+
+                if (tasks.Length is 0)
+                {
+                    return;
+                }
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
         }
 
         private static async Task DisposeClientAsync(Task<DisposableMcpClient> task)
@@ -515,6 +606,46 @@ public static class AspireMcpClientExtensions
             }
             catch
             {
+            }
+        }
+
+        private sealed class NotificationRegistration(
+            ReconnectableMcpClient owner,
+            string method,
+            Func<JsonRpcNotification, CancellationToken, ValueTask> handler) : IAsyncDisposable
+        {
+            private Task<DisposableMcpClient>? _client;
+            private IAsyncDisposable? _innerRegistration;
+            private int _disposed;
+
+            public void Register(Task<DisposableMcpClient> clientTask, DisposableMcpClient client)
+            {
+                if (Volatile.Read(ref _disposed) is not 0 || ReferenceEquals(_client, clientTask))
+                {
+                    return;
+                }
+
+                _client = clientTask;
+                _innerRegistration = client.RegisterNotificationHandler(method, handler);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) is 0)
+                {
+                    IAsyncDisposable? registration;
+                    lock (owner._lock)
+                    {
+                        owner._notificationRegistrations.Remove(this);
+                        registration = _innerRegistration;
+                        _innerRegistration = null;
+                    }
+
+                    if (registration is not null)
+                    {
+                        await registration.DisposeAsync().ConfigureAwait(false);
+                    }
+                }
             }
         }
     }

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -493,6 +493,9 @@ public static class AspireMcpClientExtensions
 
         public override IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler)
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(method);
+            ArgumentNullException.ThrowIfNull(handler);
+
             var registration = new NotificationRegistration(this, method, handler);
             while (true)
             {

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -128,9 +129,9 @@ public static class AspireMcpClientExtensions
         return builder;
     }
 
-    private sealed class McpClientRegistration : IAsyncDisposable, IDisposable
+    private sealed class McpClientRegistration
     {
-        private readonly Lazy<Task<McpClient>> _client;
+        private readonly Lazy<Task<DisposableMcpClient>> _client;
 
         public McpClientRegistration(
             Uri endpoint,
@@ -147,23 +148,7 @@ public static class AspireMcpClientExtensions
             return _client.Value.GetAwaiter().GetResult();
         }
 
-        public async ValueTask DisposeAsync()
-        {
-            if (_client.IsValueCreated && _client.Value.IsCompletedSuccessfully)
-            {
-                await _client.Value.Result.DisposeAsync().ConfigureAwait(false);
-            }
-        }
-
-        public void Dispose()
-        {
-            if (_client.IsValueCreated && _client.Value.IsCompletedSuccessfully)
-            {
-                _client.Value.Result.DisposeAsync().AsTask().GetAwaiter().GetResult();
-            }
-        }
-
-        private static async Task<McpClient> CreateClientAsync(
+        private static async Task<DisposableMcpClient> CreateClientAsync(
             Uri endpoint,
             Action<McpClientOptions>? configureClientOptions,
             Action<HttpClientTransportOptions>? configureTransportOptions,
@@ -180,7 +165,56 @@ public static class AspireMcpClientExtensions
             var clientOptions = new McpClientOptions();
             configureClientOptions?.Invoke(clientOptions);
 
-            return await McpClient.CreateAsync(transport, clientOptions).ConfigureAwait(false);
+            var client = await McpClient.CreateAsync(transport, clientOptions).ConfigureAwait(false);
+            return new DisposableMcpClient(client);
+        }
+    }
+
+    // The DI container disposes singleton factory results directly. Wrapping the async-only client
+    // gives the host a synchronous disposal path while preserving the client API surface.
+#pragma warning disable MCPEXP002 // McpClient constructor is required to provide a wrapper that supports IDisposable.
+    private sealed class DisposableMcpClient(McpClient innerClient) : McpClient, IDisposable
+#pragma warning restore MCPEXP002
+    {
+        private int _disposed;
+
+        public override ServerCapabilities ServerCapabilities => innerClient.ServerCapabilities;
+
+        public override Implementation ServerInfo => innerClient.ServerInfo;
+
+        public override string ServerInstructions => innerClient.ServerInstructions!;
+
+        public override Task<ClientCompletionDetails> Completion => innerClient.Completion;
+
+        public override string SessionId => innerClient.SessionId!;
+
+        public override string NegotiatedProtocolVersion => innerClient.NegotiatedProtocolVersion!;
+
+        public override Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken = default)
+            => innerClient.SendRequestAsync(request, cancellationToken);
+
+        public override Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default)
+            => innerClient.SendMessageAsync(message, cancellationToken);
+
+        public override IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler)
+            => innerClient.RegisterNotificationHandler(method, handler);
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) is 0)
+            {
+                innerClient.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) is 0)
+            {
+                return innerClient.DisposeAsync();
+            }
+
+            return ValueTask.CompletedTask;
         }
     }
 }

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
+using Aspire.Mcp.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -14,6 +17,8 @@ namespace Microsoft.Extensions.Hosting;
 /// </summary>
 public static class AspireMcpClientExtensions
 {
+    private const string DefaultConfigSectionName = "Aspire:Mcp:Client";
+
     /// <summary>
     /// Registers an <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
     /// </summary>
@@ -69,8 +74,8 @@ public static class AspireMcpClientExtensions
     public static IHostApplicationBuilder AddMcpClient(
         this IHostApplicationBuilder builder,
         string connectionName,
-        Action<McpClientOptions>? configureClientOptions,
-        Action<HttpClientTransportOptions>? configureTransportOptions)
+        Action<McpClientOptions>? configureClientOptions = null,
+        Action<HttpClientTransportOptions>? configureTransportOptions = null)
         => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions, configureTransportOptions);
 
     /// <summary>
@@ -133,8 +138,8 @@ public static class AspireMcpClientExtensions
     public static IHostApplicationBuilder AddKeyedMcpClient(
         this IHostApplicationBuilder builder,
         string name,
-        Action<McpClientOptions>? configureClientOptions,
-        Action<HttpClientTransportOptions>? configureTransportOptions)
+        Action<McpClientOptions>? configureClientOptions = null,
+        Action<HttpClientTransportOptions>? configureTransportOptions = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
@@ -152,7 +157,18 @@ public static class AspireMcpClientExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
-        var endpoint = CreateEndpoint(builder.Configuration, connectionName);
+        var settings = new McpClientSettings();
+        var configSection = builder.Configuration.GetSection(DefaultConfigSectionName);
+        var namedConfigSection = configSection.GetSection(connectionName);
+        configSection.Bind(settings);
+        namedConfigSection.Bind(settings);
+
+        if (builder.Configuration.GetConnectionString(connectionName) is string connectionString)
+        {
+            settings.ParseConnectionString(connectionString);
+        }
+
+        var endpoint = settings.Endpoint ?? CreateServiceDiscoveryEndpoint(builder.Configuration, connectionName);
         var registrationKey = new object();
         builder.Services.AddHttpClient();
         builder.Services.AddKeyedSingleton<McpClientRegistration>(registrationKey, (serviceProvider, _) => new McpClientRegistration(
@@ -173,20 +189,34 @@ public static class AspireMcpClientExtensions
                 serviceProvider.GetRequiredKeyedService<McpClientRegistration>(registrationKey).GetClient());
         }
 
+        if (!settings.DisableHealthChecks)
+        {
+            var healthCheckName = serviceKey is null ? "Mcp.Client" : $"Mcp.Client_{connectionName}";
+
+            builder.TryAddHealthCheck(new HealthCheckRegistration(
+                healthCheckName,
+                sp => new McpClientHealthCheck(sp, serviceKey),
+                failureStatus: default,
+                tags: default,
+                timeout: default));
+        }
+
         return builder;
     }
 
-    private static Uri CreateEndpoint(IConfiguration configuration, string connectionName)
+    private static Uri CreateServiceDiscoveryEndpoint(IConfiguration configuration, string connectionName)
     {
+        if (connectionName.IndexOfAny(['/', '\\', '?', '#', '@', ':']) >= 0)
+        {
+            throw new ArgumentException($"'{connectionName}' is not a valid MCP service-discovery connection name.", nameof(connectionName));
+        }
+
         var servicesSection = configuration.GetSection("services").GetSection(connectionName);
-        var hasHttpsEndpoint = HasServiceDiscoveryEndpoint(servicesSection, "https");
-        var hasHttpEndpoint = HasServiceDiscoveryEndpoint(servicesSection, "http");
+        var hasHttpsEndpoint = servicesSection.GetSection("https").GetChildren().Any();
+        var hasHttpEndpoint = servicesSection.GetSection("http").GetChildren().Any();
         var scheme = !hasHttpsEndpoint && hasHttpEndpoint ? "http" : "https";
         return new Uri($"{scheme}://{connectionName}/mcp", UriKind.Absolute);
     }
-
-    private static bool HasServiceDiscoveryEndpoint(IConfigurationSection serviceSection, string scheme)
-        => serviceSection.GetSection(scheme).GetChildren().Any();
 
     private sealed class McpClientRegistration : IDisposable
     {
@@ -263,19 +293,22 @@ public static class AspireMcpClientExtensions
             IHttpClientFactory httpClientFactory,
             ILoggerFactory loggerFactory)
         {
-            var transportOptions = new HttpClientTransportOptions { Endpoint = endpoint };
-            configureTransportOptions?.Invoke(transportOptions);
-            var clientOptions = new McpClientOptions();
-            configureClientOptions?.Invoke(clientOptions);
-            var httpClient = httpClientFactory.CreateClient();
-            var transport = new HttpClientTransport(
-                transportOptions,
-                httpClient,
-                loggerFactory,
-                ownsHttpClient: true);
+            HttpClient? httpClient = null;
+            HttpClientTransport? transport = null;
 
             try
             {
+                var transportOptions = new HttpClientTransportOptions { Endpoint = endpoint };
+                configureTransportOptions?.Invoke(transportOptions);
+                var clientOptions = new McpClientOptions();
+                configureClientOptions?.Invoke(clientOptions);
+                httpClient = httpClientFactory.CreateClient();
+                transport = new HttpClientTransport(
+                    transportOptions,
+                    httpClient,
+                    loggerFactory,
+                    ownsHttpClient: true);
+
                 var client = await McpClient.CreateAsync(
                     transport,
                     clientOptions,
@@ -291,8 +324,35 @@ public static class AspireMcpClientExtensions
             }
             catch
             {
-                await transport.DisposeAsync().ConfigureAwait(false);
+                if (transport is not null)
+                {
+                    await transport.DisposeAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    httpClient?.Dispose();
+                }
+
                 throw;
+            }
+        }
+    }
+
+    private sealed class McpClientHealthCheck(IServiceProvider serviceProvider, object? serviceKey) : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                _ = serviceKey is null
+                    ? serviceProvider.GetRequiredService<McpClient>()
+                    : serviceProvider.GetRequiredKeyedService<McpClient>(serviceKey);
+
+                return Task.FromResult(HealthCheckResult.Healthy());
+            }
+            catch (Exception ex)
+            {
+                return Task.FromResult(HealthCheckResult.Unhealthy("MCP client initialization failed.", ex));
             }
         }
     }

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -38,6 +38,7 @@ public static class AspireMcpClientExtensions
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
+    /// <exception cref="FormatException">Thrown when the configured connection string is not an absolute HTTP or HTTPS URI.</exception>
     public static IHostApplicationBuilder AddMcpClient(this IHostApplicationBuilder builder, string connectionName)
         => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions: null, configureTransportOptions: null, configureSettings: null);
 
@@ -72,6 +73,7 @@ public static class AspireMcpClientExtensions
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
+    /// <exception cref="FormatException">Thrown when the configured connection string is not an absolute HTTP or HTTPS URI and <paramref name="configureSettings"/> does not provide an endpoint.</exception>
     public static IHostApplicationBuilder AddMcpClient(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -99,6 +101,7 @@ public static class AspireMcpClientExtensions
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="name"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty.</exception>
+    /// <exception cref="FormatException">Thrown when the configured connection string is not an absolute HTTP or HTTPS URI.</exception>
     public static IHostApplicationBuilder AddKeyedMcpClient(this IHostApplicationBuilder builder, string name)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -138,6 +141,7 @@ public static class AspireMcpClientExtensions
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="name"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty.</exception>
+    /// <exception cref="FormatException">Thrown when the configured connection string is not an absolute HTTP or HTTPS URI and <paramref name="configureSettings"/> does not provide an endpoint.</exception>
     public static IHostApplicationBuilder AddKeyedMcpClient(
         this IHostApplicationBuilder builder,
         string name,
@@ -168,12 +172,25 @@ public static class AspireMcpClientExtensions
         configSection.Bind(settings);
         namedConfigSection.Bind(settings);
 
+        FormatException? connectionStringException = null;
         if (builder.Configuration.GetConnectionString(connectionName) is string connectionString)
         {
-            settings.ParseConnectionString(connectionString);
+            try
+            {
+                settings.ParseConnectionString(connectionString);
+            }
+            catch (FormatException ex)
+            {
+                connectionStringException = ex;
+            }
         }
 
         configureSettings?.Invoke(settings);
+
+        if (connectionStringException is not null && settings.Endpoint is null)
+        {
+            throw connectionStringException;
+        }
 
         var endpoint = settings.Endpoint ?? CreateServiceDiscoveryEndpoint(builder.Configuration, connectionName);
         var registrationKey = new object();
@@ -290,7 +307,6 @@ public static class AspireMcpClientExtensions
             }
 
             _creationCancellation.Cancel();
-            _creationCancellation.Dispose();
         }
 
         private async Task<DisposableMcpClient> CreateClientAsync(
@@ -309,7 +325,7 @@ public static class AspireMcpClientExtensions
                 configureTransportOptions?.Invoke(transportOptions);
                 var clientOptions = new McpClientOptions();
                 configureClientOptions?.Invoke(clientOptions);
-                httpClient = httpClientFactory.CreateClient();
+                httpClient = httpClientFactory.CreateClient(string.Empty);
                 transport = new HttpClientTransport(
                     transportOptions,
                     httpClient,

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -449,8 +449,18 @@ public static class AspireMcpClientExtensions
         {
             return new UriBuilder(resolvedUri)
             {
-                Path = endpoint.AbsolutePath,
+                Path = CombinePathPrefixes(resolvedUri.AbsolutePath, endpoint.AbsolutePath),
             }.Uri;
+        }
+
+        private static string CombinePathPrefixes(string basePath, string requestPath)
+        {
+            return (basePath, requestPath) switch
+            {
+                ("", _) or ("/", _) => requestPath,
+                (_, "") or (_, "/") => basePath,
+                _ => $"{basePath.TrimEnd('/')}/{requestPath.TrimStart('/')}",
+            };
         }
 
         private static Uri CreateResolvedEndpointUri(Uri endpoint, string host, int port)

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -446,7 +446,7 @@ public static class AspireMcpClientExtensions
                     ? endpoint
                     : transportOptions.Endpoint;
                 var resolvedEndpoint = await ResolveEndpointAsync(endpointToResolve, serviceEndpointResolver, _creationCancellation.Token).ConfigureAwait(false);
-                transportOptions.Endpoint = resolvedEndpoint;
+                transportOptions.Endpoint = resolvedEndpoint.Endpoint;
                 McpClientSettings.ValidateEndpoint(transportOptions.Endpoint);
                 var clientOptions = new McpClientOptions();
                 foreach (var configureClientOptions in registrationOptions.ClientOptionsActions)
@@ -467,22 +467,36 @@ public static class AspireMcpClientExtensions
                     oauth.TokenCache ??= registrationOptions.OAuthTokenCache ??= new InMemoryTokenCache();
                     transportOptions.OAuth = oauth;
                 }
-                if (registrationOptions.BearerTokenProvider is not null)
+                if (resolvedEndpoint.RequestHost is null && registrationOptions.BearerTokenProvider is null)
+                {
+                    httpClient = httpClientFactory.CreateClient(httpClientName);
+                }
+                else
                 {
                     var innerHandler = httpMessageHandlerFactory.CreateHandler(httpClientName);
-                    httpClient = new HttpClient(new BearerTokenHttpMessageHandler(serviceProvider, registrationOptions.BearerTokenProvider, resolvedEndpoint)
+                    HttpMessageHandler handler = innerHandler;
+                    if (resolvedEndpoint.RequestHost is not null)
                     {
-                        InnerHandler = innerHandler,
-                    }, disposeHandler: true);
+                        handler = new HostHeaderHttpMessageHandler(resolvedEndpoint.Endpoint, resolvedEndpoint.RequestHost)
+                        {
+                            InnerHandler = handler,
+                        };
+                    }
+
+                    if (registrationOptions.BearerTokenProvider is not null)
+                    {
+                        handler = new BearerTokenHttpMessageHandler(serviceProvider, registrationOptions.BearerTokenProvider, resolvedEndpoint.Endpoint)
+                        {
+                            InnerHandler = handler,
+                        };
+                    }
+
+                    httpClient = new HttpClient(handler, disposeHandler: true);
                     var clientFactoryOptions = serviceProvider.GetRequiredService<IOptionsMonitor<HttpClientFactoryOptions>>().Get(httpClientName);
                     foreach (var configureClient in clientFactoryOptions.HttpClientActions)
                     {
                         configureClient(httpClient);
                     }
-                }
-                else
-                {
-                    httpClient = httpClientFactory.CreateClient(httpClientName);
                 }
                 transport = new HttpClientTransport(transportOptions, httpClient, loggerFactory, ownsHttpClient: true);
                 var client = await McpClient.CreateAsync(transport, clientOptions, loggerFactory: loggerFactory, cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
@@ -514,45 +528,53 @@ public static class AspireMcpClientExtensions
                 : endpoint;
         }
 
-        private async Task<Uri> ResolveEndpointAsync(Uri endpoint, ServiceEndpointResolver? serviceEndpointResolver, CancellationToken cancellationToken)
+        private async Task<ResolvedEndpoint> ResolveEndpointAsync(Uri endpoint, ServiceEndpointResolver? serviceEndpointResolver, CancellationToken cancellationToken)
         {
             if (endpoint.Scheme is not "https+http")
             {
-                return endpoint;
+                return new(endpoint, RequestHost: null);
             }
 
             if (serviceEndpointResolver is null)
             {
-                return new UriBuilder(Uri.UriSchemeHttps, endpoint.Host, endpoint.Port, endpoint.AbsolutePath).Uri;
+                return new(new UriBuilder(Uri.UriSchemeHttps, endpoint.Host, endpoint.Port, endpoint.AbsolutePath).Uri, RequestHost: null);
             }
 
             var endpointSource = await serviceEndpointResolver.GetEndpointsAsync(endpoint.GetLeftPart(UriPartial.Authority), cancellationToken).ConfigureAwait(false);
-            var resolvedUris = endpointSource.Endpoints
-                .Select(serviceEndpoint => CreateResolvedEndpointUri(serviceEndpoint, endpoint))
-                .OfType<Uri>()
-                .Where(static uri => uri.Scheme is "http" or "https")
-                .GroupBy(static uri => uri.Scheme is "https" ? 0 : 1)
+            var resolvedEndpoints = endpointSource.Endpoints
+                .Select(serviceEndpoint => CreateResolvedEndpoint(serviceEndpoint, endpoint))
+                .OfType<ResolvedEndpoint>()
+                .Where(static endpoint => endpoint.Endpoint.Scheme is "http" or "https")
+                .GroupBy(static endpoint => endpoint.Endpoint.Scheme is "https" ? 0 : 1)
                 .OrderBy(static group => group.Key)
                 .FirstOrDefault()
                 ?.ToArray();
 
-            if (resolvedUris is null || resolvedUris.Length == 0)
+            if (resolvedEndpoints is null || resolvedEndpoints.Length == 0)
             {
                 throw new InvalidOperationException($"No HTTP or HTTPS endpoint was found for MCP service '{endpoint.Host}'.");
             }
 
-            return resolvedUris[GetNextEndpointIndex(resolvedUris.Length)];
+            return resolvedEndpoints[GetNextEndpointIndex(resolvedEndpoints.Length)];
         }
 
-        private static Uri? CreateResolvedEndpointUri(ServiceEndpoint serviceEndpoint, Uri endpoint)
+        private static ResolvedEndpoint? CreateResolvedEndpoint(ServiceEndpoint serviceEndpoint, Uri endpoint)
         {
             return serviceEndpoint.EndPoint switch
             {
-                UriEndPoint uriEndPoint => CreateResolvedEndpointUri(uriEndPoint.Uri, endpoint),
-                DnsEndPoint dnsEndPoint => CreateResolvedEndpointUri(endpoint, dnsEndPoint.Host, dnsEndPoint.Port),
-                IPEndPoint ipEndPoint => CreateResolvedEndpointUri(endpoint, serviceEndpoint.Features.Get<IHostNameFeature>()?.HostName ?? ipEndPoint.Address.ToString(), ipEndPoint.Port),
+                UriEndPoint uriEndPoint => new(CreateResolvedEndpointUri(uriEndPoint.Uri, endpoint), RequestHost: null),
+                DnsEndPoint dnsEndPoint => new(CreateResolvedEndpointUri(endpoint, dnsEndPoint.Host, dnsEndPoint.Port), RequestHost: null),
+                IPEndPoint ipEndPoint => CreateResolvedIpEndpoint(ipEndPoint, serviceEndpoint.Features.Get<IHostNameFeature>(), endpoint),
                 _ => null,
             };
+        }
+
+        private static ResolvedEndpoint CreateResolvedIpEndpoint(IPEndPoint ipEndPoint, IHostNameFeature? hostNameFeature, Uri endpoint)
+        {
+            var resolvedUri = CreateResolvedEndpointUri(endpoint, ipEndPoint.Address.ToString(), ipEndPoint.Port);
+            return string.IsNullOrWhiteSpace(hostNameFeature?.HostName)
+                ? new(resolvedUri, RequestHost: null)
+                : new(resolvedUri, hostNameFeature.HostName);
         }
 
         private static Uri CreateResolvedEndpointUri(Uri resolvedUri, Uri endpoint)
@@ -601,6 +623,24 @@ public static class AspireMcpClientExtensions
             var index = Interlocked.Increment(ref _endpointIndex);
 
             return (int)((uint)index % (uint)endpointCount);
+        }
+
+        private readonly record struct ResolvedEndpoint(Uri Endpoint, string? RequestHost);
+    }
+
+    private sealed class HostHeaderHttpMessageHandler(Uri mcpEndpoint, string requestHost) : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri is { } requestUri &&
+                requestUri.Host.Equals(mcpEndpoint.Host, StringComparison.OrdinalIgnoreCase) &&
+                requestUri.Scheme.Equals(mcpEndpoint.Scheme, StringComparison.OrdinalIgnoreCase) &&
+                requestUri.Port == mcpEndpoint.Port)
+            {
+                request.Headers.Host = requestHost;
+            }
+
+            return base.SendAsync(request, cancellationToken);
         }
     }
 

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -6,11 +6,15 @@ using Aspire.Mcp.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.ServiceDiscovery;
+using ModelContextProtocol.Authentication;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -37,11 +41,11 @@ public static class AspireMcpClientExtensions
     /// builder.AddMcpClient("mcp-server");
     /// </code>
     /// </example>
-    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <returns>An <see cref="AspireMcpClientBuilder"/> that can be used to further configure the registration.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
     /// <exception cref="FormatException">Thrown when the configured connection string is not an absolute HTTP or HTTPS URI.</exception>
-    public static IHostApplicationBuilder AddMcpClient(this IHostApplicationBuilder builder, string connectionName)
+    public static AspireMcpClientBuilder AddMcpClient(this IHostApplicationBuilder builder, string connectionName)
         => AddMcpClientCore(builder, connectionName, serviceKey: null, configureClientOptions: null, configureTransportOptions: null, configureSettings: null);
 
     /// <summary>
@@ -76,11 +80,11 @@ public static class AspireMcpClientExtensions
     ///     });
     /// </code>
     /// </example>
-    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <returns>An <see cref="AspireMcpClientBuilder"/> that can be used to further configure the registration.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="connectionName"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="connectionName"/> is empty.</exception>
     /// <exception cref="FormatException">Thrown when the configured connection string is not an absolute HTTP or HTTPS URI and <paramref name="configureSettings"/> does not provide an endpoint.</exception>
-    public static IHostApplicationBuilder AddMcpClient(
+    public static AspireMcpClientBuilder AddMcpClient(
         this IHostApplicationBuilder builder,
         string connectionName,
         Action<McpClientSettings>? configureSettings = null,
@@ -104,11 +108,11 @@ public static class AspireMcpClientExtensions
     /// builder.AddKeyedMcpClient("mcp-server");
     /// </code>
     /// </example>
-    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <returns>An <see cref="AspireMcpClientBuilder"/> that can be used to further configure the registration.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="name"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty.</exception>
     /// <exception cref="FormatException">Thrown when the configured connection string is not an absolute HTTP or HTTPS URI.</exception>
-    public static IHostApplicationBuilder AddKeyedMcpClient(this IHostApplicationBuilder builder, string name)
+    public static AspireMcpClientBuilder AddKeyedMcpClient(this IHostApplicationBuilder builder, string name)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
@@ -148,11 +152,11 @@ public static class AspireMcpClientExtensions
     ///     });
     /// </code>
     /// </example>
-    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <returns>An <see cref="AspireMcpClientBuilder"/> that can be used to further configure the registration.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="name"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty.</exception>
     /// <exception cref="FormatException">Thrown when the configured connection string is not an absolute HTTP or HTTPS URI and <paramref name="configureSettings"/> does not provide an endpoint.</exception>
-    public static IHostApplicationBuilder AddKeyedMcpClient(
+    public static AspireMcpClientBuilder AddKeyedMcpClient(
         this IHostApplicationBuilder builder,
         string name,
         Action<McpClientSettings>? configureSettings = null,
@@ -165,7 +169,7 @@ public static class AspireMcpClientExtensions
         return AddMcpClientCore(builder, name, name, configureClientOptions, configureTransportOptions, configureSettings);
     }
 
-    private static IHostApplicationBuilder AddMcpClientCore(
+    private static AspireMcpClientBuilder AddMcpClientCore(
         IHostApplicationBuilder builder,
         string connectionName,
         object? serviceKey,
@@ -204,6 +208,8 @@ public static class AspireMcpClientExtensions
             throw connectionStringException;
         }
 
+        ThrowIfDuplicateRegistration(builder.Services, serviceKey, connectionName);
+
         var endpoint = settings.Endpoint;
         if (endpoint is null)
         {
@@ -214,13 +220,27 @@ public static class AspireMcpClientExtensions
             McpClientSettings.ValidateEndpoint(endpoint);
         }
         var registrationKey = new object();
+        var registrationOptions = new McpClientRegistrationOptions();
+        if (configureClientOptions is not null)
+        {
+            registrationOptions.ClientOptionsActions.Add(configureClientOptions);
+        }
+        if (configureTransportOptions is not null)
+        {
+            registrationOptions.TransportOptionsActions.Add(configureTransportOptions);
+        }
+
+        var httpClientName = GetHttpClientName(connectionName, serviceKey);
         builder.Services.AddHttpClient();
+        builder.Services.AddHttpClient(httpClientName);
         builder.Services.AddKeyedSingleton<McpClientRegistration>(registrationKey, (serviceProvider, _) => new McpClientRegistration(
             connectionName,
             endpoint,
-            configureClientOptions,
-            configureTransportOptions,
+            registrationOptions,
+            httpClientName,
+            serviceProvider,
             serviceProvider.GetRequiredService<IHttpClientFactory>(),
+            serviceProvider.GetRequiredService<IHttpMessageHandlerFactory>(),
             serviceProvider.GetRequiredService<ILoggerFactory>(),
             serviceProvider.GetService<ServiceEndpointResolver>()));
 
@@ -237,7 +257,9 @@ public static class AspireMcpClientExtensions
 
         if (!settings.DisableHealthChecks)
         {
-            var healthCheckName = serviceKey is null ? "Mcp.Client" : $"Mcp.Client_{connectionName}";
+            var healthCheckName = serviceKey is null
+                ? $"Mcp.Client_{connectionName}"
+                : $"Mcp.Client_{connectionName}_{serviceKey}";
 
             builder.TryAddHealthCheck(new HealthCheckRegistration(
                 healthCheckName,
@@ -247,7 +269,33 @@ public static class AspireMcpClientExtensions
                 timeout: default));
         }
 
-        return builder;
+        return new AspireMcpClientBuilder(
+            builder,
+            connectionName,
+            serviceKey,
+            settings,
+            httpClientName,
+            AddClientOptionsAction,
+            AddTransportOptionsAction,
+            oauthOptions =>
+            {
+                if (registrationOptions.BearerTokenProvider is not null)
+                {
+                    throw new InvalidOperationException("MCP OAuth and bearer token provider authentication cannot be enabled at the same time.");
+                }
+                registrationOptions.OAuthOptions = oauthOptions;
+            },
+            tokenProvider =>
+            {
+                if (registrationOptions.OAuthOptions is not null)
+                {
+                    throw new InvalidOperationException("MCP OAuth and bearer token provider authentication cannot be enabled at the same time.");
+                }
+                registrationOptions.BearerTokenProvider = tokenProvider;
+            });
+
+        void AddClientOptionsAction(Action<McpClientOptions> action) => registrationOptions.ClientOptionsActions.Add(action);
+        void AddTransportOptionsAction(Action<HttpClientTransportOptions> action) => registrationOptions.TransportOptionsActions.Add(action);
     }
 
     private static Uri CreateServiceDiscoveryEndpoint(string connectionName)
@@ -258,6 +306,31 @@ public static class AspireMcpClientExtensions
         }
 
         return new Uri($"https+http://{connectionName}/mcp", UriKind.Absolute);
+    }
+
+    private static string GetHttpClientName(string connectionName, object? serviceKey)
+        => serviceKey is null
+            ? $"Aspire.Mcp.Client:{connectionName}:default"
+            : $"Aspire.Mcp.Client:{connectionName}:{serviceKey}";
+
+    private static void ThrowIfDuplicateRegistration(IServiceCollection services, object? serviceKey, string connectionName)
+    {
+        if (services.Any(descriptor =>
+            descriptor.ServiceType == typeof(McpClient) &&
+            Equals(descriptor.ServiceKey, serviceKey)))
+        {
+            var keyText = serviceKey?.ToString() ?? "default";
+            throw new InvalidOperationException($"An MCP client registration already exists for service key '{keyText}' (connection '{connectionName}').");
+        }
+    }
+
+    private sealed class McpClientRegistrationOptions
+    {
+        public List<Action<McpClientOptions>> ClientOptionsActions { get; } = [];
+        public List<Action<HttpClientTransportOptions>> TransportOptionsActions { get; } = [];
+        public ClientOAuthOptions? OAuthOptions { get; set; }
+        public ITokenCache? OAuthTokenCache { get; set; }
+        public Func<IServiceProvider, HttpRequestMessage, CancellationToken, ValueTask<string?>>? BearerTokenProvider { get; set; }
     }
 
     private sealed class McpClientRegistration : IDisposable, IAsyncDisposable
@@ -272,21 +345,19 @@ public static class AspireMcpClientExtensions
         public McpClientRegistration(
             string connectionName,
             Uri endpoint,
-            Action<McpClientOptions>? configureClientOptions,
-            Action<HttpClientTransportOptions>? configureTransportOptions,
+            McpClientRegistrationOptions registrationOptions,
+            string httpClientName,
+            IServiceProvider serviceProvider,
             IHttpClientFactory httpClientFactory,
+            IHttpMessageHandlerFactory httpMessageHandlerFactory,
             ILoggerFactory loggerFactory,
             ServiceEndpointResolver? serviceEndpointResolver)
         {
-            _createClient = () => CreateClientAsync(connectionName, endpoint, configureClientOptions, configureTransportOptions, httpClientFactory, loggerFactory, serviceEndpointResolver);
+            _createClient = () => CreateClientAsync(connectionName, endpoint, registrationOptions, httpClientName, serviceProvider, httpClientFactory, httpMessageHandlerFactory, loggerFactory, serviceEndpointResolver);
         }
 
         public McpClient GetClient()
-        {
-            var client = GetOrCreateClient();
-            client.Initialize();
-            return client;
-        }
+            => GetOrCreateClient();
 
         public async Task<McpClient> GetClientAsync(CancellationToken cancellationToken)
         {
@@ -327,30 +398,32 @@ public static class AspireMcpClientExtensions
         }
 
         public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) is 0)
             {
-                if (Interlocked.Exchange(ref _disposed, 1) is 0)
+                _creationCancellation.Cancel();
+                ReconnectableMcpClient? client;
+                lock (_lock)
                 {
-                    _creationCancellation.Cancel();
-                    ReconnectableMcpClient? client;
-                    lock (_lock)
-                    {
-                        client = _client;
-                    }
-
-                    if (client is not null)
-                    {
-                        await client.DisposeAsync().ConfigureAwait(false);
-                    }
-                    _creationCancellation.Dispose();
+                    client = _client;
                 }
+
+                if (client is not null)
+                {
+                    await client.DisposeAsync().ConfigureAwait(false);
+                }
+                _creationCancellation.Dispose();
             }
+        }
 
         private async Task<DisposableMcpClient> CreateClientAsync(
             string connectionName,
             Uri endpoint,
-            Action<McpClientOptions>? configureClientOptions,
-            Action<HttpClientTransportOptions>? configureTransportOptions,
+            McpClientRegistrationOptions registrationOptions,
+            string httpClientName,
+            IServiceProvider serviceProvider,
             IHttpClientFactory httpClientFactory,
+            IHttpMessageHandlerFactory httpMessageHandlerFactory,
             ILoggerFactory loggerFactory,
             ServiceEndpointResolver? serviceEndpointResolver)
         {
@@ -364,16 +437,53 @@ public static class AspireMcpClientExtensions
                     Endpoint = defaultTransportEndpoint,
                     Name = connectionName,
                 };
-                configureTransportOptions?.Invoke(transportOptions);
+                foreach (var configureTransportOptions in registrationOptions.TransportOptionsActions)
+                {
+                    configureTransportOptions(transportOptions);
+                }
                 transportOptions.Name ??= connectionName;
                 var endpointToResolve = endpoint.Scheme is "https+http" && Equals(transportOptions.Endpoint, defaultTransportEndpoint)
                     ? endpoint
                     : transportOptions.Endpoint;
-                transportOptions.Endpoint = await ResolveEndpointAsync(endpointToResolve, serviceEndpointResolver, _creationCancellation.Token).ConfigureAwait(false);
+                var resolvedEndpoint = await ResolveEndpointAsync(endpointToResolve, serviceEndpointResolver, _creationCancellation.Token).ConfigureAwait(false);
+                transportOptions.Endpoint = resolvedEndpoint;
                 McpClientSettings.ValidateEndpoint(transportOptions.Endpoint);
                 var clientOptions = new McpClientOptions();
-                configureClientOptions?.Invoke(clientOptions);
-                httpClient = httpClientFactory.CreateClient(string.Empty);
+                foreach (var configureClientOptions in registrationOptions.ClientOptionsActions)
+                {
+                    configureClientOptions(clientOptions);
+                }
+                if (registrationOptions.BearerTokenProvider is not null && registrationOptions.OAuthOptions is not null)
+                {
+                    throw new InvalidOperationException("MCP OAuth and bearer token provider authentication cannot be enabled at the same time.");
+                }
+                if (registrationOptions.OAuthOptions is not null)
+                {
+                    var oauth = registrationOptions.OAuthOptions;
+                    if (oauth.AuthorizationRedirectDelegate is null)
+                    {
+                        throw new InvalidOperationException("MCP OAuth requires an explicit AuthorizationRedirectDelegate.");
+                    }
+                    oauth.TokenCache ??= registrationOptions.OAuthTokenCache ??= new InMemoryTokenCache();
+                    transportOptions.OAuth = oauth;
+                }
+                if (registrationOptions.BearerTokenProvider is not null)
+                {
+                    var innerHandler = httpMessageHandlerFactory.CreateHandler(httpClientName);
+                    httpClient = new HttpClient(new BearerTokenHttpMessageHandler(serviceProvider, registrationOptions.BearerTokenProvider, resolvedEndpoint)
+                    {
+                        InnerHandler = innerHandler,
+                    }, disposeHandler: true);
+                    var clientFactoryOptions = serviceProvider.GetRequiredService<IOptionsMonitor<HttpClientFactoryOptions>>().Get(httpClientName);
+                    foreach (var configureClient in clientFactoryOptions.HttpClientActions)
+                    {
+                        configureClient(httpClient);
+                    }
+                }
+                else
+                {
+                    httpClient = httpClientFactory.CreateClient(httpClientName);
+                }
                 transport = new HttpClientTransport(transportOptions, httpClient, loggerFactory, ownsHttpClient: true);
                 var client = await McpClient.CreateAsync(transport, clientOptions, loggerFactory: loggerFactory, cancellationToken: _creationCancellation.Token).ConfigureAwait(false);
                 if (Volatile.Read(ref _disposed) is not 0)
@@ -491,6 +601,53 @@ public static class AspireMcpClientExtensions
             var index = Interlocked.Increment(ref _endpointIndex);
 
             return (int)((uint)index % (uint)endpointCount);
+        }
+    }
+
+    private sealed class BearerTokenHttpMessageHandler(
+        IServiceProvider serviceProvider,
+        Func<IServiceProvider, HttpRequestMessage, CancellationToken, ValueTask<string?>> tokenProvider,
+        Uri mcpEndpoint) : DelegatingHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri is { } requestUri &&
+                requestUri.Host.Equals(mcpEndpoint.Host, StringComparison.OrdinalIgnoreCase) &&
+                requestUri.Scheme.Equals(mcpEndpoint.Scheme, StringComparison.OrdinalIgnoreCase) &&
+                requestUri.Port == mcpEndpoint.Port)
+            {
+                var token = await tokenProvider(serviceProvider, request, cancellationToken).ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(token))
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                }
+            }
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class InMemoryTokenCache : ITokenCache
+    {
+        private TokenContainer? _tokens;
+        private readonly object _lock = new();
+
+        public ValueTask<TokenContainer?> GetTokensAsync(CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                return ValueTask.FromResult<TokenContainer?>(_tokens);
+            }
+        }
+
+        public ValueTask StoreTokensAsync(TokenContainer tokenContainer, CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                _tokens = tokenContainer;
+            }
+
+            return ValueTask.CompletedTask;
         }
     }
 
@@ -704,7 +861,8 @@ public static class AspireMcpClientExtensions
         {
             if (exception is OperationCanceledException)
             {
-                return false;
+                // Distinguish caller-initiated cancellation from transport/session cancellation.
+                return task.IsCanceled;
             }
 
             if (task.IsFaulted)

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -578,11 +578,17 @@ public static class AspireMcpClientExtensions
         {
             return serviceEndpoint.EndPoint switch
             {
-                UriEndPoint uriEndPoint => new(CreateResolvedEndpointUri(uriEndPoint.Uri, endpoint), RequestHost: null),
-                DnsEndPoint dnsEndPoint => new(CreateResolvedEndpointUri(endpoint, dnsEndPoint.Host, dnsEndPoint.Port), RequestHost: null),
+                UriEndPoint uriEndPoint => new(CreateResolvedEndpointUri(uriEndPoint.Uri, endpoint), GetRequestHost(serviceEndpoint)),
+                DnsEndPoint dnsEndPoint => new(CreateResolvedEndpointUri(endpoint, dnsEndPoint.Host, dnsEndPoint.Port), GetRequestHost(serviceEndpoint)),
                 IPEndPoint ipEndPoint => CreateResolvedIpEndpoint(ipEndPoint, serviceEndpoint.Features.Get<IHostNameFeature>(), endpoint),
                 _ => null,
             };
+        }
+
+        private static string? GetRequestHost(ServiceEndpoint serviceEndpoint)
+        {
+            var hostName = serviceEndpoint.Features.Get<IHostNameFeature>()?.HostName;
+            return string.IsNullOrWhiteSpace(hostName) ? null : hostName;
         }
 
         private static ResolvedEndpoint CreateResolvedIpEndpoint(IPEndPoint ipEndPoint, IHostNameFeature? hostNameFeature, Uri endpoint)

--- a/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
+++ b/src/Components/Aspire.Mcp.Client/AspireMcpClientExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.Hosting;
 public static class AspireMcpClientExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Mcp:Client";
+    private const string McpTelemetrySourceName = "Experimental.ModelContextProtocol";
 
     /// <summary>
     /// Registers an <see cref="McpClient"/> that connects to the specified MCP server through service discovery.
@@ -172,7 +173,7 @@ public static class AspireMcpClientExtensions
     private static AspireMcpClientBuilder AddMcpClientCore(
         IHostApplicationBuilder builder,
         string connectionName,
-        object? serviceKey,
+        string? serviceKey,
         Action<McpClientOptions>? configureClientOptions,
         Action<HttpClientTransportOptions>? configureTransportOptions,
         Action<McpClientSettings>? configureSettings)
@@ -257,9 +258,7 @@ public static class AspireMcpClientExtensions
 
         if (!settings.DisableHealthChecks)
         {
-            var healthCheckName = serviceKey is null
-                ? $"Mcp.Client_{connectionName}"
-                : $"Mcp.Client_{connectionName}_{serviceKey}";
+            var healthCheckName = GetHealthCheckName(connectionName, serviceKey);
 
             builder.TryAddHealthCheck(new HealthCheckRegistration(
                 healthCheckName,
@@ -267,6 +266,18 @@ public static class AspireMcpClientExtensions
                 failureStatus: default,
                 tags: default,
                 timeout: default));
+        }
+
+        if (!settings.DisableTracing)
+        {
+            builder.Services.AddOpenTelemetry()
+                .WithTracing(tracing => tracing.AddSource(McpTelemetrySourceName));
+        }
+
+        if (!settings.DisableMetrics)
+        {
+            builder.Services.AddOpenTelemetry()
+                .WithMetrics(metrics => metrics.AddMeter(McpTelemetrySourceName));
         }
 
         return new AspireMcpClientBuilder(
@@ -308,10 +319,15 @@ public static class AspireMcpClientExtensions
         return new Uri($"https+http://{connectionName}/mcp", UriKind.Absolute);
     }
 
-    private static string GetHttpClientName(string connectionName, object? serviceKey)
+    private static string GetHttpClientName(string connectionName, string? serviceKey)
         => serviceKey is null
-            ? $"Aspire.Mcp.Client:{connectionName}:default"
-            : $"Aspire.Mcp.Client:{connectionName}:{serviceKey}";
+            ? $"Aspire.Mcp.Client:unkeyed:{connectionName}"
+            : $"Aspire.Mcp.Client:keyed:{connectionName}:{serviceKey}";
+
+    private static string GetHealthCheckName(string connectionName, string? serviceKey)
+        => serviceKey is null
+            ? $"Mcp.Client:unkeyed:{connectionName}"
+            : $"Mcp.Client:keyed:{connectionName}:{serviceKey}";
 
     private static void ThrowIfDuplicateRegistration(IServiceCollection services, object? serviceKey, string connectionName)
     {

--- a/src/Components/Aspire.Mcp.Client/AssemblyInfo.cs
+++ b/src/Components/Aspire.Mcp.Client/AssemblyInfo.cs
@@ -5,3 +5,9 @@ using Aspire;
 using Aspire.Mcp.Client;
 
 [assembly: ConfigurationSchema("Aspire:Mcp:Client", typeof(McpClientSettings))]
+
+[assembly: LoggingCategories(
+    "ModelContextProtocol.Authentication.ClientOAuthProvider",
+    "ModelContextProtocol.Client.AutoDetectingClientSessionTransport",
+    "ModelContextProtocol.Client.HttpClientTransport",
+    "ModelContextProtocol.Client.McpClient")]

--- a/src/Components/Aspire.Mcp.Client/AssemblyInfo.cs
+++ b/src/Components/Aspire.Mcp.Client/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire;
+using Aspire.Mcp.Client;
+
+[assembly: ConfigurationSchema("Aspire:Mcp:Client", typeof(McpClientSettings))]

--- a/src/Components/Aspire.Mcp.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.Mcp.Client/ConfigurationSchema.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "Aspire": {
+      "type": "object",
+      "properties": {
+        "Mcp": {
+          "type": "object",
+          "properties": {
+            "Client": {
+              "type": "object",
+              "properties": {
+                "DisableHealthChecks": {
+                  "type": "boolean",
+                  "description": "Gets or sets a value indicating whether health checks are disabled.",
+                  "default": false
+                },
+                "Endpoint": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Gets or sets the explicit MCP endpoint URI."
+                }
+              },
+              "description": "Provides configuration settings for 'ModelContextProtocol.Client.McpClient' registrations."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Components/Aspire.Mcp.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.Mcp.Client/ConfigurationSchema.json
@@ -1,4 +1,22 @@
 {
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "ModelContextProtocol.Authentication.ClientOAuthProvider": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "ModelContextProtocol.Client.AutoDetectingClientSessionTransport": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "ModelContextProtocol.Client.HttpClientTransport": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "ModelContextProtocol.Client.McpClient": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  },
   "type": "object",
   "properties": {
     "Aspire": {

--- a/src/Components/Aspire.Mcp.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.Mcp.Client/ConfigurationSchema.json
@@ -33,6 +33,16 @@
                   "description": "Gets or sets a value indicating whether health checks are disabled.",
                   "default": false
                 },
+                "DisableMetrics": {
+                  "type": "boolean",
+                  "description": "Gets or sets a value indicating whether MCP metrics are disabled.",
+                  "default": false
+                },
+                "DisableTracing": {
+                  "type": "boolean",
+                  "description": "Gets or sets a value indicating whether MCP tracing is disabled.",
+                  "default": false
+                },
                 "Endpoint": {
                   "type": "string",
                   "format": "uri",

--- a/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
+++ b/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
@@ -28,13 +28,25 @@ public sealed class McpClientSettings
     internal void ParseConnectionString(string? connectionString)
     {
         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var endpoint) &&
-            endpoint.Scheme is "http" or "https" &&
-            !string.IsNullOrEmpty(endpoint.Host))
+            endpoint.IsAbsoluteUri)
         {
+            ValidateEndpoint(endpoint);
             Endpoint = endpoint;
             return;
         }
 
         throw new FormatException("The MCP client connection string must be an absolute HTTP or HTTPS URI.");
+    }
+
+    internal static void ValidateEndpoint(Uri endpoint)
+    {
+        if (endpoint.IsAbsoluteUri &&
+            endpoint.Scheme is "http" or "https" &&
+            !string.IsNullOrEmpty(endpoint.Host))
+        {
+            return;
+        }
+
+        throw new FormatException("The MCP client endpoint must be an absolute HTTP or HTTPS URI.");
     }
 }

--- a/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
+++ b/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
@@ -12,7 +12,8 @@ public sealed class McpClientSettings
     /// Gets or sets the explicit MCP endpoint URI.
     /// </summary>
     /// <remarks>
-    /// When not configured, the endpoint defaults to <c>https+http://{connectionName}/mcp</c> and is resolved via service discovery.
+    /// When not configured, the endpoint defaults to <c>https://{connectionName}/mcp</c>, or
+    /// <c>http://{connectionName}/mcp</c> when service discovery only provides HTTP endpoints.
     /// </remarks>
     public Uri? Endpoint { get; set; }
 
@@ -29,6 +30,9 @@ public sealed class McpClientSettings
         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var endpoint))
         {
             Endpoint = endpoint;
+            return;
         }
+
+        throw new FormatException("The MCP client connection string must be an absolute URI.");
     }
 }

--- a/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
+++ b/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
@@ -27,7 +27,8 @@ public sealed class McpClientSettings
 
     internal void ParseConnectionString(string? connectionString)
     {
-        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var endpoint))
+        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var endpoint) &&
+            endpoint.Scheme is "http" or "https")
         {
             Endpoint = endpoint;
             return;

--- a/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
+++ b/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Mcp.Client;
+
+/// <summary>
+/// Provides configuration settings for <see cref="ModelContextProtocol.Client.McpClient"/> registrations.
+/// </summary>
+public sealed class McpClientSettings
+{
+    /// <summary>
+    /// Gets or sets the explicit MCP endpoint URI.
+    /// </summary>
+    /// <remarks>
+    /// When not configured, the endpoint defaults to <c>https+http://{connectionName}/mcp</c> and is resolved via service discovery.
+    /// </remarks>
+    public Uri? Endpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether health checks are disabled.
+    /// </summary>
+    /// <value>
+    /// The default value is <see langword="false"/>.
+    /// </value>
+    public bool DisableHealthChecks { get; set; }
+
+    internal void ParseConnectionString(string? connectionString)
+    {
+        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var endpoint))
+        {
+            Endpoint = endpoint;
+        }
+    }
+}

--- a/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
+++ b/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
@@ -34,6 +34,6 @@ public sealed class McpClientSettings
             return;
         }
 
-        throw new FormatException("The MCP client connection string must be an absolute URI.");
+        throw new FormatException("The MCP client connection string must be an absolute HTTP or HTTPS URI.");
     }
 }

--- a/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
+++ b/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
@@ -28,7 +28,8 @@ public sealed class McpClientSettings
     internal void ParseConnectionString(string? connectionString)
     {
         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var endpoint) &&
-            endpoint.Scheme is "http" or "https")
+            endpoint.Scheme is "http" or "https" &&
+            !string.IsNullOrEmpty(endpoint.Host))
         {
             Endpoint = endpoint;
             return;

--- a/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
+++ b/src/Components/Aspire.Mcp.Client/McpClientSettings.cs
@@ -25,6 +25,22 @@ public sealed class McpClientSettings
     /// </value>
     public bool DisableHealthChecks { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether MCP tracing is disabled.
+    /// </summary>
+    /// <value>
+    /// The default value is <see langword="false"/>.
+    /// </value>
+    public bool DisableTracing { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether MCP metrics are disabled.
+    /// </summary>
+    /// <value>
+    /// The default value is <see langword="false"/>.
+    /// </value>
+    public bool DisableMetrics { get; set; }
+
     internal void ParseConnectionString(string? connectionString)
     {
         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var endpoint) &&

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -1,6 +1,6 @@
 # Aspire.Mcp.Client library
 
-Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery. Enables a corresponding health check and logging.
+Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery. Enables a corresponding health check, logging, and telemetry.
 
 ## Getting started
 
@@ -58,6 +58,9 @@ And then configure the endpoint URI in the `ConnectionStrings` configuration sec
   }
 }
 ```
+
+The connection string must be an absolute HTTP or HTTPS URI; malformed values throw
+`FormatException` unless `configureSettings` supplies an endpoint.
 
 ### Use configuration providers
 
@@ -119,6 +122,14 @@ builder.AddMcpClient(
         };
         options.OAuth = oauthProvider;
     });
+```
+
+Use `configureSettings` to configure Aspire integration behavior, such as disabling health checks:
+
+```csharp
+builder.AddMcpClient(
+    "mcp",
+    configureSettings: settings => settings.DisableHealthChecks = true);
 ```
 
 ### Use keyed registrations

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -1,0 +1,46 @@
+# Aspire MCP Client library
+
+Registers an [MCP client](https://modelcontextprotocol.io/) that connects to a remote MCP server through Aspire service discovery.
+
+## Install the package
+
+```dotnetcli
+dotnet add package Aspire.Mcp.Client
+```
+
+## Usage
+
+Reference the MCP server from the consuming project in the AppHost:
+
+```csharp
+var mcp = builder.AddProject<Projects.Mcp>("mcp");
+
+builder.AddProject<Projects.Api>("api")
+    .WithReference(mcp)
+    .WaitFor(mcp);
+```
+
+In the consuming application, register the client after service defaults:
+
+```csharp
+builder.AddServiceDefaults();
+builder.AddMcpClient("mcp");
+```
+
+The client is registered as a singleton and can be injected directly:
+
+```csharp
+public sealed class WeatherAgent(McpClient mcpClient)
+{
+}
+```
+
+`AddMcpClient("mcp")` connects to the `https` endpoint of the `mcp` service at `/mcp`. The application must call `AddServiceDefaults` so the configured HTTP client resolves the logical service name.
+
+Use `AddKeyedMcpClient` when the application consumes multiple MCP servers:
+
+```csharp
+builder.AddKeyedMcpClient("weather");
+
+var mcpClient = serviceProvider.GetRequiredKeyedService<McpClient>("weather");
+```

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -1,4 +1,4 @@
-# Aspire MCP Client library
+# Aspire.Mcp.Client library
 
 Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery.
 
@@ -53,7 +53,9 @@ The client resolves `https://{connectionName}/mcp`.
 
 ### Use inline delegates
 
-Use the overload to configure `McpClientOptions` and `HttpClientTransportOptions` inline, including OAuth-protected servers, custom headers, transport mode, and timeout values:
+Use the overload to configure `McpClientOptions` and `HttpClientTransportOptions` inline.
+
+Use `configureClientOptions` to configure MCP client behavior, such as client metadata and initialization timeout:
 
 ```csharp
 builder.AddMcpClient(
@@ -62,7 +64,14 @@ builder.AddMcpClient(
     {
         options.ClientInfo = new() { Name = "MyService", Version = "1.0.0" };
         options.InitializationTimeout = TimeSpan.FromSeconds(60);
-    },
+    });
+```
+
+Use `configureTransportOptions` to configure HTTP transport behavior, such as transport mode, timeout, headers, and OAuth:
+
+```csharp
+builder.AddMcpClient(
+    "mcp",
     configureTransportOptions: options =>
     {
         options.TransportMode = HttpTransportMode.StreamableHttp;

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -80,6 +80,7 @@ The Aspire MCP Client library supports [Microsoft.Extensions.Configuration](http
 ```
 
 You can also use named configuration (`Aspire:Mcp:Client:{connectionName}`) to override base settings for specific registrations.
+Configured endpoint values must be absolute HTTP or HTTPS URIs with a non-empty host.
 
 ### Use the connection name
 

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -53,7 +53,7 @@ The client resolves `https://{connectionName}/mcp` by default. If service discov
 
 ### Use inline delegates
 
-Use the overload to configure `McpClientOptions` and `HttpClientTransportOptions` inline.
+Use the overload to configure [McpClientOptions](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/src/ModelContextProtocol.Core/Client/McpClientOptions.cs) and [HttpClientTransportOptions](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/src/ModelContextProtocol.Core/Client/HttpClientTransportOptions.cs) inline.
 
 Use `configureClientOptions` to configure MCP client behavior, such as client metadata and initialization timeout:
 

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -1,46 +1,113 @@
 # Aspire MCP Client library
 
-Registers an [MCP client](https://modelcontextprotocol.io/) that connects to a remote MCP server through Aspire service discovery.
+Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery.
 
-## Install the package
+## Getting started
+
+### Prerequisites
+
+- An MCP server exposed in your distributed application.
+- A consuming service that calls `AddServiceDefaults()` so logical service names are resolved by service discovery.
+
+### Install the package
+
+Install the Aspire MCP Client library with [NuGet](https://www.nuget.org):
 
 ```dotnetcli
 dotnet add package Aspire.Mcp.Client
 ```
 
-## Usage
+## Usage example
 
-Reference the MCP server from the consuming project in the AppHost:
-
-```csharp
-var mcp = builder.AddProject<Projects.Mcp>("mcp");
-
-builder.AddProject<Projects.Api>("api")
-    .WithReference(mcp)
-    .WaitFor(mcp);
-```
-
-In the consuming application, register the client after service defaults:
+In the _Program.cs_ file of your project, call the `AddMcpClient` extension method to register an `McpClient` for use via the dependency injection container. The method takes the MCP server connection name.
 
 ```csharp
 builder.AddServiceDefaults();
 builder.AddMcpClient("mcp");
 ```
 
-The client is registered as a singleton and can be injected directly:
+You can then retrieve the `McpClient` instance using dependency injection. For example, to retrieve the client from a Web API controller:
 
 ```csharp
-public sealed class WeatherAgent(McpClient mcpClient)
+public sealed class ToolsController(McpClient mcpClient)
 {
+    private readonly McpClient _mcpClient = mcpClient;
 }
 ```
 
-`AddMcpClient("mcp")` connects to the `https` endpoint of the `mcp` service at `/mcp`. The application must call `AddServiceDefaults` so the configured HTTP client resolves the logical service name.
+`AddMcpClient("mcp")` resolves the server endpoint as `https://mcp/mcp`.
 
-Use `AddKeyedMcpClient` when the application consumes multiple MCP servers:
+## Configuration
+
+The Aspire MCP Client library configures the server endpoint from the connection name and supports inline configuration delegates for client and transport options.
+
+### Use the connection name
+
+Provide the same connection name configured by AppHost references:
 
 ```csharp
-builder.AddKeyedMcpClient("weather");
-
-var mcpClient = serviceProvider.GetRequiredKeyedService<McpClient>("weather");
+builder.AddMcpClient("mcp");
 ```
+
+The client resolves `https://{connectionName}/mcp`.
+
+### Use inline delegates
+
+Use the overload to configure `McpClientOptions` and `HttpClientTransportOptions` inline:
+
+```csharp
+builder.AddMcpClient(
+    "mcp",
+    configureClientOptions: options =>
+    {
+        options.ClientInfo = new() { Name = "MyService", Version = "1.0.0" };
+    },
+    configureTransportOptions: options =>
+    {
+        options.Endpoint = new Uri("https://mcp/mcp", UriKind.Absolute);
+    });
+```
+
+### Use keyed registrations
+
+When your application consumes multiple MCP servers, register keyed clients:
+
+```csharp
+builder.AddServiceDefaults();
+builder.AddKeyedMcpClient("weather");
+```
+
+And resolve the keyed `McpClient`:
+
+```csharp
+var weatherClient = serviceProvider.GetRequiredKeyedService<McpClient>("weather");
+```
+
+## AppHost extensions
+
+There is no dedicated `Aspire.Hosting.Mcp` package. In the _AppHost.cs_ file of `AppHost`, register your MCP server project and reference it from the consuming service:
+
+```csharp
+var mcp = builder.AddProject<Projects.Mcp>("mcp");
+
+var api = builder.AddProject<Projects.Api>("api")
+    .WithReference(mcp)
+    .WaitFor(mcp);
+```
+
+The `WithReference` method configures a connection in the `api` project named `mcp`. In the _Program.cs_ file of `api`, consume that connection with:
+
+```csharp
+builder.AddServiceDefaults();
+builder.AddMcpClient("mcp");
+```
+
+## Additional documentation
+
+* https://modelcontextprotocol.io/
+* https://github.com/modelcontextprotocol/csharp-sdk
+* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+
+## Feedback & contributing
+
+https://github.com/microsoft/aspire

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -6,7 +6,7 @@ Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-1
 
 ### Prerequisites
 
-- An MCP server exposed in your distributed application.
+- An MCP server exposed in your distributed application, with its HTTP route mapped at `/mcp`.
 - A consuming service that calls `AddServiceDefaults()` so logical service names are resolved by service discovery.
 
 ### Install the package
@@ -39,11 +39,48 @@ public sealed class ToolsController(McpClient mcpClient)
 
 ## Configuration
 
-The Aspire MCP Client library configures the server endpoint from the connection name and supports inline configuration delegates for client and transport options.
+The Aspire MCP Client library provides multiple options to configure the endpoint and behavior based on your project requirements and configuration conventions.
+
+### Use a connection string
+
+When using a connection string from the `ConnectionStrings` configuration section, provide the connection name when calling `builder.AddMcpClient()`:
+
+```csharp
+builder.AddMcpClient("mcp");
+```
+
+And then configure the endpoint URI in the `ConnectionStrings` configuration section:
+
+```json
+{
+  "ConnectionStrings": {
+    "mcp": "https://my-mcp-server.example.com/mcp"
+  }
+}
+```
+
+### Use configuration providers
+
+The Aspire MCP Client library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads [McpClientSettings](https://github.com/microsoft/aspire/blob/main/src/Components/Aspire.Mcp.Client/McpClientSettings.cs) from configuration using the `Aspire:Mcp:Client` key:
+
+```json
+{
+  "Aspire": {
+    "Mcp": {
+      "Client": {
+        "Endpoint": "https://my-mcp-server.example.com/mcp",
+        "DisableHealthChecks": false
+      }
+    }
+  }
+}
+```
+
+You can also use named configuration (`Aspire:Mcp:Client:{connectionName}`) to override base settings for specific registrations.
 
 ### Use the connection name
 
-Provide the same connection name configured by AppHost references:
+When using `WithReference` in AppHost, provide the same connection name in your service:
 
 ```csharp
 builder.AddMcpClient("mcp");
@@ -76,7 +113,10 @@ builder.AddMcpClient(
     {
         options.TransportMode = HttpTransportMode.StreamableHttp;
         options.ConnectionTimeout = TimeSpan.FromSeconds(15);
-        options.AdditionalHeaders["x-api-key"] = "api-key-value";
+        options.AdditionalHeaders = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["x-api-key"] = "api-key-value"
+        };
         options.OAuth = oauthProvider;
     });
 ```

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -29,9 +29,14 @@ builder.AddMcpClient("mcp");
 You can then retrieve the `McpClient` instance using dependency injection. For example, to retrieve the client from a Web API controller:
 
 ```csharp
-public sealed class ToolsController(McpClient mcpClient)
+public sealed class ProductsController
 {
-    private readonly McpClient _mcpClient = mcpClient;
+    private readonly McpClient _mcpClient;
+
+    public ProductsController(McpClient mcpClient)
+    {
+        _mcpClient = mcpClient;
+    }
 }
 ```
 

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -1,6 +1,6 @@
 # Aspire.Mcp.Client library
 
-Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery. Enables a corresponding health check, logging, and telemetry.
+Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery. Enables a corresponding health check and logging.
 
 ## Getting started
 

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -35,7 +35,7 @@ public sealed class ToolsController(McpClient mcpClient)
 }
 ```
 
-`AddMcpClient("mcp")` resolves the server endpoint as `https://mcp/mcp`.
+`AddMcpClient("mcp")` resolves the server endpoint as `https://mcp/mcp` by default. If service discovery only provides HTTP endpoints, it resolves `http://mcp/mcp` instead.
 
 ## Configuration
 
@@ -49,7 +49,7 @@ Provide the same connection name configured by AppHost references:
 builder.AddMcpClient("mcp");
 ```
 
-The client resolves `https://{connectionName}/mcp`.
+The client resolves `https://{connectionName}/mcp` by default. If service discovery only provides HTTP endpoints, it resolves `http://{connectionName}/mcp` instead.
 
 ### Use inline delegates
 

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -53,7 +53,7 @@ The client resolves `https://{connectionName}/mcp`.
 
 ### Use inline delegates
 
-Use the overload to configure `McpClientOptions` and `HttpClientTransportOptions` inline:
+Use the overload to configure `McpClientOptions` and `HttpClientTransportOptions` inline, including OAuth-protected servers, custom headers, transport mode, and timeout values:
 
 ```csharp
 builder.AddMcpClient(
@@ -61,10 +61,14 @@ builder.AddMcpClient(
     configureClientOptions: options =>
     {
         options.ClientInfo = new() { Name = "MyService", Version = "1.0.0" };
+        options.InitializationTimeout = TimeSpan.FromSeconds(60);
     },
     configureTransportOptions: options =>
     {
-        options.Endpoint = new Uri("https://mcp/mcp", UriKind.Absolute);
+        options.TransportMode = HttpTransportMode.StreamableHttp;
+        options.ConnectionTimeout = TimeSpan.FromSeconds(15);
+        options.AdditionalHeaders["x-api-key"] = "api-key-value";
+        options.OAuth = oauthProvider;
     });
 ```
 

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -1,6 +1,6 @@
 # Aspire.Mcp.Client library
 
-Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery.
+Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery. Enables a corresponding health check and logging.
 
 ## Getting started
 

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -1,75 +1,112 @@
 # Aspire.Mcp.Client library
 
-Registers an [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) in the DI container for connecting to a Model Context Protocol (MCP) server through Aspire service discovery. Enables a corresponding health check and logging.
+Registers [McpClient](https://modelcontextprotocol.io/specification/2025-06-18/basic/architecture) with Aspire service discovery plus MCP-specific behavior that is awkward to wire manually:
+
+- per-session endpoint affinity with reconnect rotation;
+- lazy initialization (no network I/O during DI resolution);
+- optional MCP OAuth or per-request bearer token injection;
+- keyed registrations with isolated HTTP pipelines;
+- health checks and OpenTelemetry source/meter registration.
 
 ## Getting started
 
 ### Prerequisites
 
-- An MCP server exposed in your distributed application, with its HTTP route mapped at `/mcp`.
-- A consuming service that calls `AddServiceDefaults()` so logical service names are resolved by service discovery.
+- An MCP server exposed from your distributed app (typically at `/mcp`).
+- A consuming service that calls `AddServiceDefaults()`.
 
 ### Install the package
-
-Install the Aspire MCP Client library with [NuGet](https://www.nuget.org):
 
 ```dotnetcli
 dotnet add package Aspire.Mcp.Client
 ```
 
-## Usage example
+## AppHost and service wiring
 
-In the _Program.cs_ file of your project, call the `AddMcpClient` extension method to register an `McpClient` for use via the dependency injection container. The method takes the MCP server connection name.
+No dedicated `Aspire.Hosting.Mcp` package is required. Use normal `WithReference` wiring in AppHost and consume the same connection name.
 
 ```csharp
+// AppHost
+var mcp = builder.AddProject<Projects.Mcp>("mcp");
+builder.AddProject<Projects.Api>("api")
+    .WithReference(mcp)
+    .WaitFor(mcp);
+```
+
+```csharp
+// Api Program.cs
 builder.AddServiceDefaults();
 builder.AddMcpClient("mcp");
 ```
 
-You can then retrieve the `McpClient` instance using dependency injection. For example, to retrieve the client from a Web API controller:
+By default the client resolves `https://{connectionName}/mcp`, and falls back to HTTP when only HTTP endpoints are available.
+
+## Builder API
+
+`AddMcpClient` and `AddKeyedMcpClient` return `AspireMcpClientBuilder`, which lets you compose settings, transport, client, and authentication behavior.
 
 ```csharp
-public sealed class ProductsController
-{
-    private readonly McpClient _mcpClient;
-
-    public ProductsController(McpClient mcpClient)
+builder.AddMcpClient("mcp")
+    .ConfigureClientOptions(options =>
     {
-        _mcpClient = mcpClient;
-    }
-}
+        options.ClientInfo = new() { Name = "MyService", Version = "1.0.0" };
+        options.InitializationTimeout = TimeSpan.FromSeconds(60);
+    })
+    .ConfigureTransportOptions(options =>
+    {
+        options.TransportMode = HttpTransportMode.StreamableHttp;
+        options.ConnectionTimeout = TimeSpan.FromSeconds(15);
+    });
 ```
 
-`AddMcpClient("mcp")` resolves the server endpoint as `https://mcp/mcp` by default. If service discovery only provides HTTP endpoints, it resolves `http://mcp/mcp` instead.
+### Keyed registrations
+
+```csharp
+builder.AddKeyedMcpClient("weather");
+var weatherClient = serviceProvider.GetRequiredKeyedService<McpClient>("weather");
+```
+
+## Authentication
+
+### MCP OAuth
+
+OAuth is explicit and requires an authorization redirect delegate.
+
+```csharp
+builder.AddMcpClient("mcp")
+    .UseOAuth(options =>
+    {
+        options.AuthorizationRedirectDelegate = async (authorizationUri, _, cancellationToken) =>
+        {
+            // Perform your app-specific redirect/authorization flow.
+            await HandleAuthorizationRedirectAsync(authorizationUri, cancellationToken);
+        };
+    });
+```
+
+### Bearer token provider
+
+Use a per-request token callback when your service already manages token acquisition/refresh.
+
+```csharp
+builder.AddMcpClient("mcp")
+    .UseBearerTokenProvider(async (services, request, cancellationToken) =>
+    {
+        var provider = services.GetRequiredService<IMyTokenProvider>();
+        return await provider.GetAccessTokenAsync(cancellationToken);
+    });
+```
+
+`UseOAuth` and `UseBearerTokenProvider` are mutually exclusive for a registration.
 
 ## Configuration
 
-The Aspire MCP Client library provides multiple options to configure the endpoint and behavior based on your project requirements and configuration conventions.
+Settings bind from:
 
-### Use a connection string
-
-When using a connection string from the `ConnectionStrings` configuration section, provide the connection name when calling `builder.AddMcpClient()`:
-
-```csharp
-builder.AddMcpClient("mcp");
-```
-
-And then configure the endpoint URI in the `ConnectionStrings` configuration section:
-
-```json
-{
-  "ConnectionStrings": {
-    "mcp": "https://my-mcp-server.example.com/mcp"
-  }
-}
-```
-
-The connection string must be an absolute HTTP or HTTPS URI; malformed values throw
-`FormatException` unless `configureSettings` supplies an endpoint.
-
-### Use configuration providers
-
-The Aspire MCP Client library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads [McpClientSettings](https://github.com/microsoft/aspire/blob/main/src/Components/Aspire.Mcp.Client/McpClientSettings.cs) from configuration using the `Aspire:Mcp:Client` key:
+1. `Aspire:Mcp:Client`
+2. `Aspire:Mcp:Client:{connectionName}`
+3. `ConnectionStrings:{connectionName}`
+4. `configureSettings` delegate
 
 ```json
 {
@@ -77,106 +114,22 @@ The Aspire MCP Client library supports [Microsoft.Extensions.Configuration](http
     "Mcp": {
       "Client": {
         "Endpoint": "https://my-mcp-server.example.com/mcp",
-        "DisableHealthChecks": false
+        "DisableHealthChecks": false,
+        "DisableTracing": false,
+        "DisableMetrics": false
       }
     }
   }
 }
 ```
 
-You can also use named configuration (`Aspire:Mcp:Client:{connectionName}`) to override base settings for specific registrations.
-Configured endpoint values must be absolute HTTP or HTTPS URIs with a non-empty host.
-
-### Use the connection name
-
-When using `WithReference` in AppHost, provide the same connection name in your service:
-
-```csharp
-builder.AddMcpClient("mcp");
-```
-
-The client resolves `https://{connectionName}/mcp` by default. If service discovery only provides HTTP endpoints, it resolves `http://{connectionName}/mcp` instead.
-
-### Use inline delegates
-
-Use the overload to configure [McpClientOptions](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/src/ModelContextProtocol.Core/Client/McpClientOptions.cs) and [HttpClientTransportOptions](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/src/ModelContextProtocol.Core/Client/HttpClientTransportOptions.cs) inline.
-
-Use `configureClientOptions` to configure MCP client behavior, such as client metadata and initialization timeout:
-
-```csharp
-builder.AddMcpClient(
-    "mcp",
-    configureClientOptions: options =>
-    {
-        options.ClientInfo = new() { Name = "MyService", Version = "1.0.0" };
-        options.InitializationTimeout = TimeSpan.FromSeconds(60);
-    });
-```
-
-Use `configureTransportOptions` to configure HTTP transport behavior, such as transport mode, timeout, headers, and OAuth:
-
-```csharp
-builder.AddMcpClient(
-    "mcp",
-    configureTransportOptions: options =>
-    {
-        options.TransportMode = HttpTransportMode.StreamableHttp;
-        options.ConnectionTimeout = TimeSpan.FromSeconds(15);
-        options.AdditionalHeaders = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["x-api-key"] = "api-key-value"
-        };
-        options.OAuth = oauthProvider;
-    });
-```
-
-Use `configureSettings` to configure Aspire integration behavior, such as disabling health checks:
-
-```csharp
-builder.AddMcpClient(
-    "mcp",
-    configureSettings: settings => settings.DisableHealthChecks = true);
-```
-
-### Use keyed registrations
-
-When your application consumes multiple MCP servers, register keyed clients:
-
-```csharp
-builder.AddServiceDefaults();
-builder.AddKeyedMcpClient("weather");
-```
-
-And resolve the keyed `McpClient`:
-
-```csharp
-var weatherClient = serviceProvider.GetRequiredKeyedService<McpClient>("weather");
-```
-
-## AppHost extensions
-
-There is no dedicated `Aspire.Hosting.Mcp` package. In the _AppHost.cs_ file of `AppHost`, register your MCP server project and reference it from the consuming service:
-
-```csharp
-var mcp = builder.AddProject<Projects.Mcp>("mcp");
-
-var api = builder.AddProject<Projects.Api>("api")
-    .WithReference(mcp)
-    .WaitFor(mcp);
-```
-
-The `WithReference` method configures a connection in the `api` project named `mcp`. In the _Program.cs_ file of `api`, consume that connection with:
-
-```csharp
-builder.AddServiceDefaults();
-builder.AddMcpClient("mcp");
-```
+Connection strings and configured endpoints must be absolute HTTP/HTTPS URIs with a host.
 
 ## Additional documentation
 
-* https://modelcontextprotocol.io/
-* https://github.com/modelcontextprotocol/csharp-sdk
-* https://github.com/microsoft/aspire/tree/main/src/Components/README.md
+- https://modelcontextprotocol.io/
+- https://github.com/modelcontextprotocol/csharp-sdk
+- https://github.com/microsoft/aspire/tree/main/src/Components/README.md
 
 ## Feedback & contributing
 

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -39,6 +39,17 @@ builder.AddServiceDefaults();
 builder.AddMcpClient("mcp");
 ```
 
+The registered client can be injected into a controller:
+
+```csharp
+private readonly McpClient _client;
+
+public ProductsController(McpClient client)
+{
+    _client = client;
+}
+```
+
 By default the client resolves `https://{connectionName}/mcp`, and falls back to HTTP when only HTTP endpoints are available.
 
 ## Builder API
@@ -107,6 +118,33 @@ Settings bind from:
 2. `Aspire:Mcp:Client:{connectionName}`
 3. `ConnectionStrings:{connectionName}`
 4. `configureSettings` delegate
+
+### Use a connection string
+
+The connection name is resolved from `ConnectionStrings` when no explicit endpoint is configured:
+
+```csharp
+builder.AddMcpClient("mcp");
+```
+
+```json
+{
+  "ConnectionStrings": {
+    "mcp": "https://my-mcp-server.example.com/mcp"
+  }
+}
+```
+
+### Use inline delegates
+
+Use the `configureSettings` delegate for settings that are easier to provide in code:
+
+```csharp
+builder.AddMcpClient("mcp", settings =>
+{
+    settings.DisableHealthChecks = true;
+});
+```
 
 ```json
 {

--- a/src/Components/Aspire.Mcp.Client/README.md
+++ b/src/Components/Aspire.Mcp.Client/README.md
@@ -146,6 +146,10 @@ builder.AddMcpClient("mcp", settings =>
 });
 ```
 
+### Use configuration providers
+
+The client binds settings from the `Aspire:Mcp:Client` configuration section:
+
 ```json
 {
   "Aspire": {

--- a/tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj
+++ b/tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Components\Aspire.Mcp.Client\Aspire.Mcp.Client.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj
+++ b/tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Mcp.Client\Aspire.Mcp.Client.csproj" />
+    <ProjectReference Include="..\Aspire.Components.Common.TestUtilities\Aspire.Components.Common.TestUtilities.csproj" />
     <None Include="$(RepoRoot)src\Components\Aspire.Mcp.Client\ConfigurationSchema.json" CopyToOutputDirectory="PreserveNewest" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />

--- a/tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj
+++ b/tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Mcp.Client\Aspire.Mcp.Client.csproj" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj
+++ b/tests/Aspire.Mcp.Client.Tests/Aspire.Mcp.Client.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.Mcp.Client\Aspire.Mcp.Client.csproj" />
+    <None Include="$(RepoRoot)src\Components\Aspire.Mcp.Client\ConfigurationSchema.json" CopyToOutputDirectory="PreserveNewest" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
   </ItemGroup>

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -135,6 +135,27 @@ public class AspireMcpClientExtensionsTests
         Assert.Null(Record.Exception(host.Dispose));
     }
 
+    [Fact]
+    public async Task AddMcpClientCancelsInFlightInitializationOnHostDisposal()
+    {
+        var handler = new BlockingInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        var host = builder.Build();
+        var resolutionTask = Task.Run(() => Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>()));
+        await handler.InitializeStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var disposeException = Record.Exception(host.Dispose);
+        var resolutionException = await resolutionTask;
+
+        Assert.Null(disposeException);
+        Assert.NotNull(resolutionException);
+        Assert.IsAssignableFrom<OperationCanceledException>(resolutionException);
+        Assert.True(handler.InitializeCanceled);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -230,6 +251,43 @@ public class AspireMcpClientExtensionsTests
                 if (string.Equals(methodElement.GetString(), "notifications/initialized", StringComparison.Ordinal))
                 {
                     return new HttpResponseMessage(HttpStatusCode.OK);
+                }
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+    }
+
+    private sealed class BlockingInitializationHandler : HttpMessageHandler
+    {
+        public TaskCompletionSource InitializeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool InitializeCanceled { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            var requestBody = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            using var requestJson = JsonDocument.Parse(requestBody);
+            if (requestJson.RootElement.TryGetProperty("method", out var methodElement) &&
+                string.Equals(methodElement.GetString(), "initialize", StringComparison.Ordinal))
+            {
+                InitializeStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    InitializeCanceled = true;
+                    throw;
                 }
             }
 

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -189,6 +189,25 @@ public class AspireMcpClientExtensionsTests
         Assert.True(handler.InitializeCanceled);
     }
 
+    [Fact]
+    public void AddMcpClientRetriesInitializationAfterTransientFailure()
+    {
+        var handler = new FailThenSucceedInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var firstException = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        McpClient? client = null;
+        var secondException = Record.Exception(() => client = host.Services.GetRequiredService<McpClient>());
+
+        Assert.NotNull(firstException);
+        Assert.Null(secondException);
+        Assert.NotNull(client);
+        Assert.Equal(2, handler.InitializeAttempts);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -333,6 +352,66 @@ public class AspireMcpClientExtensionsTests
                 {
                     InitializeCanceled = true;
                     throw;
+                }
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+    }
+
+    private sealed class FailThenSucceedInitializationHandler : HttpMessageHandler
+    {
+        private int _initializeAttempts;
+
+        public int InitializeAttempts => Volatile.Read(ref _initializeAttempts);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            var requestBody = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            using var requestJson = JsonDocument.Parse(requestBody);
+            if (requestJson.RootElement.TryGetProperty("method", out var methodElement))
+            {
+                if (string.Equals(methodElement.GetString(), "initialize", StringComparison.Ordinal))
+                {
+                    if (Interlocked.Increment(ref _initializeAttempts) == 1)
+                    {
+                        return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+                    }
+
+                    var id = requestJson.RootElement.GetProperty("id").GetInt32();
+                    var initializeResponse = JsonSerializer.Serialize(new
+                    {
+                        jsonrpc = "2.0",
+                        id,
+                        result = new
+                        {
+                            protocolVersion = "2025-11-25",
+                            capabilities = new { },
+                            serverInfo = new
+                            {
+                                name = "test",
+                                version = "1.0.0",
+                            },
+                        },
+                    });
+
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(initializeResponse, Encoding.UTF8, "application/json"),
+                    };
+                }
+
+                if (string.Equals(methodElement.GetString(), "notifications/initialized", StringComparison.Ordinal))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK);
                 }
             }
 

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Json.Schema;
 using Xunit;
 
 namespace Aspire.Mcp.Client.Tests;
@@ -110,6 +111,78 @@ public class AspireMcpClientExtensionsTests
         var exception = Assert.Throws<FormatException>(() => builder.AddMcpClient("mcp"));
 
         Assert.Equal("The MCP client connection string must be an absolute URI.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("not-a-uri")]
+    [InlineData("ftp://mcp")]
+    public void AddMcpClientRejectsMalformedConnectionString(string connectionString)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration["ConnectionStrings:mcp"] = connectionString;
+
+        Assert.Throws<FormatException>(() => builder.AddMcpClient("mcp"));
+    }
+
+    [Fact]
+    public void ConfigureSettingsCanOverrideMalformedConnectionString()
+    {
+        var handler = new RequestRecordingHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration["ConnectionStrings:mcp"] = "not-a-uri";
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp", configureSettings: settings => settings.Endpoint = new Uri("https://override/mcp"));
+
+        using var host = builder.Build();
+        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://override/mcp");
+    }
+
+    [Fact]
+    public void ConfigurationUsesBaseThenNamedThenConnectionStringThenSettings()
+    {
+        var handler = new RequestRecordingHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Aspire:Mcp:Client:Endpoint"] = "https://base/mcp",
+            ["Aspire:Mcp:Client:mcp:Endpoint"] = "https://named/mcp",
+            ["ConnectionStrings:mcp"] = "https://connection/mcp"
+        });
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp", configureSettings: settings => settings.Endpoint = new Uri("https://settings/mcp"));
+
+        using var host = builder.Build();
+        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://settings/mcp");
+    }
+
+    [Fact]
+    public void ConfigurationSchemaValidatesExpectedConfiguration()
+    {
+        var schema = JsonSchema.FromFile(Path.Combine(AppContext.BaseDirectory, "ConfigurationSchema.json"), new BuildOptions
+        {
+            Dialect = Dialect.Draft07,
+            SchemaRegistry = new SchemaRegistry()
+        });
+        using var config = JsonDocument.Parse("""{"Aspire":{"Mcp":{"Client":{"Endpoint":"https://mcp/mcp","DisableHealthChecks":false}}}}""");
+
+        Assert.True(schema.Evaluate(config.RootElement).IsValid);
+    }
+
+    [Fact]
+    public void ConfigurationSchemaRejectsInvalidConfiguration()
+    {
+        var schema = JsonSchema.FromFile(Path.Combine(AppContext.BaseDirectory, "ConfigurationSchema.json"), new BuildOptions
+        {
+            Dialect = Dialect.Draft07,
+            SchemaRegistry = new SchemaRegistry()
+        });
+        using var config = JsonDocument.Parse("""{"Aspire":{"Mcp":{"Client":{"DisableHealthChecks":"false"}}}}""");
+
+        Assert.False(schema.Evaluate(config.RootElement).IsValid);
     }
 
     [Fact]
@@ -267,7 +340,8 @@ public class AspireMcpClientExtensionsTests
         var handler = new SuccessfulInitializationHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.AddMcpClient("mcp");
-        builder.Services.AddSingleton<IHttpClientFactory>(new TrackingHttpClientFactory(handler));
+        var factory = new TrackingHttpClientFactory(handler);
+        builder.Services.AddSingleton<IHttpClientFactory>(factory);
 
         var host = builder.Build();
         var resolveException = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
@@ -275,6 +349,7 @@ public class AspireMcpClientExtensionsTests
         Assert.Null(resolveException);
         Assert.Null(Record.Exception(host.Dispose));
         Assert.True(handler.Disposed);
+        Assert.Equal(string.Empty, factory.Name);
     }
 
     [Fact]
@@ -608,6 +683,12 @@ public class AspireMcpClientExtensionsTests
 
     private sealed class TrackingHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
     {
-        public HttpClient CreateClient(string name) => new(handler);
+        public string? Name { get; private set; }
+
+        public HttpClient CreateClient(string name)
+        {
+            Name = name;
+            return new(handler);
+        }
     }
 }

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -211,6 +211,21 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
+    public void ConfigurationSchemaIncludesMcpLoggingCategories()
+    {
+        using var schema = JsonDocument.Parse(File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "ConfigurationSchema.json")));
+        var logLevelProperties = schema.RootElement
+            .GetProperty("definitions")
+            .GetProperty("logLevel")
+            .GetProperty("properties");
+
+        Assert.True(logLevelProperties.TryGetProperty("ModelContextProtocol.Authentication.ClientOAuthProvider", out _));
+        Assert.True(logLevelProperties.TryGetProperty("ModelContextProtocol.Client.AutoDetectingClientSessionTransport", out _));
+        Assert.True(logLevelProperties.TryGetProperty("ModelContextProtocol.Client.HttpClientTransport", out _));
+        Assert.True(logLevelProperties.TryGetProperty("ModelContextProtocol.Client.McpClient", out _));
+    }
+
+    [Fact]
     public void ConfigurationSchemaRejectsInvalidConfiguration()
     {
         var schema = JsonSchema.FromFile(Path.Combine(AppContext.BaseDirectory, "ConfigurationSchema.json"), new BuildOptions
@@ -592,6 +607,30 @@ public class AspireMcpClientExtensionsTests
         var unexpectedResult = await Task.WhenAny(unexpectedNotification.Task, Task.Delay(TimeSpan.FromSeconds(1)));
         Assert.NotSame(unexpectedNotification.Task, unexpectedResult);
         Assert.Equal(1, Volatile.Read(ref notificationCount));
+    }
+
+    [Fact]
+    public async Task AddMcpClientDoesNotRetainInvalidNotificationHandlers()
+    {
+        var handler = new NotificationRecoveryHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var client = host.Services.GetRequiredService<McpClient>();
+
+        Assert.Throws<ArgumentException>(() => client.RegisterNotificationHandler(" ", (_, _) => ValueTask.CompletedTask));
+        Assert.Throws<ArgumentNullException>(() => client.RegisterNotificationHandler("test/notification", null!));
+
+        await handler.InitialStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var failure = await Record.ExceptionAsync(async () => await client.PingAsync());
+        Assert.NotNull(failure);
+
+        var exception = Record.Exception(() => _ = client.ServerInfo);
+
+        Assert.Null(exception);
+        await handler.ReplacementStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
     }
 
     [Theory]

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.ServiceDiscovery;
 using ModelContextProtocol.Client;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.IO.Pipelines;
 using System.Text;
@@ -333,6 +336,55 @@ public class AspireMcpClientExtensionsTests
 
         Assert.Null(exception);
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "http://resolved-mcp/mcp");
+    }
+
+    public static TheoryData<EndPoint, string> PlatformServiceDiscoveryEndpoints { get; } = new()
+    {
+        { new DnsEndPoint("platform-mcp", 5001), "https://platform-mcp:5001/mcp" },
+        { new IPEndPoint(IPAddress.Loopback, 5001), "https://127.0.0.1:5001/mcp" },
+    };
+
+    [Theory]
+    [MemberData(nameof(PlatformServiceDiscoveryEndpoints))]
+    public void McpClientResolvesPlatformServiceDiscoveryEndpoint(EndPoint endPoint, string expectedEndpoint)
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton<IServiceEndpointProviderFactory>(new StaticServiceEndpointProviderFactory(endPoint));
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var exception = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Null(exception);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == expectedEndpoint);
+    }
+
+    [Fact]
+    public async Task McpClientSelectsNextServiceDiscoveryEndpointAfterReconnect()
+    {
+        var handler = new FailPingOnceHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["services:mcp:https:0"] = "https://replica-one",
+            ["services:mcp:https:1"] = "https://replica-two",
+        });
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var healthChecks = host.Services.GetRequiredService<HealthCheckService>();
+        var firstResult = await healthChecks.CheckHealthAsync();
+        var secondResult = await healthChecks.CheckHealthAsync();
+
+        Assert.Equal(HealthStatus.Unhealthy, firstResult.Status);
+        Assert.Equal(HealthStatus.Healthy, secondResult.Status);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://replica-one/mcp");
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://replica-two/mcp");
     }
 
     [Fact]
@@ -680,6 +732,34 @@ public class AspireMcpClientExtensionsTests
             }
 
             base.Dispose(disposing);
+        }
+    }
+
+    private sealed class StaticServiceEndpointProviderFactory(params EndPoint[] endPoints) : IServiceEndpointProviderFactory
+    {
+        public bool TryCreateProvider(ServiceEndpointQuery query, [NotNullWhen(true)] out IServiceEndpointProvider? provider)
+        {
+            provider = new StaticServiceEndpointProvider(endPoints);
+
+            return true;
+        }
+    }
+
+    private sealed class StaticServiceEndpointProvider(EndPoint[] endPoints) : IServiceEndpointProvider
+    {
+        public ValueTask PopulateAsync(IServiceEndpointBuilder endpoints, CancellationToken cancellationToken)
+        {
+            foreach (var endPoint in endPoints)
+            {
+                endpoints.Endpoints.Add(ServiceEndpoint.Create(endPoint, new FeatureCollection()));
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ModelContextProtocol.Client;
@@ -119,6 +120,30 @@ public class AspireMcpClientExtensionsTests
 
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://weather/mcp");
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://calendar/mcp");
+    }
+
+    [Fact]
+    public void McpClientResolvesHttpOnlyServiceDiscoveryEndpoint()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["services:mcp:http:0"] = "http://resolved-mcp",
+        });
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            http.AddServiceDiscovery();
+            http.ConfigurePrimaryHttpMessageHandler(() => handler);
+        });
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var exception = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Null(exception);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "http://resolved-mcp/mcp");
     }
 
     [Fact]
@@ -261,10 +286,14 @@ public class AspireMcpClientExtensionsTests
 
     private sealed class SuccessfulInitializationHandler : HttpMessageHandler
     {
+        public List<Uri> RequestUris { get; } = [];
+
         public bool Disposed { get; private set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            RequestUris.Add(request.RequestUri!);
+
             if (request.Method == HttpMethod.Get)
             {
                 return new HttpResponseMessage(HttpStatusCode.OK);

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -48,6 +48,7 @@ public class AspireMcpClientExtensionsTests
 
         builder.AddMcpClient(
             "mcp",
+            null,
             _ => clientOptionsConfigured = true,
             options =>
             {
@@ -74,6 +75,7 @@ public class AspireMcpClientExtensionsTests
 
         builder.AddKeyedMcpClient(
             "mcp",
+            null,
             _ => clientOptionsConfigured = true,
             options =>
             {
@@ -110,7 +112,7 @@ public class AspireMcpClientExtensionsTests
 
         var exception = Assert.Throws<FormatException>(() => builder.AddMcpClient("mcp"));
 
-        Assert.Equal("The MCP client connection string must be an absolute URI.", exception.Message);
+        Assert.Equal("The MCP client connection string must be an absolute HTTP or HTTPS URI.", exception.Message);
     }
 
     [Theory]
@@ -137,6 +139,21 @@ public class AspireMcpClientExtensionsTests
         _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
 
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://override/mcp");
+    }
+
+    [Fact]
+    public void MalformedConnectionStringDoesNotUseInheritedEndpoint()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Aspire:Mcp:Client:Endpoint"] = "https://inherited/mcp",
+            ["ConnectionStrings:mcp"] = "not-a-uri"
+        });
+
+        var exception = Assert.Throws<FormatException>(() => builder.AddMcpClient("mcp"));
+
+        Assert.Equal("The MCP client connection string must be an absolute HTTP or HTTPS URI.", exception.Message);
     }
 
     [Fact]
@@ -408,6 +425,21 @@ public class AspireMcpClientExtensionsTests
         Assert.Equal(2, handler.InitializeAttempts);
     }
 
+    [Fact]
+    public async Task AddMcpClientReconnectsAfterOperationFailure()
+    {
+        var handler = new FailPingOnceHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var result = await host.Services.GetRequiredService<HealthCheckService>().CheckHealthAsync();
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Equal(2, handler.InitializeAttempts);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -618,6 +650,35 @@ public class AspireMcpClientExtensionsTests
             }
 
             return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+    }
+
+    private sealed class FailPingOnceHandler : SuccessfulInitializationHandler
+    {
+        private int _pingFailures;
+        public int InitializeAttempts { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                var body = request.Content is null ? string.Empty : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                using var json = JsonDocument.Parse(body);
+                if (json.RootElement.TryGetProperty("method", out var method))
+                {
+                    if (string.Equals(method.GetString(), "initialize", StringComparison.Ordinal))
+                    {
+                        InitializeAttempts++;
+                    }
+                    else if (string.Equals(method.GetString(), "ping", StringComparison.Ordinal) &&
+                        Interlocked.Exchange(ref _pingFailures, 1) is 0)
+                    {
+                        return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                    }
+                }
+            }
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -4,6 +4,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ModelContextProtocol.Client;
+using System.Net;
+using System.Text;
+using System.Text.Json;
 using Xunit;
 
 namespace Aspire.Mcp.Client.Tests;
@@ -117,6 +120,21 @@ public class AspireMcpClientExtensionsTests
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://calendar/mcp");
     }
 
+    [Fact]
+    public void AddMcpClientAllowsSynchronousHostDisposalAfterSuccessfulResolution()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        var host = builder.Build();
+        var resolveException = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Null(resolveException);
+        Assert.Null(Record.Exception(host.Dispose));
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -165,6 +183,57 @@ public class AspireMcpClientExtensionsTests
         {
             RequestUris.Add(request.RequestUri!);
             return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
+        }
+    }
+
+    private sealed class SuccessfulInitializationHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            var requestBody = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            using var requestJson = JsonDocument.Parse(requestBody);
+            if (requestJson.RootElement.TryGetProperty("method", out var methodElement))
+            {
+                if (string.Equals(methodElement.GetString(), "initialize", StringComparison.Ordinal))
+                {
+                    var id = requestJson.RootElement.GetProperty("id").GetInt32();
+                    var initializeResponse = JsonSerializer.Serialize(new
+                    {
+                        jsonrpc = "2.0",
+                        id,
+                        result = new
+                        {
+                            protocolVersion = "2025-11-25",
+                            capabilities = new { },
+                            serverInfo = new
+                            {
+                                name = "test",
+                                version = "1.0.0",
+                            },
+                        },
+                    });
+
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(initializeResponse, Encoding.UTF8, "application/json"),
+                    };
+                }
+
+                if (string.Equals(methodElement.GetString(), "notifications/initialized", StringComparison.Ordinal))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
     }
 }

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -99,6 +99,7 @@ public class AspireMcpClientExtensionsTests
         var exception = Record.Exception(resolveClient);
 
         Assert.NotNull(exception);
+        Assert.NotEmpty(handler.RequestUris);
         Assert.All(handler.RequestUris, uri => Assert.Equal("https://mcp/mcp", uri.ToString()));
     }
 

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -426,7 +426,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public async Task AddMcpClientReconnectsAfterOperationFailure()
+    public async Task AddMcpClientReconnectsAfterOperationFailureWithoutReplaying()
     {
         var handler = new FailPingOnceHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -434,9 +434,12 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp");
 
         using var host = builder.Build();
-        var result = await host.Services.GetRequiredService<HealthCheckService>().CheckHealthAsync();
+        var healthChecks = host.Services.GetRequiredService<HealthCheckService>();
+        var firstResult = await healthChecks.CheckHealthAsync();
+        var secondResult = await healthChecks.CheckHealthAsync();
 
-        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Equal(HealthStatus.Unhealthy, firstResult.Status);
+        Assert.Equal(HealthStatus.Healthy, secondResult.Status);
         Assert.Equal(2, handler.InitializeAttempts);
     }
 

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -118,6 +118,8 @@ public class AspireMcpClientExtensionsTests
     [Theory]
     [InlineData("not-a-uri")]
     [InlineData("ftp://mcp")]
+    [InlineData("http:/mcp")]
+    [InlineData("https:///mcp")]
     public void AddMcpClientRejectsMalformedConnectionString(string connectionString)
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -277,7 +277,10 @@ public class AspireMcpClientExtensionsTests
     [Fact]
     public void AddMcpClientSupportsConfiguringOnlyTransportOptions()
     {
+        var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
         var transportOptionsConfigured = false;
 
         builder.AddMcpClient(
@@ -292,6 +295,7 @@ public class AspireMcpClientExtensionsTests
         _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
 
         Assert.True(transportOptionsConfigured);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://transport-only/mcp");
     }
 
     [Theory]

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -367,6 +367,25 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
+    public async Task AddMcpClientHealthCheckPassesCancellationTokenToInitialization()
+    {
+        var handler = new BlockingInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var checkTask = host.Services.GetRequiredService<HealthCheckService>().CheckHealthAsync(cancellationTokenSource.Token);
+        await handler.InitializeStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        cancellationTokenSource.Cancel();
+        var result = await checkTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+    }
+
+    [Fact]
     public void AddMcpClientDisposesHttpClientTransportOnHostDisposal()
     {
         var handler = new SuccessfulInitializationHandler();
@@ -484,13 +503,13 @@ public class AspireMcpClientExtensionsTests
             });
 
         await handler.InitialStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
-        var healthChecks = host.Services.GetRequiredService<HealthCheckService>();
-        var firstResult = await healthChecks.CheckHealthAsync();
-        var secondResult = await healthChecks.CheckHealthAsync();
+        var failure = await Record.ExceptionAsync(async () => await client.PingAsync());
+        Assert.NotNull(failure);
+
+        var serverInfo = client.ServerInfo;
         var replacementStream = await handler.ReplacementStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
-        Assert.Equal(HealthStatus.Unhealthy, firstResult.Status);
-        Assert.Equal(HealthStatus.Healthy, secondResult.Status);
+        Assert.Equal("test", serverInfo.Name);
 
         await NotificationRecoveryHandler.SendNotificationAsync(replacementStream);
         await notificationReceived.Task.WaitAsync(TimeSpan.FromSeconds(10));

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -123,6 +123,45 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
+    public void AddMcpClientSupportsConfiguringOnlyTransportOptions()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var transportOptionsConfigured = false;
+
+        builder.AddMcpClient(
+            "mcp",
+            configureTransportOptions: options =>
+            {
+                transportOptionsConfigured = true;
+                options.Endpoint = new Uri("https://transport-only/mcp", UriKind.Absolute);
+            });
+
+        using var host = builder.Build();
+        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.True(transportOptionsConfigured);
+    }
+
+    [Fact]
+    public void AddKeyedMcpClientSupportsConfiguringOnlyClientOptions()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var clientOptionsConfigured = false;
+
+        builder.AddKeyedMcpClient(
+            "mcp",
+            configureClientOptions: _ =>
+            {
+                clientOptionsConfigured = true;
+            });
+
+        using var host = builder.Build();
+        _ = Record.Exception(() => _ = host.Services.GetRequiredKeyedService<McpClient>("mcp"));
+
+        Assert.True(clientOptionsConfigured);
+    }
+
+    [Fact]
     public void McpClientResolvesHttpOnlyServiceDiscoveryEndpoint()
     {
         var handler = new SuccessfulInitializationHandler();
@@ -251,6 +290,16 @@ public class AspireMcpClientExtensionsTests
             : Assert.Throws<ArgumentException>(action);
 
         Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddMcpClientRejectsConnectionNameWithReservedUriCharacters()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.AddMcpClient("mcp/service"));
+
+        Assert.Equal("connectionName", exception.ParamName);
     }
 
     [Theory]

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -44,6 +44,9 @@ public class AspireMcpClientExtensionsTests
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration["services:mcp:https:0"] = "https://mcp";
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http => http.AddServiceDiscovery());
         builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
         var clientOptionsConfigured = false;
         var transportOptionsConfigured = false;
@@ -367,7 +370,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public async Task AddMcpClientHealthCheckPassesCancellationTokenToInitialization()
+    public async Task AddMcpClientHealthCheckCancelsInitializationWait()
     {
         var handler = new BlockingInitializationHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -383,6 +386,7 @@ public class AspireMcpClientExtensionsTests
         var result = await checkTask.WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.False(handler.InitializeCanceled);
     }
 
     [Fact]

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -4,7 +4,9 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using ModelContextProtocol.Client;
+using Microsoft.Extensions.Options;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -84,6 +86,19 @@ public class AspireMcpClientExtensionsTests
         Assert.True(clientOptionsConfigured);
         Assert.True(transportOptionsConfigured);
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://keyed/mcp");
+    }
+
+    [Fact]
+    public void AddMcpClientInvokesSettingsDelegate()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        builder.AddMcpClient("mcp", configureSettings: settings => settings.DisableHealthChecks = true);
+
+        using var host = builder.Build();
+        var options = host.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        Assert.Empty(options.Registrations);
     }
 
     [Fact]
@@ -198,6 +213,41 @@ public class AspireMcpClientExtensionsTests
 
         Assert.Null(resolveException);
         Assert.Null(Record.Exception(host.Dispose));
+    }
+
+    [Fact]
+    public async Task AddMcpClientHealthCheckPingsServer()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var result = await host.Services.GetRequiredService<HealthCheckService>().CheckHealthAsync();
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Contains(handler.RequestMethods, method => method == "ping");
+    }
+
+    [Fact]
+    public async Task AddMcpClientHealthCheckPassesCancellationTokenToPing()
+    {
+        var handler = new BlockingPingHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var checkTask = host.Services.GetRequiredService<HealthCheckService>().CheckHealthAsync(cancellationTokenSource.Token);
+        await handler.PingStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        cancellationTokenSource.Cancel();
+        var result = await checkTask;
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.True(handler.PingCanceled);
     }
 
     [Fact]
@@ -333,9 +383,11 @@ public class AspireMcpClientExtensionsTests
         }
     }
 
-    private sealed class SuccessfulInitializationHandler : HttpMessageHandler
+    private class SuccessfulInitializationHandler : HttpMessageHandler
     {
         public List<Uri> RequestUris { get; } = [];
+
+        public List<string> RequestMethods { get; } = [];
 
         public bool Disposed { get; private set; }
 
@@ -355,6 +407,7 @@ public class AspireMcpClientExtensionsTests
             using var requestJson = JsonDocument.Parse(requestBody);
             if (requestJson.RootElement.TryGetProperty("method", out var methodElement))
             {
+                RequestMethods.Add(methodElement.GetString()!);
                 if (string.Equals(methodElement.GetString(), "initialize", StringComparison.Ordinal))
                 {
                     var id = requestJson.RootElement.GetProperty("id").GetInt32();
@@ -384,6 +437,16 @@ public class AspireMcpClientExtensionsTests
                 {
                     return new HttpResponseMessage(HttpStatusCode.OK);
                 }
+
+                if (string.Equals(methodElement.GetString(), "ping", StringComparison.Ordinal))
+                {
+                    var id = requestJson.RootElement.GetProperty("id").GetInt32();
+                    var pingResponse = JsonSerializer.Serialize(new { jsonrpc = "2.0", id, result = new { } });
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(pingResponse, Encoding.UTF8, "application/json"),
+                    };
+                }
             }
 
             return new HttpResponseMessage(HttpStatusCode.NotFound);
@@ -397,6 +460,41 @@ public class AspireMcpClientExtensionsTests
             }
 
             base.Dispose(disposing);
+        }
+    }
+
+    private sealed class BlockingPingHandler : SuccessfulInitializationHandler
+    {
+        public TaskCompletionSource PingStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool PingCanceled { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Post)
+            {
+                var requestBody = request.Content is null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                using var requestJson = JsonDocument.Parse(requestBody);
+                if (requestJson.RootElement.TryGetProperty("method", out var methodElement) &&
+                    string.Equals(methodElement.GetString(), "ping", StringComparison.Ordinal))
+                {
+                    PingStarted.TrySetResult();
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        PingCanceled = true;
+                        throw;
+                    }
+                }
+            }
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol.Client;
+using Xunit;
+
+namespace Aspire.Mcp.Client.Tests;
+
+public class AspireMcpClientExtensionsTests
+{
+    [Fact]
+    public void AddMcpClientRegistersUnkeyedClient()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        builder.AddMcpClient("mcp");
+
+        Assert.Contains(builder.Services, descriptor => descriptor.ServiceType == typeof(McpClient) && descriptor.ServiceKey is null);
+    }
+
+    [Fact]
+    public void AddKeyedMcpClientRegistersKeyedClient()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        builder.AddKeyedMcpClient("mcp");
+
+        Assert.Contains(builder.Services, descriptor => descriptor.ServiceType == typeof(McpClient) && Equals(descriptor.ServiceKey, "mcp"));
+    }
+
+    [Fact]
+    public void McpClientUsesServiceDiscoveryEndpoint()
+    {
+        var handler = new RequestRecordingHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        Action resolveClient = () => _ = host.Services.GetRequiredService<McpClient>();
+
+        var exception = Record.Exception(resolveClient);
+
+        Assert.NotNull(exception);
+        Assert.All(handler.RequestUris, uri => Assert.Equal("https://mcp/mcp", uri.ToString()));
+    }
+
+    [Fact]
+    public void KeyedMcpClientsUseTheirOwnServiceDiscoveryEndpoints()
+    {
+        var handler = new RequestRecordingHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddKeyedMcpClient("weather");
+        builder.AddKeyedMcpClient("calendar");
+
+        using var host = builder.Build();
+
+        _ = Record.Exception(() => _ = host.Services.GetRequiredKeyedService<McpClient>("weather"));
+        _ = Record.Exception(() => _ = host.Services.GetRequiredKeyedService<McpClient>("calendar"));
+
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://weather/mcp");
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://calendar/mcp");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddMcpClientValidatesConnectionName(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+
+        Action action = () =>
+        {
+            builder.AddMcpClient(connectionName);
+        };
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedMcpClientValidatesName(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var name = isNull ? null! : string.Empty;
+
+        Action action = () =>
+        {
+            builder.AddKeyedMcpClient(name);
+        };
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    private sealed class RequestRecordingHandler : HttpMessageHandler
+    {
+        public List<Uri> RequestUris { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUris.Add(request.RequestUri!);
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -298,6 +298,23 @@ public class AspireMcpClientExtensionsTests
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://transport-only/mcp");
     }
 
+    [Fact]
+    public void AddMcpClientDefaultsTransportNameToConnectionName()
+    {
+        var handler = new RequestRecordingHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration["ConnectionStrings:mcp"] = "https://user:password@example.com/mcp?token=secret";
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        string? transportName = null;
+
+        builder.AddMcpClient("mcp", configureTransportOptions: options => transportName = options.Name);
+
+        using var host = builder.Build();
+        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Equal("mcp", transportName);
+    }
+
     [Theory]
     [InlineData("ftp://mcp/mcp")]
     public void AddMcpClientRejectsInvalidTransportEndpoint(string endpoint)

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -102,6 +102,17 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
+    public void AddMcpClientRejectsNonAbsoluteConnectionString()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration["ConnectionStrings:mcp"] = "not-a-uri";
+
+        var exception = Assert.Throws<FormatException>(() => builder.AddMcpClient("mcp"));
+
+        Assert.Equal("The MCP client connection string must be an absolute URI.", exception.Message);
+    }
+
+    [Fact]
     public void McpClientUsesServiceDiscoveryEndpoint()
     {
         var handler = new RequestRecordingHandler();

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -153,6 +153,22 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
+    public async Task AddMcpClientDisposesHttpClientTransportOnAsyncHostDisposal()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddMcpClient("mcp");
+        builder.Services.AddSingleton<IHttpClientFactory>(new TrackingHttpClientFactory(handler));
+
+        var host = builder.Build();
+        var resolveException = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Null(resolveException);
+        await ((IAsyncDisposable)host).DisposeAsync();
+        Assert.True(handler.Disposed);
+    }
+
+    [Fact]
     public async Task AddMcpClientCancelsInFlightInitializationOnHostDisposal()
     {
         var handler = new BlockingInitializationHandler();

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -31,6 +31,58 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
+    public void AddMcpClientInvokesConfigurationDelegates()
+    {
+        var handler = new RequestRecordingHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        var clientOptionsConfigured = false;
+        var transportOptionsConfigured = false;
+
+        builder.AddMcpClient(
+            "mcp",
+            _ => clientOptionsConfigured = true,
+            options =>
+            {
+                transportOptionsConfigured = true;
+                options.Endpoint = new Uri("https://custom/mcp", UriKind.Absolute);
+            });
+
+        using var host = builder.Build();
+        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.True(clientOptionsConfigured);
+        Assert.True(transportOptionsConfigured);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://custom/mcp");
+    }
+
+    [Fact]
+    public void AddKeyedMcpClientInvokesConfigurationDelegates()
+    {
+        var handler = new RequestRecordingHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        var clientOptionsConfigured = false;
+        var transportOptionsConfigured = false;
+
+        builder.AddKeyedMcpClient(
+            "mcp",
+            _ => clientOptionsConfigured = true,
+            options =>
+            {
+                transportOptionsConfigured = true;
+                options.Endpoint = new Uri("https://keyed/mcp", UriKind.Absolute);
+            });
+
+        using var host = builder.Build();
+        _ = Record.Exception(() => _ = host.Services.GetRequiredKeyedService<McpClient>("mcp"));
+
+        Assert.True(clientOptionsConfigured);
+        Assert.True(transportOptionsConfigured);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://keyed/mcp");
+    }
+
+    [Fact]
     public void McpClientUsesServiceDiscoveryEndpoint()
     {
         var handler = new RequestRecordingHandler();

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -7,7 +7,9 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using ModelContextProtocol.Client;
 using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
 using System.Net;
+using System.IO.Pipelines;
 using System.Text;
 using System.Text.Json;
 using Json.Schema;
@@ -124,6 +126,17 @@ public class AspireMcpClientExtensionsTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration["ConnectionStrings:mcp"] = connectionString;
+
+        Assert.Throws<FormatException>(() => builder.AddMcpClient("mcp"));
+    }
+
+    [Theory]
+    [InlineData("ftp://mcp/mcp")]
+    [InlineData("/mcp")]
+    public void AddMcpClientRejectsInvalidConfiguredEndpoint(string endpoint)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration["Aspire:Mcp:Client:Endpoint"] = endpoint;
 
         Assert.Throws<FormatException>(() => builder.AddMcpClient("mcp"));
     }
@@ -409,7 +422,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public void AddMcpClientRetriesInitializationAfterTransientFailure()
+    public async Task AddMcpClientRetriesInitializationAfterTransientFailure()
     {
         var handler = new FailThenSucceedInitializationHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -417,13 +430,12 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp");
 
         using var host = builder.Build();
-        var firstException = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
-        McpClient? client = null;
-        var secondException = Record.Exception(() => client = host.Services.GetRequiredService<McpClient>());
+        var healthChecks = host.Services.GetRequiredService<HealthCheckService>();
+        var firstResult = await healthChecks.CheckHealthAsync();
+        var secondResult = await healthChecks.CheckHealthAsync();
 
-        Assert.NotNull(firstException);
-        Assert.Null(secondException);
-        Assert.NotNull(client);
+        Assert.Equal(HealthStatus.Unhealthy, firstResult.Status);
+        Assert.Equal(HealthStatus.Healthy, secondResult.Status);
         Assert.Equal(2, handler.InitializeAttempts);
     }
 
@@ -443,6 +455,52 @@ public class AspireMcpClientExtensionsTests
         Assert.Equal(HealthStatus.Unhealthy, firstResult.Status);
         Assert.Equal(HealthStatus.Healthy, secondResult.Status);
         Assert.Equal(2, handler.InitializeAttempts);
+    }
+
+    [Fact]
+    public async Task AddMcpClientPreservesNotificationHandlersAcrossReconnect()
+    {
+        var handler = new NotificationRecoveryHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var client = host.Services.GetRequiredService<McpClient>();
+        var notificationReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var unexpectedNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var notificationCount = 0;
+        await using var registration = client.RegisterNotificationHandler(
+            "test/notification",
+            (_, _) =>
+            {
+                if (Interlocked.Increment(ref notificationCount) > 1)
+                {
+                    unexpectedNotification.TrySetResult();
+                }
+
+                notificationReceived.TrySetResult();
+                return ValueTask.CompletedTask;
+            });
+
+        await handler.InitialStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var healthChecks = host.Services.GetRequiredService<HealthCheckService>();
+        var firstResult = await healthChecks.CheckHealthAsync();
+        var secondResult = await healthChecks.CheckHealthAsync();
+        var replacementStream = await handler.ReplacementStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(HealthStatus.Unhealthy, firstResult.Status);
+        Assert.Equal(HealthStatus.Healthy, secondResult.Status);
+
+        await NotificationRecoveryHandler.SendNotificationAsync(replacementStream);
+        await notificationReceived.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(1, Volatile.Read(ref notificationCount));
+
+        await registration.DisposeAsync();
+        await NotificationRecoveryHandler.SendNotificationAsync(replacementStream);
+        var unexpectedResult = await Task.WhenAny(unexpectedNotification.Task, Task.Delay(TimeSpan.FromSeconds(1)));
+        Assert.NotSame(unexpectedNotification.Task, unexpectedResult);
+        Assert.Equal(1, Volatile.Read(ref notificationCount));
     }
 
     [Theory]
@@ -497,26 +555,26 @@ public class AspireMcpClientExtensionsTests
 
     private sealed class RequestRecordingHandler : HttpMessageHandler
     {
-        public List<Uri> RequestUris { get; } = [];
+        public ConcurrentQueue<Uri> RequestUris { get; } = [];
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            RequestUris.Add(request.RequestUri!);
+            RequestUris.Enqueue(request.RequestUri!);
             return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.NotFound));
         }
     }
 
     private class SuccessfulInitializationHandler : HttpMessageHandler
     {
-        public List<Uri> RequestUris { get; } = [];
+        public ConcurrentQueue<Uri> RequestUris { get; } = [];
 
-        public List<string> RequestMethods { get; } = [];
+        public ConcurrentQueue<string> RequestMethods { get; } = [];
 
         public bool Disposed { get; private set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            RequestUris.Add(request.RequestUri!);
+            RequestUris.Enqueue(request.RequestUri!);
 
             if (request.Method == HttpMethod.Get)
             {
@@ -530,7 +588,7 @@ public class AspireMcpClientExtensionsTests
             using var requestJson = JsonDocument.Parse(requestBody);
             if (requestJson.RootElement.TryGetProperty("method", out var methodElement))
             {
-                RequestMethods.Add(methodElement.GetString()!);
+                RequestMethods.Enqueue(methodElement.GetString()!);
                 if (string.Equals(methodElement.GetString(), "initialize", StringComparison.Ordinal))
                 {
                     var id = requestJson.RootElement.GetProperty("id").GetInt32();
@@ -687,6 +745,63 @@ public class AspireMcpClientExtensionsTests
         }
     }
 
+    private sealed class NotificationRecoveryHandler : SuccessfulInitializationHandler
+    {
+        private int _pingFailures;
+        private int _streamCount;
+
+        public TaskCompletionSource<PipeWriter> InitialStream { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<PipeWriter> ReplacementStream { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Get)
+            {
+                var pipe = new Pipe();
+                var streamNumber = Interlocked.Increment(ref _streamCount);
+                if (streamNumber is 1)
+                {
+                    InitialStream.TrySetResult(pipe.Writer);
+                }
+                else
+                {
+                    ReplacementStream.TrySetResult(pipe.Writer);
+                }
+
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StreamContent(pipe.Reader.AsStream()),
+                };
+                response.Content.Headers.ContentType = new("text/event-stream");
+                return response;
+            }
+
+            if (request.Method == HttpMethod.Post)
+            {
+                var requestBody = request.Content is null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                using var requestJson = JsonDocument.Parse(requestBody);
+                if (requestJson.RootElement.TryGetProperty("method", out var methodElement) &&
+                    string.Equals(methodElement.GetString(), "ping", StringComparison.Ordinal) &&
+                    Interlocked.Exchange(ref _pingFailures, 1) is 0)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                }
+            }
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        public static async Task SendNotificationAsync(PipeWriter writer)
+        {
+            const string message = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"test/notification\",\"params\":{}}\n\n";
+            await writer.WriteAsync(Encoding.UTF8.GetBytes(message));
+        }
+    }
+
     private sealed class FailThenSucceedInitializationHandler : HttpMessageHandler
     {
         private int _initializeAttempts;
@@ -711,6 +826,7 @@ public class AspireMcpClientExtensionsTests
                 {
                     if (Interlocked.Increment(ref _initializeAttempts) == 1)
                     {
+                        await Task.Yield();
                         return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
                     }
 
@@ -740,6 +856,16 @@ public class AspireMcpClientExtensionsTests
                 if (string.Equals(methodElement.GetString(), "notifications/initialized", StringComparison.Ordinal))
                 {
                     return new HttpResponseMessage(HttpStatusCode.OK);
+                }
+
+                if (string.Equals(methodElement.GetString(), "ping", StringComparison.Ordinal))
+                {
+                    var id = requestJson.RootElement.GetProperty("id").GetInt32();
+                    var pingResponse = JsonSerializer.Serialize(new { jsonrpc = "2.0", id, result = new { } });
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(pingResponse, Encoding.UTF8, "application/json"),
+                    };
                 }
             }
 

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -136,6 +136,22 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
+    public void AddMcpClientDisposesHttpClientTransportOnHostDisposal()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddMcpClient("mcp");
+        builder.Services.AddSingleton<IHttpClientFactory>(new TrackingHttpClientFactory(handler));
+
+        var host = builder.Build();
+        var resolveException = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Null(resolveException);
+        Assert.Null(Record.Exception(host.Dispose));
+        Assert.True(handler.Disposed);
+    }
+
+    [Fact]
     public async Task AddMcpClientCancelsInFlightInitializationOnHostDisposal()
     {
         var handler = new BlockingInitializationHandler();
@@ -209,6 +225,8 @@ public class AspireMcpClientExtensionsTests
 
     private sealed class SuccessfulInitializationHandler : HttpMessageHandler
     {
+        public bool Disposed { get; private set; }
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (request.Method == HttpMethod.Get)
@@ -256,6 +274,16 @@ public class AspireMcpClientExtensionsTests
 
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
     }
 
     private sealed class BlockingInitializationHandler : HttpMessageHandler
@@ -293,5 +321,10 @@ public class AspireMcpClientExtensionsTests
 
             return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
+    }
+
+    private sealed class TrackingHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler);
     }
 }

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -276,6 +276,22 @@ public class AspireMcpClientExtensionsTests
         Assert.True(transportOptionsConfigured);
     }
 
+    [Theory]
+    [InlineData("ftp://mcp/mcp")]
+    public void AddMcpClientRejectsInvalidTransportEndpoint(string endpoint)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddMcpClient(
+            "mcp",
+            configureTransportOptions: options => options.Endpoint = new Uri(endpoint, UriKind.RelativeOrAbsolute));
+
+        using var host = builder.Build();
+
+        void ResolveClient() => _ = host.Services.GetRequiredService<McpClient>();
+
+        Assert.Throws<ArgumentException>(ResolveClient);
+    }
+
     [Fact]
     public void AddKeyedMcpClientSupportsConfiguringOnlyClientOptions()
     {

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -536,7 +536,7 @@ public class AspireMcpClientExtensionsTests
     {
         var handler = new SuccessfulInitializationHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Services.AddSingleton<IServiceEndpointProviderFactory>(new StaticServiceEndpointProviderFactory(endPoint));
+        builder.Services.AddSingleton<IServiceEndpointProviderFactory>(new StaticServiceEndpointProviderFactory(CreateServiceEndpoint(endPoint)));
         builder.Services.AddServiceDiscovery();
         builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
         builder.AddMcpClient("mcp");
@@ -547,6 +547,26 @@ public class AspireMcpClientExtensionsTests
 
         Assert.Null(exception);
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == expectedEndpoint);
+    }
+
+    [Fact]
+    public async Task McpClientPreservesIpDestinationAndHostMetadataForPlatformServiceEndpoint()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton<IServiceEndpointProviderFactory>(new StaticServiceEndpointProviderFactory(
+            CreateServiceEndpoint(new IPEndPoint(IPAddress.Parse("127.0.0.11"), 5001), hostName: "platform-mcp")));
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var client = host.Services.GetRequiredService<McpClient>();
+        var exception = await Record.ExceptionAsync(async () => await client.PingAsync());
+
+        Assert.Null(exception);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://127.0.0.11:5001/mcp");
+        Assert.Contains(handler.RequestHosts, host => host == "platform-mcp");
     }
 
     [Fact]
@@ -871,6 +891,8 @@ public class AspireMcpClientExtensionsTests
     {
         public ConcurrentQueue<Uri> RequestUris { get; } = [];
 
+        public ConcurrentQueue<string?> RequestHosts { get; } = [];
+
         public ConcurrentQueue<string> RequestMethods { get; } = [];
 
         public bool Disposed { get; private set; }
@@ -878,6 +900,7 @@ public class AspireMcpClientExtensionsTests
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             RequestUris.Enqueue(request.RequestUri!);
+            RequestHosts.Enqueue(request.Headers.Host);
 
             if (request.Method == HttpMethod.Get)
             {
@@ -947,23 +970,39 @@ public class AspireMcpClientExtensionsTests
         }
     }
 
-    private sealed class StaticServiceEndpointProviderFactory(params EndPoint[] endPoints) : IServiceEndpointProviderFactory
+    private static ServiceEndpoint CreateServiceEndpoint(EndPoint endPoint, string? hostName = null)
+    {
+        var features = new FeatureCollection();
+        if (!string.IsNullOrWhiteSpace(hostName))
+        {
+            features.Set<IHostNameFeature>(new HostNameFeature(hostName));
+        }
+
+        return ServiceEndpoint.Create(endPoint, features);
+    }
+
+    private sealed class HostNameFeature(string hostName) : IHostNameFeature
+    {
+        public string HostName { get; } = hostName;
+    }
+
+    private sealed class StaticServiceEndpointProviderFactory(params ServiceEndpoint[] serviceEndpoints) : IServiceEndpointProviderFactory
     {
         public bool TryCreateProvider(ServiceEndpointQuery query, [NotNullWhen(true)] out IServiceEndpointProvider? provider)
         {
-            provider = new StaticServiceEndpointProvider(endPoints);
+            provider = new StaticServiceEndpointProvider(serviceEndpoints);
 
             return true;
         }
     }
 
-    private sealed class StaticServiceEndpointProvider(EndPoint[] endPoints) : IServiceEndpointProvider
+    private sealed class StaticServiceEndpointProvider(ServiceEndpoint[] serviceEndpoints) : IServiceEndpointProvider
     {
         public ValueTask PopulateAsync(IServiceEndpointBuilder endpoints, CancellationToken cancellationToken)
         {
-            foreach (var endPoint in endPoints)
+            foreach (var serviceEndpoint in serviceEndpoints)
             {
-                endpoints.Endpoints.Add(ServiceEndpoint.Create(endPoint, new FeatureCollection()));
+                endpoints.Endpoints.Add(serviceEndpoint);
             }
 
             return ValueTask.CompletedTask;

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -32,6 +32,30 @@ public class AspireMcpClientExtensionsTests
         Assert.Contains(builder.Services, descriptor => descriptor.ServiceType == typeof(McpClient) && descriptor.ServiceKey is null);
     }
 
+    private sealed class HeaderRecordingInitializationHandler : SuccessfulInitializationHandler
+    {
+        public ConcurrentQueue<string> AuthorizationHeaders { get; } = [];
+        public ConcurrentQueue<string> CustomHeaderValues { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Headers.Authorization is { } authorization)
+            {
+                AuthorizationHeaders.Enqueue(authorization.ToString());
+            }
+
+            if (request.Headers.TryGetValues("x-test", out var values))
+            {
+                foreach (var value in values)
+                {
+                    CustomHeaderValues.Enqueue(value);
+                }
+            }
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     [Fact]
     public void AddKeyedMcpClientRegistersKeyedClient()
     {
@@ -43,7 +67,72 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public void AddMcpClientInvokesConfigurationDelegates()
+    public void AddMcpClientRejectsDuplicateUnkeyedRegistration()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddMcpClient("mcp");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddMcpClient("mcp"));
+
+        Assert.Contains("already exists", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddKeyedMcpClientRejectsDuplicateKeyedRegistration()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddKeyedMcpClient("mcp");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddKeyedMcpClient("mcp"));
+
+        Assert.Contains("already exists", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddMcpClientRejectsCombiningOAuthAndBearerProvider()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var mcpBuilder = builder.AddMcpClient("mcp");
+        mcpBuilder.UseOAuth(_ => { });
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            mcpBuilder.UseBearerTokenProvider(static (_, _, _) => ValueTask.FromResult<string?>(null)));
+
+        Assert.Contains("cannot be enabled at the same time", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddMcpClientRejectsCombiningBearerProviderAndOAuth()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var mcpBuilder = builder.AddMcpClient("mcp");
+        mcpBuilder.UseBearerTokenProvider(static (_, _, _) => ValueTask.FromResult<string?>(null));
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            mcpBuilder.UseOAuth(_ => { }));
+
+        Assert.Contains("cannot be enabled at the same time", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AddMcpClientOAuthRequiresExplicitRedirectDelegate()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp").UseOAuth(_ => { });
+
+        using var host = builder.Build();
+        var client = host.Services.GetRequiredService<McpClient>();
+
+        var exception = await Record.ExceptionAsync(async () => await client.PingAsync());
+
+        Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains("AuthorizationRedirectDelegate", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AddMcpClientInvokesConfigurationDelegates()
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -65,7 +154,8 @@ public class AspireMcpClientExtensionsTests
             });
 
         using var host = builder.Build();
-        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        _ = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.True(clientOptionsConfigured);
         Assert.True(transportOptionsConfigured);
@@ -73,7 +163,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public void AddKeyedMcpClientInvokesConfigurationDelegates()
+    public async Task AddKeyedMcpClientInvokesConfigurationDelegates()
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -92,7 +182,8 @@ public class AspireMcpClientExtensionsTests
             });
 
         using var host = builder.Build();
-        _ = Record.Exception(() => _ = host.Services.GetRequiredKeyedService<McpClient>("mcp"));
+        var client = host.Services.GetRequiredKeyedService<McpClient>("mcp");
+        _ = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.True(clientOptionsConfigured);
         Assert.True(transportOptionsConfigured);
@@ -110,6 +201,20 @@ public class AspireMcpClientExtensionsTests
         var options = host.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
 
         Assert.Empty(options.Registrations);
+    }
+
+    [Fact]
+    public void AddMcpClientAndKeyedClientUseDistinctHealthCheckNames()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddMcpClient("mcp");
+        builder.AddKeyedMcpClient("mcp");
+
+        using var host = builder.Build();
+        var options = host.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        Assert.Contains(options.Registrations, registration => registration.Name == "Mcp.Client_mcp");
+        Assert.Contains(options.Registrations, registration => registration.Name == "Mcp.Client_mcp_mcp");
     }
 
     [Fact]
@@ -148,7 +253,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public void ConfigureSettingsCanOverrideMalformedConnectionString()
+    public async Task ConfigureSettingsCanOverrideMalformedConnectionString()
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -157,9 +262,29 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp", configureSettings: settings => settings.Endpoint = new Uri("https://override/mcp"));
 
         using var host = builder.Build();
-        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        _ = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://override/mcp");
+    }
+
+    [Fact]
+    public async Task AddMcpClientBearerProviderPreservesNamedHttpClientConfiguration()
+    {
+        var handler = new HeaderRecordingInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp")
+            .ConfigureHttpClient(httpClient => httpClient.ConfigureHttpClient(client => client.DefaultRequestHeaders.Add("x-test", "configured")))
+            .UseBearerTokenProvider(static (_, _, _) => ValueTask.FromResult<string?>("token"));
+
+        using var host = builder.Build();
+        var client = host.Services.GetRequiredService<McpClient>();
+        var exception = await Record.ExceptionAsync(async () => await client.PingAsync());
+
+        Assert.Null(exception);
+        Assert.Contains("Bearer token", handler.AuthorizationHeaders);
+        Assert.Contains("configured", handler.CustomHeaderValues);
     }
 
     [Fact]
@@ -178,7 +303,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public void ConfigurationUsesBaseThenNamedThenConnectionStringThenSettings()
+    public async Task ConfigurationUsesBaseThenNamedThenConnectionStringThenSettings()
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -192,7 +317,8 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp", configureSettings: settings => settings.Endpoint = new Uri("https://settings/mcp"));
 
         using var host = builder.Build();
-        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        _ = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://settings/mcp");
     }
@@ -239,7 +365,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public void McpClientUsesServiceDiscoveryEndpoint()
+    public async Task McpClientUsesServiceDiscoveryEndpoint()
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -247,9 +373,8 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp");
 
         using var host = builder.Build();
-        Action resolveClient = () => _ = host.Services.GetRequiredService<McpClient>();
-
-        var exception = Record.Exception(resolveClient);
+        var client = host.Services.GetRequiredService<McpClient>();
+        var exception = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.NotNull(exception);
         Assert.NotEmpty(handler.RequestUris);
@@ -257,7 +382,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public void KeyedMcpClientsUseTheirOwnServiceDiscoveryEndpoints()
+    public async Task KeyedMcpClientsUseTheirOwnServiceDiscoveryEndpoints()
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -267,15 +392,17 @@ public class AspireMcpClientExtensionsTests
 
         using var host = builder.Build();
 
-        _ = Record.Exception(() => _ = host.Services.GetRequiredKeyedService<McpClient>("weather"));
-        _ = Record.Exception(() => _ = host.Services.GetRequiredKeyedService<McpClient>("calendar"));
+        var weatherClient = host.Services.GetRequiredKeyedService<McpClient>("weather");
+        var calendarClient = host.Services.GetRequiredKeyedService<McpClient>("calendar");
+        _ = await Record.ExceptionAsync(async () => await weatherClient.PingAsync());
+        _ = await Record.ExceptionAsync(async () => await calendarClient.PingAsync());
 
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://weather/mcp");
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://calendar/mcp");
     }
 
     [Fact]
-    public void AddMcpClientSupportsConfiguringOnlyTransportOptions()
+    public async Task AddMcpClientSupportsConfiguringOnlyTransportOptions()
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -292,14 +419,15 @@ public class AspireMcpClientExtensionsTests
             });
 
         using var host = builder.Build();
-        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        _ = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.True(transportOptionsConfigured);
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://transport-only/mcp");
     }
 
     [Fact]
-    public void AddMcpClientDefaultsTransportNameToConnectionName()
+    public async Task AddMcpClientDefaultsTransportNameToConnectionName()
     {
         var handler = new RequestRecordingHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -310,14 +438,15 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp", configureTransportOptions: options => transportName = options.Name);
 
         using var host = builder.Build();
-        _ = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        _ = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.Equal("mcp", transportName);
     }
 
     [Theory]
     [InlineData("ftp://mcp/mcp")]
-    public void AddMcpClientRejectsInvalidTransportEndpoint(string endpoint)
+    public async Task AddMcpClientRejectsInvalidTransportEndpoint(string endpoint)
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.AddMcpClient(
@@ -325,14 +454,12 @@ public class AspireMcpClientExtensionsTests
             configureTransportOptions: options => options.Endpoint = new Uri(endpoint, UriKind.RelativeOrAbsolute));
 
         using var host = builder.Build();
-
-        void ResolveClient() => _ = host.Services.GetRequiredService<McpClient>();
-
-        Assert.Throws<ArgumentException>(ResolveClient);
+        var client = host.Services.GetRequiredService<McpClient>();
+        await Assert.ThrowsAsync<ArgumentException>(() => client.PingAsync().AsTask());
     }
 
     [Fact]
-    public void AddKeyedMcpClientSupportsConfiguringOnlyClientOptions()
+    public async Task AddKeyedMcpClientSupportsConfiguringOnlyClientOptions()
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         var clientOptionsConfigured = false;
@@ -345,13 +472,14 @@ public class AspireMcpClientExtensionsTests
             });
 
         using var host = builder.Build();
-        _ = Record.Exception(() => _ = host.Services.GetRequiredKeyedService<McpClient>("mcp"));
+        var client = host.Services.GetRequiredKeyedService<McpClient>("mcp");
+        _ = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.True(clientOptionsConfigured);
     }
 
     [Fact]
-    public void McpClientResolvesHttpOnlyServiceDiscoveryEndpoint()
+    public async Task McpClientResolvesHttpOnlyServiceDiscoveryEndpoint()
     {
         var handler = new SuccessfulInitializationHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -368,14 +496,15 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp");
 
         using var host = builder.Build();
-        var exception = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        var exception = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.Null(exception);
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "http://resolved-mcp/mcp");
     }
 
     [Fact]
-    public void McpClientPreservesServiceDiscoveryEndpointPathPrefix()
+    public async Task McpClientPreservesServiceDiscoveryEndpointPathPrefix()
     {
         var handler = new SuccessfulInitializationHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -388,7 +517,8 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp");
 
         using var host = builder.Build();
-        var exception = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        var exception = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.Null(exception);
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://resolved-mcp/base/mcp");
@@ -402,7 +532,7 @@ public class AspireMcpClientExtensionsTests
 
     [Theory]
     [MemberData(nameof(PlatformServiceDiscoveryEndpoints))]
-    public void McpClientResolvesPlatformServiceDiscoveryEndpoint(EndPoint endPoint, string expectedEndpoint)
+    public async Task McpClientResolvesPlatformServiceDiscoveryEndpoint(EndPoint endPoint, string expectedEndpoint)
     {
         var handler = new SuccessfulInitializationHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -412,7 +542,8 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp");
 
         using var host = builder.Build();
-        var exception = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        var exception = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.Null(exception);
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == expectedEndpoint);
@@ -514,7 +645,7 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
-    public void AddMcpClientDisposesHttpClientTransportOnHostDisposal()
+    public async Task AddMcpClientDisposesHttpClientTransportOnHostDisposal()
     {
         var handler = new SuccessfulInitializationHandler();
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -523,12 +654,13 @@ public class AspireMcpClientExtensionsTests
         builder.Services.AddSingleton<IHttpClientFactory>(factory);
 
         var host = builder.Build();
-        var resolveException = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        var resolveException = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.Null(resolveException);
         Assert.Null(Record.Exception(host.Dispose));
         Assert.True(handler.Disposed);
-        Assert.Equal(string.Empty, factory.Name);
+        Assert.Equal("Aspire.Mcp.Client:mcp:default", factory.Name);
     }
 
     [Fact]
@@ -540,7 +672,8 @@ public class AspireMcpClientExtensionsTests
         builder.Services.AddSingleton<IHttpClientFactory>(new TrackingHttpClientFactory(handler));
 
         var host = builder.Build();
-        var resolveException = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+        var client = host.Services.GetRequiredService<McpClient>();
+        var resolveException = await Record.ExceptionAsync(async () => await client.PingAsync());
 
         Assert.Null(resolveException);
         await ((IAsyncDisposable)host).DisposeAsync();
@@ -556,7 +689,8 @@ public class AspireMcpClientExtensionsTests
         builder.AddMcpClient("mcp");
 
         var host = builder.Build();
-        var resolutionTask = Task.Run(() => Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>()));
+        var client = host.Services.GetRequiredService<McpClient>();
+        var resolutionTask = Task.Run(async () => await Record.ExceptionAsync(async () => await client.PingAsync()));
         await handler.InitializeStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
         var disposeException = Record.Exception(host.Dispose);
@@ -630,9 +764,9 @@ public class AspireMcpClientExtensionsTests
                 return ValueTask.CompletedTask;
             });
 
-        await handler.InitialStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
         var failure = await Record.ExceptionAsync(async () => await client.PingAsync());
         Assert.NotNull(failure);
+        await handler.InitialStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
         var serverInfo = client.ServerInfo;
         var replacementStream = await handler.ReplacementStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
@@ -664,14 +798,12 @@ public class AspireMcpClientExtensionsTests
         Assert.Throws<ArgumentException>(() => client.RegisterNotificationHandler(" ", (_, _) => ValueTask.CompletedTask));
         Assert.Throws<ArgumentNullException>(() => client.RegisterNotificationHandler("test/notification", null!));
 
-        await handler.InitialStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
         var failure = await Record.ExceptionAsync(async () => await client.PingAsync());
         Assert.NotNull(failure);
 
         var exception = Record.Exception(() => _ = client.ServerInfo);
 
         Assert.Null(exception);
-        await handler.ReplacementStream.Task.WaitAsync(TimeSpan.FromSeconds(10));
     }
 
     [Theory]

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -374,6 +374,26 @@ public class AspireMcpClientExtensionsTests
         Assert.Contains(handler.RequestUris, uri => uri.ToString() == "http://resolved-mcp/mcp");
     }
 
+    [Fact]
+    public void McpClientPreservesServiceDiscoveryEndpointPathPrefix()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["services:mcp:https:0"] = "https://resolved-mcp/base",
+        });
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var exception = Record.Exception(() => _ = host.Services.GetRequiredService<McpClient>());
+
+        Assert.Null(exception);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://resolved-mcp/base/mcp");
+    }
+
     public static TheoryData<EndPoint, string> PlatformServiceDiscoveryEndpoints { get; } = new()
     {
         { new DnsEndPoint("platform-mcp", 5001), "https://platform-mcp:5001/mcp" },

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -16,6 +16,8 @@ using System.IO.Pipelines;
 using System.Text;
 using System.Text.Json;
 using Json.Schema;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 using Xunit;
 
 namespace Aspire.Mcp.Client.Tests;
@@ -213,8 +215,46 @@ public class AspireMcpClientExtensionsTests
         using var host = builder.Build();
         var options = host.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
 
-        Assert.Contains(options.Registrations, registration => registration.Name == "Mcp.Client_mcp");
-        Assert.Contains(options.Registrations, registration => registration.Name == "Mcp.Client_mcp_mcp");
+        Assert.Contains(options.Registrations, registration => registration.Name == "Mcp.Client:unkeyed:mcp");
+        Assert.Contains(options.Registrations, registration => registration.Name == "Mcp.Client:keyed:mcp:mcp");
+    }
+
+    [Fact]
+    public void AddMcpClientUsesDistinctHealthCheckNamesForKeyedAndUnkeyedRegistrations()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddMcpClient("default");
+        builder.AddKeyedMcpClient("default");
+
+        using var host = builder.Build();
+        var registrations = host.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+
+        Assert.Contains(registrations, registration => registration.Name == "Mcp.Client:unkeyed:default");
+        Assert.Contains(registrations, registration => registration.Name == "Mcp.Client:keyed:default:default");
+    }
+
+    [Fact]
+    public void AddMcpClientConfiguresMcpTelemetryByDefault()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddMcpClient("mcp");
+
+        Assert.Contains(builder.Services, static service => service.ServiceType == typeof(TracerProvider));
+        Assert.Contains(builder.Services, static service => service.ServiceType == typeof(MeterProvider));
+    }
+
+    [Fact]
+    public void AddMcpClientCanDisableMcpTelemetry()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddMcpClient("mcp", settings =>
+        {
+            settings.DisableTracing = true;
+            settings.DisableMetrics = true;
+        });
+
+        Assert.DoesNotContain(builder.Services, static service => service.ServiceType == typeof(TracerProvider));
+        Assert.DoesNotContain(builder.Services, static service => service.ServiceType == typeof(MeterProvider));
     }
 
     [Fact]
@@ -680,7 +720,7 @@ public class AspireMcpClientExtensionsTests
         Assert.Null(resolveException);
         Assert.Null(Record.Exception(host.Dispose));
         Assert.True(handler.Disposed);
-        Assert.Equal("Aspire.Mcp.Client:mcp:default", factory.Name);
+        Assert.Equal("Aspire.Mcp.Client:unkeyed:mcp", factory.Name);
     }
 
     [Fact]

--- a/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
+++ b/tests/Aspire.Mcp.Client.Tests/AspireMcpClientExtensionsTests.cs
@@ -610,6 +610,26 @@ public class AspireMcpClientExtensionsTests
     }
 
     [Fact]
+    public async Task McpClientPreservesUriDestinationAndHostMetadataForPlatformServiceEndpoint()
+    {
+        var handler = new SuccessfulInitializationHandler();
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton<IServiceEndpointProviderFactory>(new StaticServiceEndpointProviderFactory(
+            CreateServiceEndpoint(new UriEndPoint(new Uri("https://127.0.0.12:5001/base")), hostName: "platform-mcp")));
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http => http.ConfigurePrimaryHttpMessageHandler(() => handler));
+        builder.AddMcpClient("mcp");
+
+        using var host = builder.Build();
+        var client = host.Services.GetRequiredService<McpClient>();
+        var exception = await Record.ExceptionAsync(async () => await client.PingAsync());
+
+        Assert.Null(exception);
+        Assert.Contains(handler.RequestUris, uri => uri.ToString() == "https://127.0.0.12:5001/base/mcp");
+        Assert.Contains(handler.RequestHosts, host => host == "platform-mcp");
+    }
+
+    [Fact]
     public async Task McpClientSelectsNextServiceDiscoveryEndpointAfterReconnect()
     {
         var handler = new FailPingOnceHandler();


### PR DESCRIPTION
## Description

This adds a new preview component package, `Aspire.Mcp.Client`, so apps can consume remote MCP servers through normal Aspire service discovery instead of manually constructing `HttpClientTransport` and resolving `services__*` environment keys.

The integration adds `AddMcpClient("name")` and `AddKeyedMcpClient("name")` on `IHostApplicationBuilder`, resolves the server at `https://{name}/mcp` (falling back to HTTP-only service-discovery endpoints), and registers `McpClient` with configuration binding, health checks, logging, and disposal-safe singleton lifecycle handling. The injected client transparently recreates its internal MCP session after terminal failures without replaying failed operations, preserves notification handlers across reconnects, and cancels in-flight initialization during host shutdown.

It also includes package README guidance and component tests for registration, configuration precedence, endpoint validation, health checks, keyed multi-server behavior, session recovery, and shutdown cancellation.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No