### PR TITLE
Reject histogram bucket count length changes

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
@@ -82,12 +82,12 @@ public class DimensionScope
         var start = OtlpHelpers.UnixNanoSecondsToDateTime(h.StartTimeUnixNano);
         var end = OtlpHelpers.UnixNanoSecondsToDateTime(h.TimeUnixNano);
 
-        var lastHistogramValue = _lastValue as HistogramValue;
         if (h.BucketCounts.Count > 0 && h.ExplicitBounds.Count == 0)
         {
             throw new InvalidOperationException("Histogram data point has bucket counts without any explicit bounds.");
         }
 
+        var lastHistogramValue = _lastValue as HistogramValue;
         if (lastHistogramValue is not null && lastHistogramValue.Values.Length != h.BucketCounts.Count)
         {
             // Histogram bucket layouts must remain stable within a series so cumulative values can

--- a/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
@@ -83,6 +83,18 @@ public class DimensionScope
         var end = OtlpHelpers.UnixNanoSecondsToDateTime(h.TimeUnixNano);
 
         var lastHistogramValue = _lastValue as HistogramValue;
+        if (h.BucketCounts.Count > 0 && h.ExplicitBounds.Count == 0)
+        {
+            throw new InvalidOperationException("Histogram data point has bucket counts without any explicit bounds.");
+        }
+
+        if (lastHistogramValue is not null && lastHistogramValue.Values.Length != h.BucketCounts.Count)
+        {
+            // Histogram bucket layouts must remain stable within a series so cumulative values can
+            // be subtracted and combined. A changed bucket count would make the series unusable.
+            throw new InvalidOperationException("Histogram data point bucket count length changed.");
+        }
+
         if (lastHistogramValue is not null && lastHistogramValue.Count == h.Count)
         {
             lastHistogramValue.End = end;
@@ -105,11 +117,6 @@ public class DimensionScope
             }
 
             var bucketCounts = h.BucketCounts.ToArray();
-            if (bucketCounts.Length > 0 && explicitBounds.Length == 0)
-            {
-                throw new InvalidOperationException("Histogram data point has bucket counts without any explicit bounds.");
-            }
-
             _lastValue = new HistogramValue(bucketCounts, h.Sum, h.Count, start, end, explicitBounds);
             AddExemplars(_lastValue, h.Exemplars, context);
             _values.Add(_lastValue);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -1130,6 +1130,73 @@ public class MetricsTests
     }
 
     [Fact]
+    public void AddMetrics_HistogramBucketCountLengthChanges_DataPointRejected()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var addContext = new AddContext();
+        var histogramMetric = new Metric
+        {
+            Name = "test",
+            Histogram = new Histogram
+            {
+                AggregationTemporality = AggregationTemporality.Cumulative,
+                DataPoints =
+                {
+                    new HistogramDataPoint
+                    {
+                        Count = 6,
+                        ExplicitBounds = { 1, 2 },
+                        BucketCounts = { 1, 2, 3 },
+                        TimeUnixNano = DateTimeToUnixNanoseconds(s_testTime.AddMinutes(1))
+                    },
+                    new HistogramDataPoint
+                    {
+                        Count = 10,
+                        ExplicitBounds = { 1, 2, 3 },
+                        BucketCounts = { 1, 2, 3, 4 },
+                        TimeUnixNano = DateTimeToUnixNanoseconds(s_testTime.AddMinutes(2))
+                    }
+                }
+            }
+        };
+
+        // Act
+        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { histogramMetric }
+                    }
+                }
+            }
+        });
+
+        // Assert
+        Assert.Equal(1, addContext.SuccessCount);
+        Assert.Equal(1, addContext.FailureCount);
+
+        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        {
+            ResourceKey = new ResourceKey("TestService", "TestId"),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        });
+
+        Assert.NotNull(instrument);
+        var dimension = Assert.Single(instrument.Dimensions);
+        Assert.Single(dimension.Values);
+    }
+
+    [Fact]
     public void AddMetrics_OverflowDimension()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -1193,7 +1193,10 @@ public class MetricsTests
 
         Assert.NotNull(instrument);
         var dimension = Assert.Single(instrument.Dimensions);
-        Assert.Single(dimension.Values);
+var histogramValue = Assert.IsType<HistogramValue>(Assert.Single(dimension.Values));
+        Assert.Equal([1UL, 2UL, 3UL], histogramValue.Values);
+        Assert.Equal([1d, 2d], histogramValue.ExplicitBounds);
+        Assert.Equal(6UL, histogramValue.Count);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -1193,7 +1193,7 @@ public class MetricsTests
 
         Assert.NotNull(instrument);
         var dimension = Assert.Single(instrument.Dimensions);
-var histogramValue = Assert.IsType<HistogramValue>(Assert.Single(dimension.Values));
+        var histogramValue = Assert.IsType<HistogramValue>(Assert.Single(dimension.Values));
         Assert.Equal([1UL, 2UL, 3UL], histogramValue.Values);
         Assert.Equal([1d, 2d], histogramValue.ExplicitBounds);
         Assert.Equal(6UL, histogramValue.Count);


### PR DESCRIPTION
## Description

Malformed histogram telemetry can contain different bucket-count lengths for points in the same instrument and dimension series. The dashboard previously stored both points, then failed while calculating chart data because cumulative histogram values could not be compared across different bucket layouts.

Reject histogram data points when their bucket-count length changes within a series. The valid points already stored for the series remain available, so viewing the instrument no longer fails because of the rejected point.

Add a telemetry repository regression test that sends two individually valid histogram points with different bucket layouts and verifies that only the first point is accepted and stored.

### Validation

```text
dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

Passed: 1512
Failed: 0
Skipped: 0
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
