### PR TITLE
Handle ghost dev tunnel conflicts

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCli.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.DevTunnels;
 
-internal sealed class DevTunnelCli
+internal class DevTunnelCli
 {
     public const int ResourceConflictsWithExistingExitCode = 1;
     public const int ResourceNotFoundExitCode = 2;
@@ -48,7 +48,7 @@ internal sealed class DevTunnelCli
     public Task<int> UserStatusAsync(TextWriter? outputWriter = null, TextWriter? errorWriter = null, ILogger? logger = default, CancellationToken cancellationToken = default)
         => RunAsync(["user", "show", "--json", "--nologo"], outputWriter, errorWriter, logger, cancellationToken);
 
-    public Task<int> CreateTunnelAsync(
+    public virtual Task<int> CreateTunnelAsync(
         string? tunnelId = null,
         DevTunnelOptions? options = null,
         TextWriter? outputWriter = null,
@@ -68,7 +68,7 @@ internal sealed class DevTunnelCli
         , outputWriter, errorWriter, logger, cancellationToken);
     }
 
-    public Task<int> UpdateTunnelAsync(
+    public virtual Task<int> UpdateTunnelAsync(
         string tunnelId,
         DevTunnelOptions? options = null,
         TextWriter? outputWriter = null,

--- a/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelCliClient.cs
@@ -8,12 +8,26 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.DevTunnels;
 
-internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTunnelClient
+internal sealed class DevTunnelCliClient : IDevTunnelClient
 {
-    private readonly int _maxCliAttempts = configuration.GetValue<int?>("ASPIRE_DEVTUNNEL_CLI_MAX_ATTEMPTS") ?? 3;
+    private readonly int _maxCliAttempts;
     private readonly TimeSpan _cliRetryOnErrorDelay = TimeSpan.FromSeconds(2);
     private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
-    private readonly DevTunnelCli _cli = new(DevTunnelCli.GetCliPath(configuration));
+    private readonly DevTunnelCli _cli;
+
+    public DevTunnelCliClient(IConfiguration configuration)
+        : this(configuration, new DevTunnelCli(DevTunnelCli.GetCliPath(configuration)))
+    {
+    }
+
+    internal DevTunnelCliClient(IConfiguration configuration, DevTunnelCli cli)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(cli);
+
+        _maxCliAttempts = configuration.GetValue<int?>("ASPIRE_DEVTUNNEL_CLI_MAX_ATTEMPTS") ?? 3;
+        _cli = cli;
+    }
 
     public async Task<Version> GetVersionAsync(ILogger? logger = default, CancellationToken cancellationToken = default)
     {
@@ -77,9 +91,24 @@ internal sealed class DevTunnelCliClient(IConfiguration configuration) : IDevTun
             {
                 // Update the tunnel as it already exists
                 logger?.LogTrace("Dev tunnel '{TunnelId}' already exists, will update it instead.", tunnelId);
+                var createError = error;
                 (tunnel, exitCode, error) = await CallCliAsJsonAsync<DevTunnelStatus>(
                     (stdout, stderr, log, ct) => _cli.UpdateTunnelAsync(resolvedTunnelId, options, stdout, stderr, log, ct),
                     logger, cancellationToken).ConfigureAwait(false);
+                if (exitCode == DevTunnelCli.ResourceNotFoundExitCode)
+                {
+                    // A service ghost can produce:
+                    //   create <id>: exit 1, "Conflict with existing entity"
+                    //   update <id>: exit 2, "Tunnel not found"
+                    // Retrying the same candidate cannot resolve that contradictory service state.
+                    throw new DistributedApplicationException(
+                        $"Dev tunnel '{resolvedTunnelId}' could not be created because the dev tunnels service reported that it already exists, " +
+                        "but then reported it was not found when Aspire tried to update it. This tunnel ID is in an inconsistent service state " +
+                        $"and retrying it cannot recover. Specify a different tunnel ID with {nameof(DevTunnelsResourceBuilderExtensions.AddDevTunnel)}" +
+                        "(name, tunnelId: \"new-id\") and restart " +
+                        $"the AppHost. Create error: '{createError}'. Update error: '{error}'.");
+                }
+
                 if (exitCode == 0 && tunnel is not null)
                 {
                     logger?.LogTrace("Dev tunnel '{TunnelId}' updated successfully.", resolvedTunnelId);

--- a/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelCliClientTests.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/DevTunnelCliClientTests.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Hosting.DevTunnels.Tests;
+
+public class DevTunnelCliClientTests
+{
+    [Fact]
+    public async Task CreateTunnelAsync_WhenCreateConflictsAndUpdateIsNotFound_FailsWithoutRetrying()
+    {
+        var cli = new TestDevTunnelCli();
+        cli.EnqueueCreateResult(
+            DevTunnelCli.ResourceConflictsWithExistingExitCode,
+            error: "Tunnel service error: Conflict with existing entity. Retry tunnel operation.");
+        cli.EnqueueUpdateResult(
+            DevTunnelCli.ResourceNotFoundExitCode,
+            error: "Tunnel not found: ghost.eun1");
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPIRE_DEVTUNNEL_CLI_MAX_ATTEMPTS"] = "3"
+            })
+            .Build();
+        var client = new DevTunnelCliClient(configuration, cli);
+        var options = new DevTunnelOptions
+        {
+            Region = DevTunnelRegion.NorthEurope
+        };
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => client.CreateTunnelAsync("ghost", options));
+
+        Assert.Equal(
+            """
+            Dev tunnel 'ghost.eun1' could not be created because the dev tunnels service reported that it already exists, but then reported it was not found when Aspire tried to update it. This tunnel ID is in an inconsistent service state and retrying it cannot recover. Specify a different tunnel ID with AddDevTunnel(name, tunnelId: "new-id") and restart the AppHost. Create error: 'Tunnel service error: Conflict with existing entity. Retry tunnel operation.'. Update error: 'Tunnel not found: ghost.eun1'.
+            """,
+            exception.Message);
+        Assert.Collection(
+            cli.Calls,
+            call =>
+            {
+                Assert.Equal(nameof(DevTunnelCli.CreateTunnelAsync), call.Method);
+                Assert.Equal("ghost", call.TunnelId);
+            },
+            call =>
+            {
+                Assert.Equal(nameof(DevTunnelCli.UpdateTunnelAsync), call.Method);
+                Assert.Equal("ghost.eun1", call.TunnelId);
+            });
+    }
+}

--- a/tests/Aspire.Hosting.DevTunnels.Tests/TestDevTunnelCli.cs
+++ b/tests/Aspire.Hosting.DevTunnels.Tests/TestDevTunnelCli.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.DevTunnels.Tests;
+
+internal sealed class TestDevTunnelCli : DevTunnelCli
+{
+    private readonly ConcurrentQueue<TestDevTunnelCliResult> _createResults = new();
+    private readonly ConcurrentQueue<TestDevTunnelCliResult> _updateResults = new();
+
+    public TestDevTunnelCli()
+        : base("test-devtunnel")
+    {
+    }
+
+    public ConcurrentQueue<TestDevTunnelCliCall> Calls { get; } = new();
+
+    public void EnqueueCreateResult(int exitCode, string? output = null, string? error = null)
+        => _createResults.Enqueue(new(exitCode, output, error));
+
+    public void EnqueueUpdateResult(int exitCode, string? output = null, string? error = null)
+        => _updateResults.Enqueue(new(exitCode, output, error));
+
+    public override Task<int> CreateTunnelAsync(
+        string? tunnelId = null,
+        DevTunnelOptions? options = null,
+        TextWriter? outputWriter = null,
+        TextWriter? errorWriter = null,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        Calls.Enqueue(new(nameof(CreateTunnelAsync), tunnelId));
+        return CompleteAsync(_createResults, outputWriter, errorWriter, cancellationToken);
+    }
+
+    public override Task<int> UpdateTunnelAsync(
+        string tunnelId,
+        DevTunnelOptions? options = null,
+        TextWriter? outputWriter = null,
+        TextWriter? errorWriter = null,
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        Calls.Enqueue(new(nameof(UpdateTunnelAsync), tunnelId));
+        return CompleteAsync(_updateResults, outputWriter, errorWriter, cancellationToken);
+    }
+
+    private static Task<int> CompleteAsync(
+        ConcurrentQueue<TestDevTunnelCliResult> results,
+        TextWriter? outputWriter,
+        TextWriter? errorWriter,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!results.TryDequeue(out var result))
+        {
+            throw new InvalidOperationException("No test devtunnel CLI result was configured.");
+        }
+
+        if (result.Output is not null)
+        {
+            outputWriter?.WriteLine(result.Output);
+        }
+
+        if (result.Error is not null)
+        {
+            errorWriter?.WriteLine(result.Error);
+        }
+
+        return Task.FromResult(result.ExitCode);
+    }
+}
+
+internal sealed record TestDevTunnelCliCall(string Method, string? TunnelId);
+
+internal sealed record TestDevTunnelCliResult(int ExitCode, string? Output, string? Error);


### PR DESCRIPTION
## Description

Dev tunnel startup can get stuck when the service has a ghost record for a deterministic tunnel ID: `create` reports a conflict, but the follow-up `update` reports that the tunnel does not exist. The integration previously repeated that impossible create/update sequence three times before failing with generic output.

This change classifies the conflict-then-not-found sequence as an inconsistent service state and stops after one create/update pair. The resulting error preserves the create and update diagnostics and tells the user how to select a fresh explicit tunnel ID. Region-qualified IDs remain correct for update operations.

Automatic ID replacement is intentionally not included. The effective ID is also consumed by model-time host arguments, port reconciliation, access operations, and health checks, so changing it only inside the CLI client would leave downstream consumers using different IDs. Explicit user-provided IDs must also never change silently.

A fake CLI regression test verifies that a configured three-attempt client performs exactly one create with the bare ID and one update with the resolved regional ID before returning the actionable error.

Fixes #18913

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No