### PR TITLE
Update dotnet/extensions dependencies to 10.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -130,7 +130,7 @@
     <PackageVersion Include="NATS.Net" Version="2.8.0" />
     <PackageVersion Include="NCrontab.Signed" Version="3.4.0" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
-    <PackageVersion Include="OpenAI" Version="2.10.0" />
+    <PackageVersion Include="OpenAI" Version="2.12.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.26.200" />
     <PackageVersion Include="Polly.Core" Version="8.6.6" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.6" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,29 +29,29 @@
       <Uri>https://github.com/microsoft/dcp</Uri>
       <Sha>3ff074999f489b17cbf43747ebf407ca4a732667</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="10.5.0">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.AutoActivation" Version="10.8.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>958df529b628f62daa615dba271f42e2225d7a97</Sha>
+      <Sha>8f88b008401bd66a06240d1b7696cd89d921013b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="10.5.0">
+    <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="10.8.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>958df529b628f62daa615dba271f42e2225d7a97</Sha>
+      <Sha>8f88b008401bd66a06240d1b7696cd89d921013b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0">
+    <Dependency Name="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>958df529b628f62daa615dba271f42e2225d7a97</Sha>
+      <Sha>8f88b008401bd66a06240d1b7696cd89d921013b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.5.0">
+    <Dependency Name="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.8.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>958df529b628f62daa615dba271f42e2225d7a97</Sha>
+      <Sha>8f88b008401bd66a06240d1b7696cd89d921013b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0">
+    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>958df529b628f62daa615dba271f42e2225d7a97</Sha>
+      <Sha>8f88b008401bd66a06240d1b7696cd89d921013b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0">
+    <Dependency Name="Microsoft.Extensions.Diagnostics.Testing" Version="10.8.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>958df529b628f62daa615dba271f42e2225d7a97</Sha>
+      <Sha>8f88b008401bd66a06240d1b7696cd89d921013b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.14">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
@@ -165,13 +165,13 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>19c07820cb72aafc554c3bc8fe3c54010f5123f0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.AI" Version="10.5.0">
+    <Dependency Name="Microsoft.Extensions.AI" Version="10.8.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>958df529b628f62daa615dba271f42e2225d7a97</Sha>
+      <Sha>8f88b008401bd66a06240d1b7696cd89d921013b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.AI.OpenAI" Version="10.5.0">
+    <Dependency Name="Microsoft.Extensions.AI.OpenAI" Version="10.8.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>958df529b628f62daa615dba271f42e2225d7a97</Sha>
+      <Sha>8f88b008401bd66a06240d1b7696cd89d921013b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.AI.AzureAIInference" Version="10.0.0-preview.1.25559.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,15 +40,15 @@
     <MicrosoftDotNetXUnitV3ExtensionsVersion>10.0.0-beta.26324.4</MicrosoftDotNetXUnitV3ExtensionsVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>10.0.0-beta.26324.4</MicrosoftDotNetBuildTasksArchivesVersion>
     <!-- dotnet/extensions -->
-    <MicrosoftExtensionsAIVersion>10.6.0</MicrosoftExtensionsAIVersion>
-    <MicrosoftExtensionsAIOpenAIVersion>10.6.0</MicrosoftExtensionsAIOpenAIVersion>
+    <MicrosoftExtensionsAIVersion>10.8.0</MicrosoftExtensionsAIVersion>
+    <MicrosoftExtensionsAIOpenAIVersion>10.8.0</MicrosoftExtensionsAIOpenAIVersion>
     <MicrosoftExtensionsAIAzureAIInferenceVersion>10.0.0-preview.1.25559.3</MicrosoftExtensionsAIAzureAIInferenceVersion>
-    <MicrosoftExtensionsHttpResilienceVersion>10.6.0</MicrosoftExtensionsHttpResilienceVersion>
-    <MicrosoftExtensionsDependencyInjectionAutoActivationVersion>10.6.0</MicrosoftExtensionsDependencyInjectionAutoActivationVersion>
-    <MicrosoftExtensionsDiagnosticsTestingVersion>10.6.0</MicrosoftExtensionsDiagnosticsTestingVersion>
-    <MicrosoftExtensionsTimeProviderTestingVersion>10.6.0</MicrosoftExtensionsTimeProviderTestingVersion>
-    <MicrosoftExtensionsServiceDiscoveryVersion>10.6.0</MicrosoftExtensionsServiceDiscoveryVersion>
-    <MicrosoftExtensionsServiceDiscoveryYarpVersion>10.6.0</MicrosoftExtensionsServiceDiscoveryYarpVersion>
+    <MicrosoftExtensionsHttpResilienceVersion>10.8.0</MicrosoftExtensionsHttpResilienceVersion>
+    <MicrosoftExtensionsDependencyInjectionAutoActivationVersion>10.8.0</MicrosoftExtensionsDependencyInjectionAutoActivationVersion>
+    <MicrosoftExtensionsDiagnosticsTestingVersion>10.8.0</MicrosoftExtensionsDiagnosticsTestingVersion>
+    <MicrosoftExtensionsTimeProviderTestingVersion>10.8.0</MicrosoftExtensionsTimeProviderTestingVersion>
+    <MicrosoftExtensionsServiceDiscoveryVersion>10.8.0</MicrosoftExtensionsServiceDiscoveryVersion>
+    <MicrosoftExtensionsServiceDiscoveryYarpVersion>10.8.0</MicrosoftExtensionsServiceDiscoveryYarpVersion>
     <!-- OpenTelemetry (OTel) -->
     <OpenTelemetryInstrumentationAspNetCoreVersion>1.15.2</OpenTelemetryInstrumentationAspNetCoreVersion>
     <OpenTelemetryInstrumentationHttpVersion>1.15.1</OpenTelemetryInstrumentationHttpVersion>


### PR DESCRIPTION
## Description

Updates the `dotnet/extensions` packages used in the repo to their latest shipped version, **10.8.0**.

Generated by running:

```
darc update-dependencies --id 322786
```

This pulls from build `20260714.2` of `dotnet-extensions` (commit `8f88b008401bd66a06240d1b7696cd89d921013b`).

## Packages updated

- `Microsoft.Extensions.AI`
- `Microsoft.Extensions.AI.OpenAI`
- `Microsoft.Extensions.DependencyInjection.AutoActivation`
- `Microsoft.Extensions.Diagnostics.Testing`
- `Microsoft.Extensions.Http.Resilience`
- `Microsoft.Extensions.ServiceDiscovery`
- `Microsoft.Extensions.ServiceDiscovery.Yarp`
- `Microsoft.Extensions.TimeProvider.Testing`

## Additional transitive dependency update

`Microsoft.Extensions.AI.OpenAI` 10.8.0 requires `OpenAI >= 2.12.0`, but the repo centrally pinned `OpenAI` at `2.10.0`, which caused `NU1109` package-downgrade errors during restore. To resolve this, the central `OpenAI` pin in `Directory.Packages.props` is bumped from `2.10.0` to `2.12.0` — the version required transitively by `Microsoft.Extensions.AI.OpenAI` 10.8.0.

## Files changed

- `eng/Version.Details.xml`
- `eng/Versions.props`
- `Directory.Packages.props` (bump `OpenAI` to `2.12.0`, see above)