### PR TITLE
Fix Radius service discovery to match the recipe's ClusterIP Service

### DIFF
--- a/src/Aspire.Hosting.Radius/Publishing/Constructs/RadiusContainerConstruct.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/Constructs/RadiusContainerConstruct.cs
@@ -37,6 +37,15 @@ public sealed class RadiusContainerConstruct : ProvisionableResource
         set { Initialize(); _name!.Assign(value); }
     }
 
+    /// <summary>
+    /// The immutable <c>properties.containers</c> map key captured at construction (the Aspire
+    /// resource name). The container v2 schema and the Radius recipe require this to equal the
+    /// top-level <c>name:</c> (<see cref="ContainerName"/>); the publisher validates that invariant
+    /// after running <c>ConfigureRadiusInfrastructure</c> callbacks so service discovery (which is
+    /// derived from the resource name) cannot silently disagree with the generated Service name.
+    /// </summary>
+    internal string ContainerMapKey => _containerName;
+
     /// <summary>Container image (e.g., "nginx:latest").</summary>
     public BicepValue<string> Image
     {

--- a/src/Aspire.Hosting.Radius/Publishing/Constructs/RadiusContainerConstruct.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/Constructs/RadiusContainerConstruct.cs
@@ -39,10 +39,11 @@ public sealed class RadiusContainerConstruct : ProvisionableResource
 
     /// <summary>
     /// The immutable <c>properties.containers</c> map key captured at construction (the Aspire
-    /// resource name). The container v2 schema and the Radius recipe require this to equal the
-    /// top-level <c>name:</c> (<see cref="ContainerName"/>); the publisher validates that invariant
-    /// after running <c>ConfigureRadiusInfrastructure</c> callbacks so service discovery (which is
-    /// derived from the resource name) cannot silently disagree with the generated Service name.
+    /// resource name). The Radius v2 schema and recipe do <em>not</em> require this to equal the
+    /// top-level <c>name:</c> (<see cref="ContainerName"/>) — Radius permits distinct names. Aspire
+    /// requires them to match because it derives service discovery from the resource name, and the
+    /// publisher validates that invariant after running <c>ConfigureRadiusInfrastructure</c>
+    /// callbacks so service discovery cannot silently disagree with the generated Service name.
     /// </summary>
     internal string ContainerMapKey => _containerName;
 

--- a/src/Aspire.Hosting.Radius/Publishing/Constructs/RadiusContainerConstruct.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/Constructs/RadiusContainerConstruct.cs
@@ -108,8 +108,11 @@ public sealed class RadiusContainerConstruct : ProvisionableResource
     /// </param>
     /// <param name="containerName">
     /// The Radius container resource name as it should appear in the deployed manifest.
-    /// This value is used as the map key under <c>properties.containers</c>, which the
-    /// Radius container v2 schema requires to match the resource <c>name</c> field.
+    /// This value is used as the map key under <c>properties.containers</c>. The Radius v2
+    /// schema does not require this map key to equal the top-level <c>name:</c>, but Aspire
+    /// keys both by the resource name and requires them to match so the service discovery it
+    /// derives from that name resolves to the Service the recipe creates (see
+    /// <see cref="ContainerMapKey"/>).
     /// It must be the unsanitized resource name (hyphens preserved); using
     /// <c>BicepIdentifier</c> here would emit a key that does not match the <c>name</c>
     /// when the resource name contains characters that get sanitized.

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
@@ -1282,7 +1282,6 @@ internal sealed class RadiusInfrastructureBuilder
         var containersByMapKey = new Dictionary<string, RadiusContainerConstruct>(StringComparer.Ordinal);
         foreach (var container in options.Containers)
         {
-            ValidateContainerNameMatchesMapKey(container);
             containersByMapKey[container.ContainerMapKey] = container;
         }
 
@@ -1306,6 +1305,13 @@ internal sealed class RadiusInfrastructureBuilder
                     $"service discovery already emitted 'services__*' variables that address it, so dropping the " +
                     $"workload would break cross-container calls. Keep the container to keep service discovery consistent.");
             }
+
+            // Only containers that had service ports pre-callback have a Service (`{name}-{name}`)
+            // that `services__*` addresses, so the name/map-key equality is only required for them.
+            // A portless baseline container or one added entirely by the callback has no service-
+            // discovery contract — Radius permits its top-level name to differ from the map key — so
+            // gating this check on a non-empty snapshot keeps the customization escape hatch open.
+            ValidateContainerNameMatchesMapKey(container);
 
             foreach (var (portName, expected) in snapshot)
             {
@@ -1354,15 +1360,50 @@ internal sealed class RadiusInfrastructureBuilder
             }
         }
 
-        // Validate the Service-name length on the FINAL container set: a callback can add the first
-        // port to a previously portless container (or add a new container), after which the recipe
-        // creates a Service whose name must fit the Kubernetes limit. Only containers that declare
-        // ports get a Service, so only those need the check.
+        // Validate the FINAL container set. A callback can add the first port to a previously
+        // portless container, add a new container, or add a second endpoint. Once a container
+        // declares ports the recipe creates a Service, so re-check the two things the recipe cares
+        // about on the post-callback state: the Service name fits the Kubernetes limit, and the
+        // container's ports are unique by (containerPort, protocol).
         foreach (var container in options.Containers)
         {
-            if (container.Ports.Count > 0)
+            if (container.Ports.Count == 0)
             {
-                ValidateServiceNameWithinKubernetesLimit(container.ContainerMapKey);
+                continue;
+            }
+
+            ValidateServiceNameWithinKubernetesLimit(container);
+
+            // The pre-callback `seenPorts` dedup in ResolvePorts only covers the baseline ports. A
+            // callback can add a second endpoint (e.g. `http2`) that resolves to the same
+            // (containerPort, protocol) as a preserved one, which would make the recipe emit
+            // duplicate Kubernetes Service ports — exactly what the baseline dedup prevents. Re-run
+            // the dedup on the FINAL literal ports so a callback can't reintroduce the collision.
+            var seenPorts = new HashSet<(int ContainerPort, string Protocol)>();
+            foreach (var (portName, portValue) in container.Ports)
+            {
+                if (portValue.Value is not { } port)
+                {
+                    continue;
+                }
+
+                // Only literal ports can collide deterministically; non-literal (expression-backed)
+                // ports on callback-added containers are the customization's own responsibility and
+                // can't be compared here.
+                if (((IBicepValue)port.ContainerPort).LiteralValue is not int literalPort ||
+                    ((IBicepValue)port.Protocol).LiteralValue is not string literalProtocol)
+                {
+                    continue;
+                }
+
+                if (!seenPorts.Add((literalPort, literalProtocol)))
+                {
+                    throw new InvalidOperationException(
+                        $"A ConfigureRadiusInfrastructure callback left container '{container.ContainerMapKey}' with " +
+                        $"more than one port on {literalPort}/{literalProtocol} (for example port '{portName}'). The " +
+                        $"Radius container recipe creates one Kubernetes Service port per declared port, so duplicate " +
+                        $"(containerPort, protocol) pairs would emit conflicting Service ports. Remove the duplicate port.");
+                }
             }
         }
     }
@@ -1403,14 +1444,20 @@ internal sealed class RadiusInfrastructureBuilder
         }
     }
 
-    private static void ValidateServiceNameWithinKubernetesLimit(string resourceName)
+    private static void ValidateServiceNameWithinKubernetesLimit(RadiusContainerConstruct container)
     {
-        var serviceName = RadiusServiceDiscovery.GetServiceName(resourceName);
+        // The recipe names the Service `${normalizedName}-${containerName}` = `{top-level name}-
+        // {map key}`. For a baseline container the name-equality guard forces name == map key, so
+        // this is `{name}-{name}`; for a callback-added/portless container the name may legitimately
+        // differ, so compute the actual Service name from the literal top-level name when available.
+        var mapKey = container.ContainerMapKey;
+        var topLevelName = ((IBicepValue)container.ContainerName).LiteralValue is string literalName ? literalName : mapKey;
+        var serviceName = RadiusServiceDiscovery.GetServiceName(topLevelName, mapKey);
         if (serviceName.Length > MaxKubernetesServiceNameLength)
         {
             throw new InvalidOperationException(
                 $"The Radius container recipe creates a Kubernetes Service named '{serviceName}' for resource " +
-                $"'{resourceName}', but that is {serviceName.Length} characters — longer than the " +
+                $"'{mapKey}', but that is {serviceName.Length} characters — longer than the " +
                 $"{MaxKubernetesServiceNameLength}-character limit for a Kubernetes Service name (an RFC 1123 DNS " +
                 $"label). Shorten the resource name to at most {(MaxKubernetesServiceNameLength - 1) / 2} characters " +
                 $"so the doubled '{{name}}-{{name}}' Service name stays within the limit.");

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
@@ -1288,6 +1288,14 @@ internal sealed class RadiusInfrastructureBuilder
 
         foreach (var (mapKey, snapshot) in portSnapshots)
         {
+            // A portless container has no Service and no `services__*` value can address it, so
+            // removing it in a callback is harmless — skip the preservation check for empty
+            // snapshots so the invariant does not needlessly reject valid customization callbacks.
+            if (snapshot.Count == 0)
+            {
+                continue;
+            }
+
             // The workload service discovery was emitted for must still be present under the same
             // map key. A callback that removed it — or replaced it with a differently keyed
             // container — leaves consumers pointing at a Service that is no longer produced.

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
@@ -229,11 +229,13 @@ internal sealed class RadiusInfrastructureBuilder
         // (Radius.Compute/containers) parented to the UDT application.
         var containerConnectionTargets = new Dictionary<RadiusContainerConstruct, Dictionary<string, RadiusResourceTypeConstruct>>();
 
-        // Records the literal container ports (endpoint name -> port) that service discovery was
-        // derived from for each container, so a ConfigureRadiusInfrastructure callback that later
-        // changes or removes one (which would leave the emitted `services__*` URLs pointing at a
-        // stale port) can be rejected after callbacks run. See ValidateContainerPortsUnchanged.
-        var containerPortSnapshots = new Dictionary<RadiusContainerConstruct, Dictionary<string, int>>();
+        // Records the literal container ports (endpoint name -> port + protocol) that service
+        // discovery was derived from, keyed by the immutable container map key (the resource name),
+        // so a ConfigureRadiusInfrastructure callback that later changes/removes a port — or replaces
+        // or drops the whole container — can be rejected after callbacks run. Keying by the stable
+        // map key (not the construct instance) means a callback that swaps in a new construct for the
+        // same workload is still validated. See ValidatePostCallbackContainerInvariants.
+        var containerPortSnapshots = new Dictionary<string, Dictionary<string, (int Port, string Protocol)>>(StringComparer.Ordinal);
         foreach (var resource in computeResources)
         {
             var identifier = BicepPostProcessor.SanitizeIdentifier(resource.Name);
@@ -248,21 +250,15 @@ internal sealed class RadiusInfrastructureBuilder
             var env = await ResolveEnvironmentAsync(resource).ConfigureAwait(false);
             var ports = ResolvePorts(resource);
 
-            // Only a container that declares ports gets a recipe-created ClusterIP Service, and the
-            // Service name is `{resource}-{resource}` (RadiusServiceDiscovery). Validate the doubled
-            // name up front so an over-long name fails fast here instead of at deploy time.
-            if (ports.Count > 0)
-            {
-                ValidateServiceNameWithinKubernetesLimit(resource);
-            }
-
             var containerConstruct = CreateContainerConstruct(
                 identifier, resource.Name, image, appConstruct!, envConstruct, connectionTargets, env, ports);
             options.Containers.Add(containerConstruct);
             containerConnectionTargets[containerConstruct] = connectionTargets;
-            containerPortSnapshots[containerConstruct] = ports.ToDictionary(
+            containerPortSnapshots[resource.Name] = ports.ToDictionary(
                 kv => kv.Key,
-                kv => ((IBicepValue)kv.Value.ContainerPort).LiteralValue is int literalPort ? literalPort : -1,
+                kv => (
+                    ((IBicepValue)kv.Value.ContainerPort).LiteralValue is int literalPort ? literalPort : -1,
+                    ((IBicepValue)kv.Value.Protocol).LiteralValue is string literalProtocol ? literalProtocol : string.Empty),
                 StringComparer.Ordinal);
         }
 
@@ -291,17 +287,13 @@ internal sealed class RadiusInfrastructureBuilder
 
         RunConfigureCallbacks(options);
 
-        // A ConfigureRadiusInfrastructure callback can rewrite a container's top-level `name:`
-        // (ContainerName) but never its `properties.containers` map key (fixed at construction to
-        // the resource name). The container v2 schema and the recipe require the two to match, and
-        // service discovery addresses the Service by the resource name, so a divergence would both
-        // produce an invalid manifest and silently break cross-container calls. Fail fast instead.
-        ValidateContainerNamesMatchMapKeys(options);
-
-        // A callback can also mutate a container's ports. Service discovery was already emitted from
-        // the pre-callback ports, so a changed/removed port would silently break cross-container
-        // calls; reject the detectable cases (mirrors the name guard above).
-        ValidateContainerPortsUnchanged(options, containerPortSnapshots);
+        // Validate the post-callback container set. A ConfigureRadiusInfrastructure callback can
+        // rename containers, mutate/remove ports, add ports to a previously portless container, or
+        // replace/drop a workload entirely. Service discovery (`services__*` URLs and the recipe
+        // Service name/port) was derived from the pre-callback model, so all of these can silently
+        // break cross-container calls or emit an invalid manifest. Validate the final state and fail
+        // fast on any detectable divergence.
+        ValidatePostCallbackContainerInvariants(options, containerPortSnapshots);
 
         // 7. Rewire `.id` cross-references for targets whose BicepIdentifier
         // was changed by a callback; leave everything else (including callback
@@ -1266,43 +1258,6 @@ internal sealed class RadiusInfrastructureBuilder
         }
     }
 
-    // Ensures each container's top-level `name:` still equals its `properties.containers` map key
-    // after ConfigureRadiusInfrastructure callbacks. The default name is a literal (the resource
-    // name); a callback that changes it to a mismatched literal, or replaces it with a non-literal
-    // Bicep expression we cannot verify against the map key, throws so the invalid,
-    // service-discovery-breaking manifest is never emitted.
-    private static void ValidateContainerNamesMatchMapKeys(RadiusInfrastructureOptions options)
-    {
-        foreach (var container in options.Containers)
-        {
-            var name = (IBicepValue)container.ContainerName;
-
-            // A non-literal name (LiteralValue is null) means a callback replaced the resource-name
-            // literal with a Bicep expression. We can't prove it still equals the map key, and both
-            // the container v2 schema and service discovery require the literal resource name, so a
-            // non-literal name is unsupported. Fail fast rather than emit a manifest that may deploy
-            // a Service under a name service discovery never addresses.
-            if (name.LiteralValue is not string literalName)
-            {
-                throw new InvalidOperationException(
-                    $"A ConfigureRadiusInfrastructure callback replaced container '{container.ContainerMapKey}' " +
-                    $"name with a non-literal Bicep expression. The Radius container schema requires the top-level " +
-                    $"'name' to match the 'properties.containers' map key '{container.ContainerMapKey}', and Aspire " +
-                    $"service discovery targets that name, so a computed name is not supported. Remove the rename " +
-                    $"to keep the manifest valid.");
-            }
-
-            if (!string.Equals(literalName, container.ContainerMapKey, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"A ConfigureRadiusInfrastructure callback renamed container '{container.ContainerMapKey}' to " +
-                    $"'{literalName}'. The Radius container schema requires the top-level 'name' to match the " +
-                    $"'properties.containers' map key, and Aspire service discovery targets the original name, so " +
-                    $"renaming a container's name is not supported. Remove the rename to keep the manifest valid.");
-            }
-        }
-    }
-
     // A Kubernetes Service name must be a valid RFC 1123 DNS label of at most 63 characters:
     // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
     // The Radius recipe names the Service `{resource}-{resource}` (RadiusServiceDiscovery), so a
@@ -1310,56 +1265,147 @@ internal sealed class RadiusInfrastructureBuilder
     // names up to ModelName.DefaultMaxLength (64).
     private const int MaxKubernetesServiceNameLength = 63;
 
-    private static void ValidateServiceNameWithinKubernetesLimit(IResource resource)
-    {
-        var serviceName = RadiusServiceDiscovery.GetServiceName(resource);
-        if (serviceName.Length > MaxKubernetesServiceNameLength)
-        {
-            throw new InvalidOperationException(
-                $"The Radius container recipe creates a Kubernetes Service named '{serviceName}' for resource " +
-                $"'{resource.Name}', but that is {serviceName.Length} characters — longer than the " +
-                $"{MaxKubernetesServiceNameLength}-character limit for a Kubernetes Service name (an RFC 1123 DNS " +
-                $"label). Shorten the resource name to at most {(MaxKubernetesServiceNameLength - 1) / 2} characters " +
-                $"so the doubled '{{name}}-{{name}}' Service name stays within the limit.");
-        }
-    }
-
-    // Ensures a ConfigureRadiusInfrastructure callback did not change or remove the container ports
-    // that Aspire already emitted into consumer `services__*` variables. Only literal ports are
-    // checked (an expression-valued port is left to the control plane, mirroring the name guard);
-    // a detectable divergence throws so cross-container calls can't silently break.
-    private static void ValidateContainerPortsUnchanged(
+    // Validates the final (post-callback) container set. Aspire emits service discovery
+    // (`services__*` URLs and the recipe Service name/port) from the pre-callback model, so a
+    // ConfigureRadiusInfrastructure callback that renames a container, changes/removes a port,
+    // adds a port to a previously portless container, or replaces/drops a workload can silently
+    // break cross-container calls or emit an invalid manifest. Fail fast on any detectable
+    // divergence. Only literal values are validated; a non-literal (Bicep-expression) name or port
+    // cannot be reconciled with the fixed literal service-discovery value, so it is rejected too.
+    private static void ValidatePostCallbackContainerInvariants(
         RadiusInfrastructureOptions options,
-        IReadOnlyDictionary<RadiusContainerConstruct, Dictionary<string, int>> portSnapshots)
+        IReadOnlyDictionary<string, Dictionary<string, (int Port, string Protocol)>> portSnapshots)
     {
+        // Index the final containers by their immutable map key (the resource name, fixed at
+        // construction). Keying by the map key rather than the construct instance means a callback
+        // that swapped in a new construct for the same workload is still matched to its baseline.
+        var containersByMapKey = new Dictionary<string, RadiusContainerConstruct>(StringComparer.Ordinal);
         foreach (var container in options.Containers)
         {
-            // A callback-added container has no pre-callback service-discovery baseline to protect.
-            if (!portSnapshots.TryGetValue(container, out var snapshot))
+            ValidateContainerNameMatchesMapKey(container);
+            containersByMapKey[container.ContainerMapKey] = container;
+        }
+
+        foreach (var (mapKey, snapshot) in portSnapshots)
+        {
+            // The workload service discovery was emitted for must still be present under the same
+            // map key. A callback that removed it — or replaced it with a differently keyed
+            // container — leaves consumers pointing at a Service that is no longer produced.
+            if (!containersByMapKey.TryGetValue(mapKey, out var container))
             {
-                continue;
+                throw new InvalidOperationException(
+                    $"A ConfigureRadiusInfrastructure callback removed or replaced container '{mapKey}'. Aspire " +
+                    $"service discovery already emitted 'services__*' variables that address it, so dropping the " +
+                    $"workload would break cross-container calls. Keep the container to keep service discovery consistent.");
             }
 
-            foreach (var (portName, expectedPort) in snapshot)
+            foreach (var (portName, expected) in snapshot)
             {
                 if (!container.Ports.TryGetValue(portName, out var portValue) || portValue.Value is not { } port)
                 {
                     throw new InvalidOperationException(
                         $"A ConfigureRadiusInfrastructure callback removed port '{portName}' from container " +
-                        $"'{container.ContainerMapKey}'. Aspire service discovery already emitted this port " +
-                        $"({expectedPort}) into consumer 'services__*' variables, so removing it would break " +
-                        $"cross-container calls. Remove the port change to keep service discovery consistent.");
+                        $"'{mapKey}'. Aspire service discovery already emitted this port ({expected.Port}) into " +
+                        $"consumer 'services__*' variables, so removing it would break cross-container calls. " +
+                        $"Remove the port change to keep service discovery consistent.");
                 }
 
-                if (((IBicepValue)port.ContainerPort).LiteralValue is int literalPort && literalPort != expectedPort)
+                // Reject a non-literal port/protocol: service discovery is a fixed literal, so a
+                // callback that swaps in a Bicep expression could evaluate to a different value at
+                // deploy time, reintroducing exactly the mismatch this guard prevents. An
+                // expression-backed BicepValue<int> reports a default LiteralValue of 0 (not null),
+                // so a non-null Expression is the reliable "non-literal" signal, not the LiteralValue.
+                var portValueBicep = (IBicepValue)port.ContainerPort;
+                if (portValueBicep.Expression is not null || portValueBicep.LiteralValue is not int literalPort)
+                {
+                    throw new InvalidOperationException(
+                        $"A ConfigureRadiusInfrastructure callback replaced port '{portName}' on container " +
+                        $"'{mapKey}' with a non-literal Bicep expression. Aspire service discovery already emitted " +
+                        $"the literal port {expected.Port} into consumer 'services__*' variables and cannot follow a " +
+                        $"computed port, so a computed containerPort is not supported. Remove the port change.");
+                }
+
+                var protocolValueBicep = (IBicepValue)port.Protocol;
+                if (protocolValueBicep.Expression is not null || protocolValueBicep.LiteralValue is not string literalProtocol)
+                {
+                    throw new InvalidOperationException(
+                        $"A ConfigureRadiusInfrastructure callback replaced the protocol of port '{portName}' on " +
+                        $"container '{mapKey}' with a non-literal Bicep expression. Aspire service discovery assumes " +
+                        $"the literal protocol '{expected.Protocol}', so a computed protocol is not supported. Remove " +
+                        $"the protocol change.");
+                }
+
+                if (literalPort != expected.Port || !string.Equals(literalProtocol, expected.Protocol, StringComparison.Ordinal))
                 {
                     throw new InvalidOperationException(
                         $"A ConfigureRadiusInfrastructure callback changed port '{portName}' on container " +
-                        $"'{container.ContainerMapKey}' from {expectedPort} to {literalPort}. Aspire service " +
-                        $"discovery already emitted {expectedPort} into consumer 'services__*' variables, so this " +
-                        $"would break cross-container calls. Remove the port change to keep service discovery consistent.");
+                        $"'{mapKey}' from {expected.Port}/{expected.Protocol} to {literalPort}/{literalProtocol}. " +
+                        $"Aspire service discovery already emitted {expected.Port}/{expected.Protocol} into consumer " +
+                        $"'services__*' variables, so this would break cross-container calls. Remove the port change.");
                 }
             }
+        }
+
+        // Validate the Service-name length on the FINAL container set: a callback can add the first
+        // port to a previously portless container (or add a new container), after which the recipe
+        // creates a Service whose name must fit the Kubernetes limit. Only containers that declare
+        // ports get a Service, so only those need the check.
+        foreach (var container in options.Containers)
+        {
+            if (container.Ports.Count > 0)
+            {
+                ValidateServiceNameWithinKubernetesLimit(container.ContainerMapKey);
+            }
+        }
+    }
+
+    // Ensures a container's top-level `name:` still equals its `properties.containers` map key. The
+    // default name is a literal (the resource name); a callback that changes it to a mismatched
+    // literal, or replaces it with a non-literal Bicep expression we cannot compare, throws.
+    //
+    // NOTE: this is an *Aspire* service-discovery limitation, not a Radius v2 schema requirement.
+    // Radius itself permits a container resource whose map keys (e.g. `frontend`, `sidecar`) differ
+    // from the top-level name; Aspire derives `services__*` values from the original resource name,
+    // so a rename would make the emitted address diverge from the deployed Service.
+    private static void ValidateContainerNameMatchesMapKey(RadiusContainerConstruct container)
+    {
+        var name = (IBicepValue)container.ContainerName;
+
+        // An expression-backed BicepValue reports a default LiteralValue (null for string), but to
+        // stay consistent with the port guard we treat any non-null Expression as the non-literal
+        // signal.
+        if (name.Expression is not null || name.LiteralValue is not string literalName)
+        {
+            throw new InvalidOperationException(
+                $"A ConfigureRadiusInfrastructure callback replaced container '{container.ContainerMapKey}' name " +
+                $"with a non-literal Bicep expression. The Aspire Radius publisher derives service discovery from " +
+                $"the original container name, so it must stay the literal resource name '{container.ContainerMapKey}' " +
+                $"(this is an Aspire limitation, not a Radius schema requirement). Remove the rename to keep the " +
+                $"emitted 'services__*' values addressing the deployed Service.");
+        }
+
+        if (!string.Equals(literalName, container.ContainerMapKey, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"A ConfigureRadiusInfrastructure callback renamed container '{container.ContainerMapKey}' to " +
+                $"'{literalName}'. The Aspire Radius publisher derives service discovery from the original container " +
+                $"name, so renaming it makes the emitted 'services__*' values point at a Service that is no longer " +
+                $"produced (this is an Aspire limitation, not a Radius schema requirement). Remove the rename to keep " +
+                $"cross-container calls working.");
+        }
+    }
+
+    private static void ValidateServiceNameWithinKubernetesLimit(string resourceName)
+    {
+        var serviceName = RadiusServiceDiscovery.GetServiceName(resourceName);
+        if (serviceName.Length > MaxKubernetesServiceNameLength)
+        {
+            throw new InvalidOperationException(
+                $"The Radius container recipe creates a Kubernetes Service named '{serviceName}' for resource " +
+                $"'{resourceName}', but that is {serviceName.Length} characters — longer than the " +
+                $"{MaxKubernetesServiceNameLength}-character limit for a Kubernetes Service name (an RFC 1123 DNS " +
+                $"label). Shorten the resource name to at most {(MaxKubernetesServiceNameLength - 1) / 2} characters " +
+                $"so the doubled '{{name}}-{{name}}' Service name stays within the limit.");
         }
     }
 

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
@@ -273,6 +273,13 @@ internal sealed class RadiusInfrastructureBuilder
 
         RunConfigureCallbacks(options);
 
+        // A ConfigureRadiusInfrastructure callback can rewrite a container's top-level `name:`
+        // (ContainerName) but never its `properties.containers` map key (fixed at construction to
+        // the resource name). The container v2 schema and the recipe require the two to match, and
+        // service discovery addresses the Service by the resource name, so a divergence would both
+        // produce an invalid manifest and silently break cross-container calls. Fail fast instead.
+        ValidateContainerNamesMatchMapKeys(options);
+
         // 7. Rewire `.id` cross-references for targets whose BicepIdentifier
         // was changed by a callback; leave everything else (including callback
         // edits to references) alone.
@@ -883,12 +890,27 @@ internal sealed class RadiusInfrastructureBuilder
             return ports;
         }
 
+        var seenPorts = new HashSet<(int ContainerPort, string Protocol)>();
         foreach (var endpoint in endpoints)
         {
-            // Prefer the target (in-container) port; fall back to the declared host port. In
-            // publish mode neither may be allocated yet, in which case there is nothing to emit.
-            var portValue = endpoint.TargetPort ?? endpoint.Port;
-            if (portValue is not int containerPort)
+            // Use the shared service-port resolver so the container port emitted here matches the
+            // Service port the recipe exposes and the port the environment puts in service-discovery
+            // URLs (RadiusServiceDiscovery). A null result means this endpoint contributes no port
+            // (e.g. the synthetic default HTTPS endpoint), so the recipe creates no Service for it.
+            if (RadiusServiceDiscovery.ResolveServicePort(resource, endpoint.Name) is not int containerPort)
+            {
+                continue;
+            }
+
+            var protocol = endpoint.Protocol == ProtocolType.Udp ? "UDP" : "TCP";
+
+            // Deduplicate by (container port, protocol), matching the Kubernetes publisher's ToService
+            // dedup. Multiple endpoints can resolve to the same container port (e.g. an explicit
+            // portless HTTP and HTTPS endpoint on a project both default to 8080), and the recipe would
+            // otherwise emit two Kubernetes Service ports with the same (port, protocol), which the
+            // provider rejects. The first endpoint wins; the others still resolve to the same port in
+            // their service-discovery URLs, so nothing is lost. See: https://github.com/microsoft/aspire/issues/14029
+            if (!seenPorts.Add((containerPort, protocol)))
             {
                 continue;
             }
@@ -896,7 +918,7 @@ internal sealed class RadiusInfrastructureBuilder
             var port = new ContainerPortConstruct
             {
                 ContainerPort = containerPort,
-                Protocol = endpoint.Protocol == ProtocolType.Udp ? "UDP" : "TCP",
+                Protocol = protocol,
             };
             ports[endpoint.Name] = port;
         }
@@ -1218,6 +1240,27 @@ internal sealed class RadiusInfrastructureBuilder
         foreach (var callback in callbacks)
         {
             callback.Configure(options);
+        }
+    }
+
+    // Ensures each container's top-level `name:` still equals its `properties.containers` map key
+    // after ConfigureRadiusInfrastructure callbacks. Only literal renames are checked (an
+    // expression-valued name is left to the control plane); a mismatch throws so the invalid,
+    // service-discovery-breaking manifest is never emitted.
+    private static void ValidateContainerNamesMatchMapKeys(RadiusInfrastructureOptions options)
+    {
+        foreach (var container in options.Containers)
+        {
+            var name = (IBicepValue)container.ContainerName;
+            if (name.LiteralValue is string literalName &&
+                !string.Equals(literalName, container.ContainerMapKey, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"A ConfigureRadiusInfrastructure callback renamed container '{container.ContainerMapKey}' to " +
+                    $"'{literalName}'. The Radius container schema requires the top-level 'name' to match the " +
+                    $"'properties.containers' map key, and Aspire service discovery targets the original name, so " +
+                    $"renaming a container's name is not supported. Remove the rename to keep the manifest valid.");
+            }
         }
     }
 

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusInfrastructureBuilder.cs
@@ -228,6 +228,12 @@ internal sealed class RadiusInfrastructureBuilder
         // 5. Container workloads always route to the UDT compute container type
         // (Radius.Compute/containers) parented to the UDT application.
         var containerConnectionTargets = new Dictionary<RadiusContainerConstruct, Dictionary<string, RadiusResourceTypeConstruct>>();
+
+        // Records the literal container ports (endpoint name -> port) that service discovery was
+        // derived from for each container, so a ConfigureRadiusInfrastructure callback that later
+        // changes or removes one (which would leave the emitted `services__*` URLs pointing at a
+        // stale port) can be rejected after callbacks run. See ValidateContainerPortsUnchanged.
+        var containerPortSnapshots = new Dictionary<RadiusContainerConstruct, Dictionary<string, int>>();
         foreach (var resource in computeResources)
         {
             var identifier = BicepPostProcessor.SanitizeIdentifier(resource.Name);
@@ -242,10 +248,22 @@ internal sealed class RadiusInfrastructureBuilder
             var env = await ResolveEnvironmentAsync(resource).ConfigureAwait(false);
             var ports = ResolvePorts(resource);
 
+            // Only a container that declares ports gets a recipe-created ClusterIP Service, and the
+            // Service name is `{resource}-{resource}` (RadiusServiceDiscovery). Validate the doubled
+            // name up front so an over-long name fails fast here instead of at deploy time.
+            if (ports.Count > 0)
+            {
+                ValidateServiceNameWithinKubernetesLimit(resource);
+            }
+
             var containerConstruct = CreateContainerConstruct(
                 identifier, resource.Name, image, appConstruct!, envConstruct, connectionTargets, env, ports);
             options.Containers.Add(containerConstruct);
             containerConnectionTargets[containerConstruct] = connectionTargets;
+            containerPortSnapshots[containerConstruct] = ports.ToDictionary(
+                kv => kv.Key,
+                kv => ((IBicepValue)kv.Value.ContainerPort).LiteralValue is int literalPort ? literalPort : -1,
+                StringComparer.Ordinal);
         }
 
         // Emit the Bicep parameters allocated for secret/parameter-backed container env vars as
@@ -279,6 +297,11 @@ internal sealed class RadiusInfrastructureBuilder
         // service discovery addresses the Service by the resource name, so a divergence would both
         // produce an invalid manifest and silently break cross-container calls. Fail fast instead.
         ValidateContainerNamesMatchMapKeys(options);
+
+        // A callback can also mutate a container's ports. Service discovery was already emitted from
+        // the pre-callback ports, so a changed/removed port would silently break cross-container
+        // calls; reject the detectable cases (mirrors the name guard above).
+        ValidateContainerPortsUnchanged(options, containerPortSnapshots);
 
         // 7. Rewire `.id` cross-references for targets whose BicepIdentifier
         // was changed by a callback; leave everything else (including callback
@@ -1244,22 +1267,98 @@ internal sealed class RadiusInfrastructureBuilder
     }
 
     // Ensures each container's top-level `name:` still equals its `properties.containers` map key
-    // after ConfigureRadiusInfrastructure callbacks. Only literal renames are checked (an
-    // expression-valued name is left to the control plane); a mismatch throws so the invalid,
+    // after ConfigureRadiusInfrastructure callbacks. The default name is a literal (the resource
+    // name); a callback that changes it to a mismatched literal, or replaces it with a non-literal
+    // Bicep expression we cannot verify against the map key, throws so the invalid,
     // service-discovery-breaking manifest is never emitted.
     private static void ValidateContainerNamesMatchMapKeys(RadiusInfrastructureOptions options)
     {
         foreach (var container in options.Containers)
         {
             var name = (IBicepValue)container.ContainerName;
-            if (name.LiteralValue is string literalName &&
-                !string.Equals(literalName, container.ContainerMapKey, StringComparison.Ordinal))
+
+            // A non-literal name (LiteralValue is null) means a callback replaced the resource-name
+            // literal with a Bicep expression. We can't prove it still equals the map key, and both
+            // the container v2 schema and service discovery require the literal resource name, so a
+            // non-literal name is unsupported. Fail fast rather than emit a manifest that may deploy
+            // a Service under a name service discovery never addresses.
+            if (name.LiteralValue is not string literalName)
+            {
+                throw new InvalidOperationException(
+                    $"A ConfigureRadiusInfrastructure callback replaced container '{container.ContainerMapKey}' " +
+                    $"name with a non-literal Bicep expression. The Radius container schema requires the top-level " +
+                    $"'name' to match the 'properties.containers' map key '{container.ContainerMapKey}', and Aspire " +
+                    $"service discovery targets that name, so a computed name is not supported. Remove the rename " +
+                    $"to keep the manifest valid.");
+            }
+
+            if (!string.Equals(literalName, container.ContainerMapKey, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
                     $"A ConfigureRadiusInfrastructure callback renamed container '{container.ContainerMapKey}' to " +
                     $"'{literalName}'. The Radius container schema requires the top-level 'name' to match the " +
                     $"'properties.containers' map key, and Aspire service discovery targets the original name, so " +
                     $"renaming a container's name is not supported. Remove the rename to keep the manifest valid.");
+            }
+        }
+    }
+
+    // A Kubernetes Service name must be a valid RFC 1123 DNS label of at most 63 characters:
+    // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+    // The Radius recipe names the Service `{resource}-{resource}` (RadiusServiceDiscovery), so a
+    // resource name longer than 31 characters overflows the limit even though Aspire itself allows
+    // names up to ModelName.DefaultMaxLength (64).
+    private const int MaxKubernetesServiceNameLength = 63;
+
+    private static void ValidateServiceNameWithinKubernetesLimit(IResource resource)
+    {
+        var serviceName = RadiusServiceDiscovery.GetServiceName(resource);
+        if (serviceName.Length > MaxKubernetesServiceNameLength)
+        {
+            throw new InvalidOperationException(
+                $"The Radius container recipe creates a Kubernetes Service named '{serviceName}' for resource " +
+                $"'{resource.Name}', but that is {serviceName.Length} characters — longer than the " +
+                $"{MaxKubernetesServiceNameLength}-character limit for a Kubernetes Service name (an RFC 1123 DNS " +
+                $"label). Shorten the resource name to at most {(MaxKubernetesServiceNameLength - 1) / 2} characters " +
+                $"so the doubled '{{name}}-{{name}}' Service name stays within the limit.");
+        }
+    }
+
+    // Ensures a ConfigureRadiusInfrastructure callback did not change or remove the container ports
+    // that Aspire already emitted into consumer `services__*` variables. Only literal ports are
+    // checked (an expression-valued port is left to the control plane, mirroring the name guard);
+    // a detectable divergence throws so cross-container calls can't silently break.
+    private static void ValidateContainerPortsUnchanged(
+        RadiusInfrastructureOptions options,
+        IReadOnlyDictionary<RadiusContainerConstruct, Dictionary<string, int>> portSnapshots)
+    {
+        foreach (var container in options.Containers)
+        {
+            // A callback-added container has no pre-callback service-discovery baseline to protect.
+            if (!portSnapshots.TryGetValue(container, out var snapshot))
+            {
+                continue;
+            }
+
+            foreach (var (portName, expectedPort) in snapshot)
+            {
+                if (!container.Ports.TryGetValue(portName, out var portValue) || portValue.Value is not { } port)
+                {
+                    throw new InvalidOperationException(
+                        $"A ConfigureRadiusInfrastructure callback removed port '{portName}' from container " +
+                        $"'{container.ContainerMapKey}'. Aspire service discovery already emitted this port " +
+                        $"({expectedPort}) into consumer 'services__*' variables, so removing it would break " +
+                        $"cross-container calls. Remove the port change to keep service discovery consistent.");
+                }
+
+                if (((IBicepValue)port.ContainerPort).LiteralValue is int literalPort && literalPort != expectedPort)
+                {
+                    throw new InvalidOperationException(
+                        $"A ConfigureRadiusInfrastructure callback changed port '{portName}' on container " +
+                        $"'{container.ContainerMapKey}' from {expectedPort} to {literalPort}. Aspire service " +
+                        $"discovery already emitted {expectedPort} into consumer 'services__*' variables, so this " +
+                        $"would break cross-container calls. Remove the port change to keep service discovery consistent.");
+                }
             }
         }
     }

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusServiceDiscovery.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusServiceDiscovery.cs
@@ -15,8 +15,10 @@ namespace Aspire.Hosting.Radius.Publishing;
 /// The Radius Kubernetes container recipe (radius-project/resource-types-contrib) creates one
 /// ClusterIP <c>Service</c> per container that declares ports. The Service name is
 /// <c>${normalizedName}-${containerName}</c> and it is exposed on the container port
-/// (<c>port == targetPort == containerPort</c>):
-/// <see href="https://github.com/radius-project/resource-types-contrib/blob/main/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep"/>.
+/// (<c>port == targetPort == containerPort</c>). Pinned to an immutable commit so the documented
+/// contract can be verified even if <c>main</c> moves (Service name at line 338, port/targetPort at
+/// lines 329-330):
+/// <see href="https://github.com/radius-project/resource-types-contrib/blob/ab9722ac7027060693ef6d731f770436b03abbaf/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep"/>.
 /// <para>
 /// For a Radius container emitted by Aspire, both <c>normalizedName</c> (the top-level <c>name:</c>)
 /// and <c>containerName</c> (the <c>properties.containers</c> map key) equal the Aspire resource
@@ -37,7 +39,13 @@ internal static class RadiusServiceDiscovery
     /// <summary>
     /// Gets the Kubernetes <c>Service</c> name the Radius recipe creates for <paramref name="resource"/>.
     /// </summary>
-    public static string GetServiceName(IResource resource) => $"{resource.Name}-{resource.Name}";
+    public static string GetServiceName(IResource resource) => GetServiceName(resource.Name);
+
+    /// <summary>
+    /// Gets the Kubernetes <c>Service</c> name the Radius recipe creates for a container whose
+    /// Aspire resource name is <paramref name="resourceName"/>.
+    /// </summary>
+    public static string GetServiceName(string resourceName) => $"{resourceName}-{resourceName}";
 
     /// <summary>
     /// Resolves the port the Radius recipe's <c>Service</c> exposes for the endpoint named
@@ -52,10 +60,13 @@ internal static class RadiusServiceDiscovery
     /// <list type="bullet">
     /// <item>an explicit target port is used as-is;</item>
     /// <item>a <see cref="ContainerResource"/> with only a host port listens on that port;</item>
-    /// <item>a <see cref="ProjectResource"/>'s default HTTP endpoint has no resolved port (the
-    /// deployment tool would assign one), so it is defaulted to <see cref="DefaultProjectContainerPort"/>;</item>
-    /// <item>any other endpoint without an explicit port is given a distinct allocated port, so
-    /// multiple portless endpoints never collapse onto the same Service port.</item>
+    /// <item>an endpoint without an explicit port that <see cref="ResourceExtensions.ResolveEndpoints"/>
+    /// assigns a distinct allocated port to uses that allocated port, so multiple portless endpoints
+    /// never collapse onto the same Service port;</item>
+    /// <item>a <see cref="ProjectResource"/> endpoint that resolves to no port — the first portless
+    /// HTTP or HTTPS endpoint for its scheme (the deployment tool would normally assign one) — is
+    /// defaulted to <see cref="DefaultProjectContainerPort"/>, <em>except</em> the synthetic default
+    /// HTTPS endpoint, which returns <see langword="null"/> (see the port-resolution code below).</item>
     /// </list>
     /// A resolution is stateless and deterministic (the allocator always starts from the same port
     /// and endpoints are enumerated in a stable order), so the two independent callers — the Bicep

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusServiceDiscovery.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusServiceDiscovery.cs
@@ -22,10 +22,12 @@ namespace Aspire.Hosting.Radius.Publishing;
 /// <para>
 /// For a Radius container emitted by Aspire, both <c>normalizedName</c> (the top-level <c>name:</c>)
 /// and <c>containerName</c> (the <c>properties.containers</c> map key) equal the Aspire resource
-/// name, so the Service name is <c>{resource.Name}-{resource.Name}</c>. Both the recipe and the
-/// container v2 schema require the map key to equal <c>name:</c>, so a callback that renames only
-/// one of them produces an invalid manifest; the publisher guards against that so this doubling
-/// holds for every valid manifest.
+/// name, so the Service name is <c>{resource.Name}-{resource.Name}</c>. The Radius recipe and the
+/// container v2 schema do <em>not</em> require the map key to equal <c>name:</c> — Radius permits
+/// distinct top-level and container-map names. Aspire requires them to match because it derives
+/// service discovery from the original resource name, so a callback that renames only one of them
+/// would make the emitted <c>services__*</c> values address a Service that is never produced; the
+/// publisher guards against that so this doubling holds for every manifest Aspire emits.
 /// </para>
 /// </remarks>
 internal static class RadiusServiceDiscovery

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusServiceDiscovery.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusServiceDiscovery.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Radius.Publishing;
+
+/// <summary>
+/// Single source of truth for how Aspire addresses a Radius container across the cluster, so the
+/// service-discovery values emitted into consumer containers (the <c>services__*</c> env vars) can
+/// never disagree with the Kubernetes objects the Radius recipe actually creates.
+/// </summary>
+/// <remarks>
+/// The Radius Kubernetes container recipe (radius-project/resource-types-contrib) creates one
+/// ClusterIP <c>Service</c> per container that declares ports. The Service name is
+/// <c>${normalizedName}-${containerName}</c> and it is exposed on the container port
+/// (<c>port == targetPort == containerPort</c>):
+/// <see href="https://github.com/radius-project/resource-types-contrib/blob/main/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep"/>.
+/// <para>
+/// For a Radius container emitted by Aspire, both <c>normalizedName</c> (the top-level <c>name:</c>)
+/// and <c>containerName</c> (the <c>properties.containers</c> map key) equal the Aspire resource
+/// name, so the Service name is <c>{resource.Name}-{resource.Name}</c>. Both the recipe and the
+/// container v2 schema require the map key to equal <c>name:</c>, so a callback that renames only
+/// one of them produces an invalid manifest; the publisher guards against that so this doubling
+/// holds for every valid manifest.
+/// </para>
+/// </remarks>
+internal static class RadiusServiceDiscovery
+{
+    // The Kubernetes container port assigned to a project resource whose HTTP endpoint has no
+    // explicit target port in publish mode. Mirrors the Kubernetes publisher's default
+    // (GenerateDefaultProjectEndpointMapping) so a project turned into a Radius container declares
+    // a port -> the recipe creates a Service for it -> it is reachable via service discovery.
+    internal const int DefaultProjectContainerPort = 8080;
+
+    /// <summary>
+    /// Gets the Kubernetes <c>Service</c> name the Radius recipe creates for <paramref name="resource"/>.
+    /// </summary>
+    public static string GetServiceName(IResource resource) => $"{resource.Name}-{resource.Name}";
+
+    /// <summary>
+    /// Resolves the port the Radius recipe's <c>Service</c> exposes for the endpoint named
+    /// <paramref name="endpointName"/> on <paramref name="resource"/> (equivalently, the container
+    /// port emitted into the Bicep). Returns <see langword="null"/> when no port should be emitted
+    /// for this endpoint (so no Service is created for it).
+    /// </summary>
+    /// <remarks>
+    /// Port resolution runs through <see cref="ResourceExtensions.ResolveEndpoints"/> — the same
+    /// primitive the Kubernetes publisher uses — so the container/Service port is computed with the
+    /// framework's resource-aware semantics rather than a hand-rolled <c>TargetPort ?? Port</c>:
+    /// <list type="bullet">
+    /// <item>an explicit target port is used as-is;</item>
+    /// <item>a <see cref="ContainerResource"/> with only a host port listens on that port;</item>
+    /// <item>a <see cref="ProjectResource"/>'s default HTTP endpoint has no resolved port (the
+    /// deployment tool would assign one), so it is defaulted to <see cref="DefaultProjectContainerPort"/>;</item>
+    /// <item>any other endpoint without an explicit port is given a distinct allocated port, so
+    /// multiple portless endpoints never collapse onto the same Service port.</item>
+    /// </list>
+    /// A resolution is stateless and deterministic (the allocator always starts from the same port
+    /// and endpoints are enumerated in a stable order), so the two independent callers — the Bicep
+    /// container-port emission and the <c>services__*</c> URL emission — always agree.
+    /// </remarks>
+    public static int? ResolveServicePort(IResource resource, string endpointName)
+    {
+        var resolved = resource.ResolveEndpoints()
+            .FirstOrDefault(r => string.Equals(r.Endpoint.Name, endpointName, StringComparison.OrdinalIgnoreCase));
+
+        if (resolved is null)
+        {
+            return null;
+        }
+
+        // ResolveEndpoints computes the container (target) port with resource-aware rules. When it
+        // yields a concrete port (explicit target, a container's host-derived port, or an allocated
+        // port for an otherwise-portless endpoint), that is the container/Service port.
+        if (resolved.TargetPort.Value is int targetPort)
+        {
+            return targetPort;
+        }
+
+        // No resolved target port: ResolveEndpoints returns None only for a project's default
+        // endpoint for its scheme (the first portless http/https endpoint), which the deployment
+        // tool would normally assign a port to.
+        //
+        // Skip only the *synthetic* default HTTPS endpoint: containers do not terminate TLS
+        // in-cluster, and the framework reuses the HTTP port for it (see the Kubernetes publisher's
+        // DefaultHttpsEndpoint handling and the core SetBothPortsEnvVariables behavior). Any other
+        // portless project endpoint — the default HTTP endpoint or an explicit portless HTTP/HTTPS
+        // endpoint — is given the standard container port so the container declares a port and the
+        // recipe creates a Service, matching the Kubernetes publisher's 8080 default.
+        // See: https://github.com/microsoft/aspire/issues/14029
+        if (resource is IProjectLaunchDefaultsResource projectResource &&
+            ReferenceEquals(resolved.Endpoint, projectResource.DefaultHttpsEndpoint))
+        {
+            return null;
+        }
+
+        return DefaultProjectContainerPort;
+    }
+
+    public static string ToInvariantString(int value) => value.ToString(CultureInfo.InvariantCulture);
+}

--- a/src/Aspire.Hosting.Radius/Publishing/RadiusServiceDiscovery.cs
+++ b/src/Aspire.Hosting.Radius/Publishing/RadiusServiceDiscovery.cs
@@ -45,9 +45,21 @@ internal static class RadiusServiceDiscovery
 
     /// <summary>
     /// Gets the Kubernetes <c>Service</c> name the Radius recipe creates for a container whose
-    /// Aspire resource name is <paramref name="resourceName"/>.
+    /// Aspire resource name is <paramref name="resourceName"/>. Aspire keys both the top-level
+    /// <c>name:</c> and the <c>properties.containers</c> map key by the resource name, so the
+    /// recipe's <c>${normalizedName}-${containerName}</c> resolves to <c>{name}-{name}</c>.
     /// </summary>
-    public static string GetServiceName(string resourceName) => $"{resourceName}-{resourceName}";
+    public static string GetServiceName(string resourceName) => GetServiceName(resourceName, resourceName);
+
+    /// <summary>
+    /// Gets the Kubernetes <c>Service</c> name the Radius recipe creates for a container whose
+    /// top-level <c>name:</c> is <paramref name="topLevelName"/> and whose
+    /// <c>properties.containers</c> map key is <paramref name="mapKey"/>. The recipe names the
+    /// Service <c>${normalizedName}-${containerName}</c>, i.e. <c>{topLevelName}-{mapKey}</c>. Use
+    /// this overload for callback-mutated containers whose top-level name is allowed to differ from
+    /// the map key (no service-discovery contract exists for them).
+    /// </summary>
+    public static string GetServiceName(string topLevelName, string mapKey) => $"{topLevelName}-{mapKey}";
 
     /// <summary>
     /// Resolves the port the Radius recipe's <c>Service</c> exposes for the endpoint named

--- a/src/Aspire.Hosting.Radius/RadiusEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Radius/RadiusEnvironmentResource.cs
@@ -111,6 +111,74 @@ public sealed class RadiusEnvironmentResource : Resource, IComputeEnvironmentRes
         // environment: the single-environment and AKS-wrap cases share this environment's
         // namespace, so the fallback is correct there.
         var targetNamespace = (resource.GetComputeEnvironment() as RadiusEnvironmentResource)?.Namespace ?? Namespace;
-        return ReferenceExpression.Create($"{resource.Name}.{targetNamespace}.svc.cluster.local");
+
+        // The Radius Kubernetes container recipe names the ClusterIP Service `{name}-{name}` (see
+        // RadiusServiceDiscovery), not the bare resource name, so service discovery must address
+        // that Service — otherwise the FQDN never resolves and cross-container calls fail.
+        var serviceName = RadiusServiceDiscovery.GetServiceName(resource);
+        return ReferenceExpression.Create($"{serviceName}.{targetNamespace}.svc.cluster.local");
     }
+
+    /// <inheritdoc/>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    public ReferenceExpression GetEndpointPropertyExpression(EndpointReferenceExpression endpointReferenceExpression)
+    {
+        ArgumentNullException.ThrowIfNull(endpointReferenceExpression);
+
+        var endpointReference = endpointReferenceExpression.Endpoint;
+        var property = endpointReferenceExpression.Property;
+        var endpoint = endpointReference.EndpointAnnotation;
+        var scheme = endpoint.UriScheme;
+
+        // Unlike the default IComputeEnvironmentResource implementation (which uses the proxy/host
+        // port), a Radius peer is reachable on the recipe Service's port, which equals the container
+        // port (port == targetPort == containerPort). Resolve the service port from the same helper
+        // the Bicep container-port emission uses so the emitted URL and the generated Service agree.
+        var resolvedServicePort = RadiusServiceDiscovery.ResolveServicePort(endpointReference.Resource, endpoint.Name);
+        var port = resolvedServicePort ?? GetDefaultPort(scheme, endpoint);
+        var host = new Lazy<ReferenceExpression>(() => GetHostAddressExpression(endpointReference));
+
+        return property switch
+        {
+            EndpointProperty.Url => IsDefaultPort(scheme, port)
+                ? ReferenceExpression.Create($"{scheme}://{host.Value}")
+                : ReferenceExpression.Create($"{scheme}://{host.Value}:{RadiusServiceDiscovery.ToInvariantString(port)}"),
+            EndpointProperty.Host or EndpointProperty.IPV4Host => host.Value,
+            EndpointProperty.Port => ReferenceExpression.Create($"{RadiusServiceDiscovery.ToInvariantString(port)}"),
+            // The Radius recipe Service targets the container port, which equals the Service port
+            // (port == targetPort == containerPort). Use the same resolved value as Port/Url so the
+            // TargetPort property can't disagree with the container port ResolvePorts emits. Fall back
+            // to the container's port reference only when no Service port is resolved (e.g. an
+            // unallocated HTTPS endpoint that is dropped from service discovery anyway).
+            EndpointProperty.TargetPort => resolvedServicePort is int targetPort
+                ? ReferenceExpression.Create($"{RadiusServiceDiscovery.ToInvariantString(targetPort)}")
+                : ReferenceExpression.Create($"{new ContainerPortReference(endpointReference.Resource)}"),
+            EndpointProperty.Scheme => ReferenceExpression.Create($"{scheme}"),
+            EndpointProperty.HostAndPort => ReferenceExpression.Create($"{host.Value}:{RadiusServiceDiscovery.ToInvariantString(port)}"),
+            EndpointProperty.TlsEnabled => ReferenceExpression.Create($"{(endpoint.TlsEnabled ? bool.TrueString : bool.FalseString)}"),
+            _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{endpoint.Name}'.")
+        };
+    }
+
+    // Mirrors the private helpers on IComputeEnvironmentResource so this override reproduces the
+    // default port semantics (only the port *source* differs — Radius uses the Service/container
+    // port instead of the proxy/host port).
+    private static int GetDefaultPort(string scheme, EndpointAnnotation endpoint)
+    {
+        if (string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase))
+        {
+            return 80;
+        }
+
+        if (string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase))
+        {
+            return 443;
+        }
+
+        throw new InvalidOperationException($"Endpoint '{endpoint.Name}' must specify a port for scheme '{scheme}'.");
+    }
+
+    private static bool IsDefaultPort(string scheme, int port) =>
+        string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase) && port == 80 ||
+        string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) && port == 443;
 }

--- a/src/Aspire.Hosting.Radius/RadiusEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Radius/RadiusEnvironmentResource.cs
@@ -119,9 +119,11 @@ public sealed class RadiusEnvironmentResource : Resource, IComputeEnvironmentRes
         return ReferenceExpression.Create($"{serviceName}.{targetNamespace}.svc.cluster.local");
     }
 
-    /// <inheritdoc/>
-    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    public ReferenceExpression GetEndpointPropertyExpression(EndpointReferenceExpression endpointReferenceExpression)
+    // Explicit interface implementation: this override customizes only the *port source* for Radius
+    // peers (Service/container port instead of the proxy/host port) and is reached solely through
+    // IComputeEnvironmentResource. Keeping it off the public RadiusEnvironmentResource surface
+    // matches the other publishers (Kubernetes/Docker), which don't expose this member at all.
+    ReferenceExpression IComputeEnvironmentResource.GetEndpointPropertyExpression(EndpointReferenceExpression endpointReferenceExpression)
     {
         ArgumentNullException.ThrowIfNull(endpointReferenceExpression);
 

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -146,6 +146,8 @@
     <InternalsVisibleTo Include="Aspire.TestUtilities" />
     <InternalsVisibleTo Include="Aspire.Cli.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Kubernetes" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Radius" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Radius.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.RemoteHost.Tests" />
     <InternalsVisibleTo Include="Aspire.Hosting.Foundry.Tests" />
   </ItemGroup>

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -159,6 +159,7 @@ Aspire.Deployment.EndToEnd.Tests/
 ├── AzureStorageDeploymentTests.cs         # Azure Storage resource
 ├── PythonFastApiDeploymentTests.cs        # Python FastAPI to Azure Container Apps
 ├── RadiusStarterDeploymentTests.cs        # Starter template to Radius on AKS (rad deploy)
+├── RadiusAzureResourcesDeploymentTests.cs # Gap: cloud-managed Azure resource refs on Radius
 ├── TypeScriptAzureContainerAppJobDeploymentTests.cs # TypeScript AppHost ACA jobs
 ├── xunit.runner.json                  # Test runner config
 └── README.md                          # This file
@@ -186,14 +187,34 @@ Radius-specific notes:
   `rad app graph -a app --preview` (the legacy `rad app graph` routes to Applications.Core, which
   the Redis-only legacy `app` satisfies on its own) and asserts the graph names both project
   containers. Each container is then probed on its own HTTP endpoint via `kubectl port-forward`:
-  `apiservice`'s `/weatherforecast` and `webfrontend`'s home page (`/`).
-- **Cross-container connectivity is not asserted (current Radius limitation).** The `webfrontend`
-  `/weather` page fans out to `apiservice` through the Redis output cache, but Radius 0.59 does not
-  synthesize a Kubernetes `Service` for a `Radius.Compute/containers` workload, so the
-  service-discovery hostname Aspire emits for `apiservice`
-  (`apiservice.<namespace>.svc.cluster.local`) does not resolve in-cluster (`rad app graph` shows
-  `webfrontend` wired only to the cache). The test therefore validates each container in isolation
-  rather than the `/weather` end-to-end path until that connectivity is supported.
+  `apiservice`'s `/weatherforecast`, `webfrontend`'s home page (`/`), and a Redis output-cache
+  diagnostic endpoint on `webfrontend` (which verifies recipe-backed cache connection injection).
+- **Cross-container connectivity is instrumented but still gated.** The `webfrontend` `/weather`
+  page fans out to `apiservice` through the Redis output cache. The current Radius
+  `Radius.Compute/containers` Kubernetes recipe does create a ClusterIP `Service` for a container
+  that declares ports, named `${normalizedName}-${containerName}` with `port`/`targetPort` set to
+  the container port — so the merged claim that Radius creates *no* Service for container workloads
+  appears inaccurate. For Aspire's single-container emission this suggests the service-discovery
+  hostname `apiservice-apiservice.<namespace>.svc.cluster.local:8080`, but the exact Service name
+  must be confirmed by a live `deploy-test/*` run against the pinned rad 0.59 control plane before
+  asserting the direct `webfrontend` → `apiservice` diagnostic endpoint and `/weather`. The test
+  therefore adds both diagnostic endpoints, asserts the Redis one, and leaves the apiservice one
+  and `/weather` skipped pending that confirmation.
+
+## Radius Azure resource injection (gap)
+
+`RadiusAzureResourcesDeploymentTests.PublishWithAzureKeyVaultReferenceDocumentsCurrentRadiusGap`
+documents a **current gap**, not working coverage. The Aspire Radius publisher does not translate
+cloud-managed Azure resources (Key Vault, Storage, Service Bus, Azure Managed Redis) into Radius
+resources — only portable recipe-backed resources such as `AddRedis` are mapped. When a Radius
+container `WithReference`s an Azure resource, `aspire publish` does not fail fast; it **hangs**
+resolving `Azure.BicepOutputReference.GetValueAsync` inside
+`RadiusInfrastructureBuilder.ResolveEnvironmentAsync` and produces no `app.bicep`. The test asserts
+this timeout/no-output behavior so the gap is visible and regressions are caught; it needs only the
+current-build Aspire CLI (no AKS/Azure deployment). When Azure resource injection is implemented (or
+publish is made to fail fast), this test will start failing and should be converted into a real
+injection assertion. Product follow-up: add Azure resource mappings, or a deploy-time bridge from
+Azure Bicep outputs to Radius container env/connections, and fail fast instead of hanging.
 
 ## TypeScript deployment coverage
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -189,17 +189,16 @@ Radius-specific notes:
   containers. Each container is then probed on its own HTTP endpoint via `kubectl port-forward`:
   `apiservice`'s `/weatherforecast`, `webfrontend`'s home page (`/`), and a Redis output-cache
   diagnostic endpoint on `webfrontend` (which verifies recipe-backed cache connection injection).
-- **Cross-container connectivity is instrumented but still gated.** The `webfrontend` `/weather`
-  page fans out to `apiservice` through the Redis output cache. The current Radius
-  `Radius.Compute/containers` Kubernetes recipe does create a ClusterIP `Service` for a container
-  that declares ports, named `${normalizedName}-${containerName}` with `port`/`targetPort` set to
-  the container port — so the merged claim that Radius creates *no* Service for container workloads
-  appears inaccurate. For Aspire's single-container emission this suggests the service-discovery
-  hostname `apiservice-apiservice.<namespace>.svc.cluster.local:8080`, but the exact Service name
-  must be confirmed by a live `deploy-test/*` run against the pinned rad 0.59 control plane before
-  asserting the direct `webfrontend` → `apiservice` diagnostic endpoint and `/weather`. The test
-  therefore adds both diagnostic endpoints, asserts the Redis one, and leaves the apiservice one
-  and `/weather` skipped pending that confirmation.
+- **Cross-container connectivity is asserted end-to-end.** The `webfrontend` `/weather` page fans
+  out to `apiservice` through the Redis output cache. The Radius `Radius.Compute/containers`
+  Kubernetes recipe creates a ClusterIP `Service` for each container that declares ports, named
+  `${normalizedName}-${containerName}` with `port`/`targetPort` set to the container port. Aspire
+  emits a single container entry keyed by the resource name, so `apiservice`'s Service is
+  `apiservice-apiservice` on port `8080`, and Aspire's Radius service discovery emits the matching
+  address `http://apiservice-apiservice.<namespace>.svc.cluster.local:8080` (see
+  `RadiusEnvironmentResource.GetHostAddressExpression` / `RadiusServiceDiscovery`). The test asserts
+  the recipe-created Service exists on the container port, then asserts the direct
+  `webfrontend` → `apiservice` diagnostic endpoint and the `/weather` page.
 
 ## Radius Azure resource injection (gap)
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -206,14 +206,20 @@ Radius-specific notes:
 documents a **current gap**, not working coverage. The Aspire Radius publisher does not translate
 cloud-managed Azure resources (Key Vault, Storage, Service Bus, Azure Managed Redis) into Radius
 resources — only portable recipe-backed resources such as `AddRedis` are mapped. When a Radius
-container `WithReference`s an Azure resource, `aspire publish` does not fail fast; it **hangs**
-resolving `Azure.BicepOutputReference.GetValueAsync` inside
-`RadiusInfrastructureBuilder.ResolveEnvironmentAsync` and produces no `app.bicep`. The test asserts
-this timeout/no-output behavior so the gap is visible and regressions are caught; it needs only the
-current-build Aspire CLI (no AKS/Azure deployment). When Azure resource injection is implemented (or
-publish is made to fail fast), this test will start failing and should be converted into a real
-injection assertion. Product follow-up: add Azure resource mappings, or a deploy-time bridge from
-Azure Bicep outputs to Radius container env/connections, and fail fast instead of hanging.
+container `WithReference`s an Azure resource, `aspire publish` currently **hangs** resolving
+`Azure.BicepOutputReference.GetValueAsync` inside `RadiusInfrastructureBuilder.ResolveEnvironmentAsync`
+and produces no `app.bicep`. The tracking issue is
+[#18802](https://github.com/microsoft/aspire/issues/18802).
+
+Because that hang is the bug being tracked, the test is marked `[ActiveIssue("…/18802")]` and is
+**skipped** in CI. Its body asserts the **intended fail-fast behavior** — `aspire publish` should
+exit non-zero within a bounded timeout and emit no `app.bicep` — rather than the current hang, so it
+starts passing only once the gap is closed. It needs only the current-build Aspire CLI (no
+AKS/Azure deployment). When Azure resource injection is implemented (or publish is made to fail
+fast), **remove the `[ActiveIssue]` attribute** so the test runs and guards the behavior; do not
+expect it to fail automatically while skipped. Product follow-up: add Azure resource mappings, or a
+deploy-time bridge from Azure Bicep outputs to Radius container env/connections, and fail fast
+instead of hanging.
 
 ## TypeScript deployment coverage
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusAzureResourcesDeploymentTests.cs
@@ -13,11 +13,16 @@ namespace Aspire.Deployment.EndToEnd.Tests;
 /// <remarks>
 /// Radius 0.59 supports portable recipe-backed resources such as <c>AddRedis</c>, but the
 /// Aspire Radius publisher does not currently translate cloud-managed Azure resources such as
-/// Key Vault, Storage, Service Bus, or Azure Managed Redis into Radius resources.
+/// Key Vault, Storage, Service Bus, or Azure Managed Redis into Radius resources. Today
+/// <c>aspire publish</c> hangs in that scenario; the tracking issue
+/// (https://github.com/microsoft/aspire/issues/18802) covers making it fail fast instead. The
+/// test is marked <c>[ActiveIssue]</c> and asserts that intended fail-fast behavior, so it starts
+/// passing once the gap is closed.
 /// </remarks>
 public sealed class RadiusAzureResourcesDeploymentTests(ITestOutputHelper output)
 {
     [Fact]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/18802")]
     public async Task PublishWithAzureKeyVaultReferenceDocumentsCurrentRadiusGap()
     {
         if (!DeploymentE2ETestHelpers.IsRunningInCI)
@@ -89,7 +94,8 @@ public sealed class RadiusAzureResourcesDeploymentTests(ITestOutputHelper output
 
             var vault = builder.AddAzureKeyVault("vault");
 
-            builder.AddContainer("consumer", "mcr.microsoft.com/dotnet/samples", "aspnetapp")
+            builder.AddContainer("consumer", "mcr.microsoft.com/azuredocs/aci-helloworld", "latest")
+                .WithImageSHA256("456a1150aa41340a14c7be1342deda2cde9e6e7df9fde6b8a69de0ae04f92fad")
                 .WithReference(vault)
                 .WithComputeEnvironment(radius);
 
@@ -100,39 +106,29 @@ public sealed class RadiusAzureResourcesDeploymentTests(ITestOutputHelper output
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter);
 
-        output.WriteLine("Publishing is expected to time out: Radius tries to resolve Azure Bicep outputs during container env emission.");
+        output.WriteLine("Publishing should fail fast once the gap is fixed: Aspire cannot translate a cloud-managed Azure resource (Key Vault) into a Radius resource. See https://github.com/microsoft/aspire/issues/18802.");
         await auto.TypeAsync(
             "set +e; " +
-            "mkdir -p \"$HOME/.aspire/logs\"; " +
-            "rm -rf ../out ../publish.log ../radius-gap-evidence.log ../radius-gap-log-start; " +
-            ": > ../radius-gap-log-start; " +
-            "timeout 45s aspire publish --output-path ../out --non-interactive > ../publish.log 2>&1; " +
+            "rm -rf ../out ../publish.log; " +
+            // The bug in #18802 causes `aspire publish` to HANG (Radius resolves Azure Bicep outputs
+            // during container env emission). Cap it with `timeout` so an unfixed build fails the
+            // test loudly instead of hanging. Once #18802 is fixed, publish should fail fast with a
+            // non-zero exit and produce no app.bicep.
+            "timeout 120s aspire publish --output-path ../out --non-interactive > ../publish.log 2>&1; " +
             "code=$?; " +
-            "if [ \"$code\" = \"124\" ]; then " +
-            "if [ -f ../out/app.bicep ]; then cat ../publish.log; echo \"Radius app.bicep should not be produced for the current gap.\"; exit 1; fi; " +
-            "logs=$(find \"$HOME/.aspire/logs\" -maxdepth 1 -name 'cli_*.log' -newer ../radius-gap-log-start -print); " +
-            "if [ -z \"$logs\" ]; then cat ../publish.log; echo \"Radius publish timed out, but no invocation-specific CLI log was produced.\"; exit 1; fi; " +
-            "if ! grep -hE \"Azure[.]BicepOutputReference[.]GetValueAsync|RadiusInfrastructureBuilder[.]ResolveEnvironmentAsync\" $logs > ../radius-gap-evidence.log 2>/dev/null; then " +
-            "cat ../publish.log; " +
-            "echo \"Radius publish timed out, but this invocation's CLI logs did not show Azure Bicep output resolution evidence.\"; " +
-            "printf '%s\\n' $logs; " +
-            "exit 1; " +
-            "fi; " +
-            "tail -8 ../radius-gap-evidence.log; " +
-            // Split the marker token in the source command (RADIUS_AZURE_REFERENCE_GAP''_TIMEOUT
-            // evaluates to RADIUS_AZURE_REFERENCE_GAP_TIMEOUT) so Hex1b cannot self-match the
+            "if [ \"$code\" = \"124\" ]; then cat ../publish.log; echo \"Radius publish still hangs on a cloud-managed Azure reference (see issue 18802).\"; exit 1; fi; " +
+            "if [ \"$code\" = \"0\" ]; then cat ../publish.log; echo \"Radius publish unexpectedly succeeded for a cloud-managed Azure reference; it should fail fast until Azure resource translation is supported.\"; exit 1; fi; " +
+            "if [ -f ../out/app.bicep ]; then cat ../publish.log; echo \"Radius publish produced app.bicep for a cloud-managed Azure reference; it should fail before emitting output.\"; exit 1; fi; " +
+            // Split the marker token in the source command (RADIUS_AZURE_REFERENCE_GAP''_FAILFAST
+            // evaluates to RADIUS_AZURE_REFERENCE_GAP_FAILFAST) so Hex1b cannot self-match the
             // echoed command line before the shell actually reaches the gap assertion.
-            "echo RADIUS_AZURE_REFERENCE_GAP''_TIMEOUT; " +
-            "exit 0; " +
-            "fi; " +
-            "cat ../publish.log; " +
-            "echo \"Expected Radius publish to time out while resolving Azure resource references, but exit code was $code.\"; " +
-            "exit 1");
+            "echo RADIUS_AZURE_REFERENCE_GAP''_FAILFAST; " +
+            "exit 0");
         await auto.EnterAsync();
         await auto.WaitUntilAsync(
-            s => new CellPatternSearcher().Find("RADIUS_AZURE_REFERENCE_GAP_TIMEOUT").Search(s).Count > 0,
-            timeout: TimeSpan.FromSeconds(90),
-            description: "Radius/Azure reference gap timeout marker");
+            s => new CellPatternSearcher().Find("RADIUS_AZURE_REFERENCE_GAP_FAILFAST").Search(s).Count > 0,
+            timeout: TimeSpan.FromMinutes(3),
+            description: "Radius/Azure reference gap fail-fast marker");
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
         await auto.TypeAsync("exit");

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusAzureResourcesDeploymentTests.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Deployment.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Deployment.EndToEnd.Tests;
+
+/// <summary>
+/// Gap-documenting tests for cloud-managed Azure resource references when publishing to Radius.
+/// </summary>
+/// <remarks>
+/// Radius 0.59 supports portable recipe-backed resources such as <c>AddRedis</c>, but the
+/// Aspire Radius publisher does not currently translate cloud-managed Azure resources such as
+/// Key Vault, Storage, Service Bus, or Azure Managed Redis into Radius resources.
+/// </remarks>
+public sealed class RadiusAzureResourcesDeploymentTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task PublishWithAzureKeyVaultReferenceDocumentsCurrentRadiusGap()
+    {
+        if (!DeploymentE2ETestHelpers.IsRunningInCI)
+        {
+            var localCurrentBuildStrategy = DeploymentE2ETestHelpers.GetCurrentBuildCliInstallStrategy();
+            if (localCurrentBuildStrategy.Mode is CliInstallMode.InstallScript &&
+                localCurrentBuildStrategy.Quality is null &&
+                localCurrentBuildStrategy.Version is null)
+            {
+                Assert.Skip("Local Radius/Azure gap testing requires an explicit current-build CLI strategy. Set ASPIRE_E2E_ARCHIVE to a localhive archive or configure ASPIRE_E2E_QUALITY, ASPIRE_E2E_VERSION, or GITHUB_PR_NUMBER.");
+            }
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(8));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cts.Token, TestContext.Current.CancellationToken);
+        var cancellationToken = linkedCts.Token;
+
+        using var workspace = TemporaryWorkspace.Create(output);
+        const string projectName = "RadiusAzureGap";
+
+        using var terminal = DeploymentE2ETestHelpers.CreateTestTerminal();
+        var pendingRun = terminal.RunAsync(cancellationToken);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+
+        await auto.PrepareEnvironmentAsync(workspace, counter);
+        await auto.InstallCurrentBuildAspireCliAsync(counter, output);
+
+        output.WriteLine("Creating an empty AppHost for the Radius/Azure resource gap check...");
+        await auto.AspireNewAsync(projectName, counter, template: AspireTemplate.EmptyAppHost);
+
+        await auto.TypeAsync($"cd {projectName}");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.Radius --all --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.Azure.KeyVault --all --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(3));
+
+        var appHostFilePath = Path.Combine(
+            workspace.WorkspaceRoot.FullName,
+            projectName,
+            $"{projectName}.AppHost",
+            "AppHost.cs");
+
+        File.WriteAllText(appHostFilePath,
+            """
+            // Licensed to the .NET Foundation under one or more agreements.
+            // The .NET Foundation licenses this file to you under the MIT license.
+
+            #pragma warning disable ASPIREPIPELINES001
+            #pragma warning disable ASPIRERADIUS003
+
+            var builder = DistributedApplication.CreateBuilder(args);
+
+            var radius = builder.AddRadiusEnvironment("radius")
+                .WithAzureProvider(
+                    subscriptionId: "11111111-1111-1111-1111-111111111111",
+                    resourceGroup: "rg-radius-gap",
+                    azure => azure.WithWorkloadIdentity(
+                        tenantId: "22222222-2222-2222-2222-222222222222",
+                        clientId: "33333333-3333-3333-3333-333333333333"));
+
+            var vault = builder.AddAzureKeyVault("vault");
+
+            builder.AddContainer("consumer", "mcr.microsoft.com/dotnet/samples", "aspnetapp")
+                .WithReference(vault)
+                .WithComputeEnvironment(radius);
+
+            builder.Build().Run();
+            """);
+
+        await auto.TypeAsync($"cd {projectName}.AppHost");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter);
+
+        output.WriteLine("Publishing is expected to time out: Radius tries to resolve Azure Bicep outputs during container env emission.");
+        await auto.TypeAsync(
+            "set +e; " +
+            "mkdir -p \"$HOME/.aspire/logs\"; " +
+            "rm -rf ../out ../publish.log ../radius-gap-evidence.log ../radius-gap-log-start; " +
+            ": > ../radius-gap-log-start; " +
+            "timeout 45s aspire publish --output-path ../out --non-interactive > ../publish.log 2>&1; " +
+            "code=$?; " +
+            "if [ \"$code\" = \"124\" ]; then " +
+            "if [ -f ../out/app.bicep ]; then cat ../publish.log; echo \"Radius app.bicep should not be produced for the current gap.\"; exit 1; fi; " +
+            "logs=$(find \"$HOME/.aspire/logs\" -maxdepth 1 -name 'cli_*.log' -newer ../radius-gap-log-start -print); " +
+            "if [ -z \"$logs\" ]; then cat ../publish.log; echo \"Radius publish timed out, but no invocation-specific CLI log was produced.\"; exit 1; fi; " +
+            "if ! grep -hE \"Azure[.]BicepOutputReference[.]GetValueAsync|RadiusInfrastructureBuilder[.]ResolveEnvironmentAsync\" $logs > ../radius-gap-evidence.log 2>/dev/null; then " +
+            "cat ../publish.log; " +
+            "echo \"Radius publish timed out, but this invocation's CLI logs did not show Azure Bicep output resolution evidence.\"; " +
+            "printf '%s\\n' $logs; " +
+            "exit 1; " +
+            "fi; " +
+            "tail -8 ../radius-gap-evidence.log; " +
+            // Split the marker token in the source command (RADIUS_AZURE_REFERENCE_GAP''_TIMEOUT
+            // evaluates to RADIUS_AZURE_REFERENCE_GAP_TIMEOUT) so Hex1b cannot self-match the
+            // echoed command line before the shell actually reaches the gap assertion.
+            "echo RADIUS_AZURE_REFERENCE_GAP''_TIMEOUT; " +
+            "exit 0; " +
+            "fi; " +
+            "cat ../publish.log; " +
+            "echo \"Expected Radius publish to time out while resolving Azure resource references, but exit code was $code.\"; " +
+            "exit 1");
+        await auto.EnterAsync();
+        await auto.WaitUntilAsync(
+            s => new CellPatternSearcher().Find("RADIUS_AZURE_REFERENCE_GAP_TIMEOUT").Search(s).Count > 0,
+            timeout: TimeSpan.FromSeconds(90),
+            description: "Radius/Azure reference gap timeout marker");
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
+
+        await auto.TypeAsync("exit");
+        await auto.EnterAsync();
+
+        await pendingRun;
+    }
+}

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -514,10 +514,10 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            // Port-forward directly to the Deployment. Radius does not synthesize a Kubernetes
-            // Service for Radius.Compute/containers workloads (only recipe-backed resources such as
-            // the Redis cache get one), so there is no Service to target. kubectl port-forward
-            // resolves a ready pod in the Deployment; 8080 is the container port Aspire assigns to
+            // Port-forward directly to the Deployment. Even though the Radius container recipe
+            // creates a ClusterIP Service for each container that declares ports (asserted in
+            // Step 29), port-forwarding to the Deployment reaches a ready pod directly without
+            // depending on Service endpoint readiness. 8080 is the container port Aspire assigns to
             // published containers (ASPNETCORE_HTTP_PORTS=8080).
             output.WriteLine("Step 26: Verifying apiservice endpoint via port-forward...");
             await auto.TypeAsync($"kubectl port-forward -n {appNamespace} deployment/apiservice 18080:8080 &");
@@ -559,9 +559,11 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
             // Assert the recipe-created Service explicitly before asserting the app path, so a
-            // service-discovery/DNS regression is distinguishable from an application failure.
-            output.WriteLine("Step 29: Verifying the recipe created Service apiservice-apiservice on the container port (8080)...");
-            await auto.TypeAsync($"kubectl get svc -n {appNamespace} apiservice-apiservice -o jsonpath='{{.spec.ports[0].port}}' | grep -qx 8080");
+            // service-discovery/DNS regression is distinguishable from an application failure. Verify
+            // the full recipe contract (type == ClusterIP, port == targetPort == containerPort == 8080)
+            // so a change to any of those — not just the Service port — is caught here.
+            output.WriteLine("Step 29: Verifying the recipe created a ClusterIP Service apiservice-apiservice with port==targetPort==8080...");
+            await auto.TypeAsync($"test \"$(kubectl get svc -n {appNamespace} apiservice-apiservice -o jsonpath='{{.spec.type}}/{{.spec.ports[0].port}}/{{.spec.ports[0].targetPort}}')\" = 'ClusterIP/8080/8080'");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -528,25 +528,23 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
             // Verify the webfrontend container serves HTTP by probing its home page, then verify
-            // the Redis output-cache connection independently through a diagnostic endpoint added
-            // above. We also add a direct uncached webfrontend -> apiservice diagnostic endpoint,
-            // but deliberately do not assert it yet: the live Radius 0.59 behavior for Kubernetes
-            // Service creation/naming from Radius.Compute/containers is not substantiated here.
+            // the Redis output-cache connection and the direct webfrontend -> apiservice call
+            // through the diagnostic endpoints added above.
             //
-            // The current Radius resource-types-contrib Kubernetes container recipe does create a
-            // ClusterIP Service for each container that declares ports. Its service config uses:
+            // The Radius resource-types-contrib Kubernetes container recipe creates a ClusterIP
+            // Service for each container that declares ports. Its service config uses:
             //   name: '${normalizedName}-${svc.containerName}'
             //   port: port.value.containerPort
             //   targetPort: port.value.containerPort
             // where normalizedName is context.resource.name and svc.containerName is the key under
             // properties.containers. Aspire emits a single container entry keyed by the resource
-            // name, so the candidate apiservice DNS name to try is:
-            //   apiservice-apiservice.<namespace>.svc.cluster.local:8080
+            // name, so apiservice's Service is `apiservice-apiservice` listening on the container
+            // port (8080). Aspire's Radius service discovery emits the matching address
+            //   http://apiservice-apiservice.<namespace>.svc.cluster.local:8080
+            // (see RadiusEnvironmentResource.GetHostAddressExpression / RadiusServiceDiscovery), so
+            // the webfrontend -> apiservice call and the /weather page resolve in-cluster.
             // Source:
             // https://github.com/radius-project/resource-types-contrib/blob/main/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
-            //
-            // A live deploy-test/* run against the pinned rad 0.59 control plane must confirm the
-            // exact Service name before asserting /radius-diagnostics/apiservice and /weather.
             output.WriteLine("Step 27: Verifying webfrontend home page via port-forward...");
             await auto.TypeAsync($"kubectl port-forward -n {appNamespace} deployment/webfrontend 18081:8080 &");
             await auto.EnterAsync();
@@ -560,14 +558,29 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
-            output.WriteLine("Step 29: Skipping direct apiservice and /weather assertions until Radius container Service DNS is live-validated.");
+            // Assert the recipe-created Service explicitly before asserting the app path, so a
+            // service-discovery/DNS regression is distinguishable from an application failure.
+            output.WriteLine("Step 29: Verifying the recipe created Service apiservice-apiservice on the container port (8080)...");
+            await auto.TypeAsync($"kubectl get svc -n {appNamespace} apiservice-apiservice -o jsonpath='{{.spec.ports[0].port}}' | grep -qx 8080");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(30));
 
-            output.WriteLine("Step 30: Cleaning up port-forwards...");
+            output.WriteLine("Step 30: Verifying direct webfrontend -> apiservice connectivity...");
+            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/radius-diagnostics/apiservice -o /dev/null -w '%{http_code}' && echo ' OK' && break; done");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 31: Verifying the /weather page (webfrontend -> apiservice via Redis output cache)...");
+            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/weather -o /dev/null -w '%{http_code}' && echo ' OK' && break; done");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 32: Cleaning up port-forwards...");
             await auto.TypeAsync("kill %1 %2 2>/dev/null; true");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
 
-            output.WriteLine("Step 31: Exiting terminal...");
+            output.WriteLine("Step 33: Exiting terminal...");
             await auto.TypeAsync("exit");
             await auto.EnterAsync();
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -324,6 +324,7 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             var projectDir = Path.Combine(workspace.WorkspaceRoot.FullName, projectName);
             var appHostDir = Path.Combine(projectDir, $"{projectName}.AppHost");
             var appHostFilePath = Path.Combine(appHostDir, "AppHost.cs");
+            var webProgramFilePath = Path.Combine(projectDir, $"{projectName}.Web", "Program.cs");
 
             output.WriteLine($"Step 16: Modifying AppHost.cs at: {appHostFilePath}");
             var content = File.ReadAllText(appHostFilePath);
@@ -359,6 +360,39 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
 
             File.WriteAllText(appHostFilePath, content);
             output.WriteLine("Modified AppHost.cs with AddRadiusEnvironment + WithContainerImage");
+
+            output.WriteLine($"Step 16b: Adding Radius diagnostics endpoints to Web Program.cs at: {webProgramFilePath}");
+            var webProgram = File.ReadAllText(webProgramFilePath);
+            if (!webProgram.Contains("using Microsoft.AspNetCore.OutputCaching;"))
+            {
+                webProgram = "using Microsoft.AspNetCore.OutputCaching;\n" + webProgram;
+            }
+
+            webProgram = webProgram.Replace(
+                "app.MapRazorComponents<App>()",
+                """
+                app.MapGet("/radius-diagnostics/apiservice", async (WeatherApiClient weatherApi, CancellationToken cancellationToken) =>
+                {
+                    var forecasts = await weatherApi.GetWeatherAsync(cancellationToken: cancellationToken);
+                    return Results.Ok(new { count = forecasts.Length });
+                });
+
+                app.MapGet("/radius-diagnostics/cache", async (IOutputCacheStore cacheStore, CancellationToken cancellationToken) =>
+                {
+                    var key = $"radius-diagnostics:{Guid.NewGuid():N}";
+                    var payload = new byte[] { 1, 2, 3, 4 };
+
+                    await cacheStore.SetAsync(key, payload, tags: null, validFor: TimeSpan.FromMinutes(1), cancellationToken);
+                    var cached = await cacheStore.GetAsync(key, cancellationToken);
+
+                    return cached is { Length: 4 } ? Results.Ok("OK") : Results.Problem("Redis output cache round-trip failed.");
+                });
+
+                app.MapRazorComponents<App>()
+                """);
+
+            File.WriteAllText(webProgramFilePath, webProgram);
+            output.WriteLine("Modified Web Program.cs with direct apiservice and Redis output-cache diagnostics");
 
             // ===== PHASE 4: Build and push the container images to ACR =====
 
@@ -493,17 +527,26 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
-            // Verify the webfrontend container serves HTTP by probing its home page.
+            // Verify the webfrontend container serves HTTP by probing its home page, then verify
+            // the Redis output-cache connection independently through a diagnostic endpoint added
+            // above. We also add a direct uncached webfrontend -> apiservice diagnostic endpoint,
+            // but deliberately do not assert it yet: the live Radius 0.59 behavior for Kubernetes
+            // Service creation/naming from Radius.Compute/containers is not substantiated here.
             //
-            // Note: we deliberately do NOT probe /weather here. That page renders forecast data
-            // fetched from the apiservice container (@inject WeatherApiClient) through the Redis
-            // output cache. On Radius that cross-service call does not resolve: Radius creates no
-            // Kubernetes Service for a Radius.Compute/containers workload, so Aspire's service
-            // discovery hostname ("apiservice") has nothing to resolve to, and `rad app graph`
-            // shows webfrontend wired only to the cache resource, not to apiservice. The home page
-            // does not depend on apiservice, so it is the reliable end-to-end signal that the
-            // second container deployed and is serving. curl retries to absorb the brief window
-            // while the port-forward and container finish coming up.
+            // The current Radius resource-types-contrib Kubernetes container recipe does create a
+            // ClusterIP Service for each container that declares ports. Its service config uses:
+            //   name: '${normalizedName}-${svc.containerName}'
+            //   port: port.value.containerPort
+            //   targetPort: port.value.containerPort
+            // where normalizedName is context.resource.name and svc.containerName is the key under
+            // properties.containers. Aspire emits a single container entry keyed by the resource
+            // name, so the candidate apiservice DNS name to try is:
+            //   apiservice-apiservice.<namespace>.svc.cluster.local:8080
+            // Source:
+            // https://github.com/radius-project/resource-types-contrib/blob/main/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+            //
+            // A live deploy-test/* run against the pinned rad 0.59 control plane must confirm the
+            // exact Service name before asserting /radius-diagnostics/apiservice and /weather.
             output.WriteLine("Step 27: Verifying webfrontend home page via port-forward...");
             await auto.TypeAsync($"kubectl port-forward -n {appNamespace} deployment/webfrontend 18081:8080 &");
             await auto.EnterAsync();
@@ -512,12 +555,19 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
-            output.WriteLine("Step 28: Cleaning up port-forwards...");
+            output.WriteLine("Step 28: Verifying webfrontend -> Redis output-cache connectivity...");
+            await auto.TypeAsync("for i in $(seq 1 10); do sleep 3 && curl -sf http://localhost:18081/radius-diagnostics/cache -o /dev/null -w '%{http_code}' && echo ' OK' && break; done");
+            await auto.EnterAsync();
+            await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
+
+            output.WriteLine("Step 29: Skipping direct apiservice and /weather assertions until Radius container Service DNS is live-validated.");
+
+            output.WriteLine("Step 30: Cleaning up port-forwards...");
             await auto.TypeAsync("kill %1 %2 2>/dev/null; true");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(10));
 
-            output.WriteLine("Step 29: Exiting terminal...");
+            output.WriteLine("Step 31: Exiting terminal...");
             await auto.TypeAsync("exit");
             await auto.EnterAsync();
 

--- a/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
@@ -313,7 +313,8 @@ public class ConfigureRadiusInfrastructureTests
             {
                 opts.Containers[0].ContainerName = "renamed";
             });
-        builder.AddContainer("api", "myapp/api", "latest");
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
 
         using var app = builder.Build();
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -324,6 +325,30 @@ public class ConfigureRadiusInfrastructureTests
         var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
         Assert.Contains("api", ex.Message);
         Assert.Contains("renamed", ex.Message);
+    }
+
+    [Fact]
+    public void ConfigureCallback_RenamingPortlessContainerName_DoesNotThrow()
+    {
+        // A portless container has no Service and no `services__*` value addresses it, so Radius
+        // permits its top-level `name:` to differ from the map key. Renaming it must be allowed —
+        // the name-equality guard only applies to containers with a service-discovery contract.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].ContainerName = "renamed";
+            });
+        builder.AddContainer("api", "myapp/api", "latest");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var bicep = context.GenerateBicep(model);
+        Assert.Contains("renamed", bicep);
     }
 
     [Fact]
@@ -339,7 +364,8 @@ public class ConfigureRadiusInfrastructureTests
             {
                 opts.Containers[0].ContainerName = new IdentifierExpression("computedName");
             });
-        builder.AddContainer("api", "myapp/api", "latest");
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
 
         using var app = builder.Build();
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -572,5 +598,36 @@ public class ConfigureRadiusInfrastructureTests
         var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
         Assert.Contains($"{longName}-{longName}", ex.Message);
         Assert.Contains("63", ex.Message);
+    }
+
+    [Fact]
+    public void ConfigureCallback_AddingDuplicatePortToContainer_Throws()
+    {
+        // The pre-callback dedup in ResolvePorts only covers the baseline ports. A callback that adds
+        // a second endpoint resolving to the same (containerPort, protocol) as a preserved one would
+        // make the recipe emit duplicate Kubernetes Service ports, so the post-callback validation
+        // must re-run the dedup on the FINAL literal ports and fail fast.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].Ports["http2"] = new ContainerPortConstruct
+                {
+                    ContainerPort = 5000,
+                    Protocol = "TCP",
+                };
+            });
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains("api", ex.Message);
+        Assert.Contains("5000/TCP", ex.Message);
     }
 }

--- a/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
@@ -325,4 +325,110 @@ public class ConfigureRadiusInfrastructureTests
         Assert.Contains("api", ex.Message);
         Assert.Contains("renamed", ex.Message);
     }
+
+    [Fact]
+    public void ConfigureCallback_SettingNonLiteralContainerName_Throws()
+    {
+        // A callback that replaces the resource-name literal with a computed Bicep expression can't
+        // be verified against the `properties.containers` map key, and service discovery still
+        // targets the literal name, so the publisher must reject it rather than emit a Service under
+        // a name consumers never address.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].ContainerName = new IdentifierExpression("computedName");
+            });
+        builder.AddContainer("api", "myapp/api", "latest");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains("api", ex.Message);
+        Assert.Contains("non-literal", ex.Message);
+    }
+
+    [Fact]
+    public void ConfigureCallback_ChangingContainerPort_Throws()
+    {
+        // Service discovery URLs (`services__*`) are emitted from the pre-callback ports, so a
+        // callback that changes a container port would leave consumers pointing at a stale port.
+        // The publisher must fail fast instead of emitting an inconsistent manifest.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].Ports["http"] = new ContainerPortConstruct
+                {
+                    ContainerPort = 9999,
+                    Protocol = "TCP",
+                };
+            });
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains("http", ex.Message);
+        Assert.Contains("5000", ex.Message);
+        Assert.Contains("9999", ex.Message);
+    }
+
+    [Fact]
+    public void ConfigureCallback_RemovingContainerPort_Throws()
+    {
+        // Removing a port that service discovery already emitted breaks cross-container calls just
+        // like changing it, so the publisher must reject that too.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].Ports.Clear();
+            });
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains("http", ex.Message);
+        Assert.Contains("removed", ex.Message);
+    }
+
+    [Fact]
+    public void PublishingContainer_WithNameTooLongForKubernetesService_Throws()
+    {
+        // The Radius recipe names the ClusterIP Service `{name}-{name}`, and a Kubernetes Service
+        // name is an RFC 1123 DNS label limited to 63 characters. Aspire allows resource names up to
+        // 64 characters, so a container that declares ports but has a >31-character name would emit a
+        // Service the control plane rejects. Fail fast at publish time with an actionable message.
+        var longName = new string('a', 40);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv");
+        builder.AddContainer(longName, "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains($"{longName}-{longName}", ex.Message);
+        Assert.Contains("63", ex.Message);
+    }
 }

--- a/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
@@ -299,4 +299,30 @@ public class ConfigureRadiusInfrastructureTests
         Assert.Contains("environment: renamedEnv.id", bicep);
         Assert.DoesNotContain("environment: myenv.id", bicep);
     }
+
+    [Fact]
+    public void ConfigureCallback_RenamingContainerName_Throws()
+    {
+        // The container v2 schema requires the top-level `name:` to equal the
+        // `properties.containers` map key, and Aspire service discovery targets the original
+        // resource name, so renaming a container's name would produce an invalid, unreachable
+        // manifest. The publisher must fail fast instead of emitting it.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].ContainerName = "renamed";
+            });
+        builder.AddContainer("api", "myapp/api", "latest");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains("api", ex.Message);
+        Assert.Contains("renamed", ex.Message);
+    }
 }

--- a/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
@@ -409,6 +409,124 @@ public class ConfigureRadiusInfrastructureTests
     }
 
     [Fact]
+    public void ConfigureCallback_ChangingContainerPortProtocol_Throws()
+    {
+        // Service discovery emits the pre-callback protocol as well as the port, so a callback that
+        // changes only the protocol (leaving the port intact) still diverges from what consumers
+        // were told and must be rejected.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].Ports["http"] = new ContainerPortConstruct
+                {
+                    ContainerPort = 5000,
+                    Protocol = "UDP",
+                };
+            });
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains("http", ex.Message);
+        Assert.Contains("TCP", ex.Message);
+        Assert.Contains("UDP", ex.Message);
+    }
+
+    [Fact]
+    public void ConfigureCallback_SettingNonLiteralContainerPort_Throws()
+    {
+        // Service discovery emits a fixed literal port. A callback that swaps in a computed Bicep
+        // expression could evaluate to a different value at deploy time, so it cannot be reconciled
+        // with the already-emitted `services__*` port and must be rejected.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].Ports["http"] = new ContainerPortConstruct
+                {
+                    ContainerPort = new IdentifierExpression("computedPort"),
+                    Protocol = "TCP",
+                };
+            });
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains("http", ex.Message);
+        Assert.Contains("non-literal", ex.Message);
+    }
+
+    [Fact]
+    public void ConfigureCallback_RemovingContainer_Throws()
+    {
+        // Service discovery already emitted `services__*` variables addressing the container, so a
+        // callback that drops the workload entirely would leave consumers pointing at a Service that
+        // is never produced. The publisher must fail fast.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers.Clear();
+            });
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 5000, name: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains("api", ex.Message);
+        Assert.Contains("removed or replaced", ex.Message);
+    }
+
+    [Fact]
+    public void ConfigureCallback_AddingPortToPortlessContainerWithLongName_Throws()
+    {
+        // A portless container has no Service, so its long name is harmless until a callback adds the
+        // first port. The Service-name length check therefore has to run on the FINAL container set:
+        // here the callback introduces a port, and the resulting `{name}-{name}` Service name
+        // overflows the 63-character Kubernetes limit.
+        var longName = new string('a', 40);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers[0].Ports["http"] = new ContainerPortConstruct
+                {
+                    ContainerPort = 8080,
+                    Protocol = "TCP",
+                };
+            });
+        builder.AddContainer(longName, "myapp/api", "latest");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
+        Assert.Contains($"{longName}-{longName}", ex.Message);
+        Assert.Contains("63", ex.Message);
+    }
+
+    [Fact]
     public void PublishingContainer_WithNameTooLongForKubernetesService_Throws()
     {
         // The Radius recipe names the ClusterIP Service `{name}-{name}`, and a Kubernetes Service

--- a/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Radius.Tests/Publishing/ConfigureRadiusInfrastructureTests.cs
@@ -303,10 +303,10 @@ public class ConfigureRadiusInfrastructureTests
     [Fact]
     public void ConfigureCallback_RenamingContainerName_Throws()
     {
-        // The container v2 schema requires the top-level `name:` to equal the
-        // `properties.containers` map key, and Aspire service discovery targets the original
-        // resource name, so renaming a container's name would produce an invalid, unreachable
-        // manifest. The publisher must fail fast instead of emitting it.
+        // Radius permits a top-level `name:` and `properties.containers` map key to differ, but
+        // Aspire service discovery targets the original resource name, so renaming a container's
+        // name would make the emitted `services__*` values point at a Service that is never
+        // produced. The publisher must fail fast instead of emitting an unreachable manifest.
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         builder.AddRadiusEnvironment("myenv")
             .ConfigureRadiusInfrastructure(opts =>
@@ -467,6 +467,30 @@ public class ConfigureRadiusInfrastructureTests
         var ex = Assert.Throws<InvalidOperationException>(() => context.GenerateBicep(model));
         Assert.Contains("http", ex.Message);
         Assert.Contains("non-literal", ex.Message);
+    }
+
+    [Fact]
+    public void ConfigureCallback_RemovingPortlessContainer_DoesNotThrow()
+    {
+        // A portless container has no Service and no `services__*` value can address it, so removing
+        // it in a callback is harmless. The service-discovery invariant must not reject this valid
+        // customization — only removal of a container that had ports (and thus a Service) is rejected.
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv")
+            .ConfigureRadiusInfrastructure(opts =>
+            {
+                opts.Containers.Clear();
+            });
+        builder.AddContainer("api", "myapp/api", "latest");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        RadiusTestHelper.AttachDeploymentTargets(radiusEnv, model);
+        var context = new RadiusBicepPublishingContext(radiusEnv);
+
+        var bicep = context.GenerateBicep(model);
+        Assert.DoesNotContain("myapp/api", bicep);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Radius.Tests/Publishing/ContainerEnvironmentEmissionTests.cs
+++ b/tests/Aspire.Hosting.Radius.Tests/Publishing/ContainerEnvironmentEmissionTests.cs
@@ -56,9 +56,11 @@ public class ContainerEnvironmentEmissionTests
 
         var bicep = Generate(model, radiusEnv);
 
-        // Standard service-discovery variable plus a cluster FQDN that includes the namespace segment.
+        // Standard service-discovery variable plus a cluster FQDN that includes the namespace
+        // segment. The host is the recipe Service name ({name}-{name}) and the URL carries the
+        // container port (the recipe Service listens on the container port, not port 80).
         Assert.Contains("services__backend__http__0: {", bicep);
-        Assert.Contains("value: 'http://backend.default.svc.cluster.local'", bicep);
+        Assert.Contains("value: 'http://backend-backend.default.svc.cluster.local:8080'", bicep);
     }
 
     [Fact]
@@ -77,7 +79,7 @@ public class ContainerEnvironmentEmissionTests
 
         var bicep = Generate(model, radiusEnv);
 
-        Assert.Contains("value: 'http://backend.custom-ns.svc.cluster.local'", bicep);
+        Assert.Contains("value: 'http://backend-backend.custom-ns.svc.cluster.local:8080'", bicep);
     }
 
     [Fact]
@@ -104,8 +106,8 @@ public class ContainerEnvironmentEmissionTests
         var bicep = Generate(model, frontend);
 
         // The api container lives in frontend-ns but must reach backend in data-ns.
-        Assert.Contains("value: 'http://backend.data-ns.svc.cluster.local'", bicep);
-        Assert.DoesNotContain("backend.frontend-ns.svc.cluster.local", bicep, StringComparison.Ordinal);
+        Assert.Contains("value: 'http://backend-backend.data-ns.svc.cluster.local:8080'", bicep);
+        Assert.DoesNotContain("backend-backend.frontend-ns.svc.cluster.local", bicep, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -127,6 +129,31 @@ public class ContainerEnvironmentEmissionTests
         Assert.Contains("http: {", bicep);
         Assert.Contains("containerPort: 5000", bicep);
         Assert.Contains("protocol: 'TCP'", bicep);
+    }
+
+    [Fact]
+    public void EndpointsResolvingToSamePort_EmitSingleDeduplicatedContainerPort()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddRadiusEnvironment("myenv");
+        // Two endpoints that resolve to the same container port/protocol. The recipe would reject a
+        // Service with two identical (port, protocol) entries, so ResolvePorts must dedup them,
+        // matching the Kubernetes publisher. See: https://github.com/microsoft/aspire/issues/14029
+        builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 8080, name: "http")
+            .WithHttpEndpoint(targetPort: 8080, name: "http2");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+
+        var bicep = Generate(model, radiusEnv);
+
+        // Exactly one container port entry survives the (port, protocol) dedup: the first endpoint.
+        Assert.Contains("http: {", bicep);
+        Assert.DoesNotContain("http2: {", bicep);
+        var occurrences = bicep.Split("containerPort: 8080").Length - 1;
+        Assert.Equal(1, occurrences);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Radius.Tests/Publishing/RadiusServiceDiscoveryTests.cs
+++ b/tests/Aspire.Hosting.Radius.Tests/Publishing/RadiusServiceDiscoveryTests.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Radius.Publishing;
+using System.Net.Sockets;
+
+namespace Aspire.Hosting.Radius.Tests.Publishing;
+
+public class RadiusServiceDiscoveryTests
+{
+    [Fact]
+    public void GetServiceName_DoublesResourceName()
+    {
+        var resource = new ContainerResource("apiservice");
+
+        Assert.Equal("apiservice-apiservice", RadiusServiceDiscovery.GetServiceName(resource));
+    }
+
+    [Fact]
+    public void ResolveServicePort_PrefersTargetPort()
+    {
+        var resource = new ContainerResource("api");
+        resource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", port: 5000, targetPort: 8080));
+
+        Assert.Equal(8080, RadiusServiceDiscovery.ResolveServicePort(resource, "http"));
+    }
+
+    [Fact]
+    public void ResolveServicePort_ContainerUsesHostPortAsContainerPort()
+    {
+        // A container with only a host port listens on that port (ResolveEndpoints treats it as the
+        // implicit container port).
+        var resource = new ContainerResource("api");
+        resource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", port: 5000));
+
+        Assert.Equal(5000, RadiusServiceDiscovery.ResolveServicePort(resource, "http"));
+    }
+
+    [Fact]
+    public void ResolveServicePort_DefaultsProjectDefaultHttpToStandardContainerPort()
+    {
+        // A project's default HTTP endpoint has no resolved port at publish time (the deployment
+        // tool would assign one); it must still get a container port so the recipe creates a Service.
+        var resource = new ProjectResource("webapp");
+        resource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http"));
+
+        Assert.Equal(RadiusServiceDiscovery.DefaultProjectContainerPort, RadiusServiceDiscovery.ResolveServicePort(resource, "http"));
+    }
+
+    [Fact]
+    public void ResolveServicePort_DefaultsExplicitPortlessHttpsToContainerPort()
+    {
+        // An explicit portless HTTPS endpoint (not the synthetic default) must still get a container
+        // port so the recipe creates a Service — matching the Kubernetes publisher's 8080 default.
+        var resource = new ProjectResource("webapp");
+        resource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "https", name: "https"));
+
+        Assert.Equal(RadiusServiceDiscovery.DefaultProjectContainerPort, RadiusServiceDiscovery.ResolveServicePort(resource, "https"));
+    }
+
+    [Fact]
+    public void ResolveServicePort_SkipsSyntheticDefaultHttpsEndpoint()
+    {
+        // The synthetic default HTTPS endpoint is skipped: containers don't terminate TLS in-cluster
+        // and the framework reuses the HTTP port for it, so no separate Service is created.
+        var resource = new ProjectResource("webapp");
+        var https = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "https", name: "https");
+        resource.Annotations.Add(https);
+        ((IProjectLaunchDefaultsResource)resource).DefaultHttpsEndpoint = https;
+
+        Assert.Null(RadiusServiceDiscovery.ResolveServicePort(resource, "https"));
+    }
+
+    [Fact]
+    public void ResolveServicePort_AllocatesDistinctPortsForMultiplePortlessEndpoints()
+    {
+        // Multiple portless endpoints must not collapse onto the same Service port; ResolveEndpoints
+        // allocates a distinct port for each so the recipe emits a valid multi-port Service.
+        var resource = new ContainerResource("api");
+        resource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "tcp", name: "one"));
+        resource.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "tcp", name: "two"));
+
+        var first = RadiusServiceDiscovery.ResolveServicePort(resource, "one");
+        var second = RadiusServiceDiscovery.ResolveServicePort(resource, "two");
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotEqual(first, second);
+    }
+}

--- a/tests/Aspire.Hosting.Radius.Tests/RadiusEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Radius.Tests/RadiusEnvironmentResourceTests.cs
@@ -4,6 +4,8 @@
 #pragma warning disable ASPIRECOMPUTE002
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Radius.Tests;
 
@@ -61,8 +63,38 @@ public class RadiusEnvironmentResourceTests
 
         var expression = ((IComputeEnvironmentResource)environment).GetHostAddressExpression(endpoint);
 
-        // The namespace segment is required for the FQDN to resolve across namespaces; the
-        // default environment namespace is "default".
-        Assert.Equal("my-service.default.svc.cluster.local", expression.ValueExpression);
+        // The Radius Kubernetes container recipe names the Service `{name}-{name}`
+        // (${normalizedName}-${containerName}, both = the resource name), so service discovery must
+        // address that Service. The namespace segment is required for the FQDN to resolve across
+        // namespaces; the default environment namespace is "default".
+        Assert.Equal("my-service-my-service.default.svc.cluster.local", expression.ValueExpression);
+    }
+
+    [Theory]
+    [InlineData(EndpointProperty.Url, "http://api-api.default.svc.cluster.local:8080")]
+    [InlineData(EndpointProperty.Host, "api-api.default.svc.cluster.local")]
+    [InlineData(EndpointProperty.IPV4Host, "api-api.default.svc.cluster.local")]
+    [InlineData(EndpointProperty.HostAndPort, "api-api.default.svc.cluster.local:8080")]
+    [InlineData(EndpointProperty.Port, "8080")]
+    [InlineData(EndpointProperty.TargetPort, "8080")]
+    [InlineData(EndpointProperty.Scheme, "http")]
+    public void GetEndpointPropertyExpression_UsesServiceNameAndContainerPort(EndpointProperty property, string expected)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var env = builder.AddRadiusEnvironment("radius");
+        var api = builder.AddContainer("api", "myapp/api", "latest")
+            .WithHttpEndpoint(targetPort: 8080, name: "http");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var radiusEnv = model.Resources.OfType<RadiusEnvironmentResource>().First();
+        var endpoint = api.GetEndpoint("http");
+
+        var expression = ((IComputeEnvironmentResource)radiusEnv)
+            .GetEndpointPropertyExpression(endpoint.Property(property));
+
+        // The recipe Service is `{name}-{name}` and listens on the container port (8080), so the
+        // Url/Host/Port all target that Service and port rather than the bare name / port 80.
+        Assert.Equal(expected, expression.ValueExpression);
     }
 }


### PR DESCRIPTION
## Description

Aspire's Radius publisher (`src/Aspire.Hosting.Radius`) delegates Kubernetes `Service` creation to an **external** recipe ([`kubernetes-containers.bicep`](https://github.com/radius-project/resource-types-contrib/blob/main/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep), radius-project/resource-types-contrib). Unlike the Kubernetes publisher — which owns both the Service and the addresses it emits — Radius does not create the Service itself, so the service-discovery values Aspire emits into consumer containers (the `services__*` env vars) must exactly match what the recipe creates. They didn't, so cross-container calls could not resolve in-cluster: for example, deploying the Aspire Starter template to a Radius-enabled cluster and opening the Blazor `/weather` page failed because `webfrontend → apiservice` never resolved.

This change makes the emitted service-discovery values match the recipe's ClusterIP `Service`.

### What changed (user-visible behavior)

For resources deployed via a Radius compute environment, the `services__*` values now address the Service the recipe actually creates:

- **Host** is `{name}-{name}.{namespace}.svc.cluster.local` — the recipe names the Service `${normalizedName}-${containerName}`, and for an Aspire-emitted container both segments equal the resource name (previously Aspire emitted the bare `{name}`).
- **Port** is the container port (the recipe Service listens on `port == targetPort == containerPort`), not the proxy/host port (previously the http default port, which was omitted).
- A containerized **project's** default HTTP endpoint now declares a container port (`8080`, matching the Kubernetes publisher) so the recipe creates a Service for it; the synthetic default HTTPS endpoint is skipped (no in-cluster TLS termination).
- Endpoints that resolve to the same `(container port, protocol)` are de-duplicated so the recipe never emits a Service with duplicate ports.

### Implementation

- New internal `RadiusServiceDiscovery` helper is the single source of truth for the recipe Service **name** and **port**. Port resolution delegates to the framework's `ResourceExtensions.ResolveEndpoints()` — the same primitive the Kubernetes publisher uses — so the container port emitted into the Bicep and the port emitted into `services__*` URLs cannot disagree.
- `RadiusEnvironmentResource.GetHostAddressExpression` emits the `{name}-{name}` FQDN; a new `GetEndpointPropertyExpression` override sources `Url`/`Port`/`HostAndPort`/`TargetPort` from the same resolved container port.
- `RadiusInfrastructureBuilder.ResolvePorts` resolves ports through the shared helper and de-duplicates by `(container port, protocol)`, mirroring the Kubernetes publisher's `ToService` dedup.
- Reading the synthetic `DefaultHttpsEndpoint` requires internals access, granted via `InternalsVisibleTo` on `Aspire.Hosting` (mirroring `Aspire.Hosting.Kubernetes`).

This branch also includes an earlier commit adding a Radius Azure-resource gap test and Redis-cache diagnostics to the Radius E2E test.

### Validation

- Radius project builds clean; **196/196** `Aspire.Hosting.Radius.Tests` pass (excluding quarantined/outerloop). New unit tests cover the name/port resolver, per-endpoint-property emission, the port dedup, and the container-name rename guard.
- `Aspire.Deployment.EndToEnd.Tests` compiles. The `RadiusStarterDeploymentTests` `/weather` and direct-`apiservice` assertions are un-skipped and now also assert the `apiservice-apiservice` Service and its container port. The live AKS deploy runs via the deploy-test pipeline, not locally.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
