### PR TITLE
Fix Homebrew cask validation with generated tap templates

### DIFF
--- a/eng/homebrew/validate-cask-artifact.sh
+++ b/eng/homebrew/validate-cask-artifact.sh
@@ -128,9 +128,14 @@ fi
 
 trap cleanup EXIT
 remove_tap "$TAP_NAME"
+TAP_ROOT="$(brew --repository)/Library/Taps/local/homebrew-aspire"
 brew tap-new --no-git "$TAP_NAME"
 
-TAP_ROOT="$(brew --repository)/Library/Taps/local/homebrew-aspire"
+# Homebrew 6.0.11 creates a README and CI workflows for new taps. Those
+# templates are unrelated to the cask and can fail tap syntax validation
+# independently of it (https://github.com/microsoft/aspire/issues/18818).
+# Keep the temporary tap cask-only while preserving the registered tap root.
+find "$TAP_ROOT" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
 mkdir -p "$TAP_ROOT/Casks"
 TAPPED_CASK_PATH="$TAP_ROOT/Casks/aspire.rb"
 cp "$CASK_FILE" "$TAPPED_CASK_PATH"

--- a/tests/Aspire.Acquisition.Tests/Scripts/PRScriptInstallerModeTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/PRScriptInstallerModeTests.cs
@@ -151,13 +151,26 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
                 tap="${@: -1}"
                 org="${tap%%/*}"
                 repo="${tap##*/}"
-                mkdir -p "{{brewRepository}}/Library/Taps/$org/homebrew-$repo"
+                tap_root="{{brewRepository}}/Library/Taps/$org/homebrew-$repo"
+                mkdir -p "$tap_root/.github/workflows"
+                cat > "$tap_root/.github/workflows/tests.yml" <<'WORKFLOW'
+            jobs:
+              test:
+                options: --privileged
+            WORKFLOW
+                echo "# generated tap" > "$tap_root/README.md"
                 exit 0
                 ;;
               style|audit|info)
                 exit 0
                 ;;
               test-bot)
+                tap_root="{{brewRepository}}/Library/Taps/local/homebrew-aspire"
+                unexpected_file="$(find "$tap_root" -type f ! -path "$tap_root/Casks/aspire.rb" -print -quit)"
+                if [[ -n "$unexpected_file" ]]; then
+                  echo "Homebrew-generated file reached tap syntax validation: $unexpected_file" >&2
+                  exit 1
+                fi
                 exit 0
                 ;;
               install)
@@ -556,6 +569,25 @@ public class PRScriptInstallerModeTests(ITestOutputHelper testOutput)
 
         Assert.NotEqual(0, result.ExitCode);
         Assert.Contains("aspire --version failed after install", result.Output);
+    }
+
+    [Fact]
+    [RequiresTools(["ruby"])]
+    [SkipOnPlatform(TestPlatforms.Windows, "Bash script tests require bash shell")]
+    public async Task Bash_ValidateHomebrewCask_RemovesGeneratedTapTemplateBeforeSyntaxCheck()
+    {
+        using var env = new TestEnvironment();
+        var caskPath = Path.Combine(env.TempDirectory, "aspire.rb");
+        await File.WriteAllTextAsync(caskPath, "cask \"aspire\" do\n  version \"13.3.0\"\nend\n");
+        var mockBinDir = await CreateMockHomebrewBinAsync(env, aspireExitCode: 0);
+        using var cmd = new ScriptToolCommand("eng/homebrew/validate-cask-artifact.sh", env, _testOutput);
+        cmd.WithEnvironmentVariable("PATH", $"{mockBinDir}{Path.PathSeparator}/usr/bin:/bin:/usr/sbin:/sbin");
+
+        var result = await cmd.ExecuteAsync(
+            "--cask-file", caskPath,
+            "--validation-mode", "LiveArchives");
+
+        result.EnsureSuccessful();
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Homebrew 6.0.11's `brew tap-new` generates a README and CI workflows for a new tap. One of those workflows currently contains an invalid job-level `options` key, so `brew test-bot --only-tap-syntax` fails on Homebrew's template instead of validating the Aspire cask.

This removes the generated template contents from Aspire's temporary tap before copying `aspire.rb`. The tap remains cask-only, and the existing style, syntax, audit, and install validation is unchanged.

Validated with:

- Focused acquisition tests covering the generated-template scenario and existing Homebrew validation paths
- `bash -n eng/homebrew/validate-cask-artifact.sh`
- The full `LiveArchives` validation path with Homebrew 6.0.11, including `brew test-bot --only-tap-syntax` and `brew audit`

Fixes #18818

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
