### PR TITLE
Add .NET 11 support to project templates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,7 +71,7 @@
        Versions must be available on the dnceng dotnet-public mirror (originally published to nuget.org). -->
   <PropertyGroup Label="BlazorAssets">
     <MicrosoftAspNetCoreAppInternalAssetsNet10Version>10.0.8</MicrosoftAspNetCoreAppInternalAssetsNet10Version>
-    <MicrosoftAspNetCoreAppInternalAssetsNet11Version>11.0.0-preview.5.26302.115</MicrosoftAspNetCoreAppInternalAssetsNet11Version>
+    <MicrosoftAspNetCoreAppInternalAssetsNet11Version>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreAppInternalAssetsNet11Version>
   </PropertyGroup>
   <!-- .NET 11.0 Package Versions used by project templates -->
   <PropertyGroup Label="Net11Preview">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,13 +8,18 @@
     <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
     <DefaultTargetFramework>net8.0</DefaultTargetFramework>
     <AllTargetFrameworks>$(DefaultTargetFramework);net9.0;net10.0</AllTargetFrameworks>
-    <!-- dotnet versions for running tests -->
-    <DotNetRuntimePreviousVersionForTesting>8.0.21</DotNetRuntimePreviousVersionForTesting>
-    <DotNetRuntimeCurrentVersionForTesting>9.0.10</DotNetRuntimeCurrentVersionForTesting>
-    <!-- dotnet 8.0 versions for running tests - used for templates tests -->
-    <DotNetSdkPreviousVersionForTesting>8.0.415</DotNetSdkPreviousVersionForTesting>
-    <!-- dotnet 9.0 versions for running tests - used for templates tests -->
-    <DotNetSdkCurrentVersionForTesting>9.0.306</DotNetSdkCurrentVersionForTesting>
+    <!-- dotnet versions for running template tests -->
+    <DotNetRuntimeNet8VersionForTesting>8.0.21</DotNetRuntimeNet8VersionForTesting>
+    <DotNetRuntimeNet9VersionForTesting>9.0.10</DotNetRuntimeNet9VersionForTesting>
+    <DotNetRuntimeNet10VersionForTesting>10.0.8</DotNetRuntimeNet10VersionForTesting>
+    <DotNetSdkNet8VersionForTesting>8.0.415</DotNetSdkNet8VersionForTesting>
+    <DotNetSdkNet9VersionForTesting>9.0.306</DotNetSdkNet9VersionForTesting>
+    <DotNetSdkNet11VersionForTesting>11.0.100-preview.6.26359.118</DotNetSdkNet11VersionForTesting>
+    <!-- Keep these aliases for global.json and non-template test infrastructure. -->
+    <DotNetRuntimePreviousVersionForTesting>$(DotNetRuntimeNet8VersionForTesting)</DotNetRuntimePreviousVersionForTesting>
+    <DotNetRuntimeCurrentVersionForTesting>$(DotNetRuntimeNet9VersionForTesting)</DotNetRuntimeCurrentVersionForTesting>
+    <DotNetSdkPreviousVersionForTesting>$(DotNetSdkNet8VersionForTesting)</DotNetSdkPreviousVersionForTesting>
+    <DotNetSdkCurrentVersionForTesting>$(DotNetSdkNet9VersionForTesting)</DotNetSdkCurrentVersionForTesting>
     <XunitV3Version>3.2.2</XunitV3Version>
     <XUnitAnalyzersVersion>1.21.0</XUnitAnalyzersVersion>
     <XunitRunnerVisualStudioVersion>3.1.5</XunitRunnerVisualStudioVersion>
@@ -67,6 +72,10 @@
   <PropertyGroup Label="BlazorAssets">
     <MicrosoftAspNetCoreAppInternalAssetsNet10Version>10.0.8</MicrosoftAspNetCoreAppInternalAssetsNet10Version>
     <MicrosoftAspNetCoreAppInternalAssetsNet11Version>11.0.0-preview.5.26302.115</MicrosoftAspNetCoreAppInternalAssetsNet11Version>
+  </PropertyGroup>
+  <!-- .NET 11.0 Package Versions used by project templates -->
+  <PropertyGroup Label="Net11Preview">
+    <MicrosoftAspNetCoreOpenApiNet11Version>11.0.0-preview.6.26359.118</MicrosoftAspNetCoreOpenApiNet11Version>
   </PropertyGroup>
   <!-- .NET 10.0 Package Versions -->
   <PropertyGroup Label="Preview">

--- a/src/Aspire.Dashboard/BlazorAssets.targets
+++ b/src/Aspire.Dashboard/BlazorAssets.targets
@@ -46,15 +46,16 @@ foreach (var filePath in FilePaths)
 
   <ItemGroup>
     <!--
-      Map each supported runtime major version to the package version that supplies its blazor.web.js.
+      Map each supported runtime major version to the package version and asset path that supplies
+      its blazor.web.js. Preview 6 moved package static web assets under the staticwebassets directory.
       Adding a new runtime: add a row here and a matching version property in eng/Versions.props.
     -->
-    <BlazorAssetPackage Include="10" PackageVersion="$(MicrosoftAspNetCoreAppInternalAssetsNet10Version)" />
-    <BlazorAssetPackage Include="11" PackageVersion="$(MicrosoftAspNetCoreAppInternalAssetsNet11Version)" />
+    <BlazorAssetPackage Include="10" PackageVersion="$(MicrosoftAspNetCoreAppInternalAssetsNet10Version)" PackageAssetPath="_framework\blazor.web.js" />
+    <BlazorAssetPackage Include="11" PackageVersion="$(MicrosoftAspNetCoreAppInternalAssetsNet11Version)" PackageAssetPath="staticwebassets\_framework\blazor.web.js" />
   </ItemGroup>
 
   <Target Name="CopyBlazorWebJs" BeforeTargets="BeforeBuild;PrepareForPublish">
-    <Copy SourceFiles="$(NuGetPackageRoot)microsoft.aspnetcore.app.internal.assets\%(BlazorAssetPackage.PackageVersion)\_framework\blazor.web.js"
+    <Copy SourceFiles="$(NuGetPackageRoot)microsoft.aspnetcore.app.internal.assets\%(BlazorAssetPackage.PackageVersion)\%(BlazorAssetPackage.PackageAssetPath)"
           DestinationFiles="$(MSBuildProjectDirectory)\wwwroot\framework\blazor.web.%(BlazorAssetPackage.Identity).js"
           SkipUnchangedFiles="true"
           OverwriteReadOnlyFiles="true" />

--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -100,6 +100,8 @@
       <Replacements Include="$(MicrosoftAspNetCoreOpenApiVersion)" />
       <Replacements Include="!!REPLACE_WITH_ASPNETCORE_OPENAPI_10_VERSION!!" />
       <Replacements Include="$(MicrosoftAspNetCoreOpenApiPreviewVersion)" />
+      <Replacements Include="!!REPLACE_WITH_ASPNETCORE_OPENAPI_11_VERSION!!" />
+      <Replacements Include="$(MicrosoftAspNetCoreOpenApiNet11Version)" />
       <Replacements Include="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
       <Replacements Include="$(MicrosoftExtensionsHttpResilienceVersion)" />
       <Replacements Include="!!REPLACE_WITH_SERVICE_DISCOVERY_VERSION!!" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.cs.json
@@ -3,6 +3,7 @@
   "name": "Hostitel aplikací Aspire pro jednosouborové scénáře",
   "description": "Minimální Aspire AppHost pro scénáře s jedním souborem (.NET 10 a novější).",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Číslo portu, který se má použít pro koncový bod HTTP v launchSettings.json projektu AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Číslo portu, který se má použít pro koncový bod HTTP OTLP v launchSettings.json projektu AppHost.",
   "symbols/appHostResourceHttpPort/description": "Číslo portu, který se má použít pro koncový bod HTTP služby prostředků v launchSettings.json projektu AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.de.json
@@ -3,6 +3,7 @@
   "name": "Aspire App-Host für Einzeldateien",
   "description": "Ein minimaler Aspire AppHost für Einzeldateiszenarien (.NET 10 und höher).",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Portnummer, die für den HTTP-Endpunkt in launchSettings.json des AppHost-Projekts verwendet werden soll.",
   "symbols/appHostOtlpHttpPort/description": "Portnummer, die für den OTLP-HTTP-Endpunkt in launchSettings.json des AppHost-Projekts verwendet werden soll.",
   "symbols/appHostResourceHttpPort/description": "Portnummer, die für den HTTP-Endpunkt des Ressourcendiensts in launchSettings.json des AppHost-Projekts verwendet werden soll.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.en.json
@@ -3,6 +3,7 @@
   "name": "Aspire Single-File App Host",
   "description": "A minimal Aspire AppHost for single-file scenarios (.NET 10+).",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Port number to use for the HTTP endpoint in launchSettings.json of the AppHost project.",
   "symbols/appHostOtlpHttpPort/description": "Port number to use for the OTLP HTTP endpoint in launchSettings.json of the AppHost project.",
   "symbols/appHostResourceHttpPort/description": "Port number to use for the resource service HTTP endpoint in launchSettings.json of the AppHost project.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.es.json
@@ -3,6 +3,7 @@
   "name": "Host de aplicaciones de Aspire de un solo archivo",
   "description": "AppHost mínimo para escenarios de archivo único (.NET 10+).",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Número de puerto que se va a usar para el punto de conexión HTTP en launchSettings.json del proyecto AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Número de puerto que se va a usar para el punto de conexión HTTP de OTLP en launchSettings.json del proyecto AppHost.",
   "symbols/appHostResourceHttpPort/description": "Número de puerto que se va a usar para el punto de conexión HTTP del servicio de recursos en launchSettings.json del proyecto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.fr.json
@@ -3,6 +3,7 @@
   "name": "Hôte d’application à fichier unique Aspire",
   "description": "AppHost minimal pour les scénarios à fichier unique (.NET 10+).",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Numéro de port à utiliser pour le point de terminaison HTTP dans launchSettings.json du projet AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Numéro de port à utiliser pour le point de terminaison HTTP OTLP dans launchSettings.json du projet AppHost.",
   "symbols/appHostResourceHttpPort/description": "Numéro de port à utiliser pour le point de terminaison HTTP du service de ressources dans launchSettings.json du projet AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.it.json
@@ -3,6 +3,7 @@
   "name": "Host dell'app a file singolo Aspire",
   "description": "AppHost Aspire minimo per scenari a file singolo (.NET 10+).",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Numero di porta da usare per l'endpoint HTTP in launchSettings.json. del progetto AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Numero di porta da usare per l'endpoint OTLP HTTP in launchSettings.json. del progetto AppHost.",
   "symbols/appHostResourceHttpPort/description": "Numero di porta da usare per l'endpoint HTTP del servizio risorse in launchSettings.json del progetto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.ja.json
@@ -3,6 +3,7 @@
   "name": "Aspire 単一ファイル アプリ ホスト",
   "description": "単一ファイル シナリオ向けの最小構成の Aspire AppHost (.NET 10 以降)。",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "AppHost プロジェクトの launchSettings.json の HTTP エンドポイントに使用するポート番号。",
   "symbols/appHostOtlpHttpPort/description": "AppHost プロジェクトの launchSettings.json で OTLP HTTP エンドポイントに使用するポート番号。",
   "symbols/appHostResourceHttpPort/description": "AppHost プロジェクトの launchSettings.json のリソース サービス HTTP エンドポイントに使用するポート番号。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.ko.json
@@ -3,6 +3,7 @@
   "name": "Aspire 단일 파일 앱 호스트",
   "description": "단일 파일 시나리오(.NET 10+)를 위한 최소한의 Aspire AppHost입니다.",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "AppHost 프로젝트의 launchSettings.json HTTP 엔드포인트에 사용할 포트 번호입니다.",
   "symbols/appHostOtlpHttpPort/description": "AppHost 프로젝트의 launchSettings.json OTLP HTTP 엔드포인트에 사용할 포트 번호입니다.",
   "symbols/appHostResourceHttpPort/description": "AppHost 프로젝트의 launchSettings.json 리소스 서비스 HTTP 엔드포인트에 사용할 포트 번호입니다.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.pl.json
@@ -3,6 +3,7 @@
   "name": "Host AppHost z jednym plikiem platformy Aspire",
   "description": "Minimalna wersja hosta Aspire AppHost dla scenariuszy z pojedynczym plikiem (co najmniej .NET 10).",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Numer portu do użycia dla punktu końcowego HTTP w pliku launchSettings.json projektu AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Numer portu do użycia dla punktu końcowego HTTP OTLP w pliku launchSettings.json projektu AppHost.",
   "symbols/appHostResourceHttpPort/description": "Numer portu do użycia dla punktu końcowego HTTP usługi zasobów w pliku launchSettings.json projektu AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.pt-BR.json
@@ -3,6 +3,7 @@
   "name": "Host de Aplicativo de Arquivo Único Aspire",
   "description": "Um AppHost Aspire mínimo para cenários de arquivo único (.NET 10+).",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Número da porta a ser usado para o ponto de extremidade HTTP launchSettings.json do projeto AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Número da porta a ser usado para o ponto de extremidade HTTP OTLP launchSettings.json do projeto AppHost.",
   "symbols/appHostResourceHttpPort/description": "Número da porta a ser usado para o ponto de extremidade HTTP do serviço de recurso launchSettings.json do projeto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.ru.json
@@ -3,6 +3,7 @@
   "name": "Хост однофайловых приложений Aspire",
   "description": "Минимальный Aspire AppHost для сценариев с одним файлом (.NET 10+).",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Номер порта, который будет использоваться для конечной точки HTTP в файле launchSettings.json проекта AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Номер порта, который будет использоваться для конечной точки HTTP OTLP в файле launchSettings.json проекта AppHost.",
   "symbols/appHostResourceHttpPort/description": "Номер порта, который будет использоваться для конечной точки HTTP службы ресурсов в файле launchSettings.json проекта AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.tr.json
@@ -3,6 +3,7 @@
   "name": "Aspire Tek Dosya Uygulama Ana İşlemi",
   "description": "Tek dosya senaryoları için minimal Aspire Uygulama Ana İşlemi (.NET 10+).",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "AppHost projesinin HTTP uç noktası launchSettings.json bağlantı noktası numarası.",
   "symbols/appHostOtlpHttpPort/description": "AppHost projesinin OTLP HTTP uç noktası launchSettings.json bağlantı noktası numarası.",
   "symbols/appHostResourceHttpPort/description": "AppHost projesinin kaynak hizmeti HTTP uç noktası launchSettings.json bağlantı noktası numarası.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.zh-Hans.json
@@ -3,6 +3,7 @@
   "name": "Aspire 单文件应用主机",
   "description": "适用于单文件方案的最小 Aspire AppHost (.NET 10+)。",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "该端口号将用于 AppHost 项目的 launchSettings.json 中的 HTTP 终结点。",
   "symbols/appHostOtlpHttpPort/description": "该端口号将用于 AppHost 项目的 launchSettings.json 中的 OTLP HTTP 终结点。",
   "symbols/appHostResourceHttpPort/description": "该端口号将用于 AppHost 项目的 launchSettings.json 中的资源服务 HTTP 终结点。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/localize/templatestrings.zh-Hant.json
@@ -3,6 +3,7 @@
   "name": "Aspire 單一檔案主控處理程序",
   "description": "適用於單一檔案案例的精簡版 Aspire AppHost (.NET 10+)。",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "要用於 AppHost 專案 launchSettings.json 中 HTTP 端點的連接埠號碼。",
   "symbols/appHostOtlpHttpPort/description": "要用於 AppHost 專案 launchSettings.json 中 OTLP HTTP 端點的連接埠號碼。",
   "symbols/appHostResourceHttpPort/description": "要用於 AppHost 專案 launchSettings.json 中資源服務 HTTP 端點的連接埠號碼。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/.template.config/template.json
@@ -47,6 +47,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ]
     },
@@ -195,7 +199,7 @@
     "LocalhostTld": {
       "type": "parameter",
       "datatype": "bool",
-      "isEnabled": "Framework == net10.0",
+      "isEnabled": "(Framework == net10.0 || Framework == net11.0)",
       "defaultValue": "false",
       "displayName": "Use the .dev.localhost TLD in the application URL",
       "description": "Whether to combine the project name with the .dev.localhost TLD in the application URL for local development, e.g. https://myapp.dev.localhost:12345. Supported on .NET 10 and later."

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.cs.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",
   "symbols/Framework/choices/net9.0/description": "Cílit na net9.0",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Číslo portu, který se má použít pro koncový bod HTTP v launchSettings.json projektu AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Číslo portu, který se má použít pro koncový bod HTTP OTLP v launchSettings.json projektu AppHost.",
   "symbols/appHostResourceHttpPort/description": "Číslo portu, který se má použít pro koncový bod HTTP služby prostředků v launchSettings.json projektu AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.de.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",
   "symbols/Framework/choices/net9.0/description": "Ziel-Net9.0",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Portnummer, die für den HTTP-Endpunkt in launchSettings.json des AppHost-Projekts verwendet werden soll.",
   "symbols/appHostOtlpHttpPort/description": "Portnummer, die für den OTLP-HTTP-Endpunkt in launchSettings.json des AppHost-Projekts verwendet werden soll.",
   "symbols/appHostResourceHttpPort/description": "Portnummer, die für den HTTP-Endpunkt des Ressourcendiensts in launchSettings.json des AppHost-Projekts verwendet werden soll.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.en.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Port number to use for the HTTP endpoint in launchSettings.json of the AppHost project.",
   "symbols/appHostOtlpHttpPort/description": "Port number to use for the OTLP HTTP endpoint in launchSettings.json of the AppHost project.",
   "symbols/appHostResourceHttpPort/description": "Port number to use for the resource service HTTP endpoint in launchSettings.json of the AppHost project.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.es.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",
   "symbols/Framework/choices/net9.0/description": "Net9.0 de destino",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Número de puerto que se va a usar para el punto de conexión HTTP en launchSettings.json del proyecto AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Número de puerto que se va a usar para el punto de conexión HTTP de OTLP en launchSettings.json del proyecto AppHost.",
   "symbols/appHostResourceHttpPort/description": "Número de puerto que se va a usar para el punto de conexión HTTP del servicio de recursos en launchSettings.json del proyecto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.fr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",
   "symbols/Framework/choices/net9.0/description": "Cible net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Numéro de port à utiliser pour le point de terminaison HTTP dans launchSettings.json du projet AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Numéro de port à utiliser pour le point de terminaison HTTP OTLP dans launchSettings.json du projet AppHost.",
   "symbols/appHostResourceHttpPort/description": "Numéro de port à utiliser pour le point de terminaison HTTP du service de ressources dans launchSettings.json du projet AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.it.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destinazione net8.0",
   "symbols/Framework/choices/net9.0/description": "Net9.0 di destinazione",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Numero di porta da usare per l'endpoint HTTP in launchSettings.json. del progetto AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Numero di porta da usare per l'endpoint OTLP HTTP in launchSettings.json. del progetto AppHost.",
   "symbols/appHostResourceHttpPort/description": "Numero di porta da usare per l'endpoint HTTP del servizio risorse in launchSettings.json del progetto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.ja.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",
   "symbols/Framework/choices/net9.0/description": "ターゲット net9.0",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "AppHost プロジェクトの launchSettings.json の HTTP エンドポイントに使用するポート番号。",
   "symbols/appHostOtlpHttpPort/description": "AppHost プロジェクトの launchSettings.json で OTLP HTTP エンドポイントに使用するポート番号。",
   "symbols/appHostResourceHttpPort/description": "AppHost プロジェクトの launchSettings.json のリソース サービス HTTP エンドポイントに使用するポート番号。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.ko.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "대상 net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "AppHost 프로젝트의 launchSettings.json HTTP 엔드포인트에 사용할 포트 번호입니다.",
   "symbols/appHostOtlpHttpPort/description": "AppHost 프로젝트의 launchSettings.json OTLP HTTP 엔드포인트에 사용할 포트 번호입니다.",
   "symbols/appHostResourceHttpPort/description": "AppHost 프로젝트의 launchSettings.json 리소스 서비스 HTTP 엔드포인트에 사용할 포트 번호입니다.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.pl.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",
   "symbols/Framework/choices/net9.0/description": "Docelowa platforma net9.0",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Numer portu do użycia dla punktu końcowego HTTP w pliku launchSettings.json projektu AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Numer portu do użycia dla punktu końcowego HTTP OTLP w pliku launchSettings.json projektu AppHost.",
   "symbols/appHostResourceHttpPort/description": "Numer portu do użycia dla punktu końcowego HTTP usługi zasobów w pliku launchSettings.json projektu AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.pt-BR.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Número da porta a ser usado para o ponto de extremidade HTTP launchSettings.json do projeto AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Número da porta a ser usado para o ponto de extremidade HTTP OTLP launchSettings.json do projeto AppHost.",
   "symbols/appHostResourceHttpPort/description": "Número da porta a ser usado para o ponto de extremidade HTTP do serviço de recurso launchSettings.json do projeto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.ru.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",
   "symbols/Framework/choices/net9.0/description": "Целевая среда net9.0",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "Номер порта, который будет использоваться для конечной точки HTTP в файле launchSettings.json проекта AppHost.",
   "symbols/appHostOtlpHttpPort/description": "Номер порта, который будет использоваться для конечной точки HTTP OTLP в файле launchSettings.json проекта AppHost.",
   "symbols/appHostResourceHttpPort/description": "Номер порта, который будет использоваться для конечной точки HTTP службы ресурсов в файле launchSettings.json проекта AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.tr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",
   "symbols/Framework/choices/net9.0/description": "Hedef net9.0",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "AppHost projesinin HTTP uç noktası launchSettings.json bağlantı noktası numarası.",
   "symbols/appHostOtlpHttpPort/description": "AppHost projesinin OTLP HTTP uç noktası launchSettings.json bağlantı noktası numarası.",
   "symbols/appHostResourceHttpPort/description": "AppHost projesinin kaynak hizmeti HTTP uç noktası launchSettings.json bağlantı noktası numarası.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.zh-Hans.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",
   "symbols/Framework/choices/net9.0/description": "目标 net9.0",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "该端口号将用于 AppHost 项目的 launchSettings.json 中的 HTTP 终结点。",
   "symbols/appHostOtlpHttpPort/description": "该端口号将用于 AppHost 项目的 launchSettings.json 中的 OTLP HTTP 终结点。",
   "symbols/appHostResourceHttpPort/description": "该端口号将用于 AppHost 项目的 launchSettings.json 中的资源服务 HTTP 终结点。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/localize/templatestrings.zh-Hant.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",
   "symbols/Framework/choices/net9.0/description": "目標 net9.0",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/appHostHttpPort/description": "要用於 AppHost 專案 launchSettings.json 中 HTTP 端點的連接埠號碼。",
   "symbols/appHostOtlpHttpPort/description": "要用於 AppHost 專案 launchSettings.json 中 OTLP HTTP 端點的連接埠號碼。",
   "symbols/appHostResourceHttpPort/description": "要用於 AppHost 專案 launchSettings.json 中資源服務 HTTP 端點的連接埠號碼。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
@@ -47,6 +47,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ],
       "replaces": "net8.0",
@@ -207,7 +211,7 @@
     "LocalhostTld": {
       "type": "parameter",
       "datatype": "bool",
-      "isEnabled": "Framework == net10.0",
+      "isEnabled": "(Framework == net10.0 || Framework == net11.0)",
       "defaultValue": "false",
       "displayName": "Use the .dev.localhost TLD in the application URL",
       "description": "Whether to combine the project name with the .dev.localhost TLD in the application URL for local development, e.g. https://myapp.dev.localhost:12345. Supported on .NET 10 and later."

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.cs.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",
   "symbols/Framework/choices/net9.0/description": "Cílit na net9.0",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "Verze Aspire, která se má použít.",
   "symbols/AspireVersion/displayName": "Verze Aspire",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.de.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",
   "symbols/Framework/choices/net9.0/description": "Ziel-Net9.0",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "Die zu verwendende Aspire-Version.",
   "symbols/AspireVersion/displayName": "Aspire-Version",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.en.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "The version of Aspire to use.",
   "symbols/AspireVersion/displayName": "Aspire version",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.es.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",
   "symbols/Framework/choices/net9.0/description": "Net9.0 de destino",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "La versión de Aspire que se va a usar.",
   "symbols/AspireVersion/displayName": "Versión Aspire",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.fr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",
   "symbols/Framework/choices/net9.0/description": "Cible net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "La version d’Aspire à utiliser.",
   "symbols/AspireVersion/displayName": "Version Aspire",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.it.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destinazione net8.0",
   "symbols/Framework/choices/net9.0/description": "Net9.0 di destinazione",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "Versione di Aspire da usare.",
   "symbols/AspireVersion/displayName": "Versione di Aspire",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.ja.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",
   "symbols/Framework/choices/net9.0/description": "ターゲット net9.0",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "使用する Aspire のバージョン。",
   "symbols/AspireVersion/displayName": "Aspire のバージョン",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.ko.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "대상 net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "사용하려는 Aspire 버전입니다.",
   "symbols/AspireVersion/displayName": "Aspire 버전",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.pl.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",
   "symbols/Framework/choices/net9.0/description": "Docelowa platforma net9.0",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "Wersja platformy Aspire do użycia.",
   "symbols/AspireVersion/displayName": "Wersja Aspire",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.pt-BR.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "A versão do Aspire que será usada.",
   "symbols/AspireVersion/displayName": "Versão do Aspire",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.ru.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",
   "symbols/Framework/choices/net9.0/description": "Целевая среда net9.0",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "Используемая версия Aspire.",
   "symbols/AspireVersion/displayName": "Версия Aspire",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.tr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",
   "symbols/Framework/choices/net9.0/description": "Hedef net9.0",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "Kullanılacak Aspire sürümü.",
   "symbols/AspireVersion/displayName": "Aspire sürümü",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.zh-Hans.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",
   "symbols/Framework/choices/net9.0/description": "目标 net9.0",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "要使用的 Aspire 版本。",
   "symbols/AspireVersion/displayName": "Aspire 版本",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.zh-Hant.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",
   "symbols/Framework/choices/net9.0/description": "目標 net9.0",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/AspireVersion/description": "要使用的 Aspire 版本。",
   "symbols/AspireVersion/displayName": "Aspire 版本",
   "symbols/AspireVersion/choices/!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!/displayName": "!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -21,7 +21,7 @@
     "language": "C#",
     "type": "solution",
     "editorTreatAs": "solution",
-    "aspire-!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!-tfms": "net8.0;net9.0;net10.0"
+    "aspire-!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!-tfms": "net8.0;net9.0;net10.0;net11.0"
   },
   "precedence": "9000",
   "identity": "Aspire.Empty.CSharp.!!REPLACE_WITH_LATEST_MAJOR_MINOR_VERSION!!",
@@ -65,6 +65,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ],
       "replaces": "net8.0",
@@ -239,7 +243,7 @@
     "LocalhostTld": {
       "type": "parameter",
       "datatype": "bool",
-      "isEnabled": "Framework == net10.0",
+      "isEnabled": "(Framework == net10.0 || Framework == net11.0)",
       "defaultValue": "false",
       "displayName": "Use the .dev.localhost TLD in the application URL",
       "description": "Whether to combine the project name with the .dev.localhost TLD in the application URL for local development, e.g. https://myapp.dev.localhost:12345. Supported on .NET 10 and later."

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.cs.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",
   "symbols/Framework/choices/net9.0/description": "Cílit na net9.0",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restore/manualInstructions/default/text": "Spustit dotnet restore"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.de.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",
   "symbols/Framework/choices/net9.0/description": "Ziel-Net9.0",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",
   "postActions/restore/manualInstructions/default/text": "\"dotnet restore\" ausführen"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.en.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",
   "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.es.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",
   "symbols/Framework/choices/net9.0/description": "Net9.0 de destino",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restore/manualInstructions/default/text": "Ejecutar \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.fr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",
   "symbols/Framework/choices/net9.0/description": "Cible net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restore/manualInstructions/default/text": "Exécutez 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.it.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destinazione net8.0",
   "symbols/Framework/choices/net9.0/description": "Net9.0 di destinazione",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restore/manualInstructions/default/text": "Esegui 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.ja.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",
   "symbols/Framework/choices/net9.0/description": "ターゲット net9.0",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' を実行する"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.ko.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "대상 net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' 실행"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.pl.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",
   "symbols/Framework/choices/net9.0/description": "Docelowa platforma net9.0",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.pt-BR.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "postActions/restore/description": "Restaure os pacotes NuGet exigidos por este projeto.",
   "postActions/restore/manualInstructions/default/text": "Executa 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.ru.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",
   "symbols/Framework/choices/net9.0/description": "Целевая среда net9.0",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restore/manualInstructions/default/text": "Выполнить команду \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.tr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",
   "symbols/Framework/choices/net9.0/description": "Hedef net9.0",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Belirtilirse, oluşturma sırasında projenin otomatik geri yüklenmesini atlar.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' çalıştır"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.zh-Hans.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",
   "symbols/Framework/choices/net9.0/description": "目标 net9.0",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",
   "postActions/restore/manualInstructions/default/text": "运行 \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/localize/templatestrings.zh-Hant.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",
   "symbols/Framework/choices/net9.0/description": "目標 net9.0",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restore/manualInstructions/default/text": "執行 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -50,6 +50,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ],
       "replaces": "net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.cs.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",
   "symbols/Framework/choices/net9.0/description": "Cílit na net9.0",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restore/manualInstructions/default/text": "Spustit dotnet restore"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.de.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",
   "symbols/Framework/choices/net9.0/description": "Ziel-Net9.0",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",
   "postActions/restore/manualInstructions/default/text": "\"dotnet restore\" ausführen"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.en.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",
   "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.es.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",
   "symbols/Framework/choices/net9.0/description": "Net9.0 de destino",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restore/manualInstructions/default/text": "Ejecutar \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.fr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",
   "symbols/Framework/choices/net9.0/description": "Cible net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restore/manualInstructions/default/text": "Exécutez 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.it.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destinazione net8.0",
   "symbols/Framework/choices/net9.0/description": "Net9.0 di destinazione",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restore/manualInstructions/default/text": "Esegui 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.ja.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",
   "symbols/Framework/choices/net9.0/description": "ターゲット net9.0",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' を実行する"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.ko.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "대상 net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' 실행"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.pl.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",
   "symbols/Framework/choices/net9.0/description": "Docelowa platforma net9.0",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.pt-BR.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "postActions/restore/description": "Restaure os pacotes NuGet exigidos por este projeto.",
   "postActions/restore/manualInstructions/default/text": "Executa 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.ru.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",
   "symbols/Framework/choices/net9.0/description": "Целевая среда net9.0",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restore/manualInstructions/default/text": "Выполнить команду \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.tr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",
   "symbols/Framework/choices/net9.0/description": "Hedef net9.0",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Belirtilirse, oluşturma sırasında projenin otomatik geri yüklenmesini atlar.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' çalıştır"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.zh-Hans.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",
   "symbols/Framework/choices/net9.0/description": "目标 net9.0",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",
   "postActions/restore/manualInstructions/default/text": "运行 \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/localize/templatestrings.zh-Hant.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",
   "symbols/Framework/choices/net9.0/description": "目標 net9.0",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restore/manualInstructions/default/text": "執行 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -50,6 +50,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ],
       "replaces": "net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.cs.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",
   "symbols/Framework/choices/net9.0/description": "Cílit na net9.0",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restore/manualInstructions/default/text": "Spustit dotnet restore"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.de.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",
   "symbols/Framework/choices/net9.0/description": "Ziel-Net9.0",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",
   "postActions/restore/manualInstructions/default/text": "\"dotnet restore\" ausführen"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.en.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",
   "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.es.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",
   "symbols/Framework/choices/net9.0/description": "Net9.0 de destino",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restore/manualInstructions/default/text": "Ejecutar \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.fr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",
   "symbols/Framework/choices/net9.0/description": "Cible net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restore/manualInstructions/default/text": "Exécutez 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.it.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destinazione net8.0",
   "symbols/Framework/choices/net9.0/description": "Net9.0 di destinazione",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restore/manualInstructions/default/text": "Esegui 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.ja.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",
   "symbols/Framework/choices/net9.0/description": "ターゲット net9.0",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' を実行する"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.ko.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "대상 net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' 실행"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.pl.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",
   "symbols/Framework/choices/net9.0/description": "Docelowa platforma net9.0",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.pt-BR.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "postActions/restore/description": "Restaure os pacotes NuGet exigidos por este projeto.",
   "postActions/restore/manualInstructions/default/text": "Executa 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.ru.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",
   "symbols/Framework/choices/net9.0/description": "Целевая среда net9.0",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restore/manualInstructions/default/text": "Выполнить команду \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.tr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",
   "symbols/Framework/choices/net9.0/description": "Hedef net9.0",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "Belirtilirse, oluşturma sırasında projenin otomatik geri yüklenmesini atlar.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' çalıştır"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.zh-Hans.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",
   "symbols/Framework/choices/net9.0/description": "目标 net9.0",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",
   "postActions/restore/manualInstructions/default/text": "运行 \"dotnet restore\""

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/localize/templatestrings.zh-Hant.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",
   "symbols/Framework/choices/net9.0/description": "目標 net9.0",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restore/manualInstructions/default/text": "執行 'dotnet restore'"

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
@@ -48,6 +48,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ],
       "replaces": "net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.cs.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",
   "symbols/Framework/choices/net9.0/description": "Cílit na net9.0",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "Po_užít Redis pro ukládání do mezipaměti (vyžaduje Docker)",
   "symbols/UseRedisCache/description": "Nakonfiguruje, jestli se má aplikace nastavit tak, aby pro ukládání do mezipaměti používala Redis. K místnímu spouštění se vyžaduje podporovaný modul runtime kontejneru. Další podrobnosti najdete na https://aka.ms/aspire/containers.",
   "symbols/TestFx/displayName": "Vytvoření projektu _test",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.de.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",
   "symbols/Framework/choices/net9.0/description": "Ziel-Net9.0",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Use Redis für die Zwischenspeicherung (erfordert eine unterstützte Container-Runtime)",
   "symbols/UseRedisCache/description": "Konfiguriert, ob die Anwendung für die Verwendung von Redis für die Zwischenspeicherung eingerichtet werden soll. Erfordert eine unterstützte Containerruntime für die lokale Ausführung. Weitere Informationen finden Sie unter https://aka.ms/aspire/containers.",
   "symbols/TestFx/displayName": "„_test project“ erstellen",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.en.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Use Redis for caching (requires a supported container runtime)",
   "symbols/UseRedisCache/description": "Configures whether to setup the application to use Redis for caching. Requires a supported container runtime to run locally, see https://aka.ms/aspire/containers for more details.",
   "symbols/TestFx/displayName": "Create a _test project",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.es.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",
   "symbols/Framework/choices/net9.0/description": "Net9.0 de destino",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Use Redis para el almacenamiento en caché (requiere un runtime de contenedor compatible)",
   "symbols/UseRedisCache/description": "Configure si se va a configurar la aplicación para que use Redis para el almacenamiento en caché. Requiere un entorno de ejecución de contenedor compatible para ejecutarse localmente. Consulte https://aka.ms/aspire/containers para obtener más detalles.",
   "symbols/TestFx/displayName": "Crear un proyecto de _prueba.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.fr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",
   "symbols/Framework/choices/net9.0/description": "Cible net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Use Redis pour la mise en cache (nécessite un runtime de conteneur pris en charge)",
   "symbols/UseRedisCache/description": "Permet la configuration s’il faut configurer l’application afin qu’elle utilise Redis pour la mise en cache. Nécessite un runtime du conteneur pris en charge pour fonctionner localement, voir https://aka.ms/aspire/containers pour obtenir plus d’informations.",
   "symbols/TestFx/displayName": "Créer un _projet de test",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.it.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destinazione net8.0",
   "symbols/Framework/choices/net9.0/description": "Net9.0 di destinazione",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Usare Redis per la memorizzazione nella cache (richiede un runtime del contenitore supportato)",
   "symbols/UseRedisCache/description": "Configura se impostare l'applicazione per l'utilizzo di Redis per la memorizzazione nella cache. Richiede l'esecuzione locale di un runtime del contenitore supportato. Per altri dettagli, vedere https://aka.ms/aspire/containers.",
   "symbols/TestFx/displayName": "Creare un _progetto di test",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.ja.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",
   "symbols/Framework/choices/net9.0/description": "ターゲット net9.0",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "キャッシュ用に Redis を使用する (サポートされているコンテナー ランタイムが必要) (_U)",
   "symbols/UseRedisCache/description": "Redis をキャッシュに使用するようにアプリケーションを設定するかどうかを構成します。ローカルで実行するには、サポートされているコンテナー ランタイムが必要です。詳細については、https://aka.ms/aspire/containers を参照してください。",
   "symbols/TestFx/displayName": "_test プロジェクトを作成する",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.ko.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "대상 net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "캐싱용 _Use Redis(지원되는 컨테이너 런타임 필요)",
   "symbols/UseRedisCache/description": "캐싱에 Redis를 사용하도록 응용 프로그램을 설정할지 여부를 구성합니다. 로컬로 실행하려면 지원되는 컨테이너 런타임이 필요합니다. 자세한 내용은 https://aka.ms/aspire/containers를 참조하세요.",
   "symbols/TestFx/displayName": "테스트 프로젝트 만들기(_T)",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.pl.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",
   "symbols/Framework/choices/net9.0/description": "Docelowa platforma net9.0",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Skorzystaj z magazynu danych Redis na potrzeby buforowania (wymaga obsługiwanego środowiska uruchomieniowego kontenera)",
   "symbols/UseRedisCache/description": "Określa, czy konfigurować aplikację do korzystania z magazynu danych Redis na potrzeby buforowania. Wymaga obsługiwanego środowiska uruchomieniowego kontenera na potrzeby uruchomienia lokalnego. Aby uzyskać więcej informacji, zobacz https://aka.ms/aspire/containers.",
   "symbols/TestFx/displayName": "Utwórz _projekt testowy.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.pt-BR.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Usar o Redis para cache (requer um tempo de execução de contêiner compatível)",
   "symbols/UseRedisCache/description": "Configura se o aplicativo deve usar Redis para cache. Requer um runtime de contêiner com suporte para execução local; confira https://aka.ms/aspire/containers para obter mais detalhes.",
   "symbols/TestFx/displayName": "Criar um projeto _test",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.ru.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",
   "symbols/Framework/choices/net9.0/description": "Целевая среда net9.0",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Использовать Redis для кэширования (требуется поддерживаемая среда выполнения контейнера)",
   "symbols/UseRedisCache/description": "Определяет, следует ли настраивать приложение с целью использования Redis для кэширования. Для локального запуска требуется поддерживаемая среда выполнения контейнеров. Дополнительные сведения см. на странице https://aka.ms/aspire/containers.",
   "symbols/TestFx/displayName": "Не создавать _тестовый проект.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.tr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",
   "symbols/Framework/choices/net9.0/description": "Hedef net9.0",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "Önbelleğe alma için Redis’i k_ullan (desteklenen bir kapsayıcı çalışma zamanı gerektirir)",
   "symbols/UseRedisCache/description": "Uygulamanın önbelleğe alma için Redis’i kullanmak üzere ayarlanıp ayarlanmayacağını yapılandırır. Yerel olarak çalıştırmak için desteklenen bir kapsayıcı çalışma zamanı gerektirir. Daha fazla ayrıntı için https://aka.ms/aspire/containers sayfasına bakın.",
   "symbols/TestFx/displayName": "Bir _test projesi oluşturun",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.zh-Hans.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",
   "symbols/Framework/choices/net9.0/description": "目标 net9.0",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "使用 Redis 进行缓存(需要受支持的容器运行时)(_U)",
   "symbols/UseRedisCache/description": "配置是否将应用程序设置为使用 Redis 进行缓存。需要支持的容器运行时才能在本地运行，有关详细信息，请访问 https://aka.ms/aspire/containers for more details。",
   "symbols/TestFx/displayName": "创建测试项目(_T)",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.zh-Hant.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",
   "symbols/Framework/choices/net9.0/description": "目標 net9.0",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "使用 Redis 進行快取 (需要支援的容器執行階段)(_U)",
   "symbols/UseRedisCache/description": "設定是否要將應用程式設為使用 Redis 進行快取。需要支援的容器執行階段，才能在本機執行，如需詳細資料，請參閱 https://aka.ms/aspire/containers。",
   "symbols/TestFx/displayName": "建立 _test 專案",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -77,6 +77,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ],
       "replaces": "net8.0",
@@ -421,7 +425,7 @@
     "LocalhostTld": {
       "type": "parameter",
       "datatype": "bool",
-      "isEnabled": "Framework == net10.0",
+      "isEnabled": "(Framework == net10.0 || Framework == net11.0)",
       "defaultValue": "false",
       "displayName": "Use the .dev.localhost TLD in the application URL",
       "description": "Whether to combine the project name with the .dev.localhost TLD in the application URL for local development, e.g. https://myapp.dev.localhost:12345. Supported on .NET 10 and later."

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Aspire-StarterApplication.1.ApiService.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Aspire-StarterApplication.1.ApiService.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_OPENAPI_9_VERSION!!" Condition=" '$(Framework)' == 'net9.0' " />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_OPENAPI_10_VERSION!!" Condition=" '$(Framework)' == 'net10.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_OPENAPI_11_VERSION!!" Condition=" '$(Framework)' == 'net11.0' " />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/App.razor
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/App.razor
@@ -4,7 +4,11 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    @*#if (Framework == 'net11.0')
+    <BasePath />
+    ##else
     <base href="/" />
+    ##endif*@
     @*#if (Framework == 'net8.0')
     <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="app.css" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/Layout/NavMenu.razor
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/Layout/NavMenu.razor
@@ -1,4 +1,10 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+﻿@*#if (Framework == 'net8.0')
+<script type="module" src="Components/Layout/NavMenu.razor.js"></script>
+##else
+<script type="module" src="@Assets["Components/Layout/NavMenu.razor.js"]"></script>
+##endif*@
+
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">Aspire-StarterApplication.1</a>
     </div>
@@ -6,7 +12,7 @@
 
 <input type="checkbox" title="Navigation menu" class="navbar-toggler" />
 
-<div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
+<div id="nav-scrollable" class="nav-scrollable">
     <nav class="nav flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/Layout/NavMenu.razor.js
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/Layout/NavMenu.razor.js
@@ -1,0 +1,8 @@
+const navScrollable = document.getElementById("nav-scrollable");
+const navToggler = document.querySelector(".navbar-toggler");
+
+if (navScrollable && navToggler) {
+    navScrollable.addEventListener("click", function() {
+        navToggler.click();
+    });
+}

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/Pages/Error.razor
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/Pages/Error.razor
@@ -9,7 +9,7 @@
 @if (ShowRequestId)
 {
     <p>
-        <strong>Request ID:</strong> <code>@requestId</code>
+        <strong>Request ID:</strong> <code>@RequestId</code>
     </p>
 }
 
@@ -28,11 +28,17 @@
     [CascadingParameter]
     public HttpContext? HttpContext { get; set; }
 
-    private string? requestId;
-    private bool ShowRequestId => !string.IsNullOrEmpty(requestId);
+    @*#if (Framework == 'net10.0' || Framework == 'net11.0')
+    [PersistentState]
+    public string? RequestId { get; set; }
+    ##else
+    private string? RequestId { get; set; }
+    ##endif*@
+
+    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
     protected override void OnInitialized()
     {
-        requestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+        RequestId ??= Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
     }
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/_Imports.razor
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Web/Components/_Imports.razor
@@ -1,5 +1,8 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
+@*#if (Framework == 'net11.0')
+@using Microsoft.AspNetCore.Components.Endpoints
+##endif*@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.cs.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",
   "symbols/Framework/choices/net9.0/description": "Cílit na net9.0",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "Po_užít Redis pro ukládání do mezipaměti (vyžaduje Docker)",
   "symbols/UseRedisCache/description": "Nakonfiguruje, jestli se má aplikace nastavit tak, aby pro ukládání do mezipaměti používala Redis. K místnímu spouštění se vyžaduje podporovaný modul runtime kontejneru. Další podrobnosti najdete na https://aka.ms/aspire/containers.",
   "symbols/appHostHttpPort/description": "Číslo portu, který se má použít pro koncový bod HTTP v launchSettings.json projektu AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.de.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",
   "symbols/Framework/choices/net9.0/description": "Ziel-Net9.0",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Use Redis für die Zwischenspeicherung (erfordert eine unterstützte Container-Runtime)",
   "symbols/UseRedisCache/description": "Legt fest, ob die Anwendung für die Verwendung von Redis zum Zwischenspeichern eingerichtet werden soll. Erfordert eine unterstützte Containerruntime für die lokale Ausführung. Weitere Informationen finden Sie unter https://aka.ms/aspire/containers.",
   "symbols/appHostHttpPort/description": "Portnummer, die für den HTTP-Endpunkt in launchSettings.json des AppHost-Projekts verwendet werden soll.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.en.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Use Redis for caching (requires a supported container runtime)",
   "symbols/UseRedisCache/description": "Configures whether to setup the application to use Redis for caching. Requires a supported container runtime to run locally, see https://aka.ms/aspire/containers for more details.",
   "symbols/appHostHttpPort/description": "Port number to use for the HTTP endpoint in launchSettings.json of the AppHost project.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.es.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",
   "symbols/Framework/choices/net9.0/description": "Net9.0 de destino",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Use Redis para el almacenamiento en caché (requiere un runtime de contenedor compatible)",
   "symbols/UseRedisCache/description": "Configure si se va a configurar la aplicación para que use Redis para el almacenamiento en caché. Requiere un entorno de ejecución de contenedor compatible para ejecutarse localmente. Consulte https://aka.ms/aspire/containers para obtener más detalles.",
   "symbols/appHostHttpPort/description": "Número de puerto que se va a usar para el punto de conexión HTTP en launchSettings.json del proyecto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.fr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",
   "symbols/Framework/choices/net9.0/description": "Cible net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Use Redis pour la mise en cache (nécessite un runtime de conteneur pris en charge)",
   "symbols/UseRedisCache/description": "Permet la configuration s’il faut configurer l’application afin qu’elle utilise Redis pour la mise en cache. Nécessite un runtime du conteneur pris en charge pour fonctionner localement, voir https://aka.ms/aspire/containers pour obtenir plus d’informations.",
   "symbols/appHostHttpPort/description": "Numéro de port à utiliser pour le point de terminaison HTTP dans launchSettings.json du projet AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.it.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Net9.0 di destinazione",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Usare Redis per la memorizzazione nella cache (richiede un runtime del contenitore supportato)",
   "symbols/UseRedisCache/description": "Configura se impostare l'applicazione per l'utilizzo di Redis per la memorizzazione nella cache. Richiede l'esecuzione locale di un runtime del contenitore supportato. Per altri dettagli, vedere https://aka.ms/aspire/containers.",
   "symbols/appHostHttpPort/description": "Numero di porta da usare per l'endpoint HTTP in launchSettings.json. del progetto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ja.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",
   "symbols/Framework/choices/net9.0/description": "ターゲット net9.0",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "キャッシュ用に Redis を使用する (サポートされているコンテナー ランタイムが必要) (_U)",
   "symbols/UseRedisCache/description": "Redis をキャッシュに使用するようにアプリケーションを設定するかどうかを構成します。ローカルで実行するには、サポートされているコンテナー ランタイムが必要です。詳細については、https://aka.ms/aspire/containers を参照してください。",
   "symbols/appHostHttpPort/description": "AppHost プロジェクトの launchSettings.json の HTTP エンドポイントに使用するポート番号。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ko.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "캐싱용 _Use Redis(지원되는 컨테이너 런타임 필요)",
   "symbols/UseRedisCache/description": "캐싱에 Redis를 사용하도록 애플리케이션을 설정할지 여부를 구성합니다. 로컬로 실행하려면 지원되는 컨테이너 런타임이 필요합니다. 자세한 내용은 https://aka.ms/aspire/containers를 참조하세요.",
   "symbols/appHostHttpPort/description": "AppHost 프로젝트의 launchSettings.json HTTP 엔드포인트에 사용할 포트 번호입니다.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.pl.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",
   "symbols/Framework/choices/net9.0/description": "Docelowa platforma net9.0",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Skorzystaj z magazynu danych Redis na potrzeby buforowania (wymaga obsługiwanego środowiska uruchomieniowego kontenera)",
   "symbols/UseRedisCache/description": "Określa, czy konfigurować aplikację do korzystania z magazynu danych Redis na potrzeby buforowania. Wymaga obsługiwanego środowiska uruchomieniowego kontenera na potrzeby uruchomienia lokalnego. Aby uzyskać więcej informacji, zobacz https://aka.ms/aspire/containers.",
   "symbols/appHostHttpPort/description": "Numer portu do użycia dla punktu końcowego HTTP w pliku launchSettings.json projektu AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.pt-BR.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Usar o Redis para cache (requer um tempo de execução de contêiner compatível)",
   "symbols/UseRedisCache/description": "Configura se o aplicativo deve usar Redis para cache. Requer um runtime de contêiner com suporte para execução local; confira https://aka.ms/aspire/containers para obter mais detalhes.",
   "symbols/appHostHttpPort/description": "Número da porta a ser usado para o ponto de extremidade HTTP launchSettings.json do projeto AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.ru.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",
   "symbols/Framework/choices/net9.0/description": "Целевая среда net9.0",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "_Использовать Redis для кэширования (требуется поддерживаемая среда выполнения контейнера)",
   "symbols/UseRedisCache/description": "Определяет, следует ли настраивать приложение с целью использования Redis для кэширования. Для локального запуска требуется поддерживаемая среда выполнения контейнеров. Дополнительные сведения см. на странице https://aka.ms/aspire/containers.",
   "symbols/appHostHttpPort/description": "Номер порта, который будет использоваться для конечной точки HTTP в файле launchSettings.json проекта AppHost.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.tr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",
   "symbols/Framework/choices/net9.0/description": "Hedef net9.0",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "Önbelleğe alma için Redis’i k_ullan (desteklenen bir kapsayıcı çalışma zamanı gerektirir)",
   "symbols/UseRedisCache/description": "Uygulamanın önbelleğe alma için Redis’i kullanmak üzere ayarlanıp ayarlanmayacağını yapılandırır. Yerel olarak çalıştırmak için desteklenen bir kapsayıcı çalışma zamanı gerektirir. Daha fazla ayrıntı için https://aka.ms/aspire/containers sayfasına bakın.",
   "symbols/appHostHttpPort/description": "AppHost projesinin HTTP uç noktası launchSettings.json bağlantı noktası numarası.",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.zh-Hans.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",
   "symbols/Framework/choices/net9.0/description": "目标 net9.0",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "使用 Redis 进行缓存(需要受支持的容器运行时)(_U)",
   "symbols/UseRedisCache/description": "配置是否将应用程序设置为使用 Redis 进行缓存。需要支持的容器运行时才能在本地运行，有关详细信息，请访问 https://aka.ms/aspire/containers for more details。",
   "symbols/appHostHttpPort/description": "该端口号将用于 AppHost 项目的 launchSettings.json 中的 HTTP 终结点。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/localize/templatestrings.zh-Hant.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",
   "symbols/Framework/choices/net9.0/description": "目標 net9.0",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/UseRedisCache/displayName": "使用 Redis 進行快取 (需要支援的容器執行階段)(_U)",
   "symbols/UseRedisCache/description": "設定是否要將應用程式設為使用 Redis 進行快取。需要支援的容器執行階段，才能在本機執行，如需詳細資料，請參閱 https://aka.ms/aspire/containers。",
   "symbols/appHostHttpPort/description": "要用於 AppHost 專案 launchSettings.json 中 HTTP 端點的連接埠號碼。",

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/.template.config/template.json
@@ -66,6 +66,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ],
       "replaces": "net8.0",
@@ -299,7 +303,7 @@
     "LocalhostTld": {
       "type": "parameter",
       "datatype": "bool",
-      "isEnabled": "Framework == net10.0",
+      "isEnabled": "(Framework == net10.0 || Framework == net11.0)",
       "defaultValue": "false",
       "displayName": "Use the .dev.localhost TLD in the application URL",
       "description": "Whether to combine the project name with the .dev.localhost TLD in the application URL for local development, e.g. https://myapp.dev.localhost:12345. Supported on .NET 10 and later."

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/Aspire-StarterApplication.1.Server/Aspire-StarterApplication.1.Server.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/Aspire-StarterApplication.1.Server/Aspire-StarterApplication.1.Server.csproj
@@ -12,6 +12,7 @@
     <!--#endif -->
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_OPENAPI_9_VERSION!!" Condition=" '$(Framework)' == 'net9.0' " />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_OPENAPI_10_VERSION!!" Condition=" '$(Framework)' == 'net10.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="!!REPLACE_WITH_ASPNETCORE_OPENAPI_11_VERSION!!" Condition=" '$(Framework)' == 'net11.0' " />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_SERVICE_DISCOVERY_VERSION!!" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="!!REPLACE_WITH_OTEL_EXPORTER_VERSION!!" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.cs.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.cs.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cílový net8.0",
   "symbols/Framework/choices/net9.0/description": "Cílit na net9.0",
   "symbols/Framework/choices/net10.0/description": "Cíl net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "Verze xUnit.net, která se použije.",
   "symbols/XUnitVersion/displayName": "Verze xUnit.net",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.de.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.de.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Ziel net8.0",
   "symbols/Framework/choices/net9.0/description": "Ziel-Net9.0",
   "symbols/Framework/choices/net10.0/description": "Ziel.-NET10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "Die Version von xUnit.net, die verwendet werden soll.",
   "symbols/XUnitVersion/displayName": "xUnit.net-Version",
   "symbols/XUnitVersion/choices/v2/displayName": "V2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.en.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Target net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Target net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "The version of xUnit.net to use.",
   "symbols/XUnitVersion/displayName": "xUnit.net version",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.es.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.es.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "NET8.0 de destino",
   "symbols/Framework/choices/net9.0/description": "Net9.0 de destino",
   "symbols/Framework/choices/net10.0/description": "Destino net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "La versión de xUnit.net que se utilizará.",
   "symbols/XUnitVersion/displayName": "Versión de xUnit.net",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.fr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.fr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Cible net8.0",
   "symbols/Framework/choices/net9.0/description": "Cible net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 cible",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "Version de xUnit.net à utiliser.",
   "symbols/XUnitVersion/displayName": "version xUnit.net",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.it.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.it.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destinazione net8.0",
   "symbols/Framework/choices/net9.0/description": "Net9.0 di destinazione",
   "symbols/Framework/choices/net10.0/description": "Destinazione net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "Versione di xUnit.net da usare.",
   "symbols/XUnitVersion/displayName": "Versione di xUnit.net",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.ja.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.ja.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "ターゲット net8.0",
   "symbols/Framework/choices/net9.0/description": "ターゲット net9.0",
   "symbols/Framework/choices/net10.0/description": "ターゲット net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "使用する xUnit.net のバージョン。",
   "symbols/XUnitVersion/displayName": "xUnit.net バージョン",
   "symbols/XUnitVersion/choices/v2/displayName": "V2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.ko.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.ko.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "대상 net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "대상 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "사용할 xUnit.net 버전.",
   "symbols/XUnitVersion/displayName": "xUnit.net 버전",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.pl.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.pl.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Docelowa platforma net8.0",
   "symbols/Framework/choices/net9.0/description": "Docelowa platforma net9.0",
   "symbols/Framework/choices/net10.0/description": "Docelowa platforma net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "Wersja xUnit.net do użycia.",
   "symbols/XUnitVersion/displayName": "wersja xUnit.net",
   "symbols/XUnitVersion/choices/v2/displayName": "wersja 2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.pt-BR.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Destino net8.0",
   "symbols/Framework/choices/net9.0/description": "Target net9.0",
   "symbols/Framework/choices/net10.0/description": "Net10.0 de destino",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "A versão do xUnit.net a ser usada.",
   "symbols/XUnitVersion/displayName": "Versão xUnit.net",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.ru.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.ru.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Целевая среда net8.0",
   "symbols/Framework/choices/net9.0/description": "Целевая среда net9.0",
   "symbols/Framework/choices/net10.0/description": "Целевая платформа .NET 10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "Используемая версия xUnit.net.",
   "symbols/XUnitVersion/displayName": "Версия xUnit.net",
   "symbols/XUnitVersion/choices/v2/displayName": "версия 2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.tr.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.tr.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "Hedef net8.0",
   "symbols/Framework/choices/net9.0/description": "Hedef net9.0",
   "symbols/Framework/choices/net10.0/description": "Hedef net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "Kullanılacak xUnit.net sürümü.",
   "symbols/XUnitVersion/displayName": "xUnit.net sürümü",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.zh-Hans.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目标 net8.0",
   "symbols/Framework/choices/net9.0/description": "目标 net9.0",
   "symbols/Framework/choices/net10.0/description": "目标 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "要使用的 xUnit.net 版本。",
   "symbols/XUnitVersion/displayName": "xUnit.net 版本",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/localize/templatestrings.zh-Hant.json
@@ -6,6 +6,7 @@
   "symbols/Framework/choices/net8.0/description": "目標 net8.0",
   "symbols/Framework/choices/net9.0/description": "目標 net9.0",
   "symbols/Framework/choices/net10.0/description": "目標 net10.0",
+  "symbols/Framework/choices/net11.0/description": "Target net11.0",
   "symbols/XUnitVersion/description": "要使用 xUnit.net 的版本。",
   "symbols/XUnitVersion/displayName": "xUnit.net 版本",
   "symbols/XUnitVersion/choices/v2/displayName": "v2",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -50,6 +50,10 @@
         {
           "choice": "net10.0",
           "description": "Target net10.0"
+        },
+        {
+          "choice": "net11.0",
+          "description": "Target net11.0"
         }
       ],
       "replaces": "net8.0",

--- a/tests/Aspire.Templates.Tests/LocalhostTldHostnameTests.cs
+++ b/tests/Aspire.Templates.Tests/LocalhostTldHostnameTests.cs
@@ -12,39 +12,50 @@ public partial class LocalhostTldHostnameTests(ITestOutputHelper testOutput) : T
     [GeneratedRegex(@"://([^:]+)\.dev\.localhost:")]
     private static partial Regex HostnamePattern();
 
-    public static TheoryData<string, string, string> LocalhostTldHostname_TestData() => new()
+    public static TheoryData<string, string, string, TestTargetFramework> LocalhostTldHostname_TestData()
     {
-        // templateName, projectName, expectedHostname
-        { "aspire", "my.namespace.app", "my-namespace-app" },
-        { "aspire", ".StartWithDot", "startwithdot" },
-        { "aspire", "EndWithDot.", "endwithdot" },
-        { "aspire", "My..Test__Project", "my-test-project" },
-        { "aspire", "Project123.Test456", "project123-test456" },
-        { "aspire-apphost", "my.service.name", "my-service-name" },
-        { "aspire-apphost-singlefile", "-my.service..name-", "my-service-name" },
-        { "aspire-starter", "Test_App.1", "test-app-1" },
-        { "aspire-ts-cs-starter", "My-App.Test", "my-app-test" }
-    };
+        TheoryData<string, string, string, TestTargetFramework> data = [];
+
+        foreach (var framework in new[] { TestTargetFramework.Net10, TestTargetFramework.Net11 })
+        {
+            data.Add("aspire", "my.namespace.app", "my-namespace-app", framework);
+            data.Add("aspire", ".StartWithDot", "startwithdot", framework);
+            data.Add("aspire", "EndWithDot.", "endwithdot", framework);
+            data.Add("aspire", "My..Test__Project", "my-test-project", framework);
+            data.Add("aspire", "Project123.Test456", "project123-test456", framework);
+            data.Add("aspire-apphost", "my.service.name", "my-service-name", framework);
+            data.Add("aspire-apphost-singlefile", "-my.service..name-", "my-service-name", framework);
+            data.Add("aspire-starter", "Test_App.1", "test-app-1", framework);
+            data.Add("aspire-ts-cs-starter", "My-App.Test", "my-app-test", framework);
+        }
+
+        return data;
+    }
 
     [Theory]
     [MemberData(nameof(LocalhostTldHostname_TestData))]
     [Trait("category", "basic-build")]
-    public async Task LocalhostTld_GeneratesDnsCompliantHostnames(string templateName, string projectName, string expectedHostname)
+    public async Task LocalhostTld_GeneratesDnsCompliantHostnames(string templateName, string projectName, string expectedHostname, TestTargetFramework framework)
     {
         var id = GetNewProjectId(prefix: $"localhost_tld_{templateName}");
 
-        var targetFramework = templateName switch
+        var buildEnvironment = framework switch
         {
-            "aspire-apphost-singlefile" => TestTargetFramework.None, // These templates do not support -f argument
-            _ => TestTargetFramework.Next // LocalhostTld only available on net10.0
+            TestTargetFramework.Net10 => BuildEnvironment.ForNet10SdkOnly,
+            TestTargetFramework.Net11 => BuildEnvironment.ForNet11SdkOnly,
+            _ => throw new ArgumentOutOfRangeException(nameof(framework))
         };
+
+        // Single-file AppHosts have no project file for the helper to validate, so pass -f directly.
+        var targetFramework = templateName == "aspire-apphost-singlefile" ? TestTargetFramework.None : framework;
+        var frameworkArg = templateName == "aspire-apphost-singlefile" ? $"-f {framework.ToTFMString()} " : "";
 
         await using var project = await AspireProject.CreateNewTemplateProjectAsync(
             id,
             templateName,
             _testOutput,
-            buildEnvironment: BuildEnvironment.ForNextSdkOnly, // Need Next SDK for net10.0
-            extraArgs: $"--localhost-tld -n \"{projectName}\"",
+            buildEnvironment: buildEnvironment,
+            extraArgs: $"{frameworkArg}--localhost-tld -n \"{projectName}\"",
             targetFramework,
             addEndpointsHook: false); // Don't add endpoint hook since we're just checking file generation
 

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildStandaloneTemplateTests.cs
@@ -18,10 +18,11 @@ public class NewUpAndBuildStandaloneTemplateTests(ITestOutputHelper testOutput) 
 
         var buildEnvToUse = sdk switch
         {
-            TestSdk.Current => BuildEnvironment.ForCurrentSdkOnly,
-            TestSdk.Previous => BuildEnvironment.ForPreviousSdkOnly,
-            TestSdk.Next => BuildEnvironment.ForNextSdkOnly,
-            TestSdk.NextSdkWithCurrentAndPreviousRuntime => BuildEnvironment.ForNextSdkWithCurrentAndPreviousRuntimes,
+            TestSdk.Net8 => BuildEnvironment.ForNet8SdkOnly,
+            TestSdk.Net9 => BuildEnvironment.ForNet9SdkOnly,
+            TestSdk.Net10 => BuildEnvironment.ForNet10SdkOnly,
+            TestSdk.Net11 => BuildEnvironment.ForNet11SdkOnly,
+            TestSdk.Net11WithAllSupportedRuntimes => BuildEnvironment.ForNet11SdkWithAllSupportedRuntimes,
             _ => throw new ArgumentOutOfRangeException(nameof(sdk))
         };
 
@@ -37,6 +38,11 @@ public class NewUpAndBuildStandaloneTemplateTests(ITestOutputHelper testOutput) 
 
             Assert.True(error is null, $"Expected to throw an exception with message: {error}");
 
+            if (templateName == "aspire-starter")
+            {
+                await AssertStarterAspNetCoreTemplateContentAsync(project, tfm);
+            }
+
             await project.BuildAsync(extraBuildArgs: [$"-c Debug"]);
         }
         catch (ToolCommandException tce) when (error is not null)
@@ -44,5 +50,29 @@ public class NewUpAndBuildStandaloneTemplateTests(ITestOutputHelper testOutput) 
             Assert.NotNull(tce.Result);
             Assert.Contains(error, tce.Result.Value.Output);
         }
+    }
+
+    private static async Task AssertStarterAspNetCoreTemplateContentAsync(AspireProject project, TestTargetFramework tfm)
+    {
+        var webProjectDirectory = Path.Combine(project.RootDir, $"{project.Id}.Web");
+
+        var appContent = await File.ReadAllTextAsync(Path.Combine(webProjectDirectory, "Components", "App.razor"));
+        Assert.Equal(tfm == TestTargetFramework.Net11, appContent.Contains("<BasePath />", StringComparison.Ordinal));
+        Assert.Equal(tfm != TestTargetFramework.Net11, appContent.Contains("<base href=\"/\" />", StringComparison.Ordinal));
+
+        var importsContent = await File.ReadAllTextAsync(Path.Combine(webProjectDirectory, "Components", "_Imports.razor"));
+        Assert.Equal(tfm == TestTargetFramework.Net11, importsContent.Contains("@using Microsoft.AspNetCore.Components.Endpoints", StringComparison.Ordinal));
+
+        var errorPageContent = await File.ReadAllTextAsync(Path.Combine(webProjectDirectory, "Components", "Pages", "Error.razor"));
+        Assert.Equal(tfm is TestTargetFramework.Net10 or TestTargetFramework.Net11, errorPageContent.Contains("[PersistentState]", StringComparison.Ordinal));
+
+        var navMenuContent = await File.ReadAllTextAsync(Path.Combine(webProjectDirectory, "Components", "Layout", "NavMenu.razor"));
+        var expectedNavMenuScript = tfm == TestTargetFramework.Net8
+            ? "<script type=\"module\" src=\"Components/Layout/NavMenu.razor.js\"></script>"
+            : "<script type=\"module\" src=\"@Assets[\"Components/Layout/NavMenu.razor.js\"]\"></script>";
+        Assert.Contains(expectedNavMenuScript, navMenuContent, StringComparison.Ordinal);
+        Assert.Contains("id=\"nav-scrollable\"", navMenuContent, StringComparison.Ordinal);
+        Assert.False(navMenuContent.Contains("onclick=", StringComparison.Ordinal));
+        Assert.True(File.Exists(Path.Combine(webProjectDirectory, "Components", "Layout", "NavMenu.razor.js")));
     }
 }

--- a/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
+++ b/tests/Aspire.Templates.Tests/NewUpAndBuildSupportProjectTemplatesTests.cs
@@ -16,10 +16,11 @@ public abstract class NewUpAndBuildSupportProjectTemplatesBase(ITestOutputHelper
 
         var buildEnvToUse = sdk switch
         {
-            TestSdk.Current => BuildEnvironment.ForCurrentSdkOnly,
-            TestSdk.Previous => BuildEnvironment.ForPreviousSdkOnly,
-            TestSdk.Next => BuildEnvironment.ForNextSdkOnly,
-            TestSdk.NextSdkWithCurrentAndPreviousRuntime => BuildEnvironment.ForNextSdkWithCurrentAndPreviousRuntimes,
+            TestSdk.Net8 => BuildEnvironment.ForNet8SdkOnly,
+            TestSdk.Net9 => BuildEnvironment.ForNet9SdkOnly,
+            TestSdk.Net10 => BuildEnvironment.ForNet10SdkOnly,
+            TestSdk.Net11 => BuildEnvironment.ForNet11SdkOnly,
+            TestSdk.Net11WithAllSupportedRuntimes => BuildEnvironment.ForNet11SdkWithAllSupportedRuntimes,
             _ => throw new ArgumentOutOfRangeException(nameof(sdk))
         };
 

--- a/tests/Aspire.Templates.Tests/StarterTemplateFixture_Net11.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateFixture_Net11.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Sdk;
+
+namespace Aspire.Templates.Tests;
+
+public sealed class StarterTemplateFixture_Net11 : TemplateAppFixture
+{
+    public StarterTemplateFixture_Net11(IMessageSink diagnosticMessageSink)
+        : base(diagnosticMessageSink, "aspire-starter", tfm: TestTargetFramework.Net11)
+    {
+    }
+}

--- a/tests/Aspire.Templates.Tests/StarterTemplateFixture_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateFixture_PreviousTFM.cs
@@ -8,7 +8,7 @@ namespace Aspire.Templates.Tests;
 public sealed class StarterTemplateFixture_PreviousTFM : TemplateAppFixture
 {
     public StarterTemplateFixture_PreviousTFM(IMessageSink diagnosticMessageSink)
-        : base(diagnosticMessageSink, "aspire-starter", tfm: TestTargetFramework.Previous)
+        : base(diagnosticMessageSink, "aspire-starter", tfm: TestTargetFramework.Net8)
     {
     }
 }

--- a/tests/Aspire.Templates.Tests/StarterTemplateRunTests_Net11.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateRunTests_Net11.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TestUtilities;
+using Xunit;
+
+namespace Aspire.Templates.Tests;
+
+[RequiresFeature(TestFeature.SSLCertificate)]
+public class StarterTemplateRunTests_Net11 : StarterTemplateRunTestsBase<StarterTemplateFixture_Net11>
+{
+    public StarterTemplateRunTests_Net11(StarterTemplateFixture_Net11 fixture, ITestOutputHelper testOutput)
+        : base(fixture, testOutput)
+    {
+    }
+}

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheFixture_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheFixture_PreviousTFM.cs
@@ -8,7 +8,7 @@ namespace Aspire.Templates.Tests;
 public sealed class StarterTemplateWithRedisCacheFixture_PreviousTFM : TemplateAppFixture
 {
     public StarterTemplateWithRedisCacheFixture_PreviousTFM(IMessageSink diagnosticMessageSink)
-        : base(diagnosticMessageSink, "aspire-starter", "--use-redis-cache", tfm: TestTargetFramework.Previous)
+        : base(diagnosticMessageSink, "aspire-starter", "--use-redis-cache", tfm: TestTargetFramework.Net8)
     {
     }
 }

--- a/tests/Aspire.Templates.Tests/TemplateAppFixture.cs
+++ b/tests/Aspire.Templates.Tests/TemplateAppFixture.cs
@@ -22,7 +22,7 @@ public class TemplateAppFixture : IAsyncLifetime
     public string Id { get; init; }
     public string TemplateName { get; set; }
 
-    public TemplateAppFixture(IMessageSink diagnosticMessageSink, string templateName, string? dotnetNewArgs = null, string config = "Debug", TestTargetFramework tfm = TestTargetFramework.Current)
+    public TemplateAppFixture(IMessageSink diagnosticMessageSink, string templateName, string? dotnetNewArgs = null, string config = "Debug", TestTargetFramework tfm = TestTargetFramework.Net9)
     {
         _diagnosticMessageSink = diagnosticMessageSink;
         _testOutput = new TestOutputWrapper(messageSink: _diagnosticMessageSink);

--- a/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
+++ b/tests/Aspire.Templates.Tests/TemplateTestsBase.cs
@@ -342,31 +342,27 @@ public partial class TemplateTestsBase
 
     public static TheoryData<string, string, TestSdk, TestTargetFramework, string?> TestDataForNewAndBuildTemplateTests(string templateName, string extraArgs) => new()
         {
-            // Previous Sdk, Previous TFM
-            { templateName, extraArgs, TestSdk.Previous, TestTargetFramework.Previous, null },
-            // Previous Sdk - Current TFM
-            { templateName, extraArgs, TestSdk.Previous, TestTargetFramework.Current, "The current .NET SDK does not support targeting .NET 9.0" },
+            { templateName, extraArgs, TestSdk.Net8, TestTargetFramework.Net8, null },
+            { templateName, extraArgs, TestSdk.Net8, TestTargetFramework.Net9, "The current .NET SDK does not support targeting .NET 9.0" },
 
-            // Current SDK, Previous TFM
-            { templateName, extraArgs, TestSdk.Current, TestTargetFramework.Previous, null },
-            // Current SDK, Current TFM
-            { templateName, extraArgs, TestSdk.Current, TestTargetFramework.Current, null },
-            // Current SDK, Next TFM
-            { templateName, extraArgs, TestSdk.Current, TestTargetFramework.Next, "The current .NET SDK does not support targeting .NET 10.0" },
+            { templateName, extraArgs, TestSdk.Net9, TestTargetFramework.Net8, null },
+            { templateName, extraArgs, TestSdk.Net9, TestTargetFramework.Net9, null },
+            { templateName, extraArgs, TestSdk.Net9, TestTargetFramework.Net10, "The current .NET SDK does not support targeting .NET 10.0" },
 
-            // Next SDK, Previous TFM
-            { templateName, extraArgs, TestSdk.Next, TestTargetFramework.Previous, null },
-            // Next SDK, Current TFM
-            { templateName, extraArgs, TestSdk.Next, TestTargetFramework.Current, null },
-            // Next SDK, Next TFM
-            { templateName, extraArgs, TestSdk.Next, TestTargetFramework.Next, null },
+            { templateName, extraArgs, TestSdk.Net10, TestTargetFramework.Net8, null },
+            { templateName, extraArgs, TestSdk.Net10, TestTargetFramework.Net9, null },
+            { templateName, extraArgs, TestSdk.Net10, TestTargetFramework.Net10, null },
+            { templateName, extraArgs, TestSdk.Net10, TestTargetFramework.Net11, "The current .NET SDK does not support targeting .NET 11.0" },
 
-            // Current SDK + previous runtime, Previous TFM
-            { templateName, extraArgs, TestSdk.NextSdkWithCurrentAndPreviousRuntime, TestTargetFramework.Previous, null },
-            // Current SDK + previous runtime, Current TFM
-            { templateName, extraArgs, TestSdk.NextSdkWithCurrentAndPreviousRuntime, TestTargetFramework.Current, null },
-            // Next SDK + current runtime, Next TFM
-            { templateName, extraArgs, TestSdk.NextSdkWithCurrentAndPreviousRuntime, TestTargetFramework.Next, null },
+            { templateName, extraArgs, TestSdk.Net11, TestTargetFramework.Net8, null },
+            { templateName, extraArgs, TestSdk.Net11, TestTargetFramework.Net9, null },
+            { templateName, extraArgs, TestSdk.Net11, TestTargetFramework.Net10, null },
+            { templateName, extraArgs, TestSdk.Net11, TestTargetFramework.Net11, null },
+
+            { templateName, extraArgs, TestSdk.Net11WithAllSupportedRuntimes, TestTargetFramework.Net8, null },
+            { templateName, extraArgs, TestSdk.Net11WithAllSupportedRuntimes, TestTargetFramework.Net9, null },
+            { templateName, extraArgs, TestSdk.Net11WithAllSupportedRuntimes, TestTargetFramework.Net10, null },
+            { templateName, extraArgs, TestSdk.Net11WithAllSupportedRuntimes, TestTargetFramework.Net11, null },
         };
 
     // Taken from dotnet/runtime src/tasks/Common/Utils.cs

--- a/tests/Aspire.Templates.Tests/TestSdk.cs
+++ b/tests/Aspire.Templates.Tests/TestSdk.cs
@@ -5,8 +5,9 @@ namespace Aspire.Templates.Tests;
 
 public enum TestSdk
 {
-    Previous,
-    Current,
-    Next,
-    NextSdkWithCurrentAndPreviousRuntime
+    Net8,
+    Net9,
+    Net10,
+    Net11,
+    Net11WithAllSupportedRuntimes
 }

--- a/tests/Shared/Aspire.Templates.Testing.targets
+++ b/tests/Shared/Aspire.Templates.Testing.targets
@@ -1,105 +1,100 @@
 <Project>
   <!--
-    For template testing we track 3 different set of versions, and each as a corresponding TFM, and SDK version.
+    For template testing we track four SDK and TFM versions.
 
-      Previous: 8.0
-      Current: 9.0
-      Next: 10.0
+      .NET 8
+      .NET 9
+      .NET 10
+      .NET 11
 
     Keep this list in sync with the version mapping in tests/Shared/TemplatesTesting/BuildEnvironment.cs
   -->
   <PropertyGroup>
-    <SdkVersionForCurrentTFM>$(DotNetSdkCurrentVersionForTesting)</SdkVersionForCurrentTFM>
-    <SdkVersionForPreviousTFM>$(DotNetSdkPreviousVersionForTesting)</SdkVersionForPreviousTFM>
+    <SdkVersionForNet8TFM>$(DotNetSdkNet8VersionForTesting)</SdkVersionForNet8TFM>
+    <SdkVersionForNet9TFM>$(DotNetSdkNet9VersionForTesting)</SdkVersionForNet9TFM>
+    <SdkVersionForNet11TFM>$(DotNetSdkNet11VersionForTesting)</SdkVersionForNet11TFM>
 
-    <!-- global.json is using the next sdk now - 10.0x -->
+    <!-- global.json uses the .NET 10 SDK. -->
     <_GlobalJsonContent>$([System.IO.File]::ReadAllText('$(RepoRoot)global.json'))</_GlobalJsonContent>
     <_DotNetCliVersionFromGlobalJson>$([System.Text.RegularExpressions.Regex]::Match($(_GlobalJsonContent), '(%3F&lt;="dotnet": ").*(%3F=")'))</_DotNetCliVersionFromGlobalJson>
-    <SdkVersionForNextTFM>$(_DotNetCliVersionFromGlobalJson)</SdkVersionForNextTFM>
+    <SdkVersionForNet10TFM>$(_DotNetCliVersionFromGlobalJson)</SdkVersionForNet10TFM>
 
-    <SdkDirForCurrentTFM>$(ArtifactsBinDir)dotnet-9\</SdkDirForCurrentTFM>
-    <SdkStampPathForCurrentTFM>$(SdkDirForCurrentTFM).version-$(SdkVersionForCurrentTFM).stamp</SdkStampPathForCurrentTFM>
+    <SdkDirForNet8TFM>$(ArtifactsBinDir)dotnet-8\</SdkDirForNet8TFM>
+    <SdkStampPathForNet8TFM>$(SdkDirForNet8TFM).version-$(SdkVersionForNet8TFM).stamp</SdkStampPathForNet8TFM>
 
-    <SdkDirForCurrentAndPreviousTFM>$(ArtifactsBinDir)dotnet-tests\</SdkDirForCurrentAndPreviousTFM>
-    <SdkStampPathForCurrentAndPreviousTFM>$(SdkDirForCurrentAndPreviousTFM).version-$(SdkVersionForCurrentTFM)-$(SdkVersionForPreviousTFM).stamp</SdkStampPathForCurrentAndPreviousTFM>
+    <SdkDirForNet9TFM>$(ArtifactsBinDir)dotnet-9\</SdkDirForNet9TFM>
+    <SdkStampPathForNet9TFM>$(SdkDirForNet9TFM).version-$(SdkVersionForNet9TFM).stamp</SdkStampPathForNet9TFM>
 
-    <SdkDirForPreviousTFM>$(ArtifactsBinDir)dotnet-8\</SdkDirForPreviousTFM>
-    <SdkStampPathForPreviousTFM>$(SdkDirForPreviousTFM).version-$(SdkVersionForPreviousTFM).stamp</SdkStampPathForPreviousTFM>
+    <SdkDirForNet10TFM>$(ArtifactsBinDir)dotnet-10\</SdkDirForNet10TFM>
+    <SdkStampPathForNet10TFM>$(SdkDirForNet10TFM).version-$(SdkVersionForNet10TFM).stamp</SdkStampPathForNet10TFM>
 
-    <SdkDirForNextTFM>$(ArtifactsBinDir)dotnet-10\</SdkDirForNextTFM>
-    <SdkStampPathForNextTFM>$(SdkDirForNextTFM).version-$(SdkVersionForNextTFM).stamp</SdkStampPathForNextTFM>
+    <SdkDirForNet11TFM>$(ArtifactsBinDir)dotnet-11\</SdkDirForNet11TFM>
+    <SdkStampPathForNet11TFM>$(SdkDirForNet11TFM).version-$(SdkVersionForNet11TFM).stamp</SdkStampPathForNet11TFM>
 
-    <SdkDirForNextWithCurrentAndPreviousRuntimes>$(ArtifactsBinDir)dotnet-tests\</SdkDirForNextWithCurrentAndPreviousRuntimes>
-    <SdkStampPathForNextAndCurrentTFM>$(SdkDirForNextWithCurrentAndPreviousRuntimes).version-$(SdkVersionForNextTFM)-$(SdkVersionForCurrentTFM).stamp</SdkStampPathForNextAndCurrentTFM>
+    <SdkDirForNet11WithAllSupportedRuntimes>$(ArtifactsBinDir)dotnet-tests\</SdkDirForNet11WithAllSupportedRuntimes>
+    <SdkStampPathForNet11WithAllSupportedRuntimes>$(SdkDirForNet11WithAllSupportedRuntimes).version-$(SdkVersionForNet11TFM)-$(DotNetRuntimeNet10VersionForTesting)-$(DotNetRuntimeNet9VersionForTesting)-$(DotNetRuntimeNet8VersionForTesting).stamp</SdkStampPathForNet11WithAllSupportedRuntimes>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)InstallSdk.props" />
 
   <ItemGroup>
-    <PreviousRuntimeToInstallArguments Include="-Runtime dotnet -Version $(DotNetRuntimePreviousVersionForTesting)" />
-    <PreviousRuntimeToInstallArguments Include="-Runtime aspnetcore -Version $(DotNetRuntimePreviousVersionForTesting)" />
-    <CurrentRuntimeToInstallArguments Include="-Runtime dotnet -Version $(DotNetRuntimeCurrentVersionForTesting)" />
-    <CurrentRuntimeToInstallArguments Include="-Runtime aspnetcore -Version $(DotNetRuntimeCurrentVersionForTesting)" />
+    <SupportedRuntimeToInstallArguments Include="-Runtime dotnet -Version $(DotNetRuntimeNet8VersionForTesting)" />
+    <SupportedRuntimeToInstallArguments Include="-Runtime aspnetcore -Version $(DotNetRuntimeNet8VersionForTesting)" />
+    <SupportedRuntimeToInstallArguments Include="-Runtime dotnet -Version $(DotNetRuntimeNet9VersionForTesting)" />
+    <SupportedRuntimeToInstallArguments Include="-Runtime aspnetcore -Version $(DotNetRuntimeNet9VersionForTesting)" />
+    <SupportedRuntimeToInstallArguments Include="-Runtime dotnet -Version $(DotNetRuntimeNet10VersionForTesting)" />
+    <SupportedRuntimeToInstallArguments Include="-Runtime aspnetcore -Version $(DotNetRuntimeNet10VersionForTesting)" />
   </ItemGroup>
 
   <Target Name="ProvisionSdksForTesting">
 
-    <!-- Install For Previous tfm -->
+    <!-- Install the SDK for each supported TFM. -->
     <MSBuild Projects="$(MSBuildThisFileDirectory)InstallSdk.targets"
-             Properties="SdkVersionToInstall=$(SdkVersionForPreviousTFM);SdkTargetDir=$(SdkDirForPreviousTFM);SdkStampPath=$(SdkStampPathForPreviousTFM);ArtifactsObjDir=$(ArtifactsObjDir)"
+             Properties="SdkVersionToInstall=$(SdkVersionForNet8TFM);SdkTargetDir=$(SdkDirForNet8TFM);SdkStampPath=$(SdkStampPathForNet8TFM);ArtifactsObjDir=$(ArtifactsObjDir)"
              Targets="ProvisionSdk" />
-    <Touch Files="$(SdkStampPathForPreviousTFM)" AlwaysCreate="true" />
+    <Touch Files="$(SdkStampPathForNet8TFM)" AlwaysCreate="true" />
 
-    <!-- Install For Current tfm -->
     <MSBuild Projects="$(MSBuildThisFileDirectory)InstallSdk.targets"
-             Properties="SdkVersionToInstall=$(SdkVersionForCurrentTFM);SdkTargetDir=$(SdkDirForCurrentTFM);SdkStampPath=$(SdkStampPathForCurrentTFM);ArtifactsObjDir=$(ArtifactsObjDir)"
+             Properties="SdkVersionToInstall=$(SdkVersionForNet9TFM);SdkTargetDir=$(SdkDirForNet9TFM);SdkStampPath=$(SdkStampPathForNet9TFM);ArtifactsObjDir=$(ArtifactsObjDir)"
              Targets="ProvisionSdk" />
-    <Touch Files="$(SdkStampPathForCurrentTFM)" AlwaysCreate="true" />
+    <Touch Files="$(SdkStampPathForNet9TFM)" AlwaysCreate="true" />
 
-    <!-- Install For Next tfm -->
     <MSBuild Projects="$(MSBuildThisFileDirectory)InstallSdk.targets"
-             Properties="SdkVersionToInstall=$(SdkVersionForNextTFM);SdkTargetDir=$(SdkDirForNextTFM);SdkStampPath=$(SdkStampPathForNextTFM);ArtifactsObjDir=$(ArtifactsObjDir)"
+             Properties="SdkVersionToInstall=$(SdkVersionForNet10TFM);SdkTargetDir=$(SdkDirForNet10TFM);SdkStampPath=$(SdkStampPathForNet10TFM);ArtifactsObjDir=$(ArtifactsObjDir)"
              Targets="ProvisionSdk" />
-    <Touch Files="$(SdkStampPathForNextTFM)" AlwaysCreate="true" />
+    <Touch Files="$(SdkStampPathForNet10TFM)" AlwaysCreate="true" />
 
-    <CallTarget Targets="ProvisionNextSDKWithCurrentAndPreviousRuntimes" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)InstallSdk.targets"
+             Properties="SdkVersionToInstall=$(SdkVersionForNet11TFM);SdkTargetDir=$(SdkDirForNet11TFM);SdkStampPath=$(SdkStampPathForNet11TFM);ArtifactsObjDir=$(ArtifactsObjDir)"
+             Targets="ProvisionSdk" />
+    <Touch Files="$(SdkStampPathForNet11TFM)" AlwaysCreate="true" />
+
+    <CallTarget Targets="ProvisionNet11SdkWithAllSupportedRuntimes" />
   </Target>
 
-  <Target Name="ProvisionNextSDKWithCurrentAndPreviousRuntimes" Condition="!Exists($(SdkStampPathForNextAndCurrentTFM))">
-
-    <!-- Install For Next sdk + current + prev runtimes -->
+  <Target Name="ProvisionNet11SdkWithAllSupportedRuntimes" Condition="!Exists($(SdkStampPathForNet11WithAllSupportedRuntimes))">
 
     <PropertyGroup>
-      <_SdkDirToInstallTo>$(SdkDirForNextWithCurrentAndPreviousRuntimes)</_SdkDirToInstallTo>
+      <_SdkDirToInstallTo>$(SdkDirForNet11WithAllSupportedRuntimes)</_SdkDirToInstallTo>
     </PropertyGroup>
 
-    <!-- 1. Prepare the target dir -->
-    <RemoveDir Directories="$(SdkDirForNextWithCurrentAndPreviousRuntimes)" />
-    <MakeDir Directories="$(SdkDirForNextWithCurrentAndPreviousRuntimes)" />
+    <RemoveDir Directories="$(_SdkDirToInstallTo)" />
+    <MakeDir Directories="$(_SdkDirToInstallTo)" />
 
-    <!-- 2. Make a copy of next -->
     <ItemGroup>
-      <_SdkNextFile Include="$(SdkDirForNextTFM)\**\*" />
+      <_SdkNet11File Include="$(SdkDirForNet11TFM)\**\*" />
     </ItemGroup>
-    <Copy SourceFiles="@(_SdkNextFile)" DestinationFolder="$(_SdkDirToInstallTo)\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_SdkNet11File)" DestinationFolder="$(_SdkDirToInstallTo)\%(RecursiveDir)" SkipUnchangedFiles="true" />
 
-    <!-- 3. Install current runtimes -->
-    <Exec Condition="'%(CurrentRuntimeToInstallArguments.Identity)' != '' and !$([MSBuild]::IsOSPlatform('windows'))"
+    <Exec Condition="'%(SupportedRuntimeToInstallArguments.Identity)' != '' and !$([MSBuild]::IsOSPlatform('windows'))"
           IgnoreStandardErrorWarningFormat="true"
-          Command="$(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(CurrentRuntimeToInstallArguments.Identity)" />
+          Command="$(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(SupportedRuntimeToInstallArguments.Identity)" />
 
-    <Exec Condition="'%(CurrentRuntimeToInstallArguments.Identity)' != '' and $([MSBuild]::IsOSPlatform('windows'))"
+    <Exec Condition="'%(SupportedRuntimeToInstallArguments.Identity)' != '' and $([MSBuild]::IsOSPlatform('windows'))"
           IgnoreStandardErrorWarningFormat="true"
-          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(CurrentRuntimeToInstallArguments.Identity)"' />
+          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(SupportedRuntimeToInstallArguments.Identity)"' />
 
-    <Exec Condition="'%(PreviousRuntimeToInstallArguments.Identity)' != '' and !$([MSBuild]::IsOSPlatform('windows'))"
-          IgnoreStandardErrorWarningFormat="true"
-          Command="$(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(PreviousRuntimeToInstallArguments.Identity)" />
-
-    <Exec Condition="'%(PreviousRuntimeToInstallArguments.Identity)' != '' and $([MSBuild]::IsOSPlatform('windows'))"
-          IgnoreStandardErrorWarningFormat="true"
-          Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(_SdkDirToInstallTo) -SkipNonVersionedFiles %(PreviousRuntimeToInstallArguments.Identity)"' />
-    <Touch Files="$(SdkStampPathForNextAndCurrentTFM)" AlwaysCreate="true" />
+    <Touch Files="$(SdkStampPathForNet11WithAllSupportedRuntimes)" AlwaysCreate="true" />
   </Target>
 
   <Target Name="InstallSdksForTemplateTesting" DependsOnTargets="ProvisionSdksForTesting;_ValidateExpectedSetOfPackagesExist" />

--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -37,31 +37,33 @@ public class BuildEnvironment
     public static bool IsRunningOnCI => IsRunningOnHelix || IsRunningOnCIBuildMachine || IsRunningOnGithubActions;
     public static bool ShouldRunPlaywrightTests => PlaywrightProvider.HasPlaywrightSupport && !EnvironmentVariables.RunOnlyBasicBuildTemplatesTests;
 
-    private static readonly Lazy<BuildEnvironment> s_instance_80 = new(() =>
+    private static readonly Lazy<BuildEnvironment> s_net8Sdk = new(() =>
         new BuildEnvironment(sdkDirName: "dotnet-8"));
 
-    private static readonly Lazy<BuildEnvironment> s_instance_90 = new(() =>
+    private static readonly Lazy<BuildEnvironment> s_net9Sdk = new(() =>
         new BuildEnvironment(sdkDirName: "dotnet-9"));
 
-    private static readonly Lazy<BuildEnvironment> s_instance_100 = new(() =>
+    private static readonly Lazy<BuildEnvironment> s_net10Sdk = new(() =>
         new BuildEnvironment(sdkDirName: "dotnet-10"));
 
-    private static readonly Lazy<BuildEnvironment> s_instance_100_90_80 = new(() =>
+    private static readonly Lazy<BuildEnvironment> s_net11Sdk = new(() =>
+        new BuildEnvironment(sdkDirName: "dotnet-11"));
+
+    private static readonly Lazy<BuildEnvironment> s_net11SdkWithAllSupportedRuntimes = new(() =>
         new BuildEnvironment(sdkDirName: "dotnet-tests"));
 
-    public static BuildEnvironment ForPreviousSdkOnly => s_instance_80.Value;
-    public static BuildEnvironment ForCurrentSdkOnly => s_instance_90.Value;
-    public static BuildEnvironment ForNextSdkOnly => s_instance_100.Value;
-    public static BuildEnvironment ForNextSdkWithCurrentAndPreviousRuntimes => s_instance_100_90_80.Value;
+    public static BuildEnvironment ForNet8SdkOnly => s_net8Sdk.Value;
+    public static BuildEnvironment ForNet9SdkOnly => s_net9Sdk.Value;
+    public static BuildEnvironment ForNet10SdkOnly => s_net10Sdk.Value;
+    public static BuildEnvironment ForNet11SdkOnly => s_net11Sdk.Value;
+    public static BuildEnvironment ForNet11SdkWithAllSupportedRuntimes => s_net11SdkWithAllSupportedRuntimes.Value;
 
     public static BuildEnvironment ForDefaultFramework =>
         DefaultTargetFramework switch
         {
-            TestTargetFramework.Previous => ForPreviousSdkOnly,
-
-            // Use current+previous to allow running tests on helix built with 9.0 sdk
-            // but targeting 8.0 tfm
-            TestTargetFramework.Current => ForNextSdkWithCurrentAndPreviousRuntimes,
+            TestTargetFramework.Net8 => ForNet8SdkOnly,
+            TestTargetFramework.Net9 or TestTargetFramework.Net10 => ForNet11SdkWithAllSupportedRuntimes,
+            TestTargetFramework.Net11 => ForNet11SdkOnly,
 
             _ => throw new ArgumentOutOfRangeException(nameof(DefaultTargetFramework))
         };
@@ -291,9 +293,10 @@ public class BuildEnvironment
     private static TestTargetFramework ComputeDefaultTargetFramework()
         => EnvironmentVariables.DefaultTFMForTesting?.ToLowerInvariant() switch
         {
-            null or "" or "net9.0" => TestTargetFramework.Current,
-            "net8.0" => TestTargetFramework.Previous,
-            "net10.0" => TestTargetFramework.Next,
+            null or "" or "net9.0" => TestTargetFramework.Net9,
+            "net8.0" => TestTargetFramework.Net8,
+            "net10.0" => TestTargetFramework.Net10,
+            "net11.0" => TestTargetFramework.Net11,
             _ => throw new ArgumentOutOfRangeException(nameof(EnvironmentVariables.DefaultTFMForTesting), EnvironmentVariables.DefaultTFMForTesting, "Invalid value")
         };
 
@@ -301,10 +304,10 @@ public class BuildEnvironment
 
 public enum TestTargetFramework
 {
-    // Current is default
-    Current,
-    Previous,
-    Next,
+    Net8,
+    Net9,
+    Net10,
+    Net11,
     None
 }
 
@@ -312,9 +315,10 @@ public static class TestTargetFrameworkExtensions
 {
     public static string ToTFMString(this TestTargetFramework tfm) => tfm switch
     {
-        TestTargetFramework.Previous => "net8.0",
-        TestTargetFramework.Current => "net9.0",
-        TestTargetFramework.Next => "net10.0",
+        TestTargetFramework.Net8 => "net8.0",
+        TestTargetFramework.Net9 => "net9.0",
+        TestTargetFramework.Net10 => "net10.0",
+        TestTargetFramework.Net11 => "net11.0",
         _ => throw new ArgumentOutOfRangeException(nameof(tfm))
     };
 }

--- a/tests/helix/send-to-helix-templatestests.targets
+++ b/tests/helix/send-to-helix-templatestests.targets
@@ -49,6 +49,7 @@
       <HelixCorrelationPayload Include="$(ArtifactsBinDir)dotnet-8" Destination="dotnet-8" />
       <HelixCorrelationPayload Include="$(ArtifactsBinDir)dotnet-9" Destination="dotnet-9" />
       <HelixCorrelationPayload Include="$(ArtifactsBinDir)dotnet-10" Destination="dotnet-10" />
+      <HelixCorrelationPayload Include="$(ArtifactsBinDir)dotnet-11" Destination="dotnet-11" />
 
       <!-- PreCommands="" needed for batching below -->
       <_TemplateTestsClassNames TestNameSuffix="$([System.String]::Copy('%(Identity)').Replace('Aspire.Template.Tests.', ''))" PreCommands="" />


### PR DESCRIPTION
## Description

Adds .NET 11 Preview 6 as an opt-in target framework for Aspire project templates so users can start evaluating Aspire applications on .NET 11 while the templates continue to default to .NET 10.

This updates all nine framework-aware templates, adds the .NET 11 `Microsoft.AspNetCore.OpenApi` package substitution, and provisions dedicated .NET 8, 9, 10, and 11 SDK layouts for template compatibility testing. The combined test layout now uses the .NET 11 SDK with all supported runtimes.

The Aspire .NET starter also adopts applicable changes from the ASP.NET Core .NET 11 Preview 6 Blazor template:

- Uses the new `<BasePath />` component when targeting .NET 11.
- Persists the error page request ID on .NET 10 and later.
- Replaces the inline navigation click handler with a collocated JavaScript module.

The existing .NET 10 template default and repository `global.json` SDK pin remain unchanged.

### User-facing usage

Create an Aspire starter application targeting .NET 11:

```console
dotnet new aspire-starter -f net11.0
```

Validation included provisioning all template SDK layouts, packing all shipping packages, and running the standalone, support-project, and `.dev.localhost` template test matrices across the supported SDK/TFM combinations.

Fixes #13957

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
