### PR TITLE
Fix duplicate dashboard stopping message

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -43,6 +43,11 @@ internal abstract class BaseCommand : Command
 
     protected AspireCliTelemetry Telemetry { get; }
 
+    protected virtual void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
+    {
+        InteractionService.DisplayCancellationMessage(consoleOverride);
+    }
+
     protected BaseCommand(string name, string description, CommonCommandServices services) : base(name, description)
     {
         _executionContext = services.ExecutionContext;
@@ -130,7 +135,7 @@ internal abstract class BaseCommand : Command
                 {
                     // 200ms elapsed after cancellation — show stopping message and continue waiting.
                     stoppingMessageShown = true;
-                    InteractionService.DisplayCancellationMessage();
+                    DisplayCancellationMessage();
                     tasksToAwait.Remove(stoppingMessageTcs.Task);
                 }
             }
@@ -166,7 +171,7 @@ internal abstract class BaseCommand : Command
 
         if (result.ShouldDisplayCancellationMessage && !stoppingMessageShown)
         {
-            InteractionService.DisplayCancellationMessage(isErrorExitCode ? ConsoleOutput.Error : null);
+            DisplayCancellationMessage(isErrorExitCode ? ConsoleOutput.Error : null);
         }
 
         // Display the CLI log file path on non-zero exit codes so the user knows

--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -43,9 +43,11 @@ internal abstract class BaseCommand : Command
 
     protected AspireCliTelemetry Telemetry { get; }
 
-    protected virtual void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
+    protected virtual string? CancellationMessage => null;
+
+    private void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
     {
-        InteractionService.DisplayCancellationMessage(consoleOverride);
+        InteractionService.DisplayCancellationMessage(CancellationMessage, consoleOverride);
     }
 
     protected BaseCommand(string name, string description, CommonCommandServices services) : base(name, description)

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -25,6 +25,11 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => true;
 
+    protected override void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
+    {
+        InteractionService.DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]", allowMarkup: true, consoleOverride);
+    }
+
     private readonly IBundleService _bundleService;
     private readonly LayoutProcessRunner _layoutProcessRunner;
     private readonly FileLoggerProvider _fileLoggerProvider;
@@ -412,8 +417,6 @@ internal sealed class DashboardRunCommand : BaseCommand
 
         if (cancellationToken.IsCancellationRequested)
         {
-            InteractionService.DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]", allowMarkup: true);
-
             if (!process.HasExited)
             {
                 process.Kill(entireProcessTree: true);
@@ -464,8 +467,6 @@ internal sealed class DashboardRunCommand : BaseCommand
         }
         catch (OperationCanceledException)
         {
-            InteractionService.DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]", allowMarkup: true);
-
             if (!process.HasExited)
             {
                 process.Kill(entireProcessTree: true);

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -25,10 +25,7 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     protected override bool UpdateNotificationsEnabled => true;
 
-    protected override void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
-    {
-        InteractionService.DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]", allowMarkup: true, consoleOverride: consoleOverride);
-    }
+    protected override string CancellationMessage => DashboardCommandStrings.StoppingDashboard;
 
     private readonly IBundleService _bundleService;
     private readonly LayoutProcessRunner _layoutProcessRunner;

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -27,7 +27,7 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     protected override void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
     {
-        InteractionService.DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]", allowMarkup: true, consoleOverride);
+        InteractionService.DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]", allowMarkup: true, consoleOverride: consoleOverride);
     }
 
     private readonly IBundleService _bundleService;

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -653,10 +653,10 @@ internal class ConsoleInteractionService : IInteractionService
             });
     }
 
-    public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
+    public void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null)
     {
         GetConsoleOutput(consoleOverride).WriteLine();
-        DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{InteractionServiceStrings.StoppingAspire}[/]", allowMarkup: true, consoleOverride: consoleOverride);
+        DisplayMessage(KnownEmojis.StopSign, $"[teal bold]{message ?? InteractionServiceStrings.StoppingAspire}[/]", allowMarkup: true, consoleOverride: consoleOverride);
     }
 
     public async Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)

--- a/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ExtensionInteractionService.cs
@@ -442,11 +442,11 @@ internal class ExtensionInteractionService : IExtensionInteractionService, IDisp
         // here would surface every line twice.
     }
 
-    public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
+    public void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null)
     {
         var result = _extensionTaskChannel.Writer.TryWrite(() => Backchannel.DisplayCancellationMessageAsync(_cancellationToken));
         Debug.Assert(result);
-        _consoleInteractionService.DisplayCancellationMessage(consoleOverride);
+        _consoleInteractionService.DisplayCancellationMessage(message, consoleOverride);
     }
 
     public void DisplayEmptyLine()

--- a/src/Aspire.Cli/Interaction/IInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/IInteractionService.cs
@@ -39,7 +39,7 @@ internal interface IInteractionService
     void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines);
     void DisplayRenderable(IRenderable renderable);
     Task DisplayLiveAsync(IRenderable initialRenderable, Func<Action<IRenderable>, Task> callback);
-    void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null);
+    void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null);
     void DisplayEmptyLine();
 
     /// <summary>

--- a/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
@@ -184,6 +184,6 @@
     <value>Failed to start Aspire dashboard: {0}</value>
   </data>
   <data name="StoppingDashboard" xml:space="preserve">
-    <value>Stopping dashboard</value>
+    <value>Stopping dashboard.</value>
   </data>
 </root>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoppingDashboard">
-        <source>Stopping dashboard</source>
-        <target state="new">Stopping dashboard</target>
+        <source>Stopping dashboard.</source>
+        <target state="new">Stopping dashboard.</target>
         <note />
       </trans-unit>
     </body>

--- a/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/BaseCommandTests.cs
@@ -239,8 +239,9 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
         // add catches OperationCanceledException and returns CommandResult.Cancelled() (exit code 130)
         Assert.Equal(CliExitCodes.Cancelled, exitCode);
 
-        var cancellationOverride = Assert.Single(testInteractionService.DisplayedCancellations);
-        Assert.Equal(ConsoleOutput.Error, cancellationOverride);
+        var cancellation = Assert.Single(testInteractionService.DisplayedCancellations);
+        Assert.Null(cancellation.Message);
+        Assert.Equal(ConsoleOutput.Error, cancellation.ConsoleOverride);
     }
 
     [Fact]
@@ -272,8 +273,9 @@ public class BaseCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
 
-        var cancellationOverride = Assert.Single(testInteractionService.DisplayedCancellations);
-        Assert.Null(cancellationOverride);
+        var cancellation = Assert.Single(testInteractionService.DisplayedCancellations);
+        Assert.Null(cancellation.Message);
+        Assert.Null(cancellation.ConsoleOverride);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -337,8 +337,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var readyTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var stoppingMessageDisplayedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var shutdownTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var expectedMessage = $"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]";
-        testInteractionService.DisplayMessageCallback = (_, message, _) =>
+        var expectedMessage = DashboardCommandStrings.StoppingDashboard;
+        testInteractionService.DisplayCancellationMessageCallback = (message, _) =>
         {
             if (message == expectedMessage)
             {
@@ -397,9 +397,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await pendingRun.DefaultTimeout();
 
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.Empty(testInteractionService.DisplayedCancellations);
-        var stoppingMessage = Assert.Single(testInteractionService.DisplayedMessages);
-        Assert.Equal(KnownEmojis.StopSign, stoppingMessage.Emoji);
+        Assert.Empty(testInteractionService.DisplayedMessages);
+        var stoppingMessage = Assert.Single(testInteractionService.DisplayedCancellations);
         Assert.Equal(expectedMessage, stoppingMessage.Message);
         Assert.Null(stoppingMessage.ConsoleOverride);
     }

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -335,6 +335,16 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         var testInteractionService = new TestInteractionService();
         var readyTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stoppingMessageDisplayedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shutdownTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expectedMessage = $"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]";
+        testInteractionService.DisplayMessageCallback = (_, message, _) =>
+        {
+            if (message == expectedMessage)
+            {
+                stoppingMessageDisplayedTcs.TrySetResult();
+            }
+        };
         var (services, _, executionFactory) = CreateServicesWithLayout(workspace, interactionService: testInteractionService);
         executionFactory.CreateExecutionCallback = (_, _, _, options) =>
             new TestProcessExecution("fake", [], null, options, (_, _, _) => Task.FromResult((0, (string?)null)), () => 0)
@@ -351,7 +361,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
                     {
                         if (slowShutdown)
                         {
-                            await Task.Delay(500, CancellationToken.None);
+                            await shutdownTcs.Task.ConfigureAwait(false);
                         }
 
                         throw;
@@ -371,13 +381,26 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         await readyTcs.Task.DefaultTimeout();
         await cts.CancelAsync();
 
+        if (slowShutdown)
+        {
+            try
+            {
+                var firstCompletedTask = await Task.WhenAny(stoppingMessageDisplayedTcs.Task, pendingRun).DefaultTimeout();
+                Assert.Same(stoppingMessageDisplayedTcs.Task, firstCompletedTask);
+            }
+            finally
+            {
+                shutdownTcs.TrySetResult();
+            }
+        }
+
         var exitCode = await pendingRun.DefaultTimeout();
 
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Empty(testInteractionService.DisplayedCancellations);
         var stoppingMessage = Assert.Single(testInteractionService.DisplayedMessages);
         Assert.Equal(KnownEmojis.StopSign, stoppingMessage.Emoji);
-        Assert.Equal($"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]", stoppingMessage.Message);
+        Assert.Equal(expectedMessage, stoppingMessage.Message);
         Assert.Null(stoppingMessage.ConsoleOverride);
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -326,8 +326,10 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         Assert.Equal(expectedMessage, errorMessage);
     }
 
-    [Fact]
-    public async Task DashboardRunCommand_WhenCancelled_DisplaysCancellationMessageAndReturnsSuccess()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DashboardRunCommand_WhenCancelled_DisplaysCancellationMessageAndReturnsSuccess(bool slowShutdown)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
 
@@ -341,7 +343,20 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
                 {
                     processOptions.StandardOutputCallback?.Invoke("Now listening on: http://localhost:18888");
                     readyTcs.TrySetResult();
-                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        if (slowShutdown)
+                        {
+                            await Task.Delay(500, CancellationToken.None);
+                        }
+
+                        throw;
+                    }
+
                     return 0;
                 }
             };
@@ -359,7 +374,11 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await pendingRun.DefaultTimeout();
 
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.Single(testInteractionService.DisplayedCancellations);
+        Assert.Empty(testInteractionService.DisplayedCancellations);
+        var stoppingMessage = Assert.Single(testInteractionService.DisplayedMessages);
+        Assert.Equal(KnownEmojis.StopSign, stoppingMessage.Emoji);
+        Assert.Equal($"[teal bold]{DashboardCommandStrings.StoppingDashboard}[/]", stoppingMessage.Message);
+        Assert.Null(stoppingMessage.ConsoleOverride);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -1239,7 +1239,7 @@ internal sealed class TestConsoleInteractionServiceWithPromptTracking : IInterac
     public void DisplaySuccess(string message, bool allowMarkup = false) { }
     public void DisplaySubtleMessage(string message, bool allowMarkup = false) { }
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) { }
-    public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null) { }
+    public void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null) { }
     public void DisplayEmptyLine() { }
     public void DisplayPlainText(string text) { }
     public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }

--- a/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -3352,10 +3352,10 @@ internal sealed class CancellationTrackingInteractionService : IInteractionServi
     public void DisplaySuccess(string message, bool allowMarkup = false) => _innerService.DisplaySuccess(message, allowMarkup);
     public void DisplaySubtleMessage(string message, bool allowMarkup = false) => _innerService.DisplaySubtleMessage(message, allowMarkup);
     public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) => _innerService.DisplayLines(lines);
-    public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null) 
+    public void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null)
     {
         OnCancellationMessageDisplayed?.Invoke();
-        _innerService.DisplayCancellationMessage(consoleOverride);
+        _innerService.DisplayCancellationMessage(message, consoleOverride);
     }
     public void DisplayEmptyLine() => _innerService.DisplayEmptyLine();
     public void DisplayVersionUpdateNotification(string newerVersion, string? updateCommand = null) 

--- a/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ExtensionInteractionServiceTests.cs
@@ -61,6 +61,51 @@ public class ExtensionInteractionServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DisplayCancellationMessage_WithCustomMessage_UsesCancellationBackchannel()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.TrueColor,
+            Out = new AnsiConsoleOutput(new StringWriter(output)),
+            Enrichment = new ProfileEnrichment { UseDefaultEnrichers = false }
+        });
+
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var executionContext = workspace.CreateExecutionContext();
+        var consoleInteractionService = new ConsoleInteractionService(
+            new ConsoleEnvironment(console, console),
+            executionContext,
+            TestHelpers.CreateInteractiveHostEnvironment(),
+            new EnvironmentProcessPathProvider(),
+            NullLoggerFactory.Instance,
+            new ConsoleLogBufferContext());
+        var cancellationMessageCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var displayMessageCalled = false;
+        var backchannel = new TestExtensionBackchannel
+        {
+            DisplayCancellationMessageAsyncCalled = cancellationMessageCalled,
+            DisplayMessageAsyncCallback = (_, _) =>
+            {
+                displayMessageCalled = true;
+                return Task.CompletedTask;
+            }
+        };
+        using var extensionInteractionService = new ExtensionInteractionService(
+            consoleInteractionService,
+            backchannel,
+            extensionPromptEnabled: false,
+            logger: NullLogger<ExtensionInteractionService>.Instance);
+
+        extensionInteractionService.DisplayCancellationMessage("Stopping dashboard.");
+        await extensionInteractionService.FlushAsync();
+
+        Assert.True(cancellationMessageCalled.Task.IsCompletedSuccessfully);
+        Assert.False(displayMessageCalled);
+    }
+
+    [Fact]
     public async Task Dispose_StopsBackgroundPump()
     {
         var output = new StringBuilder();

--- a/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ExtensionGuestLauncherTests.cs
@@ -173,7 +173,7 @@ public class ExtensionGuestLauncherTests
         public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false, ConsoleOutput? consoleOverride = null) => throw new NotImplementedException();
         public void DisplaySuccess(string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) => throw new NotImplementedException();
-        public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null) => throw new NotImplementedException();
+        public void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null) => throw new NotImplementedException();
         public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void DisplaySubtleMessage(string message, bool allowMarkup = false) => throw new NotImplementedException();
         public void DisplayEmptyLine() => throw new NotImplementedException();

--- a/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/DotNetTemplateFactoryTests.cs
@@ -404,7 +404,7 @@ public class DotNetTemplateFactoryTests
         public void DisplayError(string message, bool allowMarkup = false) { }
         public void DisplayMessage(KnownEmoji emoji, string message, bool allowMarkup = false, ConsoleOutput? consoleOverride = null) { }
         public void DisplayLines(IEnumerable<(OutputLineStream Stream, string Line)> lines) { }
-        public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null) { }
+        public void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null) { }
         public int DisplayIncompatibleVersionError(AppHostIncompatibleException ex, string appHostHostingVersion) => 0;
         public void DisplayPlainText(string text) { }
         public void DisplayRawText(string text, ConsoleOutput? consoleOverride = null) { }

--- a/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestExtensionInteractionService.cs
@@ -146,7 +146,7 @@ internal sealed class TestExtensionInteractionService(IServiceProvider servicePr
         DisplayedLines.AddRange(lines);
     }
 
-    public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
+    public void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null)
     {
     }
 

--- a/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestInteractionService.cs
@@ -27,6 +27,7 @@ internal sealed class TestInteractionService : IInteractionService
     public Action<string>? ShowStatusCallback { get; set; }
     public Action<string>? ShowDynamicStatusCallback { get; set; }
     public Action<KnownEmoji, string, ConsoleOutput?>? DisplayMessageCallback { get; set; }
+    public Action<string?, ConsoleOutput?>? DisplayCancellationMessageCallback { get; set; }
     public Action<string>? DisplayVersionUpdateNotificationCallback { get; set; }
     public string? LastVersionUpdateCommand { get; private set; }
 
@@ -57,7 +58,7 @@ internal sealed class TestInteractionService : IInteractionService
     public List<string> DisplayedSuccess { get; } = [];
     public List<string> ShownStatuses { get; } = [];
     public int DisplayEmptyLineCount { get; private set; }
-    public List<ConsoleOutput?> DisplayedCancellations { get; } = [];
+    public List<(string? Message, ConsoleOutput? ConsoleOverride)> DisplayedCancellations { get; } = [];
 
     // Response queue setup methods
     public void SetupStringPromptResponse(string response) => _responses.Enqueue((response, ResponseType.String));
@@ -273,12 +274,14 @@ internal sealed class TestInteractionService : IInteractionService
         }
     }
 
-    public void DisplayCancellationMessage(ConsoleOutput? consoleOverride = null)
+    public void DisplayCancellationMessage(string? message = null, ConsoleOutput? consoleOverride = null)
     {
         lock (_displayLock)
         {
-            DisplayedCancellations.Add(consoleOverride);
+            DisplayedCancellations.Add((message, consoleOverride));
         }
+
+        DisplayCancellationMessageCallback?.Invoke(message, consoleOverride);
     }
 
     public Task<bool> PromptConfirmAsync(string promptText, PromptBinding<bool>? binding = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description

Stopping `aspire dashboard run` currently displays both the dashboard-specific shutdown message and the generic Aspire shutdown message. This change centralizes cancellation rendering in `BaseCommand` while allowing commands to customize the message, so dashboard run emits exactly one punctuated shutdown line for both fast and slow cancellation paths.

### User-facing usage

Pressing Ctrl+C while the standalone dashboard is running now changes the shutdown output from:

```text
Stopping dashboard
Stopping Aspire.
```

to:

```text
Stopping dashboard.
```

<img width="970" height="234" alt="image" src="https://github.com/user-attachments/assets/d2f016c6-9579-46ed-8373-18f336f0c7b3" />


### Validation

- 73 `BaseCommandTests` and `DashboardRunCommandTests` passed.
- Updated localization files with `dotnet build /t:UpdateXlf src/Aspire.Cli/Aspire.Cli.csproj`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
