### PR TITLE
Fix waiting resource start and stop command behavior

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -27,7 +27,7 @@ internal static class CommandsConfigurationExtensions
             {
                 var orchestrator = context.Services.GetRequiredService<ApplicationOrchestrator>();
 
-                await orchestrator.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
+                await orchestrator.RequestStartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 return new ExecuteCommandResult { Success = true, Message = string.Format(CultureInfo.InvariantCulture, CommandStrings.ResourceStarted, resource.GetResolvedDisplayResourceName(context.ResourceName)) };
             },
             updateState: context =>
@@ -70,7 +70,7 @@ internal static class CommandsConfigurationExtensions
                 {
                     return ResourceCommandState.Disabled;
                 }
-                else if (!IsStopped(state) && !IsStarting(state) && !IsWaiting(state) && !IsBuilding(state) && !IsRuntimeUnhealthy(state) && !HasNoState(state))
+                else if (!IsStopped(state) && !IsStarting(state) && !IsBuilding(state) && !IsRuntimeUnhealthy(state) && !HasNoState(state))
                 {
                     return ResourceCommandState.Enabled;
                 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceStartAbortedException.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceStartAbortedException.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal sealed class ResourceStartAbortedException : DistributedApplicationException
+{
+    public ResourceStartAbortedException(string resourceName, string? state)
+        : base(string.Format(CultureInfo.InvariantCulture, "Startup for resource '{0}' was canceled while waiting for dependencies. Current state is '{1}'.", resourceName, state ?? "<none>"))
+    {
+    }
+}

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1265,6 +1265,10 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             // more diagnostic information reduce logging level for DCP log category to Debug.
             await _executorEvents.PublishAsync(new OnResourceFailedToStartContext(cancellationToken, resourceType, resourceReference.ModelResource, resourceReference.DcpResourceName, ex.Message)).ConfigureAwait(false);
         }
+        catch (ResourceStartAbortedException ex)
+        {
+            _logger.LogDebug(ex, "Startup for resource '{ResourceName}' was canceled before creation.", resourceReference.ModelResource.Name);
+        }
         catch (Exception ex)
         {
             activity.SetError(ex);

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -120,6 +120,18 @@ internal sealed class ApplicationOrchestrator
                 // Make error visible from completed task.
                 await completedTask.ConfigureAwait(false);
             }
+
+            // If the wait ended because the state was manually moved out of Waiting to anything
+            // other than Starting, treat that as an explicit cancellation of this startup attempt.
+            // This is used by the Stop command to abort a dependency-blocked start.
+            if (completedTask == waitForNonWaitingStateTask && waitForNonWaitingStateTask.IsCompletedSuccessfully)
+            {
+                var state = waitForNonWaitingStateTask.Result.Snapshot.State?.Text;
+                if (!string.Equals(state, KnownResourceStates.Starting, StringComparisons.ResourceState))
+                {
+                    throw new ResourceStartAbortedException(@event.Resource.Name, state);
+                }
+            }
         }
         catch (Exception ex)
         {
@@ -607,10 +619,64 @@ internal sealed class ApplicationOrchestrator
         }
     }
 
+    public Task RequestStartResourceAsync(string resourceName, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var startTask = StartResourceAsync(resourceName, _shutdownCancellation.Token);
+
+        if (startTask.IsCompleted)
+        {
+            return startTask;
+        }
+
+        _ = ObserveBackgroundStartAsync(resourceName, startTask);
+        return Task.CompletedTask;
+    }
+
     public async Task StopResourceAsync(string resourceName, CancellationToken cancellationToken)
     {
         var resourceReference = _dcpExecutor.GetResource(resourceName);
+        var isWaiting = false;
+        await _notificationService.PublishUpdateAsync(
+            resourceReference.ModelResource,
+            resourceReference.DcpResourceName,
+            s =>
+            {
+                if (s.State?.Text == KnownResourceStates.Waiting)
+                {
+                    isWaiting = true;
+                    return s with
+                    {
+                        State = KnownResourceStates.NotStarted
+                    };
+                }
+
+                return s;
+            }).ConfigureAwait(false);
+
+        if (isWaiting)
+        {
+            return;
+        }
+
         await _dcpExecutor.StopResourceAsync(resourceReference, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ObserveBackgroundStartAsync(string resourceName, Task startTask)
+    {
+        try
+        {
+            await startTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (_shutdownCancellation.IsCancellationRequested)
+        {
+            // Expected when the host is shutting down while the start operation is still pending.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start resource '{ResourceName}'.", resourceName);
+        }
     }
 
     private async Task SetChildResourceAsync(IResource resource, string? state, DateTime? startTimeStamp, DateTime? stopTimeStamp)

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -7,6 +7,7 @@
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Pipelines;
@@ -549,13 +550,78 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         Assert.Null(snapshotEvent.Snapshot.State?.Style);
     }
 
+    [Fact]
+    public async Task StopResourceAsync_WaitingResource_CancelsStartWithoutCallingDcpStop()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var resource = builder.AddExecutable("resource", "pwsh", ".");
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+        var dcpExecutor = new TrackingDcpExecutor(resource.Resource, "resource");
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, dcpExecutor: dcpExecutor);
+        await appOrchestrator.RunApplicationAsync();
+
+        await resourceNotificationService.PublishUpdateAsync(resource.Resource, "resource", s => s with
+        {
+            State = KnownResourceStates.Waiting
+        });
+
+        await appOrchestrator.StopResourceAsync("resource", CancellationToken.None);
+
+        Assert.Equal(0, dcpExecutor.StopCalls);
+
+        Assert.True(resourceNotificationService.TryGetCurrentState("resource", out var snapshotEvent));
+        Assert.Equal(KnownResourceStates.NotStarted, snapshotEvent.Snapshot.State?.Text);
+    }
+
+    [Fact]
+    public async Task RequestStartResourceAsync_DoesNotWaitForDcpStartCompletion()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var resource = builder.AddExecutable("resource", "pwsh", ".");
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+        var dcpExecutor = new TrackingDcpExecutor(resource.Resource, "resource")
+        {
+            BlockStart = true
+        };
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, dcpExecutor: dcpExecutor);
+        await appOrchestrator.RunApplicationAsync();
+
+        await resourceNotificationService.PublishUpdateAsync(resource.Resource, "resource", s => s with
+        {
+            State = KnownResourceStates.Finished
+        });
+
+        await appOrchestrator.RequestStartResourceAsync("resource", CancellationToken.None);
+
+        Assert.Equal(1, dcpExecutor.StartCalls);
+
+        dcpExecutor.ReleaseStart();
+    }
+
     private ApplicationOrchestrator CreateOrchestrator(
         DistributedApplicationModel distributedAppModel,
         ResourceNotificationService notificationService,
         DcpExecutorEvents? dcpEvents = null,
         IDistributedApplicationEventing? applicationEventing = null,
         ResourceLoggerService? resourceLoggerService = null,
-        DashboardOptions? dashboardOptions = null)
+        DashboardOptions? dashboardOptions = null,
+        IDcpExecutor? dcpExecutor = null)
     {
         var services = new ServiceCollection();
         var configuration = new ConfigurationManager();
@@ -568,7 +634,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
 
         return new ApplicationOrchestrator(
             distributedAppModel,
-            new TestDcpExecutor(),
+            dcpExecutor ?? new TestDcpExecutor(),
             dcpEvents ?? new DcpExecutorEvents(),
             [],
             notificationService,
@@ -689,6 +755,47 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
         {
             return ValueTask.FromResult<string?>(connectionString);
+        }
+    }
+
+    private sealed class TrackingDcpExecutor(IResource modelResource, string dcpResourceName) : IDcpExecutor
+    {
+        private readonly TaskCompletionSource _startGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly IResourceReference _resourceReference = new RenderedModelResource<Executable>(
+            modelResource,
+            new Executable(new ExecutableSpec())
+            {
+                Metadata = new() { Name = dcpResourceName }
+            });
+
+        public bool BlockStart { get; set; }
+        public int StartCalls { get; private set; }
+        public int StopCalls { get; private set; }
+
+        public IResourceReference GetResource(string resourceName) => _resourceReference;
+
+        public Task RunApplicationAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public async Task StartResourceAsync(IResourceReference resourceReference, CancellationToken cancellationToken)
+        {
+            StartCalls++;
+            if (BlockStart)
+            {
+                await _startGate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopResourceAsync(IResourceReference resource, CancellationToken cancellationToken)
+        {
+            StopCalls++;
+            return Task.CompletedTask;
+        }
+
+        public void ReleaseStart()
+        {
+            _startGate.TrySetResult();
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
@@ -29,7 +29,7 @@ public class ResourceCommandAnnotationTests
     [InlineData("stop", "Finished", ResourceCommandState.Hidden)]
     [InlineData("stop", "FailedToStart", ResourceCommandState.Hidden)]
     [InlineData("stop", "Unknown", ResourceCommandState.Hidden)]
-    [InlineData("stop", "Waiting", ResourceCommandState.Hidden)]
+    [InlineData("stop", "Waiting", ResourceCommandState.Enabled)]
     [InlineData("stop", "Building", ResourceCommandState.Hidden)]
     [InlineData("stop", "RuntimeUnhealthy", ResourceCommandState.Hidden)]
     [InlineData("stop", "", ResourceCommandState.Hidden)]


### PR DESCRIPTION
## Description

This fixes two related resource lifecycle issues around dependency waits and force start behavior. In the previous behavior, a resource in `Waiting` could not be canceled with `Stop`, and after force starting once, a subsequent `Waiting` run could no longer be force started.

The change updates lifecycle command handling so:
- `Stop` is enabled for `Waiting` resources and cancels the pending startup by moving the resource back to `NotStarted`.
- user-triggered `Start` is treated as a start request that does not block command execution while dependency waits are in progress, so force start remains usable on subsequent runs.
- startup cancellation while waiting is handled explicitly in orchestration/DCP flow without surfacing a generic failure.

Targeted tests were updated and added to cover command state behavior and waiting-resource start/stop orchestration paths.

Fixes #14812
Fixes #14813

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No