### PR TITLE
Fix disabled argument validation for interactive resource commands

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -347,6 +347,13 @@ public class ResourceCommandService
                     }
 
                     arguments = promptedArguments!;
+                    // The interaction service returns the final server-validated input state after applying
+                    // dynamic loading callbacks. Preserve that fact so disabled inputs with harmless retained
+                    // defaults aren't treated as unresolved submitted arguments during the final validation.
+                    loadedDynamicArgumentNames = arguments
+                        .Where(argument => argument.DynamicLoading is { } dynamicLoading && ShouldLoadDynamicCommandArgument(dynamicLoading, arguments))
+                        .Select(argument => argument.Name)
+                        .ToHashSet(StringComparers.InteractionInputName);
                 }
                 else
                 {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -590,11 +590,11 @@ public class ResourceCommandService
 
             if (argument.Disabled)
             {
-                // Dynamic loading can leave a dependent input disabled after it has normalized a
-                // harmless default/sentinel value, such as Browser Logs using the default profile
-                // while Shared mode is off. Only report submitted values for dynamic inputs that
-                // never loaded because their dependencies were incomplete, for example
-                // priority=express without a selected item.
+                // Interactive prompts own disabled-input handling, so loadedDynamicArgumentNames is
+                // null for arguments they accept. For non-interactive requests, reject a value only
+                // when the dynamic callback could not run because its dependencies were incomplete.
+                // A callback that ran may intentionally retain a harmless default while leaving the
+                // input disabled, such as Browser Logs keeping the default profile when Shared mode is off.
                 if (loadedDynamicArgumentNames is not null && !string.IsNullOrEmpty(value) && argument.DynamicLoading is not null && !loadedDynamicArgumentNames.Contains(argument.Name))
                 {
                     context.AddValidationError(argument, "Argument is disabled.");

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandService.cs
@@ -347,13 +347,6 @@ public class ResourceCommandService
                     }
 
                     arguments = promptedArguments!;
-                    // The interaction service returns the final server-validated input state after applying
-                    // dynamic loading callbacks. Preserve that fact so disabled inputs with harmless retained
-                    // defaults aren't treated as unresolved submitted arguments during the final validation.
-                    loadedDynamicArgumentNames = arguments
-                        .Where(argument => argument.DynamicLoading is { } dynamicLoading && ShouldLoadDynamicCommandArgument(dynamicLoading, arguments))
-                        .Select(argument => argument.Name)
-                        .ToHashSet(StringComparers.InteractionInputName);
                 }
                 else
                 {
@@ -602,7 +595,7 @@ public class ResourceCommandService
                 // while Shared mode is off. Only report submitted values for dynamic inputs that
                 // never loaded because their dependencies were incomplete, for example
                 // priority=express without a selected item.
-                if (!string.IsNullOrEmpty(value) && argument.DynamicLoading is not null && loadedDynamicArgumentNames?.Contains(argument.Name) != true)
+                if (loadedDynamicArgumentNames is not null && !string.IsNullOrEmpty(value) && argument.DynamicLoading is not null && !loadedDynamicArgumentNames.Contains(argument.Name))
                 {
                     context.AddValidationError(argument, "Argument is disabled.");
                 }

--- a/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandServiceTests.cs
@@ -1289,6 +1289,78 @@ public class ResourceCommandServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task ExecuteCommandAsync_InteractiveDisabledDynamicArgumentWithDefaultValue_Succeeds()
+    {
+        using var builder = CreateBuilder();
+
+        var testInteractionService = new TestInteractionService();
+        builder.Services.AddSingleton<IInteractionService>(testInteractionService);
+
+        InteractionInputCollection? capturedArguments = null;
+        var custom = builder.AddResource(new CustomResource("myResource"));
+        custom.WithCommand(
+            name: "mycommand",
+            displayName: "My command",
+            executeCommand: context =>
+            {
+                capturedArguments = context.Arguments;
+                return Task.FromResult(CommandResults.Success());
+            },
+            commandOptions: new CommandOptions
+            {
+                Arguments =
+                [
+                    new InteractionInput
+                    {
+                        Name = "generateTraces",
+                        InputType = InputType.Boolean,
+                        Required = true,
+                        Value = "true"
+                    },
+                    new InteractionInput
+                    {
+                        Name = "traceCount",
+                        InputType = InputType.Number,
+                        Required = true,
+                        Value = "50000",
+                        DynamicLoading = new InputLoadOptions
+                        {
+                            DependsOnInputs = ["generateTraces"],
+                            LoadCallback = context =>
+                            {
+                                context.Input.Disabled = !context.AllInputs.GetBoolean("generateTraces");
+                                return Task.CompletedTask;
+                            }
+                        }
+                    }
+                ]
+            });
+
+        var app = builder.Build();
+        await app.StartAsync();
+
+        var resultTask = app.ResourceCommands.ExecuteCommandAsync(
+            "myResource",
+            "mycommand",
+            new ResourceCommandExecutionOptions { NonInteractive = false },
+            CancellationToken.None).DefaultTimeout();
+
+        var interaction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        interaction.Inputs["generateTraces"].Value = "false";
+        interaction.Inputs["traceCount"].Disabled = true;
+        interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
+
+        var result = await resultTask;
+
+        Assert.True(result.Success);
+        Assert.NotNull(capturedArguments);
+        Assert.False(capturedArguments.GetBoolean("generateTraces"));
+        Assert.Equal(50000, capturedArguments.GetInt32("traceCount"));
+        Assert.True(capturedArguments["traceCount"].Disabled);
+        Assert.Empty(capturedArguments["traceCount"].ValidationErrors);
+    }
+
+    [Fact]
     public async Task ExecuteCommandAsync_NonInteractiveWithoutArguments_DoesNotPrompt()
     {
         using var builder = CreateBuilder();


### PR DESCRIPTION
## Description

Interactive resource commands can return disabled dynamic inputs that retain harmless default values. `ResourceCommandService` records which dynamic load callbacks ran when it processes arguments itself, but that set is intentionally `null` for arguments accepted by an interactive prompt.

The previous disabled-input check treated a null loaded-argument set as though no dynamic callback had run. As a result, an interactive command failed with `Argument is disabled.` when a toggle disabled a dependent argument that retained its default value.

This change limits that check to non-interactive paths, where the loaded-argument set is available. Interactive prompts continue through the normal argument validation pipeline without reinterpreting their disabled-input state. Non-interactive requests still reject values for disabled dynamic inputs whose callbacks could not run because dependencies were incomplete.

A regression test covers an interactive command with `generateTraces=false` and a disabled `traceCount` retaining its default value. Existing focused tests continue to cover unresolved and successfully loaded non-interactive dynamic arguments.

## Validation

- Focused interactive and non-interactive dynamic argument tests: 3 passed
- `ResourceCommandServiceTests`: 49 passed, 1 unrelated failure (`ExecuteCommandAsync_RebuildCommand_ReturnsBuildOutput` timed out waiting for a resource state transition)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review?
      - [ ] Yes
      - [ ] No
    - Did you add the required XML documentation elements?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No