### PR TITLE
Fix removing resources without telemetry

### DIFF
--- a/playground/Stress/Stress.TelemetryService/TelemetryStresser.cs
+++ b/playground/Stress/Stress.TelemetryService/TelemetryStresser.cs
@@ -3,8 +3,10 @@
 
 using Grpc.Core;
 using Grpc.Net.Client;
+using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Proto.Collector.Metrics.V1;
 using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Resource.V1;
 
@@ -15,12 +17,15 @@ namespace Stress.TelemetryService;
 /// </summary>
 public class TelemetryStresser(ILogger<TelemetryStresser> logger, IConfiguration config) : BackgroundService
 {
+    private const string ExternalLogSourceName = "external-log-source";
+
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         var address = config["OTEL_EXPORTER_OTLP_ENDPOINT"]!;
         var channel = GrpcChannel.ForAddress(address);
 
-        var client = new MetricsService.MetricsServiceClient(channel);
+        var metricsClient = new MetricsService.MetricsServiceClient(channel);
+        var logsClient = new LogsService.LogsServiceClient(channel);
         var otlpApiKey = config["OTEL_EXPORTER_OTLP_HEADERS"]!.Split('=')[1];
         var metadata = new Metadata
         {
@@ -32,7 +37,8 @@ public class TelemetryStresser(ILogger<TelemetryStresser> logger, IConfiguration
         {
             value += Random.Shared.Next(0, 10);
 
-            await ExportMetrics(logger, metadata, client, value, cancellationToken);
+            await ExportMetrics(logger, metadata, metricsClient, value, cancellationToken);
+            await ExportStructuredLog(logger, metadata, logsClient, value, cancellationToken);
 
             await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
         }
@@ -77,6 +83,50 @@ public class TelemetryStresser(ILogger<TelemetryStresser> logger, IConfiguration
         if (response.PartialSuccess is { RejectedDataPoints: > 0 } result)
         {
             logger.LogDebug($"Export complete. Rejected count: {result.RejectedDataPoints}");
+        }
+    }
+
+    private static async Task ExportStructuredLog(ILogger<TelemetryStresser> logger, Metadata metadata, LogsService.LogsServiceClient client, int value, CancellationToken cancellationToken)
+    {
+        var timestamp = DateTimeToUnixNanoseconds(DateTime.UtcNow);
+        var request = new ExportLogsServiceRequest
+        {
+            ResourceLogs =
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(ExternalLogSourceName, "instance-1"),
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            Scope = new InstrumentationScope { Name = "ExternalLogSource" },
+                            LogRecords =
+                            {
+                                new LogRecord
+                                {
+                                    TimeUnixNano = timestamp,
+                                    ObservedTimeUnixNano = timestamp,
+                                    SeverityNumber = SeverityNumber.Info,
+                                    SeverityText = "Information",
+                                    Body = new AnyValue { StringValue = $"Processed item {value}." },
+                                    Attributes =
+                                    {
+                                        new KeyValue { Key = "{OriginalFormat}", Value = new AnyValue { StringValue = "Processed item {ItemId}." } },
+                                        new KeyValue { Key = "ItemId", Value = new AnyValue { IntValue = value } }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var response = await client.ExportAsync(request, headers: metadata, cancellationToken: cancellationToken);
+        if (response.PartialSuccess is { RejectedLogRecords: > 0 } result)
+        {
+            logger.LogDebug("Export complete. Rejected log count: {RejectedLogCount}", result.RejectedLogRecords);
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -102,7 +102,7 @@
                 {
                     @if (context.ResourceRow.TelemetryData.Count == 0)
                     {
-                        <span class="empty-data"></span>
+                        <span class="empty-data" style="margin-left: 12px;"></span>
                     }
                     else
                     {

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -101,14 +101,21 @@
                 @if (context.IsResourceRow && context.ResourceRow is not null)
                 {
                     <span @onclick:stopPropagation="true">
-                        @foreach (var dataRow in context.ResourceRow.TelemetryData)
+                        @if (context.ResourceRow.TelemetryData.Count == 0)
                         {
-                            <FluentButton Appearance="Appearance.Lightweight"
-                                          IconEnd="@dataRow.Icon"
-                                          OnClick="@(() => NavigateToDataPage(dataRow))"
-                                          Title="@GetDataTypeDisplayName(dataRow.DataType)"
-                                          aria-label="@GetDataTypeDisplayName(dataRow.DataType)"
-                                          Style="margin-right: 4px;" />
+                            <span class="empty-data"></span>
+                        }
+                        else
+                        {
+                            @foreach (var dataRow in context.ResourceRow.TelemetryData)
+                            {
+                                <FluentButton Appearance="Appearance.Lightweight"
+                                              IconEnd="@dataRow.Icon"
+                                              OnClick="@(() => NavigateToDataPage(dataRow))"
+                                              Title="@GetDataTypeDisplayName(dataRow.DataType)"
+                                              aria-label="@GetDataTypeDisplayName(dataRow.DataType)"
+                                              Style="margin-right: 4px;" />
+                            }
                         }
                     </span>
                 }

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -100,13 +100,13 @@
             <TemplateColumn Title="@Loc[nameof(Dialogs.ManageDataSummaryColumnHeader)]">
                 @if (context.IsResourceRow && context.ResourceRow is not null)
                 {
-                    <span @onclick:stopPropagation="true">
-                        @if (context.ResourceRow.TelemetryData.Count == 0)
-                        {
-                            <span class="empty-data"></span>
-                        }
-                        else
-                        {
+                    @if (context.ResourceRow.TelemetryData.Count == 0)
+                    {
+                        <span class="empty-data"></span>
+                    }
+                    else
+                    {
+                        <span @onclick:stopPropagation="true">
                             @foreach (var dataRow in context.ResourceRow.TelemetryData)
                             {
                                 <FluentButton Appearance="Appearance.Lightweight"
@@ -116,8 +116,8 @@
                                               aria-label="@GetDataTypeDisplayName(dataRow.DataType)"
                                               Style="margin-right: 4px;" />
                             }
-                        }
-                    </span>
+                        </span>
+                    }
                 }
             </TemplateColumn>
         </ChildContent>

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -132,7 +132,7 @@
         <FluentButton IconStart="@(new Icons.Regular.Size16.ArrowDownload())"
                       OnClick="ExportSelectedAsync"
                       Loading="@_isExporting"
-                      Disabled="@AreNoneSelected()"
+                      Disabled="@AreNoneExportableSelected()"
                       Title="@Loc[nameof(Dialogs.ManageDataExportButtonText)]"
                       aria-label="@Loc[nameof(Dialogs.ManageDataExportButtonText)]">
             @Loc[nameof(Dialogs.ManageDataExportButtonText)]

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -443,12 +443,9 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     {
         foreach (var row in _resourceDataRows.Values)
         {
-            foreach (var dataRow in row.TelemetryData)
+            if (!AreAllDataRowsSelected(row))
             {
-                if (!_selectedRows.Contains((row.Name, dataRow.DataType)))
-                {
-                    return false;
-                }
+                return false;
             }
         }
         return _resourceDataRows.Count > 0;
@@ -467,6 +464,11 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     /// </summary>
     private bool AreAllDataRowsSelected(ResourceDataRow row)
     {
+        if (row.TelemetryData.Count == 0)
+        {
+            return _selectedRows.Contains((row.Name, AspireDataType.Resource));
+        }
+
         foreach (var dataRow in row.TelemetryData)
         {
             if (!_selectedRows.Contains((row.Name, dataRow.DataType)))
@@ -482,6 +484,11 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     /// </summary>
     private bool AreNoDataRowsSelected(ResourceDataRow row)
     {
+        if (row.TelemetryData.Count == 0)
+        {
+            return !_selectedRows.Contains((row.Name, AspireDataType.Resource));
+        }
+
         foreach (var dataRow in row.TelemetryData)
         {
             if (_selectedRows.Contains((row.Name, dataRow.DataType)))
@@ -662,6 +669,14 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private void SelectAllDataTypesForResource(string resourceName, List<TelemetryDataRow> dataRows)
     {
+        _selectedRows.Remove((resourceName, AspireDataType.Resource));
+
+        if (dataRows.Count == 0)
+        {
+            _selectedRows.Add((resourceName, AspireDataType.Resource));
+            return;
+        }
+
         foreach (var dataRow in dataRows)
         {
             _selectedRows.Add((resourceName, dataRow.DataType));

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -143,8 +143,9 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
             }
         }
 
-        // Remove selections for resources that no longer exist
-        _selectedRows.RemoveWhere(r => !_resourceDataRows.ContainsKey(r.ResourceName));
+        // Signals can be cleared outside this dialog. Remove selections that no longer
+        // correspond to a displayed row so hidden selections can't enable actions.
+        _selectedRows.RemoveWhere(selection => !IsSelectionAvailable(selection));
     }
 
     private async Task SubscribeResourcesAsync()
@@ -459,6 +460,11 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
         return _selectedRows.Count == 0;
     }
 
+    private bool AreNoneExportableSelected()
+    {
+        return !_selectedRows.Any(r => r.DataType is not AspireDataType.Resource);
+    }
+
     /// <summary>
     /// Returns true if all data rows for a resource are selected.
     /// </summary>
@@ -505,6 +511,18 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private IconCheckboxState GetDataRowCheckboxState(string resourceName, AspireDataType dataType) =>
         IsDataRowSelected(resourceName, dataType) ? IconCheckboxState.Checked : IconCheckboxState.Unchecked;
+
+    private bool IsSelectionAvailable((string ResourceName, AspireDataType DataType) selection)
+    {
+        if (!_resourceDataRows.TryGetValue(selection.ResourceName, out var row))
+        {
+            return false;
+        }
+
+        return row.TelemetryData.Count == 0
+            ? selection.DataType is AspireDataType.Resource
+            : row.TelemetryData.Any(dataRow => dataRow.DataType == selection.DataType);
+    }
 
     private static IconCheckboxState GetCheckboxState(bool isChecked, bool isUnchecked) => (isChecked, isUnchecked) switch
     {

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -8,14 +8,19 @@ using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.ManageData;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Tests.Shared.DashboardModel;
 using Bunit;
+using Google.Protobuf.Collections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.FluentUI.AspNetCore.Components;
+using OpenTelemetry.Proto.Logs.V1;
 using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Components.Tests.Dialogs;
 
@@ -146,6 +151,59 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         Assert.Equal(0, clickCount);
     }
 
+    [Fact]
+    public async Task Render_TelemetryOnlyResourceWithoutSignals_CanBeSelectedAndRemoved()
+    {
+        var dashboardClient = new TestDashboardClient(isEnabled: false, initialResources: []);
+        SetupManageDataDialogServices(dashboardClient);
+
+        var repository = Services.GetRequiredService<TelemetryRepository>();
+        var resourceKey = new ResourceKey("orphan", "instance");
+        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: resourceKey.Name, instanceId: resourceKey.InstanceId),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("test-scope"),
+                        LogRecords = { CreateLogRecord() }
+                    }
+                }
+            }
+        });
+
+        var cut = RenderComponent<ManageDataDialog>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(repository.GetResources());
+            AssertSelectionCheckboxCount(cut, 2);
+            AssertSelectionCheckbox(cut, "orphan", "true");
+        });
+
+        repository.ClearStructuredLogs(resourceKey);
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Single(repository.GetResources());
+            AssertSelectionCheckboxCount(cut, 2);
+            AssertSelectionCheckbox(cut, "orphan", "true");
+        });
+
+        await cut.InvokeAsync(() => GetResourceRows(cut).Single().Click());
+        cut.WaitForAssertion(() => AssertSelectionCheckbox(cut, "orphan", "false"));
+
+        await cut.InvokeAsync(() => GetResourceRows(cut).Single().Click());
+        cut.WaitForAssertion(() => AssertSelectionCheckbox(cut, "orphan", "true"));
+
+        cut.Find("fluent-button[aria-label='Remove selected']").Click();
+
+        cut.WaitForAssertion(() => Assert.Empty(repository.GetResources()));
+    }
+
     private void SetupManageDataDialogServices(TestDashboardClient dashboardClient)
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
@@ -251,5 +309,11 @@ public sealed class ManageDataDialogTests : DashboardTestContext
     private static IReadOnlyList<IElement> GetSelectionCheckboxes(IRenderedComponent<ManageDataDialog> cut)
     {
         return cut.FindComponent<FluentDataGrid<ManageDataGridItem>>().FindAll("[role='checkbox']");
+    }
+
+    private static IReadOnlyList<IElement> GetResourceRows(IRenderedComponent<ManageDataDialog> cut)
+    {
+        return cut.FindComponent<FluentDataGrid<ManageDataGridItem>>()
+            .FindAll(".fluent-data-grid-row:not([row-type='header'], [row-type='sticky-header'])");
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -228,7 +228,7 @@ public sealed class ManageDataDialogTests : DashboardTestContext
             AssertButtonDisabled(cut, "Remove selected", expectedDisabled: true);
         });
 
-        await cut.InvokeAsync(() => GetResourceRows(cut).Single().Click());
+        await cut.InvokeAsync(() => cut.Find(".empty-data").Click());
         cut.WaitForAssertion(() =>
         {
             AssertSelectionCheckbox(cut, "orphan", "true");
@@ -353,11 +353,5 @@ public sealed class ManageDataDialogTests : DashboardTestContext
     private static IReadOnlyList<IElement> GetSelectionCheckboxes(IRenderedComponent<ManageDataDialog> cut)
     {
         return cut.FindComponent<FluentDataGrid<ManageDataGridItem>>().FindAll("[role='checkbox']");
-    }
-
-    private static IReadOnlyList<IElement> GetResourceRows(IRenderedComponent<ManageDataDialog> cut)
-    {
-        return cut.FindComponent<FluentDataGrid<ManageDataGridItem>>()
-            .FindAll(".fluent-data-grid-row:not([row-type='header'], [row-type='sticky-header'])");
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.FluentUI.AspNetCore.Components;
 using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
 using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
@@ -152,7 +153,7 @@ public sealed class ManageDataDialogTests : DashboardTestContext
     }
 
     [Fact]
-    public async Task Render_TelemetryOnlyResourceWithoutSignals_CanBeSelectedAndRemoved()
+    public async Task Render_ClearedSignals_PrunesSelectionsAndSupportsRemovingEmptyResource()
     {
         var dashboardClient = new TestDashboardClient(isEnabled: false, initialResources: []);
         SetupManageDataDialogServices(dashboardClient);
@@ -174,6 +175,22 @@ public sealed class ManageDataDialogTests : DashboardTestContext
                 }
             }
         });
+        var timestamp = DateTime.UnixEpoch;
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: resourceKey.Name, instanceId: resourceKey.InstanceId),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("test-scope"),
+                        Spans = { CreateSpan(traceId: "trace", spanId: "span", startTime: timestamp, endTime: timestamp.AddSeconds(1)) }
+                    }
+                }
+            }
+        });
 
         var cut = RenderComponent<ManageDataDialog>();
 
@@ -184,21 +201,40 @@ public sealed class ManageDataDialogTests : DashboardTestContext
             AssertSelectionCheckbox(cut, "orphan", "true");
         });
 
+        await ExpandResourceRowsAsync(cut, expectedCount: 1);
+        cut.WaitForAssertion(() => AssertSelectionCheckbox(cut, "Structured logs for orphan", "true"));
+        await ClickSelectionCheckboxAsync(cut, "Structured logs for orphan", "true");
+
+        repository.ClearTraces(resourceKey);
+
+        cut.WaitForAssertion(() =>
+        {
+            AssertNoButtonHasAccessibleName(cut, "Traces");
+            AssertSelectionCheckbox(cut, "orphan", "false");
+            AssertButtonDisabled(cut, "Export selected", expectedDisabled: true);
+            AssertButtonDisabled(cut, "Remove selected", expectedDisabled: true);
+        });
+
         repository.ClearStructuredLogs(resourceKey);
 
         cut.WaitForAssertion(() =>
         {
             Assert.Single(repository.GetResources());
             AssertSelectionCheckboxCount(cut, 2);
-            AssertSelectionCheckbox(cut, "orphan", "true");
+            AssertSelectionCheckbox(cut, "orphan", "false");
+            AssertNoButtonHasAccessibleName(cut, "Structured logs");
             Assert.Single(cut.FindAll(".empty-data"));
+            AssertButtonDisabled(cut, "Export selected", expectedDisabled: true);
+            AssertButtonDisabled(cut, "Remove selected", expectedDisabled: true);
         });
 
         await cut.InvokeAsync(() => GetResourceRows(cut).Single().Click());
-        cut.WaitForAssertion(() => AssertSelectionCheckbox(cut, "orphan", "false"));
-
-        await cut.InvokeAsync(() => GetResourceRows(cut).Single().Click());
-        cut.WaitForAssertion(() => AssertSelectionCheckbox(cut, "orphan", "true"));
+        cut.WaitForAssertion(() =>
+        {
+            AssertSelectionCheckbox(cut, "orphan", "true");
+            AssertButtonDisabled(cut, "Export selected", expectedDisabled: true);
+            AssertButtonDisabled(cut, "Remove selected", expectedDisabled: false);
+        });
 
         cut.Find("fluent-button[aria-label='Remove selected']").Click();
 
@@ -299,6 +335,13 @@ public sealed class ManageDataDialogTests : DashboardTestContext
             element =>
                 string.Equals(element.GetAttribute("title"), accessibleName, StringComparison.Ordinal) ||
                 string.Equals(element.GetAttribute("aria-label"), accessibleName, StringComparison.Ordinal));
+
+    private static void AssertButtonDisabled(IRenderedComponent<ManageDataDialog> cut, string accessibleName, bool expectedDisabled)
+    {
+        var button = cut.Find($"fluent-button[aria-label='{accessibleName}']");
+
+        Assert.Equal(expectedDisabled, button.HasAttribute("disabled"));
+    }
 
     private static bool ElementHasAccessibleName(IElement element, string accessibleName) =>
         string.Equals(element.GetAttribute("title"), accessibleName, StringComparison.Ordinal) &&

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -191,6 +191,7 @@ public sealed class ManageDataDialogTests : DashboardTestContext
             Assert.Single(repository.GetResources());
             AssertSelectionCheckboxCount(cut, 2);
             AssertSelectionCheckbox(cut, "orphan", "true");
+            Assert.Single(cut.FindAll(".empty-data"));
         });
 
         await cut.InvokeAsync(() => GetResourceRows(cut).Single().Click());


### PR DESCRIPTION
## Description

Resources that remain known to the dashboard after all of their telemetry signals are cleared could not be selected on the **Manage logs and telemetry** page. This prevented users from removing those empty resources.

This change gives resources without data-type rows an explicit resource-level selection state. Their checkbox and grid row can now toggle selection, and **Remove selected** removes the resource. The Stress playground also emits structured logs from `external-log-source`, a service name unrelated to the AppHost resource model, so the telemetry-only resource flow can be exercised manually.

### User-facing usage

Open **Settings** > **Resource logs and telemetry** > **Manage**. A resource with no remaining data types can now be selected using either its checkbox or its row and removed with **Remove selected**.

### Screenshots / Recordings

<img width="1132" height="886" alt="remove-empty-resource" src="https://github.com/user-attachments/assets/67407186-df62-49de-b71e-12bea1a46b19" />


### Validation

- `dotnet test --project tests\Aspire.Dashboard.Components.Tests\Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-class "*.ManageDataDialogTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- Manually verified in Chromium against the locally built dashboard that both the checkbox and empty row toggle selection and that **Remove selected** deletes the resource.
- `git diff --check`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
