### PR TITLE
Fix trace details grid scrolling

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -22,6 +22,7 @@
 }
 
 ::deep .tracedetails-grid-container {
+    height: 100%;
     overflow: auto;
 }
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -21,8 +21,14 @@
     line-height: 1;
 }
 
+::deep .summary-container {
+    display: flex;
+    flex-direction: column;
+}
+
 ::deep .tracedetails-grid-container {
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     overflow: auto;
 }
 


### PR DESCRIPTION
## Description

The trace details grid could cause an incorrect ancestor element to scroll because its scroll container did not fill the available height. Set the trace details grid container height to 100% so its existing overflow behavior keeps scrolling within the grid.

### User-facing usage

The trace details grid now scrolls within its available area when its content exceeds the visible height.

Validation: `dotnet build .\src\Aspire.Dashboard\Aspire.Dashboard.csproj --no-restore`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No