### PR TITLE
Fix HTML injection in code block titles

### DIFF
--- a/src/Aspire.Dashboard/Model/Markdown/HighlightedCodeBlockRenderer.cs
+++ b/src/Aspire.Dashboard/Model/Markdown/HighlightedCodeBlockRenderer.cs
@@ -95,7 +95,7 @@ public class HighlightedCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
         renderer.Writer.Write(@"<div class=""code-block"">");
 
         renderer.Writer.Write(@"<div class=""code-title"">");
-        renderer.Writer.Write(title);
+        renderer.WriteEscape(title);
         renderer.Writer.Write("</div>");
 
         renderer.Writer.Write(@"<div class=""code-buttons-anchor"">");

--- a/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
@@ -169,6 +169,27 @@ public class MarkdownProcessorTests
     }
 
     [Fact]
+    public void ToHtml_FencedCodeBlockLanguageWithHtml_HtmlEncoded()
+    {
+        // Arrange
+        var processor = CreateMarkdownProcessor();
+
+        var markdown =
+            """
+            ```</div><svg/onload=alert(1)>
+            In code block.
+            ```
+            """;
+
+        // Act
+        var html = processor.ToHtml(markdown, inCompleteDocument: true);
+
+        // Assert
+        var title = Regex.Match(html, "<div class=\"code-title\">(.*?)</div>").Groups[1].Value;
+        Assert.Equal("&lt;/div&gt;&lt;svg/onload=alert(1)&gt;", title);
+    }
+
+    [Fact]
     public void ToHtml_ContainsHtml_HtmlIgnored()
     {
         // Arrange


### PR DESCRIPTION
## Description

Fenced code block language metadata was written directly into the code block title while the rendered Markdown was later trusted as HTML. A crafted language value could therefore escape the title element and inject arbitrary HTML even though raw HTML is disabled in the Markdown pipeline.

This change HTML-encodes the visible code block title at the renderer boundary. The existing attribute and code body rendering behavior is unchanged.

### Security considerations

This closes an HTML injection path for untrusted Markdown by treating fenced code block language metadata as untrusted input and encoding it at the HTML sink. A regression test covers a compact SVG event-handler payload. A formal security review has not yet been completed.

Validation:

```text
MarkdownProcessorTests: 26 passed, 0 failed
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No