### PR TITLE
Add wrap-lines toggle to result viewer dialogs

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -31,6 +31,11 @@
                         <FluentIcon Value="@item.Icon" Style="vertical-align: text-bottom;" Width="16px" />
                     </span>
                 }
+                else if (item.ReserveIconSpace)
+                {
+                    @* Empty placeholder preserves the icon column width so sibling items' text aligns. *@
+                    <span slot="start" style="display: inline-block; width: 16px;"></span>
+                }
             </FluentMenuItem>;
         }
     }

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor
@@ -4,7 +4,7 @@
 @if (Virtualize)
 {
     <div class="log-overflow">
-        <div class="log-container" @ref="_containerElement">
+        <div class="@GetLogContainerClass()" @ref="_containerElement">
             <Virtualize @ref="VirtualizeRef" Items="@(!DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)" ItemSize="20" OverscanCount="200" ItemContent="@RenderLogLine">
             </Virtualize>
         </div>
@@ -12,7 +12,7 @@
 }
 else
 {
-    <div class="log-container" @ref="_containerElement">
+    <div class="@GetLogContainerClass()" @ref="_containerElement">
         @foreach (var item in !DisplayUnformatted ? ViewModel.FormattedLines : ViewModel.Lines)
         {
             @RenderLogLine(item)

--- a/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TextVisualizer.razor.cs
@@ -36,6 +36,9 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
     [Parameter]
     public bool Virtualize { get; set; } = true;
 
+    [Parameter]
+    public bool NoWrap { get; set; }
+
     private Virtualize<StringLogLine>? VirtualizeRef
     {
         get => field;
@@ -121,5 +124,10 @@ public partial class TextVisualizer : ComponentBase, IAsyncDisposable
         }
 
         return (MarkupString)WebUtility.HtmlEncode(line.Content);
+    }
+
+    private string GetLogContainerClass()
+    {
+        return $"log-container {(NoWrap ? "wrap-log-container" : null)}";
     }
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -158,7 +158,7 @@
                                         }
                                         else
                                         {
-                                            <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
+                                            <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" NoWrap="@_noWrap" />
                                         }
 
                                         if (itemPart.MessagePart is ToolCallRequestPart toolCallPart && !string.IsNullOrEmpty(toolCallPart.Name))
@@ -214,28 +214,36 @@
                             <div class="tab-container">
                                 @foreach (var itemPart in selectedItem.ItemParts)
                                 {
-                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" DisplayUnformatted="true" Virtualize="false" />
+                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" DisplayUnformatted="true" Virtualize="false" NoWrap="@_noWrap" />
                                 }
                             </div>
                         }
                         var copyButtonLabel = ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)];
+                        var wrapLinesLabel = ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)];
                         var copyButtonAttributes = FluentUIExtensions.GetClipboardCopyAdditionalAttributes(
                             string.Join(Environment.NewLine + Environment.NewLine, selectedItem.ItemParts.Select(p => p.TextVisualizerViewModel?.FormattedText ?? string.Empty)),
                             copyButtonLabel,
                             ControlsStringsLoc[nameof(ControlsStrings.GridValueCopied)]);
                         copyButtonAttributes["aria-label"] = copyButtonLabel;
 
-                        <FluentButton Id="@_copyButtonId"
-                                      Class="message-copy-button"
-                                      Appearance="Appearance.Stealth"
-                                      Title="@copyButtonLabel"
-                                      AdditionalAttributes="@copyButtonAttributes">
-                            <span slot="start">
-                                <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
-                                <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
-                            </span>
-                            @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
-                        </FluentButton>
+                        <div class="message-actions">
+                            <FluentCheckbox Class="word-wrap-checkbox"
+                                            Value="@(!_noWrap)"
+                                            ValueChanged="SetWrapLines"
+                                            Label="@wrapLinesLabel"
+                                            AriaLabel="@wrapLinesLabel" />
+                            <FluentButton Id="@_copyButtonId"
+                                          Class="message-copy-button"
+                                          Appearance="Appearance.Stealth"
+                                          Title="@copyButtonLabel"
+                                          AdditionalAttributes="@copyButtonAttributes">
+                                <span slot="start">
+                                    <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
+                                    <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
+                                </span>
+                                @ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]
+                            </FluentButton>
+                        </div>
                     }
                     else
                     {
@@ -515,7 +523,7 @@
                                 // Don't display text if it is a copy of the error message
                                 if (itemPart.ErrorMessage != itemPart.TextVisualizerViewModel.Text)
                                 {
-                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
+                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" NoWrap="@_noWrap" />
                                 }
                             }
                         }

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -219,7 +219,7 @@
                             </div>
                         }
                         var copyButtonLabel = ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)];
-                        var wrapLinesLabel = ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)];
+                        var wrapLinesLabel = ConsoleLogsLoc[nameof(Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWrapLogs)];
                         var showWrapLinesToggle = CanToggleWrapLines(selectedItem, selectedView);
                         var copyButtonAttributes = FluentUIExtensions.GetClipboardCopyAdditionalAttributes(
                             string.Join(Environment.NewLine + Environment.NewLine, selectedItem.ItemParts.Select(p => p.TextVisualizerViewModel?.FormattedText ?? string.Empty)),

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -219,7 +219,9 @@
                             </div>
                         }
                         var copyButtonLabel = ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)];
-                        var wrapLinesLabel = ConsoleLogsLoc[nameof(Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWrapLogs)];
+                        var wrapLinesLabel = _noWrap
+                            ? ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]
+                            : ControlsStringsLoc[nameof(ControlsStrings.GridValueNoWrapLines)];
                         var showWrapLinesToggle = CanToggleWrapLines(selectedItem, selectedView);
                         var copyButtonAttributes = FluentUIExtensions.GetClipboardCopyAdditionalAttributes(
                             string.Join(Environment.NewLine + Environment.NewLine, selectedItem.ItemParts.Select(p => p.TextVisualizerViewModel?.FormattedText ?? string.Empty)),

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -527,7 +527,7 @@
                                 // Don't display text if it is a copy of the error message
                                 if (itemPart.ErrorMessage != itemPart.TextVisualizerViewModel.Text)
                                 {
-                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" NoWrap="@_noWrap" />
+                                    <TextVisualizer ViewModel="@itemPart.TextVisualizerViewModel" HideLineNumbers="true" Virtualize="false" />
                                 }
                             }
                         }

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor
@@ -220,6 +220,7 @@
                         }
                         var copyButtonLabel = ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)];
                         var wrapLinesLabel = ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)];
+                        var showWrapLinesToggle = CanToggleWrapLines(selectedItem, selectedView);
                         var copyButtonAttributes = FluentUIExtensions.GetClipboardCopyAdditionalAttributes(
                             string.Join(Environment.NewLine + Environment.NewLine, selectedItem.ItemParts.Select(p => p.TextVisualizerViewModel?.FormattedText ?? string.Empty)),
                             copyButtonLabel,
@@ -227,11 +228,14 @@
                         copyButtonAttributes["aria-label"] = copyButtonLabel;
 
                         <div class="message-actions">
-                            <FluentCheckbox Class="word-wrap-checkbox"
-                                            Value="@(!_noWrap)"
-                                            ValueChanged="SetWrapLines"
-                                            Label="@wrapLinesLabel"
-                                            AriaLabel="@wrapLinesLabel" />
+                            @if (showWrapLinesToggle)
+                            {
+                                <FluentCheckbox Class="word-wrap-checkbox"
+                                                Value="@(!_noWrap)"
+                                                ValueChanged="SetWrapLines"
+                                                Label="@wrapLinesLabel"
+                                                AriaLabel="@wrapLinesLabel" />
+                            }
                             <FluentButton Id="@_copyButtonId"
                                           Class="message-copy-button"
                                           Appearance="Appearance.Stealth"

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -283,6 +283,39 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         return Task.CompletedTask;
     }
 
+    private static bool CanToggleWrapLines(GenAIItemViewModel selectedItem, ItemViewKind selectedView)
+    {
+        return selectedView switch
+        {
+            ItemViewKind.Raw => selectedItem.ItemParts.Count > 0,
+            ItemViewKind.Preview => selectedItem.ItemParts.Any(IsPreviewPartRenderedByTextVisualizer),
+            _ => false
+        };
+    }
+
+    private static bool IsPreviewPartRenderedByTextVisualizer(GenAIItemPartViewModel itemPart)
+    {
+        if (itemPart.ErrorMessage == itemPart.TextVisualizerViewModel.Text)
+        {
+            return false;
+        }
+
+        if (TryGetDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes, out _)
+            || TryGetDataPart(itemPart, MimeTypeHelpers.SupportedAudioTypes, out _)
+            || TryGetDataPart(itemPart, MimeTypeHelpers.SupportedVideoTypes, out _)
+            || TryGetDataPart(itemPart, matchingMimeTypes: null, out _))
+        {
+            return false;
+        }
+
+        if (itemPart.AdditionalProperties is { Count: > 0 })
+        {
+            return false;
+        }
+
+        return itemPart.TextVisualizerViewModel.FormatKind is not DashboardUIHelpers.PlaintextFormat and not DashboardUIHelpers.MarkdownFormat;
+    }
+
     private static string GetToolHeadingTooltip(ToolDefinitionViewModel vm)
     {
         if (string.IsNullOrEmpty(vm.ToolDefinition.Description))

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -57,9 +57,6 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
     public required IStringLocalizer<ControlsStrings> ControlsStringsLoc { get; init; }
 
     [Inject]
-    public required IStringLocalizer<Aspire.Dashboard.Resources.ConsoleLogs> ConsoleLogsLoc { get; init; }
-
-    [Inject]
     public required ILogger<GenAIVisualizerDialog> Logger { get; init; }
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -57,6 +57,9 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
     public required IStringLocalizer<ControlsStrings> ControlsStringsLoc { get; init; }
 
     [Inject]
+    public required IStringLocalizer<Aspire.Dashboard.Resources.ConsoleLogs> ConsoleLogsLoc { get; init; }
+
+    [Inject]
     public required ILogger<GenAIVisualizerDialog> Logger { get; init; }
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -300,10 +300,10 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
             return false;
         }
 
-        if (TryGetDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes, out _)
-            || TryGetDataPart(itemPart, MimeTypeHelpers.SupportedAudioTypes, out _)
-            || TryGetDataPart(itemPart, MimeTypeHelpers.SupportedVideoTypes, out _)
-            || TryGetDataPart(itemPart, matchingMimeTypes: null, out _))
+        if (CanRenderAsDataPart(itemPart, MimeTypeHelpers.SupportedImageTypes)
+            || CanRenderAsDataPart(itemPart, MimeTypeHelpers.SupportedAudioTypes)
+            || CanRenderAsDataPart(itemPart, MimeTypeHelpers.SupportedVideoTypes)
+            || CanRenderAsDataPart(itemPart, matchingMimeTypes: null))
         {
             return false;
         }
@@ -327,6 +327,20 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
     }
 
     private record DataInfo(string Url, string MimeType, string FileName);
+
+    private static bool CanRenderAsDataPart(GenAIItemPartViewModel itemPart, HashSet<string>? matchingMimeTypes)
+    {
+        return itemPart.MessagePart switch
+        {
+            BlobPart blobPart => MatchMimeType(blobPart.MimeType, matchingMimeTypes) && !string.IsNullOrEmpty(blobPart.Content),
+            UriPart uriPart => MatchMimeType(uriPart.MimeType, matchingMimeTypes)
+                && !string.IsNullOrEmpty(uriPart.Uri)
+                // Only attempt to display image if it is an http/https address.
+                && Uri.TryCreate(uriPart.Uri, UriKind.Absolute, out var result)
+                && result.Scheme.ToLowerInvariant() is "http" or "https",
+            _ => false
+        };
+    }
 
     private static bool TryGetDataPart(GenAIItemPartViewModel itemPart, HashSet<string>? matchingMimeTypes, [NotNullWhen(true)] out DataInfo? dataInfo)
     {
@@ -370,34 +384,34 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
         dataInfo = null;
         return false;
+    }
 
-        static bool MatchMimeType(string? mimeType, HashSet<string>? matchingMimeTypes)
+    private static bool MatchMimeType(string? mimeType, HashSet<string>? matchingMimeTypes)
+    {
+        if (!string.IsNullOrEmpty(mimeType))
         {
-            if (!string.IsNullOrEmpty(mimeType))
-            {
-                return matchingMimeTypes is null || matchingMimeTypes.Contains(mimeType);
-            }
-
-            return false;
+            return matchingMimeTypes is null || matchingMimeTypes.Contains(mimeType);
         }
 
-        static string CalculateFileName(string? currentFileName, string mimeType)
-        {
-            if (!string.IsNullOrEmpty(currentFileName))
-            {
-                return currentFileName;
-            }
+        return false;
+    }
 
-            if (MimeTypeHelpers.MimeToExtension.TryGetValue(mimeType, out var extension))
-            {
-                return $"download{extension}";
-            }
-            else
-            {
-                // The part didn't include a name (probably a blob) and we don't know the mime type.
-                // We have to give a download file name without an extension.
-                return "download";
-            }
+    private static string CalculateFileName(string? currentFileName, string mimeType)
+    {
+        if (!string.IsNullOrEmpty(currentFileName))
+        {
+            return currentFileName;
+        }
+
+        if (MimeTypeHelpers.MimeToExtension.TryGetValue(mimeType, out var extension))
+        {
+            return $"download{extension}";
+        }
+        else
+        {
+            // The part didn't include a name (probably a blob) and we don't know the mime type.
+            // We have to give a download file name without an extension.
+            return "download";
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -33,6 +33,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
     private List<OtlpSpan> _contextSpans = default!;
     private int _currentSpanContextIndex;
+    private bool _noWrap;
     private GenAIVisualizerDialogViewModel? _content;
 
     private GenAIItemViewModel? SelectedItem { get; set; }
@@ -276,6 +277,12 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         return true;
     }
 
+    private Task SetWrapLines(bool wrapLines)
+    {
+        _noWrap = !wrapLines;
+        return Task.CompletedTask;
+    }
+
     private static string GetToolHeadingTooltip(ToolDefinitionViewModel vm)
     {
         if (string.IsNullOrEmpty(vm.ToolDefinition.Description))
@@ -391,4 +398,3 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         await dialogService.ShowDialogAsync<GenAIVisualizerDialog>(dialogViewModel, parameters);
     }
 }
-

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -246,10 +246,14 @@
 ::deep .message-actions {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 8px;
     margin-left: auto;
     margin-top: 4px;
     margin-right: 4px;
+    max-width: 100%;
+    min-width: 0;
 }
 
 ::deep .message-copy-button {

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.css
@@ -243,10 +243,23 @@
     padding-bottom: 12px;
 }
 
-::deep .message-copy-button {
+::deep .message-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     margin-left: auto;
     margin-top: 4px;
     margin-right: 4px;
+}
+
+::deep .message-copy-button {
+    margin-left: 0;
+    margin-top: 0;
+    margin-right: 0;
+}
+
+::deep .word-wrap-checkbox::part(label) {
+    white-space: nowrap;
 }
 
 ::deep .markdown-container {

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -13,21 +13,14 @@
             @Content.Description
         </FluentLabel>
 
-        @if (!HasFixedFormat)
+        @if (ShowOptionsMenu)
         {
             <div Style="grid-area: dialog-format;">
-                <FluentSelect TOption="SelectViewModel<string>"
-                              Id="@_selectFormatId"
-                              Items="@_options"
-                              Position="SelectPosition.Below"
-                              OptionText="@(option => option.Name)"
-                              OptionValue="@(option => option.Id)"
-                              OptionDisabled="@(option => !EnabledOptions.Contains(option.Id))"
-                              OptionTitle="@(option => option.Name)"
-                              @bind-SelectedOption="@_selectedFormat"
-                              @bind-SelectedOption:after="OnSelectedFormatChanged"
-                              AriaLabel="@Loc[nameof(Dialogs.TextVisualizerSelectFormatType)]"
-                              Style="min-width: 12rem; width: max-content; max-width: 100%;" />
+                <AspireMenuButton ButtonClass="text-visualizer-options-menu-button"
+                                  ButtonAppearance="Appearance.Lightweight"
+                                  Icon="@(new Icons.Regular.Size20.Options())"
+                                  Items="@_menuItems"
+                                  Title="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerOptionsHeader)]" />
             </div>
         }
     </div>
@@ -73,15 +66,6 @@
             }
 
             <div class="button-container-right">
-                @if (IsTextContentDisplayed && !IsMarkdownFormat)
-                {
-                    <FluentCheckbox Class="word-wrap-checkbox"
-                                    Value="@(!_noWrap)"
-                                    ValueChanged="SetWrapLines"
-                                    Label="@ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]"
-                                    AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]" />
-                }
-
                 @if (Content.DownloadFileName is not null)
                 {
                     <FluentButton OnClick="@DownloadAsync"

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -73,11 +73,14 @@
             }
 
             <div class="button-container-right">
-                <FluentCheckbox Class="word-wrap-checkbox"
-                                Value="@(!_noWrap)"
-                                ValueChanged="SetWrapLines"
-                                Label="@ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]"
-                                AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]" />
+                @if (IsTextContentDisplayed && !IsMarkdownFormat)
+                {
+                    <FluentCheckbox Class="word-wrap-checkbox"
+                                    Value="@(!_noWrap)"
+                                    ValueChanged="SetWrapLines"
+                                    Label="@ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]"
+                                    AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]" />
+                }
 
                 @if (Content.DownloadFileName is not null)
                 {

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -4,6 +4,7 @@
 
 @inject IStringLocalizer<Dialogs> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
+@inject IStringLocalizer<ConsoleLogs> ConsoleLogsLoc
 @implements IDialogContentComponent<Aspire.Dashboard.Model.TextVisualizerDialogViewModel>
 
 <FluentDialogHeader ShowDismiss="true">

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -45,7 +45,7 @@
             }
             else
             {
-                <TextVisualizer ViewModel="TextVisualizerViewModel" />
+                <TextVisualizer ViewModel="TextVisualizerViewModel" NoWrap="@_noWrap" />
             }
         }
         else if (ShowSecretsWarning is true)
@@ -73,6 +73,12 @@
             }
 
             <div class="button-container-right">
+                <FluentCheckbox Class="word-wrap-checkbox"
+                                Value="@(!_noWrap)"
+                                ValueChanged="SetWrapLines"
+                                Label="@ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]"
+                                AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]" />
+
                 @if (Content.DownloadFileName is not null)
                 {
                     <FluentButton OnClick="@DownloadAsync"

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -4,7 +4,6 @@
 
 @inject IStringLocalizer<Dialogs> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
-@inject IStringLocalizer<ConsoleLogs> ConsoleLogsLoc
 @implements IDialogContentComponent<Aspire.Dashboard.Model.TextVisualizerDialogViewModel>
 
 <FluentDialogHeader ShowDismiss="true">

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -20,6 +20,7 @@
                                   ButtonAppearance="Appearance.Lightweight"
                                   Icon="@(new Icons.Regular.Size20.Options())"
                                   Items="@_menuItems"
+                                  RestoreFocusOnItemClick="true"
                                   Title="@ControlsStringsLoc[nameof(ControlsStrings.ChartContainerOptionsHeader)]" />
             </div>
         }

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -187,16 +187,20 @@ public partial class TextVisualizerDialog : ComponentBase
             var formatItems = new List<MenuButtonItem>(_options.Count);
             foreach (var option in _options)
             {
+                var isSelected = _selectedFormat.Id == option.Id;
                 formatItems.Add(new()
                 {
                     Text = option.Name,
                     OnClick = () => ChangeFormatAsync(option.Id),
-                    Icon = _selectedFormat.Id == option.Id ? new Icons.Regular.Size16.Checkmark() : null,
+                    // Show a checkmark only for the selected option; reserve the icon column
+                    // for unselected options so all label text aligns at the same position.
+                    Icon = isSelected ? new Icons.Regular.Size16.Checkmark() : null,
+                    ReserveIconSpace = !isSelected,
                     IsDisabled = !EnabledOptions.Contains(option.Id),
                     AdditionalAttributes = new Dictionary<string, object>
                     {
                         ["role"] = "menuitemradio",
-                        ["aria-checked"] = _selectedFormat.Id == option.Id ? "true" : "false"
+                        ["aria-checked"] = isSelected ? "true" : "false"
                     }
                 });
             }
@@ -214,10 +218,11 @@ public partial class TextVisualizerDialog : ComponentBase
             {
                 OnClick = ToggleWrapLinesAsync,
                 Text = ConsoleLogsLoc[nameof(ConsoleLogs.ConsoleLogsWrapLogs)],
+                // Use explicit checkbox icons instead of role="menuitemcheckbox" to avoid the
+                // native FAST indicator zone that would add extra left padding before the icon.
                 Icon = _noWrap ? new Icons.Regular.Size16.CheckboxUnchecked() : new Icons.Regular.Size16.CheckboxChecked(),
                 AdditionalAttributes = new Dictionary<string, object>
                 {
-                    ["role"] = "menuitemcheckbox",
                     ["aria-checked"] = _noWrap ? "false" : "true"
                 }
             });

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -219,7 +219,9 @@ public partial class TextVisualizerDialog : ComponentBase
             _menuItems.Add(new()
             {
                 OnClick = ToggleWrapLinesAsync,
-                Text = ConsoleLogsLoc[nameof(ConsoleLogs.ConsoleLogsWrapLogs)],
+                Text = _noWrap
+                    ? ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)]
+                    : ControlsStringsLoc[nameof(ControlsStrings.GridValueNoWrapLines)],
                 // Use explicit wrap icons instead of role="menuitemcheckbox" to avoid the
                 // native FAST indicator zone that would add extra left padding before the icon.
                 // Match the icon style used on the console logs page.

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -194,12 +194,13 @@ public partial class TextVisualizerDialog : ComponentBase
                     OnClick = () => ChangeFormatAsync(option.Id),
                     // Show a checkmark only for the selected option; reserve the icon column
                     // for unselected options so all label text aligns at the same position.
+                    // Do NOT set role="menuitemradio" — that activates FAST's native indicator
+                    // zone which adds extra left padding before slot="start", breaking alignment.
                     Icon = isSelected ? new Icons.Regular.Size16.Checkmark() : null,
                     ReserveIconSpace = !isSelected,
                     IsDisabled = !EnabledOptions.Contains(option.Id),
                     AdditionalAttributes = new Dictionary<string, object>
                     {
-                        ["role"] = "menuitemradio",
                         ["aria-checked"] = isSelected ? "true" : "false"
                     }
                 });
@@ -208,6 +209,7 @@ public partial class TextVisualizerDialog : ComponentBase
             _menuItems.Add(new()
             {
                 Text = Loc[nameof(Resources.Dialogs.TextVisualizerSelectFormatType)],
+                Icon = new Icons.Regular.Size16.TextBulletListSquare(),
                 NestedMenuItems = formatItems
             });
         }
@@ -218,9 +220,10 @@ public partial class TextVisualizerDialog : ComponentBase
             {
                 OnClick = ToggleWrapLinesAsync,
                 Text = ConsoleLogsLoc[nameof(ConsoleLogs.ConsoleLogsWrapLogs)],
-                // Use explicit checkbox icons instead of role="menuitemcheckbox" to avoid the
+                // Use explicit wrap icons instead of role="menuitemcheckbox" to avoid the
                 // native FAST indicator zone that would add extra left padding before the icon.
-                Icon = _noWrap ? new Icons.Regular.Size16.CheckboxUnchecked() : new Icons.Regular.Size16.CheckboxChecked(),
+                // Match the icon style used on the console logs page.
+                Icon = _noWrap ? new Icons.Regular.Size16.TextWrapOff() : new Icons.Regular.Size16.TextWrap(),
                 AdditionalAttributes = new Dictionary<string, object>
                 {
                     ["aria-checked"] = _noWrap ? "false" : "true"

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -225,7 +225,9 @@ public partial class TextVisualizerDialog : ComponentBase
                 // Use explicit wrap icons instead of role="menuitemcheckbox" to avoid the
                 // native FAST indicator zone that would add extra left padding before the icon.
                 // Match the icon style used on the console logs page.
-                Icon = _noWrap ? new Icons.Regular.Size16.TextWrapOff() : new Icons.Regular.Size16.TextWrap(),
+                // The icon represents the action label shown to the user.
+                // "Wrap lines" -> TextWrap, "Don't wrap lines" -> TextWrapOff.
+                Icon = _noWrap ? new Icons.Regular.Size16.TextWrap() : new Icons.Regular.Size16.TextWrapOff(),
                 AdditionalAttributes = new Dictionary<string, object>
                 {
                     ["aria-checked"] = _noWrap ? "false" : "true"

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -191,7 +191,7 @@ public partial class TextVisualizerDialog : ComponentBase
                 {
                     Text = option.Name,
                     OnClick = () => ChangeFormatAsync(option.Id),
-                    Icon = _selectedFormat.Id == option.Id ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked(),
+                    Icon = _selectedFormat.Id == option.Id ? new Icons.Regular.Size16.Checkmark() : null,
                     IsDisabled = !EnabledOptions.Contains(option.Id),
                     AdditionalAttributes = new Dictionary<string, object>
                     {
@@ -213,7 +213,7 @@ public partial class TextVisualizerDialog : ComponentBase
             _menuItems.Add(new()
             {
                 OnClick = ToggleWrapLinesAsync,
-                Text = ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)],
+                Text = ConsoleLogsLoc[nameof(ConsoleLogs.ConsoleLogsWrapLogs)],
                 Icon = _noWrap ? new Icons.Regular.Size16.CheckboxUnchecked() : new Icons.Regular.Size16.CheckboxChecked(),
                 AdditionalAttributes = new Dictionary<string, object>
                 {

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -160,16 +160,16 @@ public partial class TextVisualizerDialog : ComponentBase
         }
     }
 
-    private Task ChangeFormatAsync(string? newFormat)
+    private async Task ChangeFormatAsync(string? newFormat)
     {
         ChangeFormat(newFormat);
-        return Task.CompletedTask;
+        await InvokeAsync(StateHasChanged);
     }
 
-    private Task ToggleWrapLinesAsync()
+    private async Task ToggleWrapLinesAsync()
     {
         ToggleWrapLines();
-        return Task.CompletedTask;
+        await InvokeAsync(StateHasChanged);
     }
 
     internal void ToggleWrapLines()

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -4,20 +4,22 @@
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Markdown;
+using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Dialogs;
 
 public partial class TextVisualizerDialog : ComponentBase
 {
     private readonly string _copyButtonId = $"copy-{Guid.NewGuid():N}";
-    private readonly string _selectFormatId = $"select-format-{Guid.NewGuid():N}";
 
     private List<SelectViewModel<string>> _options = null!;
     private SelectViewModel<string> _selectedFormat = null!;
+    private readonly List<MenuButtonItem> _menuItems = [];
     private bool _isLoading = true;
     private bool _noWrap;
     private MarkdownProcessor? _markdownProcessor;
@@ -27,6 +29,7 @@ public partial class TextVisualizerDialog : ComponentBase
     public HashSet<string?> EnabledOptions { get; } = [];
     internal bool? ShowSecretsWarning { get; private set; }
     internal bool IsMarkdownFormat => TextVisualizerViewModel.FormatKind == DashboardUIHelpers.MarkdownFormat;
+    internal bool ShowOptionsMenu => _menuItems.Count > 0;
 
     /// <summary>
     /// Returns true if the dialog has a fixed format that cannot be changed by the user.
@@ -69,6 +72,7 @@ public partial class TextVisualizerDialog : ComponentBase
         if (_previousContent == Content)
         {
             _selectedFormat = GetSelectedFormatOption(TextVisualizerViewModel.FormatKind);
+            UpdateMenuItems();
             return;
         }
 
@@ -102,6 +106,7 @@ public partial class TextVisualizerDialog : ComponentBase
 
         _previousContent = Content;
         _selectedFormat = GetSelectedFormatOption(TextVisualizerViewModel.FormatKind);
+        UpdateMenuItems();
     }
 
     private bool IsTextContentDisplayed
@@ -117,12 +122,11 @@ public partial class TextVisualizerDialog : ComponentBase
         }
     }
 
-    private void OnSelectedFormatChanged() => ChangeFormat(_selectedFormat.Id);
-
     internal void ChangeFormat(string? newFormat)
     {
         _selectedFormat = GetSelectedFormatOption(newFormat);
         TextVisualizerViewModel.UpdateFormat(_selectedFormat.Id ?? DashboardUIHelpers.PlaintextFormat);
+        UpdateMenuItems();
     }
 
     private SelectViewModel<string> GetSelectedFormatOption(string? format) => _options.SingleOrDefault(o => o.Id == format) ?? _options[0];
@@ -156,10 +160,58 @@ public partial class TextVisualizerDialog : ComponentBase
         }
     }
 
-    private Task SetWrapLines(bool wrapLines)
+    private Task ChangeFormatAsync(string? newFormat)
     {
-        _noWrap = !wrapLines;
+        ChangeFormat(newFormat);
         return Task.CompletedTask;
+    }
+
+    private Task ToggleWrapLinesAsync()
+    {
+        ToggleWrapLines();
+        return Task.CompletedTask;
+    }
+
+    internal void ToggleWrapLines()
+    {
+        _noWrap = !_noWrap;
+        UpdateMenuItems();
+    }
+
+    private void UpdateMenuItems()
+    {
+        _menuItems.Clear();
+
+        if (!HasFixedFormat)
+        {
+            var formatItems = new List<MenuButtonItem>(_options.Count);
+            foreach (var option in _options)
+            {
+                formatItems.Add(new()
+                {
+                    Text = option.Name,
+                    OnClick = () => ChangeFormatAsync(option.Id),
+                    Icon = _selectedFormat.Id == option.Id ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked(),
+                    IsDisabled = !EnabledOptions.Contains(option.Id)
+                });
+            }
+
+            _menuItems.Add(new()
+            {
+                Text = Loc[nameof(Resources.Dialogs.TextVisualizerSelectFormatType)],
+                NestedMenuItems = formatItems
+            });
+        }
+
+        if (!IsMarkdownFormat)
+        {
+            _menuItems.Add(new()
+            {
+                OnClick = ToggleWrapLinesAsync,
+                Text = ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)],
+                Icon = _noWrap ? new Icons.Regular.Size16.CheckboxUnchecked() : new Icons.Regular.Size16.CheckboxChecked()
+            });
+        }
     }
 
     internal sealed record TextVisualizerDialogSettings(bool SecretsWarningAcknowledged);

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -19,6 +19,7 @@ public partial class TextVisualizerDialog : ComponentBase
     private List<SelectViewModel<string>> _options = null!;
     private SelectViewModel<string> _selectedFormat = null!;
     private bool _isLoading = true;
+    private bool _noWrap;
     private MarkdownProcessor? _markdownProcessor;
     private TextVisualizerDialogViewModel? _previousContent;
     internal TextVisualizerViewModel TextVisualizerViewModel { get; set; } = default!;
@@ -153,6 +154,12 @@ public partial class TextVisualizerDialog : ComponentBase
         {
             await JS.DownloadFileAsync(Content.DownloadFileName, TextVisualizerViewModel.FormattedText);
         }
+    }
+
+    private Task SetWrapLines(bool wrapLines)
+    {
+        _noWrap = !wrapLines;
+        return Task.CompletedTask;
     }
 
     internal sealed record TextVisualizerDialogSettings(bool SecretsWarningAcknowledged);

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.cs
@@ -192,7 +192,12 @@ public partial class TextVisualizerDialog : ComponentBase
                     Text = option.Name,
                     OnClick = () => ChangeFormatAsync(option.Id),
                     Icon = _selectedFormat.Id == option.Id ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked(),
-                    IsDisabled = !EnabledOptions.Contains(option.Id)
+                    IsDisabled = !EnabledOptions.Contains(option.Id),
+                    AdditionalAttributes = new Dictionary<string, object>
+                    {
+                        ["role"] = "menuitemradio",
+                        ["aria-checked"] = _selectedFormat.Id == option.Id ? "true" : "false"
+                    }
                 });
             }
 
@@ -209,7 +214,12 @@ public partial class TextVisualizerDialog : ComponentBase
             {
                 OnClick = ToggleWrapLinesAsync,
                 Text = ControlsStringsLoc[nameof(ControlsStrings.GridValueWrapLines)],
-                Icon = _noWrap ? new Icons.Regular.Size16.CheckboxUnchecked() : new Icons.Regular.Size16.CheckboxChecked()
+                Icon = _noWrap ? new Icons.Regular.Size16.CheckboxUnchecked() : new Icons.Regular.Size16.CheckboxChecked(),
+                AdditionalAttributes = new Dictionary<string, object>
+                {
+                    ["role"] = "menuitemcheckbox",
+                    ["aria-checked"] = _noWrap ? "false" : "true"
+                }
             });
         }
     }

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -19,20 +19,31 @@
 
 .text-visualizer-container ::deep.button-container-right {
     display: flex;
+    align-items: center;
     gap: 8px;
     margin-left: auto;
+}
+
+.text-visualizer-container ::deep.word-wrap-checkbox::part(label) {
+    white-space: nowrap;
 }
 
 .text-visualizer-container {
     display: flex;
     flex-direction: column;
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
     min-height: 120px;
 }
 
 .text-visualizer-container ::deep.log-overflow {
+    width: 0;
+    max-width: 100%;
     max-height: 60vh;
     margin-bottom: 16px;
+    overflow-x: auto;
+    min-width: 100%;
 }
 
 .markdown-content {

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -9,7 +9,9 @@
 
 .text-visualizer-container ::deep.button-container {
     display: flex;
+    flex-wrap: wrap;
     width: 100%;
+    gap: 8px;
     margin-top: auto;
 }
 
@@ -20,8 +22,12 @@
 .text-visualizer-container ::deep.button-container-right {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 8px;
     margin-left: auto;
+    max-width: 100%;
+    min-width: 0;
 }
 
 .text-visualizer-container ::deep.word-wrap-checkbox::part(label) {

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor.css
@@ -30,10 +30,6 @@
     min-width: 0;
 }
 
-.text-visualizer-container ::deep.word-wrap-checkbox::part(label) {
-    white-space: nowrap;
-}
-
 .text-visualizer-container {
     display: flex;
     flex-direction: column;

--- a/src/Aspire.Dashboard/Model/MenuButtonItem.cs
+++ b/src/Aspire.Dashboard/Model/MenuButtonItem.cs
@@ -12,6 +12,13 @@ public class MenuButtonItem
     public string? Text { get; set; }
     public string? Tooltip { get; set; }
     public Icon? Icon { get; set; }
+    /// <summary>
+    /// When <see langword="true"/>, an empty start-slot placeholder is always rendered so
+    /// that all sibling items in the same menu align their label text regardless of whether
+    /// they carry an icon. Only set this for items in menus where some (but not all) items
+    /// have icons and text alignment matters.
+    /// </summary>
+    public bool ReserveIconSpace { get; set; }
     public Func<Task>? OnClick { get; set; }
     public bool IsDisabled { get; set; }
     public string Id { get; set; } = Identifier.NewId();

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -502,6 +502,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t wrap lines.
+        /// </summary>
+        public static string GridValueNoWrapLines {
+            get {
+                return ResourceManager.GetString("GridValueNoWrapLines", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hide value.
         /// </summary>
         public static string GridValueMaskHideValue {
@@ -516,6 +525,15 @@ namespace Aspire.Dashboard.Resources {
         public static string GridValueMaskShowValue {
             get {
                 return ResourceManager.GetString("GridValueMaskShowValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wrap lines.
+        /// </summary>
+        public static string GridValueWrapLines {
+            get {
+                return ResourceManager.GetString("GridValueWrapLines", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -520,6 +520,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Wrap lines.
+        /// </summary>
+        public static string GridValueWrapLines {
+            get {
+                return ResourceManager.GetString("GridValueWrapLines", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hide hidden resources.
         /// </summary>
         public static string HideHiddenResources {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -520,15 +520,6 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Wrap lines.
-        /// </summary>
-        public static string GridValueWrapLines {
-            get {
-                return ResourceManager.GetString("GridValueWrapLines", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Hide hidden resources.
         /// </summary>
         public static string HideHiddenResources {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -168,9 +168,6 @@
   <data name="GridValueCopyToClipboard" xml:space="preserve">
     <value>Copy to clipboard</value>
   </data>
-  <data name="GridValueWrapLines" xml:space="preserve">
-    <value>Wrap lines</value>
-  </data>
   <data name="ExceptionDetailsTitle" xml:space="preserve">
     <value>Exception details</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -168,6 +168,12 @@
   <data name="GridValueCopyToClipboard" xml:space="preserve">
     <value>Copy to clipboard</value>
   </data>
+  <data name="GridValueNoWrapLines" xml:space="preserve">
+    <value>Don't wrap lines</value>
+  </data>
+  <data name="GridValueWrapLines" xml:space="preserve">
+    <value>Wrap lines</value>
+  </data>
   <data name="ExceptionDetailsTitle" xml:space="preserve">
     <value>Exception details</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -168,6 +168,9 @@
   <data name="GridValueCopyToClipboard" xml:space="preserve">
     <value>Copy to clipboard</value>
   </data>
+  <data name="GridValueWrapLines" xml:space="preserve">
+    <value>Wrap lines</value>
+  </data>
   <data name="ExceptionDetailsTitle" xml:space="preserve">
     <value>Exception details</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -152,6 +152,16 @@
         <target state="translated">Exportovat .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Exportovat .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Exportovat .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -152,6 +152,11 @@
         <target state="translated">.env exportieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -152,6 +152,16 @@
         <target state="translated">.env exportieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -152,11 +152,6 @@
         <target state="translated">.env exportieren</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -152,6 +152,16 @@
         <target state="translated">Exportar .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Exportar .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Exportar .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Exporter le fichier .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Exporter le fichier .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -152,6 +152,16 @@
         <target state="translated">Exporter le fichier .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Esporta .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Esporta .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -152,6 +152,16 @@
         <target state="translated">Esporta .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -152,6 +152,11 @@
         <target state="translated">.env のエクスポート</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -152,11 +152,6 @@
         <target state="translated">.env のエクスポート</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -152,6 +152,16 @@
         <target state="translated">.env のエクスポート</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -152,6 +152,11 @@
         <target state="translated">.env 내보내기</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -152,11 +152,6 @@
         <target state="translated">.env 내보내기</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -152,6 +152,16 @@
         <target state="translated">.env 내보내기</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -152,6 +152,16 @@
         <target state="translated">Eksportuj .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Eksportuj .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Eksportuj .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -152,6 +152,16 @@
         <target state="translated">Exportar .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Exportar .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Exportar .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -152,11 +152,6 @@
         <target state="translated">Экспорт .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -152,6 +152,16 @@
         <target state="translated">Экспорт .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -152,6 +152,11 @@
         <target state="translated">Экспорт .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -152,6 +152,11 @@
         <target state="translated">ENV dosyasını dışarı aktar</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -152,11 +152,6 @@
         <target state="translated">ENV dosyasını dışarı aktar</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -152,6 +152,16 @@
         <target state="translated">ENV dosyasını dışarı aktar</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -152,11 +152,6 @@
         <target state="translated">导出 .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -152,6 +152,11 @@
         <target state="translated">导出 .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -152,6 +152,16 @@
         <target state="translated">导出 .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -152,11 +152,6 @@
         <target state="translated">匯出 .env</target>
         <note />
       </trans-unit>
-      <trans-unit id="GridValueWrapLines">
-        <source>Wrap lines</source>
-        <target state="new">Wrap lines</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -152,6 +152,16 @@
         <target state="translated">匯出 .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueNoWrapLines">
+        <source>Don't wrap lines</source>
+        <target state="new">Don't wrap lines</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -152,6 +152,11 @@
         <target state="translated">匯出 .env</target>
         <note />
       </trans-unit>
+      <trans-unit id="GridValueWrapLines">
+        <source>Wrap lines</source>
+        <target state="new">Wrap lines</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Resources tab</source>
         <target state="new">Graph. For an accessible view please navigate to the Resources tab</target>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -720,8 +720,14 @@ fluent-switch.table-switch::part(label) {
 }
 
 .wrap-log-container .log-content {
-    white-space: nowrap;
+    white-space: pre;
     overflow-wrap: normal;
+}
+
+.wrap-log-container .log-line-row {
+    white-space: pre;
+    width: max-content;
+    min-width: 100%;
 }
 
 .log-line-row-container {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -268,15 +268,20 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             getContextGenAISpans: () => []
             );
 
-        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.ConsoleLogs>>()
-            [nameof(Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWrapLogs)].Value;
+        var controlsStrings = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>();
+        var wrapLinesLabel = controlsStrings[nameof(ControlsStrings.GridValueWrapLines)].Value;
+        var noWrapLinesLabel = controlsStrings[nameof(ControlsStrings.GridValueNoWrapLines)].Value;
         var wrapCheckbox = cut.FindComponent<FluentCheckbox>();
 
-        Assert.Equal(wrapLinesLabel, wrapCheckbox.Instance.Label);
+        Assert.Equal(noWrapLinesLabel, wrapCheckbox.Instance.Label);
         Assert.Empty(cut.FindAll(".wrap-log-container"));
 
         await wrapCheckbox.InvokeAsync(() => wrapCheckbox.Instance.ValueChanged.InvokeAsync(false));
-        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".wrap-log-container")));
+        cut.WaitForAssertion(() =>
+        {
+            Assert.NotEmpty(cut.FindAll(".wrap-log-container"));
+            Assert.Equal(wrapLinesLabel, cut.FindComponent<FluentCheckbox>().Instance.Label);
+        });
 
         cut.Find("fluent-button.back-button").Click();
         cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".wrap-log-container")));

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -277,6 +277,9 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
 
         await wrapCheckbox.InvokeAsync(() => wrapCheckbox.Instance.ValueChanged.InvokeAsync(false));
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".wrap-log-container")));
+
+        cut.Find("fluent-button.back-button").Click();
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".wrap-log-container")));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -268,8 +268,8 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             getContextGenAISpans: () => []
             );
 
-        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>()
-            [nameof(ControlsStrings.GridValueWrapLines)].Value;
+        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.ConsoleLogs>>()
+            [nameof(Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWrapLogs)].Value;
         var wrapCheckbox = cut.FindComponent<FluentCheckbox>();
 
         Assert.Equal(wrapLinesLabel, wrapCheckbox.Instance.Label);

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -16,6 +16,7 @@ using Google.Protobuf.Collections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.FluentUI.AspNetCore.Components;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
@@ -170,6 +171,112 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
 
         Assert.Equal(copyButtonLabel, copyButton.GetAttribute("aria-label"));
         Assert.Equal(copyButtonLabel, copyButton.GetAttribute("title"));
+    }
+
+    [Fact]
+    public async Task Render_HasPlaintextSelectedMessage_WrapLinesCheckboxHidden()
+    {
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var resource = new OtlpResource("app", "instance", uninstrumentedPeer: false, context);
+
+        var trace = new OtlpTrace(new byte[] { (byte)'t', (byte)'r', (byte)'a', (byte)'c', (byte)'e' }, DateTime.MinValue);
+        var scope = CreateOtlpScope(context);
+        var span = CreateOtlpSpan(resource, trace, scope, spanId: GetHexId("abc"), parentSpanId: null, startDate: s_testTime);
+
+        var cut = SetUpDialog(out var dialogService);
+        var repository = Services.GetRequiredService<TelemetryRepository>();
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app", instanceId: "instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(
+                                message: """{"content":"User!"}""",
+                                traceId: "trace",
+                                spanId: "abc",
+                                eventName: "gen_ai.user.message")
+                        }
+                    }
+                }
+            }
+        });
+        var selectedLogEntryId = repository.GetLogsForSpan(trace.TraceId, span.SpanId).Single().InternalId;
+
+        await GenAIVisualizerDialog.OpenDialogAsync(
+            dialogService: dialogService,
+            span: span,
+            selectedLogEntryId: selectedLogEntryId,
+            telemetryRepository: repository,
+            errorRecorder: new TestTelemetryErrorRecorder(),
+            resources: [],
+            getContextGenAISpans: () => []
+            );
+
+        Assert.Empty(cut.FindComponents<FluentCheckbox>());
+    }
+
+    [Fact]
+    public async Task Render_HasJsonSelectedMessage_WrapLinesCheckboxTogglesNoWrapClass()
+    {
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var resource = new OtlpResource("app", "instance", uninstrumentedPeer: false, context);
+
+        var trace = new OtlpTrace(new byte[] { (byte)'t', (byte)'r', (byte)'a', (byte)'c', (byte)'e' }, DateTime.MinValue);
+        var scope = CreateOtlpScope(context);
+        var span = CreateOtlpSpan(resource, trace, scope, spanId: GetHexId("abc"), parentSpanId: null, startDate: s_testTime);
+
+        var cut = SetUpDialog(out var dialogService);
+        var repository = Services.GetRequiredService<TelemetryRepository>();
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app", instanceId: "instance"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(name: "test-scope"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(
+                                message: """{"content":"{\"a\":1}"}""",
+                                traceId: "trace",
+                                spanId: "abc",
+                                eventName: "gen_ai.user.message")
+                        }
+                    }
+                }
+            }
+        });
+        var selectedLogEntryId = repository.GetLogsForSpan(trace.TraceId, span.SpanId).Single().InternalId;
+
+        await GenAIVisualizerDialog.OpenDialogAsync(
+            dialogService: dialogService,
+            span: span,
+            selectedLogEntryId: selectedLogEntryId,
+            telemetryRepository: repository,
+            errorRecorder: new TestTelemetryErrorRecorder(),
+            resources: [],
+            getContextGenAISpans: () => []
+            );
+
+        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>()
+            [nameof(ControlsStrings.GridValueWrapLines)].Value;
+        var wrapCheckbox = cut.FindComponent<FluentCheckbox>();
+
+        Assert.Equal(wrapLinesLabel, wrapCheckbox.Instance.Label);
+        Assert.Empty(cut.FindAll(".wrap-log-container"));
+
+        await wrapCheckbox.InvokeAsync(() => wrapCheckbox.Instance.ValueChanged.InvokeAsync(false));
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".wrap-log-container")));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -362,6 +362,9 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         FluentUISetupHelpers.SetupDialogInfrastructure(this);
         FluentUISetupHelpers.SetupFluentTab(this);
         FluentUISetupHelpers.SetupFluentOverflow(this);
+        FluentUISetupHelpers.SetupFluentCheckbox(this);
+        JSInterop.SetupModule("/Components/Controls/MarkdownRenderer.razor.js").SetupVoid();
+        JSInterop.SetupModule("/Components/Controls/TextVisualizer.razor.js").SetupVoid();
 
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -5,10 +5,12 @@ using System.Collections.Immutable;
 using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 
@@ -168,6 +170,45 @@ public class TextVisualizerDialogTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task Render_TextVisualizerDialog_ToggleWrapLines_UpdatesTextVisualizerClassAsync()
+    {
+        const string rawText = "line 1\nline 2";
+
+        var cut = SetUpDialog(out var dialogService);
+        await dialogService.ShowDialogAsync<TextVisualizerDialog>(new TextVisualizerDialogViewModel(rawText, string.Empty, false), []);
+        cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
+
+        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>()
+            [nameof(ControlsStrings.GridValueWrapLines)].Value;
+        var wrapCheckbox = cut.FindComponent<FluentCheckbox>();
+
+        Assert.Equal(wrapLinesLabel, wrapCheckbox.Instance.Label);
+        Assert.Empty(cut.FindAll(".wrap-log-container"));
+
+        await wrapCheckbox.InvokeAsync(() => wrapCheckbox.Instance.ValueChanged.InvokeAsync(false));
+        cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".wrap-log-container")));
+
+        await wrapCheckbox.InvokeAsync(() => wrapCheckbox.Instance.ValueChanged.InvokeAsync(true));
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".wrap-log-container")));
+    }
+
+    [Fact]
+    public async Task Render_TextVisualizerDialog_WithDownloadFile_RendersWrapLinesBeforeActionsAsync()
+    {
+        const string rawText = "line 1\nline 2";
+
+        var cut = SetUpDialog(out var dialogService);
+        await dialogService.ShowDialogAsync<TextVisualizerDialog>(new TextVisualizerDialogViewModel(rawText, string.Empty, false, DownloadFileName: "test.txt"), []);
+        cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
+
+        var controlsStrings = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>();
+        var actions = cut.Find(".button-container-right").Children;
+        Assert.Equal("fluent-checkbox", actions[0].LocalName);
+        Assert.Contains(controlsStrings[nameof(ControlsStrings.Download)].Value, actions[1].TextContent);
+        Assert.Contains(controlsStrings[nameof(ControlsStrings.GridValueCopyToClipboard)].Value, actions[2].TextContent);
+    }
+
+    [Fact]
     public async Task Render_TextVisualizerDialog_WithDifferentThemes_LineClassesChange()
     {
         var xml = @"<hello><!-- world --></hello>";
@@ -297,6 +338,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentInputLabel(this);
         FluentUISetupHelpers.SetupFluentList(this);
         FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentCheckbox(this);
 
         var cut = FluentUISetupHelpers.RenderDialogProvider(this);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -103,8 +103,9 @@ public class TextVisualizerDialogTests : DashboardTestContext
             Assert.True(option.AdditionalAttributes.ContainsKey("aria-checked"));
         });
         Assert.Single(formatOptions, option => string.Equals(option.AdditionalAttributes!["aria-checked"]?.ToString(), "true", StringComparison.Ordinal));
+        // Only the selected option has an icon; unselected options reserve icon space for text alignment.
         Assert.Single(formatOptions, option => option.Icon is not null);
-        Assert.Equal(formatOptions.Count - 1, formatOptions.Count(option => option.Icon is null));
+        Assert.Equal(formatOptions.Count - 1, formatOptions.Count(option => option.Icon is null && option.ReserveIconSpace));
 
         var plaintextOption = formatOptions.Single(i => i.Text == Aspire.Dashboard.Resources.Dialogs.TextVisualizerDialogPlaintextFormat);
         await plaintextOption.OnClick!.Invoke();
@@ -120,7 +121,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
                 .Instance.Items.Single(i => i.NestedMenuItems is not null).NestedMenuItems!;
             Assert.Single(selectedOptions, option => string.Equals(option.AdditionalAttributes!["aria-checked"]?.ToString(), "true", StringComparison.Ordinal));
             Assert.Single(selectedOptions, option => option.Icon is not null);
-            Assert.Equal(selectedOptions.Count - 1, selectedOptions.Count(option => option.Icon is null));
+            Assert.Equal(selectedOptions.Count - 1, selectedOptions.Count(option => option.Icon is null && option.ReserveIconSpace));
         });
 
         cut.FindComponent<TextVisualizerDialog>().SetParametersAndRender(parameters => parameters.Add(p => p.Content, content));
@@ -198,7 +199,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
         var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
         var wrapMenuItem = Assert.Single(menuButton.Instance.Items, i => i.Text == wrapLinesLabel);
         Assert.NotNull(wrapMenuItem.AdditionalAttributes);
-        Assert.Equal("menuitemcheckbox", wrapMenuItem.AdditionalAttributes!["role"]);
+        Assert.False(wrapMenuItem.AdditionalAttributes!.ContainsKey("role"), "Wrap item should not set role= to avoid native indicator padding.");
         Assert.Equal("true", wrapMenuItem.AdditionalAttributes["aria-checked"]);
         Assert.Empty(cut.FindAll(".wrap-log-container"));
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -197,10 +197,11 @@ public class TextVisualizerDialogTests : DashboardTestContext
         await dialogService.ShowDialogAsync<TextVisualizerDialog>(new TextVisualizerDialogViewModel(rawText, string.Empty, false), []);
         cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
 
-        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.ConsoleLogs>>()
-            [nameof(Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWrapLogs)].Value;
+        var controlsStrings = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>();
+        var wrapLinesLabel = controlsStrings[nameof(ControlsStrings.GridValueWrapLines)].Value;
+        var noWrapLinesLabel = controlsStrings[nameof(ControlsStrings.GridValueNoWrapLines)].Value;
         var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
-        var wrapMenuItem = Assert.Single(menuButton.Instance.Items, i => i.Text == wrapLinesLabel);
+        var wrapMenuItem = Assert.Single(menuButton.Instance.Items, i => i.Text == noWrapLinesLabel);
         Assert.NotNull(wrapMenuItem.AdditionalAttributes);
         Assert.False(wrapMenuItem.AdditionalAttributes!.ContainsKey("role"), "Wrap item should not set role= to avoid native indicator padding.");
         Assert.Equal("true", wrapMenuItem.AdditionalAttributes["aria-checked"]);
@@ -215,7 +216,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
             .Instance.Items.Single(i => i.Text == wrapLinesLabel).OnClick!.Invoke();
         cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".wrap-log-container")));
         Assert.Equal("true", Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
-            .Instance.Items.Single(i => i.Text == wrapLinesLabel).AdditionalAttributes!["aria-checked"]);
+            .Instance.Items.Single(i => i.Text == noWrapLinesLabel).AdditionalAttributes!["aria-checked"]);
     }
 
     [Fact]
@@ -231,13 +232,18 @@ public class TextVisualizerDialogTests : DashboardTestContext
         dialog.Instance.ChangeFormat(DashboardUIHelpers.MarkdownFormat);
         dialog.Render();
 
-        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.ConsoleLogs>>()
-            [nameof(Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWrapLogs)].Value;
+        var controlsStrings = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>();
+        var wrapLinesLabel = controlsStrings[nameof(ControlsStrings.GridValueWrapLines)].Value;
+        var noWrapLinesLabel = controlsStrings[nameof(ControlsStrings.GridValueNoWrapLines)].Value;
 
         cut.WaitForAssertion(() =>
         {
             var menuItems = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>()).Instance.Items;
-            Assert.All(menuItems, item => Assert.NotEqual(wrapLinesLabel, item.Text));
+            Assert.All(menuItems, item =>
+            {
+                Assert.NotEqual(wrapLinesLabel, item.Text);
+                Assert.NotEqual(noWrapLinesLabel, item.Text);
+            });
         });
     }
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -93,9 +93,18 @@ public class TextVisualizerDialogTests : DashboardTestContext
         var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
         var formatMenu = Assert.Single(menuButton.Instance.Items, i => i.NestedMenuItems is not null);
         Assert.Equal(Aspire.Dashboard.Resources.Dialogs.TextVisualizerSelectFormatType, formatMenu.Text);
+        Assert.True(menuButton.Instance.RestoreFocusOnItemClick);
 
-        var plaintextOption = (formatMenu.NestedMenuItems ?? throw new InvalidOperationException("Expected nested format options."))
-            .Single(i => i.Text == Aspire.Dashboard.Resources.Dialogs.TextVisualizerDialogPlaintextFormat);
+        var formatOptions = formatMenu.NestedMenuItems ?? throw new InvalidOperationException("Expected nested format options.");
+        Assert.All(formatOptions, option =>
+        {
+            Assert.NotNull(option.AdditionalAttributes);
+            Assert.Equal("menuitemradio", option.AdditionalAttributes!["role"]);
+            Assert.True(option.AdditionalAttributes.ContainsKey("aria-checked"));
+        });
+        Assert.Single(formatOptions, option => string.Equals(option.AdditionalAttributes!["aria-checked"]?.ToString(), "true", StringComparison.Ordinal));
+
+        var plaintextOption = formatOptions.Single(i => i.Text == Aspire.Dashboard.Resources.Dialogs.TextVisualizerDialogPlaintextFormat);
         await plaintextOption.OnClick!.Invoke();
 
         cut.WaitForAssertion(() =>
@@ -104,6 +113,10 @@ public class TextVisualizerDialogTests : DashboardTestContext
             Assert.Equal(DashboardUIHelpers.PlaintextFormat, dialog.TextVisualizerViewModel.FormatKind);
             Assert.Equal(rawXml, dialog.TextVisualizerViewModel.FormattedText);
             Assert.Equal(DashboardUIHelpers.PlaintextFormat, dialog.TextVisualizerViewModel.FormatKind);
+
+            var selectedOptions = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
+                .Instance.Items.Single(i => i.NestedMenuItems is not null).NestedMenuItems!;
+            Assert.Single(selectedOptions, option => string.Equals(option.AdditionalAttributes!["aria-checked"]?.ToString(), "true", StringComparison.Ordinal));
         });
 
         cut.FindComponent<TextVisualizerDialog>().SetParametersAndRender(parameters => parameters.Add(p => p.Content, content));
@@ -179,17 +192,24 @@ public class TextVisualizerDialogTests : DashboardTestContext
         var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>()
             [nameof(ControlsStrings.GridValueWrapLines)].Value;
         var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
-        Assert.Contains(menuButton.Instance.Items, i => i.Text == wrapLinesLabel);
+        var wrapMenuItem = Assert.Single(menuButton.Instance.Items, i => i.Text == wrapLinesLabel);
+        Assert.NotNull(wrapMenuItem.AdditionalAttributes);
+        Assert.Equal("menuitemcheckbox", wrapMenuItem.AdditionalAttributes!["role"]);
+        Assert.Equal("true", wrapMenuItem.AdditionalAttributes["aria-checked"]);
         var dialog = cut.FindComponent<TextVisualizerDialog>();
         Assert.Empty(cut.FindAll(".wrap-log-container"));
 
         dialog.Instance.ToggleWrapLines();
         dialog.Render();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".wrap-log-container")));
+        Assert.Equal("false", Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
+            .Instance.Items.Single(i => i.Text == wrapLinesLabel).AdditionalAttributes!["aria-checked"]);
 
         dialog.Instance.ToggleWrapLines();
         dialog.Render();
         cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".wrap-log-container")));
+        Assert.Equal("true", Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
+            .Instance.Items.Single(i => i.Text == wrapLinesLabel).AdditionalAttributes!["aria-checked"]);
     }
 
     [Fact]
@@ -225,9 +245,17 @@ public class TextVisualizerDialogTests : DashboardTestContext
         cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
 
         var controlsStrings = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>();
-        Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
-        Assert.Contains(cut.FindAll("fluent-button").Select(button => button.TextContent), text => text.Contains(controlsStrings[nameof(ControlsStrings.Download)].Value));
-        Assert.Contains(cut.FindAll("fluent-button").Select(button => button.TextContent), text => text.Contains(controlsStrings[nameof(ControlsStrings.GridValueCopyToClipboard)].Value));
+        Assert.True(cut.HasComponent<Aspire.Dashboard.Components.AspireMenuButton>());
+        var markup = cut.Markup;
+        var optionsButtonIndex = markup.IndexOf("text-visualizer-options-menu-button", StringComparison.Ordinal);
+        var downloadButtonIndex = markup.IndexOf(controlsStrings[nameof(ControlsStrings.Download)].Value, StringComparison.Ordinal);
+        var copyButtonIndex = markup.IndexOf(controlsStrings[nameof(ControlsStrings.GridValueCopyToClipboard)].Value, StringComparison.Ordinal);
+
+        Assert.True(optionsButtonIndex >= 0);
+        Assert.True(downloadButtonIndex >= 0);
+        Assert.True(copyButtonIndex >= 0);
+        Assert.True(optionsButtonIndex < downloadButtonIndex);
+        Assert.True(optionsButtonIndex < copyButtonIndex);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -205,12 +205,15 @@ public class TextVisualizerDialogTests : DashboardTestContext
         Assert.NotNull(wrapMenuItem.AdditionalAttributes);
         Assert.False(wrapMenuItem.AdditionalAttributes!.ContainsKey("role"), "Wrap item should not set role= to avoid native indicator padding.");
         Assert.Equal("true", wrapMenuItem.AdditionalAttributes["aria-checked"]);
+        Assert.Equal("TextWrapOff", wrapMenuItem.Icon?.GetType().Name);
         Assert.Empty(cut.FindAll(".wrap-log-container"));
 
         await wrapMenuItem.OnClick!.Invoke();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".wrap-log-container")));
         Assert.Equal("false", Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
             .Instance.Items.Single(i => i.Text == wrapLinesLabel).AdditionalAttributes!["aria-checked"]);
+        Assert.Equal("TextWrap", Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
+            .Instance.Items.Single(i => i.Text == wrapLinesLabel).Icon?.GetType().Name);
 
         await Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
             .Instance.Items.Single(i => i.Text == wrapLinesLabel).OnClick!.Invoke();

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -196,17 +196,15 @@ public class TextVisualizerDialogTests : DashboardTestContext
         Assert.NotNull(wrapMenuItem.AdditionalAttributes);
         Assert.Equal("menuitemcheckbox", wrapMenuItem.AdditionalAttributes!["role"]);
         Assert.Equal("true", wrapMenuItem.AdditionalAttributes["aria-checked"]);
-        var dialog = cut.FindComponent<TextVisualizerDialog>();
         Assert.Empty(cut.FindAll(".wrap-log-container"));
 
-        dialog.Instance.ToggleWrapLines();
-        dialog.Render();
+        await wrapMenuItem.OnClick!.Invoke();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".wrap-log-container")));
         Assert.Equal("false", Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
             .Instance.Items.Single(i => i.Text == wrapLinesLabel).AdditionalAttributes!["aria-checked"]);
 
-        dialog.Instance.ToggleWrapLines();
-        dialog.Render();
+        await Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
+            .Instance.Items.Single(i => i.Text == wrapLinesLabel).OnClick!.Invoke();
         cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".wrap-log-container")));
         Assert.Equal("true", Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
             .Instance.Items.Single(i => i.Text == wrapLinesLabel).AdditionalAttributes!["aria-checked"]);

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -103,6 +103,8 @@ public class TextVisualizerDialogTests : DashboardTestContext
             Assert.True(option.AdditionalAttributes.ContainsKey("aria-checked"));
         });
         Assert.Single(formatOptions, option => string.Equals(option.AdditionalAttributes!["aria-checked"]?.ToString(), "true", StringComparison.Ordinal));
+        Assert.Single(formatOptions, option => option.Icon is not null);
+        Assert.Equal(formatOptions.Count - 1, formatOptions.Count(option => option.Icon is null));
 
         var plaintextOption = formatOptions.Single(i => i.Text == Aspire.Dashboard.Resources.Dialogs.TextVisualizerDialogPlaintextFormat);
         await plaintextOption.OnClick!.Invoke();
@@ -117,6 +119,8 @@ public class TextVisualizerDialogTests : DashboardTestContext
             var selectedOptions = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>())
                 .Instance.Items.Single(i => i.NestedMenuItems is not null).NestedMenuItems!;
             Assert.Single(selectedOptions, option => string.Equals(option.AdditionalAttributes!["aria-checked"]?.ToString(), "true", StringComparison.Ordinal));
+            Assert.Single(selectedOptions, option => option.Icon is not null);
+            Assert.Equal(selectedOptions.Count - 1, selectedOptions.Count(option => option.Icon is null));
         });
 
         cut.FindComponent<TextVisualizerDialog>().SetParametersAndRender(parameters => parameters.Add(p => p.Content, content));
@@ -189,8 +193,8 @@ public class TextVisualizerDialogTests : DashboardTestContext
         await dialogService.ShowDialogAsync<TextVisualizerDialog>(new TextVisualizerDialogViewModel(rawText, string.Empty, false), []);
         cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
 
-        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>()
-            [nameof(ControlsStrings.GridValueWrapLines)].Value;
+        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.ConsoleLogs>>()
+            [nameof(Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWrapLogs)].Value;
         var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
         var wrapMenuItem = Assert.Single(menuButton.Instance.Items, i => i.Text == wrapLinesLabel);
         Assert.NotNull(wrapMenuItem.AdditionalAttributes);
@@ -223,8 +227,8 @@ public class TextVisualizerDialogTests : DashboardTestContext
         dialog.Instance.ChangeFormat(DashboardUIHelpers.MarkdownFormat);
         dialog.Render();
 
-        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>()
-            [nameof(ControlsStrings.GridValueWrapLines)].Value;
+        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.ConsoleLogs>>()
+            [nameof(Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWrapLogs)].Value;
 
         cut.WaitForAssertion(() =>
         {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -93,13 +93,16 @@ public class TextVisualizerDialogTests : DashboardTestContext
         var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
         var formatMenu = Assert.Single(menuButton.Instance.Items, i => i.NestedMenuItems is not null);
         Assert.Equal(Aspire.Dashboard.Resources.Dialogs.TextVisualizerSelectFormatType, formatMenu.Text);
+        Assert.NotNull(formatMenu.Icon);
         Assert.True(menuButton.Instance.RestoreFocusOnItemClick);
 
         var formatOptions = formatMenu.NestedMenuItems ?? throw new InvalidOperationException("Expected nested format options.");
         Assert.All(formatOptions, option =>
         {
             Assert.NotNull(option.AdditionalAttributes);
-            Assert.Equal("menuitemradio", option.AdditionalAttributes!["role"]);
+            // Do NOT assert role="menuitemradio" here — that role activates the FAST indicator zone
+            // which adds extra left padding. We rely on aria-checked alone.
+            Assert.False(option.AdditionalAttributes!.ContainsKey("role"), "Format items should not set role= to avoid native indicator padding.");
             Assert.True(option.AdditionalAttributes.ContainsKey("aria-checked"));
         });
         Assert.Single(formatOptions, option => string.Equals(option.AdditionalAttributes!["aria-checked"]?.ToString(), "true", StringComparison.Ordinal));

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -81,7 +81,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
     }
 
     [Fact]
-    public async Task Render_TextVisualizerDialog_FormatPicker_UsesFluentSelectAndPreservesSelectionAfterParentRerenderAsync()
+    public async Task Render_TextVisualizerDialog_FormatMenu_ContainsFormatItemsAndPreservesSelectionAfterParentRerenderAsync()
     {
         const string rawXml = """<parent><child>text<!-- comment --></child></parent>""";
 
@@ -90,22 +90,20 @@ public class TextVisualizerDialogTests : DashboardTestContext
         await dialogService.ShowDialogAsync<TextVisualizerDialog>(content, []);
         cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
 
-        var formatSelect = Assert.Single(cut.FindComponents<FluentSelect<SelectViewModel<string>>>());
-        Assert.NotNull(formatSelect.Find("fluent-select"));
+        var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
+        var formatMenu = Assert.Single(menuButton.Instance.Items, i => i.NestedMenuItems is not null);
+        Assert.Equal(Aspire.Dashboard.Resources.Dialogs.TextVisualizerSelectFormatType, formatMenu.Text);
 
-        Assert.Equal(Aspire.Dashboard.Resources.Dialogs.TextVisualizerSelectFormatType, formatSelect.Instance.AriaLabel);
-        Assert.Equal(DashboardUIHelpers.XmlFormat, formatSelect.Instance.SelectedOption?.Id);
-
-        var formatOptions = formatSelect.Instance.Items ?? throw new InvalidOperationException("Expected format options.");
-        var plaintextOption = formatOptions.Single(o => o.Id == DashboardUIHelpers.PlaintextFormat);
-        await formatSelect.InvokeAsync(() => formatSelect.Instance.SelectedOptionChanged.InvokeAsync(plaintextOption));
+        var plaintextOption = (formatMenu.NestedMenuItems ?? throw new InvalidOperationException("Expected nested format options."))
+            .Single(i => i.Text == Aspire.Dashboard.Resources.Dialogs.TextVisualizerDialogPlaintextFormat);
+        await plaintextOption.OnClick!.Invoke();
 
         cut.WaitForAssertion(() =>
         {
             var dialog = cut.FindComponent<TextVisualizerDialog>().Instance;
             Assert.Equal(DashboardUIHelpers.PlaintextFormat, dialog.TextVisualizerViewModel.FormatKind);
             Assert.Equal(rawXml, dialog.TextVisualizerViewModel.FormattedText);
-            Assert.Equal(DashboardUIHelpers.PlaintextFormat, cut.FindComponent<FluentSelect<SelectViewModel<string>>>().Instance.SelectedOption?.Id);
+            Assert.Equal(DashboardUIHelpers.PlaintextFormat, dialog.TextVisualizerViewModel.FormatKind);
         });
 
         cut.FindComponent<TextVisualizerDialog>().SetParametersAndRender(parameters => parameters.Add(p => p.Content, content));
@@ -115,7 +113,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
             var dialog = cut.FindComponent<TextVisualizerDialog>().Instance;
             Assert.Equal(DashboardUIHelpers.PlaintextFormat, dialog.TextVisualizerViewModel.FormatKind);
             Assert.Equal(rawXml, dialog.TextVisualizerViewModel.FormattedText);
-            Assert.Equal(DashboardUIHelpers.PlaintextFormat, cut.FindComponent<FluentSelect<SelectViewModel<string>>>().Instance.SelectedOption?.Id);
+            Assert.Equal(DashboardUIHelpers.PlaintextFormat, dialog.TextVisualizerViewModel.FormatKind);
         });
     }
 
@@ -180,20 +178,22 @@ public class TextVisualizerDialogTests : DashboardTestContext
 
         var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>()
             [nameof(ControlsStrings.GridValueWrapLines)].Value;
-        var wrapCheckbox = cut.FindComponent<FluentCheckbox>();
-
-        Assert.Equal(wrapLinesLabel, wrapCheckbox.Instance.Label);
+        var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
+        Assert.Contains(menuButton.Instance.Items, i => i.Text == wrapLinesLabel);
+        var dialog = cut.FindComponent<TextVisualizerDialog>();
         Assert.Empty(cut.FindAll(".wrap-log-container"));
 
-        await wrapCheckbox.InvokeAsync(() => wrapCheckbox.Instance.ValueChanged.InvokeAsync(false));
+        dialog.Instance.ToggleWrapLines();
+        dialog.Render();
         cut.WaitForAssertion(() => Assert.NotEmpty(cut.FindAll(".wrap-log-container")));
 
-        await wrapCheckbox.InvokeAsync(() => wrapCheckbox.Instance.ValueChanged.InvokeAsync(true));
+        dialog.Instance.ToggleWrapLines();
+        dialog.Render();
         cut.WaitForAssertion(() => Assert.Empty(cut.FindAll(".wrap-log-container")));
     }
 
     [Fact]
-    public async Task Render_TextVisualizerDialog_MarkdownFormat_HidesWrapLinesCheckboxAsync()
+    public async Task Render_TextVisualizerDialog_MarkdownFormat_HidesWrapLinesMenuItemAsync()
     {
         const string rawText = "# heading";
 
@@ -201,16 +201,22 @@ public class TextVisualizerDialogTests : DashboardTestContext
         await dialogService.ShowDialogAsync<TextVisualizerDialog>(new TextVisualizerDialogViewModel(rawText, string.Empty, false), []);
         cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
 
-        var formatSelect = cut.FindComponent<FluentSelect<SelectViewModel<string>>>();
-        var markdownOption = (formatSelect.Instance.Items ?? throw new InvalidOperationException("Expected format options."))
-            .Single(o => o.Id == DashboardUIHelpers.MarkdownFormat);
-        await formatSelect.InvokeAsync(() => formatSelect.Instance.SelectedOptionChanged.InvokeAsync(markdownOption));
+        var dialog = cut.FindComponent<TextVisualizerDialog>();
+        dialog.Instance.ChangeFormat(DashboardUIHelpers.MarkdownFormat);
+        dialog.Render();
 
-        cut.WaitForAssertion(() => Assert.Empty(cut.FindComponents<FluentCheckbox>()));
+        var wrapLinesLabel = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>()
+            [nameof(ControlsStrings.GridValueWrapLines)].Value;
+
+        cut.WaitForAssertion(() =>
+        {
+            var menuItems = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>()).Instance.Items;
+            Assert.All(menuItems, item => Assert.NotEqual(wrapLinesLabel, item.Text));
+        });
     }
 
     [Fact]
-    public async Task Render_TextVisualizerDialog_WithDownloadFile_RendersWrapLinesBeforeActionsAsync()
+    public async Task Render_TextVisualizerDialog_WithDownloadFile_RendersOptionsMenuBeforeActionsAsync()
     {
         const string rawText = "line 1\nline 2";
 
@@ -219,10 +225,9 @@ public class TextVisualizerDialogTests : DashboardTestContext
         cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
 
         var controlsStrings = Services.GetRequiredService<IStringLocalizer<ControlsStrings>>();
-        var actions = cut.Find(".button-container-right").Children;
-        Assert.Equal("fluent-checkbox", actions[0].LocalName);
-        Assert.Contains(controlsStrings[nameof(ControlsStrings.Download)].Value, actions[1].TextContent);
-        Assert.Contains(controlsStrings[nameof(ControlsStrings.GridValueCopyToClipboard)].Value, actions[2].TextContent);
+        Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
+        Assert.Contains(cut.FindAll("fluent-button").Select(button => button.TextContent), text => text.Contains(controlsStrings[nameof(ControlsStrings.Download)].Value));
+        Assert.Contains(cut.FindAll("fluent-button").Select(button => button.TextContent), text => text.Contains(controlsStrings[nameof(ControlsStrings.GridValueCopyToClipboard)].Value));
     }
 
     [Fact]
@@ -303,7 +308,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
     }
 
     [Fact]
-    public async Task Render_TextVisualizerDialog_WithFixedFormat_UsesFixedFormatAndHidesDropdownAsync()
+    public async Task Render_TextVisualizerDialog_WithFixedFormat_UsesFixedFormatAndHidesFormatMenuAsync()
     {
         const string rawText = """export VAR=value""";
 
@@ -317,8 +322,9 @@ public class TextVisualizerDialogTests : DashboardTestContext
         Assert.Equal(DashboardUIHelpers.PropertiesFormat, instance.TextVisualizerViewModel.FormatKind);
         Assert.True(instance.HasFixedFormat);
 
-        // Verify the format dropdown is not rendered
-        Assert.Empty(cut.FindComponents<FluentSelect<SelectViewModel<string>>>());
+        var formatMenuText = Services.GetRequiredService<IStringLocalizer<Aspire.Dashboard.Resources.Dialogs>>()[nameof(Aspire.Dashboard.Resources.Dialogs.TextVisualizerSelectFormatType)].Value;
+        var menuButton = Assert.Single(cut.FindComponents<Aspire.Dashboard.Components.AspireMenuButton>());
+        Assert.All(menuButton.Instance.Items, item => Assert.NotEqual(formatMenuText, item.Text));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TextVisualizerDialogTests.cs
@@ -193,6 +193,23 @@ public class TextVisualizerDialogTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task Render_TextVisualizerDialog_MarkdownFormat_HidesWrapLinesCheckboxAsync()
+    {
+        const string rawText = "# heading";
+
+        var cut = SetUpDialog(out var dialogService);
+        await dialogService.ShowDialogAsync<TextVisualizerDialog>(new TextVisualizerDialogViewModel(rawText, string.Empty, false), []);
+        cut.WaitForAssertion(() => Assert.True(cut.HasComponent<TextVisualizerDialog>()));
+
+        var formatSelect = cut.FindComponent<FluentSelect<SelectViewModel<string>>>();
+        var markdownOption = (formatSelect.Instance.Items ?? throw new InvalidOperationException("Expected format options."))
+            .Single(o => o.Id == DashboardUIHelpers.MarkdownFormat);
+        await formatSelect.InvokeAsync(() => formatSelect.Instance.SelectedOptionChanged.InvokeAsync(markdownOption));
+
+        cut.WaitForAssertion(() => Assert.Empty(cut.FindComponents<FluentCheckbox>()));
+    }
+
+    [Fact]
     public async Task Render_TextVisualizerDialog_WithDownloadFile_RendersWrapLinesBeforeActionsAsync()
     {
         const string rawText = "line 1\nline 2";
@@ -333,6 +350,7 @@ public class TextVisualizerDialogTests : DashboardTestContext
 
         var module = JSInterop.SetupModule("/Components/Controls/TextVisualizer.razor.js");
         module.SetupVoid();
+        JSInterop.SetupModule("/Components/Controls/MarkdownRenderer.razor.js").SetupVoid();
 
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
         FluentUISetupHelpers.SetupFluentInputLabel(this);

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -6,8 +6,10 @@ using Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
 using Aspire.Dashboard.Resources;
 using Aspire.TestUtilities;
 using Aspire.Tests.Shared.DashboardModel;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Playwright;
+using System.Text.Json;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Integration.Playwright;
@@ -103,6 +105,64 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
         });
     }
 
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task TextVisualizer_NoWrap_KeepsDialogWidthAndShowsHorizontalOverflow()
+    {
+        await RunTestAsync(async page =>
+        {
+            await page.SetViewportSizeAsync(1280, 900);
+            await PlaywrightFixture.GoToHomeAndWaitForDataGridLoad(page).DefaultTimeout();
+
+            var row = page.GetByText("LongSourceResource", new PageGetByTextOptions { Exact = true })
+                .Locator("xpath=ancestor::*[@role='row']")
+                .First;
+            await Assertions.Expect(row).ToBeVisibleAsync();
+
+            var sourceCell = row.Locator("td[col-index='4']");
+            await sourceCell.HoverAsync();
+
+            var openTextVisualizerButton = page.GetByRole(AriaRole.Button, new PageGetByRoleOptions
+            {
+                Name = Dashboard.Resources.Dialogs.OpenInTextVisualizer,
+                Exact = true
+            });
+            await Assertions.Expect(openTextVisualizerButton).ToBeVisibleAsync();
+            await openTextVisualizerButton.ClickAsync();
+
+            var wrapCheckbox = page.Locator("fluent-checkbox.word-wrap-checkbox");
+            await Assertions.Expect(wrapCheckbox).ToHaveAttributeAsync("current-checked", "true");
+            await wrapCheckbox.ClickAsync();
+            await Assertions.Expect(page.Locator(".text-visualizer-container .wrap-log-container")).ToHaveCountAsync(1);
+
+            var metricsJson = await page.EvaluateAsync<string>(@"() => {
+                const overflow = document.querySelector('.text-visualizer-container .log-overflow');
+                const dialog = document.querySelector('.text-visualizer-dialog');
+                if (overflow) {
+                    overflow.scrollLeft = 50;
+                }
+
+                return JSON.stringify({
+                    overflowScrollLeft: overflow ? overflow.scrollLeft : 0,
+                    dialogRight: dialog ? dialog.getBoundingClientRect().right : 0,
+                    viewportWidth: window.innerWidth,
+                    documentScrollWidth: document.documentElement.scrollWidth
+                });
+            }");
+
+            using var metricsDocument = JsonDocument.Parse(metricsJson);
+            var metrics = metricsDocument.RootElement;
+            var overflowScrollLeft = metrics.GetProperty("overflowScrollLeft").GetDouble();
+            var dialogRight = metrics.GetProperty("dialogRight").GetDouble();
+            var viewportWidth = metrics.GetProperty("viewportWidth").GetDouble();
+            var documentScrollWidth = metrics.GetProperty("documentScrollWidth").GetDouble();
+
+            Assert.True(overflowScrollLeft > 0, "No-wrap should allow horizontal scrolling inside the viewer.");
+            Assert.True(dialogRight <= viewportWidth, "Dialog should remain within viewport width when no-wrap is enabled.");
+            Assert.True(documentScrollWidth <= viewportWidth, "No-wrap should not cause page-level horizontal overflow.");
+        });
+    }
+
     public sealed class ResourcesDashboardServerFixture : DashboardServerFixture
     {
         protected override IReadOnlyList<ResourceViewModel> Resources =>
@@ -119,6 +179,27 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
                 resourceName: "HiddenResource",
                 resourceType: KnownResourceTypes.Container,
                 hidden: true)
+            ,
+            ModelTestHelpers.CreateResource(
+                resourceName: "LongSourceResource",
+                resourceType: KnownResourceTypes.Project,
+                state: KnownResourceState.Running,
+                properties: new[]
+                {
+                    new KeyValuePair<string, ResourcePropertyViewModel>(
+                        KnownProperties.Project.Path,
+                        new ResourcePropertyViewModel(
+                            KnownProperties.Project.Path,
+                            new Value
+                            {
+                                StringValue = new string('a', 12000)
+                            },
+                            isValueSensitive: false,
+                            knownProperty: new(KnownProperties.Project.Path, _ => "Path"),
+                            sortOrder: 0,
+                            displayName: null,
+                            isHighlighted: false))
+                }.ToDictionary())
         ];
     }
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -163,6 +163,49 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
         });
     }
 
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task TextVisualizer_ActionsStayWithinDialogAtNarrowViewport()
+    {
+        await RunTestAsync(async page =>
+        {
+            await page.SetViewportSizeAsync(1280, 900);
+            await PlaywrightFixture.GoToHomeAndWaitForDataGridLoad(page).DefaultTimeout();
+
+            var row = page.GetByText("LongSourceResource", new PageGetByTextOptions { Exact = true })
+                .Locator("xpath=ancestor::*[@role='row']")
+                .First;
+            await Assertions.Expect(row).ToBeVisibleAsync();
+
+            var sourceCell = row.Locator("td[col-index='4']");
+            await sourceCell.HoverAsync();
+
+            var openTextVisualizerButton = page.GetByRole(AriaRole.Button, new PageGetByRoleOptions
+            {
+                Name = Dashboard.Resources.Dialogs.OpenInTextVisualizer,
+                Exact = true
+            });
+            await Assertions.Expect(openTextVisualizerButton).ToBeVisibleAsync();
+            await openTextVisualizerButton.ClickAsync();
+
+            await page.SetViewportSizeAsync(360, 900);
+
+            var wrapCheckbox = page.GetByRole(AriaRole.Checkbox, new PageGetByRoleOptions
+            {
+                Name = ControlsStrings.GridValueWrapLines,
+                Exact = true
+            });
+            var copyButton = page.GetByRole(AriaRole.Button, new PageGetByRoleOptions
+            {
+                Name = ControlsStrings.GridValueCopyToClipboard,
+                Exact = true
+            });
+
+            await AssertElementWithinViewportAsync(wrapCheckbox, 360);
+            await AssertElementWithinViewportAsync(copyButton, 360);
+        });
+    }
+
     public sealed class ResourcesDashboardServerFixture : DashboardServerFixture
     {
         protected override IReadOnlyList<ResourceViewModel> Resources =>
@@ -211,5 +254,16 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
         Assert.NotNull(tabBounds);
         Assert.True(tabBounds.X >= 0, $"Tab should be within the viewport, but its X position was {tabBounds.X}.");
         Assert.True(tabBounds.X + tabBounds.Width <= viewportWidth, $"Tab should fit inside the {viewportWidth}px viewport, but its right edge was {tabBounds.X + tabBounds.Width}.");
+    }
+
+    private static async Task AssertElementWithinViewportAsync(ILocator element, int viewportWidth)
+    {
+        await Assertions.Expect(element).ToBeVisibleAsync();
+
+        var elementBounds = await element.BoundingBoxAsync();
+
+        Assert.NotNull(elementBounds);
+        Assert.True(elementBounds.X >= 0, $"Element should not overflow the viewport on the left. Element X: {elementBounds.X}.");
+        Assert.True(elementBounds.X + elementBounds.Width <= viewportWidth, $"Element should fit inside the {viewportWidth}px viewport. Element right edge: {elementBounds.X + elementBounds.Width}.");
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -132,7 +132,7 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
 
             var optionsButton = page.Locator("fluent-button.text-visualizer-options-menu-button");
             await optionsButton.ClickAsync();
-            await page.GetByRole(AriaRole.Menuitem, new() { Name = ControlsStrings.GridValueWrapLines, Exact = true }).ClickAsync();
+            await page.GetByRole(AriaRole.Menuitemcheckbox, new() { Name = ControlsStrings.GridValueWrapLines, Exact = true }).ClickAsync();
             await Assertions.Expect(page.Locator(".text-visualizer-container .wrap-log-container")).ToHaveCountAsync(1);
 
             var metricsJson = await page.EvaluateAsync<string>(@"() => {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -132,7 +132,7 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
 
             var optionsButton = page.Locator("fluent-button.text-visualizer-options-menu-button");
             await optionsButton.ClickAsync();
-            await page.GetByRole(AriaRole.Menuitemcheckbox, new() { Name = ControlsStrings.GridValueWrapLines, Exact = true }).ClickAsync();
+            await page.GetByRole(AriaRole.Menuitemcheckbox, new() { Name = ConsoleLogs.ConsoleLogsWrapLogs, Exact = true }).ClickAsync();
             await Assertions.Expect(page.Locator(".text-visualizer-container .wrap-log-container")).ToHaveCountAsync(1);
 
             var metricsJson = await page.EvaluateAsync<string>(@"() => {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -132,7 +132,7 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
 
             var optionsButton = page.Locator("fluent-button.text-visualizer-options-menu-button");
             await optionsButton.ClickAsync();
-            await page.GetByRole(AriaRole.Menuitem, new() { Name = ConsoleLogs.ConsoleLogsWrapLogs, Exact = true }).ClickAsync();
+            await page.GetByRole(AriaRole.Menuitem, new() { Name = ControlsStrings.GridValueNoWrapLines, Exact = true }).ClickAsync();
             await Assertions.Expect(page.Locator(".text-visualizer-container .wrap-log-container")).ToHaveCountAsync(1);
 
             var metricsJson = await page.EvaluateAsync<string>(@"() => {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -132,7 +132,7 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
 
             var optionsButton = page.Locator("fluent-button.text-visualizer-options-menu-button");
             await optionsButton.ClickAsync();
-            await page.GetByRole(AriaRole.Menuitemcheckbox, new() { Name = ConsoleLogs.ConsoleLogsWrapLogs, Exact = true }).ClickAsync();
+            await page.GetByRole(AriaRole.Menuitem, new() { Name = ConsoleLogs.ConsoleLogsWrapLogs, Exact = true }).ClickAsync();
             await Assertions.Expect(page.Locator(".text-visualizer-container .wrap-log-container")).ToHaveCountAsync(1);
 
             var metricsJson = await page.EvaluateAsync<string>(@"() => {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -130,9 +130,9 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
             await Assertions.Expect(openTextVisualizerButton).ToBeVisibleAsync();
             await openTextVisualizerButton.ClickAsync();
 
-            var wrapCheckbox = page.Locator("fluent-checkbox.word-wrap-checkbox");
-            await Assertions.Expect(wrapCheckbox).ToHaveAttributeAsync("current-checked", "true");
-            await wrapCheckbox.ClickAsync();
+            var optionsButton = page.Locator("fluent-button.text-visualizer-options-menu-button");
+            await optionsButton.ClickAsync();
+            await page.GetByRole(AriaRole.Menuitem, new() { Name = ControlsStrings.GridValueWrapLines, Exact = true }).ClickAsync();
             await Assertions.Expect(page.Locator(".text-visualizer-container .wrap-log-container")).ToHaveCountAsync(1);
 
             var metricsJson = await page.EvaluateAsync<string>(@"() => {
@@ -195,18 +195,14 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
 
             await page.SetViewportSizeAsync(360, 900);
 
-            var wrapCheckbox = page.GetByRole(AriaRole.Checkbox, new PageGetByRoleOptions
-            {
-                Name = ControlsStrings.GridValueWrapLines,
-                Exact = true
-            });
+            var optionsButton = page.Locator("fluent-button.text-visualizer-options-menu-button");
             var copyButton = page.GetByRole(AriaRole.Button, new PageGetByRoleOptions
             {
                 Name = ControlsStrings.GridValueCopyToClipboard,
                 Exact = true
             });
 
-            await AssertElementWithinViewportAsync(wrapCheckbox, 360);
+            await AssertElementWithinViewportAsync(optionsButton, 360);
             await AssertElementWithinViewportAsync(copyButton, 360);
         });
     }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -137,14 +137,19 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
 
             var metricsJson = await page.EvaluateAsync<string>(@"() => {
                 const overflow = document.querySelector('.text-visualizer-container .log-overflow');
-                const dialog = document.querySelector('.text-visualizer-dialog');
+                const dialogHost = document.querySelector('fluent-dialog.fluent-dialog-main');
+                const dialog = dialogHost?.shadowRoot?.querySelector('[part=""control""]');
                 if (overflow) {
                     overflow.scrollLeft = 50;
                 }
 
+                if (!dialog) {
+                    throw new Error('Could not find the fluent-dialog control part for the text visualizer dialog.');
+                }
+
                 return JSON.stringify({
                     overflowScrollLeft: overflow ? overflow.scrollLeft : 0,
-                    dialogRight: dialog ? dialog.getBoundingClientRect().right : 0,
+                    dialogRight: dialog.getBoundingClientRect().right,
                     viewportWidth: window.innerWidth,
                     documentScrollWidth: document.documentElement.scrollWidth
                 });


### PR DESCRIPTION
## Description

This change adds a Wrap lines toggle to result-viewer popups so users can switch between wrapped and unwrapped text when inspecting long values.

When wrapping is disabled, the text area now scrolls horizontally inside the dialog instead of overflowing the modal, while preserving whitespace/indentation for structured content such as JSON.

The update applies to both the text visualizer dialog and the GenAI visualizer message popup. It also adds localized UI text and component tests for wrap toggling and action ordering.

Fixes: #17252

<img width="923" height="956" alt="image" src="https://github.com/user-attachments/assets/301eeadf-9f1f-4a17-bbe7-e21bc4c58f71" />

<img width="923" height="956" alt="image" src="https://github.com/user-attachments/assets/27a31bc1-1f2b-4206-b2a1-359e78db3a16" />


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No