### PR TITLE
Improve Linux dev certificate trust handling

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -484,17 +484,19 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         if (File.Exists(certPath))
         {
             var openSslUntrustSucceeded = false;
+            var certificateFileDeleted = TryDeleteCertificateFile(certPath);
 
-            if (IsCommandAvailable(OpenSslCommand))
+            if (certificateFileDeleted)
             {
-                if (TryDeleteCertificateFile(certPath) && TryRehashOpenSslCertificates(certDir))
+                if (IsCommandAvailable(OpenSslCommand))
                 {
+                    openSslUntrustSucceeded = TryRehashOpenSslCertificates(certDir);
+                }
+                else
+                {
+                    Log.UnixMissingOpenSslCommand(OpenSslCommand);
                     openSslUntrustSucceeded = true;
                 }
-            }
-            else
-            {
-                Log.UnixMissingOpenSslCommand(OpenSslCommand);
             }
 
             if (openSslUntrustSucceeded)

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -5,6 +5,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Aspire.Cli;
@@ -116,11 +117,18 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 var certPath = Path.Combine(sslCertDir, certificateNickname + ".pem");
                 if (File.Exists(certPath))
                 {
-                    using var candidate = X509CertificateLoader.LoadCertificateFromFile(certPath);
-                    if (AreCertificatesEqual(certificate, candidate))
+                    try
                     {
-                        foundCert = true;
-                        break;
+                        using var candidate = X509CertificateLoader.LoadCertificateFromFile(certPath);
+                        if (AreCertificatesEqual(certificate, candidate))
+                        {
+                            foundCert = true;
+                            break;
+                        }
+                    }
+                    catch (Exception ex) when (ex is CryptographicException or IOException or UnauthorizedAccessException)
+                    {
+                        Log.UnixNotTrustedByOpenSsl(OpenSslCertificateDirectoryVariableName);
                     }
                 }
             }

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -128,7 +128,8 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                     }
                     catch (Exception ex) when (ex is CryptographicException or IOException or UnauthorizedAccessException)
                     {
-                        Log.UnixNotTrustedByOpenSsl(OpenSslCertificateDirectoryVariableName);
+                        // Treat unreadable entries as a miss. A later SSL_CERT_DIR entry may still contain
+                        // the expected certificate, so only report OpenSSL as untrusted after the full search.
                     }
                 }
             }

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -483,15 +483,6 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates..
-        /// </summary>
-        public static string DevCertsOpenSslCacheUnreadableDetailsFormat {
-            get {
-                return ResourceManager.GetString("DevCertsOpenSslCacheUnreadableDetailsFormat", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates..
         /// </summary>
         public static string DevCertsOpenSslCacheUnreadableFilesDetailsFormat {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -456,6 +456,51 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to OpenSSL HTTPS development certificate cache is missing the current certificate.
+        /// </summary>
+        public static string DevCertsOpenSslCacheMissingCurrentCertificateMessage {
+            get {
+                return ResourceManager.GetString("DevCertsOpenSslCacheMissingCurrentCertificateMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates..
+        /// </summary>
+        public static string DevCertsOpenSslCacheMissingDetailsFormat {
+            get {
+                return ResourceManager.GetString("DevCertsOpenSslCacheMissingDetailsFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to OpenSSL HTTPS development certificate cache contains unreadable certificate files.
+        /// </summary>
+        public static string DevCertsOpenSslCacheUnreadableMessage {
+            get {
+                return ResourceManager.GetString("DevCertsOpenSslCacheUnreadableMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates..
+        /// </summary>
+        public static string DevCertsOpenSslCacheUnreadableDetailsFormat {
+            get {
+                return ResourceManager.GetString("DevCertsOpenSslCacheUnreadableDetailsFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates..
+        /// </summary>
+        public static string DevCertsOpenSslCacheUnreadableFilesDetailsFormat {
+            get {
+                return ResourceManager.GetString("DevCertsOpenSslCacheUnreadableFilesDetailsFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Developer Control Plane (DCP) bundle not found; skipping connection health checks.
         /// </summary>
         public static string DcpBundleNotFoundMessage {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -319,6 +319,15 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("DevCertsCleanAndTrustFixFormat", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Install {0}, run &apos;{1}&apos; to remove all certificates, then run &apos;{2}&apos; to create and trust a new one..
+        /// </summary>
+        public static string DevCertsInstallOpenSslCleanAndTrustFixFormat {
+            get {
+                return ResourceManager.GetString("DevCertsInstallOpenSslCleanAndTrustFixFormat", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Multiple HTTPS development certificates found ({0} certificates), but none are trusted.
@@ -488,6 +497,24 @@ namespace Aspire.Cli.Resources {
         public static string DevCertsOpenSslCacheUnreadableFilesDetailsFormat {
             get {
                 return ResourceManager.GetString("DevCertsOpenSslCacheUnreadableFilesDetailsFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to OpenSSL HTTPS development certificate cache is missing subject-hash links.
+        /// </summary>
+        public static string DevCertsOpenSslCacheMissingHashLinkMessage {
+            get {
+                return ResourceManager.GetString("DevCertsOpenSslCacheMissingHashLinkMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories..
+        /// </summary>
+        public static string DevCertsOpenSslCacheMissingHashLinkDetailsFormat {
+            get {
+                return ResourceManager.GetString("DevCertsOpenSslCacheMissingHashLinkDetailsFormat", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -200,6 +200,24 @@
   <data name="DevCertsMissingCertUtilFix" xml:space="preserve">
     <value>Install certutil from your distribution's NSS tools package (for example, libnss3-tools).</value>
   </data>
+  <data name="DevCertsOpenSslCacheMissingCurrentCertificateMessage" xml:space="preserve">
+    <value>OpenSSL HTTPS development certificate cache is missing the current certificate</value>
+  </data>
+  <data name="DevCertsOpenSslCacheMissingDetailsFormat" xml:space="preserve">
+    <value>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</value>
+    <comment>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</comment>
+  </data>
+  <data name="DevCertsOpenSslCacheUnreadableMessage" xml:space="preserve">
+    <value>OpenSSL HTTPS development certificate cache contains unreadable certificate files</value>
+  </data>
+  <data name="DevCertsOpenSslCacheUnreadableDetailsFormat" xml:space="preserve">
+    <value>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</value>
+    <comment>{0} is the OpenSSL certificate cache directory. {1} is the error message.</comment>
+  </data>
+  <data name="DevCertsOpenSslCacheUnreadableFilesDetailsFormat" xml:space="preserve">
+    <value>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</value>
+    <comment>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</comment>
+  </data>
   <data name="DcpBundleNotFoundMessage" xml:space="preserve">
     <value>Developer Control Plane (DCP) bundle not found; skipping connection health checks</value>
   </data>

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -155,6 +155,10 @@
     <value>Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</value>
     <comment>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</comment>
   </data>
+  <data name="DevCertsInstallOpenSslCleanAndTrustFixFormat" xml:space="preserve">
+    <value>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</value>
+    <comment>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</comment>
+  </data>
   <data name="DevCertsMultipleNoneTrustedMessageFormat" xml:space="preserve">
     <value>Multiple HTTPS development certificates found ({0} certificates), but none are trusted</value>
   </data>
@@ -213,6 +217,13 @@
   <data name="DevCertsOpenSslCacheUnreadableFilesDetailsFormat" xml:space="preserve">
     <value>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</value>
     <comment>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</comment>
+  </data>
+  <data name="DevCertsOpenSslCacheMissingHashLinkMessage" xml:space="preserve">
+    <value>OpenSSL HTTPS development certificate cache is missing subject-hash links</value>
+  </data>
+  <data name="DevCertsOpenSslCacheMissingHashLinkDetailsFormat" xml:space="preserve">
+    <value>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</value>
+    <comment>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</comment>
   </data>
   <data name="DcpBundleNotFoundMessage" xml:space="preserve">
     <value>Developer Control Plane (DCP) bundle not found; skipping connection health checks</value>

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -210,10 +210,6 @@
   <data name="DevCertsOpenSslCacheUnreadableMessage" xml:space="preserve">
     <value>OpenSSL HTTPS development certificate cache contains unreadable certificate files</value>
   </data>
-  <data name="DevCertsOpenSslCacheUnreadableDetailsFormat" xml:space="preserve">
-    <value>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</value>
-    <comment>{0} is the OpenSSL certificate cache directory. {1} is the error message.</comment>
-  </data>
   <data name="DevCertsOpenSslCacheUnreadableFilesDetailsFormat" xml:space="preserve">
     <value>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</value>
     <comment>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</comment>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -222,6 +222,11 @@
         <target state="new">Run '{0}' to remove all certificates, then run '{1}' to create and trust a new one.</target>
         <note>{0} is the aspire certs clean command, {1} is the aspire certs trust command (not localizable)</note>
       </trans-unit>
+      <trans-unit id="DevCertsInstallOpenSslCleanAndTrustFixFormat">
+        <source>Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</source>
+        <target state="new">Install {0}, run '{1}' to remove all certificates, then run '{2}' to create and trust a new one.</target>
+        <note>{0} is the openssl command/package name, {1} is the aspire certs clean command, {2} is the aspire certs trust command (not localizable)</note>
+      </trans-unit>
       <trans-unit id="DevCertsMissingCertUtilDetails">
         <source>Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</source>
         <target state="new">Aspire uses certutil to query and update NSS certificate databases used by Firefox and Chromium browsers on Linux.</target>
@@ -296,6 +301,16 @@
         <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' contains certificate {1}, but no subject-hash entry points to it. OpenSSL workloads use subject-hash entries when loading CA directories.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingHashLinkMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing subject-hash links</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing subject-hash links</target>
+        <note />
       </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -297,11 +297,6 @@
         <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
         <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
       </trans-unit>
-      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
-        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
-        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
-        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
-      </trans-unit>
       <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
         <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
         <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -287,6 +287,31 @@
         <target state="new">HTTPS development certificate has an older version ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingCurrentCertificateMessage">
+        <source>OpenSSL HTTPS development certificate cache is missing the current certificate</source>
+        <target state="new">OpenSSL HTTPS development certificate cache is missing the current certificate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheMissingDetailsFormat">
+        <source>The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">The OpenSSL certificate cache at '{0}' does not contain certificate {1} from the .NET current user certificate store. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the certificate thumbprint.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableDetailsFormat">
+        <source>Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read the OpenSSL certificate cache at '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is the error message.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableFilesDetailsFormat">
+        <source>Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</source>
+        <target state="new">Could not read certificate files under '{0}': {1}. Run 'aspire certs clean' and then 'aspire certs trust' to remove stale or corrupt certificates and regenerate trusted development certificates.</target>
+        <note>{0} is the OpenSSL certificate cache directory. {1} is a comma-separated list of certificate file names.</note>
+      </trans-unit>
+      <trans-unit id="DevCertsOpenSslCacheUnreadableMessage">
+        <source>OpenSSL HTTPS development certificate cache contains unreadable certificate files</source>
+        <target state="new">OpenSSL HTTPS development certificate cache contains unreadable certificate files</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DevCertsPartiallyTrustedDetailsFormat">
         <source>The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</source>
         <target state="new">The certificate is in the trusted store, but SSL_CERT_DIR is not configured to include '{0}'. Some applications may not trust the certificate. 'aspire run' will configure this automatically.</target>

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -25,7 +25,6 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     internal const string OpenSslCertificateCacheCheckName = "dev-certs-openssl-cache";
     private const string OpenSslCommand = "openssl";
     private const int OpenSslHashCollisionSearchLimit = 10;
-    private static readonly TimeSpan s_openSslHashTimeout = TimeSpan.FromSeconds(5);
 
     public int Order => 35; // After SDK check (30), before container checks (40+)
 
@@ -424,18 +423,16 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                 StandardErrorCallback = _ => { },
             });
         var started = false;
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutCts.CancelAfter(s_openSslHashTimeout);
 
         try
         {
-            started = await process.StartAsync(timeoutCts.Token).ConfigureAwait(false);
+            started = await process.StartAsync(cancellationToken).ConfigureAwait(false);
             if (!started)
             {
                 return (false, "");
             }
 
-            var exitCode = await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+            var exitCode = await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
             if (exitCode != 0)
             {
                 return (false, "");

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -1,10 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Resources;
 using Microsoft.AspNetCore.Certificates.Generation;
@@ -21,11 +25,15 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     internal const string VersionCheckName = "dev-certs-version";
     internal const string CertUtilCheckName = "dev-certs-certutil";
     internal const string OpenSslCertificateCacheCheckName = "dev-certs-openssl-cache";
+    private const string OpenSslCommand = "openssl";
+    private const int OpenSslHashCollisionSearchLimit = 10;
 
     public int Order => 35; // After SDK check (30), before container checks (40+)
 
     private static readonly string s_trustFixCommand = string.Format(CultureInfo.InvariantCulture, DoctorCommandStrings.DevCertsTrustFixFormat, "aspire certs trust");
     private static readonly string s_cleanAndTrustFixCommand = string.Format(CultureInfo.InvariantCulture, DoctorCommandStrings.DevCertsCleanAndTrustFixFormat, "aspire certs clean", "aspire certs trust");
+    private static readonly string s_installOpenSslCleanAndTrustFixCommand = string.Format(CultureInfo.InvariantCulture, DoctorCommandStrings.DevCertsInstallOpenSslCleanAndTrustFixFormat, "openssl", "aspire certs clean", "aspire certs trust");
+    private static readonly Regex s_openSslHashFileNameRegex = new("^[0-9a-fA-F]{8}\\.\\d+$", RegexOptions.CultureInvariant);
 
     public Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
     {
@@ -221,7 +229,10 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         }
 
         var trustPath = CertificateHelpers.GetDevCertsTrustPath(environment);
-        var cacheStatus = EvaluateOpenSslCertificateCache(trustPath, currentCertificates);
+        var environmentVariables = GetEnvironmentVariables(environment);
+        PathLookupHelper.TryResolveExecutablePath(OpenSslCommand, out var openSslPath, environmentVariables);
+
+        var cacheStatus = EvaluateOpenSslCertificateCache(trustPath, currentCertificates, openSslPath);
         if (cacheStatus is null)
         {
             return;
@@ -234,7 +245,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             Status = EnvironmentCheckStatus.Warning,
             Message = cacheStatus.Message,
             Details = cacheStatus.Details,
-            Fix = s_cleanAndTrustFixCommand,
+            Fix = cacheStatus.Fix,
             Link = "https://aka.ms/aspire-prerequisites#dev-certs"
         });
     }
@@ -252,8 +263,10 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             .ThenBy(c => c.Thumbprint, StringComparer.OrdinalIgnoreCase);
     }
 
-    private static OpenSslCertificateCacheStatus? EvaluateOpenSslCertificateCache(string trustPath, IReadOnlyList<DevCertInfo> currentCertificates)
+    private static OpenSslCertificateCacheStatus? EvaluateOpenSslCertificateCache(string trustPath, IReadOnlyList<DevCertInfo> currentCertificates, string? openSslPath)
     {
+        var fix = GetOpenSslCertificateCacheFix(openSslPath);
+
         if (!Directory.Exists(trustPath))
         {
             var trustedThumbprints = GetTrustedThumbprints(currentCertificates);
@@ -264,12 +277,14 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
 
             return new(
                 DoctorCommandStrings.DevCertsOpenSslCacheMissingCurrentCertificateMessage,
-                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", trustedThumbprints)));
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", trustedThumbprints)),
+                fix);
         }
 
         var unreadableFiles = new List<string>();
         var mismatchedThumbprints = new List<string>();
         var missingTrustedThumbprints = new List<string>();
+        var missingHashLinkThumbprints = new List<string>();
 
         foreach (var certificate in currentCertificates)
         {
@@ -292,6 +307,11 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                 {
                     mismatchedThumbprints.Add(certificate.Thumbprint!);
                 }
+                else if (certificate.TrustLevel != CertificateManager.TrustLevel.None &&
+                    !HasOpenSslHashEntry(trustPath, certificateFile, cachedCertificate, openSslPath))
+                {
+                    missingHashLinkThumbprints.Add(certificate.Thumbprint!);
+                }
             }
             catch (Exception ex) when (ex is CryptographicException or IOException or UnauthorizedAccessException)
             {
@@ -303,24 +323,127 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         {
             return new(
                 DoctorCommandStrings.DevCertsOpenSslCacheUnreadableMessage,
-                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheUnreadableFilesDetailsFormat, trustPath, string.Join(", ", unreadableFiles)));
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheUnreadableFilesDetailsFormat, trustPath, string.Join(", ", unreadableFiles)),
+                fix);
         }
 
         if (mismatchedThumbprints.Count > 0)
         {
             return new(
                 DoctorCommandStrings.DevCertsOpenSslCacheMissingCurrentCertificateMessage,
-                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", mismatchedThumbprints)));
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", mismatchedThumbprints)),
+                fix);
         }
 
         if (missingTrustedThumbprints.Count > 0)
         {
             return new(
                 DoctorCommandStrings.DevCertsOpenSslCacheMissingCurrentCertificateMessage,
-                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", missingTrustedThumbprints)));
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", missingTrustedThumbprints)),
+                fix);
+        }
+
+        if (missingHashLinkThumbprints.Count > 0)
+        {
+            return new(
+                DoctorCommandStrings.DevCertsOpenSslCacheMissingHashLinkMessage,
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingHashLinkDetailsFormat, trustPath, string.Join(", ", missingHashLinkThumbprints)),
+                fix);
         }
 
         return null;
+    }
+
+    private static string GetOpenSslCertificateCacheFix(string? openSslPath) =>
+        openSslPath is null ? s_installOpenSslCleanAndTrustFixCommand : s_cleanAndTrustFixCommand;
+
+    private static bool HasOpenSslHashEntry(string trustPath, string certificateFile, X509Certificate2 certificate, string? openSslPath)
+    {
+        if (openSslPath is not null)
+        {
+            return TryGetOpenSslHash(openSslPath, certificateFile, out var hash) &&
+                HasMatchingHashEntry(trustPath, hash, certificate);
+        }
+
+        // Without openssl we cannot compute the subject hash that OpenSSL requires. The
+        // absence of any hash-style entry for the certificate is still definitely broken,
+        // but a matching entry can only be treated as sufficient evidence to avoid warning.
+        return Directory.EnumerateFiles(trustPath)
+            .Where(path => s_openSslHashFileNameRegex.IsMatch(Path.GetFileName(path)))
+            .Any(path => CertificateFileMatches(path, certificate));
+    }
+
+    private static bool HasMatchingHashEntry(string trustPath, string hash, X509Certificate2 certificate)
+    {
+        for (var i = 0; i < OpenSslHashCollisionSearchLimit; i++)
+        {
+            var hashEntryPath = Path.Combine(trustPath, $"{hash}.{i}");
+            if (CertificateFileMatches(hashEntryPath, certificate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool CertificateFileMatches(string certificateFile, X509Certificate2 certificate)
+    {
+        if (!File.Exists(certificateFile))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var cachedCertificate = X509CertificateLoader.LoadCertificateFromFile(certificateFile);
+
+            return string.Equals(certificate.Thumbprint, cachedCertificate.Thumbprint, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex) when (ex is CryptographicException or IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetOpenSslHash(string openSslPath, string certificateFile, [NotNullWhen(true)] out string? hash)
+    {
+        hash = null;
+
+        var processInfo = new ProcessStartInfo(openSslPath)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        processInfo.ArgumentList.Add("x509");
+        processInfo.ArgumentList.Add("-hash");
+        processInfo.ArgumentList.Add("-noout");
+        processInfo.ArgumentList.Add("-in");
+        processInfo.ArgumentList.Add(certificateFile);
+
+        Process? process = null;
+        try
+        {
+            process = Process.Start(processInfo);
+            var stdout = process!.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                return false;
+            }
+
+            hash = stdout.Trim();
+            return hash.Length > 0;
+        }
+        catch (Exception ex) when (ex is Win32Exception or IOException or InvalidOperationException)
+        {
+            return false;
+        }
+        finally
+        {
+            process?.Dispose();
+        }
     }
 
     private static List<string> GetTrustedThumbprints(IReadOnlyList<DevCertInfo> currentCertificates)
@@ -341,9 +464,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             return;
         }
 
-        var environmentVariables = environment.GetEnvironmentVariables()
-            .Where(kv => kv.Value is not null)
-            .ToDictionary(kv => kv.Name, kv => kv.Value!);
+        var environmentVariables = GetEnvironmentVariables(environment);
 
         if (PathLookupHelper.TryResolveExecutablePath(CertificateHelpers.CertUtilCommand, out _, environmentVariables))
         {
@@ -361,6 +482,11 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             Link = "https://aka.ms/aspire-prerequisites#dev-certs"
         });
     }
+
+    private static Dictionary<string, string> GetEnvironmentVariables(IEnvironment environment) =>
+        environment.GetEnvironmentVariables()
+            .Where(kv => kv.Value is not null)
+            .ToDictionary(kv => kv.Name, kv => kv.Value!);
 
     /// <summary>
     /// Builds structured metadata from certificate information for JSON output.
@@ -420,5 +546,5 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         return $"export SSL_CERT_DIR=\"$SSL_CERT_DIR:{string.Join(':', systemCertDirs)}\"";
     }
 
-    private sealed record OpenSslCertificateCacheStatus(string Message, string Details);
+    private sealed record OpenSslCertificateCacheStatus(string Message, string Details, string Fix);
 }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -470,8 +470,10 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                 process.Kill(entireProcessTree: true);
             }
         }
-        catch (InvalidOperationException)
+        catch (Exception)
         {
+            // Process cleanup is best-effort; do not let a kill failure mask caller cancellation
+            // or turn a non-critical OpenSSL probe failure into a failed doctor check.
         }
     }
 

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Nodes;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Resources;
@@ -18,6 +20,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     internal const string CheckName = "dev-certs";
     internal const string VersionCheckName = "dev-certs-version";
     internal const string CertUtilCheckName = "dev-certs-certutil";
+    internal const string OpenSslCertificateCacheCheckName = "dev-certs-openssl-cache";
 
     public int Order => 35; // After SDK check (30), before container checks (40+)
 
@@ -30,6 +33,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         {
             var trustResult = certificateToolRunner.CheckHttpCertificate();
             var results = EvaluateCertificateResults(trustResult.Certificates, environment);
+            AddLinuxOpenSslCertificateCacheWarnings(results, trustResult.Certificates, environment);
             AddLinuxCertificateToolWarnings(results, environment);
 
             return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>(results);
@@ -203,6 +207,122 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         return results;
     }
 
+    private static void AddLinuxOpenSslCertificateCacheWarnings(List<EnvironmentCheckResult> results, IReadOnlyList<DevCertInfo> certInfos, IEnvironment environment)
+    {
+        if (!environment.IsLinux())
+        {
+            return;
+        }
+
+        var currentCertificate = GetCurrentDevCertificate(certInfos);
+        if (currentCertificate?.Thumbprint is null)
+        {
+            return;
+        }
+
+        var trustPath = CertificateHelpers.GetDevCertsTrustPath(environment);
+        var cacheStatus = EvaluateOpenSslCertificateCache(trustPath, currentCertificate.Thumbprint);
+        if (cacheStatus is null)
+        {
+            return;
+        }
+
+        results.Add(new EnvironmentCheckResult
+        {
+            Category = EnvironmentCheckCategories.Environment,
+            Name = OpenSslCertificateCacheCheckName,
+            Status = EnvironmentCheckStatus.Warning,
+            Message = cacheStatus.Message,
+            Details = cacheStatus.Details,
+            Fix = s_cleanAndTrustFixCommand,
+            Link = "https://aka.ms/aspire-prerequisites#dev-certs"
+        });
+    }
+
+    private static DevCertInfo? GetCurrentDevCertificate(IReadOnlyList<DevCertInfo> certInfos)
+    {
+        var now = DateTimeOffset.Now;
+        return certInfos
+            .Where(c => c.IsHttpsDevelopmentCertificate &&
+                c.ValidityNotBefore <= now &&
+                now <= c.ValidityNotAfter &&
+                !string.IsNullOrEmpty(c.Thumbprint))
+            .OrderByDescending(c => c.Version)
+            .ThenByDescending(c => c.ValidityNotAfter)
+            .FirstOrDefault();
+    }
+
+    private static OpenSslCertificateCacheStatus? EvaluateOpenSslCertificateCache(string trustPath, string currentCertificateThumbprint)
+    {
+        if (!Directory.Exists(trustPath))
+        {
+            return new(
+                DoctorCommandStrings.DevCertsOpenSslCacheMissingCurrentCertificateMessage,
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, currentCertificateThumbprint));
+        }
+
+        string[] certificateFiles;
+        try
+        {
+            // The Linux dev-certs OpenSSL cache stores certificate files such as:
+            //   aspnetcore-localhost-<thumbprint>.pem
+            // OpenSSL/c_rehash can also create hash symlinks like <hash>.0 in the same directory,
+            // but only .pem/.crt/.cer files are certificate inputs that should be parsed here.
+            certificateFiles = Directory.GetFiles(trustPath)
+                .Where(IsOpenSslCertificateFile)
+                .ToArray();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new(
+                DoctorCommandStrings.DevCertsOpenSslCacheUnreadableMessage,
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheUnreadableDetailsFormat, trustPath, ex.Message));
+        }
+
+        var cachedThumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var unreadableFiles = new List<string>();
+
+        foreach (var certificateFile in certificateFiles)
+        {
+            try
+            {
+                using var cachedCertificate = X509CertificateLoader.LoadCertificateFromFile(certificateFile);
+                if (cachedCertificate.Thumbprint is not null)
+                {
+                    cachedThumbprints.Add(cachedCertificate.Thumbprint);
+                }
+            }
+            catch (Exception ex) when (ex is CryptographicException or IOException or UnauthorizedAccessException)
+            {
+                unreadableFiles.Add(Path.GetFileName(certificateFile));
+            }
+        }
+
+        if (unreadableFiles.Count > 0)
+        {
+            return new(
+                DoctorCommandStrings.DevCertsOpenSslCacheUnreadableMessage,
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheUnreadableFilesDetailsFormat, trustPath, string.Join(", ", unreadableFiles)));
+        }
+
+        if (!cachedThumbprints.Contains(currentCertificateThumbprint))
+        {
+            return new(
+                DoctorCommandStrings.DevCertsOpenSslCacheMissingCurrentCertificateMessage,
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, currentCertificateThumbprint));
+        }
+
+        return null;
+    }
+
+    private static bool IsOpenSslCertificateFile(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension.Equals(".pem", StringComparison.OrdinalIgnoreCase) ||
+            extension.Equals(".crt", StringComparison.OrdinalIgnoreCase) ||
+            extension.Equals(".cer", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static void AddLinuxCertificateToolWarnings(List<EnvironmentCheckResult> results, IEnvironment environment)
     {
         if (!environment.IsLinux())
@@ -288,4 +408,6 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         // We still prepend $SSL_CERT_DIR to be safe in case the user makes later modifications to their environment
         return $"export SSL_CERT_DIR=\"$SSL_CERT_DIR:{string.Join(':', systemCertDirs)}\"";
     }
+
+    private sealed record OpenSslCertificateCacheStatus(string Message, string Details);
 }

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -453,7 +453,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
 
             throw;
         }
-        catch (Exception ex) when (ex is OperationCanceledException or IOException or InvalidOperationException)
+        catch
         {
             if (started)
             {

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -6,7 +6,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Resources;
@@ -33,7 +32,6 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     private static readonly string s_trustFixCommand = string.Format(CultureInfo.InvariantCulture, DoctorCommandStrings.DevCertsTrustFixFormat, "aspire certs trust");
     private static readonly string s_cleanAndTrustFixCommand = string.Format(CultureInfo.InvariantCulture, DoctorCommandStrings.DevCertsCleanAndTrustFixFormat, "aspire certs clean", "aspire certs trust");
     private static readonly string s_installOpenSslCleanAndTrustFixCommand = string.Format(CultureInfo.InvariantCulture, DoctorCommandStrings.DevCertsInstallOpenSslCleanAndTrustFixFormat, "openssl", "aspire certs clean", "aspire certs trust");
-    private static readonly Regex s_openSslHashFileNameRegex = new("^[0-9a-fA-F]{8}\\.\\d+$", RegexOptions.CultureInvariant);
 
     public async Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
     {
@@ -366,22 +364,13 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         if (openSslPath is not null)
         {
             var (success, hash) = await TryGetOpenSslHashAsync(openSslPath, certificateFile, cancellationToken).ConfigureAwait(false);
-            return success
-                ? HasMatchingHashEntry(trustPath, hash, certificate)
-                : HasMatchingHashStyleEntry(trustPath, certificate);
+            return success &&
+                HasMatchingHashEntry(trustPath, hash, certificate);
         }
 
-        // Without openssl we cannot compute the subject hash that OpenSSL requires. The
-        // absence of any hash-style entry for the certificate is still definitely broken,
-        // but a matching entry can only be treated as sufficient evidence to avoid warning.
-        return HasMatchingHashStyleEntry(trustPath, certificate);
-    }
-
-    private static bool HasMatchingHashStyleEntry(string trustPath, X509Certificate2 certificate)
-    {
-        return Directory.EnumerateFiles(trustPath)
-            .Where(path => s_openSslHashFileNameRegex.IsMatch(Path.GetFileName(path)))
-            .Any(path => CertificateFileMatches(path, certificate));
+        // Without openssl we cannot compute the subject hash that OpenSSL requires, so
+        // friendly-name PEM checks are the strongest validation we can perform.
+        return true;
     }
 
     private static bool HasMatchingHashEntry(string trustPath, string hash, X509Certificate2 certificate)

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -46,6 +46,10 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
 
             return results;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Error checking dev-certs");
@@ -362,13 +366,19 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         if (openSslPath is not null)
         {
             var (success, hash) = await TryGetOpenSslHashAsync(openSslPath, certificateFile, cancellationToken).ConfigureAwait(false);
-            return success &&
-                HasMatchingHashEntry(trustPath, hash, certificate);
+            return success
+                ? HasMatchingHashEntry(trustPath, hash, certificate)
+                : HasMatchingHashStyleEntry(trustPath, certificate);
         }
 
         // Without openssl we cannot compute the subject hash that OpenSSL requires. The
         // absence of any hash-style entry for the certificate is still definitely broken,
         // but a matching entry can only be treated as sufficient evidence to avoid warning.
+        return HasMatchingHashStyleEntry(trustPath, certificate);
+    }
+
+    private static bool HasMatchingHashStyleEntry(string trustPath, X509Certificate2 certificate)
+    {
         return Directory.EnumerateFiles(trustPath)
             .Where(path => s_openSslHashFileNameRegex.IsMatch(Path.GetFileName(path)))
             .Any(path => CertificateFileMatches(path, certificate));
@@ -444,6 +454,15 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
 
             var hash = stdout.ToString().Trim();
             return hash.Length > 0 ? (true, hash) : (false, "");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            if (started)
+            {
+                TryKillProcess(process);
+            }
+
+            throw;
         }
         catch (Exception ex) when (ex is OperationCanceledException or IOException or InvalidOperationException)
         {

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -27,6 +27,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     internal const string OpenSslCertificateCacheCheckName = "dev-certs-openssl-cache";
     private const string OpenSslCommand = "openssl";
     private const int OpenSslHashCollisionSearchLimit = 10;
+    private static readonly TimeSpan s_openSslHashTimeout = TimeSpan.FromSeconds(5);
 
     public int Order => 35; // After SDK check (30), before container checks (40+)
 
@@ -41,7 +42,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         {
             var trustResult = certificateToolRunner.CheckHttpCertificate();
             var results = EvaluateCertificateResults(trustResult.Certificates, environment);
-            AddLinuxOpenSslCertificateCacheWarnings(results, trustResult.Certificates, environment);
+            AddLinuxOpenSslCertificateCacheWarnings(results, trustResult.Certificates, environment, cancellationToken);
             AddLinuxCertificateToolWarnings(results, environment);
 
             return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>(results);
@@ -215,7 +216,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         return results;
     }
 
-    private static void AddLinuxOpenSslCertificateCacheWarnings(List<EnvironmentCheckResult> results, IReadOnlyList<DevCertInfo> certInfos, IEnvironment environment)
+    private static void AddLinuxOpenSslCertificateCacheWarnings(List<EnvironmentCheckResult> results, IReadOnlyList<DevCertInfo> certInfos, IEnvironment environment, CancellationToken cancellationToken)
     {
         if (!environment.IsLinux())
         {
@@ -232,7 +233,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         var environmentVariables = GetEnvironmentVariables(environment);
         PathLookupHelper.TryResolveExecutablePath(OpenSslCommand, out var openSslPath, environmentVariables);
 
-        var cacheStatus = EvaluateOpenSslCertificateCache(trustPath, currentCertificates, openSslPath);
+        var cacheStatus = EvaluateOpenSslCertificateCache(trustPath, currentCertificates, openSslPath, cancellationToken);
         if (cacheStatus is null)
         {
             return;
@@ -263,7 +264,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             .ThenBy(c => c.Thumbprint, StringComparer.OrdinalIgnoreCase);
     }
 
-    private static OpenSslCertificateCacheStatus? EvaluateOpenSslCertificateCache(string trustPath, IReadOnlyList<DevCertInfo> currentCertificates, string? openSslPath)
+    private static OpenSslCertificateCacheStatus? EvaluateOpenSslCertificateCache(string trustPath, IReadOnlyList<DevCertInfo> currentCertificates, string? openSslPath, CancellationToken cancellationToken)
     {
         var fix = GetOpenSslCertificateCacheFix(openSslPath);
 
@@ -308,7 +309,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                     mismatchedThumbprints.Add(certificate.Thumbprint!);
                 }
                 else if (certificate.TrustLevel != CertificateManager.TrustLevel.None &&
-                    !HasOpenSslHashEntry(trustPath, certificateFile, cachedCertificate, openSslPath))
+                    !HasOpenSslHashEntry(trustPath, certificateFile, cachedCertificate, openSslPath, cancellationToken))
                 {
                     missingHashLinkThumbprints.Add(certificate.Thumbprint!);
                 }
@@ -357,11 +358,11 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     private static string GetOpenSslCertificateCacheFix(string? openSslPath) =>
         openSslPath is null ? s_installOpenSslCleanAndTrustFixCommand : s_cleanAndTrustFixCommand;
 
-    private static bool HasOpenSslHashEntry(string trustPath, string certificateFile, X509Certificate2 certificate, string? openSslPath)
+    private static bool HasOpenSslHashEntry(string trustPath, string certificateFile, X509Certificate2 certificate, string? openSslPath, CancellationToken cancellationToken)
     {
         if (openSslPath is not null)
         {
-            return TryGetOpenSslHash(openSslPath, certificateFile, out var hash) &&
+            return TryGetOpenSslHash(openSslPath, certificateFile, cancellationToken, out var hash) &&
                 HasMatchingHashEntry(trustPath, hash, certificate);
         }
 
@@ -406,7 +407,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         }
     }
 
-    private static bool TryGetOpenSslHash(string openSslPath, string certificateFile, [NotNullWhen(true)] out string? hash)
+    private static bool TryGetOpenSslHash(string openSslPath, string certificateFile, CancellationToken cancellationToken, [NotNullWhen(true)] out string? hash)
     {
         hash = null;
 
@@ -429,7 +430,20 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             // while the process is still running.
             var stdoutTask = process!.StandardOutput.ReadToEndAsync();
             var stderrTask = process.StandardError.ReadToEndAsync();
-            process.WaitForExit();
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(s_openSslHashTimeout);
+
+            try
+            {
+                process.WaitForExitAsync(timeoutCts.Token).GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+                TryKillProcess(process);
+                return false;
+            }
+
             var stdout = stdoutTask.GetAwaiter().GetResult();
             _ = stderrTask.GetAwaiter().GetResult();
 
@@ -448,6 +462,21 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         finally
         {
             process?.Dispose();
+        }
+    }
+
+    private static void TryKillProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(milliseconds: 1000);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or Win32Exception)
+        {
         }
     }
 

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -425,8 +425,13 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         try
         {
             process = Process.Start(processInfo);
-            var stdout = process!.StandardOutput.ReadToEnd();
+            // Read both redirected streams concurrently to avoid deadlock if openssl fills a pipe
+            // while the process is still running.
+            var stdoutTask = process!.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
             process.WaitForExit();
+            var stdout = stdoutTask.GetAwaiter().GetResult();
+            _ = stderrTask.GetAwaiter().GetResult();
 
             if (process.ExitCode != 0)
             {

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -214,14 +214,14 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             return;
         }
 
-        var currentCertificate = GetCurrentDevCertificate(certInfos);
-        if (currentCertificate?.Thumbprint is null)
+        var currentCertificates = GetCurrentDevCertificates(certInfos).ToList();
+        if (currentCertificates.Count == 0)
         {
             return;
         }
 
         var trustPath = CertificateHelpers.GetDevCertsTrustPath(environment);
-        var cacheStatus = EvaluateOpenSslCertificateCache(trustPath, currentCertificate.Thumbprint);
+        var cacheStatus = EvaluateOpenSslCertificateCache(trustPath, currentCertificates);
         if (cacheStatus is null)
         {
             return;
@@ -239,7 +239,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         });
     }
 
-    private static DevCertInfo? GetCurrentDevCertificate(IReadOnlyList<DevCertInfo> certInfos)
+    private static IEnumerable<DevCertInfo> GetCurrentDevCertificates(IReadOnlyList<DevCertInfo> certInfos)
     {
         var now = DateTimeOffset.Now;
         return certInfos
@@ -249,52 +249,53 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                 !string.IsNullOrEmpty(c.Thumbprint))
             .OrderByDescending(c => c.Version)
             .ThenByDescending(c => c.ValidityNotAfter)
-            .FirstOrDefault();
+            .ThenBy(c => c.Thumbprint, StringComparer.OrdinalIgnoreCase);
     }
 
-    private static OpenSslCertificateCacheStatus? EvaluateOpenSslCertificateCache(string trustPath, string currentCertificateThumbprint)
+    private static OpenSslCertificateCacheStatus? EvaluateOpenSslCertificateCache(string trustPath, IReadOnlyList<DevCertInfo> currentCertificates)
     {
         if (!Directory.Exists(trustPath))
         {
+            var trustedThumbprints = GetTrustedThumbprints(currentCertificates);
+            if (trustedThumbprints.Count == 0)
+            {
+                return null;
+            }
+
             return new(
                 DoctorCommandStrings.DevCertsOpenSslCacheMissingCurrentCertificateMessage,
-                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, currentCertificateThumbprint));
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", trustedThumbprints)));
         }
 
-        string[] certificateFiles;
-        try
-        {
-            // The Linux dev-certs OpenSSL cache stores certificate files such as:
-            //   aspnetcore-localhost-<thumbprint>.pem
-            // OpenSSL/c_rehash can also create hash symlinks like <hash>.0 in the same directory,
-            // but only .pem/.crt/.cer files are certificate inputs that should be parsed here.
-            certificateFiles = Directory.GetFiles(trustPath)
-                .Where(IsOpenSslCertificateFile)
-                .ToArray();
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            return new(
-                DoctorCommandStrings.DevCertsOpenSslCacheUnreadableMessage,
-                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheUnreadableDetailsFormat, trustPath, ex.Message));
-        }
-
-        var cachedThumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var unreadableFiles = new List<string>();
+        var mismatchedThumbprints = new List<string>();
+        var missingTrustedThumbprints = new List<string>();
 
-        foreach (var certificateFile in certificateFiles)
+        foreach (var certificate in currentCertificates)
         {
+            var certificateFileName = GetOpenSslCertificateFileName(certificate.Thumbprint!);
+            var certificateFile = Path.Combine(trustPath, certificateFileName);
+            if (!File.Exists(certificateFile))
+            {
+                if (certificate.TrustLevel != CertificateManager.TrustLevel.None)
+                {
+                    missingTrustedThumbprints.Add(certificate.Thumbprint!);
+                }
+
+                continue;
+            }
+
             try
             {
                 using var cachedCertificate = X509CertificateLoader.LoadCertificateFromFile(certificateFile);
-                if (cachedCertificate.Thumbprint is not null)
+                if (!string.Equals(certificate.Thumbprint, cachedCertificate.Thumbprint, StringComparison.OrdinalIgnoreCase))
                 {
-                    cachedThumbprints.Add(cachedCertificate.Thumbprint);
+                    mismatchedThumbprints.Add(certificate.Thumbprint!);
                 }
             }
             catch (Exception ex) when (ex is CryptographicException or IOException or UnauthorizedAccessException)
             {
-                unreadableFiles.Add(Path.GetFileName(certificateFile));
+                unreadableFiles.Add(certificateFileName);
             }
         }
 
@@ -305,23 +306,33 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                 string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheUnreadableFilesDetailsFormat, trustPath, string.Join(", ", unreadableFiles)));
         }
 
-        if (!cachedThumbprints.Contains(currentCertificateThumbprint))
+        if (mismatchedThumbprints.Count > 0)
         {
             return new(
                 DoctorCommandStrings.DevCertsOpenSslCacheMissingCurrentCertificateMessage,
-                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, currentCertificateThumbprint));
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", mismatchedThumbprints)));
+        }
+
+        if (missingTrustedThumbprints.Count > 0)
+        {
+            return new(
+                DoctorCommandStrings.DevCertsOpenSslCacheMissingCurrentCertificateMessage,
+                string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.DevCertsOpenSslCacheMissingDetailsFormat, trustPath, string.Join(", ", missingTrustedThumbprints)));
         }
 
         return null;
     }
 
-    private static bool IsOpenSslCertificateFile(string path)
+    private static List<string> GetTrustedThumbprints(IReadOnlyList<DevCertInfo> currentCertificates)
     {
-        var extension = Path.GetExtension(path);
-        return extension.Equals(".pem", StringComparison.OrdinalIgnoreCase) ||
-            extension.Equals(".crt", StringComparison.OrdinalIgnoreCase) ||
-            extension.Equals(".cer", StringComparison.OrdinalIgnoreCase);
+        return currentCertificates
+            .Where(c => c.TrustLevel != CertificateManager.TrustLevel.None)
+            .Select(c => c.Thumbprint!)
+            .ToList();
     }
+
+    private static string GetOpenSslCertificateFileName(string certificateThumbprint) =>
+        $"aspnetcore-localhost-{certificateThumbprint}.pem";
 
     private static void AddLinuxCertificateToolWarnings(List<EnvironmentCheckResult> results, IEnvironment environment)
     {

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -1,15 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Aspire.Cli.Certificates;
+using Aspire.Cli.DotNet;
 using Aspire.Cli.Resources;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.Extensions.Logging;
@@ -19,7 +18,7 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// <summary>
 /// Checks if the HTTPS development certificate is trusted and detects multiple certificates.
 /// </summary>
-internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateToolRunner certificateToolRunner, IEnvironment environment) : IEnvironmentCheck
+internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateToolRunner certificateToolRunner, IEnvironment environment, IProcessExecutionFactory processExecutionFactory) : IEnvironmentCheck
 {
     internal const string CheckName = "dev-certs";
     internal const string VersionCheckName = "dev-certs-version";
@@ -36,28 +35,28 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     private static readonly string s_installOpenSslCleanAndTrustFixCommand = string.Format(CultureInfo.InvariantCulture, DoctorCommandStrings.DevCertsInstallOpenSslCleanAndTrustFixFormat, "openssl", "aspire certs clean", "aspire certs trust");
     private static readonly Regex s_openSslHashFileNameRegex = new("^[0-9a-fA-F]{8}\\.\\d+$", RegexOptions.CultureInvariant);
 
-    public Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
     {
         try
         {
             var trustResult = certificateToolRunner.CheckHttpCertificate();
             var results = EvaluateCertificateResults(trustResult.Certificates, environment);
-            AddLinuxOpenSslCertificateCacheWarnings(results, trustResult.Certificates, environment, cancellationToken);
+            await AddLinuxOpenSslCertificateCacheWarningsAsync(results, trustResult.Certificates, environment, cancellationToken).ConfigureAwait(false);
             AddLinuxCertificateToolWarnings(results, environment);
 
-            return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>(results);
+            return results;
         }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Error checking dev-certs");
-            return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([new EnvironmentCheckResult
+            return [new EnvironmentCheckResult
             {
                 Category = EnvironmentCheckCategories.Environment,
                 Name = CheckName,
                 Status = EnvironmentCheckStatus.Warning,
                 Message = "Unable to check HTTPS development certificate",
                 Details = ex.Message
-            }]);
+            }];
         }
     }
 
@@ -216,7 +215,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         return results;
     }
 
-    private static void AddLinuxOpenSslCertificateCacheWarnings(List<EnvironmentCheckResult> results, IReadOnlyList<DevCertInfo> certInfos, IEnvironment environment, CancellationToken cancellationToken)
+    private async Task AddLinuxOpenSslCertificateCacheWarningsAsync(List<EnvironmentCheckResult> results, IReadOnlyList<DevCertInfo> certInfos, IEnvironment environment, CancellationToken cancellationToken)
     {
         if (!environment.IsLinux())
         {
@@ -233,7 +232,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         var environmentVariables = GetEnvironmentVariables(environment);
         PathLookupHelper.TryResolveExecutablePath(OpenSslCommand, out var openSslPath, environmentVariables);
 
-        var cacheStatus = EvaluateOpenSslCertificateCache(trustPath, currentCertificates, openSslPath, cancellationToken);
+        var cacheStatus = await EvaluateOpenSslCertificateCacheAsync(trustPath, currentCertificates, openSslPath, cancellationToken).ConfigureAwait(false);
         if (cacheStatus is null)
         {
             return;
@@ -264,7 +263,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
             .ThenBy(c => c.Thumbprint, StringComparer.OrdinalIgnoreCase);
     }
 
-    private static OpenSslCertificateCacheStatus? EvaluateOpenSslCertificateCache(string trustPath, IReadOnlyList<DevCertInfo> currentCertificates, string? openSslPath, CancellationToken cancellationToken)
+    private async Task<OpenSslCertificateCacheStatus?> EvaluateOpenSslCertificateCacheAsync(string trustPath, IReadOnlyList<DevCertInfo> currentCertificates, string? openSslPath, CancellationToken cancellationToken)
     {
         var fix = GetOpenSslCertificateCacheFix(openSslPath);
 
@@ -309,7 +308,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
                     mismatchedThumbprints.Add(certificate.Thumbprint!);
                 }
                 else if (certificate.TrustLevel != CertificateManager.TrustLevel.None &&
-                    !HasOpenSslHashEntry(trustPath, certificateFile, cachedCertificate, openSslPath, cancellationToken))
+                    !await HasOpenSslHashEntryAsync(trustPath, certificateFile, cachedCertificate, openSslPath, cancellationToken).ConfigureAwait(false))
                 {
                     missingHashLinkThumbprints.Add(certificate.Thumbprint!);
                 }
@@ -358,11 +357,12 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     private static string GetOpenSslCertificateCacheFix(string? openSslPath) =>
         openSslPath is null ? s_installOpenSslCleanAndTrustFixCommand : s_cleanAndTrustFixCommand;
 
-    private static bool HasOpenSslHashEntry(string trustPath, string certificateFile, X509Certificate2 certificate, string? openSslPath, CancellationToken cancellationToken)
+    private async Task<bool> HasOpenSslHashEntryAsync(string trustPath, string certificateFile, X509Certificate2 certificate, string? openSslPath, CancellationToken cancellationToken)
     {
         if (openSslPath is not null)
         {
-            return TryGetOpenSslHash(openSslPath, certificateFile, cancellationToken, out var hash) &&
+            var (success, hash) = await TryGetOpenSslHashAsync(openSslPath, certificateFile, cancellationToken).ConfigureAwait(false);
+            return success &&
                 HasMatchingHashEntry(trustPath, hash, certificate);
         }
 
@@ -407,75 +407,65 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
         }
     }
 
-    private static bool TryGetOpenSslHash(string openSslPath, string certificateFile, CancellationToken cancellationToken, [NotNullWhen(true)] out string? hash)
+    private async Task<(bool Success, string Hash)> TryGetOpenSslHashAsync(string openSslPath, string certificateFile, CancellationToken cancellationToken)
     {
-        hash = null;
+        var stdout = new StringBuilder();
+        var workingDirectory = Path.GetDirectoryName(certificateFile) is { } directory
+            ? new DirectoryInfo(directory)
+            : new DirectoryInfo(Directory.GetCurrentDirectory());
+        await using var process = processExecutionFactory.CreateExecution(
+            openSslPath,
+            ["x509", "-hash", "-noout", "-in", certificateFile],
+            env: null,
+            workingDirectory,
+            new ProcessInvocationOptions
+            {
+                SuppressLogging = true,
+                StandardOutputCallback = line => stdout.AppendLine(line),
+                StandardErrorCallback = _ => { },
+            });
+        var started = false;
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(s_openSslHashTimeout);
 
-        var processInfo = new ProcessStartInfo(openSslPath)
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true
-        };
-        processInfo.ArgumentList.Add("x509");
-        processInfo.ArgumentList.Add("-hash");
-        processInfo.ArgumentList.Add("-noout");
-        processInfo.ArgumentList.Add("-in");
-        processInfo.ArgumentList.Add(certificateFile);
-
-        Process? process = null;
         try
         {
-            process = Process.Start(processInfo);
-            // Read both redirected streams concurrently to avoid deadlock if openssl fills a pipe
-            // while the process is still running.
-            var stdoutTask = process!.StandardOutput.ReadToEndAsync();
-            var stderrTask = process.StandardError.ReadToEndAsync();
-
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeoutCts.CancelAfter(s_openSslHashTimeout);
-
-            try
+            started = await process.StartAsync(timeoutCts.Token).ConfigureAwait(false);
+            if (!started)
             {
-                process.WaitForExitAsync(timeoutCts.Token).GetAwaiter().GetResult();
+                return (false, "");
             }
-            catch (OperationCanceledException)
+
+            var exitCode = await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+            if (exitCode != 0)
+            {
+                return (false, "");
+            }
+
+            var hash = stdout.ToString().Trim();
+            return hash.Length > 0 ? (true, hash) : (false, "");
+        }
+        catch (Exception ex) when (ex is OperationCanceledException or IOException or InvalidOperationException)
+        {
+            if (started)
             {
                 TryKillProcess(process);
-                return false;
             }
 
-            var stdout = stdoutTask.GetAwaiter().GetResult();
-            _ = stderrTask.GetAwaiter().GetResult();
-
-            if (process.ExitCode != 0)
-            {
-                return false;
-            }
-
-            hash = stdout.Trim();
-            return hash.Length > 0;
-        }
-        catch (Exception ex) when (ex is Win32Exception or IOException or InvalidOperationException)
-        {
-            return false;
-        }
-        finally
-        {
-            process?.Dispose();
+            return (false, "");
         }
     }
 
-    private static void TryKillProcess(Process process)
+    private static void TryKillProcess(IProcessExecution process)
     {
         try
         {
             if (!process.HasExited)
             {
                 process.Kill(entireProcessTree: true);
-                process.WaitForExit(milliseconds: 1000);
             }
         }
-        catch (Exception ex) when (ex is InvalidOperationException or Win32Exception)
+        catch (InvalidOperationException)
         {
         }
     }

--- a/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
@@ -16,6 +16,9 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfigurationGatherer
 {
+    internal const string SslCertDirEnvironmentVariable = "SSL_CERT_DIR";
+    internal const string SslCertFileEnvironmentVariable = "SSL_CERT_FILE";
+
     private readonly Func<CertificateTrustScope, CertificateTrustExecutionConfigurationContext> _configContextFactory;
 
     /// <summary>
@@ -83,11 +86,11 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
         var configurationContext = _configContextFactory(additionalData.Scope);
 
         // Apply default OpenSSL environment configuration for certificate trust
-        context.EnvironmentVariables["SSL_CERT_DIR"] = configurationContext.CertificateDirectoriesPath;
+        context.EnvironmentVariables[SslCertDirEnvironmentVariable] = configurationContext.CertificateDirectoriesPath;
 
         if (additionalData.Scope != CertificateTrustScope.Append)
         {
-            context.EnvironmentVariables["SSL_CERT_FILE"] = configurationContext.CertificateBundlePath;
+            context.EnvironmentVariables[SslCertFileEnvironmentVariable] = configurationContext.CertificateBundlePath;
         }
 
         var callbackContext = new CertificateTrustConfigurationCallbackAnnotationContext

--- a/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
@@ -81,18 +81,9 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
         }
 
         var configurationContext = _configContextFactory(additionalData.Scope);
-        var certificateDirectoriesPath = configurationContext.CertificateDirectoriesPath;
-        if (additionalData.Scope == CertificateTrustScope.Append &&
-            context.EnvironmentVariables.TryGetValue("SSL_CERT_DIR", out var existingCertificateDirectoriesPath))
-        {
-            certificateDirectoriesPath = AppendCertificateDirectoriesPath(
-                configurationContext.CertificateDirectoriesPathBeforeFallback ?? certificateDirectoriesPath,
-                existingCertificateDirectoriesPath,
-                configurationContext.IsContainer ? ':' : Path.PathSeparator);
-        }
 
         // Apply default OpenSSL environment configuration for certificate trust
-        context.EnvironmentVariables["SSL_CERT_DIR"] = certificateDirectoriesPath;
+        context.EnvironmentVariables["SSL_CERT_DIR"] = configurationContext.CertificateDirectoriesPath;
 
         if (additionalData.Scope != CertificateTrustScope.Append)
         {
@@ -105,7 +96,7 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
             Resource = resource,
             Scope = additionalData.Scope,
             CertificateBundlePath = configurationContext.CertificateBundlePath,
-            CertificateDirectoriesPath = certificateDirectoriesPath,
+            CertificateDirectoriesPath = configurationContext.CertificateDirectoriesPath,
             // Must use the tracked reference to ensure proper tracking of usage
             RootCertificatesPath = configurationContext.RootCertificatesPath,
             Arguments = context.Arguments,
@@ -132,28 +123,6 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
             resourceLogger.LogInformation("Resource '{ResourceName}' has a certificate trust scope of '{Scope}'. Automatically including system root certificates in the trusted configuration.", resource.Name, Enum.GetName(additionalData.Scope));
         }
 
-    }
-
-    private static ReferenceExpression AppendCertificateDirectoriesPath(ReferenceExpression certificateDirectoriesPath, object existingCertificateDirectoriesPath, char pathSeparator)
-    {
-        if (existingCertificateDirectoriesPath is string { Length: 0 })
-        {
-            return certificateDirectoriesPath;
-        }
-
-        var builder = new ReferenceExpressionBuilder();
-        builder.Append($"{certificateDirectoriesPath}");
-        builder.AppendLiteral(pathSeparator.ToString());
-        if (existingCertificateDirectoriesPath is string existingCertificateDirectoriesPathString)
-        {
-            builder.Append($"{existingCertificateDirectoriesPathString}");
-        }
-        else
-        {
-            builder.AppendValueProvider(existingCertificateDirectoriesPath);
-        }
-
-        return builder.Build();
     }
 }
 
@@ -195,8 +164,6 @@ public class CertificateTrustExecutionConfigurationContext
     /// The path(s) to the certificate directories in the resource context (e.g., container filesystem).
     /// </summary>
     public required ReferenceExpression CertificateDirectoriesPath { get; init; }
-
-    internal ReferenceExpression? CertificateDirectoriesPathBeforeFallback { get; init; }
 
     /// <summary>
     /// The root path certificates will be written to in the resource context (e.g., container filesystem).

--- a/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
@@ -81,9 +81,15 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
         }
 
         var configurationContext = _configContextFactory(additionalData.Scope);
+        var certificateDirectoriesPath = configurationContext.CertificateDirectoriesPath;
+        if (additionalData.Scope == CertificateTrustScope.Append &&
+            context.EnvironmentVariables.TryGetValue("SSL_CERT_DIR", out var existingCertificateDirectoriesPath))
+        {
+            certificateDirectoriesPath = AppendCertificateDirectoriesPath(certificateDirectoriesPath, existingCertificateDirectoriesPath, configurationContext.IsContainer ? ':' : Path.PathSeparator);
+        }
 
         // Apply default OpenSSL environment configuration for certificate trust
-        context.EnvironmentVariables["SSL_CERT_DIR"] = configurationContext.CertificateDirectoriesPath;
+        context.EnvironmentVariables["SSL_CERT_DIR"] = certificateDirectoriesPath;
 
         if (additionalData.Scope != CertificateTrustScope.Append)
         {
@@ -96,7 +102,7 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
             Resource = resource,
             Scope = additionalData.Scope,
             CertificateBundlePath = configurationContext.CertificateBundlePath,
-            CertificateDirectoriesPath = configurationContext.CertificateDirectoriesPath,
+            CertificateDirectoriesPath = certificateDirectoriesPath,
             // Must use the tracked reference to ensure proper tracking of usage
             RootCertificatesPath = configurationContext.RootCertificatesPath,
             Arguments = context.Arguments,
@@ -123,6 +129,28 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
             resourceLogger.LogInformation("Resource '{ResourceName}' has a certificate trust scope of '{Scope}'. Automatically including system root certificates in the trusted configuration.", resource.Name, Enum.GetName(additionalData.Scope));
         }
 
+    }
+
+    private static ReferenceExpression AppendCertificateDirectoriesPath(ReferenceExpression certificateDirectoriesPath, object existingCertificateDirectoriesPath, char pathSeparator)
+    {
+        if (existingCertificateDirectoriesPath is string { Length: 0 })
+        {
+            return certificateDirectoriesPath;
+        }
+
+        var builder = new ReferenceExpressionBuilder();
+        builder.Append($"{certificateDirectoriesPath}");
+        builder.AppendLiteral(pathSeparator.ToString());
+        if (existingCertificateDirectoriesPath is string existingCertificateDirectoriesPathString)
+        {
+            builder.Append($"{existingCertificateDirectoriesPathString}");
+        }
+        else
+        {
+            builder.AppendValueProvider(existingCertificateDirectoriesPath);
+        }
+
+        return builder.Build();
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CertificateTrustExecutionConfigurationGatherer.cs
@@ -85,7 +85,10 @@ internal class CertificateTrustExecutionConfigurationGatherer : IExecutionConfig
         if (additionalData.Scope == CertificateTrustScope.Append &&
             context.EnvironmentVariables.TryGetValue("SSL_CERT_DIR", out var existingCertificateDirectoriesPath))
         {
-            certificateDirectoriesPath = AppendCertificateDirectoriesPath(certificateDirectoriesPath, existingCertificateDirectoriesPath, configurationContext.IsContainer ? ':' : Path.PathSeparator);
+            certificateDirectoriesPath = AppendCertificateDirectoriesPath(
+                configurationContext.CertificateDirectoriesPathBeforeFallback ?? certificateDirectoriesPath,
+                existingCertificateDirectoriesPath,
+                configurationContext.IsContainer ? ':' : Path.PathSeparator);
         }
 
         // Apply default OpenSSL environment configuration for certificate trust
@@ -192,6 +195,8 @@ public class CertificateTrustExecutionConfigurationContext
     /// The path(s) to the certificate directories in the resource context (e.g., container filesystem).
     /// </summary>
     public required ReferenceExpression CertificateDirectoriesPath { get; init; }
+
+    internal ReferenceExpression? CertificateDirectoriesPathBeforeFallback { get; init; }
 
     /// <summary>
     /// The root path certificates will be written to in the resource context (e.g., container filesystem).

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -700,6 +700,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         }
 
         var serverAuthCertificatesBasePath = $"{certificatesDestination}/private";
+        var resourceCertificateDirectoriesPath = ReferenceExpression.Create($"{certificatesDestination}/certs");
 
         var configuration = await ExecutionConfigurationBuilder.Create(cr.ModelResource)
             .WithArgumentsConfig()
@@ -716,6 +717,7 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                 {
                     CertificateBundlePath = ReferenceExpression.Create($"{certificatesDestination}/cert.pem"),
                     CertificateDirectoriesPath = ReferenceExpression.Create($"{string.Join(':', dirs)}"),
+                    CertificateDirectoriesPathBeforeFallback = resourceCertificateDirectoriesPath,
                     RootCertificatesPath = certificatesDestination,
                     IsContainer = true,
                 };

--- a/src/Aspire.Hosting/Dcp/ContainerCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ContainerCreator.cs
@@ -700,7 +700,6 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
         }
 
         var serverAuthCertificatesBasePath = $"{certificatesDestination}/private";
-        var resourceCertificateDirectoriesPath = ReferenceExpression.Create($"{certificatesDestination}/certs");
 
         var configuration = await ExecutionConfigurationBuilder.Create(cr.ModelResource)
             .WithArgumentsConfig()
@@ -717,7 +716,6 @@ internal sealed class ContainerCreator : IObjectCreator<Container, ContainerCrea
                 {
                     CertificateBundlePath = ReferenceExpression.Create($"{certificatesDestination}/cert.pem"),
                     CertificateDirectoriesPath = ReferenceExpression.Create($"{string.Join(':', dirs)}"),
-                    CertificateDirectoriesPathBeforeFallback = resourceCertificateDirectoriesPath,
                     RootCertificatesPath = certificatesDestination,
                     IsContainer = true,
                 };

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -494,7 +494,6 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         var customBundleOutputPath = Path.Join(certificatesRootDir, "bundles");
         var certificatesOutputPath = Path.Join(certificatesRootDir, "certs");
         var baseServerAuthOutputPath = Path.Join(certificatesRootDir, "private");
-        var resourceCertificateDirectoriesPath = ReferenceExpression.Create($"{certificatesOutputPath}");
 
         var configuration = await ExecutionConfigurationBuilder.Create(er.ModelResource)
             .WithArgumentsConfig()
@@ -509,7 +508,6 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                         scope,
                         Environment.GetEnvironmentVariable(SslCertDirEnvVar),
                         includeWellKnownCertificateDirectories: OperatingSystem.IsLinux())}"),
-                    CertificateDirectoriesPathBeforeFallback = resourceCertificateDirectoriesPath,
                     RootCertificatesPath = certificatesRootDir,
                 };
             })

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -23,6 +23,8 @@ using ExecutableConfiguration = (IExecutionConfigurationResult Configuration, Ex
 /// </summary>
 internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreationContext>
 {
+    private const string SslCertDirEnvVar = "SSL_CERT_DIR";
+
     private readonly IConfiguration _configuration;
     private readonly DcpNameGenerator _nameGenerator;
     private readonly DistributedApplicationModel _model;
@@ -498,21 +500,14 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             .WithEnvironmentVariablesConfig()
             .WithCertificateTrustConfig(scope =>
             {
-                var dirs = new List<string> { certificatesOutputPath };
-                if (scope == CertificateTrustScope.Append)
-                {
-                    var existing = Environment.GetEnvironmentVariable("SSL_CERT_DIR");
-                    if (!string.IsNullOrEmpty(existing))
-                    {
-                        dirs.AddRange(existing.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries));
-                    }
-                }
-
                 return new()
                 {
                     CertificateBundlePath = ReferenceExpression.Create($"{bundleOutputPath}"),
-                    // Build the SSL_CERT_DIR value by combining the new certs directory with any existing directories.
-                    CertificateDirectoriesPath = ReferenceExpression.Create($"{string.Join(Path.PathSeparator, dirs)}"),
+                    CertificateDirectoriesPath = ReferenceExpression.Create($"{BuildCertificateDirectoriesPath(
+                        certificatesOutputPath,
+                        scope,
+                        Environment.GetEnvironmentVariable(SslCertDirEnvVar),
+                        includeWellKnownCertificateDirectories: OperatingSystem.IsLinux())}"),
                     RootCertificatesPath = certificatesRootDir,
                 };
             })
@@ -598,6 +593,33 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         }
 
         return (configuration, pemCertificates);
+    }
+
+    internal static string BuildCertificateDirectoriesPath(
+        string certificatesOutputPath,
+        CertificateTrustScope scope,
+        string? existingSslCertDir,
+        bool includeWellKnownCertificateDirectories,
+        Func<string, bool>? directoryExists = null)
+    {
+        var dirs = new List<string> { certificatesOutputPath };
+        if (scope == CertificateTrustScope.Append)
+        {
+            if (existingSslCertDir is not null)
+            {
+                dirs.AddRange(existingSslCertDir.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries));
+            }
+            else if (includeWellKnownCertificateDirectories)
+            {
+                directoryExists ??= Directory.Exists;
+                // Do not invoke the openssl CLI here. This fallback is only for dotnet-run AppHosts
+                // where Aspire CLI did not already materialize OpenSSL's default directory into
+                // SSL_CERT_DIR, so reuse the same well-known certificate directories used for containers.
+                dirs.AddRange(ContainerCertificatePathsAnnotation.DefaultCertificateDirectoriesPaths.Where(directoryExists));
+            }
+        }
+
+        return string.Join(Path.PathSeparator, dirs);
     }
 
     private string GetCertificatesRootDirectory(RenderedModelResource<Executable> er, Executable exe)

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -494,6 +494,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         var customBundleOutputPath = Path.Join(certificatesRootDir, "bundles");
         var certificatesOutputPath = Path.Join(certificatesRootDir, "certs");
         var baseServerAuthOutputPath = Path.Join(certificatesRootDir, "private");
+        var resourceCertificateDirectoriesPath = ReferenceExpression.Create($"{certificatesOutputPath}");
 
         var configuration = await ExecutionConfigurationBuilder.Create(er.ModelResource)
             .WithArgumentsConfig()
@@ -508,6 +509,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                         scope,
                         Environment.GetEnvironmentVariable(SslCertDirEnvVar),
                         includeWellKnownCertificateDirectories: OperatingSystem.IsLinux())}"),
+                    CertificateDirectoriesPathBeforeFallback = resourceCertificateDirectoriesPath,
                     RootCertificatesPath = certificatesRootDir,
                 };
             })

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -23,8 +23,6 @@ using ExecutableConfiguration = (IExecutionConfigurationResult Configuration, Ex
 /// </summary>
 internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreationContext>
 {
-    private const string SslCertDirEnvVar = "SSL_CERT_DIR";
-
     private readonly IConfiguration _configuration;
     private readonly DcpNameGenerator _nameGenerator;
     private readonly DistributedApplicationModel _model;
@@ -500,14 +498,28 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             .WithEnvironmentVariablesConfig()
             .WithCertificateTrustConfig(scope =>
             {
+                var dirs = new List<string> { certificatesOutputPath };
+                if (scope == CertificateTrustScope.Append)
+                {
+                    var existingSslCertDir = Environment.GetEnvironmentVariable(CertificateTrustExecutionConfigurationGatherer.SslCertDirEnvironmentVariable);
+                    if (existingSslCertDir is not null)
+                    {
+                        dirs.AddRange(existingSslCertDir.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries));
+                    }
+                    else if (OperatingSystem.IsLinux())
+                    {
+                        // Do not invoke the openssl CLI here. This fallback is only for dotnet-run AppHosts
+                        // where Aspire CLI did not already materialize OpenSSL's default directory into
+                        // SSL_CERT_DIR, so reuse the same well-known certificate directories used for containers.
+                        dirs.AddRange(ContainerCertificatePathsAnnotation.DefaultCertificateDirectoriesPaths.Where(Directory.Exists));
+                    }
+                }
+
                 return new()
                 {
                     CertificateBundlePath = ReferenceExpression.Create($"{bundleOutputPath}"),
-                    CertificateDirectoriesPath = ReferenceExpression.Create($"{BuildCertificateDirectoriesPath(
-                        certificatesOutputPath,
-                        scope,
-                        Environment.GetEnvironmentVariable(SslCertDirEnvVar),
-                        includeWellKnownCertificateDirectories: OperatingSystem.IsLinux())}"),
+                    // Build the SSL_CERT_DIR value by combining the new certs directory with any existing directories.
+                    CertificateDirectoriesPath = ReferenceExpression.Create($"{string.Join(Path.PathSeparator, dirs)}"),
                     RootCertificatesPath = certificatesRootDir,
                 };
             })
@@ -593,33 +605,6 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         }
 
         return (configuration, pemCertificates);
-    }
-
-    internal static string BuildCertificateDirectoriesPath(
-        string certificatesOutputPath,
-        CertificateTrustScope scope,
-        string? existingSslCertDir,
-        bool includeWellKnownCertificateDirectories,
-        Func<string, bool>? directoryExists = null)
-    {
-        var dirs = new List<string> { certificatesOutputPath };
-        if (scope == CertificateTrustScope.Append)
-        {
-            if (existingSslCertDir is not null)
-            {
-                dirs.AddRange(existingSslCertDir.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries));
-            }
-            else if (includeWellKnownCertificateDirectories)
-            {
-                directoryExists ??= Directory.Exists;
-                // Do not invoke the openssl CLI here. This fallback is only for dotnet-run AppHosts
-                // where Aspire CLI did not already materialize OpenSSL's default directory into
-                // SSL_CERT_DIR, so reuse the same well-known certificate directories used for containers.
-                dirs.AddRange(ContainerCertificatePathsAnnotation.DefaultCertificateDirectoriesPaths.Where(directoryExists));
-            }
-        }
-
-        return string.Join(Path.PathSeparator, dirs);
     }
 
     private string GetCertificatesRootDirectory(RenderedModelResource<Executable> er, Executable exe)

--- a/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
@@ -5,6 +5,7 @@ using Aspire.Cli.Certificates;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Cli.Tests.Certificates;
 
@@ -39,6 +40,44 @@ public class UnixCertificateManagerTests
         finally
         {
             openSslDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetTrustLevel_WithCorruptOpenSslCertificateBeforeValidCertificate_DoesNotLogOpenSslWarning()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "OpenSSL certificate directory trust is only exercised on Linux.");
+
+        var corruptOpenSslDirectory = Directory.CreateTempSubdirectory();
+        var validOpenSslDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            var sink = new TestSink();
+            var logger = new TestLogger(nameof(UnixCertificateManager), sink, enabled: true);
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = Path.Combine(corruptOpenSslDirectory.FullName, "missing-tools"),
+                ["SSL_CERT_DIR"] = string.Join(Path.PathSeparator, corruptOpenSslDirectory.FullName, validOpenSslDirectory.FullName),
+                ["DOTNET_DEV_CERTS_NSSDB_PATHS"] = Path.Combine(corruptOpenSslDirectory.FullName, "missing-nss-db")
+            });
+            var manager = new UnixCertificateManager(logger, environment);
+            using var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(365));
+            var certificateFileName = $"aspnetcore-localhost-{certificate.Thumbprint}.pem";
+            File.WriteAllText(Path.Combine(corruptOpenSslDirectory.FullName, certificateFileName), "not a certificate");
+            File.WriteAllText(Path.Combine(validOpenSslDirectory.FullName, certificateFileName), certificate.ExportCertificatePem());
+
+            var trustLevel = manager.GetTrustLevel(certificate);
+
+            Assert.NotEqual(CertificateManager.TrustLevel.None, trustLevel);
+            Assert.DoesNotContain(sink.Writes, w => w.Message?.Contains("not trusted by OpenSSL", StringComparison.Ordinal) == true);
+        }
+        finally
+        {
+            corruptOpenSslDirectory.Delete(recursive: true);
+            validOpenSslDirectory.Delete(recursive: true);
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
@@ -11,6 +11,38 @@ namespace Aspire.Cli.Tests.Certificates;
 public class UnixCertificateManagerTests
 {
     [Fact]
+    public void GetTrustLevel_WithCorruptOpenSslCertificate_DoesNotThrow()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "OpenSSL certificate directory trust is only exercised on Linux.");
+
+        var openSslDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = Path.Combine(openSslDirectory.FullName, "missing-tools"),
+                ["SSL_CERT_DIR"] = openSslDirectory.FullName,
+                ["DOTNET_DEV_CERTS_NSSDB_PATHS"] = Path.Combine(openSslDirectory.FullName, "missing-nss-db")
+            });
+            var manager = new UnixCertificateManager(NullLogger.Instance, environment);
+            using var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(365));
+            var certificatePath = Path.Combine(openSslDirectory.FullName, $"aspnetcore-localhost-{certificate.Thumbprint}.pem");
+            File.WriteAllText(certificatePath, "not a certificate");
+
+            var exception = Record.Exception(() => manager.GetTrustLevel(certificate));
+
+            Assert.Null(exception);
+        }
+        finally
+        {
+            openSslDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void RemoveCertificate_WithMissingCertUtilAndNssDbs_SkipsNssCleanup()
     {
         Assert.SkipUnless(OperatingSystem.IsLinux(), "NSS certificate cleanup is only exercised on Linux.");

--- a/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
@@ -32,9 +32,9 @@ public class UnixCertificateManagerTests
             var certificatePath = Path.Combine(openSslDirectory.FullName, $"aspnetcore-localhost-{certificate.Thumbprint}.pem");
             File.WriteAllText(certificatePath, "not a certificate");
 
-            var exception = Record.Exception(() => manager.GetTrustLevel(certificate));
+            var trustLevel = manager.GetTrustLevel(certificate);
 
-            Assert.Null(exception);
+            Assert.Equal(CertificateManager.TrustLevel.None, trustLevel);
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
@@ -43,6 +43,40 @@ public class UnixCertificateManagerTests
     }
 
     [Fact]
+    public void RemoveCertificate_WithMissingOpenSsl_DeletesOpenSslCertificate()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "OpenSSL certificate cleanup is only exercised on Linux.");
+
+        var openSslDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = Path.Combine(openSslDirectory.FullName, "missing-tools"),
+                ["DOTNET_DEV_CERTS_NSSDB_PATHS"] = Path.Combine(openSslDirectory.FullName, "missing-nss-db"),
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = openSslDirectory.FullName
+            });
+            var manager = new UnixCertificateManager(NullLogger.Instance, environment);
+            using var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(365));
+            using var savedCertificate = manager.SaveCertificate(certificate);
+            var certificatePath = Path.Combine(openSslDirectory.FullName, $"aspnetcore-localhost-{savedCertificate.Thumbprint}.pem");
+            File.WriteAllText(certificatePath, "not a certificate");
+
+            var exception = Record.Exception(() => manager.RemoveCertificate(savedCertificate, CertificateManager.RemoveLocations.All));
+
+            Assert.Null(exception);
+            Assert.False(File.Exists(certificatePath));
+        }
+        finally
+        {
+            openSslDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void RemoveCertificate_WithMissingCertUtilAndNssDbs_SkipsNssCleanup()
     {
         Assert.SkipUnless(OperatingSystem.IsLinux(), "NSS certificate cleanup is only exercised on Linux.");

--- a/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestProcessExecutionFactory.cs
@@ -191,6 +191,8 @@ internal sealed class TestProcessExecution : IProcessExecution
 
     public bool StartReturnValue { get; init; } = true;
 
+    public Exception? StartException { get; init; }
+
     public bool ThrowOnHasExitedBeforeStart { get; init; }
 
     public Func<ProcessInvocationOptions, CancellationToken, Task<int>>? WaitForExitAsyncCallback { get; init; }
@@ -208,6 +210,11 @@ internal sealed class TestProcessExecution : IProcessExecution
     public Task<bool> StartAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        if (StartException is not null)
+        {
+            throw StartException;
+        }
 
         if (!StartReturnValue)
         {

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -66,6 +66,9 @@ public class DevCertsCheckTests
         return certUtilPath;
     }
 
+    private static string GetOpenSslCertificateFileName(X509Certificate2 certificate) =>
+        $"aspnetcore-localhost-{certificate.Thumbprint}.pem";
+
     [Fact]
     public void EvaluateCertificateResults_NoCertificates_ReturnsWarning()
     {
@@ -348,7 +351,7 @@ public class DevCertsCheckTests
         {
             CreateCertUtil(tempDirectory);
             var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
-            File.WriteAllText(Path.Combine(trustDirectory.FullName, "localhost.pem"), certificate.ExportCertificatePem());
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
 
             var certs = new List<DevCertInfo>
             {
@@ -390,7 +393,8 @@ public class DevCertsCheckTests
         {
             CreateCertUtil(tempDirectory);
             var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
-            File.WriteAllText(Path.Combine(trustDirectory.FullName, "broken.pem"), "not a certificate");
+            var corruptCertificateFileName = GetOpenSslCertificateFileName(certificate);
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, corruptCertificateFileName), "not a certificate");
 
             var certs = new List<DevCertInfo>
             {
@@ -416,7 +420,7 @@ public class DevCertsCheckTests
 
             var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
             Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
-            Assert.Contains("broken.pem", cacheResult.Details);
+            Assert.Contains(corruptCertificateFileName, cacheResult.Details);
             Assert.Contains("aspire certs clean", cacheResult.Fix);
         }
         finally
@@ -435,7 +439,8 @@ public class DevCertsCheckTests
         {
             CreateCertUtil(tempDirectory);
             var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
-            File.WriteAllText(Path.Combine(trustDirectory.FullName, "broken.pem"), "not a certificate");
+            var corruptCertificateFileName = GetOpenSslCertificateFileName(certificate);
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, corruptCertificateFileName), "not a certificate");
 
             var certs = new List<DevCertInfo>
             {
@@ -461,8 +466,51 @@ public class DevCertsCheckTests
 
             var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
             Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
-            Assert.Contains("broken.pem", cacheResult.Details);
+            Assert.Contains(corruptCertificateFileName, cacheResult.Details);
             Assert.Contains("aspire certs clean", cacheResult.Fix);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithUnrelatedCorruptOpenSslCertificateCache_DoesNotReturnOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, "unrelated.pem"), "not a certificate");
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
         }
         finally
         {
@@ -481,7 +529,7 @@ public class DevCertsCheckTests
         {
             CreateCertUtil(tempDirectory);
             var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
-            File.WriteAllText(Path.Combine(trustDirectory.FullName, "stale.pem"), staleCertificate.ExportCertificatePem());
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), staleCertificate.ExportCertificatePem());
 
             var certs = new List<DevCertInfo>
             {

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -98,6 +98,21 @@ public class DevCertsCheckTests
         return openSslPath;
     }
 
+    private static string CreateOpenSslThatWaits(DirectoryInfo directory)
+    {
+        var openSslPath = Path.Combine(directory.FullName, "openssl");
+        File.WriteAllText(openSslPath, """
+            #!/bin/sh
+            sleep 30
+            """);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(openSslPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        }
+
+        return openSslPath;
+    }
+
     private static string GetOpenSslCertificateFileName(X509Certificate2 certificate) =>
         $"aspnetcore-localhost-{certificate.Thumbprint}.pem";
 
@@ -469,6 +484,55 @@ public class DevCertsCheckTests
             Assert.Contains("subject-hash", cacheResult.Details);
             Assert.Contains("aspire certs clean", cacheResult.Fix);
             Assert.DoesNotContain("Install openssl", cacheResult.Fix);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
+    public async Task CheckAsync_LinuxWithCanceledOpenSslHashProbe_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            CreateOpenSslThatWaits(tempDirectory);
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            await cancellationTokenSource.CancelAsync();
+
+            var results = await check.CheckAsync(cancellationTokenSource.Token);
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("subject-hash", cacheResult.Details);
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -489,6 +489,61 @@ public class DevCertsCheckTests
 
     [Fact]
     [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
+    public async Task CheckAsync_LinuxWithOpenSslHashProbeStartFailure_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            CreateOpenSsl(tempDirectory, "12345678");
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            WriteOpenSslCertificateCache(trustDirectory, certificate, "12345678.0");
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var processExecutionFactory = new TestProcessExecutionFactory
+            {
+                CreateExecutionWithFileNameCallback = (fileName, args, env, workingDirectory, options) =>
+                    new TestProcessExecution(fileName, args, env, options, (_, _, _) => Task.FromResult((0, (string?)"12345678")), () => 1)
+                    {
+                        StartException = new InvalidOperationException("openssl failed to start")
+                    }
+            };
+            var check = CreateCheck(toolRunner, environment, processExecutionFactory);
+
+            var results = await check.CheckAsync();
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("subject-hash", cacheResult.Details);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
     public async Task CheckAsync_LinuxWithMissingOpenSslHashEntry_ReturnsOpenSslCertificateCacheWarning()
     {
         using var certificate = CreateCertificate();

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -384,6 +384,94 @@ public class DevCertsCheckTests
     }
 
     [Fact]
+    public async Task CheckAsync_LinuxWithMissingOpenSslCertificateCacheDirectory_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            var trustDirectory = Path.Combine(tempDirectory.FullName, "missing-trust");
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("aspire certs clean", cacheResult.Fix);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithMissingOpenSslCertificateCacheEntry_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("aspire certs clean", cacheResult.Fix);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task CheckAsync_LinuxWithCorruptOpenSslCertificateCache_ReturnsOpenSslCertificateCacheWarning()
     {
         using var certificate = CreateCertificate();

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -593,7 +593,7 @@ public class DevCertsCheckTests
 
     [Fact]
     [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
-    public async Task CheckAsync_LinuxWithCallerCanceledOpenSslHashProbe_ThrowsOperationCanceledException()
+    public async Task CheckAsync_LinuxWithCallerCanceledOpenSslHashProbeAndKillFailure_ThrowsOperationCanceledException()
     {
         using var certificate = CreateCertificate();
         var tempDirectory = Directory.CreateTempSubdirectory();
@@ -626,16 +626,79 @@ public class DevCertsCheckTests
             });
             var processExecutionFactory = new TestProcessExecutionFactory
             {
-                AsyncAttemptCallback = async (_, _, cancellationToken) =>
-                {
-                    await cancellationTokenSource.CancelAsync();
-                    await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
-                    return (0, (string?)"12345678");
-                }
+                CreateExecutionWithFileNameCallback = (fileName, args, env, workingDirectory, options) =>
+                    new TestProcessExecution(fileName, args, env, options, async (_, _, cancellationToken) =>
+                    {
+                        await cancellationTokenSource.CancelAsync();
+                        await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+                        return (0, (string?)"12345678");
+                    }, () => 1)
+                    {
+                        KillCallback = _ => throw new NotSupportedException("Process tree termination is unavailable.")
+                    }
             };
             var check = CreateCheck(toolRunner, environment, processExecutionFactory);
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => check.CheckAsync(cancellationTokenSource.Token));
+
+            var processExecution = Assert.IsType<TestProcessExecution>(Assert.Single(processExecutionFactory.CreatedExecutions));
+            Assert.Equal(1, processExecution.KillCount);
+            Assert.True(processExecution.KilledEntireProcessTree);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
+    public async Task CheckAsync_LinuxWithOpenSslHashProbeFailureAndKillFailure_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            CreateOpenSsl(tempDirectory, "12345678");
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var processExecutionFactory = new TestProcessExecutionFactory
+            {
+                CreateExecutionWithFileNameCallback = (fileName, args, env, workingDirectory, options) =>
+                    new TestProcessExecution(fileName, args, env, options, (_, _, _) => throw new IOException("openssl pipe failed"), () => 1)
+                    {
+                        KillCallback = _ => throw new NotSupportedException("Process tree termination is unavailable.")
+                    }
+            };
+            var check = CreateCheck(toolRunner, environment, processExecutionFactory);
+
+            var results = await check.CheckAsync();
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("subject-hash", cacheResult.Details);
 
             var processExecution = Assert.IsType<TestProcessExecution>(Assert.Single(processExecutionFactory.CreatedExecutions));
             Assert.Equal(1, processExecution.KillCount);

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -438,7 +438,7 @@ public class DevCertsCheckTests
 
     [Fact]
     [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
-    public async Task CheckAsync_LinuxWithFailedOpenSslHashProbeAndMatchingHashStyleEntry_DoesNotReturnOpenSslCertificateCacheWarning()
+    public async Task CheckAsync_LinuxWithFailedOpenSslHashProbeAndMatchingHashStyleEntry_ReturnsOpenSslCertificateCacheWarning()
     {
         using var certificate = CreateCertificate();
         var tempDirectory = Directory.CreateTempSubdirectory();
@@ -476,7 +476,10 @@ public class DevCertsCheckTests
 
             var results = await check.CheckAsync();
 
-            Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("subject-hash", cacheResult.Details);
         }
         finally
         {
@@ -649,7 +652,7 @@ public class DevCertsCheckTests
     }
 
     [Fact]
-    public async Task CheckAsync_LinuxWithMissingOpenSslHashEntryAndNoOpenSsl_ReturnsOpenSslCertificateCacheWarningWithOpenSslFix()
+    public async Task CheckAsync_LinuxWithMissingOpenSslHashEntryAndNoOpenSsl_DoesNotReturnOpenSslCertificateCacheWarning()
     {
         using var certificate = CreateCertificate();
         var tempDirectory = Directory.CreateTempSubdirectory();
@@ -682,11 +685,7 @@ public class DevCertsCheckTests
 
             var results = await check.CheckAsync();
 
-            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
-            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
-            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
-            Assert.Contains("Install openssl", cacheResult.Fix);
-            Assert.Contains("aspire certs trust", cacheResult.Fix);
+            Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -648,65 +648,6 @@ public class DevCertsCheckTests
     }
 
     [Fact]
-    [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
-    public async Task CheckAsync_LinuxWithCanceledOpenSslHashProbe_ReturnsOpenSslCertificateCacheWarning()
-    {
-        using var certificate = CreateCertificate();
-        var tempDirectory = Directory.CreateTempSubdirectory();
-        using var cancellationTokenSource = new CancellationTokenSource();
-
-        try
-        {
-            CreateCertUtil(tempDirectory);
-            CreateOpenSsl(tempDirectory, "12345678");
-            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
-            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
-
-            var certs = new List<DevCertInfo>
-            {
-                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
-            };
-            var toolRunner = new TestCertificateToolRunner
-            {
-                CheckHttpCertificateCallback = () => new CertificateTrustResult
-                {
-                    HasCertificates = true,
-                    TrustLevel = CertificateManager.TrustLevel.Full,
-                    Certificates = certs
-                }
-            };
-            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
-            {
-                ["PATH"] = tempDirectory.FullName,
-                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
-            });
-            var processExecutionFactory = new TestProcessExecutionFactory
-            {
-                AsyncAttemptCallback = async (_, _, cancellationToken) =>
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
-                    return (0, (string?)"12345678");
-                }
-            };
-            var check = CreateCheck(toolRunner, environment, processExecutionFactory);
-
-            var results = await check.CheckAsync(cancellationTokenSource.Token);
-
-            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
-            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
-            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
-            Assert.Contains("subject-hash", cacheResult.Details);
-            var processExecution = Assert.IsType<TestProcessExecution>(Assert.Single(processExecutionFactory.CreatedExecutions));
-            Assert.Equal(1, processExecution.KillCount);
-            Assert.True(processExecution.KilledEntireProcessTree);
-        }
-        finally
-        {
-            tempDirectory.Delete(recursive: true);
-        }
-    }
-
-    [Fact]
     public async Task CheckAsync_LinuxWithMissingOpenSslHashEntryAndNoOpenSsl_DoesNotReturnOpenSslCertificateCacheWarning()
     {
         using var certificate = CreateCertificate();

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -438,6 +438,54 @@ public class DevCertsCheckTests
 
     [Fact]
     [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
+    public async Task CheckAsync_LinuxWithFailedOpenSslHashProbeAndMatchingHashStyleEntry_DoesNotReturnOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            CreateOpenSsl(tempDirectory, "12345678");
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            WriteOpenSslCertificateCache(trustDirectory, certificate, "87654321.0");
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var processExecutionFactory = new TestProcessExecutionFactory
+            {
+                AsyncAttemptCallback = (_, _, _) => Task.FromResult((1, (string?)null))
+            };
+            var check = CreateCheck(toolRunner, environment, processExecutionFactory);
+
+            var results = await check.CheckAsync();
+
+            Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
     public async Task CheckAsync_LinuxWithMissingOpenSslHashEntry_ReturnsOpenSslCertificateCacheWarning()
     {
         using var certificate = CreateCertificate();
@@ -478,6 +526,62 @@ public class DevCertsCheckTests
             Assert.Contains("subject-hash", cacheResult.Details);
             Assert.Contains("aspire certs clean", cacheResult.Fix);
             Assert.DoesNotContain("Install openssl", cacheResult.Fix);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
+    public async Task CheckAsync_LinuxWithCallerCanceledOpenSslHashProbe_ThrowsOperationCanceledException()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            CreateOpenSsl(tempDirectory, "12345678");
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var processExecutionFactory = new TestProcessExecutionFactory
+            {
+                AsyncAttemptCallback = async (_, _, cancellationToken) =>
+                {
+                    await cancellationTokenSource.CancelAsync();
+                    await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+                    return (0, (string?)"12345678");
+                }
+            };
+            var check = CreateCheck(toolRunner, environment, processExecutionFactory);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => check.CheckAsync(cancellationTokenSource.Token));
+
+            var processExecution = Assert.IsType<TestProcessExecution>(Assert.Single(processExecutionFactory.CreatedExecutions));
+            Assert.Equal(1, processExecution.KillCount);
+            Assert.True(processExecution.KilledEntireProcessTree);
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Aspire.Cli.Certificates;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Utils.EnvironmentChecker;
@@ -27,6 +29,41 @@ public class DevCertsCheckTests
             IsHttpsDevelopmentCertificate = true,
             IsExportable = true
         };
+    }
+
+    private static DevCertInfo CreateDevCertInfo(CertificateManager.TrustLevel trustLevel, X509Certificate2 certificate, int version)
+    {
+        return new DevCertInfo
+        {
+            TrustLevel = trustLevel,
+            Thumbprint = certificate.Thumbprint,
+            Version = version,
+            ValidityNotBefore = certificate.NotBefore,
+            ValidityNotAfter = certificate.NotAfter,
+            Subject = certificate.Subject,
+            IsHttpsDevelopmentCertificate = true,
+            IsExportable = true
+        };
+    }
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var key = RSA.Create(2048);
+        var request = new CertificateRequest("CN=localhost", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+        return X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
+    }
+
+    private static string CreateCertUtil(DirectoryInfo directory)
+    {
+        var certUtilPath = Path.Combine(directory.FullName, CertificateHelpers.CertUtilCommand);
+        File.WriteAllText(certUtilPath, "");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(certUtilPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        }
+
+        return certUtilPath;
     }
 
     [Fact]
@@ -270,12 +307,7 @@ public class DevCertsCheckTests
 
         try
         {
-            var certUtilPath = Path.Combine(tempDirectory.FullName, CertificateHelpers.CertUtilCommand);
-            File.WriteAllText(certUtilPath, "");
-            if (!OperatingSystem.IsWindows())
-            {
-                File.SetUnixFileMode(certUtilPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
-            }
+            CreateCertUtil(tempDirectory);
 
             var certs = new List<DevCertInfo>
             {
@@ -299,6 +331,184 @@ public class DevCertsCheckTests
             var results = await check.CheckAsync();
 
             Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.CertUtilCheckName);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithMatchingOpenSslCertificateCache_DoesNotReturnOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, "localhost.pem"), certificate.ExportCertificatePem());
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithCorruptOpenSslCertificateCache_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, "broken.pem"), "not a certificate");
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains("broken.pem", cacheResult.Details);
+            Assert.Contains("aspire certs clean", cacheResult.Fix);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithUntrustedCertificateAndCorruptOpenSslCertificateCache_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, "broken.pem"), "not a certificate");
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.None, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.None,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains("broken.pem", cacheResult.Details);
+            Assert.Contains("aspire certs clean", cacheResult.Fix);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithStaleOpenSslCertificateCache_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        using var staleCertificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, "stale.pem"), staleCertificate.ExportCertificatePem());
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("aspire certs clean", cacheResult.Fix);
         }
         finally
         {

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -66,8 +66,47 @@ public class DevCertsCheckTests
         return certUtilPath;
     }
 
+    private static string CreateOpenSsl(DirectoryInfo directory, string hash)
+    {
+        var openSslPath = OperatingSystem.IsWindows()
+            ? Path.Combine(directory.FullName, "openssl.cmd")
+            : Path.Combine(directory.FullName, "openssl");
+
+        var contents = OperatingSystem.IsWindows()
+            ? $"""
+                @echo off
+                if "%1"=="x509" (
+                  echo {hash}
+                  exit /b 0
+                )
+                exit /b 1
+                """
+            : $"""
+                #!/bin/sh
+                if [ "$1" = "x509" ]; then
+                  echo {hash}
+                  exit 0
+                fi
+                exit 1
+                """;
+        File.WriteAllText(openSslPath, contents);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(openSslPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        }
+
+        return openSslPath;
+    }
+
     private static string GetOpenSslCertificateFileName(X509Certificate2 certificate) =>
         $"aspnetcore-localhost-{certificate.Thumbprint}.pem";
+
+    private static void WriteOpenSslCertificateCache(DirectoryInfo trustDirectory, X509Certificate2 certificate, string hashEntryName = "12345678.0")
+    {
+        var certificatePem = certificate.ExportCertificatePem();
+        File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificatePem);
+        File.WriteAllText(Path.Combine(trustDirectory.FullName, hashEntryName), certificatePem);
+    }
 
     [Fact]
     public void EvaluateCertificateResults_NoCertificates_ReturnsWarning()
@@ -350,6 +389,55 @@ public class DevCertsCheckTests
         try
         {
             CreateCertUtil(tempDirectory);
+            if (!OperatingSystem.IsWindows())
+            {
+                CreateOpenSsl(tempDirectory, "12345678");
+            }
+
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            WriteOpenSslCertificateCache(trustDirectory, certificate);
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    [SkipOnPlatform(TestPlatforms.Windows, "The synthetic openssl command uses a POSIX shell script.")]
+    public async Task CheckAsync_LinuxWithMissingOpenSslHashEntry_ReturnsOpenSslCertificateCacheWarning()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            CreateOpenSsl(tempDirectory, "12345678");
             var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
             File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
 
@@ -375,7 +463,58 @@ public class DevCertsCheckTests
 
             var results = await check.CheckAsync();
 
-            Assert.DoesNotContain(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("subject-hash", cacheResult.Details);
+            Assert.Contains("aspire certs clean", cacheResult.Fix);
+            Assert.DoesNotContain("Install openssl", cacheResult.Fix);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CheckAsync_LinuxWithMissingOpenSslHashEntryAndNoOpenSsl_ReturnsOpenSslCertificateCacheWarningWithOpenSslFix()
+    {
+        using var certificate = CreateCertificate();
+        var tempDirectory = Directory.CreateTempSubdirectory();
+
+        try
+        {
+            CreateCertUtil(tempDirectory);
+            var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
+            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
+
+            var certs = new List<DevCertInfo>
+            {
+                CreateDevCertInfo(CertificateManager.TrustLevel.Full, certificate, MinVersion),
+            };
+            var toolRunner = new TestCertificateToolRunner
+            {
+                CheckHttpCertificateCallback = () => new CertificateTrustResult
+                {
+                    HasCertificates = true,
+                    TrustLevel = CertificateManager.TrustLevel.Full,
+                    Certificates = certs
+                }
+            };
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
+            });
+            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+
+            var results = await check.CheckAsync();
+
+            var cacheResult = Assert.Single(results, r => r.Name == DevCertsCheck.OpenSslCertificateCacheCheckName);
+            Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
+            Assert.Contains(certificate.Thumbprint, cacheResult.Details);
+            Assert.Contains("Install openssl", cacheResult.Fix);
+            Assert.Contains("aspire certs trust", cacheResult.Fix);
         }
         finally
         {
@@ -573,7 +712,7 @@ public class DevCertsCheckTests
         {
             CreateCertUtil(tempDirectory);
             var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
-            File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
+            WriteOpenSslCertificateCache(trustDirectory, certificate);
             File.WriteAllText(Path.Combine(trustDirectory.FullName, "unrelated.pem"), "not a certificate");
 
             var certs = new List<DevCertInfo>

--- a/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/DevCertsCheckTests.cs
@@ -54,6 +54,15 @@ public class DevCertsCheckTests
         return X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
     }
 
+    private static DevCertsCheck CreateCheck(TestCertificateToolRunner toolRunner, IEnvironment environment, TestProcessExecutionFactory? processExecutionFactory = null) =>
+        new(NullLogger<DevCertsCheck>.Instance, toolRunner, environment, processExecutionFactory ?? CreateOpenSslProcessExecutionFactory());
+
+    private static TestProcessExecutionFactory CreateOpenSslProcessExecutionFactory(string hash = "12345678") =>
+        new()
+        {
+            AsyncAttemptCallback = (_, _, _) => Task.FromResult((0, (string?)hash))
+        };
+
     private static string CreateCertUtil(DirectoryInfo directory)
     {
         var certUtilPath = Path.Combine(directory.FullName, CertificateHelpers.CertUtilCommand);
@@ -90,21 +99,6 @@ public class DevCertsCheckTests
                 exit 1
                 """;
         File.WriteAllText(openSslPath, contents);
-        if (!OperatingSystem.IsWindows())
-        {
-            File.SetUnixFileMode(openSslPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
-        }
-
-        return openSslPath;
-    }
-
-    private static string CreateOpenSslThatWaits(DirectoryInfo directory)
-    {
-        var openSslPath = Path.Combine(directory.FullName, "openssl");
-        File.WriteAllText(openSslPath, """
-            #!/bin/sh
-            sleep 30
-            """);
         if (!OperatingSystem.IsWindows())
         {
             File.SetUnixFileMode(openSslPath, UnixFileMode.UserRead | UnixFileMode.UserExecute);
@@ -348,7 +342,7 @@ public class DevCertsCheckTests
         {
             ["PATH"] = Path.Combine(AppContext.BaseDirectory, Guid.NewGuid().ToString("N"))
         });
-        var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+        var check = CreateCheck(toolRunner, environment);
 
         var results = await check.CheckAsync();
 
@@ -383,7 +377,7 @@ public class DevCertsCheckTests
             {
                 ["PATH"] = tempDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -430,7 +424,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -474,7 +468,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -502,7 +496,7 @@ public class DevCertsCheckTests
         try
         {
             CreateCertUtil(tempDirectory);
-            CreateOpenSslThatWaits(tempDirectory);
+            CreateOpenSsl(tempDirectory, "12345678");
             var trustDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "trust"));
             File.WriteAllText(Path.Combine(trustDirectory.FullName, GetOpenSslCertificateFileName(certificate)), certificate.ExportCertificatePem());
 
@@ -524,8 +518,15 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
-            await cancellationTokenSource.CancelAsync();
+            var processExecutionFactory = new TestProcessExecutionFactory
+            {
+                AsyncAttemptCallback = async (_, _, cancellationToken) =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+                    return (0, (string?)"12345678");
+                }
+            };
+            var check = CreateCheck(toolRunner, environment, processExecutionFactory);
 
             var results = await check.CheckAsync(cancellationTokenSource.Token);
 
@@ -533,6 +534,9 @@ public class DevCertsCheckTests
             Assert.Equal(EnvironmentCheckStatus.Warning, cacheResult.Status);
             Assert.Contains(certificate.Thumbprint, cacheResult.Details);
             Assert.Contains("subject-hash", cacheResult.Details);
+            var processExecution = Assert.IsType<TestProcessExecution>(Assert.Single(processExecutionFactory.CreatedExecutions));
+            Assert.Equal(1, processExecution.KillCount);
+            Assert.True(processExecution.KilledEntireProcessTree);
         }
         finally
         {
@@ -570,7 +574,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -615,7 +619,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -659,7 +663,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -705,7 +709,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -751,7 +755,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -797,7 +801,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -840,7 +844,7 @@ public class DevCertsCheckTests
                 ["PATH"] = tempDirectory.FullName,
                 [CertificateHelpers.DevCertsOpenSslCertDirEnvVar] = trustDirectory.FullName
             });
-            var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+            var check = CreateCheck(toolRunner, environment);
 
             var results = await check.CheckAsync();
 
@@ -875,7 +879,7 @@ public class DevCertsCheckTests
         {
             ["PATH"] = Path.Combine(AppContext.BaseDirectory, Guid.NewGuid().ToString("N"))
         });
-        var check = new DevCertsCheck(NullLogger<DevCertsCheck>.Instance, toolRunner, environment);
+        var check = CreateCheck(toolRunner, environment);
 
         var results = await check.CheckAsync();
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3542,7 +3542,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task PlainExecutableCertificateDirectoriesPath_PreservesResourceSslCertDirForAppend()
+    public async Task PlainExecutableCertificateDirectoriesPath_IgnoresResourceSslCertDirForAppend()
     {
         var builder = DistributedApplication.CreateBuilder();
         var customSslCertDir = $"/resource-certs-{Guid.NewGuid():N}";
@@ -3566,37 +3566,15 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var sslCertDir = Assert.Single(exe.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
 
         Assert.NotNull(sslCertDir);
-        var sslCertDirs = sslCertDir.Split(Path.PathSeparator);
-        Assert.Equal(2, sslCertDirs.Length);
-        Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", sslCertDirs[0]);
-        Assert.Equal(customSslCertDir, sslCertDirs[1]);
-    }
-
-    [Fact]
-    public async Task ContainerCertificateDirectoriesPath_PreservesResourceSslCertDirForAppend()
-    {
-        var builder = DistributedApplication.CreateBuilder();
-        var customSslCertDir = $"/resource-certs-{Guid.NewGuid():N}";
-        using var certificate = CreateTestCertificate();
-        var certificateAuthorities = builder.AddCertificateAuthorityCollection("certificates")
-            .WithCertificate(certificate);
-
-        builder.AddContainer("database", "image")
-            .WithEnvironment("SSL_CERT_DIR", customSslCertDir)
-            .WithCertificateAuthorityCollection(certificateAuthorities);
-
-        var kubernetesService = new TestKubernetesService();
-        using var app = builder.Build();
-        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
-
-        await appExecutor.RunApplicationAsync();
-
-        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
-        var sslCertDir = Assert.Single(container.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
-
-        Assert.NotNull(sslCertDir);
-        Assert.Equal($"{ContainerCertificatePathsAnnotation.DefaultCustomCertificatesDestination}/certs:{customSslCertDir}", sslCertDir);
+        var generatedCertificatesPath = sslCertDir.Split(Path.PathSeparator)[0];
+        Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", generatedCertificatesPath);
+        Assert.Equal(
+            ExecutableCreator.BuildCertificateDirectoriesPath(
+                generatedCertificatesPath,
+                CertificateTrustScope.Append,
+                Environment.GetEnvironmentVariable("SSL_CERT_DIR"),
+                includeWellKnownCertificateDirectories: OperatingSystem.IsLinux()),
+            sslCertDir);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3566,73 +3566,9 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var sslCertDir = Assert.Single(exe.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
 
         Assert.NotNull(sslCertDir);
-        var generatedCertificatesPath = sslCertDir.Split(Path.PathSeparator)[0];
-        Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", generatedCertificatesPath);
-        Assert.Equal(
-            ExecutableCreator.BuildCertificateDirectoriesPath(
-                generatedCertificatesPath,
-                CertificateTrustScope.Append,
-                Environment.GetEnvironmentVariable("SSL_CERT_DIR"),
-                includeWellKnownCertificateDirectories: OperatingSystem.IsLinux()),
-            sslCertDir);
-    }
-
-    [Fact]
-    public void ExecutableCertificateDirectoriesPath_IncludesExistingWellKnownDirectoriesForAppendWhenSslCertDirIsUnset()
-    {
-        var result = ExecutableCreator.BuildCertificateDirectoriesPath(
-            "/tmp/aspire/certs",
-            CertificateTrustScope.Append,
-            existingSslCertDir: null,
-            includeWellKnownCertificateDirectories: true,
-            directoryExists: path => path is "/etc/ssl/certs" or "/etc/pki/tls/certs");
-
-        Assert.Equal(
-            string.Join(Path.PathSeparator, "/tmp/aspire/certs", "/etc/ssl/certs", "/etc/pki/tls/certs"),
-            result);
-    }
-
-    [Fact]
-    public void ExecutableCertificateDirectoriesPath_PreservesExistingSslCertDirForAppendWithoutAddingWellKnownDirectories()
-    {
-        var existingSslCertDir = string.Join(Path.PathSeparator, "/custom/certs", "/home/me/.aspnet/dev-certs/trust");
-
-        var result = ExecutableCreator.BuildCertificateDirectoriesPath(
-            "/tmp/aspire/certs",
-            CertificateTrustScope.Append,
-            existingSslCertDir,
-            includeWellKnownCertificateDirectories: true,
-            directoryExists: _ => true);
-
-        Assert.Equal(
-            string.Join(Path.PathSeparator, "/tmp/aspire/certs", "/custom/certs", "/home/me/.aspnet/dev-certs/trust"),
-            result);
-    }
-
-    [Fact]
-    public void ExecutableCertificateDirectoriesPath_PreservesEmptySslCertDirForAppendWithoutAddingWellKnownDirectories()
-    {
-        var result = ExecutableCreator.BuildCertificateDirectoriesPath(
-            "/tmp/aspire/certs",
-            CertificateTrustScope.Append,
-            existingSslCertDir: string.Empty,
-            includeWellKnownCertificateDirectories: true,
-            directoryExists: _ => true);
-
-        Assert.Equal("/tmp/aspire/certs", result);
-    }
-
-    [Fact]
-    public void ExecutableCertificateDirectoriesPath_DoesNotIncludeExistingOrWellKnownDirectoriesForOverride()
-    {
-        var result = ExecutableCreator.BuildCertificateDirectoriesPath(
-            "/tmp/aspire/certs",
-            CertificateTrustScope.Override,
-            existingSslCertDir: "/custom/certs",
-            includeWellKnownCertificateDirectories: true,
-            directoryExists: _ => true);
-
-        Assert.Equal("/tmp/aspire/certs", result);
+        var sslCertDirs = sslCertDir.Split(Path.PathSeparator);
+        Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", sslCertDirs[0]);
+        Assert.All(sslCertDirs, dir => Assert.NotEqual(customSslCertDir, dir));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -25,6 +25,7 @@ using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.UserSecrets;
 using k8s.Models;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -3539,6 +3540,49 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(Path.Join(expectedCertificatesRoot, "certs"), sslCertDir);
         Assert.Equal(Path.Join(expectedCertificatesRoot, "cert.pem"), sslCertFile);
+    }
+
+    [Fact]
+    public void PlainExecutableCertificateDirectoriesPath_IncludesExistingWellKnownDirectoriesForAppendWhenSslCertDirIsUnsetOnLinux()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "OpenSSL default certificate directories are only inferred on Linux.");
+
+        var options = new RemoteInvokeOptions();
+        options.StartInfo.Environment.Remove("SSL_CERT_DIR");
+
+        RemoteExecutor.Invoke(static async () =>
+        {
+            Environment.SetEnvironmentVariable("SSL_CERT_DIR", null);
+
+            var expectedWellKnownCertificateDirectories = ContainerCertificatePathsAnnotation.DefaultCertificateDirectoriesPaths
+                .Where(Directory.Exists)
+                .ToArray();
+            Assert.NotEmpty(expectedWellKnownCertificateDirectories);
+
+            var builder = DistributedApplication.CreateBuilder();
+            using var certificate = CreateTestCertificate();
+            var certificateAuthorities = builder.AddCertificateAuthorityCollection("certificates")
+                .WithCertificate(certificate);
+
+            var executable = new TestExecutableResource("test-working-directory");
+            builder.AddResource(executable)
+                .WithCertificateAuthorityCollection(certificateAuthorities);
+
+            var kubernetesService = new TestKubernetesService();
+            using var app = builder.Build();
+            var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+            var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+
+            await appExecutor.RunApplicationAsync();
+
+            var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "TestExecutable");
+            var sslCertDir = Assert.Single(exe.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
+
+            Assert.NotNull(sslCertDir);
+            var sslCertDirs = sslCertDir.Split(Path.PathSeparator);
+            Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", sslCertDirs[0]);
+            Assert.Equal(expectedWellKnownCertificateDirectories, sslCertDirs.Skip(1));
+        }, options).Dispose();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3613,8 +3613,6 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         RemoteExecutor.Invoke(static () =>
         {
-            Environment.SetEnvironmentVariable("SSL_CERT_DIR", string.Empty);
-
             var sslCertDir = GetPlainExecutableSslCertDirAsync().GetAwaiter().GetResult();
 
             Assert.NotNull(sslCertDir);

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3566,7 +3566,10 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var sslCertDir = Assert.Single(exe.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
 
         Assert.NotNull(sslCertDir);
-        Assert.Contains(customSslCertDir, sslCertDir.Split(Path.PathSeparator));
+        var sslCertDirs = sslCertDir.Split(Path.PathSeparator);
+        Assert.Equal(2, sslCertDirs.Length);
+        Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", sslCertDirs[0]);
+        Assert.Equal(customSslCertDir, sslCertDirs[1]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3573,6 +3573,33 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ContainerCertificateDirectoriesPath_PreservesResourceSslCertDirForAppend()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var customSslCertDir = $"/resource-certs-{Guid.NewGuid():N}";
+        using var certificate = CreateTestCertificate();
+        var certificateAuthorities = builder.AddCertificateAuthorityCollection("certificates")
+            .WithCertificate(certificate);
+
+        builder.AddContainer("database", "image")
+            .WithEnvironment("SSL_CERT_DIR", customSslCertDir)
+            .WithCertificateAuthorityCollection(certificateAuthorities);
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+
+        await appExecutor.RunApplicationAsync();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        var sslCertDir = Assert.Single(container.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
+
+        Assert.NotNull(sslCertDir);
+        Assert.Equal($"{ContainerCertificatePathsAnnotation.DefaultCustomCertificatesDestination}/certs:{customSslCertDir}", sslCertDir);
+    }
+
+    [Fact]
     public void ExecutableCertificateDirectoriesPath_IncludesExistingWellKnownDirectoriesForAppendWhenSslCertDirIsUnset()
     {
         var result = ExecutableCreator.BuildCertificateDirectoriesPath(

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3586,28 +3586,69 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void PlainExecutableCertificateDirectoriesPath_PreservesAppHostSslCertDirForAppend()
+    {
+        var expectedExistingSslCertDirs = new[] { "/custom/certs", "/home/me/.aspnet/dev-certs/trust" };
+        var options = new RemoteInvokeOptions();
+        options.StartInfo.Environment["SSL_CERT_DIR"] = string.Join(Path.PathSeparator, expectedExistingSslCertDirs);
+
+        RemoteExecutor.Invoke(static expectedExistingSslCertDir =>
+        {
+            Environment.SetEnvironmentVariable("SSL_CERT_DIR", expectedExistingSslCertDir);
+
+            var sslCertDir = GetPlainExecutableSslCertDirAsync().GetAwaiter().GetResult();
+
+            Assert.NotNull(sslCertDir);
+            var sslCertDirs = sslCertDir.Split(Path.PathSeparator);
+            Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", sslCertDirs[0]);
+            Assert.Equal(expectedExistingSslCertDir.Split(Path.PathSeparator), sslCertDirs.Skip(1));
+        }, string.Join(Path.PathSeparator, expectedExistingSslCertDirs), options).Dispose();
+    }
+
+    [Fact]
+    public void PlainExecutableCertificateDirectoriesPath_PreservesEmptyAppHostSslCertDirForAppend()
+    {
+        var options = new RemoteInvokeOptions();
+        options.StartInfo.Environment["SSL_CERT_DIR"] = string.Empty;
+
+        RemoteExecutor.Invoke(static () =>
+        {
+            Environment.SetEnvironmentVariable("SSL_CERT_DIR", string.Empty);
+
+            var sslCertDir = GetPlainExecutableSslCertDirAsync().GetAwaiter().GetResult();
+
+            Assert.NotNull(sslCertDir);
+            var sslCertDirs = sslCertDir.Split(Path.PathSeparator);
+            Assert.Single(sslCertDirs);
+            Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", sslCertDirs[0]);
+        }, options).Dispose();
+    }
+
+    [Fact]
+    public void PlainExecutableCertificateDirectoriesPath_DoesNotIncludeAppHostSslCertDirForOverride()
+    {
+        var options = new RemoteInvokeOptions();
+        options.StartInfo.Environment["SSL_CERT_DIR"] = "/custom/certs";
+
+        RemoteExecutor.Invoke(static () =>
+        {
+            Environment.SetEnvironmentVariable("SSL_CERT_DIR", "/custom/certs");
+
+            var sslCertDir = GetPlainExecutableSslCertDirAsync(builder => builder.WithCertificateTrustScope(CertificateTrustScope.Override)).GetAwaiter().GetResult();
+
+            Assert.NotNull(sslCertDir);
+            var sslCertDirs = sslCertDir.Split(Path.PathSeparator);
+            Assert.Single(sslCertDirs);
+            Assert.EndsWith($"{Path.DirectorySeparatorChar}certs", sslCertDirs[0]);
+        }, options).Dispose();
+    }
+
+    [Fact]
     public async Task PlainExecutableCertificateDirectoriesPath_IgnoresResourceSslCertDirForAppend()
     {
-        var builder = DistributedApplication.CreateBuilder();
         var customSslCertDir = $"/resource-certs-{Guid.NewGuid():N}";
-        using var certificate = CreateTestCertificate();
-        var certificateAuthorities = builder.AddCertificateAuthorityCollection("certificates")
-            .WithCertificate(certificate);
 
-        var executable = new TestExecutableResource("test-working-directory");
-        builder.AddResource(executable)
-            .WithEnvironment("SSL_CERT_DIR", customSslCertDir)
-            .WithCertificateAuthorityCollection(certificateAuthorities);
-
-        var kubernetesService = new TestKubernetesService();
-        using var app = builder.Build();
-        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
-
-        await appExecutor.RunApplicationAsync();
-
-        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "TestExecutable");
-        var sslCertDir = Assert.Single(exe.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
+        var sslCertDir = await GetPlainExecutableSslCertDirAsync(builder => builder.WithEnvironment("SSL_CERT_DIR", customSslCertDir));
 
         Assert.NotNull(sslCertDir);
         var sslCertDirs = sslCertDir.Split(Path.PathSeparator);
@@ -6785,6 +6826,29 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             new ProfilingTelemetry(configuration),
             proxylessEndpointPortAllocator,
             userSecretsManager ?? NoopUserSecretsManager.Instance);
+    }
+
+    private static async Task<string?> GetPlainExecutableSslCertDirAsync(Action<IResourceBuilder<TestExecutableResource>>? configure = null)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        using var certificate = CreateTestCertificate();
+        var certificateAuthorities = builder.AddCertificateAuthorityCollection("certificates")
+            .WithCertificate(certificate);
+
+        var executable = new TestExecutableResource("test-working-directory");
+        var executableBuilder = builder.AddResource(executable)
+            .WithCertificateAuthorityCollection(certificateAuthorities);
+        configure?.Invoke(executableBuilder);
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "TestExecutable");
+        return Assert.Single(exe.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
     }
 
     private static void AssertPortAllocatedFromProxylessEndpointAllocatorRange(int port)

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3542,6 +3542,64 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void ExecutableCertificateDirectoriesPath_IncludesExistingWellKnownDirectoriesForAppendWhenSslCertDirIsUnset()
+    {
+        var result = ExecutableCreator.BuildCertificateDirectoriesPath(
+            "/tmp/aspire/certs",
+            CertificateTrustScope.Append,
+            existingSslCertDir: null,
+            includeWellKnownCertificateDirectories: true,
+            directoryExists: path => path is "/etc/ssl/certs" or "/etc/pki/tls/certs");
+
+        Assert.Equal(
+            string.Join(Path.PathSeparator, "/tmp/aspire/certs", "/etc/ssl/certs", "/etc/pki/tls/certs"),
+            result);
+    }
+
+    [Fact]
+    public void ExecutableCertificateDirectoriesPath_PreservesExistingSslCertDirForAppendWithoutAddingWellKnownDirectories()
+    {
+        var existingSslCertDir = string.Join(Path.PathSeparator, "/custom/certs", "/home/me/.aspnet/dev-certs/trust");
+
+        var result = ExecutableCreator.BuildCertificateDirectoriesPath(
+            "/tmp/aspire/certs",
+            CertificateTrustScope.Append,
+            existingSslCertDir,
+            includeWellKnownCertificateDirectories: true,
+            directoryExists: _ => true);
+
+        Assert.Equal(
+            string.Join(Path.PathSeparator, "/tmp/aspire/certs", "/custom/certs", "/home/me/.aspnet/dev-certs/trust"),
+            result);
+    }
+
+    [Fact]
+    public void ExecutableCertificateDirectoriesPath_PreservesEmptySslCertDirForAppendWithoutAddingWellKnownDirectories()
+    {
+        var result = ExecutableCreator.BuildCertificateDirectoriesPath(
+            "/tmp/aspire/certs",
+            CertificateTrustScope.Append,
+            existingSslCertDir: string.Empty,
+            includeWellKnownCertificateDirectories: true,
+            directoryExists: _ => true);
+
+        Assert.Equal("/tmp/aspire/certs", result);
+    }
+
+    [Fact]
+    public void ExecutableCertificateDirectoriesPath_DoesNotIncludeExistingOrWellKnownDirectoriesForOverride()
+    {
+        var result = ExecutableCreator.BuildCertificateDirectoriesPath(
+            "/tmp/aspire/certs",
+            CertificateTrustScope.Override,
+            existingSslCertDir: "/custom/certs",
+            includeWellKnownCertificateDirectories: true,
+            directoryExists: _ => true);
+
+        Assert.Equal("/tmp/aspire/certs", result);
+    }
+
+    [Fact]
     public async Task SessionScopedExplicitStartPlainExecutable_DefersDcpObjectCreationUntilManualStart()
     {
         var builder = DistributedApplication.CreateBuilder();

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -3542,6 +3542,34 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task PlainExecutableCertificateDirectoriesPath_PreservesResourceSslCertDirForAppend()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var customSslCertDir = $"/resource-certs-{Guid.NewGuid():N}";
+        using var certificate = CreateTestCertificate();
+        var certificateAuthorities = builder.AddCertificateAuthorityCollection("certificates")
+            .WithCertificate(certificate);
+
+        var executable = new TestExecutableResource("test-working-directory");
+        builder.AddResource(executable)
+            .WithEnvironment("SSL_CERT_DIR", customSslCertDir)
+            .WithCertificateAuthorityCollection(certificateAuthorities);
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = Assert.Single(kubernetesService.CreatedResources.OfType<Executable>(), e => e.AppModelResourceName == "TestExecutable");
+        var sslCertDir = Assert.Single(exe.Spec.Env!, e => e.Name == "SSL_CERT_DIR").Value;
+
+        Assert.NotNull(sslCertDir);
+        Assert.Contains(customSslCertDir, sslCertDir.Split(Path.PathSeparator));
+    }
+
+    [Fact]
     public void ExecutableCertificateDirectoriesPath_IncludesExistingWellKnownDirectoriesForAppendWhenSslCertDirIsUnset()
     {
         var result = ExecutableCreator.BuildCertificateDirectoriesPath(

--- a/tests/Aspire.Hosting.Tests/ExecutionConfigurationGathererTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutionConfigurationGathererTests.cs
@@ -408,6 +408,48 @@ public class ExecutionConfigurationGathererTests
     }
 
     [Fact]
+    public async Task CertificateTrustExecutionConfigurationGatherer_WithAppendScopeAndExistingSslCertDir_UsesResourceValueBeforeFallback()
+    {
+        // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var cert = CreateTestCertificate();
+        var caCollection = builder.AddCertificateAuthorityCollection("test-ca").WithCertificate(cert);
+
+        var resource = builder.AddContainer("test", "image")
+            .WithCertificateAuthorityCollection(caCollection)
+            .WithCertificateTrustScope(CertificateTrustScope.Append)
+            .Resource;
+
+        await builder.BuildAsync();
+
+        var context = new ExecutionConfigurationGathererContext();
+        context.EnvironmentVariables["SSL_CERT_DIR"] = "/private-roots";
+        var gatherer = new CertificateTrustExecutionConfigurationGatherer(_ => new CertificateTrustExecutionConfigurationContext
+        {
+            CertificateBundlePath = ReferenceExpression.Create($"/aspire/cert.pem"),
+            CertificateDirectoriesPath = ReferenceExpression.Create($"/aspire/certs:/ambient-roots"),
+            CertificateDirectoriesPathBeforeFallback = ReferenceExpression.Create($"/aspire/certs"),
+            RootCertificatesPath = "/aspire",
+            IsContainer = true,
+        });
+
+        // Act
+        await gatherer.GatherAsync(context, resource, NullLogger.Instance, builder.ExecutionContext);
+
+        // Assert
+        var sslCertDir = Assert.IsType<ReferenceExpression>(context.EnvironmentVariables["SSL_CERT_DIR"]);
+        Assert.Equal("/aspire/certs:/private-roots", await sslCertDir.GetValueAsync(CancellationToken.None));
+
+        var emptyContext = new ExecutionConfigurationGathererContext();
+        emptyContext.EnvironmentVariables["SSL_CERT_DIR"] = string.Empty;
+
+        await gatherer.GatherAsync(emptyContext, resource, NullLogger.Instance, builder.ExecutionContext);
+
+        sslCertDir = Assert.IsType<ReferenceExpression>(emptyContext.EnvironmentVariables["SSL_CERT_DIR"]);
+        Assert.Equal("/aspire/certs", await sslCertDir.GetValueAsync(CancellationToken.None));
+    }
+
+    [Fact]
     public async Task CertificateTrustExecutionConfigurationGatherer_WithAppendScope_DoesNotSetSSL_CERT_FILE()
     {
         // Arrange

--- a/tests/Aspire.Hosting.Tests/ExecutionConfigurationGathererTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutionConfigurationGathererTests.cs
@@ -408,48 +408,6 @@ public class ExecutionConfigurationGathererTests
     }
 
     [Fact]
-    public async Task CertificateTrustExecutionConfigurationGatherer_WithAppendScopeAndExistingSslCertDir_UsesResourceValueBeforeFallback()
-    {
-        // Arrange
-        using var builder = TestDistributedApplicationBuilder.Create();
-        var cert = CreateTestCertificate();
-        var caCollection = builder.AddCertificateAuthorityCollection("test-ca").WithCertificate(cert);
-
-        var resource = builder.AddContainer("test", "image")
-            .WithCertificateAuthorityCollection(caCollection)
-            .WithCertificateTrustScope(CertificateTrustScope.Append)
-            .Resource;
-
-        await builder.BuildAsync();
-
-        var context = new ExecutionConfigurationGathererContext();
-        context.EnvironmentVariables["SSL_CERT_DIR"] = "/private-roots";
-        var gatherer = new CertificateTrustExecutionConfigurationGatherer(_ => new CertificateTrustExecutionConfigurationContext
-        {
-            CertificateBundlePath = ReferenceExpression.Create($"/aspire/cert.pem"),
-            CertificateDirectoriesPath = ReferenceExpression.Create($"/aspire/certs:/ambient-roots"),
-            CertificateDirectoriesPathBeforeFallback = ReferenceExpression.Create($"/aspire/certs"),
-            RootCertificatesPath = "/aspire",
-            IsContainer = true,
-        });
-
-        // Act
-        await gatherer.GatherAsync(context, resource, NullLogger.Instance, builder.ExecutionContext);
-
-        // Assert
-        var sslCertDir = Assert.IsType<ReferenceExpression>(context.EnvironmentVariables["SSL_CERT_DIR"]);
-        Assert.Equal("/aspire/certs:/private-roots", await sslCertDir.GetValueAsync(CancellationToken.None));
-
-        var emptyContext = new ExecutionConfigurationGathererContext();
-        emptyContext.EnvironmentVariables["SSL_CERT_DIR"] = string.Empty;
-
-        await gatherer.GatherAsync(emptyContext, resource, NullLogger.Instance, builder.ExecutionContext);
-
-        sslCertDir = Assert.IsType<ReferenceExpression>(emptyContext.EnvironmentVariables["SSL_CERT_DIR"]);
-        Assert.Equal("/aspire/certs", await sslCertDir.GetValueAsync(CancellationToken.None));
-    }
-
-    [Fact]
     public async Task CertificateTrustExecutionConfigurationGatherer_WithAppendScope_DoesNotSetSSL_CERT_FILE()
     {
         // Arrange


### PR DESCRIPTION
## Description

Linux AppHosts launched with `dotnet run` or an IDE can bypass the `aspire run` setup that materializes `SSL_CERT_DIR`. When Aspire then configures local project/executable resources with only its generated certificate directory, Linux workloads can lose OpenSSL's implicit system certificate roots and fail outbound HTTPS requests.

This change preserves Linux system trust for append-scope local executable resources by appending the existing `SSL_CERT_DIR` when it is set, or by materializing well-known system certificate directories that actually exist when it is unset. Explicit `SSL_CERT_DIR` values, including an empty value, are preserved as user configuration.

It also expands `aspire doctor` to detect stale, missing, or corrupt OpenSSL development certificate cache entries under the dev-certs trust directory and recommend `aspire certs clean` followed by `aspire certs trust`. The Unix trust probe now treats corrupt expected PEM files as an OpenSSL trust miss instead of aborting the entire doctor check.

### User-facing usage

Users with a stale or corrupt Linux development certificate setup can discover the repair guidance with:

```bash
aspire doctor
aspire certs clean
aspire certs trust
```

Validation:

```bash
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.DevCertsCheckTests" --filter-class "*.UnixCertificateManagerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-method "*.ExecutableCertificateDirectoriesPath_IncludesExistingWellKnownDirectoriesForAppendWhenSslCertDirIsUnset" --filter-method "*.ExecutableCertificateDirectoriesPath_PreservesExistingSslCertDirForAppendWithoutAddingWellKnownDirectories" --filter-method "*.ExecutableCertificateDirectoriesPath_PreservesEmptySslCertDirForAppendWithoutAddingWellKnownDirectories" --filter-method "*.ExecutableCertificateDirectoriesPath_DoesNotIncludeExistingOrWellKnownDirectoriesForOverride" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet build /t:UpdateXlf src/Aspire.Cli/Aspire.Cli.csproj
```

Fixes #18066

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No