### PR TITLE
[auto-sec] consolidate aspire security dependency remediations

### DIFF
--- a/playground/AspireWithJavaScript/AspireJavaScript.React/package-lock.json
+++ b/playground/AspireWithJavaScript/AspireJavaScript.React/package-lock.json
@@ -6859,9 +6859,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/playground/AspireWithJavaScript/AspireJavaScript.React/package.json
+++ b/playground/AspireWithJavaScript/AspireJavaScript.React/package.json
@@ -32,6 +32,7 @@
     "uuid": "14.0.0",
     "esbuild": "0.28.1",
     "http-proxy-middleware": "3.0.7",
-    "launch-editor": "2.14.1"
+    "launch-editor": "2.14.1",
+    "websocket-driver": "0.7.5"
   }
 }

--- a/playground/FoundryAgentBasic/app/uv.lock
+++ b/playground/FoundryAgentBasic/app/uv.lock
@@ -1558,11 +1558,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## [auto-sec] Consolidated low-risk dependency security remediation

This canonical PR remediates the current open Dependabot alerts in a single low-risk batch for `microsoft/aspire`.

### Alerts addressed
- [x] https://github.com/microsoft/aspire/security/dependabot/1467 (`websocket-driver`, critical) — patched to `0.7.5`
- [x] https://github.com/microsoft/aspire/security/dependabot/764 (`Pygments`, low) — patched to `2.20.0`

### Changes
- Added npm override `websocket-driver: 0.7.5` in `playground/AspireWithJavaScript/AspireJavaScript.React/package.json` and regenerated lockfile.
- Upgraded `pygments` in `playground/FoundryAgentBasic/app/uv.lock` from `2.19.2` to `2.20.0`.

### Verification status
- `npm ci --ignore-scripts` succeeds in `playground/AspireWithJavaScript/AspireJavaScript.React`.
- `uv sync --frozen` succeeds in `playground/FoundryAgentBasic/app`.

### Superseded PRs
- None.