### PR TITLE
Only inject Blazor gateway SPA fallback when manifest lacks one

### DIFF
--- a/src/Aspire.Hosting.Blazor/Manifests/EndpointsManifestTransformer.cs
+++ b/src/Aspire.Hosting.Blazor/Manifests/EndpointsManifestTransformer.cs
@@ -14,8 +14,15 @@ internal static class EndpointsManifestTransformer
 {
     /// <summary>
     /// Reads an endpoints manifest and prefixes every <c>AssetFile</c> with <c>{prefix}/</c>.
-    /// Also adds a SPA catch-all fallback endpoint cloned from the <c>index.html</c> entry.
+    /// Also adds a SPA catch-all fallback endpoint cloned from the <c>index.html</c> entry,
+    /// but only when the manifest doesn't already define its own <c>{**path:nonfile}</c> fallback.
     /// Routes are left unchanged — <c>MapGroup</c> handles URL prefixing at the routing level.
+    /// <para>
+    /// TEMPORARY: this is interim scaffolding for the experimental Blazor gateway and will be
+    /// removed once the .NET gateway CLI package and the SDK static-web-assets fallback feature
+    /// (StaticWebAssetSpaFallbackEnabled, https://github.com/dotnet/aspnetcore/issues/64828) own
+    /// SPA fallback routing directly. See the body of <see cref="PrefixEndpointsAssetFileAsync"/>.
+    /// </para>
     /// </summary>
     public static async Task<string> PrefixEndpointsAssetFileAsync(string manifestPath, string prefix, CancellationToken ct)
     {
@@ -26,6 +33,30 @@ internal static class EndpointsManifestTransformer
 
         var fallbackEndpoints = new List<EndpointEntry>();
 
+        // TEMPORARY: this whole transformer is interim scaffolding for the experimental Blazor
+        // gateway (ASPIREBLAZOR001) and is expected to be deleted, not evolved. It will be
+        // replaced by two proper mechanisms:
+        //   1. The .NET gateway CLI package (the .NET 11 gateway), which owns SPA fallback routing
+        //      correctly instead of us rewriting each app's endpoints manifest.
+        //      See: https://github.com/dotnet/aspnetcore/pull/67599.
+        //   2. The SDK static-web-assets fallback feature (StaticWebAssetSpaFallbackEnabled), which
+        //      emits the fallback endpoint at build time so hosts don't have to synthesize it.
+        //      See: https://github.com/dotnet/aspnetcore/issues/64828.
+        // Because it is temporary, we deliberately keep the detection dumb: only skip injection when
+        // the manifest already contains the exact "{**path:nonfile}" route (the same literal the SDK
+        // emits and that we would otherwise clone). We do NOT try to parse routes with
+        // RoutePattern.Parse — that would pull the ASP.NET Core routing framework reference into this
+        // hosting library (and the plain-SDK PrefixEndpoints.cs Docker script) just to inspect one
+        // string, which isn't worth it for code on its way out.
+        //
+        // In the hosted Blazor Web App shape the server already owns request routing (Razor components
+        // plus its own fallback), so a second {**path:nonfile} catch-all collides with the existing
+        // routing and causes the app to return HTTP 500. Skipping injection when a fallback is already
+        // present keeps us correct for both the standalone-WASM-plus-gateway shape (none present, so we
+        // add one) and the hosted-Web-App shape (already present, so we leave it alone).
+        var hasExistingFallback = manifest.Endpoints.Any(
+            e => string.Equals(e.Route, "{**path:nonfile}", StringComparison.OrdinalIgnoreCase));
+
         foreach (var ep in manifest.Endpoints)
         {
             ep.AssetFile = $"{prefix}/{ep.AssetFile}";
@@ -34,7 +65,7 @@ internal static class EndpointsManifestTransformer
             // We skip compressed variants (those with Content-Encoding selectors) because the
             // ContentEncodingNegotiationMatcherPolicy would otherwise prefer the catch-all over
             // literal routes (like _blazor/_configuration) that lack encoding metadata.
-            if (string.Equals(ep.Route, "index.html", StringComparison.OrdinalIgnoreCase))
+            if (!hasExistingFallback && string.Equals(ep.Route, "index.html", StringComparison.OrdinalIgnoreCase))
             {
                 var hasContentEncoding = ep.Selectors?.Any(s => s.Name == "Content-Encoding") == true;
 

--- a/src/Aspire.Hosting.Blazor/Scripts/PrefixEndpoints.cs
+++ b/src/Aspire.Hosting.Blazor/Scripts/PrefixEndpoints.cs
@@ -10,7 +10,13 @@
 //
 // The script prefixes every AssetFile path with the app's URL segment so the gateway
 // can serve multiple WASM apps under distinct path prefixes, and adds a SPA catch-all
-// fallback endpoint cloned from index.html.
+// fallback endpoint cloned from index.html unless the manifest already defines its own
+// {**path:nonfile} fallback (as the hosted Blazor Web App shape does).
+//
+// TEMPORARY: this is interim scaffolding for the experimental Blazor gateway and will be
+// removed once the .NET gateway CLI package and the SDK static-web-assets fallback feature
+// (StaticWebAssetSpaFallbackEnabled, https://github.com/dotnet/aspnetcore/issues/64828) own
+// SPA fallback routing directly.
 //
 // Usage: dotnet run PrefixEndpoints.cs -- <manifest-path> <prefix> <output-path>
 
@@ -34,6 +40,28 @@ var manifest = JsonSerializer.Deserialize(
 
 var fallbackEndpoints = new List<EndpointEntry>();
 
+// TEMPORARY: this whole script is interim scaffolding for the experimental Blazor gateway
+// (ASPIREBLAZOR001) and is expected to be deleted, not evolved. It will be replaced by two
+// proper mechanisms:
+//   1. The .NET gateway CLI package (the .NET 11 gateway), which owns SPA fallback routing
+//      correctly instead of us rewriting each app's endpoints manifest.
+//      See: https://github.com/dotnet/aspnetcore/pull/67599.
+//   2. The SDK static-web-assets fallback feature (StaticWebAssetSpaFallbackEnabled), which
+//      emits the fallback endpoint at build time so hosts don't have to synthesize it.
+//      See: https://github.com/dotnet/aspnetcore/issues/64828.
+// Because it is temporary, we keep the detection dumb: only skip injection when the manifest
+// already contains the exact "{**path:nonfile}" route (the same literal the SDK emits and that
+// we would otherwise clone). We do NOT parse routes with RoutePattern.Parse — that would pull
+// the ASP.NET Core routing framework reference into this plain-SDK Docker-build script just to
+// inspect one string, which isn't worth it for code on its way out.
+//
+// In the hosted Blazor Web App shape the server already owns request routing (Razor components
+// plus its own fallback), so a second {**path:nonfile} catch-all collides with the existing
+// routing and causes the app to return HTTP 500. Skipping injection when a fallback is already
+// present keeps us correct for both the standalone-WASM-plus-gateway shape (none present, so we
+// add one) and the hosted-Web-App shape (already present, so we leave it alone).
+var hasExistingFallback = manifest.Endpoints.Any(e => string.Equals(e.Route, "{**path:nonfile}", StringComparison.OrdinalIgnoreCase));
+
 foreach (var ep in manifest.Endpoints)
 {
     ep.AssetFile = $"{prefix}/{ep.AssetFile}";
@@ -42,7 +70,7 @@ foreach (var ep in manifest.Endpoints)
     // Skip compressed variants (those with Content-Encoding selectors) because the
     // ContentEncodingNegotiationMatcherPolicy would otherwise prefer the catch-all over
     // literal routes (like _blazor/_configuration) that lack encoding metadata.
-    if (ep.Route == "index.html")
+    if (!hasExistingFallback && string.Equals(ep.Route, "index.html", StringComparison.OrdinalIgnoreCase))
     {
         var hasContentEncoding = ep.Selectors?.Any(s => s.Name == "Content-Encoding") == true;
 

--- a/tests/Aspire.Hosting.Blazor.Tests/EndpointsManifestTransformerTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/EndpointsManifestTransformerTests.cs
@@ -76,6 +76,33 @@ public class EndpointsManifestTransformerTests : IDisposable
     }
 
     [Fact]
+    public async Task PrefixEndpointsAssetFile_DoesNotAddFallback_WhenManifestAlreadyHasOne()
+    {
+        // Hosted Blazor Web App shape: the server already owns routing and the manifest ships
+        // its own {**path:nonfile} catch-all. Injecting a second one collides and causes HTTP 500.
+        var manifest = new EndpointsManifest
+        {
+            Endpoints =
+            [
+                new EndpointEntry { Route = "index.html", AssetFile = "index.html" },
+                new EndpointEntry { Route = "{**path:nonfile}", AssetFile = "index.html" }
+            ]
+        };
+
+        var manifestPath = Path.Combine(_tempDir, "endpoints.json");
+        await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(manifest, ManifestJsonContext.Default.EndpointsManifest));
+
+        var result = await EndpointsManifestTransformer.PrefixEndpointsAssetFileAsync(manifestPath, "store", CancellationToken.None);
+
+        var transformed = JsonSerializer.Deserialize(result, ManifestJsonContext.Default.EndpointsManifest)!;
+
+        // No extra fallback appended, and the existing one is left untouched (only one remains).
+        Assert.Equal(2, transformed.Endpoints.Length);
+        Assert.Single(transformed.Endpoints, ep => ep.Route == "{**path:nonfile}");
+        Assert.All(transformed.Endpoints, ep => Assert.StartsWith("store/", ep.AssetFile));
+    }
+
+    [Fact]
     public async Task PrefixEndpointsAssetFile_SkipsFallback_ForCompressedIndexHtml()
     {
         var manifest = new EndpointsManifest


### PR DESCRIPTION
The Aspire Blazor gateway manifest transformer unconditionally cloned the identity index.html endpoint into a {**path:nonfile} catch-all SPA fallback. In the hosted Blazor Web App shape the server already owns routing and ships its own {**path:nonfile} fallback, so the injected catch-all collided with existing routing and the app returned HTTP 500.

Make the injection resilient: skip it when the manifest already defines a {**path:nonfile} route. Standalone-WASM-plus-gateway manifests (no fallback) still get one; hosted-Web-App manifests are left untouched. AssetFile prefixing is unchanged. Kept the embedded PrefixEndpoints.cs script in sync and added a regression test.

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
