### PR TITLE
Show telemetry pause warning immediately

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SignalsActionsDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SignalsActionsDisplay.razor.cs
@@ -19,7 +19,7 @@ public partial class SignalsActionsDisplay
     public required bool IsPaused { get; set; }
 
     [Parameter, EditorRequired]
-    public required Action<bool> OnPausedChanged { get; set; }
+    public required EventCallback<bool> OnPausedChanged { get; set; }
 
     [Parameter, EditorRequired]
     public required Func<ResourceKey?, Task> HandleClearSignal { get; set; }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
@@ -228,6 +229,27 @@ public partial class StructuredLogsTests : DashboardTestContext
                 string.Equals(invocation.Arguments[0]?.ToString(), "structuredLogsScrollContainer", StringComparison.Ordinal) &&
                 string.Equals(invocation.Arguments[1]?.ToString(), bool.TrueString, StringComparison.OrdinalIgnoreCase));
         });
+    }
+
+    [Fact]
+    public void PauseIncomingData_DisplaysPauseWarningImmediately()
+    {
+        SetupStructureLogsServices();
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<StructuredLogs>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        cut.FindComponent<PauseIncomingDataSwitch>().WaitForElement("fluent-button").Click();
+
+        Assert.True(Services.GetRequiredService<PauseManager>().AreStructuredLogsPaused(out _));
+        Assert.Contains("Capture paused", cut.Markup);
     }
 
     private void SetupStructureLogsServices()


### PR DESCRIPTION
## Description

Pausing capture on the structured logs, traces, and metrics pages now displays the "Capture paused" message immediately. Previously, the pause state changed but the page containing the warning did not rerender until it was refreshed.

The shared `SignalsActionsDisplay` callback now uses `EventCallback<bool>` so Blazor rerenders the owning page after capture is paused or resumed. A structured logs component test verifies that clicking pause updates both the pause manager and the visible warning in the same interaction.

### User-facing usage

On the structured logs, traces, or metrics page, select the pause action. The page immediately displays the capture-paused warning without requiring a refresh.

### Screenshots / Recordings

> **This PR includes UI changes.** Please add screenshots or screen recordings so reviewers can evaluate the visual changes without running locally.
>
> - For before/after comparisons, place them side-by-side or label them clearly.
> - For interactive changes (animations, transitions, new flows), prefer a short screen recording (GIF or video).
> - If you cannot capture visuals now, note what scenario to test and mark this section as TODO.

TODO: Record toggling pause on the structured logs, traces, and metrics pages and show the warning appearing immediately.

### Validation

- `dotnet msbuild src/Aspire.Dashboard/Aspire.Dashboard.csproj /t:Compile /p:SkipNativeBuild=true /p:RestoreIgnoreFailedSources=true`
- `dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile /p:ArtifactsDir=C:\Development\Source\aspire\artifacts\tmp\pause-test -- --filter-class "*.StructuredLogsTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (6 passed)

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
