### PR TITLE
Fix DCP monitor timestamp serialization

### DIFF
--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -69,6 +69,7 @@ internal sealed class ContainerSpec
 
     // Optional parent process identity timestamp used with MonitorPid to guard against PID reuse.
     [JsonPropertyName("monitorTimestamp")]
+    [JsonConverter(typeof(KubernetesMicroTimeJsonConverter))]
     public DateTime? MonitorTimestamp { get; set; }
 
     [JsonPropertyName("networks")]

--- a/src/Aspire.Hosting/Dcp/Model/Executable.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Executable.cs
@@ -75,6 +75,7 @@ internal sealed class ExecutableSpec
     /// Optional parent process identity timestamp used with <see cref="MonitorPid"/> to guard against PID reuse.
     /// </summary>
     [JsonPropertyName("monitorTimestamp")]
+    [JsonConverter(typeof(KubernetesMicroTimeJsonConverter))]
     public DateTime? MonitorTimestamp { get; set; }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dcp/Model/KubernetesMicroTimeJsonConverter.cs
+++ b/src/Aspire.Hosting/Dcp/Model/KubernetesMicroTimeJsonConverter.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aspire.Hosting.Dcp.Model;
+
+internal sealed class KubernetesMicroTimeJsonConverter : JsonConverter<DateTime?>
+{
+    private const string UtcFormat = "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'";
+    private const string OffsetFormat = "yyyy-MM-dd'T'HH:mm:ss.ffffffzzz";
+
+    public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType is JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType is not JsonTokenType.String)
+        {
+            throw new JsonException($"Expected a string token for Kubernetes MicroTime but found {reader.TokenType}.");
+        }
+
+        var value = reader.GetString();
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new JsonException("Expected a non-empty Kubernetes MicroTime value.");
+        }
+
+        return value.EndsWith('Z')
+            ? DateTime.ParseExact(value, UtcFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal)
+            : DateTimeOffset.ParseExact(value, OffsetFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).UtcDateTime;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        // DCP models these fields as Kubernetes metav1.MicroTime, whose JSON shape is fixed-width:
+        //   "2026-07-15T18:46:06.123000Z"
+        // See https://github.com/kubernetes/apimachinery/blob/v0.36.0/pkg/apis/meta/v1/micro_time.go.
+        // System.Text.Json trims fractional seconds for DateTime by default, which DCP rejects when
+        // the value is submitted to the API server.
+        var timestamp = value.Value.Kind switch
+        {
+            DateTimeKind.Utc => value.Value,
+            DateTimeKind.Local => value.Value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value.Value, DateTimeKind.Utc)
+        };
+
+        writer.WriteStringValue(timestamp.ToString(UtcFormat, CultureInfo.InvariantCulture));
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3399,10 +3399,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         await appExecutor.RunApplicationAsync();
 
+        var expectedMonitorTimestamp = ToMicroTimePrecision(parentProcessIdentity.Timestamp);
         var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
         Assert.True(container.Spec.Persistent.GetValueOrDefault());
         Assert.Equal(parentProcessIdentity.ProcessId, container.Spec.MonitorPid);
-        Assert.Equal(parentProcessIdentity.Timestamp, container.Spec.MonitorTimestamp);
+        Assert.Equal(expectedMonitorTimestamp, container.Spec.MonitorTimestamp);
 
         var executables = kubernetesService.CreatedResources.OfType<Executable>()
             .Where(e => e.AppModelResourceName is "worker" or "project")
@@ -3412,9 +3413,17 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         {
             Assert.True(exe.Spec.Persistent.GetValueOrDefault());
             Assert.Equal(parentProcessIdentity.ProcessId, exe.Spec.MonitorPid);
-            Assert.Equal(parentProcessIdentity.Timestamp, exe.Spec.MonitorTimestamp);
+            Assert.Equal(expectedMonitorTimestamp, exe.Spec.MonitorTimestamp);
             Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
         });
+
+        static DateTime ToMicroTimePrecision(DateTime timestamp)
+        {
+            // TestKubernetesService clones resources through JSON to catch DCP wire-contract issues.
+            // Kubernetes MicroTime preserves microsecond precision, so sub-microsecond DateTime ticks
+            // are truncated during that round-trip.
+            return new DateTime(timestamp.Ticks - (timestamp.Ticks % 10), timestamp.Kind);
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -6119,6 +6119,44 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             json);
     }
 
+    [Fact]
+    public void MonitorTimestamps_SerializeToDcpMicroTimeWireContract()
+    {
+        var wholeSecondTimestamp = DateTime.SpecifyKind(DateTime.MinValue.AddMinutes(6).AddSeconds(30), DateTimeKind.Utc);
+        var fractionalSecondTimestamp = DateTime.SpecifyKind(DateTime.MinValue.AddMinutes(6).AddSeconds(30).AddMilliseconds(123), DateTimeKind.Utc);
+
+        AssertMonitorTimestamp(new ContainerSpec { MonitorPid = 1234, MonitorTimestamp = wholeSecondTimestamp }, "0001-01-01T00:06:30.000000Z");
+        AssertMonitorTimestamp(new ContainerSpec { MonitorPid = 1234, MonitorTimestamp = fractionalSecondTimestamp }, "0001-01-01T00:06:30.123000Z");
+        AssertMonitorTimestamp(new ExecutableSpec { MonitorPid = 1234, MonitorTimestamp = wholeSecondTimestamp }, "0001-01-01T00:06:30.000000Z");
+        AssertMonitorTimestamp(new ExecutableSpec { MonitorPid = 1234, MonitorTimestamp = fractionalSecondTimestamp }, "0001-01-01T00:06:30.123000Z");
+
+        static void AssertMonitorTimestamp<T>(T spec, string expected)
+        {
+            // DCP models monitorTimestamp as Kubernetes metav1.MicroTime:
+            //   "0001-01-01T00:06:30.000000Z"
+            // Kubernetes requires exactly six fractional digits, while System.Text.Json's
+            // default DateTime converter trims trailing zeroes and can produce values
+            // such as "0001-01-01T00:06:30Z" that DCP rejects.
+            var json = JsonSerializer.Serialize(spec);
+            using var document = JsonDocument.Parse(json);
+
+            Assert.Equal(expected, document.RootElement.GetProperty("monitorTimestamp").GetString());
+        }
+    }
+
+    [Fact]
+    public void MonitorTimestamps_DeserializeFromDcpMicroTimeWireContract()
+    {
+        var containerSpec = JsonSerializer.Deserialize<ContainerSpec>("""{"monitorPid":1234,"monitorTimestamp":"0001-01-01T00:06:30.123000Z"}""");
+        var executableSpec = JsonSerializer.Deserialize<ExecutableSpec>("""{"monitorPid":1234,"monitorTimestamp":"0001-01-01T00:06:30.123000Z"}""");
+        var expectedTimestamp = DateTime.SpecifyKind(DateTime.MinValue.AddMinutes(6).AddSeconds(30).AddMilliseconds(123), DateTimeKind.Utc);
+
+        Assert.NotNull(containerSpec);
+        Assert.Equal(expectedTimestamp, containerSpec.MonitorTimestamp);
+        Assert.NotNull(executableSpec);
+        Assert.Equal(expectedTimestamp, executableSpec.MonitorTimestamp);
+    }
+
     private static DcpExecutor CreateAppExecutor(
         DistributedApplicationModel distributedAppModel,
         IHostEnvironment? hostEnvironment = null,

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3399,11 +3399,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         await appExecutor.RunApplicationAsync();
 
-        var expectedMonitorTimestamp = ToMicroTimePrecision(parentProcessIdentity.Timestamp);
         var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
         Assert.True(container.Spec.Persistent.GetValueOrDefault());
         Assert.Equal(parentProcessIdentity.ProcessId, container.Spec.MonitorPid);
-        Assert.Equal(expectedMonitorTimestamp, container.Spec.MonitorTimestamp);
+        Assert.NotNull(container.Spec.MonitorTimestamp);
+        Assert.Equal(parentProcessIdentity.Timestamp, container.Spec.MonitorTimestamp.Value, TimeSpan.FromMicroseconds(1));
 
         var executables = kubernetesService.CreatedResources.OfType<Executable>()
             .Where(e => e.AppModelResourceName is "worker" or "project")
@@ -3413,17 +3413,10 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         {
             Assert.True(exe.Spec.Persistent.GetValueOrDefault());
             Assert.Equal(parentProcessIdentity.ProcessId, exe.Spec.MonitorPid);
-            Assert.Equal(expectedMonitorTimestamp, exe.Spec.MonitorTimestamp);
+            Assert.NotNull(exe.Spec.MonitorTimestamp);
+            Assert.Equal(parentProcessIdentity.Timestamp, exe.Spec.MonitorTimestamp.Value, TimeSpan.FromMicroseconds(1));
             Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
         });
-
-        static DateTime ToMicroTimePrecision(DateTime timestamp)
-        {
-            // TestKubernetesService clones resources through JSON to catch DCP wire-contract issues.
-            // Kubernetes MicroTime preserves microsecond precision, so sub-microsecond DateTime ticks
-            // are truncated during that round-trip.
-            return new DateTime(timestamp.Ticks - (timestamp.Ticks % 10), timestamp.Kind);
-        }
     }
 
     [Fact]


### PR DESCRIPTION
## Description

DCP rejects parent-process monitor timestamps unless the JSON value matches Kubernetes `metav1.MicroTime`, which requires exactly six fractional second digits. Parent-process lifetime resources on Linux can produce boot-relative timestamps such as `0001-01-01T00:06:30Z`; the default `System.Text.Json` `DateTime` converter trims the fractional seconds, causing DCP to reject the container and executable specs before startup.

This adds a DCP model converter for `monitorTimestamp` on container and executable specs so those values are written in fixed-width MicroTime form, for example `0001-01-01T00:06:30.000000Z`. It also adds focused regression tests for whole-second and millisecond timestamps on both resource types.

Validation:

```bash
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-method "*.MonitorTimestamps_SerializeToDcpMicroTimeWireContract" --filter-method "*.MonitorTimestamps_DeserializeFromDcpMicroTimeWireContract" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Related to #18794

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No