### PR TITLE
Add SQLite persistence and run history to the Dashboard

### DIFF
--- a/.github/instructions/dashboard.instructions.md
+++ b/.github/instructions/dashboard.instructions.md
@@ -13,3 +13,16 @@ applyTo: "src/Aspire.Dashboard/**/*.{cs,razor,js}"
 - For bounded channels feeding one consumer, prefer `BoundedChannelFullMode.DropOldest` and set `SingleReader = true`.
 - Use `FormatHelpers` for culture-aware date/time/number display. Reserve invariant formatting for intentionally fixed diagnostic formats.
 - Localize user-visible dashboard text with resource-backed localizers. Prefer typed localizers and `nameof` keys when practical, but existing model/helpers also generate localized UI text.
+
+## Blazor components
+
+- Avoid `@code` blocks and substantial C# logic in `.razor` files. Keep `.razor` files focused on markup, directives, and simple binding or event expressions; put component state, lifecycle methods, event handlers, and other logic in the matching `.razor.cs` code-behind partial class for better IDE and compiler support.
+- Declare injected component dependencies as public, required, init-only properties:
+
+	```csharp
+	[Inject]
+	public required IDashboardClient DashboardClient { get; init; }
+	```
+
+- `public` keeps dependencies visible to component and test infrastructure, `required` expresses that the component cannot operate without the service, and `init` prevents reassignment after component activation.
+- Do not use non-public injected properties, mutable `set` accessors, or null-forgiving initializers such as `= null!;`. These weaken compile-time validation and hide missing dependencies when components are constructed in tests.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,6 +123,7 @@
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.17.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.11" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.4" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.4" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" /> <!-- No stable release available -->
@@ -141,6 +142,7 @@
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageVersion Include="Qdrant.Client" Version="1.19.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.2" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
     <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.11" />

--- a/benchmarks/Aspire.Dashboard.Benchmarks/Aspire.Dashboard.Benchmarks.csproj
+++ b/benchmarks/Aspire.Dashboard.Benchmarks/Aspire.Dashboard.Benchmarks.csproj
@@ -14,6 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/benchmarks/Aspire.Dashboard.Benchmarks/SqliteTraceBenchmarks.cs
+++ b/benchmarks/Aspire.Dashboard.Benchmarks/SqliteTraceBenchmarks.cs
@@ -1,0 +1,217 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.ServiceClient;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Proto.Collector.Trace.V1;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Resource.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using OtlpProtoSpan = OpenTelemetry.Proto.Trace.V1.Span;
+
+namespace Aspire.Dashboard.Benchmarks;
+
+[MemoryDiagnoser]
+[Config(typeof(Config))]
+public class SqliteTraceBenchmarks
+{
+    private const string TraceFileEnvironmentVariable = "ASPIRE_DASHBOARD_TRACE_BENCHMARK_FILE";
+    private const int GeneratedSpanCount = 10_000;
+    private static readonly DateTime s_generatedTraceStartTime = DateTime.UnixEpoch;
+
+    private string _temporaryDirectory = null!;
+    private DashboardSqliteDatabase _database = null!;
+    private SqliteTelemetryRepository _repository = null!;
+    private RepeatedField<ResourceSpans> _appendResourceSpans = null!;
+    private long _appendIndex;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _temporaryDirectory = Directory.CreateTempSubdirectory("aspire-dashboard-trace-benchmark-").FullName;
+        _database = new DashboardSqliteDatabase(Path.Combine(_temporaryDirectory, "dashboard.db"));
+        _repository = CreateRepository(_database);
+
+        var resourceSpans = LoadResourceSpans();
+        var context = new AddContext();
+        await _repository.AddTracesAsync(context, resourceSpans);
+        if (context.FailureCount != 0)
+        {
+            throw new InvalidOperationException($"Failed to ingest {context.FailureCount} benchmark spans.");
+        }
+
+        _appendResourceSpans = CreateAppendResourceSpans(resourceSpans);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _repository.Dispose();
+        _database.ClearPool();
+        _database.Dispose();
+        Directory.Delete(_temporaryDirectory, recursive: true);
+    }
+
+    [Benchmark(Description = "SQLite: summarize large trace")]
+    public int GetTraceSummaries()
+    {
+        var response = _repository.GetTraceSummaries(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 100,
+            Filters = []
+        });
+
+        return response.PagedResult.Items.Count;
+    }
+
+    [Benchmark(Description = "SQLite: append one span to large trace")]
+    public async Task<int> AppendSpan()
+    {
+        var appendSpan = _appendResourceSpans[0].ScopeSpans[0].Spans[0];
+        appendSpan.SpanId = ByteString.CopyFrom(BitConverter.GetBytes(long.MaxValue - Interlocked.Increment(ref _appendIndex)));
+        var context = new AddContext();
+        await _repository.AddTracesAsync(context, _appendResourceSpans);
+        return context.SuccessCount;
+    }
+
+    private static RepeatedField<ResourceSpans> LoadResourceSpans()
+    {
+        var traceFile = Environment.GetEnvironmentVariable(TraceFileEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(traceFile))
+        {
+            return CreateGeneratedResourceSpans();
+        }
+
+        var request = JsonParser.Default.Parse<ExportTraceServiceRequest>(File.ReadAllText(traceFile));
+        return request.ResourceSpans;
+    }
+
+    private static RepeatedField<ResourceSpans> CreateGeneratedResourceSpans()
+    {
+        var resourceSpans = new ResourceSpans
+        {
+            Resource = CreateResource("benchmark-app"),
+            ScopeSpans =
+            {
+                new ScopeSpans
+                {
+                    Scope = new InstrumentationScope { Name = "BenchmarkScope" }
+                }
+            }
+        };
+        var scopeSpans = resourceSpans.ScopeSpans[0];
+        var traceId = ByteString.CopyFrom(Encoding.UTF8.GetBytes("benchmark-trace"));
+        for (var spanIndex = 0; spanIndex < GeneratedSpanCount; spanIndex++)
+        {
+            var spanStartTime = s_generatedTraceStartTime.AddTicks(spanIndex);
+            scopeSpans.Spans.Add(new OtlpProtoSpan
+            {
+                TraceId = traceId,
+                SpanId = CreateSpanId(spanIndex),
+                ParentSpanId = spanIndex == 0 ? ByteString.Empty : CreateSpanId(spanIndex - 1),
+                Name = spanIndex == 0 ? "root-span" : $"span-{spanIndex}",
+                Kind = OtlpProtoSpan.Types.SpanKind.Internal,
+                StartTimeUnixNano = DateTimeToUnixNanoseconds(spanStartTime),
+                EndTimeUnixNano = DateTimeToUnixNanoseconds(spanStartTime.AddMilliseconds(5))
+            });
+        }
+
+        return [resourceSpans];
+    }
+
+    private static RepeatedField<ResourceSpans> CreateAppendResourceSpans(RepeatedField<ResourceSpans> resourceSpans)
+    {
+        var firstSpan = resourceSpans.SelectMany(resource => resource.ScopeSpans).SelectMany(scope => scope.Spans).First();
+        return
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource("append-app"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = new InstrumentationScope { Name = "AppendScope" },
+                        Spans =
+                        {
+                            new OtlpProtoSpan
+                            {
+                                TraceId = firstSpan.TraceId,
+                                SpanId = ByteString.CopyFrom(Encoding.UTF8.GetBytes("append-span-0001")),
+                                ParentSpanId = firstSpan.SpanId,
+                                Name = "appended-span",
+                                Kind = OtlpProtoSpan.Types.SpanKind.Internal,
+                                StartTimeUnixNano = firstSpan.EndTimeUnixNano + 100,
+                                EndTimeUnixNano = firstSpan.EndTimeUnixNano + 200
+                            }
+                        }
+                    }
+                }
+            }
+        ];
+    }
+
+    private static SqliteTelemetryRepository CreateRepository(DashboardSqliteDatabase database)
+    {
+        return new SqliteTelemetryRepository(
+            database,
+            NullLoggerFactory.Instance,
+            Options.Create(new DashboardOptions
+            {
+                TelemetryLimits = new TelemetryLimitOptions { MaxTraceCount = 1_000 }
+            }),
+            new PauseManager(),
+            TimeProvider.System,
+            []);
+    }
+
+    private static Resource CreateResource(string name)
+    {
+        return new Resource
+        {
+            Attributes =
+            {
+                new KeyValue { Key = "service.name", Value = new AnyValue { StringValue = name } }
+            }
+        };
+    }
+
+    private static ByteString CreateSpanId(int spanIndex) =>
+        ByteString.CopyFrom(Encoding.UTF8.GetBytes($"span-{spanIndex:0000}"));
+
+    private static ulong DateTimeToUnixNanoseconds(DateTime dateTime)
+    {
+        var timeSinceEpoch = dateTime.ToUniversalTime() - DateTime.UnixEpoch;
+        return (ulong)timeSinceEpoch.Ticks * 100;
+    }
+
+    private sealed class Config : ManualConfig
+    {
+        public Config()
+        {
+            AddJob(Job.Default
+                .WithToolchain(InProcessNoEmitToolchain.Instance)
+                .WithWarmupCount(1)
+                .WithIterationCount(3)
+                .WithInvocationCount(1)
+                .WithUnrollFactor(1));
+
+            AddDiagnoser(MemoryDiagnoser.Default);
+        }
+    }
+}

--- a/benchmarks/Aspire.Dashboard.Benchmarks/TelemetryRepositoryBenchmarks.cs
+++ b/benchmarks/Aspire.Dashboard.Benchmarks/TelemetryRepositoryBenchmarks.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.ServiceClient;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
@@ -63,30 +64,45 @@ public class TelemetryRepositoryBenchmarks
     ];
 
     private RepeatedField<ResourceSpans> _resourceSpans = [];
-    private TelemetryRepository _queryRepository = null!;
+    private string _temporaryDirectory = null!;
+    private DashboardSqliteDatabase _queryDatabase = null!;
+    private SqliteTelemetryRepository _queryRepository = null!;
 
     [GlobalSetup]
-    public void Setup()
+    public async Task Setup()
     {
         _resourceSpans = CreateResourceSpans(TraceCount, SpansPerTrace);
-        _queryRepository = CreateRepository();
-        _queryRepository.AddTraces(new AddContext(), _resourceSpans);
+        _temporaryDirectory = Directory.CreateTempSubdirectory("aspire-dashboard-telemetry-benchmark-").FullName;
+        _queryDatabase = new DashboardSqliteDatabase(Path.Combine(_temporaryDirectory, "query.db"));
+        _queryRepository = CreateRepository(_queryDatabase);
+        await _queryRepository.AddTracesAsync(new AddContext(), _resourceSpans);
     }
 
     [GlobalCleanup]
     public void Cleanup()
     {
         _queryRepository.Dispose();
+        _queryDatabase.ClearPool();
+        _queryDatabase.Dispose();
+        Directory.Delete(_temporaryDirectory, recursive: true);
     }
 
     [Benchmark(Description = "TelemetryRepository: add 10k spans")]
-    public int AddTracesLargeBatch()
+    public async Task<int> AddTracesLargeBatch()
     {
-        using var repository = CreateRepository();
-        var context = new AddContext();
-        repository.AddTraces(context, _resourceSpans);
+        var temporaryDirectory = Directory.CreateTempSubdirectory("aspire-dashboard-telemetry-add-benchmark-");
+        using var database = new DashboardSqliteDatabase(Path.Combine(temporaryDirectory.FullName, "add.db"));
+        int successCount;
+        using (var repository = CreateRepository(database))
+        {
+            var context = new AddContext();
+            await repository.AddTracesAsync(context, _resourceSpans);
+            successCount = context.SuccessCount;
+        }
+        database.ClearPool();
+        Directory.Delete(temporaryDirectory.FullName, recursive: true);
 
-        return context.SuccessCount;
+        return successCount;
     }
 
     [Benchmark(Description = "TelemetryRepository: query no filters")]
@@ -94,8 +110,7 @@ public class TelemetryRepositoryBenchmarks
     {
         var result = _queryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
-            FilterText = string.Empty,
+            ResourceKeys = [],
             Filters = [],
             StartIndex = 0,
             Count = 100
@@ -109,8 +124,7 @@ public class TelemetryRepositoryBenchmarks
     {
         var result = _queryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
-            FilterText = string.Empty,
+            ResourceKeys = [],
             Filters = _durationFilters,
             StartIndex = 0,
             Count = 100
@@ -124,8 +138,7 @@ public class TelemetryRepositoryBenchmarks
     {
         var result = _queryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
-            FilterText = string.Empty,
+            ResourceKeys = [],
             Filters = _noMatchDurationFilters,
             StartIndex = 0,
             Count = 100
@@ -139,8 +152,7 @@ public class TelemetryRepositoryBenchmarks
     {
         var result = _queryRepository.GetTraces(new GetTracesRequest
         {
-            ResourceKey = null,
-            FilterText = string.Empty,
+            ResourceKeys = [],
             Filters = _noMatchAttributeFilters,
             StartIndex = 0,
             Count = 100
@@ -149,9 +161,10 @@ public class TelemetryRepositoryBenchmarks
         return result.PagedResult.Items.Count;
     }
 
-    private static TelemetryRepository CreateRepository()
+    private static SqliteTelemetryRepository CreateRepository(DashboardSqliteDatabase database)
     {
-        return new TelemetryRepository(
+        return new SqliteTelemetryRepository(
+            database,
             NullLoggerFactory.Instance,
             Options.Create(new DashboardOptions
             {
@@ -161,6 +174,7 @@ public class TelemetryRepositoryBenchmarks
                 }
             }),
             new PauseManager(),
+            TimeProvider.System,
             []);
     }
 

--- a/benchmarks/Aspire.Dashboard.Benchmarks/TelemetryRepositoryMetricsBenchmarks.cs
+++ b/benchmarks/Aspire.Dashboard.Benchmarks/TelemetryRepositoryMetricsBenchmarks.cs
@@ -1,0 +1,394 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Dashboard.Components;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.ServiceClient;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Resource.V1;
+
+namespace Aspire.Dashboard.Benchmarks;
+
+[MemoryDiagnoser]
+[ThreadingDiagnoser]
+[Config(typeof(Config))]
+public class TelemetryRepositoryMetricsBenchmarks
+{
+    private const int MetricSamplesPerBatch = 100;
+    private const string MetricMeterName = "benchmark-meter";
+    private const string MetricInstrumentName = "benchmark.metric";
+    private const string HistogramMetricInstrumentName = "benchmark.histogram";
+    private static readonly TimeSpan s_metricDataDuration = TimeSpan.FromHours(6);
+    private static readonly TimeSpan s_metricDisplayDuration = TimeSpan.FromHours(6);
+    private static readonly TimeSpan s_metricInterval = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan s_metricExemplarInterval = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan s_metricDataPointInterval = MetricDataPointInterval.Get(s_metricDisplayDuration);
+    private static readonly TimeSpan s_metricHistoryDuration = TimeSpan.FromTicks(Math.Max(TimeSpan.FromSeconds(30).Ticks, s_metricDataPointInterval.Ticks));
+    private static readonly ResourceKey s_metricResourceKey = new("benchmark-app", "benchmark-instance");
+
+    private string _temporaryDirectory = null!;
+    private DashboardSqliteDatabase _database = null!;
+    private SqliteTelemetryRepository _queryRepository = null!;
+    private IReadOnlyList<MetricDimensionCursor> _incrementalCursors = null!;
+
+    [Params(1, 5)]
+    public int DimensionCount { get; set; }
+
+    [GlobalSetup(Target = nameof(GetMetricsLongDuration))]
+    public Task SetupMetrics() => SetupAsync(isHistogram: false);
+
+    [GlobalSetup(Target = nameof(GetHistogramMetricsLongDuration))]
+    public Task SetupHistogramMetrics() => SetupAsync(isHistogram: true);
+
+    [GlobalSetup(Target = nameof(GetMetricsLongDurationRollup))]
+    public Task SetupMetricsRollup() => SetupAsync(isHistogram: false);
+
+    [GlobalSetup(Target = nameof(GetHistogramMetricsLongDurationRollup))]
+    public Task SetupHistogramMetricsRollup() => SetupAsync(isHistogram: true);
+
+    [GlobalSetup(Target = nameof(GetMetricsIncrementalRollup))]
+    public Task SetupMetricsIncrementalRollup() => SetupIncrementalAsync(isHistogram: false, MetricInstrumentName);
+
+    [GlobalSetup(Target = nameof(GetHistogramMetricsIncrementalRollup))]
+    public Task SetupHistogramMetricsIncrementalRollup() => SetupIncrementalAsync(isHistogram: true, HistogramMetricInstrumentName);
+
+    private async Task SetupAsync(bool isHistogram)
+    {
+        _temporaryDirectory = Directory.CreateTempSubdirectory("aspire-dashboard-metrics-benchmark-").FullName;
+        _database = new DashboardSqliteDatabase(Path.Combine(_temporaryDirectory, "query.db"));
+        _queryRepository = CreateRepository(_database);
+        var addContext = new AddContext();
+        foreach (var batch in CreateLongDurationMetricBatches(DimensionCount, isHistogram))
+        {
+            await _queryRepository.AddMetricsAsync(addContext, batch);
+        }
+        if (addContext.FailureCount > 0)
+        {
+            throw new InvalidOperationException($"Failed to add {addContext.FailureCount} benchmark metric points.");
+        }
+    }
+
+    private async Task SetupIncrementalAsync(bool isHistogram, string instrumentName)
+    {
+        await SetupAsync(isHistogram);
+        var instrument = GetLongDurationInstrument(instrumentName, s_metricDataPointInterval);
+        _incrementalCursors = instrument.Dimensions.Select(dimension =>
+        {
+            var latestValue = dimension.Values[^1];
+            return new MetricDimensionCursor
+            {
+                Attributes = dimension.Attributes,
+                StartTime = latestValue.End.Subtract(s_metricDataPointInterval)
+            };
+        }).ToArray();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _queryRepository.Dispose();
+        _database.ClearPool();
+        _database.Dispose();
+        Directory.Delete(_temporaryDirectory, recursive: true);
+    }
+
+    [Benchmark(Description = "TelemetryRepository: query 6h metrics display")]
+    public int GetMetricsLongDuration()
+    {
+        var instrument = GetLongDurationInstrument(MetricInstrumentName);
+
+        return instrument.Dimensions.Sum(dimension => dimension.Values.Count);
+    }
+
+    [Benchmark(Description = "TelemetryRepository: query 6h histogram metrics display")]
+    public int GetHistogramMetricsLongDuration()
+    {
+        var instrument = GetLongDurationInstrument(HistogramMetricInstrumentName);
+
+        return instrument.Dimensions.Sum(dimension =>
+            dimension.Values.Count + dimension.Values.Sum(value => value.Exemplars.Count));
+    }
+
+    [Benchmark(Description = "TelemetryRepository: query 6h metrics with dashboard rollup")]
+    public int GetMetricsLongDurationRollup()
+    {
+        var instrument = GetLongDurationInstrument(MetricInstrumentName, s_metricDataPointInterval);
+
+        return instrument.Dimensions.Sum(dimension => dimension.Values.Count);
+    }
+
+    [Benchmark(Description = "TelemetryRepository: query 6h histogram metrics with dashboard rollup")]
+    public int GetHistogramMetricsLongDurationRollup()
+    {
+        var instrument = GetLongDurationInstrument(HistogramMetricInstrumentName, s_metricDataPointInterval);
+
+        return instrument.Dimensions.Sum(dimension =>
+            dimension.Values.Count + dimension.Values.Sum(value => value.Exemplars.Count));
+    }
+
+    [Benchmark(Description = "TelemetryRepository: query incremental metrics with dashboard rollup")]
+    public int GetMetricsIncrementalRollup()
+    {
+        var instrument = GetLongDurationInstrument(MetricInstrumentName, s_metricDataPointInterval, _incrementalCursors);
+
+        return instrument.Dimensions.Sum(dimension => dimension.Values.Count);
+    }
+
+    [Benchmark(Description = "TelemetryRepository: query incremental histogram metrics with dashboard rollup")]
+    public int GetHistogramMetricsIncrementalRollup()
+    {
+        var instrument = GetLongDurationInstrument(HistogramMetricInstrumentName, s_metricDataPointInterval, _incrementalCursors);
+
+        return instrument.Dimensions.Sum(dimension =>
+            dimension.Values.Count + dimension.Values.Sum(value => value.Exemplars.Count));
+    }
+
+    private OtlpInstrumentData GetLongDurationInstrument(
+        string instrumentName,
+        TimeSpan? dataPointInterval = null,
+        IReadOnlyList<MetricDimensionCursor>? dimensionCursors = null)
+    {
+        var endTime = _queryRepository.GetInstrumentLatestEndTime(s_metricResourceKey, MetricMeterName, instrumentName)
+            ?? throw new InvalidOperationException($"Unable to find the benchmark metric '{instrumentName}' end time.");
+
+        // Match the dashboard metrics display query, which includes one preceding rollup for histogram calculations.
+        return _queryRepository.GetInstrument(new GetInstrumentRequest
+        {
+            ResourceKey = s_metricResourceKey,
+            MeterName = MetricMeterName,
+            InstrumentName = instrumentName,
+            StartTime = endTime.Subtract(s_metricDisplayDuration + s_metricHistoryDuration),
+            EndTime = endTime,
+            DataPointInterval = dataPointInterval,
+            PopulateExemplarAttributes = false,
+            DimensionCursors = dimensionCursors ?? []
+        }) ?? throw new InvalidOperationException($"Unable to find the benchmark metric '{instrumentName}'.");
+    }
+
+    private static SqliteTelemetryRepository CreateRepository(DashboardSqliteDatabase database)
+    {
+        return new SqliteTelemetryRepository(
+            database,
+            NullLoggerFactory.Instance,
+            Options.Create(new DashboardOptions()),
+            new PauseManager(),
+            TimeProvider.System,
+            []);
+    }
+
+    private static IEnumerable<RepeatedField<ResourceMetrics>> CreateLongDurationMetricBatches(int dimensionCount, bool isHistogram)
+    {
+        var startTime = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        double[] observations = [5, 25, 75, 150];
+        var bucketCounts = Enumerable.Range(0, dimensionCount).Select(_ => new ulong[observations.Length]).ToArray();
+        var sums = new double[dimensionCount];
+        var totalSampleCount = (int)(s_metricDataDuration / s_metricInterval);
+
+        for (var firstSampleIndex = 0; firstSampleIndex < totalSampleCount; firstSampleIndex += MetricSamplesPerBatch)
+        {
+            var sampleCount = Math.Min(MetricSamplesPerBatch, totalSampleCount - firstSampleIndex);
+            yield return CreateLongDurationMetrics(
+                startTime,
+                dimensionCount,
+                firstSampleIndex,
+                sampleCount,
+                observations,
+                bucketCounts,
+                sums,
+                isHistogram);
+        }
+    }
+
+    private static RepeatedField<ResourceMetrics> CreateLongDurationMetrics(
+        DateTime startTime,
+        int dimensionCount,
+        int firstSampleIndex,
+        int sampleCount,
+        double[] observations,
+        ulong[][] bucketCounts,
+        double[] sums,
+        bool isHistogram)
+    {
+        return
+        [
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = new InstrumentationScope { Name = MetricMeterName },
+                        Metrics =
+                        {
+                            CreateMetric(startTime, dimensionCount, firstSampleIndex, sampleCount, observations, bucketCounts, sums, isHistogram)
+                        }
+                    }
+                }
+            }
+        ];
+    }
+
+    private static Metric CreateMetric(
+        DateTime startTime,
+        int dimensionCount,
+        int firstSampleIndex,
+        int sampleCount,
+        double[] observations,
+        ulong[][] bucketCounts,
+        double[] sums,
+        bool isHistogram)
+    {
+        return isHistogram
+            ? new Metric
+            {
+                Name = HistogramMetricInstrumentName,
+                Description = "Long-running benchmark histogram metric",
+                Unit = "ms",
+                Histogram = new Histogram
+                {
+                    AggregationTemporality = AggregationTemporality.Cumulative,
+                    DataPoints = { CreateHistogramMetricPoints(startTime, dimensionCount, firstSampleIndex, sampleCount, observations, bucketCounts, sums) }
+                }
+            }
+            : new Metric
+            {
+                Name = MetricInstrumentName,
+                Description = "Long-running benchmark metric",
+                Unit = "requests",
+                Sum = new Sum
+                {
+                    AggregationTemporality = AggregationTemporality.Cumulative,
+                    IsMonotonic = true,
+                    DataPoints = { CreateMetricPoints(startTime, dimensionCount, firstSampleIndex, sampleCount) }
+                }
+            };
+    }
+
+    private static IEnumerable<NumberDataPoint> CreateMetricPoints(
+        DateTime startTime,
+        int dimensionCount,
+        int firstSampleIndex,
+        int sampleCount)
+    {
+        for (var sampleOffset = 0; sampleOffset < sampleCount; sampleOffset++)
+        {
+            var sampleIndex = firstSampleIndex + sampleOffset;
+            var pointTime = startTime.AddTicks(s_metricInterval.Ticks * sampleIndex);
+            for (var dimensionIndex = 0; dimensionIndex < dimensionCount; dimensionIndex++)
+            {
+                yield return new NumberDataPoint
+                {
+                    AsInt = sampleIndex,
+                    StartTimeUnixNano = DateTimeToUnixNanoseconds(pointTime),
+                    TimeUnixNano = DateTimeToUnixNanoseconds(pointTime),
+                    Attributes = { CreateDimensionAttribute(dimensionIndex) }
+                };
+            }
+        }
+    }
+
+    private static IEnumerable<HistogramDataPoint> CreateHistogramMetricPoints(
+        DateTime startTime,
+        int dimensionCount,
+        int firstSampleIndex,
+        int sampleCount,
+        double[] observations,
+        ulong[][] bucketCounts,
+        double[] sums)
+    {
+        for (var sampleOffset = 0; sampleOffset < sampleCount; sampleOffset++)
+        {
+            var sampleIndex = firstSampleIndex + sampleOffset;
+            var pointTime = startTime.AddTicks(s_metricInterval.Ticks * sampleIndex);
+            var observationIndex = sampleIndex % observations.Length;
+            var observation = observations[observationIndex];
+            for (var dimensionIndex = 0; dimensionIndex < dimensionCount; dimensionIndex++)
+            {
+                bucketCounts[dimensionIndex][observationIndex]++;
+                sums[dimensionIndex] += observation;
+
+                var point = new HistogramDataPoint
+                {
+                    Count = checked((ulong)sampleIndex + 1),
+                    Sum = sums[dimensionIndex],
+                    StartTimeUnixNano = DateTimeToUnixNanoseconds(startTime),
+                    TimeUnixNano = DateTimeToUnixNanoseconds(pointTime),
+                    ExplicitBounds = { 10, 50, 100 },
+                    Attributes = { CreateDimensionAttribute(dimensionIndex) }
+                };
+                point.BucketCounts.Add(bucketCounts[dimensionIndex]);
+
+                if ((pointTime - startTime).Ticks % s_metricExemplarInterval.Ticks == 0)
+                {
+                    point.Exemplars.Add(CreateMetricExemplar(pointTime, observation));
+                }
+
+                yield return point;
+            }
+        }
+    }
+
+    private static KeyValue CreateDimensionAttribute(int dimensionIndex)
+    {
+        return new KeyValue
+        {
+            Key = "benchmark.dimension",
+            Value = new AnyValue { StringValue = dimensionIndex.ToString(CultureInfo.InvariantCulture) }
+        };
+    }
+
+    private static Exemplar CreateMetricExemplar(DateTime pointTime, double value)
+    {
+        return new Exemplar
+        {
+            TimeUnixNano = DateTimeToUnixNanoseconds(pointTime),
+            AsDouble = value,
+            SpanId = ByteString.CopyFromUtf8("span-id0"),
+            TraceId = ByteString.CopyFromUtf8("trace-id00000000")
+        };
+    }
+
+    private static Resource CreateResource()
+    {
+        return new Resource
+        {
+            Attributes =
+            {
+                new KeyValue { Key = "service.name", Value = new AnyValue { StringValue = "benchmark-app" } },
+                new KeyValue { Key = "service.instance.id", Value = new AnyValue { StringValue = "benchmark-instance" } }
+            }
+        };
+    }
+
+    private static ulong DateTimeToUnixNanoseconds(DateTime dateTime)
+    {
+        var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var timeSinceEpoch = dateTime.ToUniversalTime() - unixEpoch;
+
+        return (ulong)timeSinceEpoch.Ticks * 100;
+    }
+
+    private sealed class Config : ManualConfig
+    {
+        public Config()
+        {
+            AddJob(Job.Dry);
+
+            AddDiagnoser(MemoryDiagnoser.Default);
+        }
+    }
+}

--- a/docs/specs/dashboard-persistence.md
+++ b/docs/specs/dashboard-persistence.md
@@ -1,0 +1,359 @@
+# Dashboard persistence
+
+**Status:** Implemented by [microsoft/aspire#18768](https://github.com/microsoft/aspire/pull/18768)
+
+## Summary
+
+The Aspire Dashboard stores resource snapshots and telemetry in SQLite. Persistence makes completed application runs available after the AppHost and Dashboard processes stop, while retaining the live Dashboard experience for the active run.
+
+The design has three persistence modes:
+
+| Mode | Database lifetime | Historical run selection | Default use |
+|------|-------------------|--------------------------|-------------|
+| `None` | One temporary database per Dashboard process | No | Standalone Dashboard |
+| `Run` | One persistent database per Dashboard process | Yes | AppHost Dashboard |
+| `Resume` | One persistent database reused by later Dashboard processes | No | Explicit opt-in |
+
+## Usage examples
+
+### `None`: temporary standalone Dashboard
+
+The standalone Dashboard defaults to `None`:
+
+```bash
+aspire dashboard run
+```
+
+This mode is useful for inspecting telemetry during a single development or diagnostic session. Data is lost when the CLI process or standalone Dashboard container stops.
+
+### `Run`: compare AppHost runs
+
+An AppHost-launched Dashboard defaults to `Run`; no additional configuration is required. Each time the AppHost starts, the Dashboard creates a separate run database. After changing the application code and restarting the AppHost, use the run selector to compare the current telemetry and resources with historical runs and evaluate the impact of the change.
+
+### `Resume`: long-running standalone Dashboard
+
+A standalone Dashboard can reuse one persistent database across restarts. For a CLI-managed Dashboard, select `Resume` and give the application a stable name:
+
+```bash
+aspire dashboard run --application-name my-app --persistence Resume
+```
+
+The CLI uses the configured data directory or the default directory under `ASPIRE_HOME`. A container must mount the configured data directory from persistent storage. For example, a Docker named volume preserves the database when the container stops or is replaced:
+
+```bash
+docker volume create aspire-dashboard-data
+
+docker run --rm -d \
+    --name aspire-dashboard \
+    -p 18888:18888 \
+    -p 4317:18889 \
+    -p 4318:18890 \
+    --mount type=volume,source=aspire-dashboard-data,target=/dashboard-data \
+    --env ASPIRE_DASHBOARD_APPLICATION_NAME=my-app \
+    --env ASPIRE_DASHBOARD_DATA_DIRECTORY=/dashboard-data \
+    --env ASPIRE_DASHBOARD_PERSISTENCE_MODE=Resume \
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+Restart the container with the same volume, application name, data directory, and persistence mode to continue using the existing database. The Dashboard can remain running through idle periods, and its data remains available after stop and restart, subject to the configured telemetry retention limits.
+
+The AppHost console-log protocol does not identify the AppHost generation that produced a line. Resume prioritizes preserving logs from later AppHost generations, whose line numbers restart at 1. If the Dashboard restarts while the same AppHost remains running, console logs replayed by that AppHost can therefore be persisted again.
+
+## Goals
+
+- Preserve resources, console logs, structured logs, traces, spans, and metrics after an application run ends.
+- Let users switch between the current run and completed runs without reloading the Dashboard.
+- Keep historical runs read-only so viewing old data cannot affect the active application.
+- Execute filtering, searching, paging, aggregation, field-value lookup, and retention in SQLite instead of loading the full data set into memory.
+- Support high-volume ingestion through normalized storage, batched commands, transactions, and targeted caches.
+- Keep the in-memory and SQLite telemetry repository contracts behaviorally equivalent where practical.
+
+## Non-goals
+
+- Providing a durable production telemetry backend or replacing an observability service.
+- Sharing a writable database across machines or Dashboard processes.
+- Replication, backup, or database-level user authentication.
+- Encryption at rest. Protection of persisted data is delegated to the containing directory's access controls.
+- Migrating persisted data between incompatible schema versions.
+
+## Configuration
+
+The Dashboard binds persistence settings from configuration or their environment-variable equivalents:
+
+| Configuration key | Environment variable | Description |
+|-------------------|----------------------|-------------|
+| `Dashboard:ApplicationName` | `ASPIRE_DASHBOARD_APPLICATION_NAME` | Logical application name that partitions persisted data |
+| `Dashboard:Data:Directory` | `ASPIRE_DASHBOARD_DATA_DIRECTORY` | Root directory for persistent Dashboard data |
+| `Dashboard:Data:PersistenceMode` | `ASPIRE_DASHBOARD_PERSISTENCE_MODE` | `None`, `Run`, or `Resume` |
+
+An AppHost-launched Dashboard receives the normalized application name and defaults to `Run`. The AppHost can override the mode with `Aspire:Dashboard:PersistenceMode` or `ASPIRE_DASHBOARD_PERSISTENCE_MODE`.
+
+The standalone `aspire dashboard run` command accepts `--application-name` and `--persistence`. It does not set a persistence default, so the Dashboard default of `None` applies unless configuration, an environment variable, or the command-line option selects another mode.
+
+When no data directory is configured, persistent modes use the `dashboard` directory under `ASPIRE_HOME`, whose default is the current user's `.aspire` directory. The configured directory must be scoped to and protected for the current user.
+
+On Unix, the per-application directory beneath the data root is created with owner-only (`0700`) permissions. Existing application directories are also restricted to that mode before persistent data is accessed. On Windows, the directory is created without Unix permission flags and uses the inherited ACL.
+
+## Storage layout
+
+Persistent data is partitioned by application. The application directory name contains a readable prefix and a stable hash:
+
+```text
+<sanitized-application-name>-<16-character-xxhash3>
+```
+
+The prefix preserves ASCII letters, digits, `-`, and `_`; other characters become `-`. It is trimmed and truncated so the complete directory name is at most 80 characters. The hash prevents different original names that sanitize to the same prefix from colliding.
+
+### `None`
+
+```text
+<system-temp>/aspire-dashboard-<random>/
+└── dashboard.db
+```
+
+The Dashboard creates the directory with `Directory.CreateTempSubdirectory`, removes it on clean shutdown, and opportunistically removes abandoned `aspire-dashboard-*` directories that contain a database and are not locked by another process.
+
+### `Run`
+
+```text
+<data-root>/
+└── <application-directory>/
+    └── runs/
+        ├── <utc-run-id>.lock
+        └── <utc-run-id>/
+            ├── dashboard.db
+            └── run.json
+```
+
+Run IDs use the UTC start time in `yyyyMMddTHHmmssfffZ` format. `run.json` contains:
+
+- schema version
+- run ID
+- UTC start and end times
+- clean-shutdown flag
+- application name
+- database file name
+
+The metadata is written only after the database schema is initialized, so an interrupted startup does not publish an unusable run. On graceful disposal it is rewritten with the end time and `CleanShutdown` set to `true`. A published run left with `CleanShutdown` set to `false` is still discoverable after its process releases the lock; the flag records how it ended rather than disqualifying its data.
+
+### `Resume`
+
+```text
+<data-root>/
+├── <application-directory>.lock
+└── <application-directory>/
+    └── dashboard.db
+```
+
+Later Dashboard processes continue writing to the same database. This mode does not create run metadata or expose the run selector.
+
+SQLite can also create `dashboard.db-wal` and `dashboard.db-shm` beside a writable database.
+
+## Run ownership and retention
+
+Each writable run has an adjacent lock file held open with exclusive sharing and `DeleteOnClose`. An adjacent lock lets a cooperating process hold the lock while deleting the run directory on Windows. A second Dashboard cannot use the same `Run` directory or `Resume` application database while its owner holds the lock.
+
+Historical discovery only includes directories that:
+
+- are not the current run;
+- are not locked by another Dashboard process;
+- have readable, valid `run.json` metadata; and
+- have the current metadata schema version.
+
+Run discovery orders pinned runs before unpinned runs, then orders each group by descending start time. The run selector applies its presentation order separately: the current run is first, followed by pinned historical runs and then unpinned historical runs, with each historical group ordered by descending start time. Pin state is stored in `run.json`; both current and historical runs can be pinned or unpinned.
+
+`Run` mode retains the five newest unpinned historical run directories. The current run and pinned historical runs do not count toward this limit, so the total number of retained runs is not fixed. Pruning happens after a new run writes its metadata. Before deleting a candidate, the pruner acquires its lock and rechecks its pin state. A historical run selected by another Dashboard circuit or a run owned by another Dashboard process is skipped, which can temporarily leave more than five unpinned historical runs. I/O and access failures are logged and do not prevent Dashboard startup.
+
+## Database lifecycle
+
+All modes use the same SQLite repositories. `None` changes only the directory lifetime.
+
+The Dashboard uses the `Microsoft.Data.Sqlite.Core` package and explicitly references `SQLitePCLRaw.bundle_e_sqlite3` so the native SQLite runtime can be updated independently from the managed provider.
+
+The current schema version is stored as exactly one row in `dashboard_schema`. Ordered embedded scripts under `ServiceClient/DatabaseSchema` initialize the schema in one transaction. Schema creation enables:
+
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+```
+
+WAL lets readers continue while the writer commits. `synchronous=NORMAL` preserves database consistency while allowing a power loss to discard the newest transactions, which is an acceptable tradeoff for development telemetry.
+
+There are no schema migrations. Behavior on incompatibility depends on the mode:
+
+- `None` always starts with a new temporary database.
+- `Run` creates a new database for each process and ignores historical runs whose metadata schema version is incompatible.
+- `Resume` deletes the database, WAL, and shared-memory files and creates a new database only after reading a schema version that is incompatible. Failures while probing compatibility are surfaced and leave the existing files in place.
+- Opening a selected historical run validates that its database schema matches its metadata and fails the switch if it does not.
+
+## Data model
+
+The schema is normalized and uses SQLite `STRICT` tables, foreign keys, cascade deletion, and query-specific indexes. OTLP payloads are not stored as opaque JSON or protobuf blobs.
+
+### Resources and console logs
+
+`dashboard_resources` stores the latest snapshot for each resource replica. Child tables preserve ordered environment variables, URLs, volumes, health reports, relationships, properties, commands, command inputs, input options, and validation errors.
+
+`console_logs` stores resource name, line number, content, and whether the line came from standard error. An index supports ordered retrieval by resource.
+
+### Shared telemetry identity
+
+`telemetry_resources` identifies a resource and optional service instance and records which signal types it has produced. Resource views preserve the resource attributes associated with an individual telemetry item.
+
+`telemetry_scopes` and `telemetry_scope_attributes` normalize instrumentation scope data shared by logs, spans, and metrics. Scope identity intentionally uses only the scope name; the version and attributes from the first observed scope are retained.
+
+### Structured logs
+
+`telemetry_logs` stores resource and scope references, timestamp, severity, message, trace and span correlation, flags, original format, and event name. `telemetry_log_attributes` stores ordered key/value attributes.
+
+Indexes support global and per-resource time ordering, trace and span correlation, and case-insensitive attribute filtering.
+
+### Traces and spans
+
+`telemetry_traces` stores query-oriented summaries, including first and last timestamps, duration, display name, primary span, error state, and generative-AI state.
+
+`telemetry_spans` stores span identity, parent, resource view, scope, name, kind, timestamps, status, trace state, and resolved uninstrumented peer. Related tables store:
+
+- per-trace resource summaries and ordering;
+- span attributes;
+- events and event attributes; and
+- links and link attributes.
+
+Summary tables and indexes let trace list queries avoid reconstructing every trace. When a late parent or another change invalidates an incremental summary, the repository rebuilds the affected trace data rather than all stored traces.
+
+### Metrics
+
+`telemetry_metric_instruments` identifies instruments by resource, scope, and name and stores type, temporality, monotonicity, unit, and description.
+
+Metric dimensions are normalized into an attribute set and stable non-cryptographic hash. Points store timestamps, point type, repeated-value count, integer or floating-point values, and histogram data. Histogram bucket counts and explicit bounds are compact binary values rather than JSON. Exemplars and their filtered attributes are separate rows correlated to trace and span IDs.
+
+Indexes support instrument lookup, dimension matching, time-window queries, retention, and exemplar lookup.
+
+## Repository behavior
+
+`DashboardDataSourcePool` owns the current writable database and pools selected historical databases across Blazor circuits. `DashboardDataSource` is scoped to a circuit and exposes the resource and telemetry repositories for that circuit's selected run.
+
+```mermaid
+flowchart LR
+    AppHost[AppHost resource stream] --> CurrentResources[Current resource repository]
+    OTLP[OTLP receivers] --> CurrentTelemetry[Current telemetry repository]
+    CurrentResources --> CurrentDB[(Current dashboard.db)]
+    CurrentTelemetry --> CurrentDB
+    RunSelector[Run selector] --> DataSource[DashboardDataSource]
+    DataSource --> CurrentResources
+    DataSource --> CurrentTelemetry
+    DataSource --> HistoricalResources[Historical resource repository]
+    DataSource --> HistoricalTelemetry[Historical telemetry repository]
+    HistoricalResources --> HistoricalDB[(Historical dashboard.db, read-only)]
+    HistoricalTelemetry --> HistoricalDB
+```
+
+Selecting `Current` uses the pool-owned writable repositories. Selecting a historical run:
+
+1. Acquires the run lock so pruning cannot remove it while selected.
+2. Opens the database with `SqliteOpenMode.ReadOnly`.
+3. Validates the schema version.
+4. Reference-counts and shares the database across circuits.
+5. Releases the database and run lock after the last circuit stops using it.
+
+The replacement database and repositories are acquired and validated before the selected data source changes. If acquisition or validation fails, the previous repositories and run lease remain active. Interactive failures are logged without terminating the Blazor circuit, and browser session storage retains the run that remains selected.
+
+The repository interfaces preserve subscriptions and watcher behavior for the live database. Historical repositories are immutable snapshots: write methods reject calls, and pages do not register for incoming telemetry updates.
+
+## Write and query strategy
+
+SQLite has one writer. `DashboardSqliteDatabase.WriteLock` serializes resource and telemetry writes before they begin transactions. Add operations batch rows and commands, perform related writes in a transaction, and roll back the batch on failure.
+
+Connection strings enable foreign keys and pooling and use a five-second default timeout. Repository-level caches avoid repeated lookups for stable resource views, scopes, telemetry resources, instruments, and dimensions. Writes invalidate the affected query caches.
+
+The repositories push work into SQL for:
+
+- text and structured-field filtering;
+- attribute key and value lookup;
+- stable paging and ordering;
+- trace summaries and resource aggregation;
+- metric dimension and time-window aggregation; and
+- count- and time-based retention cleanup.
+
+This keeps memory proportional to the requested page or active ingestion batch rather than the complete run history.
+
+## Data limits and performance
+
+The Dashboard applies these default ingestion limits:
+
+| Configuration key | Default | Scope and behavior |
+|-------------------|---------|--------------------|
+| `Dashboard:TelemetryLimits:MaxLogCount` | 10,000 | Structured logs per database |
+| `Dashboard:TelemetryLimits:MaxTraceCount` | 10,000 | Traces per database |
+| `Dashboard:TelemetryLimits:MaxMetricsCount` | 50,000 | Metric points per dimension |
+| `Dashboard:TelemetryLimits:MaxAttributeCount` | 128 | Attributes per telemetry item |
+| `Dashboard:TelemetryLimits:MaxAttributeLength` | Unlimited | Attribute value length |
+| `Dashboard:TelemetryLimits:MaxSpanEventCount` | Unlimited | Events per span |
+| `Dashboard:TelemetryLimits:MaxResourceCount` | 10,000 | Distinct OTLP resources |
+
+The oldest logs, traces, and metric points are removed when their limits are exceeded. Fixed limits of 10,000 also apply to resource views per resource, scopes per database, instruments per resource, and dimensions per instrument; additional identities are rejected.
+
+Console logs are persisted only after their stream is viewed or exported. The frontend keeps up to `Dashboard:Frontend:MaxConsoleLogCount` entries in memory, which defaults to 10,000, but persisted console logs are unbounded. Historical runs can therefore omit uncaptured logs or contain many captured logs.
+
+### Database file size
+
+The Dashboard does not limit SQLite file size. `Run` retains ten databases but does not limit each database; long-running `Resume` databases require monitoring. Deleted rows leave reusable pages but do not shrink `dashboard.db` because the Dashboard does not run `VACUUM`. WAL files also use disk space. Telemetry limits are not disk quotas because attributes, span events, console logs, and metric cardinality can increase storage.
+
+### UI performance
+
+Views are virtualized; logs and traces use paged SQL, and metrics query selected dimensions and time ranges. Larger limits, broad searches, high cardinality, large traces, and long console streams increase I/O, memory use, and UI latency. Keep the defaults unless more history is required. For `Resume`, set finite attribute and event limits, control metric cardinality, and monitor disk space and query latency.
+
+## Dashboard experience
+
+`Run` mode adds a selector to the Dashboard header. `Current` is visually distinct from completed runs, which are labeled by their local start time. Switching the selector replaces the repositories used by resource, console log, structured log, trace, and metric pages without reloading the browser.
+
+Historical runs are read-only throughout the UI:
+
+- resource commands and parameter mutations are disabled;
+- clearing telemetry is disabled;
+- pausing incoming data is disabled;
+- telemetry import is disabled; and
+- metric charts and tables use the latest stored metric timestamp as their fixed end time.
+
+The repository and database layers also enforce read-only access so UI checks are not the only protection.
+
+## Security and privacy
+
+Network ingestion, endpoint authentication and authorization, transport security, and data-read APIs are existing Dashboard concerns and are outside the scope of this persistence specification. See [Dashboard configuration: OTLP authentication](https://aspire.dev/dashboard/configuration#otlp-authentication) and [Security considerations: Secure telemetry endpoint](https://aspire.dev/dashboard/security-considerations#secure-telemetry-endpoint).
+
+Persisted Dashboard data can include sensitive application-supplied content, including resource properties, environment values, console output, structured log bodies and attributes, trace attributes and events, metric dimensions, and exemplars.
+
+Resource property values marked as sensitive are persisted without redaction or encryption. The sensitivity marker is also persisted, so these values continue to be masked when displayed in the UI for current and historical runs. UI masking does not protect values read directly from the database, WAL files, backups, or copies.
+
+When `ASPIRE_HOME` is not configured, it defaults to the `.aspire` directory in the current user's profile, such as `%USERPROFILE%\.aspire` on Windows or `$HOME/.aspire` on Unix-like systems. Persisted Dashboard data is stored under `<ASPIRE_HOME>/dashboard/<application-directory>` by default. This places the content in the user's directory on the machine.
+
+The database has no independent authorization or encryption layer. Its security boundary is the local file system. The Dashboard does not set or validate specific access control lists or Unix file modes. Before enabling persistence, the operator must ensure that `ASPIRE_HOME` or `Dashboard:Data:Directory` and all files beneath it have restrictive access controls that prevent unauthorized local users from reading or modifying persisted data. This requirement applies even when the directory is inherited from the user's profile, and equivalent protection is required for backups and copies.
+
+SQL values are parameterized. Schema SQL is compiled into the Dashboard assembly. Historical databases are opened with SQLite read-only mode in addition to application-level mutation checks.
+
+## Failure behavior
+
+- A lock collision fails startup instead of allowing two writers to share a run database.
+- An invalid persistence mode fails Dashboard option validation and lists the accepted values.
+- Incomplete or unreadable historical metadata is ignored during discovery.
+- A historical run that disappears between discovery and selection leaves the previous run selected.
+- A historical schema mismatch fails that run switch without releasing the previous data source.
+- An interactive run-switch failure is logged and does not terminate the Blazor circuit.
+- Failure to prune an expired or abandoned directory is logged and does not fail startup.
+- A write attempted through a historical repository throws `InvalidOperationException`.
+
+## Files of interest
+
+| Concern | File |
+|---------|------|
+| Persistence options | `src/Aspire.Dashboard/Configuration/DashboardOptions.cs` |
+| AppHost defaults and environment | `src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs` |
+| Standalone CLI options | `src/Aspire.Cli/Commands/DashboardRunCommand.cs` |
+| Run layout, locking, discovery, and pruning | `src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs` |
+| Per-circuit run selection | `src/Aspire.Dashboard/ServiceClient/DashboardDataSource.cs` |
+| Historical database pooling | `src/Aspire.Dashboard/ServiceClient/DashboardDataSourcePool.cs` |
+| SQLite initialization and compatibility | `src/Aspire.Dashboard/ServiceClient/DashboardSqliteDatabase.cs` |
+| Resource repository | `src/Aspire.Dashboard/ServiceClient/SqliteResourceRepository.cs` |
+| Telemetry repository | `src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.cs` |
+| Versioned schema | `src/Aspire.Dashboard/ServiceClient/DatabaseSchema/` |
+| Run selector | `src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor` |

--- a/playground/Stress/Stress.ApiService/LargeTelemetryGenerationOptions.cs
+++ b/playground/Stress/Stress.ApiService/LargeTelemetryGenerationOptions.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Stress.ApiService;
+
+public sealed class LargeTelemetryGenerationOptions
+{
+    public bool GenerateTraces { get; init; } = true;
+    public int TraceCount { get; init; } = LargeTelemetryGenerator.TraceCount;
+    public int SpansPerTrace { get; init; } = LargeTelemetryGenerator.SpansPerTrace;
+    public bool GenerateLargeTrace { get; init; } = true;
+    public int LargeTraceSpanCount { get; init; } = LargeTelemetryGenerator.LargeTraceSpanCount;
+    public bool GenerateStructuredLogs { get; init; } = true;
+    public int StructuredLogCount { get; init; } = LargeTelemetryGenerator.StructuredLogCount;
+    public bool GenerateConsoleLogs { get; init; } = true;
+    public int ConsoleLogCount { get; init; } = LargeTelemetryGenerator.ConsoleLogCount;
+    public bool GenerateMetrics { get; init; } = true;
+    public int MetricDurationHours { get; init; } = LargeTelemetryGenerator.MetricDurationHours;
+    public int MetricDimensionCount { get; init; } = LargeTelemetryGenerator.MetricDimensionCount;
+
+    public string? GetValidationError()
+    {
+        if (!GenerateTraces && !GenerateLargeTrace && !GenerateStructuredLogs && !GenerateConsoleLogs && !GenerateMetrics)
+        {
+            return "At least one telemetry kind must be enabled.";
+        }
+        if (GenerateTraces && TraceCount <= 0)
+        {
+            return "TraceCount must be positive when trace generation is enabled.";
+        }
+        if (GenerateTraces && SpansPerTrace <= 0)
+        {
+            return "SpansPerTrace must be positive when trace generation is enabled.";
+        }
+        if (GenerateLargeTrace && LargeTraceSpanCount <= 0)
+        {
+            return "LargeTraceSpanCount must be positive when large trace generation is enabled.";
+        }
+        if (GenerateStructuredLogs && StructuredLogCount <= 0)
+        {
+            return "StructuredLogCount must be positive when structured log generation is enabled.";
+        }
+        if (GenerateConsoleLogs && ConsoleLogCount <= 0)
+        {
+            return "ConsoleLogCount must be positive when console log generation is enabled.";
+        }
+        if (GenerateMetrics && MetricDurationHours <= 0)
+        {
+            return "MetricDurationHours must be positive when metric generation is enabled.";
+        }
+        if (GenerateMetrics && MetricDimensionCount <= 0)
+        {
+            return "MetricDimensionCount must be positive when metric generation is enabled.";
+        }
+
+        return null;
+    }
+}

--- a/playground/Stress/Stress.ApiService/LargeTelemetryGenerator.cs
+++ b/playground/Stress/Stress.ApiService/LargeTelemetryGenerator.cs
@@ -1,0 +1,492 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Net.Client;
+using OpenTelemetry.Proto.Collector.Logs.V1;
+using OpenTelemetry.Proto.Collector.Metrics.V1;
+using OpenTelemetry.Proto.Collector.Trace.V1;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Resource.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using OtlpSpan = OpenTelemetry.Proto.Trace.V1.Span;
+
+namespace Stress.ApiService;
+
+public sealed class LargeTelemetryGenerator(ILogger<LargeTelemetryGenerator> logger, IConfiguration configuration)
+{
+    public const int TraceCount = 50_000;
+    public const int SpansPerTrace = 6;
+    public const int LargeTraceSpanCount = 50_000;
+    public const int StructuredLogCount = 100_000;
+    public const int ConsoleLogCount = 100_000;
+    public const int MetricDurationHours = 24;
+    public const int MetricDimensionCount = 5;
+
+    private const int TraceBatchSize = 1_000;
+    private const int LargeTraceBatchSize = 1_000;
+    private const int LogBatchSize = 1_000;
+    private const int MetricSecondsPerBatch = 100;
+    private const int ProgressInterval = 10_000;
+    private static readonly double[] s_histogramValues = [5, 25, 75, 150];
+    private readonly SemaphoreSlim _runLock = new(1, 1);
+
+    public async Task<bool> TryGenerateAsync(LargeTelemetryGenerationOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.GetValidationError() is { } validationError)
+        {
+            throw new ArgumentException(validationError, nameof(options));
+        }
+
+        if (!await _runLock.WaitAsync(0, cancellationToken))
+        {
+            return false;
+        }
+
+        try
+        {
+            var endpoint = configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]
+                ?? throw new InvalidOperationException("OTEL_EXPORTER_OTLP_ENDPOINT is required.");
+            using var channel = GrpcChannel.ForAddress(endpoint);
+            var metadata = CreateMetadata(configuration["OTEL_EXPORTER_OTLP_HEADERS"]);
+
+            if (options.GenerateTraces)
+            {
+                logger.LogInformation("Generating {TraceCount} traces with {SpansPerTrace} spans each.", options.TraceCount, options.SpansPerTrace);
+                var traceClient = new TraceService.TraceServiceClient(channel);
+                await ExportTracesAsync(traceClient, metadata, options.TraceCount, options.SpansPerTrace, cancellationToken);
+            }
+
+            if (options.GenerateLargeTrace)
+            {
+                logger.LogInformation("Generating one trace with {SpanCount} spans.", options.LargeTraceSpanCount);
+                var traceClient = new TraceService.TraceServiceClient(channel);
+                await ExportLargeTraceAsync(traceClient, metadata, options.LargeTraceSpanCount, cancellationToken);
+            }
+
+            if (options.GenerateStructuredLogs)
+            {
+                logger.LogInformation("Generating {LogCount} structured logs.", options.StructuredLogCount);
+                var logsClient = new LogsService.LogsServiceClient(channel);
+                await ExportStructuredLogsAsync(logsClient, metadata, options.StructuredLogCount, cancellationToken);
+            }
+
+            if (options.GenerateConsoleLogs)
+            {
+                logger.LogInformation("Writing {LogCount} console logs through ILogger.", options.ConsoleLogCount);
+                var nextProgressCount = ProgressInterval;
+                for (var logIndex = 0; logIndex < options.ConsoleLogCount; logIndex++)
+                {
+                    logger.LogInformation("Large console log {LogIndex}.", logIndex + 1);
+                    LogProgress(logIndex + 1, ref nextProgressCount, "console logs");
+                    if ((logIndex + 1) % LogBatchSize == 0)
+                    {
+                        await Task.Yield();
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                }
+            }
+
+            if (options.GenerateMetrics)
+            {
+                logger.LogInformation(
+                    "Generating {DurationHours} hours of counter and histogram data across {DimensionCount} dimensions.",
+                    options.MetricDurationHours,
+                    options.MetricDimensionCount);
+                var metricsClient = new MetricsService.MetricsServiceClient(channel);
+                await ExportMetricsAsync(
+                    metricsClient,
+                    metadata,
+                    options.MetricDurationHours,
+                    options.MetricDimensionCount,
+                    Math.Max(options.TraceCount, 1),
+                    Math.Max(options.SpansPerTrace, 1),
+                    cancellationToken);
+            }
+
+            logger.LogInformation("Large telemetry generation completed.");
+            return true;
+        }
+        finally
+        {
+            _runLock.Release();
+        }
+    }
+
+    private async Task ExportTracesAsync(
+        TraceService.TraceServiceClient client,
+        Metadata metadata,
+        int totalTraceCount,
+        int spansPerTrace,
+        CancellationToken cancellationToken)
+    {
+        var finalTraceTime = DateTime.UtcNow;
+        var nextProgressCount = ProgressInterval;
+        for (var firstTraceIndex = 0; firstTraceIndex < totalTraceCount; firstTraceIndex += TraceBatchSize)
+        {
+            var scopeSpans = CreateScopeSpans("LargeTelemetry.ManyTraces");
+            var traceCount = Math.Min(TraceBatchSize, totalTraceCount - firstTraceIndex);
+            for (var traceOffset = 0; traceOffset < traceCount; traceOffset++)
+            {
+                var traceIndex = firstTraceIndex + traceOffset;
+                var traceId = CreateTraceId(discriminator: 1, traceIndex + 1);
+                var traceStart = finalTraceTime.AddMilliseconds(traceIndex - totalTraceCount);
+                for (var spanIndex = 0; spanIndex < spansPerTrace; spanIndex++)
+                {
+                    var isRoot = spanIndex == 0;
+                    scopeSpans.Spans.Add(CreateSpan(
+                        traceId,
+                        CreateSpanId(spanIndex + 1),
+                        isRoot ? ByteString.Empty : CreateSpanId(1),
+                        $"GET /stress/page/{spanIndex + 1}",
+                        traceStart.AddMilliseconds(spanIndex),
+                        isRoot ? traceStart.AddMilliseconds(spansPerTrace) : traceStart.AddMilliseconds(spanIndex + 1)));
+                }
+            }
+
+            await ExportTraceBatchAsync(client, metadata, scopeSpans, cancellationToken);
+            LogProgress(firstTraceIndex + traceCount, ref nextProgressCount, "traces");
+        }
+    }
+
+    private async Task ExportLargeTraceAsync(
+        TraceService.TraceServiceClient client,
+        Metadata metadata,
+        int totalSpanCount,
+        CancellationToken cancellationToken)
+    {
+        var traceId = CreateTraceId(discriminator: 2, value: 1);
+        var traceStart = DateTime.UtcNow.AddMinutes(-1);
+        var nextProgressCount = ProgressInterval;
+        for (var firstSpanIndex = 0; firstSpanIndex < totalSpanCount; firstSpanIndex += LargeTraceBatchSize)
+        {
+            var scopeSpans = CreateScopeSpans("LargeTelemetry.LargeTrace");
+            var spanCount = Math.Min(LargeTraceBatchSize, totalSpanCount - firstSpanIndex);
+            for (var spanOffset = 0; spanOffset < spanCount; spanOffset++)
+            {
+                var spanIndex = firstSpanIndex + spanOffset;
+                var isRoot = spanIndex == 0;
+                scopeSpans.Spans.Add(CreateSpan(
+                    traceId,
+                    CreateSpanId(spanIndex + 1),
+                    isRoot ? ByteString.Empty : CreateSpanId(1),
+                    $"large-trace-span-{spanIndex + 1}",
+                    traceStart.AddTicks(spanIndex * 10L),
+                        isRoot ? traceStart.AddTicks(totalSpanCount * 10L) : traceStart.AddTicks((spanIndex + 1L) * 10L)));
+            }
+
+            await ExportTraceBatchAsync(client, metadata, scopeSpans, cancellationToken);
+            LogProgress(firstSpanIndex + spanCount, ref nextProgressCount, "large trace spans");
+        }
+    }
+
+    private static async Task ExportTraceBatchAsync(
+        TraceService.TraceServiceClient client,
+        Metadata metadata,
+        ScopeSpans scopeSpans,
+        CancellationToken cancellationToken)
+    {
+        // Export requests use the OTLP shape ResourceSpans -> ScopeSpans -> Span. Keeping each request
+        // below 6,000 spans avoids large gRPC messages while allowing one trace to cross request boundaries.
+        var request = new ExportTraceServiceRequest
+        {
+            ResourceSpans =
+            {
+                new ResourceSpans
+                {
+                    Resource = CreateResource("large-telemetry-traces"),
+                    ScopeSpans = { scopeSpans }
+                }
+            }
+        };
+        var response = await client.ExportAsync(request, headers: metadata, cancellationToken: cancellationToken);
+        if (response.PartialSuccess is { RejectedSpans: > 0 } partialSuccess)
+        {
+            throw new InvalidOperationException($"Dashboard rejected {partialSuccess.RejectedSpans} spans: {partialSuccess.ErrorMessage}");
+        }
+    }
+
+    private async Task ExportStructuredLogsAsync(
+        LogsService.LogsServiceClient client,
+        Metadata metadata,
+        int totalLogCount,
+        CancellationToken cancellationToken)
+    {
+        var finalLogTime = DateTime.UtcNow;
+        var nextProgressCount = ProgressInterval;
+        for (var firstLogIndex = 0; firstLogIndex < totalLogCount; firstLogIndex += LogBatchSize)
+        {
+            var scopeLogs = new ScopeLogs
+            {
+                Scope = new InstrumentationScope { Name = "LargeTelemetry.StructuredLogs" }
+            };
+            var logCount = Math.Min(LogBatchSize, totalLogCount - firstLogIndex);
+            for (var logOffset = 0; logOffset < logCount; logOffset++)
+            {
+                var logIndex = firstLogIndex + logOffset;
+                var timestamp = DateTimeToUnixNanoseconds(finalLogTime.AddMilliseconds(logIndex - totalLogCount));
+                scopeLogs.LogRecords.Add(new LogRecord
+                {
+                    TimeUnixNano = timestamp,
+                    ObservedTimeUnixNano = timestamp,
+                    SeverityNumber = SeverityNumber.Info,
+                    SeverityText = "Information",
+                    Body = new AnyValue { StringValue = $"Large structured log {logIndex + 1}." },
+                    Attributes =
+                    {
+                        new KeyValue { Key = "{OriginalFormat}", Value = new AnyValue { StringValue = "Large structured log {LogIndex}." } },
+                        new KeyValue { Key = "LogIndex", Value = new AnyValue { IntValue = logIndex + 1 } }
+                    }
+                });
+            }
+
+            // Log batches use the OTLP shape ResourceLogs -> ScopeLogs -> LogRecord.
+            var request = new ExportLogsServiceRequest
+            {
+                ResourceLogs =
+                {
+                    new ResourceLogs
+                    {
+                        Resource = CreateResource("large-telemetry-structured-logs"),
+                        ScopeLogs = { scopeLogs }
+                    }
+                }
+            };
+            var response = await client.ExportAsync(request, headers: metadata, cancellationToken: cancellationToken);
+            if (response.PartialSuccess is { RejectedLogRecords: > 0 } partialSuccess)
+            {
+                throw new InvalidOperationException($"Dashboard rejected {partialSuccess.RejectedLogRecords} logs: {partialSuccess.ErrorMessage}");
+            }
+
+            LogProgress(firstLogIndex + logCount, ref nextProgressCount, "structured logs");
+        }
+    }
+
+    private async Task ExportMetricsAsync(
+        MetricsService.MetricsServiceClient client,
+        Metadata metadata,
+        int durationHours,
+        int dimensionCount,
+        int exemplarTraceCount,
+        int exemplarSpansPerTrace,
+        CancellationToken cancellationToken)
+    {
+        var durationSeconds = checked(durationHours * 60 * 60);
+        var startTime = DateTime.UtcNow.AddSeconds(-durationSeconds);
+        var addedMetricCount = 0L;
+        var nextProgressCount = ProgressInterval;
+        for (var firstSecond = 0; firstSecond < durationSeconds; firstSecond += MetricSecondsPerBatch)
+        {
+            var counter = new Metric
+            {
+                Name = "large.telemetry.counter",
+                Description = "One-second counter data.",
+                Unit = "requests",
+                Sum = new Sum
+                {
+                    AggregationTemporality = AggregationTemporality.Cumulative,
+                    IsMonotonic = true
+                }
+            };
+            var histogram = new Metric
+            {
+                Name = "large.telemetry.histogram",
+                Description = "One-second histogram data with exemplars.",
+                Unit = "ms",
+                Histogram = new Histogram
+                {
+                    AggregationTemporality = AggregationTemporality.Cumulative
+                }
+            };
+
+            var secondCount = Math.Min(MetricSecondsPerBatch, durationSeconds - firstSecond);
+            for (var secondOffset = 0; secondOffset < secondCount; secondOffset++)
+            {
+                var secondIndex = firstSecond + secondOffset;
+                var pointTime = startTime.AddSeconds(secondIndex + 1L);
+                var timestamp = DateTimeToUnixNanoseconds(pointTime);
+                for (var dimensionIndex = 0; dimensionIndex < dimensionCount; dimensionIndex++)
+                {
+                    var dimension = new KeyValue
+                    {
+                        Key = "stress.dimension",
+                        Value = new AnyValue { StringValue = dimensionIndex.ToString(CultureInfo.InvariantCulture) }
+                    };
+                    counter.Sum.DataPoints.Add(new NumberDataPoint
+                    {
+                        StartTimeUnixNano = DateTimeToUnixNanoseconds(startTime),
+                        TimeUnixNano = timestamp,
+                        AsInt = (long)(secondIndex + 1) * (dimensionIndex + 1),
+                        Attributes = { dimension }
+                    });
+
+                    var observationIndex = secondIndex % s_histogramValues.Length;
+                    var histogramPoint = new HistogramDataPoint
+                    {
+                        StartTimeUnixNano = DateTimeToUnixNanoseconds(startTime),
+                        TimeUnixNano = timestamp,
+                        Count = (ulong)secondIndex + 1,
+                        Sum = CalculateHistogramSum(secondIndex + 1),
+                        ExplicitBounds = { 10, 50, 100 },
+                        Attributes = { dimension },
+                        Exemplars =
+                        {
+                            new Exemplar
+                            {
+                                TimeUnixNano = timestamp,
+                                AsDouble = s_histogramValues[observationIndex],
+                                TraceId = CreateTraceId(discriminator: 1, (secondIndex % exemplarTraceCount) + 1),
+                                SpanId = CreateSpanId((dimensionIndex % exemplarSpansPerTrace) + 1)
+                            }
+                        }
+                    };
+                    histogramPoint.BucketCounts.Add(CalculateBucketCount(secondIndex + 1, 0));
+                    histogramPoint.BucketCounts.Add(CalculateBucketCount(secondIndex + 1, 1));
+                    histogramPoint.BucketCounts.Add(CalculateBucketCount(secondIndex + 1, 2));
+                    histogramPoint.BucketCounts.Add(CalculateBucketCount(secondIndex + 1, 3));
+                    histogram.Histogram.DataPoints.Add(histogramPoint);
+                }
+            }
+
+            // Metric batches use ResourceMetrics -> ScopeMetrics -> Metric and contain 100 seconds at a
+            // time. At five dimensions and two instruments this caps each request at 1,000 data points.
+            var request = new ExportMetricsServiceRequest
+            {
+                ResourceMetrics =
+                {
+                    new ResourceMetrics
+                    {
+                        Resource = CreateResource("large-telemetry-metrics"),
+                        ScopeMetrics =
+                        {
+                            new ScopeMetrics
+                            {
+                                Scope = new InstrumentationScope { Name = "LargeTelemetry.Metrics" },
+                                Metrics = { counter, histogram }
+                            }
+                        }
+                    }
+                }
+            };
+            var response = await client.ExportAsync(request, headers: metadata, cancellationToken: cancellationToken);
+            if (response.PartialSuccess is { RejectedDataPoints: > 0 } partialSuccess)
+            {
+                throw new InvalidOperationException($"Dashboard rejected {partialSuccess.RejectedDataPoints} metric points: {partialSuccess.ErrorMessage}");
+            }
+
+            addedMetricCount += (long)secondCount * dimensionCount * 2;
+            LogProgress(addedMetricCount, ref nextProgressCount, "metric data points");
+        }
+    }
+
+    private void LogProgress(long addedCount, ref int nextProgressCount, string telemetryKind)
+    {
+        while (addedCount >= nextProgressCount)
+        {
+            logger.LogInformation("{TelemetryCount} {TelemetryKind} added.", nextProgressCount, telemetryKind);
+            nextProgressCount += ProgressInterval;
+        }
+    }
+
+    private static ScopeSpans CreateScopeSpans(string name) => new()
+    {
+        Scope = new InstrumentationScope { Name = name }
+    };
+
+    private static OtlpSpan CreateSpan(
+        ByteString traceId,
+        ByteString spanId,
+        ByteString parentSpanId,
+        string name,
+        DateTime startTime,
+        DateTime endTime) => new()
+        {
+            TraceId = traceId,
+            SpanId = spanId,
+            ParentSpanId = parentSpanId,
+            Name = name,
+            Kind = OtlpSpan.Types.SpanKind.Server,
+            StartTimeUnixNano = DateTimeToUnixNanoseconds(startTime),
+            EndTimeUnixNano = DateTimeToUnixNanoseconds(endTime),
+            Status = new OpenTelemetry.Proto.Trace.V1.Status
+            {
+                Code = OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode.Ok
+            }
+        };
+
+    private static Resource CreateResource(string serviceName) => new()
+    {
+        Attributes =
+        {
+            new KeyValue { Key = "service.name", Value = new AnyValue { StringValue = serviceName } },
+            new KeyValue { Key = "service.instance.id", Value = new AnyValue { StringValue = "large-telemetry-1" } }
+        }
+    };
+
+    private static Metadata CreateMetadata(string? headers)
+    {
+        var metadata = new Metadata();
+        if (string.IsNullOrWhiteSpace(headers))
+        {
+            return metadata;
+        }
+
+        // OTEL_EXPORTER_OTLP_HEADERS uses comma-separated key=value pairs. Values may contain '=' and
+        // may be URL encoded, so split each pair only at its first '=' delimiter.
+        foreach (var pair in headers.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var separatorIndex = pair.IndexOf('=');
+            if (separatorIndex <= 0)
+            {
+                continue;
+            }
+
+            metadata.Add(
+                pair[..separatorIndex].Trim().ToLowerInvariant(),
+                Uri.UnescapeDataString(pair[(separatorIndex + 1)..].Trim()));
+        }
+        return metadata;
+    }
+
+    private static ByteString CreateTraceId(byte discriminator, int value)
+    {
+        var id = new byte[16];
+        id[0] = discriminator;
+        BinaryPrimitives.WriteInt32BigEndian(id.AsSpan(12), value);
+        return ByteString.CopyFrom(id);
+    }
+
+    private static ByteString CreateSpanId(int value)
+    {
+        var id = new byte[8];
+        BinaryPrimitives.WriteInt32BigEndian(id.AsSpan(4), value);
+        return ByteString.CopyFrom(id);
+    }
+
+    private static ulong CalculateBucketCount(int sampleCount, int observationIndex)
+    {
+        var completeCycles = sampleCount / s_histogramValues.Length;
+        var remainder = sampleCount % s_histogramValues.Length;
+        return (ulong)(completeCycles + (observationIndex < remainder ? 1 : 0));
+    }
+
+    private static double CalculateHistogramSum(int sampleCount)
+    {
+        var completeCycles = sampleCount / s_histogramValues.Length;
+        var remainder = sampleCount % s_histogramValues.Length;
+        var cycleSum = s_histogramValues.Sum();
+        return completeCycles * cycleSum + s_histogramValues.Take(remainder).Sum();
+    }
+
+    private static ulong DateTimeToUnixNanoseconds(DateTime dateTime)
+    {
+        var timeSinceEpoch = dateTime.ToUniversalTime() - DateTime.UnixEpoch;
+        return (ulong)timeSinceEpoch.Ticks * 100;
+    }
+}

--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddOpenTelemetry()
 
     });
 builder.Services.AddSingleton<TestMetrics>();
+builder.Services.AddSingleton<LargeTelemetryGenerator>();
 
 var app = builder.Build();
 
@@ -42,6 +43,19 @@ app.Lifetime.ApplicationStarted.Register(() =>
 });
 
 app.MapGet("/", () => "Hello world");
+
+app.MapPost("/large-telemetry", async (LargeTelemetryGenerationOptions options, LargeTelemetryGenerator generator, CancellationToken cancellationToken) =>
+{
+  if (options.GetValidationError() is { } validationError)
+  {
+    return Results.BadRequest(validationError);
+  }
+
+  var generated = await generator.TryGenerateAsync(options, cancellationToken);
+  return generated
+    ? Results.Ok()
+    : Results.Conflict("Large telemetry generation is already running.");
+});
 
 app.MapGet("/write-console", () =>
 {

--- a/playground/Stress/Stress.ApiService/Stress.ApiService.csproj
+++ b/playground/Stress/Stress.ApiService/Stress.ApiService.csproj
@@ -16,4 +16,16 @@
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Net.ClientFactory" />
+    <PackageReference Include="Grpc.Tools" VersionOverride="2.68.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\Stress.TelemetryService\Otlp\**\*.proto"
+              ProtoRoot="..\Stress.TelemetryService\Otlp"
+              Link="Otlp\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
 </Project>

--- a/playground/Stress/Stress.AppHost/AppHost.cs
+++ b/playground/Stress/Stress.AppHost/AppHost.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 var builder = DistributedApplication.CreateBuilder(args);
 builder.Services.AddHttpClient();
+builder.Services.AddHttpClient("large-telemetry", client => client.Timeout = Timeout.InfiniteTimeSpan);
 builder.Services.AddHealthChecks().AddAsyncCheck("health-test", async (ct) =>
 {
     await Task.Delay(5_000, ct);
@@ -99,7 +100,28 @@ builder.AddCommandResources(serviceBuilder, telemetryBuilder);
 // dashboard launch experience, Refer to Directory.Build.props for the path to
 // the dashboard binary (defaults to the Aspire.Dashboard bin output in the
 // artifacts dir).
-builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+var dashboardBuilder = builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+if (string.Equals(builder.Configuration["STRESS_REMOVE_DASHBOARD_LIMITS"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+{
+    var unlimited = int.MaxValue.ToString(CultureInfo.InvariantCulture);
+    dashboardBuilder
+        .WithEnvironment("Dashboard__TelemetryLimits__MaxLogCount", unlimited)
+        .WithEnvironment("Dashboard__TelemetryLimits__MaxTraceCount", unlimited)
+        .WithEnvironment("Dashboard__TelemetryLimits__MaxMetricsCount", unlimited)
+        .WithEnvironment("Dashboard__TelemetryLimits__MaxAttributeCount", unlimited)
+        .WithEnvironment("Dashboard__TelemetryLimits__MaxAttributeLength", unlimited)
+        .WithEnvironment("Dashboard__TelemetryLimits__MaxSpanEventCount", unlimited)
+        .WithEnvironment("Dashboard__TelemetryLimits__MaxResourceCount", unlimited);
+}
+if (builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] is { Length: > 0 } dashboardOtlpEndpoint)
+{
+    // The AppHost normally points every project at its own dashboard. Preserve an explicitly configured
+    // external endpoint for dashboard self-telemetry so its activities can be inspected separately.
+    dashboardBuilder
+        .WithEnvironment("OTEL_EXPORTER_OTLP_ENDPOINT", dashboardOtlpEndpoint)
+        .WithEnvironment("OTEL_EXPORTER_OTLP_PROTOCOL", builder.Configuration["OTEL_EXPORTER_OTLP_PROTOCOL"] ?? "grpc")
+        .WithEnvironment("OTEL_EXPORTER_OTLP_HEADERS", builder.Configuration["OTEL_EXPORTER_OTLP_HEADERS"] ?? string.Empty);
+}
 #endif
 
 builder.AddExecutable("executableWithSingleArg", "dotnet", Environment.CurrentDirectory, "--version");

--- a/playground/Stress/Stress.AppHost/CommandResources.cs
+++ b/playground/Stress/Stress.AppHost/CommandResources.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +10,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 internal static class CommandResources
 {
+    // AppHost project references identify orchestrated projects without exposing their runtime assemblies.
+    // Keep these command defaults aligned with LargeTelemetryGenerator in Stress.ApiService.
+    private const int DefaultTraceCount = 50_000;
+    private const int DefaultSpansPerTrace = 6;
+    private const int DefaultLargeTraceSpanCount = 50_000;
+    private const int DefaultStructuredLogCount = 100_000;
+    private const int DefaultConsoleLogCount = 100_000;
+    private const int DefaultMetricDurationHours = 24;
+    private const int DefaultMetricDimensionCount = 5;
+
     private static string NodeExecutablePath { get; } = Environment.GetEnvironmentVariable("NODE") ?? "node";
     private static string DotnetExecutablePath { get; } = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet";
 
@@ -889,13 +901,9 @@ internal static class CommandResources
             });
 
         serviceBuilder.WithHttpCommand("/write-console", "Write to console", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
-        serviceBuilder.WithHttpCommand("/write-console-large", "Write to console large", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
         serviceBuilder.WithHttpCommand("/increment-counter", "Increment counter", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
         serviceBuilder.WithHttpCommand("/big-trace", "Big trace", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
-        serviceBuilder.WithHttpCommand("/trace-limit", "Trace limit", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
         serviceBuilder.WithHttpCommand("/log-message", "Log message", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
-        serviceBuilder.WithHttpCommand("/log-message-limit", "Log message limit", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
-        serviceBuilder.WithHttpCommand("/log-message-limit-large", "Log message limit large", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
         serviceBuilder.WithHttpCommand("/http-command-auto-result", "HTTP command auto result", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning", ResultMode = HttpCommandResultMode.Auto, Description = "Run an HTTP command and infer the result format from the response content type" });
         serviceBuilder.WithHttpCommand("/http-command-json-result", "HTTP command JSON result", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning", ResultMode = HttpCommandResultMode.Json, Description = "Run an HTTP command and flow the JSON response back to the caller" });
         serviceBuilder.WithHttpCommand("/http-command-text-result", "HTTP command text result", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning", ResultMode = HttpCommandResultMode.Text, Description = "Run an HTTP command and flow the plain-text response back to the caller" });
@@ -908,7 +916,175 @@ internal static class CommandResources
         serviceBuilder.WithHttpCommand("/genai-trace-display-error", "Gen AI trace display error", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
         serviceBuilder.WithHttpCommand("/genai-evaluations", "Gen AI evaluations", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
         serviceBuilder.WithHttpCommand("/log-formatting", "Log formatting", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
-        serviceBuilder.WithHttpCommand("/big-nested-trace", "Big nested trace", commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+
+        var largeTelemetryCommands = builder.AddHttpCommandGroup("large-telemetry-commands", serviceBuilder.Resource);
+        largeTelemetryCommands.WithHttpCommand(
+            "/write-console-large",
+            "Write to console large",
+            endpointSelector: () => serviceBuilder.GetEndpoint("http"),
+            commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+        largeTelemetryCommands.WithHttpCommand(
+            "/trace-limit",
+            "Trace limit",
+            endpointSelector: () => serviceBuilder.GetEndpoint("http"),
+            commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+        largeTelemetryCommands.WithHttpCommand(
+            "/log-message-limit",
+            "Log message limit",
+            endpointSelector: () => serviceBuilder.GetEndpoint("http"),
+            commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+        largeTelemetryCommands.WithHttpCommand(
+            "/log-message-limit-large",
+            "Log message limit large",
+            endpointSelector: () => serviceBuilder.GetEndpoint("http"),
+            commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+        largeTelemetryCommands.WithHttpCommand(
+            "/big-nested-trace",
+            "Big nested trace",
+            endpointSelector: () => serviceBuilder.GetEndpoint("http"),
+            commandOptions: new() { Method = HttpMethod.Get, IconName = "ContentViewGalleryLightning" });
+        largeTelemetryCommands.WithHttpCommand(
+            "/large-telemetry",
+            "Generate large telemetry data",
+            endpointSelector: () => serviceBuilder.GetEndpoint("http"),
+            commandOptions: new()
+        {
+            Method = HttpMethod.Post,
+            HttpClientName = "large-telemetry",
+            IconName = "DatabaseLightning",
+            ConfirmationMessage = "Generate a large telemetry workload. This operation can take several minutes and consume significant disk space.",
+            ValidateArguments = context =>
+            {
+                var options = ReadLargeTelemetryGenerationOptions(context.Inputs);
+                if (!options.GenerateTraces && !options.GenerateLargeTrace && !options.GenerateStructuredLogs && !options.GenerateConsoleLogs && !options.GenerateMetrics)
+                {
+                    context.AddValidationError("generateTraces", "At least one telemetry kind must be enabled.");
+                }
+
+                AddPositiveCountValidation(context, options.GenerateTraces, "traceCount");
+                AddPositiveCountValidation(context, options.GenerateTraces, "spansPerTrace");
+                AddPositiveCountValidation(context, options.GenerateLargeTrace, "largeTraceSpanCount");
+                AddPositiveCountValidation(context, options.GenerateStructuredLogs, "structuredLogCount");
+                AddPositiveCountValidation(context, options.GenerateConsoleLogs, "consoleLogCount");
+                AddPositiveCountValidation(context, options.GenerateMetrics, "metricDurationHours");
+                AddPositiveCountValidation(context, options.GenerateMetrics, "metricDimensionCount");
+                return Task.CompletedTask;
+            },
+            PrepareRequest = context =>
+            {
+                context.Request.Content = JsonContent.Create(ReadLargeTelemetryGenerationOptions(context.Arguments));
+                return Task.CompletedTask;
+            },
+            Arguments =
+            [
+                new InteractionInput
+                {
+                    Name = "generateTraces",
+                    Label = "Generate traces",
+                    Description = "Generate many traces with a configurable number of spans.",
+                    InputType = InputType.Boolean,
+                    Required = true,
+                    Value = "true"
+                },
+                new InteractionInput
+                {
+                    Name = "traceCount",
+                    Label = "Trace count",
+                    InputType = InputType.Number,
+                    Required = true,
+                    Value = DefaultTraceCount.ToString(CultureInfo.InvariantCulture),
+                    DynamicLoading = CreateEnabledWhenTrue("generateTraces")
+                },
+                new InteractionInput
+                {
+                    Name = "spansPerTrace",
+                    Label = "Spans per trace",
+                    InputType = InputType.Number,
+                    Required = true,
+                    Value = DefaultSpansPerTrace.ToString(CultureInfo.InvariantCulture),
+                    DynamicLoading = CreateEnabledWhenTrue("generateTraces")
+                },
+                new InteractionInput
+                {
+                    Name = "generateLargeTrace",
+                    Label = "Generate large trace",
+                    Description = "Generate one trace containing many spans.",
+                    InputType = InputType.Boolean,
+                    Required = true,
+                    Value = "true"
+                },
+                new InteractionInput
+                {
+                    Name = "largeTraceSpanCount",
+                    Label = "Large trace span count",
+                    InputType = InputType.Number,
+                    Required = true,
+                    Value = DefaultLargeTraceSpanCount.ToString(CultureInfo.InvariantCulture),
+                    DynamicLoading = CreateEnabledWhenTrue("generateLargeTrace")
+                },
+                new InteractionInput
+                {
+                    Name = "generateStructuredLogs",
+                    Label = "Generate structured logs",
+                    InputType = InputType.Boolean,
+                    Required = true,
+                    Value = "true"
+                },
+                new InteractionInput
+                {
+                    Name = "structuredLogCount",
+                    Label = "Structured log count",
+                    InputType = InputType.Number,
+                    Required = true,
+                    Value = DefaultStructuredLogCount.ToString(CultureInfo.InvariantCulture),
+                    DynamicLoading = CreateEnabledWhenTrue("generateStructuredLogs")
+                },
+                new InteractionInput
+                {
+                    Name = "generateConsoleLogs",
+                    Label = "Generate console logs",
+                    InputType = InputType.Boolean,
+                    Required = true,
+                    Value = "true"
+                },
+                new InteractionInput
+                {
+                    Name = "consoleLogCount",
+                    Label = "Console log count",
+                    InputType = InputType.Number,
+                    Required = true,
+                    Value = DefaultConsoleLogCount.ToString(CultureInfo.InvariantCulture),
+                    DynamicLoading = CreateEnabledWhenTrue("generateConsoleLogs")
+                },
+                new InteractionInput
+                {
+                    Name = "generateMetrics",
+                    Label = "Generate metrics",
+                    Description = "Generate counter and histogram data points.",
+                    InputType = InputType.Boolean,
+                    Required = true,
+                    Value = "true"
+                },
+                new InteractionInput
+                {
+                    Name = "metricDurationHours",
+                    Label = "Metric duration (hours)",
+                    InputType = InputType.Number,
+                    Required = true,
+                    Value = DefaultMetricDurationHours.ToString(CultureInfo.InvariantCulture),
+                    DynamicLoading = CreateEnabledWhenTrue("generateMetrics")
+                },
+                new InteractionInput
+                {
+                    Name = "metricDimensionCount",
+                    Label = "Metric dimension count",
+                    InputType = InputType.Number,
+                    Required = true,
+                    Value = DefaultMetricDimensionCount.ToString(CultureInfo.InvariantCulture),
+                    DynamicLoading = CreateEnabledWhenTrue("generateMetrics")
+                }
+            ]
+        });
     }
 
     private static void AddTelemetryCommands(IDistributedApplicationBuilder builder, IResourceBuilder<ProjectResource> telemetryBuilder)
@@ -1083,6 +1259,46 @@ internal static class CommandResources
         };
     }
 
+    private static LargeTelemetryCommandOptions ReadLargeTelemetryGenerationOptions(InteractionInputCollection arguments)
+    {
+        return new LargeTelemetryCommandOptions
+        {
+            GenerateTraces = arguments.GetBoolean("generateTraces"),
+            TraceCount = arguments.GetInt32("traceCount"),
+            SpansPerTrace = arguments.GetInt32("spansPerTrace"),
+            GenerateLargeTrace = arguments.GetBoolean("generateLargeTrace"),
+            LargeTraceSpanCount = arguments.GetInt32("largeTraceSpanCount"),
+            GenerateStructuredLogs = arguments.GetBoolean("generateStructuredLogs"),
+            StructuredLogCount = arguments.GetInt32("structuredLogCount"),
+            GenerateConsoleLogs = arguments.GetBoolean("generateConsoleLogs"),
+            ConsoleLogCount = arguments.GetInt32("consoleLogCount"),
+            GenerateMetrics = arguments.GetBoolean("generateMetrics"),
+            MetricDurationHours = arguments.GetInt32("metricDurationHours"),
+            MetricDimensionCount = arguments.GetInt32("metricDimensionCount")
+        };
+    }
+
+    private static void AddPositiveCountValidation(InputsDialogValidationContext context, bool enabled, string inputName)
+    {
+        if (enabled && context.Inputs.GetInt32(inputName) <= 0)
+        {
+            context.AddValidationError(inputName, "The value must be positive when this telemetry kind is enabled.");
+        }
+    }
+
+    private static InputLoadOptions CreateEnabledWhenTrue(string inputName)
+    {
+        return new InputLoadOptions
+        {
+            DependsOnInputs = [inputName],
+            LoadCallback = context =>
+            {
+                context.Input.Disabled = !bool.TryParse(context.AllInputs.GetString(inputName), out var enabled) || !enabled;
+                return Task.CompletedTask;
+            }
+        };
+    }
+
     private static IReadOnlyList<InteractionInput> CreateArgumentStressInputs(int fieldCount)
     {
         var inputs = new List<InteractionInput>
@@ -1223,6 +1439,22 @@ internal static class CommandResources
         public int TimeoutSeconds { get; set; } = 30;
 
         public bool RequireHealthy { get; set; } = true;
+    }
+
+    private sealed class LargeTelemetryCommandOptions
+    {
+        public bool GenerateTraces { get; init; }
+        public int TraceCount { get; init; }
+        public int SpansPerTrace { get; init; }
+        public bool GenerateLargeTrace { get; init; }
+        public int LargeTraceSpanCount { get; init; }
+        public bool GenerateStructuredLogs { get; init; }
+        public int StructuredLogCount { get; init; }
+        public bool GenerateConsoleLogs { get; init; }
+        public int ConsoleLogCount { get; init; }
+        public bool GenerateMetrics { get; init; }
+        public int MetricDurationHours { get; init; }
+        public int MetricDimensionCount { get; init; }
     }
 }
 

--- a/playground/Stress/Stress.AppHost/Properties/launchSettings.json
+++ b/playground/Stress/Stress.AppHost/Properties/launchSettings.json
@@ -12,6 +12,33 @@
         "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
       }
     },
+    "https-unlimited-dashboard": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://Stress.dev.localhost:16309;http://Stress.dev.localhost:16310",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "STRESS_REMOVE_DASHBOARD_LIMITS": "true"
+      }
+    },
+    "https-unlimited-dashboard (profiling)": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://Stress.dev.localhost:16309;http://Stress.dev.localhost:16310",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "STRESS_REMOVE_DASHBOARD_LIMITS": "true",
+        "AppHost__DefaultLaunchProfileName": "https",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/playground/Stress/Stress.AppHost/TestResource.cs
+++ b/playground/Stress/Stress.AppHost/TestResource.cs
@@ -66,6 +66,23 @@ static class TestResourceExtensions
     }
 
     [AspireExportIgnore(Reason = "Stress playground helper; not part of the supported ATS surface.")]
+    public static IResourceBuilder<HttpCommandGroupResource> AddHttpCommandGroup(this IDistributedApplicationBuilder builder, string name, IResource parent)
+    {
+        var rb = builder.AddResource(new HttpCommandGroupResource(name, parent))
+                      .WithInitialState(new()
+                      {
+                          ResourceType = "Command Group",
+                          State = "Running",
+                          Properties = [
+                              new(KnownProperties.Resource.ParentName, parent.Name)
+                          ]
+                      })
+                      .ExcludeFromManifest();
+
+        return rb;
+    }
+
+    [AspireExportIgnore(Reason = "Stress playground helper; not part of the supported ATS surface.")]
     public static IResourceBuilder<NoStatusResource> AddNoStatusResource(this IDistributedApplicationBuilder builder, string name)
     {
         var rb = builder.AddResource(new NoStatusResource(name))
@@ -197,6 +214,11 @@ sealed class TestNestedResource(string name, IResource parent) : Resource(name),
 }
 
 sealed class CommandGroupResource(string name, IResource parent) : Resource(name), IResourceWithParent
+{
+    public IResource Parent { get; } = parent;
+}
+
+sealed class HttpCommandGroupResource(string name, IResource parent) : Resource(name), IResourceWithParent, IResourceWithEndpoints
 {
     public IResource Parent { get; } = parent;
 }

--- a/playground/TestShop/TestShop.AppHost/AppHost.cs
+++ b/playground/TestShop/TestShop.AppHost/AppHost.cs
@@ -136,7 +136,16 @@ yarp.WithConfiguration(builder =>
 // dashboard launch experience. The opt-out and project reference are defined in
 // playground/Directory.Build.targets. The repo-root Directory.Build.props sets the
 // default dashboard binary path to the Aspire.Dashboard output in the artifacts dir.
-builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+var dashboardBuilder = builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+if (builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] is { Length: > 0 } dashboardOtlpEndpoint)
+{
+    // The AppHost normally points every project at its own dashboard. Preserve an explicitly configured
+    // external endpoint for dashboard self-telemetry so its activities can be inspected separately.
+    dashboardBuilder
+        .WithEnvironment("OTEL_EXPORTER_OTLP_ENDPOINT", dashboardOtlpEndpoint)
+        .WithEnvironment("OTEL_EXPORTER_OTLP_PROTOCOL", builder.Configuration["OTEL_EXPORTER_OTLP_PROTOCOL"] ?? "grpc")
+        .WithEnvironment("OTEL_EXPORTER_OTLP_HEADERS", builder.Configuration["OTEL_EXPORTER_OTLP_HEADERS"] ?? string.Empty);
+}
 #endif
 
 builder.Build().Run();

--- a/playground/TestShop/TestShop.AppHost/Properties/launchSettings.json
+++ b/playground/TestShop/TestShop.AppHost/Properties/launchSettings.json
@@ -10,6 +10,19 @@
         "DOTNET_ENVIRONMENT": "Development"
       }
     },
+    "https (profiling)": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://TestShop.dev.localhost:16319;http://TestShop.dev.localhost:16320",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "AppHost__DefaultLaunchProfileName": "https",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
+      }
+    },
     "http": {
       "commandName": "Project",
       "launchBrowser": true,

--- a/src/Aspire.Cli/Aspire.Cli.csproj
+++ b/src/Aspire.Cli/Aspire.Cli.csproj
@@ -135,7 +135,10 @@
     <Compile Include="$(SharedDir)ChannelExtensions.cs" Link="Utils\ChannelExtensions.cs" />
     <Compile Include="$(SharedDir)CommandLineArgsParser.cs" Link="Utils\CommandLineArgsParser.cs" />
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
+    <Compile Include="$(SharedDir)FileLock.cs" Link="Utils\FileLock.cs" />
     <Compile Include="$(SharedDir)FileUploadHelpers.cs" Link="Utils\FileUploadHelpers.cs" />
+    <Compile Include="$(SharedDir)AspireHomeDirectory.cs" Link="Utils\AspireHomeDirectory.cs" />
+    <Compile Include="$(SharedDir)DirectoryHelper.cs" Link="Utils\DirectoryHelper.cs" />
     <Compile Include="$(SharedDir)KnownAspNetCoreConfigNames.cs" Link="Utils\KnownAspNetCoreConfigNames.cs" />
     <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)IntegrationPackageProbeManifest.cs" Link="Utils\IntegrationPackageProbeManifest.cs" />

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/MacOSCertificateManager.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
 using Aspire.Cli.Certificates;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
@@ -540,7 +541,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
         }
         else
         {
-            Directory.CreateDirectory(directoryPath, DirectoryPermissions);
+            DirectoryHelper.CreateWithOwnerOnlyPermissions(directoryPath);
         }
 #pragma warning restore CA1416 // Validate platform compatibility
     }

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using Aspire.Cli;
 using Aspire.Cli.Certificates;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Certificates.Generation;
@@ -577,7 +578,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         }
         else
         {
-            Directory.CreateDirectory(directoryPath, DirectoryPermissions);
+            DirectoryHelper.CreateWithOwnerOnlyPermissions(directoryPath);
         }
 #pragma warning restore CA1416 // Validate platform compatibility
     }

--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -59,6 +59,16 @@ internal sealed class DashboardRunCommand : BaseCommand
         Description = DashboardCommandStrings.AllowAnonymousOptionDescription
     };
 
+    private static readonly Option<string?> s_applicationNameOption = new("--application-name")
+    {
+        Description = DashboardCommandStrings.ApplicationNameOptionDescription
+    };
+
+    private static readonly Option<string?> s_persistenceModeOption = new("--persistence")
+    {
+        Description = DashboardCommandStrings.PersistenceModeOptionDescription
+    };
+
     private static readonly Option<string?> s_configFilePathOption = new("--config-file-path")
     {
         Description = DashboardCommandStrings.ConfigFilePathOptionDescription
@@ -83,6 +93,8 @@ internal sealed class DashboardRunCommand : BaseCommand
         Options.Add(s_otlpGrpcUrlOption);
         Options.Add(s_otlpHttpUrlOption);
         Options.Add(s_allowAnonymousOption);
+        Options.Add(s_applicationNameOption);
+        Options.Add(s_persistenceModeOption);
         Options.Add(s_configFilePathOption);
         TreatUnmatchedTokensAsErrors = false;
     }
@@ -114,7 +126,12 @@ internal sealed class DashboardRunCommand : BaseCommand
         // Tokens and keys are passed via environment variables (not command-line args)
         // to avoid exposing them in process listings (e.g. ps, Task Manager).
         string? browserToken = null;
-        var environmentVariables = new Dictionary<string, string>();
+        var environmentVariables = new Dictionary<string, string>
+        {
+            // Dashboard output is captured in the CLI log instead of written to the console,
+            // so include debug details without increasing console verbosity.
+            ["Logging__LogLevel__Default"] = LogLevel.Debug.ToString()
+        };
         layoutLease?.AddEnvironment(environmentVariables);
         if (!allowAnonymous && !ConfigSettingHasValue(unmatchedTokens, _environment, KnownConfigNames.DashboardUnsecuredAllowAnonymous))
         {
@@ -167,6 +184,8 @@ internal sealed class DashboardRunCommand : BaseCommand
         AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_otlpGrpcUrlOption, KnownConfigNames.DashboardOtlpGrpcEndpointUrl, defaultValue: "http://localhost:4317");
         AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_otlpHttpUrlOption, KnownConfigNames.DashboardOtlpHttpEndpointUrl, defaultValue: "http://localhost:4318");
         AddBoolOptionArg(parseResult, args, unmatchedTokens, environment, s_allowAnonymousOption, KnownConfigNames.DashboardUnsecuredAllowAnonymous);
+        AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_applicationNameOption, DashboardConfigNames.DashboardApplicationName.EnvVarName, defaultValue: null);
+        AddStringOptionArg(parseResult, args, unmatchedTokens, environment, s_persistenceModeOption, DashboardConfigNames.DashboardPersistenceModeName.EnvVarName, defaultValue: null);
 
         // Always enable the telemetry API so CLI commands (e.g. aspire otel) can query the dashboard,
         // unless the user has explicitly configured either the enabled or disabled setting.

--- a/src/Aspire.Cli/NuGet/BundleNuGetService.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetService.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Configuration;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.NuGet;

--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -15,6 +15,7 @@ using Aspire.Cli.Telemetry;
 using Aspire.Cli.Utils;
 using Aspire.Hosting;
 using Aspire.Hosting.Utils;
+using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;

--- a/src/Aspire.Cli/Resources/DashboardCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DashboardCommandStrings.Designer.cs
@@ -129,6 +129,18 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string ApplicationNameOptionDescription {
+            get {
+                return ResourceManager.GetString("ApplicationNameOptionDescription", resourceCulture);
+            }
+        }
+
+        public static string PersistenceModeOptionDescription {
+            get {
+                return ResourceManager.GetString("PersistenceModeOptionDescription", resourceCulture);
+            }
+        }
+
         public static string ConfigFilePathOptionDescription {
             get {
                 return ResourceManager.GetString("ConfigFilePathOptionDescription", resourceCulture);

--- a/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
@@ -159,6 +159,12 @@
   <data name="AllowAnonymousOptionDescription" xml:space="preserve">
     <value>Allow anonymous access to the dashboard</value>
   </data>
+  <data name="ApplicationNameOptionDescription" xml:space="preserve">
+    <value>The application name displayed in the dashboard and used to scope persisted dashboard data</value>
+  </data>
+  <data name="PersistenceModeOptionDescription" xml:space="preserve">
+    <value>The dashboard data persistence mode: None, Run, or Resume</value>
+  </data>
   <data name="ConfigFilePathOptionDescription" xml:space="preserve">
     <value>The path for a JSON configuration file</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="new">Allow anonymous access to the dashboard</target>
         <note />
       </trans-unit>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>The application name displayed in the dashboard and used to scope persisted dashboard data</source>
+        <target state="new">The application name displayed in the dashboard and used to scope persisted dashboard data</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BundleLayoutNotFound">
         <source>The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</source>
         <target state="new">The 'aspire dashboard' command requires the CLI bundle, but no bundle layout was found. The bundle provides the dashboard binary and supporting files. Run 'aspire setup --force' to extract the bundle, or reinstall the Aspire CLI.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="OtlpHttpUrlOptionDescription">
         <source>The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</source>
         <target state="new">The OTLP/HTTP endpoint. This endpoint hosts an OTLP service and receives telemetry using Protobuf over HTTP</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PersistenceModeOptionDescription">
+        <source>The dashboard data persistence mode: None, Run, or Resume</source>
+        <target state="new">The dashboard data persistence mode: None, Run, or Resume</target>
         <note />
       </trans-unit>
       <trans-unit id="RunDescription">

--- a/src/Aspire.Cli/Utils/CliPathHelper.cs
+++ b/src/Aspire.Cli/Utils/CliPathHelper.cs
@@ -5,13 +5,14 @@ using System.IO.Hashing;
 using System.Text;
 using Aspire.Cli.Acquisition;
 using Aspire.Hosting.Backchannel;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Utils;
 
 internal static class CliPathHelper
 {
-    internal const string AspireHomeEnvironmentVariable = "ASPIRE_HOME";
+    internal const string AspireHomeEnvironmentVariable = AspireHomeDirectory.EnvironmentVariable;
 
     /// <summary>
     /// Name of the directory under <c>ASPIRE_HOME</c> that holds NuGet package caches keyed by
@@ -49,15 +50,11 @@ internal static class CliPathHelper
     }
 
     internal static string GetDefaultAspireHomeDirectory()
-        => GetDefaultAspireHomeDirectory(
-            Environment.GetEnvironmentVariable(AspireHomeEnvironmentVariable),
-            GetUserProfileDirectory());
+        => AspireHomeDirectory.GetDefault();
 
     internal static string GetDefaultAspireHomeDirectory(string? configuredAspireHome, string userProfileDirectory)
     {
-        return string.IsNullOrWhiteSpace(configuredAspireHome)
-            ? Path.Combine(userProfileDirectory, ".aspire")
-            : configuredAspireHome;
+        return AspireHomeDirectory.GetDefault(configuredAspireHome, userProfileDirectory);
     }
 
     /// <summary>
@@ -150,9 +147,6 @@ internal static class CliPathHelper
 
         return Path.GetDirectoryName(dogfoodDir);
     }
-
-    internal static string GetUserProfileDirectory()
-        => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
     /// <summary>
     /// Normalizes the casing of a filesystem <paramref name="path"/> so that paths which differ only

--- a/src/Aspire.Dashboard/Api/TelemetryApiService.cs
+++ b/src/Aspire.Dashboard/Api/TelemetryApiService.cs
@@ -15,21 +15,17 @@ namespace Aspire.Dashboard.Api;
 /// <summary>
 /// Handles telemetry API requests, returning data in OTLP JSON format.
 /// </summary>
-internal sealed class TelemetryApiService(
-    TelemetryRepository telemetryRepository,
-    IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+internal sealed class TelemetryApiService(ITelemetryRepository telemetryRepository)
 {
     private const int DefaultLimit = 200;
     private const int DefaultTraceLimit = 100;
-
-    private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers = outgoingPeerResolvers.ToArray();
 
     /// <summary>
     /// Gets spans in OTLP JSON format.
     /// Returns null if resource filter is specified but not found.
     /// Supports multiple resource names.
     /// </summary>
-    public TelemetryApiResponse? GetSpans(string[]? resourceNames, string? traceId, bool? hasError, int? limit, string? search = null)
+    public async Task<TelemetryApiResponse?> GetSpansAsync(string[]? resourceNames, string? traceId, bool? hasError, int? limit, CancellationToken cancellationToken, string? search = null)
     {
         // Resolve resource keys for all specified resources
         var resources = telemetryRepository.GetResources();
@@ -46,7 +42,7 @@ internal sealed class TelemetryApiService(
         var searchTextFragments = ParseAndApplySearchFilters(search, spanFilters, AddSpanFiltersFromQualifiers, key => ResolveSpanFieldKey(key) is not null);
 
         // Get spans for all resource keys (empty list means no filter / all resources)
-        var result = telemetryRepository.GetSpans(new GetSpansRequest
+        var result = await telemetryRepository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = resourceKeys,
             StartIndex = 0,
@@ -55,7 +51,7 @@ internal sealed class TelemetryApiService(
             TraceId = traceId,
             HasError = hasError,
             TextFragments = searchTextFragments
-        });
+        }, cancellationToken).ConfigureAwait(false);
         var allSpans = result.PagedResult.Items;
 
         var totalCount = allSpans.Count;
@@ -67,7 +63,7 @@ internal sealed class TelemetryApiService(
             spans = spans.Skip(spans.Count - effectiveLimit).ToList();
         }
 
-        var otlpData = TelemetryExportService.ConvertSpansToOtlpJson(spans, _outgoingPeerResolvers);
+        var otlpData = TelemetryExportService.ConvertSpansToOtlpJson(spans);
 
         return new TelemetryApiResponse
         {
@@ -82,7 +78,7 @@ internal sealed class TelemetryApiService(
     /// Returns null if resource filter is specified but not found.
     /// Supports multiple resource names.
     /// </summary>
-    public TelemetryApiResponse? GetTraces(string[]? resourceNames, bool? hasError, int? limit, string? search = null)
+    public async Task<TelemetryApiResponse?> GetTracesAsync(string[]? resourceNames, bool? hasError, int? limit, CancellationToken cancellationToken, string? search = null)
     {
         // Resolve resource keys for all specified resources
         var resources = telemetryRepository.GetResources();
@@ -96,32 +92,28 @@ internal sealed class TelemetryApiService(
 
         // Convert structured search qualifiers into TelemetryFilter objects for repository-level filtering
         var traceFilters = new List<TelemetryFilter>();
+        if (hasError is not null)
+        {
+            traceFilters.Add(new FieldTelemetryFilter
+            {
+                Field = KnownTraceFields.StatusField,
+                Value = nameof(OtlpSpanStatusCode.Error),
+                Condition = hasError.Value ? FilterCondition.Equals : FilterCondition.NotEqual
+            });
+        }
         var searchTextFragments = ParseAndApplySearchFilters(search, traceFilters, AddSpanFiltersFromQualifiers, key => ResolveSpanFieldKey(key) is not null);
 
         // Get traces for all resource keys (empty list means no filter / all resources)
-        var result = telemetryRepository.GetTraces(new GetTracesRequest
+        var result = await telemetryRepository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = resourceKeys,
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = traceFilters,
             TextFragments = searchTextFragments
-        });
-        var allTraces = result.PagedResult.Items;
-
-        var traces = allTraces;
-
-        // Filter traces by hasError
-        if (hasError == true)
-        {
-            traces = traces.Where(t => t.Spans.Any(s => s.Status == OtlpSpanStatusCode.Error)).ToList();
-        }
-        else if (hasError == false)
-        {
-            traces = traces.Where(t => !t.Spans.Any(s => s.Status == OtlpSpanStatusCode.Error)).ToList();
-        }
-
-        var totalCount = traces.Count;
+        }, cancellationToken).ConfigureAwait(false);
+        var traces = result.PagedResult.Items;
+        var totalCount = result.PagedResult.TotalItemCount;
 
         // Apply limit (take from end for most recent)
         if (traces.Count > effectiveLimit)
@@ -132,7 +124,7 @@ internal sealed class TelemetryApiService(
         var spans = traces.SelectMany(t => t.Spans).ToList();
         var returnedCount = traces.Count;
 
-        var otlpData = TelemetryExportService.ConvertSpansToOtlpJson(spans, _outgoingPeerResolvers);
+        var otlpData = TelemetryExportService.ConvertSpansToOtlpJson(spans);
 
         return new TelemetryApiResponse
         {
@@ -156,7 +148,7 @@ internal sealed class TelemetryApiService(
 
         var spans = trace.Spans.ToList();
 
-        var otlpData = TelemetryExportService.ConvertSpansToOtlpJson(spans, _outgoingPeerResolvers);
+        var otlpData = TelemetryExportService.ConvertSpansToOtlpJson(spans);
 
         return new TelemetryApiResponse
         {
@@ -171,7 +163,7 @@ internal sealed class TelemetryApiService(
     /// Returns null if resource filter is specified but not found.
     /// Supports multiple resource names.
     /// </summary>
-    public TelemetryApiResponse? GetLogs(string[]? resourceNames, string? traceId, string? severity, int? limit, string? search = null)
+    public async Task<TelemetryApiResponse?> GetLogsAsync(string[]? resourceNames, string? traceId, string? severity, int? limit, CancellationToken cancellationToken, string? search = null)
     {
         // Resolve resource keys for all specified resources
         var resources = telemetryRepository.GetResources();
@@ -213,14 +205,14 @@ internal sealed class TelemetryApiService(
         var searchTextFragments = ParseAndApplySearchFilters(search, filters, AddLogFiltersFromQualifiers, key => ResolveLogFieldKey(key) is not null);
 
         // Get logs for all resource keys (empty list means no filter / all resources)
-        var result = telemetryRepository.GetLogs(new GetLogsContext
+        var result = await telemetryRepository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = resourceKeys,
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = filters,
             TextFragments = searchTextFragments
-        });
+        }, cancellationToken).ConfigureAwait(false);
 
         var logs = result.Items;
 
@@ -275,7 +267,7 @@ internal sealed class TelemetryApiService(
         await foreach (var span in telemetryRepository.WatchSpansAsync(watchRequest, cancellationToken).ConfigureAwait(false))
         {
             // Use compact JSON for NDJSON streaming (no indentation)
-            yield return TelemetryExportService.ConvertSpanToJson(span, _outgoingPeerResolvers, logs: null, indent: false);
+            yield return TelemetryExportService.ConvertSpanToJson(span, logs: null, indent: false);
         }
     }
 

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -44,12 +44,15 @@
     <Protobuf Include="..\Aspire.Hosting\Dashboard\proto\dashboard_service.proto">
       <Link>ServiceClient\dashboard_service.proto</Link>
     </Protobuf>
+
+    <EmbeddedResource Include="ServiceClient\DatabaseSchema\*.sql" />
   </ItemGroup>
 
   <!-- Used by publishing infrastructure to get the version to use for blob publishing -->
   <Target Name="ReturnPackageVersion" Returns="$(PackageVersion)" />
 
   <ItemGroup>
+    <PackageReference Include="Dapper" />
     <PackageReference Include="Grpc.AspNetCore" />
     <PackageReference Include="Hex1b" />
     <PackageReference Include="Humanizer.Core" />
@@ -57,8 +60,14 @@
     <PackageReference Include="Semver" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 
   <ItemGroup>
@@ -262,9 +271,12 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)AssemblyVersionHelper.cs" Link="Utils\AssemblyVersionHelper.cs" />
+    <Compile Include="$(SharedDir)AspireHomeDirectory.cs" Link="Utils\AspireHomeDirectory.cs" />
     <Compile Include="$(SharedDir)ChannelExtensions.cs" Link="Extensions\ChannelExtensions.cs" />
     <Compile Include="$(SharedDir)ColorGenerator.cs" Link="Utils\ColorGenerator.cs" />
+    <Compile Include="$(SharedDir)DirectoryHelper.cs" Link="Utils\DirectoryHelper.cs" />
     <Compile Include="$(SharedDir)EnumerableExtensions.cs" Link="Utils\EnumerableExtensions.cs" />
+    <Compile Include="$(SharedDir)FileLock.cs" Link="Utils\FileLock.cs" />
     <Compile Include="$(SharedDir)FormatHelpers.cs" Link="Utils\FormatHelpers.cs" />
     <Compile Include="$(SharedDir)DateFormatStringsHelpers.cs" Link="Utils\DateFormatStringsHelpers.cs" />
     <Compile Include="$(SharedDir)TimeProviderExtensions.cs" Link="Extensions\TimeProviderExtensions.cs" />

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -35,13 +35,31 @@
             return @<FluentMenuItem Id="@item.Id" Class="@item.Class" OnClick="() => HandleItemClicked(item)" Disabled="@item.IsDisabled" Role="@item.Role" Checked="@item.Checked" AdditionalAttributes="@additionalMenuItemAttributes" Label="@item.Text" MenuItems="@RenderNestedItems(item)">
                 @if (item.Icon != null)
                 {
-                    <span slot="start">
-                        <FluentIcon Value="@item.Icon" Style="vertical-align: text-bottom;" Width="16px" />
+                    <FluentIcon Value="@item.Icon" Style="vertical-align: text-bottom;" Width="16px" Slot="@GetIconSlot(item.Role)" />
+                }
+                @if (item.SecondaryActionIcon is not null)
+                {
+                    <span slot="end" @onclick:stopPropagation="true" @onkeydown:stopPropagation="true">
+                        <FluentButton Class="@($"aspire-menu-secondary-action{(item.IsSecondaryActionSelected ? " selected" : null)}")"
+                                      Appearance="Appearance.Stealth"
+                                      Title="@item.SecondaryActionAriaLabel"
+                                      AriaLabel="@item.SecondaryActionAriaLabel"
+                                      aria-pressed="@(item.IsSecondaryActionSelected ? "true" : "false")"
+                                      @onclick="() => HandleSecondaryActionClicked(item)">
+                            <FluentIcon Value="@item.SecondaryActionIcon" Width="16px" />
+                        </FluentButton>
                     </span>
                 }
             </FluentMenuItem>;
         }
     }
+
+    private static string GetIconSlot(MenuItemRole? role) => role switch
+    {
+        MenuItemRole.MenuItemCheckbox => "checkbox-indicator",
+        MenuItemRole.MenuItemRadio => "radio-indicator",
+        _ => "start"
+    };
 
     private RenderFragment? RenderNestedItems(MenuButtonItem item)
     {

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -36,6 +36,12 @@ public partial class AspireMenu : FluentComponentBase
     [Parameter]
     public EventCallback OnRenderComplete { get; set; }
 
+    /// <summary>
+    /// Raised after a menu item's secondary action completes so the owner can regenerate the menu items.
+    /// </summary>
+    [Parameter]
+    public EventCallback OnSecondaryActionComplete { get; set; }
+
     [Parameter]
     public required IReadOnlyList<MenuButtonItem> Items { get; set; }
 
@@ -154,6 +160,28 @@ public partial class AspireMenu : FluentComponentBase
         if (item.OnClick is { } onClick)
         {
             await onClick();
+        }
+    }
+
+    private async Task HandleSecondaryActionClicked(MenuButtonItem item)
+    {
+        if (item.OnSecondaryActionClick is { } onSecondaryActionClick)
+        {
+            await onSecondaryActionClick();
+        }
+
+        if (OnSecondaryActionComplete.HasDelegate)
+        {
+            await OnSecondaryActionComplete.InvokeAsync();
+        }
+        else
+        {
+            StateHasChanged();
+
+            if (_menu is { Id: not null } menu)
+            {
+                await MenuService.RefreshMenuAsync(menu.Id, isOpen: true);
+            }
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.css
@@ -1,0 +1,27 @@
+::deep .aspire-menu-secondary-action {
+    opacity: 0;
+    visibility: hidden;
+    padding-left: 8px;
+}
+
+::deep .aspire-menu-secondary-action::part(control) {
+    background-color: transparent;
+}
+
+::deep .aspire-menu-secondary-action:hover::part(control) {
+    background-color: var(--neutral-fill-secondary-hover);
+}
+
+fluent-menu-item:hover > span[slot="end"] ::deep .aspire-menu-secondary-action,
+fluent-menu-item:focus-within > span[slot="end"] ::deep .aspire-menu-secondary-action,
+::deep .aspire-menu-secondary-action.selected {
+    opacity: 1;
+    visibility: visible;
+}
+
+@media (hover: none) {
+    fluent-menu-item > span[slot="end"] ::deep .aspire-menu-secondary-action {
+        opacity: 1;
+        visibility: visible;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -12,7 +12,12 @@
     };
 }
 
-<FluentButton Id="@MenuButtonId" Title="@Title" Appearance="@ButtonAppearance" IconStart="@IconStart" @onclick="ToggleMenu" Disabled="@_disabled" AdditionalAttributes="@additionalButtonAttributes" Class="@ButtonClass">
+<FluentButton Id="@MenuButtonId" Title="@Title" Appearance="@ButtonAppearance" @onclick="ToggleMenu" Disabled="@_disabled" AdditionalAttributes="@additionalButtonAttributes" Class="@ButtonClass">
+    @if (IconStart is not null)
+    {
+        <FluentIcon Class="@IconStartClass" Value="@IconStart" Color="@IconStartColor" CustomColor="@IconStartCustomColor" Slot="start" />
+    }
+
     @if (string.IsNullOrWhiteSpace(Text))
     {
         <FluentIcon Value="@_icon" Color="@IconColor" CustomColor="@IconCustomColor" />
@@ -31,5 +36,5 @@
 @* Render lazily because FluentMenu is expensive: building menu items and initializing its JavaScript interop add significant overhead when many menu buttons are displayed. *@
 @if (_renderMenu)
 {
-    <AspireMenu Anchor="@MenuButtonId" Open="@_visible" OpenChanged="OnMenuOpenChanged" OnRenderComplete="OnMenuRenderComplete" Items="_items" RestoreFocusOnItemClick="@RestoreFocusOnItemClick" />
+    <AspireMenu Anchor="@MenuButtonId" Open="@_visible" OpenChanged="OnMenuOpenChanged" OnRenderComplete="OnMenuRenderComplete" OnSecondaryActionComplete="RefreshItems" Items="_items" RestoreFocusOnItemClick="@RestoreFocusOnItemClick" />
 }

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -24,6 +24,7 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
     private Icon? _icon;
     private MenuButtonItem[] _items = [];
     private bool _disabled;
+    private bool _hasActionableItems = true;
     private Func<IList<MenuButtonItem>>? _renderedItemsProvider;
 
     [Parameter]
@@ -31,6 +32,15 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
 
     [Parameter]
     public Icon? IconStart { get; set; }
+
+    [Parameter]
+    public string? IconStartClass { get; set; }
+
+    [Parameter]
+    public Color? IconStartColor { get; set; }
+
+    [Parameter]
+    public string? IconStartCustomColor { get; set; }
 
     [Parameter]
     public Icon? Icon { get; set; }
@@ -50,6 +60,9 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
     [Parameter]
     public required Func<IList<MenuButtonItem>> ItemsProvider { get; set; }
 
+    // Exposed only for tests to inspect the rendered menu items.
+    internal IReadOnlyList<MenuButtonItem> Items => _items;
+
     [Parameter]
     public Appearance? ButtonAppearance { get; set; }
 
@@ -61,6 +74,15 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
 
     [Parameter]
     public bool HideIcon { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the button is unconditionally disabled.
+    /// </summary>
+    /// <remarks>
+    /// This is independent of the automatic disabling that happens when the menu has no actionable items.
+    /// </remarks>
+    [Parameter]
+    public bool Disabled { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether focus should return to this menu button after a menu item is clicked.
@@ -81,7 +103,10 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
         if (!ReferenceEquals(_renderedItemsProvider, ItemsProvider))
         {
             _renderedItemsProvider = ItemsProvider;
-            _disabled = false;
+
+            // The provider hasn't run for this delegate yet, so the menu contents are unknown.
+            // Assume it has content so only Disabled can disable the button before the first open.
+            _hasActionableItems = true;
         }
 
         if (_visible || _openWhenMenuRenderCompletes)
@@ -92,6 +117,10 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
             {
                 OnMenuOpenChanged(false);
             }
+        }
+        else
+        {
+            UpdateDisabled();
         }
     }
 
@@ -136,7 +165,13 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
     private void RefreshItems()
     {
         _items = ItemsProvider().ToArray();
-        _disabled = !_items.Any(i => !i.IsDivider);
+        _hasActionableItems = _items.Any(i => !i.IsDivider);
+        UpdateDisabled();
+    }
+
+    private void UpdateDisabled()
+    {
+        _disabled = Disabled || !_hasActionableItems;
     }
 
     private async Task OnMenuRenderComplete()

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
@@ -29,6 +29,10 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
     private OtlpInstrumentKey? _renderedInstrument;
     private string? _renderedTheme;
     private bool _renderedShowCount;
+    private DateTimeOffset? _previousDataEndTime;
+
+    // Full updates always run. This interval only throttles recurring tick updates.
+    protected virtual TimeSpan UpdateInterval => TimeSpan.FromSeconds(0.2);
 
     [Inject]
     public required IStringLocalizer<ControlsStrings> Loc { get; init; }
@@ -40,7 +44,9 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
     public required BrowserTimeProvider TimeProvider { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     [Inject]
     public required PauseManager PauseManager { get; init; }
@@ -54,6 +60,9 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
     [Parameter]
     public required List<OtlpResource> Resources { get; set; }
 
+    [Parameter]
+    public DateTimeOffset? DataEndTime { get; set; }
+
     // Stores a cache of the last set of spans returned as exemplars.
     // This dictionary is replaced each time the chart is updated.
     private Dictionary<SpanKey, OtlpSpan> _currentCache = new Dictionary<SpanKey, OtlpSpan>();
@@ -63,8 +72,8 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
     {
         // Copy the token so there is no chance it is accessed on CTS after it is disposed.
         CancellationToken = _cts.Token;
-        _currentDataStartTime = PauseManager.AreMetricsPaused(out var pausedAt) ? pausedAt.Value : GetCurrentDataTime();
-        InstrumentViewModel.DataUpdateSubscriptions.Add(OnInstrumentDataUpdate);
+        _currentDataStartTime = GetCurrentDataTime(out _);
+        InstrumentViewModel.AddDataUpdateSubscription(OnInstrumentDataUpdate);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -77,11 +86,10 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
             return;
         }
 
-        var inProgressDataTime = PauseManager.AreMetricsPaused(out var pausedAt) ? pausedAt.Value : GetCurrentDataTime();
+        var inProgressDataTime = GetCurrentDataTime(out var isTimeFrozen);
 
-        // Only advance the time window when not paused. When paused, keep the chart's
-        // time axis stable so filter changes don't cause the x-axis to jump.
-        if (pausedAt is null)
+        // Keep the time axis stable for historical data and while live data is paused.
+        if (!isTimeFrozen)
         {
             while (_currentDataStartTime.Add(_tickDuration) < inProgressDataTime)
             {
@@ -101,8 +109,11 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
             _renderedTheme = InstrumentViewModel.Theme;
             _renderedShowCount = InstrumentViewModel.ShowCount;
             await UpdateChartAsync(tickUpdate: false, inProgressDataTime).ConfigureAwait(false);
+            _lastUpdateTime = TimeProvider.GetUtcNow();
+            // Derived components can update Blazor-rendered state during OnAfterRenderAsync.
+            await InvokeAsync(StateHasChanged);
         }
-        else if (_lastUpdateTime.Add(TimeSpan.FromSeconds(0.2)) < TimeProvider.GetUtcNow())
+        else if (_lastUpdateTime.Add(UpdateInterval) < TimeProvider.GetUtcNow())
         {
             // Throttle how often the chart is updated.
             _lastUpdateTime = TimeProvider.GetUtcNow();
@@ -113,11 +124,16 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
     protected override void OnParametersSet()
     {
         _tickDuration = Duration / GraphPointCount;
+        if (_previousDataEndTime != DataEndTime)
+        {
+            _currentDataStartTime = GetCurrentDataTime(out _);
+            _previousDataEndTime = DataEndTime;
+        }
     }
 
     private Task OnInstrumentDataUpdate()
     {
-        return InvokeAsync(StateHasChanged);
+        return CancellationToken.IsCancellationRequested ? Task.CompletedTask : InvokeAsync(StateHasChanged);
     }
 
     private string FormatTooltip(string name, double yValue, DateTimeOffset xValue)
@@ -230,9 +246,23 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
         }
     }
 
-    private DateTimeOffset GetCurrentDataTime()
+    private DateTimeOffset GetCurrentDataTime(out bool isTimeFrozen)
     {
-        return TimeProvider.GetUtcNow().Subtract(TimeSpan.FromSeconds(1)); // Compensate for delay in receiving metrics from services.
+        if (DataEndTime is { } dataEndTime)
+        {
+            isTimeFrozen = true;
+            return dataEndTime;
+        }
+
+        if (PauseManager.AreMetricsPaused(out var pausedAt))
+        {
+            isTimeFrozen = true;
+            return pausedAt.Value;
+        }
+
+        isTimeFrozen = false;
+        // Compensate for delay in receiving metrics from services.
+        return TimeProvider.GetUtcNow().Subtract(TimeSpan.FromSeconds(1));
     }
 
     private string GetDisplayedUnit(OtlpInstrumentSummary instrument)
@@ -249,6 +279,7 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
     protected virtual ValueTask DisposeAsync(bool disposing)
     {
         _cts.Cancel();
+        InstrumentViewModel.RemoveDataUpdateSubscription(OnInstrumentDataUpdate);
         _cts.Dispose();
         return ValueTask.CompletedTask;
     }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -30,24 +30,27 @@ else
                 </div>
             }
         </div>
+        @* Avoid rendering the inactive graph or table because both subscribe to and process metric data updates. *@
         <FluentTabs ActiveTabId="@($"tab-{ActiveView}")" OnTabChange="@OnTabChangeAsync" Size="null">
             <FluentTab LabelClass="tab-label"
                        Id="@($"tab-{Metrics.MetricViewKind.Graph}")"
                        aria-label="@Loc[nameof(ControlsStrings.ChartContainerGraphAccessibleLabel)]"
                        Label="@Loc[nameof(ControlsStrings.ChartContainerGraphTab)]"
+                       DeferredLoading="true"
                        Icon="@(new Icons.Regular.Size24.DataArea())">
                 <div class="metrics-chart-container metric-tab">
-                    <PlotlyChart InstrumentViewModel="_instrumentViewModel" Duration="Duration" Resources="Resources"/>
-                    <ChartFilters InstrumentViewModel="_instrumentViewModel" Instrument="_instrument" DimensionFilters="@DimensionFilters" OnDimensionValuesChanged="DimensionValuesChangedAsync" />
+                    <PlotlyChart InstrumentViewModel="_instrumentViewModel" Duration="Duration" Resources="Resources" DataEndTime="_dataEndTime"/>
+                    <ChartFilters InstrumentType="_instrument.Summary.Type" ShowCount="_instrumentViewModel.ShowCount" ShowCountChanged="ShowCountChangedAsync" DimensionFilters="@DimensionFilters" OnDimensionValuesChanged="DimensionValuesChangedAsync" />
                 </div>
             </FluentTab>
             <FluentTab LabelClass="tab-label"
                        Id="@($"tab-{Metrics.MetricViewKind.Table}")"
                        Label="@Loc[nameof(ControlsStrings.ChartContainerTableTab)]"
+                       DeferredLoading="true"
                        Icon="@(new Icons.Regular.Size24.Table())">
                 <div class="metrics-chart-container metric-tab">
-                    <MetricTable InstrumentViewModel="_instrumentViewModel" Duration="Duration" Resources="Resources" />
-                    <ChartFilters InstrumentViewModel="_instrumentViewModel" Instrument="_instrument" DimensionFilters="@DimensionFilters" OnDimensionValuesChanged="DimensionValuesChangedAsync" />
+                    <MetricTable InstrumentViewModel="_instrumentViewModel" Duration="Duration" Resources="Resources" DataEndTime="_dataEndTime" />
+                    <ChartFilters InstrumentType="_instrument.Summary.Type" ShowCount="_instrumentViewModel.ShowCount" ShowCountChanged="ShowCountChangedAsync" DimensionFilters="@DimensionFilters" OnDimensionValuesChanged="DimensionValuesChangedAsync" />
                 </div>
             </FluentTab>
         </FluentTabs>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
-using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
@@ -15,12 +15,21 @@ namespace Aspire.Dashboard.Components;
 
 public partial class ChartContainer : ComponentBase, IAsyncDisposable
 {
+    private static readonly TimeSpan s_chartUpdateInterval = TimeSpan.FromSeconds(0.2);
+    private static readonly TimeSpan s_dataFetchInterval = TimeSpan.FromSeconds(1);
+
+    private readonly object _instrumentUpdateLock = new();
     private OtlpInstrumentData? _instrument;
-    private PeriodicTimer? _tickTimer;
+    private readonly CancellationTokenSource _disposeCts = new();
     private Task? _tickTask;
     private IDisposable? _themeChangedSubscription;
-    private int _renderedDimensionsCount;
     private readonly InstrumentViewModel _instrumentViewModel = new InstrumentViewModel();
+    private (ResourceKey ResourceKey, string MeterName, string InstrumentName)? _dataEndTimeKey;
+    private (ResourceKey ResourceKey, string MeterName, string InstrumentName, TimeSpan Duration)? _instrumentRequestKey;
+    private DateTimeOffset? _dataEndTime;
+    private long _lastDataFetchTimestamp = -1;
+    private long _instrumentUpdateVersion;
+    private int _disposed;
 
     [Parameter, EditorRequired]
     public required ResourceKey ResourceKey { get; set; }
@@ -44,7 +53,9 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
     public required List<OtlpResource> Resources { get; set; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     [Inject]
     public required ILogger<ChartContainer> Logger { get; init; }
@@ -55,6 +66,12 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
     [Inject]
     public required PauseManager PauseManager { get; init; }
 
+    [Inject]
+    public required DashboardActivitySource DashboardActivitySource { get; init; }
+
+    [Inject]
+    public required TimeProvider TimeProvider { get; init; }
+
     public ImmutableList<DimensionFilterViewModel> DimensionFilters { get; set; } = [];
     public string? PreviousMeterName { get; set; }
     public string? PreviousInstrumentName { get; set; }
@@ -63,9 +80,13 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
     {
         await ThemeManager.EnsureInitializedAsync();
 
-        // Update the graph every 200ms. This displays the latest data and moves time forward.
-        _tickTimer = new PeriodicTimer(TimeSpan.FromSeconds(0.2));
-        _tickTask = Task.Run(UpdateDataAsync);
+        if (!TelemetryRepository.IsReadOnly)
+        {
+            // Update the graph every 200ms. This displays the latest data and moves time forward.
+            var cancellationToken = _disposeCts.Token;
+            // Don't suppress the execution context because graph updates use the current culture for formatting.
+            _tickTask = Task.Run(() => UpdateDataAsync(cancellationToken));
+        }
         _themeChangedSubscription = ThemeManager.OnThemeChanged(async () =>
         {
             _instrumentViewModel.Theme = ThemeManager.EffectiveTheme;
@@ -75,43 +96,82 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        lock (_instrumentUpdateLock)
+        {
+            _instrumentUpdateVersion++;
+        }
+
         _themeChangedSubscription?.Dispose();
-        _tickTimer?.Dispose();
+        _disposeCts.Cancel();
 
         // Wait for UpdateData to complete.
         if (_tickTask is { } t)
         {
             await t;
         }
+
+        _disposeCts.Dispose();
     }
 
-    private async Task UpdateDataAsync()
+    private async Task UpdateDataAsync(CancellationToken cancellationToken)
     {
-        var timer = _tickTimer;
-        while (await timer!.WaitForNextTickAsync())
+        using var timer = new PeriodicTimer(s_chartUpdateInterval, TimeProvider);
+        try
         {
-            _instrument = GetInstrument();
-            if (_instrument == null || PauseManager.AreMetricsPaused(out _))
+            while (await timer.WaitForNextTickAsync(cancellationToken))
             {
-                continue;
-            }
+                var lastDataFetchTimestamp = Volatile.Read(ref _lastDataFetchTimestamp);
+                if (lastDataFetchTimestamp < 0 || TimeProvider.GetElapsedTime(lastDataFetchTimestamp) >= s_dataFetchInterval)
+                {
+                    using var activity = DashboardActivitySource.ActivitySource.StartActivity("Update metric chart data from tick");
 
-            if (_instrument.Dimensions.Count > _renderedDimensionsCount)
-            {
-                // Re-render the entire control if the number of dimensions has changed.
-                _renderedDimensionsCount = _instrument.Dimensions.Count;
-                await InvokeAsync(StateHasChanged);
-            }
-            else
-            {
+                    var result = await GetInstrumentAsync(useIncrementalCache: true, cancellationToken).ConfigureAwait(false);
+                    if (!TryPublishInstrument(result))
+                    {
+                        continue;
+                    }
+
+                    if (_instrument is not null && HaveDimensionFilterValuesChanged(_instrument))
+                    {
+                        await InvokeAsync(() =>
+                        {
+                            UpdateDimensionFilters(hasInstrumentChanged: false);
+                            StateHasChanged();
+                        });
+                    }
+                }
+
+                if (_instrument == null || PauseManager.AreMetricsPaused(out _))
+                {
+                    continue;
+                }
+
                 await UpdateInstrumentDataAsync(_instrument);
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unexpected error in UpdateDataAsync");
         }
     }
 
     public async Task DimensionValuesChangedAsync(DimensionFilterViewModel dimensionViewModel)
     {
-        if (_instrument == null)
+        var result = await GetInstrumentAsync(useIncrementalCache: false, _disposeCts.Token).ConfigureAwait(false);
+        if (!TryPublishInstrument(result))
+        {
+            return;
+        }
+
+        if (_instrument is null)
         {
             return;
         }
@@ -121,93 +181,183 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
 
     private async Task UpdateInstrumentDataAsync(OtlpInstrumentData instrument)
     {
-        var matchedDimensions = instrument.Dimensions.Where(MatchDimension).ToList();
-
         // Only update data in plotly
-        await _instrumentViewModel.UpdateDataAsync(instrument.Summary, matchedDimensions);
+        await _instrumentViewModel.UpdateDataAsync(instrument.Summary, instrument.Dimensions);
     }
 
-    private bool MatchDimension(DimensionScope dimension)
+    private async Task ShowCountChangedAsync(bool showCount)
     {
-        foreach (var dimensionFilter in DimensionFilters)
+        if (_instrumentViewModel.ShowCount == showCount)
         {
-            if (!MatchFilter(dimension.Attributes, dimensionFilter))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static bool MatchFilter(KeyValuePair<string, string>[] attributes, DimensionFilterViewModel filter)
-    {
-        var selectedValues = filter.SelectedValues;
-
-        // No filter selected.
-        if (selectedValues.Count == 0)
-        {
-            return false;
+            return;
         }
 
-        var value = OtlpHelpers.GetValue(attributes, filter.Name);
-        foreach (var item in selectedValues)
+        _instrumentViewModel.ShowCount = showCount;
+        if (_instrument is not null)
         {
-            if (item.Value == value)
-            {
-                return true;
-            }
+            await UpdateInstrumentDataAsync(_instrument);
         }
-
-        return false;
     }
 
     protected override async Task OnParametersSetAsync()
     {
-        _instrument = GetInstrument();
+        var requestKey = (ResourceKey, MeterName, InstrumentName, Duration);
+        if (_instrumentRequestKey != requestKey)
+        {
+            _instrumentRequestKey = requestKey;
+            await RefreshChartAsync();
+        }
+    }
+
+    private async Task RefreshChartAsync()
+    {
+        // Track the selection change before awaiting. hasInstrumentChanged describes the selected
+        // parameters, not the fetched data, so it must not be lost when a concurrent tick wins the
+        // version race below.
+        var hasInstrumentChanged = PreviousMeterName != MeterName || PreviousInstrumentName != InstrumentName;
+        PreviousMeterName = MeterName;
+        PreviousInstrumentName = InstrumentName;
+
+        var result = await GetInstrumentAsync(useIncrementalCache: false, _disposeCts.Token).ConfigureAwait(false);
+        if (!TryPublishInstrument(result))
+        {
+            // A newer fetch owns _instrument now, but the dimension filters still belong to this
+            // selection. The tick loop only ever calls UpdateDimensionFilters with
+            // hasInstrumentChanged: false, which carries the previous instrument's selections forward by
+            // attribute name, so returning here would leave the new instrument filtered by the old one.
+            if (hasInstrumentChanged)
+            {
+                UpdateDimensionFilters(hasInstrumentChanged: true);
+            }
+
+            return;
+        }
 
         if (_instrument == null)
         {
             return;
         }
 
-        var hasInstrumentChanged = PreviousMeterName != MeterName || PreviousInstrumentName != InstrumentName;
-        PreviousMeterName = MeterName;
-        PreviousInstrumentName = InstrumentName;
-
-        // Replace filters collection on change. Filters can be accessed from a background task so it is immutable for thread safety.
-        DimensionFilters = ImmutableList.Create(CollectionsMarshal.AsSpan(CreateUpdatedFilters(hasInstrumentChanged)));
+        UpdateDimensionFilters(hasInstrumentChanged);
 
         await UpdateInstrumentDataAsync(_instrument);
     }
 
-    private OtlpInstrumentData? GetInstrument()
+    private async Task<(long UpdateVersion, OtlpInstrumentData? Instrument)> GetInstrumentAsync(bool useIncrementalCache, CancellationToken cancellationToken)
     {
-        // When paused, use the paused time to keep the data window stable.
-        // This ensures filter changes while paused still show the same data.
-        var endDate = PauseManager.AreMetricsPaused(out var pausedAt) ? pausedAt.Value : DateTime.UtcNow;
-        // Get more data than is being displayed. Histogram graph uses some historical data to calculate bucket counts.
-        // It's ok to get more data than is needed here. An additional date filter is applied when building chart values.
-        var startDate = endDate.Subtract(Duration + TimeSpan.FromSeconds(30));
-
-        var instrument = TelemetryRepository.GetInstrument(new GetInstrumentRequest
+        long updateVersion;
+        OtlpInstrumentData? baseInstrument;
+        lock (_instrumentUpdateLock)
         {
-            ResourceKey = ResourceKey,
-            MeterName = MeterName,
-            InstrumentName = InstrumentName,
-            StartTime = startDate,
-            EndTime = endDate,
-        });
+            updateVersion = ++_instrumentUpdateVersion;
 
-        if (instrument == null)
+            // Capture the base instrument under the same lock that stamps the version. TryPublishInstrument
+            // writes _instrument under this lock, so reading it outside would let an incremental refresh
+            // merge the previously selected instrument's series into the newly selected one: the guard below
+            // only proves no newer call started, not that the base snapshot still matches the selection.
+            baseInstrument = _instrument;
+        }
+
+        var resourceKey = ResourceKey;
+        var meterName = MeterName;
+        var instrumentName = InstrumentName;
+        var duration = Duration;
+        var dimensionFilters = DimensionFilters
+            .Where(filter => filter.AreAllValuesSelected is not true)
+            .ToDictionary(
+                filter => filter.Name,
+                filter => (IReadOnlyList<string?>)filter.SelectedValues.Select(value => value.Value).ToArray());
+
+        var instrumentSummary = TelemetryRepository.GetInstrumentSummary(resourceKey, meterName, instrumentName);
+        if (instrumentSummary is null)
         {
             Logger.LogDebug(
                 "Unable to find instrument. ResourceKey: {ResourceKey}, MeterName: {MeterName}, InstrumentName: {InstrumentName}",
-                ResourceKey,
-                MeterName,
-                InstrumentName);
+                resourceKey,
+                meterName,
+                instrumentName);
+            return (updateVersion, Instrument: null);
         }
 
-        return instrument;
+        DateTime endDate;
+        if (TelemetryRepository.IsReadOnly)
+        {
+            EnsureDataEndTime(resourceKey, meterName, instrumentName);
+            endDate = _dataEndTime?.UtcDateTime ?? DateTime.UtcNow;
+        }
+        else
+        {
+            // When paused, use the paused time to keep the data window stable.
+            // This ensures filter changes while paused still show the same data.
+            endDate = PauseManager.AreMetricsPaused(out var pausedAt) ? pausedAt.Value : DateTime.UtcNow;
+        }
+
+        var dataPointInterval = MetricDataPointInterval.Get(duration);
+        var includeExemplars = instrumentSummary.Type == OtlpInstrumentType.Histogram;
+
+        // Histogram graphs need one preceding rollup to calculate bucket count changes at the beginning of the chart.
+        var historyDuration = TimeSpan.FromTicks(Math.Max(TimeSpan.FromSeconds(30).Ticks, dataPointInterval.Ticks));
+        var startDate = endDate.Subtract(duration + historyDuration);
+        var cursors = useIncrementalCache && baseInstrument is not null
+            ? MetricInstrumentDataCache.CreateCursors(baseInstrument, historyDuration, dataPointInterval)
+            : [];
+
+        var refreshedInstrument = await TelemetryRepository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resourceKey,
+            MeterName = meterName,
+            InstrumentName = instrumentName,
+            StartTime = startDate,
+            EndTime = endDate,
+            DataPointInterval = dataPointInterval,
+            IncludeExemplars = includeExemplars,
+            PopulateExemplarAttributes = false,
+            DimensionCursors = cursors,
+            DimensionFilters = dimensionFilters
+        }, cancellationToken).ConfigureAwait(false);
+        Debug.Assert(refreshedInstrument is not null);
+
+        lock (_instrumentUpdateLock)
+        {
+            if (updateVersion != _instrumentUpdateVersion)
+            {
+                return (updateVersion, Instrument: null);
+            }
+
+            Volatile.Write(ref _lastDataFetchTimestamp, TimeProvider.GetTimestamp());
+        }
+
+        var instrument = baseInstrument is not null && cursors.Count > 0
+            ? MetricInstrumentDataCache.Merge(baseInstrument, refreshedInstrument, cursors, startDate)
+            : refreshedInstrument;
+        return (updateVersion, instrument);
+    }
+
+    private bool TryPublishInstrument((long UpdateVersion, OtlpInstrumentData? Instrument) result)
+    {
+        lock (_instrumentUpdateLock)
+        {
+            if (result.UpdateVersion != _instrumentUpdateVersion)
+            {
+                return false;
+            }
+
+            _instrument = result.Instrument;
+            return true;
+        }
+    }
+
+    private void EnsureDataEndTime(ResourceKey resourceKey, string meterName, string instrumentName)
+    {
+        var key = (resourceKey, meterName, instrumentName);
+        if (_dataEndTimeKey == key)
+        {
+            return;
+        }
+
+        var latestEndTime = TelemetryRepository.GetInstrumentLatestEndTime(resourceKey, meterName, instrumentName);
+        _dataEndTime = latestEndTime is not null ? new DateTimeOffset(latestEndTime.Value) : null;
+        _dataEndTimeKey = key;
     }
 
     private List<DimensionFilterViewModel> CreateUpdatedFilters(bool hasInstrumentChanged)
@@ -270,6 +420,74 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
         }
 
         return filters;
+    }
+
+    private bool UpdateDimensionFilters(bool hasInstrumentChanged)
+    {
+        var updatedFilters = ImmutableList.Create(CollectionsMarshal.AsSpan(CreateUpdatedFilters(hasInstrumentChanged)));
+        if (HaveSameDimensionFilterContent(DimensionFilters, updatedFilters))
+        {
+            return false;
+        }
+
+        // Filters can be accessed from a background task, so replace the immutable collection atomically.
+        DimensionFilters = updatedFilters;
+        return true;
+    }
+
+    private bool HaveDimensionFilterValuesChanged(OtlpInstrumentData instrument)
+    {
+        if (instrument.KnownAttributeValues.Count != DimensionFilters.Count)
+        {
+            return true;
+        }
+
+        var index = 0;
+        foreach (var attribute in instrument.KnownAttributeValues.OrderBy(attribute => attribute.Key))
+        {
+            var filter = DimensionFilters[index++];
+            if (filter.Name != attribute.Key ||
+                !filter.Values.Select(value => value.Value).SequenceEqual(attribute.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HaveSameDimensionFilterContent(
+        ImmutableList<DimensionFilterViewModel> currentFilters,
+        ImmutableList<DimensionFilterViewModel> updatedFilters)
+    {
+        if (currentFilters.Count != updatedFilters.Count)
+        {
+            return false;
+        }
+
+        for (var filterIndex = 0; filterIndex < currentFilters.Count; filterIndex++)
+        {
+            var currentFilter = currentFilters[filterIndex];
+            var updatedFilter = updatedFilters[filterIndex];
+            if (currentFilter.Name != updatedFilter.Name || currentFilter.Values.Count != updatedFilter.Values.Count)
+            {
+                return false;
+            }
+
+            for (var valueIndex = 0; valueIndex < currentFilter.Values.Count; valueIndex++)
+            {
+                var currentValue = currentFilter.Values[valueIndex];
+                var updatedValue = updatedFilter.Values[valueIndex];
+                if (currentValue.Text != updatedValue.Text ||
+                    currentValue.Value != updatedValue.Value ||
+                    currentFilter.SelectedValues.Contains(currentValue) != updatedFilter.SelectedValues.Contains(updatedValue))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private Task OnTabChangeAsync(FluentTab newTab)

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -25,15 +25,15 @@
             </FluentDataGrid>
         </div>
     }
-    @if (Instrument.Summary.Type == OtlpInstrumentType.Histogram)
+    @if (InstrumentType == OtlpInstrumentType.Histogram)
     {
         <div class="metrics-filters-section">
             <h5>@Loc[nameof(ControlsStrings.ChartContainerOptionsHeader)]</h5>
             <div>
                 <FluentSwitch Class="table-switch"
                               Label="@Loc[nameof(ControlsStrings.ChartContainerShowCountLabel)]"
-                              @bind-Value="@ShowCounts"
-                              @bind-Value:after="ShowCountChanged"/>
+                              Value="@ShowCount"
+                              ValueChanged="@OnShowCountChangedAsync"/>
             </div>
         </div>
     }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
@@ -11,10 +11,13 @@ namespace Aspire.Dashboard.Components;
 public partial class ChartFilters
 {
     [Parameter, EditorRequired]
-    public required OtlpInstrumentData Instrument { get; set; }
+    public required OtlpInstrumentType InstrumentType { get; set; }
 
     [Parameter, EditorRequired]
-    public required InstrumentViewModel InstrumentViewModel { get; set; }
+    public required bool ShowCount { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ShowCountChanged { get; set; }
 
     [Parameter, EditorRequired]
     public required ImmutableList<DimensionFilterViewModel> DimensionFilters { get; set; }
@@ -22,19 +25,5 @@ public partial class ChartFilters
     [Parameter]
     public EventCallback<DimensionFilterViewModel> OnDimensionValuesChanged { get; set; }
 
-    public bool ShowCounts { get; set; }
-
-    protected override void OnInitialized()
-    {
-        InstrumentViewModel.DataUpdateSubscriptions.Add(() =>
-        {
-            ShowCounts = InstrumentViewModel.ShowCount;
-            return Task.CompletedTask;
-        });
-    }
-
-    private void ShowCountChanged()
-    {
-        InstrumentViewModel.ShowCount = ShowCounts;
-    }
+    private Task OnShowCountChangedAsync(bool value) => ShowCountChanged.InvokeAsync(value);
 }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricDataPointInterval.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricDataPointInterval.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Components;
+
+/// <summary>
+/// Selects the metric data point interval for a chart duration.
+/// </summary>
+internal static class MetricDataPointInterval
+{
+    /// <summary>
+    /// Gets the metric data point interval for the specified chart duration.
+    /// </summary>
+    public static TimeSpan Get(TimeSpan duration)
+    {
+        if (duration <= TimeSpan.FromMinutes(5))
+        {
+            return TimeSpan.FromSeconds(1);
+        }
+
+        if (duration <= TimeSpan.FromMinutes(15))
+        {
+            return TimeSpan.FromSeconds(2);
+        }
+
+        if (duration <= TimeSpan.FromMinutes(30))
+        {
+            return TimeSpan.FromSeconds(5);
+        }
+
+        if (duration <= TimeSpan.FromHours(1))
+        {
+            return TimeSpan.FromSeconds(10);
+        }
+
+        if (duration <= TimeSpan.FromHours(3))
+        {
+            return TimeSpan.FromSeconds(30);
+        }
+
+        if (duration <= TimeSpan.FromHours(6))
+        {
+            return TimeSpan.FromMinutes(1);
+        }
+
+        if (duration <= TimeSpan.FromHours(12))
+        {
+            return TimeSpan.FromMinutes(2);
+        }
+
+        return TimeSpan.FromMinutes(5);
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricInstrumentDataCache.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricInstrumentDataCache.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Aspire.Dashboard.Otlp.Storage;
+
+namespace Aspire.Dashboard.Components;
+
+internal static class MetricInstrumentDataCache
+{
+    public static List<MetricDimensionCursor> CreateCursors(OtlpInstrumentData data, TimeSpan refreshLookback, TimeSpan dataPointInterval)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(refreshLookback, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(dataPointInterval, TimeSpan.Zero);
+
+        var cursors = new List<MetricDimensionCursor>(data.Dimensions.Count);
+        foreach (var dimension in data.Dimensions)
+        {
+            if (dimension.Values.Count == 0)
+            {
+                continue;
+            }
+
+            var latestValue = dimension.Values[^1];
+            // Refresh recent complete buckets because data can arrive behind the latest displayed value. Starting from
+            // the rolled value's start when it is earlier also retains source points that determine its representative.
+            var lookbackStartTicks = latestValue.End.Ticks - Math.Min(latestValue.End.Ticks, refreshLookback.Ticks);
+            var alignedLookbackStartTicks = lookbackStartTicks - (lookbackStartTicks % dataPointInterval.Ticks);
+            cursors.Add(new MetricDimensionCursor
+            {
+                Attributes = dimension.Attributes,
+                StartTime = new DateTime(Math.Min(latestValue.Start.Ticks, alignedLookbackStartTicks), DateTimeKind.Utc)
+            });
+        }
+        return cursors;
+    }
+
+    public static OtlpInstrumentData Merge(
+        OtlpInstrumentData cached,
+        OtlpInstrumentData refreshed,
+        IReadOnlyList<MetricDimensionCursor> cursors,
+        DateTime windowStart)
+    {
+        var dimensions = new List<DimensionScope>(refreshed.Dimensions.Count);
+        foreach (var refreshedDimension in refreshed.Dimensions)
+        {
+            var cachedDimension = cached.Dimensions.FirstOrDefault(dimension => AttributesEqual(dimension.Attributes, refreshedDimension.Attributes));
+            var cursor = cursors.FirstOrDefault(cursor => AttributesEqual(cursor.Attributes, refreshedDimension.Attributes));
+            if (cachedDimension is null || cursor is null)
+            {
+                dimensions.Add(CloneDimension(refreshedDimension, windowStart));
+                continue;
+            }
+
+            var mergedDimension = new DimensionScope(refreshedDimension.Capacity, refreshedDimension.Attributes);
+            foreach (var value in cachedDimension.Values)
+            {
+                if (value.End >= windowStart && value.End < cursor.StartTime)
+                {
+                    mergedDimension.Values.Add(MetricValueBase.Clone(value));
+                }
+            }
+            foreach (var value in refreshedDimension.Values)
+            {
+                if (value.End >= windowStart)
+                {
+                    mergedDimension.Values.Add(MetricValueBase.Clone(value));
+                }
+            }
+            dimensions.Add(mergedDimension);
+        }
+
+        return new OtlpInstrumentData
+        {
+            Summary = refreshed.Summary,
+            Dimensions = dimensions,
+            KnownAttributeValues = refreshed.KnownAttributeValues,
+            HasOverflow = refreshed.HasOverflow
+        };
+    }
+
+    private static DimensionScope CloneDimension(DimensionScope dimension, DateTime windowStart)
+    {
+        var clone = new DimensionScope(dimension.Capacity, dimension.Attributes);
+        foreach (var value in dimension.Values)
+        {
+            if (value.End >= windowStart)
+            {
+                clone.Values.Add(MetricValueBase.Clone(value));
+            }
+        }
+        return clone;
+    }
+
+    private static bool AttributesEqual(KeyValuePair<string, string>[] left, KeyValuePair<string, string>[] right)
+        => left.AsSpan().SequenceEqual(right);
+}

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
@@ -95,7 +95,14 @@
             }
         </ChildContent>
         <EmptyContent>
-            <FluentIcon Icon="Icons.Regular.Size24.ChartMultiple" />&nbsp;@Loc[nameof(ControlsStrings.MetricTableNoMetricsFound)]
+            @if (_hasUpdated)
+            {
+                <FluentIcon Icon="Icons.Regular.Size24.ChartMultiple" />@:&nbsp;@Loc[nameof(ControlsStrings.MetricTableNoMetricsFound)]
+            }
+            else
+            {
+                @Loc[nameof(ControlsStrings.Loading)]
+            }
         </EmptyContent>
     </FluentDataGrid>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
@@ -27,7 +27,9 @@ public partial class MetricTable : ChartBase
 
     private OtlpInstrumentSummary? _instrument;
     private bool _showCount;
-    private DateTimeOffset? _lastUpdate;
+    private bool _hasUpdated;
+
+    protected override TimeSpan UpdateInterval => TimeSpan.FromSeconds(1);
 
     private IQueryable<MetricViewBase> _metricsView => _metrics.Values.AsEnumerable().Reverse().ToList().AsQueryable();
 
@@ -46,14 +48,6 @@ public partial class MetricTable : ChartBase
     {
         Debug.Assert(_jsModule != null, "The module should be initialized before chart data is sent to control.");
 
-        // Only update the data grid once per second to avoid additional DOM re-renders.
-        if (inProgressDataTime - _lastUpdate < TimeSpan.FromSeconds(1))
-        {
-            return;
-        }
-
-        _lastUpdate = inProgressDataTime;
-
         if (!Equals(_instrument?.Name, InstrumentViewModel.Instrument?.Name) || _showCount != InstrumentViewModel.ShowCount)
         {
             _metrics.Clear();
@@ -66,12 +60,19 @@ public partial class MetricTable : ChartBase
 
         _metrics = UpdateMetrics(out var xValuesToAnnounce, traces, xValues, exemplars);
         _exemplars = exemplars;
+        // A newly activated table can calculate before its first live tick reaches the current data window.
+        // Keep showing the loading state until rows are available or a tick confirms that the window is empty.
+        _hasUpdated |= tickUpdate || _metrics.Count > 0;
+
+        // Render the updated rows before delaying their accessibility announcement.
+        await InvokeAsync(StateHasChanged);
 
         if (xValuesToAnnounce.Count == 0)
         {
             return;
         }
 
+        // Give the data grid time to render the new rows before announcing their positions to screen readers.
         await Task.Delay(500, cancellationToken);
 
         var metricView = _metricsView.ToList();

--- a/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor
@@ -9,4 +9,5 @@
                   ItemsProvider="@(() => _clearMenuItems)"
                   ButtonAppearance="Appearance.Neutral"
                   ButtonClass="clear-button"
+                  Disabled="@TelemetryRepository.IsReadOnly"
                   Title="@Loc[nameof(ControlsStrings.ClearSignalsButtonTitle)]" />

--- a/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor.cs
@@ -18,6 +18,11 @@ public partial class ClearSignalsButton : ComponentBase
     private static readonly Icon s_clearAllResourcesIcon = new Icons.Regular.Size16.Stack();
 
     [Inject]
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
+
+    [Inject]
     public required IStringLocalizer<ControlsStrings> ControlsStringsLoc { get; init; }
 
     [Parameter]
@@ -37,6 +42,7 @@ public partial class ClearSignalsButton : ComponentBase
             Id = "clear-menu-all",
             Icon = s_clearAllResourcesIcon,
             OnClick = () => HandleClearSignal(null),
+            IsDisabled = TelemetryRepository.IsReadOnly,
             Text = ControlsStringsLoc[name: nameof(ControlsStrings.ClearAllResources)],
         });
 
@@ -45,7 +51,7 @@ public partial class ClearSignalsButton : ComponentBase
             Id = "clear-menu-resource",
             Icon = s_clearSelectedResourceIcon,
             OnClick = () => HandleClearSignal(SelectedResource.Id?.GetResourceKey()),
-            IsDisabled = SelectedResource.Id == null,
+            IsDisabled = TelemetryRepository.IsReadOnly || SelectedResource.Id == null,
             Text = SelectedResource.Id == null
                 ? ControlsStringsLoc[nameof(ControlsStrings.ClearPendingSelectedResource)]
                 : string.Format(CultureInfo.InvariantCulture, ControlsStringsLoc[name: nameof(ControlsStrings.ClearSelectedResource)], SelectedResource.Name),

--- a/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor
@@ -1,0 +1,13 @@
+<div class="application-run-select">
+    <AspireMenuButton Text="@SelectedRunText"
+                      Title="@RunSelectTitle"
+                      aria-label="@RunSelectAccessibleLabel"
+                      IconStart="@(new Icons.Filled.Size12.Circle())"
+                      IconStartClass="application-run-status"
+                      IconStartColor="@(SelectedRunIsCurrent ? Color.Success : Color.Warning)"
+                      ItemsProvider="@LoadRuns"
+                      ButtonAppearance="Appearance.Stealth"
+                      ButtonClass="application-run-select-button"
+                      HideIcon="true"
+                      RestoreFocusOnItemClick="true" />
+</div>

--- a/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
+using LayoutResources = Aspire.Dashboard.Resources.Layout;
+
+namespace Aspire.Dashboard.Components.Controls;
+
+public partial class DashboardRunSelect : ComponentBase
+{
+    private static readonly Icon s_checkmarkIcon = new Icons.Regular.Size16.Checkmark();
+    private static readonly Icon s_pinIcon = new Icons.Regular.Size16.Pin();
+    private static readonly Icon s_pinnedIcon = new Icons.Filled.Size16.Pin();
+
+    private string RunSelectTitle => Loc[nameof(LayoutResources.DashboardRunSelectTitle)];
+    private string RunSelectAccessibleLabel => Loc[nameof(LayoutResources.DashboardRunSelectAccessibleLabel), SelectedRunText];
+    private string SelectedRunText => SelectedRunIsCurrent
+        ? Loc[nameof(LayoutResources.DashboardRunSelectCurrent)]
+        : FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, SelectedRunStartedAtUtc.UtcDateTime);
+
+    [Parameter, EditorRequired]
+    public required string SelectedRunId { get; set; }
+
+    [Parameter]
+    public bool SelectedRunIsCurrent { get; set; }
+
+    [Parameter]
+    public DateTimeOffset SelectedRunStartedAtUtc { get; set; }
+
+    [Parameter]
+    public EventCallback<string?> SelectedRunIdChanged { get; set; }
+
+    [Inject]
+    public required IStringLocalizer<LayoutResources> Loc { get; init; }
+
+    [Inject]
+    public required BrowserTimeProvider TimeProvider { get; init; }
+
+    [Inject]
+    public required IDashboardRunStore RunStore { get; init; }
+
+    [Inject]
+    public required ILogger<DashboardRunSelect> Logger { get; init; }
+
+    private IList<MenuButtonItem> LoadRuns()
+    {
+        var runs = RunStore.GetRuns()
+            .Where(run => !run.IsPruned)
+            .OrderByDescending(run => run.IsCurrent)
+            .ThenByDescending(run => run.IsPinned)
+            .ThenByDescending(run => run.StartedAtUtc)
+            .ToArray();
+        var menuItems = new List<MenuButtonItem>();
+        foreach (var run in runs)
+        {
+            var menuItem = new MenuButtonItem
+            {
+                Text = FormatRunOption(run),
+                Role = MenuItemRole.MenuItemRadio,
+                Checked = string.Equals(run.RunId, SelectedRunId, StringComparison.Ordinal),
+                Icon = s_checkmarkIcon,
+                SecondaryActionIcon = run.IsPinned ? s_pinnedIcon : s_pinIcon,
+                SecondaryActionAriaLabel = Loc[run.IsPinned
+                    ? nameof(LayoutResources.DashboardRunSelectUnpin)
+                    : nameof(LayoutResources.DashboardRunSelectPin)],
+                IsSecondaryActionSelected = run.IsPinned,
+                OnSecondaryActionClick = () =>
+                {
+                    SetRunPinned(run, !run.IsPinned);
+                    return Task.CompletedTask;
+                },
+                OnClick = () => SelectedRunIdChanged.InvokeAsync(run.IsCurrent ? null : run.RunId)
+            };
+            menuItems.Add(menuItem);
+
+            if (run.IsCurrent && runs.Any(candidate => !candidate.IsCurrent))
+            {
+                menuItems.Add(new MenuButtonItem { IsDivider = true });
+            }
+        }
+
+        return menuItems;
+    }
+
+    private void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
+    {
+        try
+        {
+            RunStore.SetRunPinned(run, isPinned);
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError(exception, "Failed to update the pinned state of dashboard run '{RunId}'.", run.RunId);
+        }
+    }
+
+    private string FormatRunOption(DashboardRunDescriptor run)
+    {
+        if (run.IsCurrent)
+        {
+            return Loc[nameof(LayoutResources.DashboardRunSelectCurrent)];
+        }
+
+        return FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, run.StartedAtUtc.UtcDateTime);
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.css
@@ -1,0 +1,8 @@
+.application-run-select ::deep .application-run-select-button {
+    margin-right: 8px;
+}
+
+.application-run-select ::deep .application-run-select-button::part(control) {
+    padding-left: 8px;
+    padding-right: 8px;
+}

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -16,7 +16,7 @@
             {
                 <div class="console-empty-message" role="status" aria-live="polite">
                     <FluentIcon Value="@(new Icons.Regular.Size24.SlideText())" aria-hidden="true" />
-                    <span>@Loc[nameof(ConsoleLogs.ConsoleLogsNoLogsFound)]</span>
+                    <span>@(NoLogsMessage ?? Loc[nameof(ConsoleLogs.ConsoleLogsNoLogsFound)])</span>
                 </div>
             }
             else if (!string.IsNullOrWhiteSpace(FilterText) && logEntries.EntriesCount > 0 && GetVisibleEntries().Count == 0)

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -59,6 +59,9 @@ public sealed partial class LogViewer
     public bool ShowNoLogsMessage { get; set; }
 
     [Parameter]
+    public string? NoLogsMessage { get; set; }
+
+    [Parameter]
     public string? FilterText { get; set; }
 
     private Virtualize<LogEntry>? VirtualizeRef

--- a/src/Aspire.Dashboard/Components/Controls/ParameterValueDisplay.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ParameterValueDisplay.razor
@@ -1,6 +1,7 @@
 ﻿@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
+@inject IDashboardClient DashboardClient
 
 @if (SetCommand is not null)
 {
@@ -29,7 +30,7 @@ else
     public required Func<ResourceViewModel, CommandViewModel, bool> IsCommandExecuting { get; set; }
 
     private CommandViewModel? SetCommand { get; set; }
-    private bool IsSetCommandDisabled => SetCommand is null || SetCommand.State == CommandViewModelState.Disabled || IsSetCommandExecuting;
+    private bool IsSetCommandDisabled => DashboardClient.IsReadOnly || SetCommand is null || SetCommand.State == CommandViewModelState.Disabled || IsSetCommandExecuting;
     private bool IsSetCommandExecuting => SetCommand is not null && IsCommandExecuting(Resource, SetCommand);
 
     protected override void OnParametersSet()
@@ -48,7 +49,8 @@ else
 
     private Task OnClickAsync()
     {
-        if (SetCommand is not { } setCommand ||
+        if (DashboardClient.IsReadOnly ||
+            SetCommand is not { } setCommand ||
             setCommand.State == CommandViewModelState.Disabled ||
             IsCommandExecuting(Resource, setCommand))
         {

--- a/src/Aspire.Dashboard/Components/Controls/PauseIncomingDataSwitch.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PauseIncomingDataSwitch.razor
@@ -2,6 +2,7 @@
 @inject IStringLocalizer<ControlsStrings> Loc
 
 <FluentButton Appearance="Appearance.Neutral"
+              Disabled="@Disabled"
               Title="@(IsPaused ? Loc[nameof(ControlsStrings.ResumeButtonTitle)] : Loc[nameof(ControlsStrings.PauseButtonTitle)])"
               OnClick="@OnTogglePauseCoreAsync">
     @if (IsPaused)

--- a/src/Aspire.Dashboard/Components/Controls/PauseIncomingDataSwitch.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PauseIncomingDataSwitch.razor.cs
@@ -12,8 +12,16 @@ public partial class PauseIncomingDataSwitch : ComponentBase
     [Parameter]
     public EventCallback<bool> IsPausedChanged { get; set; }
 
+    [Parameter]
+    public bool Disabled { get; set; }
+
     private async Task OnTogglePauseCoreAsync()
     {
+        if (Disabled)
+        {
+            return;
+        }
+
         IsPaused = !IsPaused;
         await IsPausedChanged.InvokeAsync(IsPaused);
     }

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameButtonValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/ResourceNameButtonValue.razor.cs
@@ -28,6 +28,9 @@ public partial class ResourceNameButtonValue
     public required IDashboardClient DashboardClient { get; init; }
 
     [Inject]
+    public required DashboardDataSource DataSource { get; init; }
+
+    [Inject]
     public required IconResolver IconResolver { get; init; }
 
     private ResourceViewModel? _resource;
@@ -39,7 +42,7 @@ public partial class ResourceNameButtonValue
 
         if (DashboardClient.IsEnabled)
         {
-            _resource = DashboardClient.GetResource(Resource.ResourceKey.ToString());
+            _resource = DataSource.ResourceRepository.GetResource(Resource.ResourceKey.ToString());
             if (_resource != null)
             {
                 _resourceIcon = ResourceIconHelpers.GetIconForResource(IconResolver, _resource, IconSize.Size16, IconVariant.Regular);

--- a/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanIdButtonValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyValues/SpanIdButtonValue.razor.cs
@@ -24,7 +24,9 @@ public partial class SpanIdButtonValue
     public required DashboardDialogService DialogService { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     [Inject]
     public required IStringLocalizer<Resources.Dialogs> Loc { get; init; }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -17,7 +17,7 @@
                 {
                     var highlightedCommand = _highlightedCommands[i];
 
-                    <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.GetDisplayDescription()) ? highlightedCommand.GetDisplayDescription() : highlightedCommand.GetDisplayName())" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
+                    <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.GetDisplayDescription()) ? highlightedCommand.GetDisplayDescription() : highlightedCommand.GetDisplayName())" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(DashboardClient.IsReadOnly || highlightedCommand.State == CommandViewModelState.Disabled || IsCommandExecuting(Resource, highlightedCommand))">
                         <FluentIcon Value="@IconResolver.ResolveHighlightedCommandIcon(highlightedCommand.IconName, highlightedCommand.IconVariant)" Width="16px" />
                     </FluentButton>
                 }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -32,6 +32,9 @@ public partial class ResourceActions : ComponentBase
     [Inject]
     public required IconResolver IconResolver { get; init; }
 
+    [Inject]
+    public required IDashboardClient DashboardClient { get; init; }
+
     [Parameter]
     public required EventCallback<CommandViewModel> CommandSelected { get; set; }
 

--- a/src/Aspire.Dashboard/Components/Controls/SignalsActionsDisplay.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SignalsActionsDisplay.razor
@@ -3,7 +3,7 @@
 
 @if (ViewportInformation.IsDesktop)
 {
-    <PauseIncomingDataSwitch IsPaused="@IsPaused" IsPausedChanged="@OnPausedChanged"/>
+    <PauseIncomingDataSwitch IsPaused="@IsPaused" IsPausedChanged="@OnPausedChanged" Disabled="@TelemetryRepository.IsReadOnly"/>
     <ClearSignalsButton SelectedResource="@SelectedResource"
                         HandleClearSignal="@HandleClearSignal"/>
 }
@@ -12,7 +12,7 @@ else
     <FluentLabel>@ControlsStringsLoc[nameof(ControlsStrings.ResourceActions)]</FluentLabel>
 
     <FluentStack Orientation="Orientation.Horizontal">
-        <PauseIncomingDataSwitch IsPaused="@IsPaused" IsPausedChanged="@OnPausedChanged" />
+        <PauseIncomingDataSwitch IsPaused="@IsPaused" IsPausedChanged="@OnPausedChanged" Disabled="@TelemetryRepository.IsReadOnly" />
         <ClearSignalsButton SelectedResource="@SelectedResource"
                             HandleClearSignal="@HandleClearSignal"/>
     </FluentStack>

--- a/src/Aspire.Dashboard/Components/Controls/SignalsActionsDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SignalsActionsDisplay.razor.cs
@@ -9,6 +9,11 @@ namespace Aspire.Dashboard.Components.Controls;
 
 public partial class SignalsActionsDisplay
 {
+    [Inject]
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
+
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; set; }
 

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -34,7 +34,9 @@ public partial class SpanDetails : IDisposable
     public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     [Inject]
     public required IJSRuntime JS { get; init; }

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -23,7 +23,7 @@ public partial class StructuredLogActions : ComponentBase
     public required EventCallback<string> OnViewDetails { get; set; }
 
     [Parameter]
-    public required OtlpLogEntry LogEntry { get; set; }
+    public required LogSummary LogEntry { get; set; }
 
     private IList<MenuButtonItem> GetMenuItems()
     {

--- a/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
@@ -2,7 +2,14 @@
 
 <div class="items-footer">
     <span class="result-count" aria-live="polite" aria-atomic="true">
-        @((MarkupString)string.Format(TotalItemCount == 1 ? SingularText : PluralText, TotalItemCount))
+        @if (DisplayedItemCount is { } displayedItemCount && displayedItemCount < TotalItemCount && PartialText is not null)
+        {
+            @((MarkupString)string.Format(PartialText, displayedItemCount, TotalItemCount))
+        }
+        else
+        {
+            @((MarkupString)string.Format(TotalItemCount == 1 ? SingularText : PluralText, TotalItemCount))
+        }
     </span>
 
     @if (PauseText is not null)

--- a/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor.cs
@@ -16,11 +16,23 @@ public partial class TotalItemsFooter
     [Parameter]
     public int TotalItemCount { get; set; }
 
+    /// <summary>
+    /// Gets or sets the number of items that can be displayed when it is less than <see cref="TotalItemCount"/>.
+    /// </summary>
+    [Parameter]
+    public int? DisplayedItemCount { get; set; }
+
     [Parameter, EditorRequired]
     public required string SingularText { get; set; }
 
     [Parameter, EditorRequired]
     public required string PluralText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the format used when <see cref="DisplayedItemCount"/> has a value. The displayed count is {0}, and the total count is {1}.
+    /// </summary>
+    [Parameter]
+    public string? PartialText { get; set; }
 
     [Parameter]
     public string? PauseText { get; set; }
@@ -31,6 +43,18 @@ public partial class TotalItemsFooter
     public void UpdateDisplayedCount(int totalItemCount)
     {
         TotalItemCount = totalItemCount;
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Updates the total and displayed item counts, then refreshes the control.
+    /// </summary>
+    /// <param name="totalItemCount">The item count to display.</param>
+    /// <param name="displayedItemCount">The number of items that can be displayed, or <see langword="null"/> when all items can be displayed.</param>
+    public void UpdateDisplayedCount(int totalItemCount, int? displayedItemCount)
+    {
+        TotalItemCount = totalItemCount;
+        DisplayedItemCount = displayedItemCount;
         StateHasChanged();
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -20,12 +20,12 @@ public partial class TraceActions : ComponentBase
     public required IStringLocalizer<ControlsStrings> ControlsLoc { get; init; }
 
     [Parameter]
-    public required OtlpTrace Trace { get; set; }
+    public required TraceSummary Summary { get; set; }
 
     private IList<MenuButtonItem> GetMenuItems()
     {
         var menuItems = new List<MenuButtonItem>();
-        TraceMenuBuilder.AddMenuItems(menuItems, Trace);
+        TraceMenuBuilder.AddMenuItems(menuItems, Summary);
         return menuItems;
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/TreeMetricSelector.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TreeMetricSelector.razor.cs
@@ -19,7 +19,9 @@ public partial class TreeMetricSelector
     public bool IncludeLabel { get; set; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     public void OnResourceChanged()
     {

--- a/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor.cs
@@ -27,7 +27,9 @@ public partial class ExemplarsDialog : IDisposable
     public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     public IQueryable<ChartExemplar> MetricView => Content.Exemplars.AsQueryable();
 

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -5,60 +5,80 @@
 
 @inject IStringLocalizer<Dialogs> Loc
 @inject IStringLocalizer<StructuredFiltering> FilterLoc
+@inject IStringLocalizer<ControlsStrings> ControlsLoc
 
 <EditForm EditContext="@EditContext" OnValidSubmit="@Apply">
     <DataAnnotationsValidator />
 
     <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
         <div class="filter-input-container input-container">
-            <FluentSelect TOption="SelectViewModel<string>"
-                          Placeholder="@Loc[nameof(Dialogs.FilterDialogFieldPlaceholder)]"
-                          Label="@Loc[nameof(Dialogs.FilterDialogParameterInputLabel)]"
-                          Items="@_parameters"
-                          @bind-SelectedOption="@_formModel.Parameter"
-                          @bind-SelectedOption:after="ParameterChangedAsync"
-                          Width="100%"
-                          Height="400px"
-                          OptionText="@(c => c.Name)"
-                          OptionDisabled="@(c => c.Id is null)"
-                          OptionTitle="@(c => DashboardUIHelpers.ResolveTooltip(c.Name))">
-            </FluentSelect>
+            <FluentInputLabel ForId="filter-dialog-parameter-select"
+                              Label="@Loc[nameof(Dialogs.FilterDialogParameterInputLabel)]"
+                              AriaLabel="@Loc[nameof(Dialogs.FilterDialogParameterInputLabel)]" />
+            <div class="input-line-container">
+                <FluentSelect Id="filter-dialog-parameter-select"
+                              TOption="SelectViewModel<string>"
+                              Placeholder="@Loc[nameof(Dialogs.FilterDialogFieldPlaceholder)]"
+                              Items="@_parameters"
+                              @bind-SelectedOption="@_formModel.Parameter"
+                              @bind-SelectedOption:after="ParameterChangedAsync"
+                              Height="400px"
+                              Disabled="@_loadingPropertyKeys"
+                              OptionText="@(c => c.Name)"
+                              OptionDisabled="@(c => c.Id is null)"
+                              OptionTitle="@(c => DashboardUIHelpers.ResolveTooltip(c.Name))">
+                </FluentSelect>
+                @if (_loadingPropertyKeys)
+                {
+                    <FluentProgressRing Width="20px" Class="input-progress" aria-label="@ControlsLoc[nameof(ControlsStrings.Loading)]" />
+                }
+            </div>
         </div>
 
         <div class="filter-input-container input-container">
-            <FluentSelect TOption="SelectViewModel<FilterCondition>"
-                          Items="@_filterConditions"
-                          @bind-SelectedOption="@_formModel.Condition"
-                          Label="@Loc[nameof(Dialogs.FilterDialogConditionInputLabel)]"
-                          OptionText="@(i => i.Name)"
-                          Width="100%" />
+            <FluentInputLabel ForId="filter-dialog-condition-select"
+                              Label="@Loc[nameof(Dialogs.FilterDialogConditionInputLabel)]"
+                              AriaLabel="@Loc[nameof(Dialogs.FilterDialogConditionInputLabel)]" />
+            <div class="input-line-container">
+                <FluentSelect Id="filter-dialog-condition-select"
+                              TOption="SelectViewModel<FilterCondition>"
+                              Items="@_filterConditions"
+                              @bind-SelectedOption="@_formModel.Condition"
+                              OptionText="@(i => i.Name)" />
+            </div>
         </div>
 
         @if (_formModel.ValueIsNumeric)
         {
             <div class="filter-input-container input-container">
-                <FluentNumberField TValue="double?"
-                                   @bind-Value="_formModel.NumericValue"
-                                   Min="0"
-                                   Step="50"
-                                   Width="100%"
-                                   Immediate="true"
-                                   ImmediateDelay="@FluentUIExtensions.InputDelay"
-                                   Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]" />
+                <FluentInputLabel ForId="filter-dialog-number-field"
+                                  Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]"
+                                  AriaLabel="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]" />
+                <div class="input-line-container">
+                    <FluentNumberField Id="filter-dialog-number-field"
+                                       TValue="double?"
+                                       @bind-Value="_formModel.NumericValue"
+                                       Min="0"
+                                       Step="50"
+                                       Immediate="true"
+                                       ImmediateDelay="@FluentUIExtensions.InputDelay" />
+                </div>
                 <ValidationMessage For="() => _formModel.NumericValue" />
             </div>
         }
         else if (_formModel.ValueIsDate)
         {
             <div class="filter-input-container input-container">
+                <FluentInputLabel ForId="filter-dialog-date-value"
+                                  Label="@Loc[nameof(Dialogs.FilterDialogDateValueLabel)]"
+                                  AriaLabel="@Loc[nameof(Dialogs.FilterDialogDateValueLabel)]" />
                 @* Position relative to correctly align the absolute positioned date picker *@
-                <div style="position: relative;">
-                    <FluentTextField @bind-Value="_formModel.Value"
-                                    Style="min-width: 100%"
-                                    Immediate="true"
-                                    ImmediateDelay="@FluentUIExtensions.InputDelay"
-                                    Placeholder="@Loc[nameof(Dialogs.FilterDialogDatePlaceholder)]"
-                                    Label="@Loc[nameof(Dialogs.FilterDialogDateValueLabel)]">
+                <div class="input-line-container" style="position: relative;">
+                    <FluentTextField Id="filter-dialog-date-value"
+                                     @bind-Value="_formModel.Value"
+                                     Immediate="true"
+                                     ImmediateDelay="@FluentUIExtensions.InputDelay"
+                                     Placeholder="@Loc[nameof(Dialogs.FilterDialogDatePlaceholder)]">
                         <FluentIcon slot="end"
                                     Value="@(new Icons.Regular.Size16.Calendar())"
                                     Title="@Loc[nameof(Dialogs.FilterDialogPickDateButtonTitle)]"
@@ -66,11 +86,11 @@
                                     Style="cursor: pointer;" />
                     </FluentTextField>
                     <input type="datetime-local"
-                        @ref="_datePickerInput"
-                        step="1"
-                        value="@_formModel.DateTimeLocalValue"
-                        @oninput="OnDateTimePickerChanged"
-                        style="position: absolute; right: 0; bottom: 0; height: 0; width: 0; overflow: hidden; border: none; padding: 0; margin: 0; pointer-events: none; opacity: 0;" />
+                           @ref="_datePickerInput"
+                           step="1"
+                           value="@_formModel.DateTimeLocalValue"
+                           @oninput="OnDateTimePickerChanged"
+                           style="position: absolute; right: 0; bottom: 0; height: 0; width: 0; overflow: hidden; border: none; padding: 0; margin: 0; pointer-events: none; opacity: 0;" />
                 </div>
                 <ValidationMessage For="() => _formModel.Value" />
             </div>
@@ -78,28 +98,37 @@
         else
         {
             <div class="filter-input-container input-container">
-                <FluentCombobox TOption="SelectViewModel<FieldValue>"
-                                @bind-Value="_formModel.Value"
-                                @bind-Value:after="ValueChanged"
-                                Items="@_filteredValues"
-                                Width="100%"
-                                Height="400px"
-                                OptionText="@(c => c.Name)"
-                                OptionValue="@(c => c.Name)"
-                                OptionTitle="@(c => DashboardUIHelpers.ResolveTooltip(c.Name))"
-                                Immediate="true"
-                                ImmediateDelay="@FluentUIExtensions.InputDelay"
-                                Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]">
-                    <OptionTemplate Context="optionContext">
-                        <FluentBadge Circular=true Appearance="Appearance.Neutral" Slot="end">
-                            @* There is FluentUI bug that causes bad data if there is additional text in an option. *@
-                            @* https://github.com/microsoft/fluentui-blazor/issues/2695 *@
-                            @* Workaround this issue by inserting extra text using CSS. *@
-                            <span data-filtercount="@optionContext.Id!.Count"></span>
-                        </FluentBadge>
-                        <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" />
-                    </OptionTemplate>
-                </FluentCombobox>
+                <FluentInputLabel ForId="filter-dialog-text-value"
+                                  Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]"
+                                  AriaLabel="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]" />
+                <div class="input-line-container">
+                    <FluentCombobox Id="filter-dialog-text-value"
+                                    TOption="SelectViewModel<FieldValue>"
+                                    @bind-Value="_formModel.Value"
+                                    @bind-Value:after="ValueChanged"
+                                    Items="@_filteredValues"
+                                    Height="400px"
+                                    Disabled="@_loadingFieldValues"
+                                    OptionText="@(c => c.Name)"
+                                    OptionValue="@(c => c.Name)"
+                                    OptionTitle="@(c => DashboardUIHelpers.ResolveTooltip(c.Name))"
+                                    Immediate="true"
+                                    ImmediateDelay="@FluentUIExtensions.InputDelay">
+                        <OptionTemplate Context="optionContext">
+                            <FluentBadge Circular=true Appearance="Appearance.Neutral" Slot="end">
+                                @* There is FluentUI bug that causes bad data if there is additional text in an option. *@
+                                @* https://github.com/microsoft/fluentui-blazor/issues/2695 *@
+                                @* Workaround this issue by inserting extra text using CSS. *@
+                                <span data-filtercount="@optionContext.Id!.Count"></span>
+                            </FluentBadge>
+                            <FluentHighlighter Text="@optionContext.Name" HighlightedText="@_formModel.Value" />
+                        </OptionTemplate>
+                    </FluentCombobox>
+                    @if (_loadingFieldValues)
+                    {
+                        <FluentProgressRing Width="20px" Class="input-progress" aria-label="@ControlsLoc[nameof(ControlsStrings.Loading)]" />
+                    }
+                </div>
                 <ValidationMessage For="() => _formModel.Value" />
             </div>
         }

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -15,6 +15,10 @@ namespace Aspire.Dashboard.Components.Dialogs;
 
 public partial class FilterDialog : IAsyncDisposable
 {
+    // Cancels in-flight telemetry reads when the dialog closes. Reads now run against SQLite on the thread
+    // pool, so without this a closed dialog leaves a full-table scan running with nobody waiting on it.
+    private readonly CancellationTokenSource _disposeCts = new();
+    private long _fieldValuesUpdateVersion;
     private List<SelectViewModel<FilterCondition>> _filterConditions = null!;
     private List<SelectViewModel<FilterCondition>> _stringFilterConditions = null!;
     private List<SelectViewModel<FilterCondition>> _numericFilterConditions = null!;
@@ -30,7 +34,12 @@ public partial class FilterDialog : IAsyncDisposable
     public FilterDialogViewModel Content { get; set; } = default!;
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    [Inject]
+    public required ILogger<FilterDialog> Logger { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     [Inject]
     public required IJSRuntime JS { get; init; }
@@ -41,10 +50,12 @@ public partial class FilterDialog : IAsyncDisposable
     private List<SelectViewModel<string>> _parameters = default!;
     private List<SelectViewModel<FieldValue>> _filteredValues = default!;
     private List<SelectViewModel<FieldValue>>? _allValues;
+    private bool _loadingPropertyKeys = true;
+    private bool _loadingFieldValues = true;
 
     public EditContext EditContext { get; private set; } = default!;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         _stringFilterConditions =
         [
@@ -80,26 +91,7 @@ public partial class FilterDialog : IAsyncDisposable
         EditContext = new EditContext(_formModel);
 
         _filteredValues = [];
-    }
-
-    protected override void OnParametersSet()
-    {
-        var knownFields = Content.KnownKeys.Select(p => new SelectViewModel<string> { Id = p, Name = FieldTelemetryFilter.ResolveFieldName(p) }).ToList();
-        var customFields = Content.PropertyKeys.Select(p => new SelectViewModel<string> { Id = p, Name = FieldTelemetryFilter.ResolveFieldName(p) }).ToList();
-
-        if (customFields.Count > 0)
-        {
-            _parameters =
-            [
-                .. knownFields,
-                new SelectViewModel<string> { Id = null, Name = "-" },
-                .. customFields
-            ];
-        }
-        else
-        {
-            _parameters = knownFields;
-        }
+        _parameters = CreateParameters([]);
 
         if (Content.Filter is { } filter)
         {
@@ -116,8 +108,58 @@ public partial class FilterDialog : IAsyncDisposable
             SetFormValue("");
         }
 
-        UpdateParameterFieldValues();
+        if (!await UpdateParameterFieldValuesAsync())
+        {
+            return;
+        }
         ValueChanged();
+
+        try
+        {
+            var propertyKeys = await Content.GetPropertyKeysAsync(_disposeCts.Token);
+
+            var selectedParameter = _formModel.Parameter?.Id;
+            _parameters = CreateParameters(propertyKeys);
+            _formModel.Parameter = _parameters.SingleOrDefault(parameter => parameter.Id == selectedParameter) ?? _parameters.FirstOrDefault();
+        }
+        catch (OperationCanceledException) when (_disposeCts.IsCancellationRequested)
+        {
+            // The dialog closed while the read was in flight.
+        }
+        catch (Exception ex)
+        {
+            // Custom property keys are additive to KnownKeys, so the dialog is still usable without them.
+            // Letting the exception escape OnInitializedAsync would tear down the circuit and take the whole
+            // dashboard tab with it for what is a recoverable read failure.
+            Logger.LogWarning(ex, "Error loading filter property keys.");
+        }
+        finally
+        {
+            // Property keys are read from the database on a background thread, so this can fault.
+            // Clear the flag in a finally, otherwise the parameter combobox stays disabled with a
+            // spinner for the lifetime of the dialog and the only recovery is reloading the page.
+            _loadingPropertyKeys = false;
+        }
+    }
+
+    private List<SelectViewModel<string>> CreateParameters(List<string> propertyKeys)
+    {
+        var knownFields = Content.KnownKeys.Select(p => new SelectViewModel<string> { Id = p, Name = FieldTelemetryFilter.ResolveFieldName(p) }).ToList();
+        var customFields = propertyKeys
+            .Append(Content.Filter is { Field: { } field } && !Content.KnownKeys.Contains(field, StringComparers.OtlpAttribute) ? field : null)
+            .OfType<string>()
+            .Distinct(StringComparers.OtlpAttribute)
+            .Select(propertyKey => new SelectViewModel<string> { Id = propertyKey, Name = FieldTelemetryFilter.ResolveFieldName(propertyKey) })
+            .ToList();
+
+        return customFields.Count > 0
+            ?
+            [
+                .. knownFields,
+                new SelectViewModel<string> { Id = null, Name = "-" },
+                .. customFields
+            ]
+            : knownFields;
     }
 
     private void UpdateSelectedParameter()
@@ -155,29 +197,68 @@ public partial class FilterDialog : IAsyncDisposable
         }
     }
 
-    private void UpdateParameterFieldValues()
+    private async Task<bool> UpdateParameterFieldValuesAsync()
     {
+        var updateVersion = Interlocked.Increment(ref _fieldValuesUpdateVersion);
+
         if (_formModel.ValueIsNumeric || _formModel.ValueIsDate)
         {
             _allValues = null;
             _filteredValues = [];
-            return;
+            _loadingFieldValues = false;
+            return true;
         }
 
         if (_formModel.Parameter?.Id is { } parameterName)
         {
-            var fieldValues = Content.GetFieldValues(parameterName);
-            _allValues = fieldValues
-                .Select(kvp => new FieldValue { Value = kvp.Key, Count = kvp.Value })
-                .OrderByDescending(v => v.Count)
-                .ThenBy(v => v.Value, StringComparers.OtlpFieldValue)
-                .Select(v => new SelectViewModel<FieldValue> { Id = v, Name = v.Value })
-                .ToList();
+            _loadingFieldValues = true;
+            _allValues = null;
+            _filteredValues = [];
+
+            try
+            {
+                var fieldValues = await Content.GetFieldValuesAsync(parameterName, _disposeCts.Token);
+                if (updateVersion != Volatile.Read(ref _fieldValuesUpdateVersion))
+                {
+                    return false;
+                }
+
+                _allValues = fieldValues
+                    .Select(kvp => new FieldValue { Value = kvp.Key, Count = kvp.Value })
+                    .OrderByDescending(v => v.Count)
+                    .ThenBy(v => v.Value, StringComparers.OtlpFieldValue)
+                    .Select(v => new SelectViewModel<FieldValue> { Id = v, Name = v.Value })
+                    .ToList();
+                _loadingFieldValues = false;
+            }
+            catch (OperationCanceledException) when (_disposeCts.IsCancellationRequested)
+            {
+                // The dialog closed while the read was in flight.
+                return false;
+            }
+            catch (Exception ex)
+            {
+                // Field values only drive the value autocomplete, so the user can still type a value. Failing
+                // the whole dialog for a recoverable read error would be a worse outcome.
+                Logger.LogWarning(ex, "Error loading filter values for field '{FieldName}'.", parameterName);
+
+                // Only the newest in-flight load owns the loading flag. A stale load clearing it here
+                // would hide the spinner while a newer load is still running.
+                if (updateVersion != Volatile.Read(ref _fieldValuesUpdateVersion))
+                {
+                    return false;
+                }
+
+                _loadingFieldValues = false;
+            }
         }
         else
         {
             _allValues = null;
+            _loadingFieldValues = false;
         }
+
+        return true;
     }
 
     private async Task ParameterChangedAsync()
@@ -185,7 +266,10 @@ public partial class FilterDialog : IAsyncDisposable
         UpdateSelectedParameter();
         _formModel.Condition = GetDefaultCondition();
         SetFormValue("");
-        UpdateParameterFieldValues();
+        if (!await UpdateParameterFieldValuesAsync())
+        {
+            return;
+        }
 
         StateHasChanged();
 
@@ -310,6 +394,8 @@ public partial class FilterDialog : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        await _disposeCts.CancelAsync();
+        _disposeCts.Dispose();
         await JSInteropHelpers.SafeDisposeAsync(_jsModule);
     }
 

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.css
@@ -1,3 +1,18 @@
 ::deep [data-filtercount]::before {
     content: attr(data-filtercount);
 }
+
+.input-line-container {
+    display: flex;
+    column-gap: 12px;
+    align-items: center;
+}
+
+.input-line-container > div,
+.input-line-container ::deep fluent-select,
+.input-line-container ::deep fluent-number-field,
+.input-line-container ::deep fluent-text-field,
+.input-line-container ::deep fluent-combobox {
+    flex: 1;
+    min-width: 0;
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/GenAIVisualizerDialog.razor.cs
@@ -25,6 +25,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
     private static readonly Icon s_toolIcon = new Icons.Regular.Size16.Code();
 
     private readonly string _copyButtonId = $"copy-{Guid.NewGuid():N}";
+    private readonly CancellationTokenSource _cts = new();
 
     private MarkdownProcessor _markdownProcess = default!;
     private Subscription? _resourcesSubscription;
@@ -33,6 +34,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
     private List<OtlpSpan> _contextSpans = default!;
     private int _currentSpanContextIndex;
+    private long _contentUpdateVersion;
     private GenAIVisualizerDialogViewModel? _content;
 
     private GenAIItemViewModel? SelectedItem { get; set; }
@@ -47,7 +49,9 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
     public required BrowserTimeProvider TimeProvider { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     [Inject]
     public required IStringLocalizer<Resources.Dialogs> Loc { get; init; }
@@ -87,6 +91,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
     {
         if (_content != Content)
         {
+            Interlocked.Increment(ref _contentUpdateVersion);
             _contextSpans = Content.GetContextGenAISpans();
             _currentSpanContextIndex = _contextSpans.FindIndex(s => s.SpanId == Content.Span.SpanId);
             _content = Content;
@@ -101,7 +106,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
     private async Task UpdateDialogData()
     {
         // Multiple threads can call this. Run check inside InvokeAsync to avoid concurrency issues.
-        await InvokeAsync(() =>
+        await InvokeAsync(async () =>
         {
             var hasUpdatedTrace = TelemetryRepository.HasUpdatedTrace(Content.Span.Trace);
             var newContextSpans = Content.GetContextGenAISpans();
@@ -116,7 +121,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
                 _contextSpans = newContextSpans;
                 _currentSpanContextIndex = _contextSpans.IndexOf(span);
 
-                TryUpdateViewedGenAISpan(span);
+                await TryUpdateViewedGenAISpanAsync(span);
                 StateHasChanged();
             }
         });
@@ -227,19 +232,19 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         MessageActiveView = viewKind;
     }
 
-    private void OnPreviousGenAISpan()
+    private async Task OnPreviousGenAISpan()
     {
         if (TryGetContextSpanByIndex(_currentSpanContextIndex - 1, out var span))
         {
-            TryUpdateViewedGenAISpan(span);
+            await TryUpdateViewedGenAISpanAsync(span);
         }
     }
 
-    private void OnNextGenAISpan()
+    private async Task OnNextGenAISpan()
     {
         if (TryGetContextSpanByIndex(_currentSpanContextIndex + 1, out var span))
         {
-            TryUpdateViewedGenAISpan(span);
+            await TryUpdateViewedGenAISpanAsync(span);
         }
     }
 
@@ -249,12 +254,19 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
         return span != null;
     }
 
-    private bool TryUpdateViewedGenAISpan(OtlpSpan newSpan)
+    private async Task<bool> TryUpdateViewedGenAISpanAsync(OtlpSpan newSpan)
     {
+        var updateVersion = Interlocked.Increment(ref _contentUpdateVersion);
         var selectedIndex = SelectedItem?.Index;
+        var getContextGenAISpans = Content.GetContextGenAISpans;
 
         var spanDetailsViewModel = SpanDetailsViewModel.Create(newSpan, TelemetryRepository, TelemetryRepository.GetResources());
-        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId: null, ErrorRecorder, TelemetryRepository, Content.GetContextGenAISpans);
+        var dialogViewModel = await GenAIVisualizerDialogViewModel.CreateAsync(spanDetailsViewModel, selectedLogEntryId: null, ErrorRecorder, TelemetryRepository, getContextGenAISpans, _cts.Token);
+
+        if (updateVersion != Volatile.Read(ref _contentUpdateVersion))
+        {
+            return false;
+        }
 
         if (selectedIndex != null)
         {
@@ -363,6 +375,9 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
     public void Dispose()
     {
+        Interlocked.Increment(ref _contentUpdateVersion);
+        _cts.Cancel();
+        _cts.Dispose();
         _resourcesSubscription?.Dispose();
         _tracesSubscription?.Dispose();
         _logsSubscription?.Dispose();
@@ -371,7 +386,8 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
     public static async Task OpenDialogAsync(DashboardDialogService dialogService,
         OtlpSpan span, long? selectedLogEntryId,
-        TelemetryRepository telemetryRepository, ITelemetryErrorRecorder errorRecorder, List<OtlpResource> resources, Func<List<OtlpSpan>> getContextGenAISpans)
+        ITelemetryRepository telemetryRepository, ITelemetryErrorRecorder errorRecorder, List<OtlpResource> resources, Func<List<OtlpSpan>> getContextGenAISpans,
+        CancellationToken cancellationToken)
     {
         var title = span.Name;
         var width = dialogService.IsDesktop ? "75vw" : "100vw";
@@ -386,7 +402,7 @@ public partial class GenAIVisualizerDialog : ComponentBase, IComponentWithTeleme
 
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, telemetryRepository, resources);
 
-        var dialogViewModel = GenAIVisualizerDialogViewModel.Create(spanDetailsViewModel, selectedLogEntryId, errorRecorder, telemetryRepository, getContextGenAISpans);
+        var dialogViewModel = await GenAIVisualizerDialogViewModel.CreateAsync(spanDetailsViewModel, selectedLogEntryId, errorRecorder, telemetryRepository, getContextGenAISpans, cancellationToken);
 
         await dialogService.ShowDialogAsync<GenAIVisualizerDialog>(dialogViewModel, parameters);
     }

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -34,9 +34,6 @@ public partial class InteractionsInputDialog : IAsyncDisposable
     [Inject]
     public required IJSRuntime JS { get; init; }
 
-    [Inject]
-    public required IDashboardClient DashboardClient { get; init; }
-
     private readonly CancellationTokenSource _disposalCts = new();
     private InteractionsInputsDialogViewModel? _content;
     private EditContext _editContext = default!;
@@ -243,7 +240,7 @@ public partial class InteractionsInputDialog : IAsyncDisposable
             try
             {
                 using var stream = file.OpenReadStream(maxFileSize);
-                var fileId = await DashboardClient.UploadFileAsync(stream, file.Name, file.Size, Content.Interaction.InteractionId, inputModel.Input.Name, _disposalCts.Token);
+                var fileId = await Content.DashboardClient.UploadFileAsync(stream, file.Name, file.Size, Content.Interaction.InteractionId, inputModel.Input.Name, _disposalCts.Token);
                 fileReferences.Add(new FileReferenceViewModel { Id = fileId, Name = file.Name });
             }
             catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor
@@ -140,13 +140,13 @@
         <FluentButton IconStart="@(new Icons.Regular.Size16.Delete())"
                       OnClick="RemoveSelectedAsync"
                       Loading="@_isRemoving"
-                      Disabled="@AreNoneSelected()"
+                      Disabled="@(TelemetryRepository.IsReadOnly || AreNoneSelected())"
                       Title="@Loc[nameof(Dialogs.ManageDataRemoveButtonText)]"
                       aria-label="@Loc[nameof(Dialogs.ManageDataRemoveButtonText)]">
             @Loc[nameof(Dialogs.ManageDataRemoveButtonText)]
         </FluentButton>
     </div>
-    @if (TelemetryImportService.IsImportEnabled)
+    @if (TelemetryImportService.IsImportEnabled && !TelemetryRepository.IsReadOnly)
     {
         <div>
             <FluentInputFile AnchorId="import-button"

--- a/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ManageDataDialog.razor.cs
@@ -30,7 +30,12 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
     public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
+
+    [Inject]
+    public required ITelemetryRepositoryWriter TelemetryRepositoryWriter { get; init; }
 
     [Inject]
     public required IDashboardClient DashboardClient { get; init; }
@@ -150,7 +155,7 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
 
     private async Task SubscribeResourcesAsync()
     {
-        var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_cts.Token);
+        var (snapshot, subscription) = await DataSource.ResourceRepository.SubscribeResourcesAsync(_cts.Token);
 
         // Apply snapshot.
         foreach (var resource in snapshot)
@@ -552,22 +557,25 @@ public partial class ManageDataDialog : IDialogContentComponent, IAsyncDisposabl
             var selectedResources = GetSelectedResourcesAndDataTypes();
 
             // Clear telemetry signals via repository
-            TelemetryRepository.ClearSelectedSignals(selectedResources);
+            DataSource.EnsureWritable();
+            await TelemetryRepositoryWriter.ClearSelectedSignalsAsync(selectedResources);
 
-            // Handle console logs filtering separately (not stored in TelemetryRepository)
-            // Console logs are only available when the dashboard client is enabled
+            // Console logs are stored by the resource repository and are only available when the dashboard client is enabled.
             if (DashboardClient.IsEnabled)
             {
-                var consoleLogResourcesToFilter = selectedResources
+                var consoleLogResourceNames = selectedResources
                     .Where(kvp => kvp.Value.Contains(AspireDataType.ConsoleLogs))
                     .Select(kvp => kvp.Key)
                     .ToList();
 
-                if (consoleLogResourcesToFilter.Count > 0)
+                if (consoleLogResourceNames.Count > 0)
                 {
                     var filterDate = TimeProvider.GetUtcNow().UtcDateTime;
+                    await DataSource.ResourceRepository.ClearConsoleLogsAsync(consoleLogResourceNames, filterDate);
+
+                    // Keep the filter to suppress console logs already buffered by the live AppHost.
                     var filters = ConsoleLogsManager.Filters;
-                    foreach (var resourceName in consoleLogResourcesToFilter)
+                    foreach (var resourceName in consoleLogResourceNames)
                     {
                         filters = filters.WithResourceCleared(resourceName, filterDate);
                     }

--- a/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
+++ b/src/Aspire.Dashboard/Components/Interactions/InteractionsProvider.cs
@@ -65,7 +65,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
         }
     }
 
-    [Inject]
+    [Inject(Key = ServiceClient.DashboardClient.LiveAppHostServiceKey)]
     public required IDashboardClient DashboardClient { get; init; }
 
     [Inject]
@@ -232,6 +232,7 @@ public class InteractionsProvider : ComponentBase, IAsyncDisposable
                     {
                         Interaction = item,
                         Message = GetMessageHtml(item),
+                        DashboardClient = DashboardClient,
                         OnSubmitCallback = async (savedInteraction, update) =>
                         {
                             var request = new WatchInteractionsRequestUpdate

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -24,6 +24,14 @@
                 <SectionOutlet SectionName="@DashboardUIHelpers.PageTitleTopBarSection" />
             </div>
             <div class="flex-filler"></div>
+            @if (RunStore.SupportsRunSelection)
+            {
+                var selectedRun = RunSelection.SelectedRun;
+                <DashboardRunSelect SelectedRunId="@selectedRun.RunId"
+                                    SelectedRunIsCurrent="@selectedRun.IsCurrent"
+                                    SelectedRunStartedAtUtc="@selectedRun.StartedAtUtc"
+                                    SelectedRunIdChanged="@SwitchDashboardRunAsync" />
+            }
             <FluentAnchor Class="header-button"
                           Appearance="Appearance.Stealth"
                           Href="https://aka.ms/aspire/repo" Target="_blank" Rel="noreferrer noopener"
@@ -91,7 +99,14 @@
                 <ApplicationName/>
             </FluentAnchor>
             <div class="flex-filler"></div>
-
+            @if (RunStore.SupportsRunSelection)
+            {
+                var selectedRun = RunSelection.SelectedRun;
+                <DashboardRunSelect SelectedRunId="@selectedRun.RunId"
+                                    SelectedRunIsCurrent="@selectedRun.IsCurrent"
+                                    SelectedRunStartedAtUtc="@selectedRun.StartedAtUtc"
+                                    SelectedRunIdChanged="@SwitchDashboardRunAsync" />
+            }
             <UserProfile/>
             <FluentButton
                 IconEnd="@(_isNavMenuOpen ? new Icons.Regular.Size24.Dismiss() : new Icons.Regular.Size24.Navigation())"
@@ -119,7 +134,13 @@
     <div class="layout-body-container">
         <FluentBodyContent Class="custom-body-content body-content">
             <FluentToastProvider MaxToastCount="3" Timeout="5000" />
-            @Body
+            @if (!_isSwitchingRuns)
+            {
+                var selectedRun = RunSelection.SelectedRun;
+                <CascadingValue @key="selectedRun.RunId" Name="DashboardRunId" Value="selectedRun.RunId" IsFixed="true">
+                    @Body
+                </CascadingValue>
+            }
         </FluentBodyContent>
     </div>
 

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -18,6 +18,8 @@ namespace Aspire.Dashboard.Components.Layout;
 public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 {
     private bool _isNavMenuOpen;
+    private bool _runSelectionChanged;
+    private bool _isSwitchingRuns;
 
     // Desktop nav rail layout. false = collapsed to icons only (default, most content space,
     // labels still available via each item's tooltip); true = expanded so each item shows its
@@ -77,11 +79,46 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     [Inject]
     public required ILocalStorage LocalStorage { get; init; }
 
+    [Inject]
+    public required ISessionStorage SessionStorage { get; init; }
+
+    [Inject]
+    public required IDashboardRunStore RunStore { get; init; }
+
+    [Inject]
+    public required IDashboardRunSelection RunSelection { get; init; }
+
+    [Inject]
+    public required ILogger<MainLayout> Logger { get; init; }
+
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
+        if (RunStore.SupportsRunSelection)
+        {
+            var selectedRunResult = await SessionStorage.GetAsync<string>(BrowserStorageKeys.SelectedDashboardRunId);
+            var selectedRunId = selectedRunResult is { Success: true } ? selectedRunResult.Value : null;
+            if (!_runSelectionChanged && !string.IsNullOrEmpty(selectedRunId))
+            {
+                try
+                {
+                    RunSelection.SelectRun(selectedRunId);
+                }
+                catch (Exception exception)
+                {
+                    Logger.LogError(exception, "Failed to restore dashboard run '{RunId}'. Falling back to the current run.", selectedRunId);
+                    RunSelection.SelectRun(runId: null);
+                }
+
+                if (RunSelection.SelectedRun.IsCurrent)
+                {
+                    await SessionStorage.SetAsync(BrowserStorageKeys.SelectedDashboardRunId, string.Empty);
+                }
+            }
+        }
+
         // Theme change can be triggered from the settings dialog. This logic applies the new theme to the browser window.
         // Note that this event could be raised from a settings dialog opened in a different browser window.
         _themeChangedSubscription = ThemeManager.OnThemeChanged(async () =>
@@ -224,6 +261,41 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     }
 
     private string GetDefaultReturnFocusElementId(string desktopButtonId) => ViewportInformation.IsDesktop ? desktopButtonId : NavigationButtonId;
+
+    private async Task SwitchDashboardRunAsync(string? runId)
+    {
+        _runSelectionChanged = true;
+        var selectedRunId = RunSelection.SelectedRun is { IsCurrent: false } selectedRun ? selectedRun.RunId : null;
+        if (string.Equals(runId, selectedRunId, StringComparison.Ordinal))
+        {
+            await SessionStorage.SetAsync(BrowserStorageKeys.SelectedDashboardRunId, runId ?? string.Empty);
+            return;
+        }
+
+        _isSwitchingRuns = true;
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            RunSelection.SelectRun(runId);
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError(
+                exception,
+                "Failed to switch to dashboard run '{RunId}'. Keeping dashboard run '{SelectedRunId}' selected.",
+                runId,
+                RunSelection.SelectedRun.RunId);
+        }
+        finally
+        {
+            _isSwitchingRuns = false;
+            await InvokeAsync(StateHasChanged);
+        }
+
+        var persistedRunId = RunSelection.SelectedRun is { IsCurrent: false } actualSelectedRun ? actualSelectedRun.RunId : string.Empty;
+        await SessionStorage.SetAsync(BrowserStorageKeys.SelectedDashboardRunId, persistedRunId);
+    }
 
     private string? GetVisibleReturnFocusElementId(string? returnFocusElementId, string desktopButtonId)
     {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -46,7 +46,7 @@
                 {
                     <FluentButton Appearance="Appearance.Lightweight"
                                   Title="@(!string.IsNullOrEmpty(command.GetDisplayDescription()) ? command.GetDisplayDescription() : command.GetDisplayName())"
-                                  Disabled="@(command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(selectedResource.Name, command.Name))"
+                                  Disabled="@(DashboardClient.IsReadOnly || command.State == CommandViewModelState.Disabled || DashboardCommandExecutor.IsExecuting(selectedResource.Name, command.Name))"
                                   OnClick="@(() => ExecuteResourceCommandAsync(command))"
                                   Class="highlighted-command">
                         <FluentIcon Value="@IconResolver.ResolveHighlightedCommandIcon(command.IconName, command.IconVariant)" Width="16px" />
@@ -153,6 +153,7 @@
                         IsTimestampUtc="@_isTimestampUtc"
                         NoWrapLogs="@_noWrapLogs"
                         ShowNoLogsMessage="@_showNoLogsMessage"
+                        NoLogsMessage="@GetNoLogsMessage()"
                         ShowResourcePrefix="@_isSubscribedToAll"/>
                 </div>
                 <div style="@(_activeView == ConsoleLogsView.Terminal ? "display: contents;" : "display: none;")">
@@ -173,6 +174,7 @@
                     IsTimestampUtc="@_isTimestampUtc"
                     NoWrapLogs="@_noWrapLogs"
                     ShowNoLogsMessage="@_showNoLogsMessage"
+                    NoLogsMessage="@GetNoLogsMessage()"
                     ShowResourcePrefix="@_isSubscribedToAll"/>
             }
         </MainSection>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -82,7 +82,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     public required ISessionStorage SessionStorage { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     [Inject]
     public required ILogger<ConsoleLogs> Logger { get; init; }
@@ -195,6 +197,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private bool _isTimestampUtc;
     private bool _noWrapLogs;
     private bool _showNoLogsMessage;
+    private bool _consoleLogsWereLoaded = true;
     private string _logFilter = string.Empty;
     public ConsoleLogsViewModel PageViewModel { get; set; } = null!;
     private IDisposable? _consoleLogsFiltersChangedSubscription;
@@ -206,7 +209,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     {
         TelemetryContextProvider.Initialize(TelemetryContext);
         _resourceSubscriptionToken = _resourceSubscriptionCts.Token;
-        _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
+        _logEntries = new(DashboardUIHelpers.GetVirtualizedItemCount(Options.Value.Frontend.MaxConsoleLogCount));
         _allResource = new() { Id = null, Name = ControlsStringsLoc[nameof(ControlsStrings.LabelAll)] };
         PageViewModel = new ConsoleLogsViewModel { SelectedResource = _allResource, Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources)] };
         _logEntryChannelReaderTask = StartLogEntryChannelReaderTask();
@@ -265,7 +268,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 return;
             }
 
-            var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_resourceSubscriptionToken);
+            var (snapshot, subscription) = await DataSource.ResourceRepository.SubscribeResourcesAsync(_resourceSubscriptionToken);
 
             Logger.LogDebug("Received initial resource snapshot with {ResourceCount} resources.", snapshot.Length);
 
@@ -518,8 +521,12 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             _activeView = ConsoleLogsView.Console;
         }
 
-        if (!isAllSelected && selectedResourceName is not null &&
-            _resourceByName.TryGetValue(selectedResourceName, out var selectedResource) &&
+        var selectedResource = selectedResourceName is not null
+            ? _resourceByName.GetValueOrDefault(selectedResourceName)
+            : null;
+
+        if (!DashboardClient.IsReadOnly &&
+            !isAllSelected && selectedResource is not null &&
             selectedResource.HasTerminal() &&
             selectedResource.TryGetTerminalReplicaInfo(out var replicaIndex, out _))
         {
@@ -560,6 +567,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         }
         ResetNoLogsMessage();
 
+        _consoleLogsWereLoaded = !DashboardClient.IsReadOnly || WereConsoleLogsLoaded(isAllSelected, selectedResource);
+
         await InvokeAsync(_logViewerRef.SafeRefreshDataAsync);
 
         if (isAllSelected)
@@ -568,11 +577,11 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             _isSubscribedToAll = true;
             await SubscribeToAllResourcesAsync();
         }
-        else if (selectedResourceName is not null && _resourceByName.TryGetValue(selectedResourceName, out var resource))
+        else if (selectedResource is not null)
         {
             // Subscribe to single resource
             _isSubscribedToAll = false;
-            await SubscribeToSingleResourceAsync(resource);
+            await SubscribeToSingleResourceAsync(selectedResource);
         }
         else
         {
@@ -592,6 +601,22 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
         // that has no WithTerminal(), and be missing on the reverse switch.
         UpdateMenuButtons();
     }
+
+    private bool WereConsoleLogsLoaded(bool isAllSelected, ResourceViewModel? selectedResource)
+    {
+        if (isAllSelected)
+        {
+            return _resourceByName.Values
+                .Where(resource => !resource.IsResourceHidden(_showHiddenResources))
+                .Any(resource => resource.ConsoleLogsLoaded);
+        }
+
+        return selectedResource?.ConsoleLogsLoaded == true;
+    }
+
+    private string GetNoLogsMessage() => _consoleLogsWereLoaded
+        ? Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsNoLogsFound)]
+        : Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsNotCapturedForRun)];
 
     private bool IsAllSelected()
     {
@@ -1210,6 +1235,12 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private async Task ClearConsoleLogs(ResourceKey? key)
     {
         var now = TimeProvider.GetUtcNow().UtcDateTime;
+        var resourceNames = key is null
+            ? DataSource.ResourceRepository.GetResources().Select(resource => resource.Name).ToList()
+            : [key.Value.ToString()];
+
+        await DataSource.ResourceRepository.ClearConsoleLogsAsync(resourceNames, now);
+
         var newFilters = key is null
             ? ConsoleLogsFilters.CreateClearAll(now)
             : ConsoleLogsManager.Filters.WithResourceCleared(key.Value.ToString(), now);

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -60,7 +60,12 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
     public required ISessionStorage SessionStorage { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
+
+    [Inject]
+    public required ITelemetryRepositoryWriter TelemetryRepositoryWriter { get; init; }
 
     [Inject]
     public required ILogger<Metrics> Logger { get; init; }
@@ -176,7 +181,7 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
     private void UpdateInstruments(MetricsViewModel viewModel)
     {
         var selectedInstance = viewModel.SelectedResource.Id?.GetResourceKey();
-        viewModel.Instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummaries(selectedInstance.Value) : null;
+        viewModel.Instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentSummaries(selectedInstance.Value) : null;
     }
 
     private void UpdateResources()
@@ -236,8 +241,8 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
 
     private Task ClearMetrics(ResourceKey? key)
     {
-        TelemetryRepository.ClearMetrics(key);
-        return Task.CompletedTask;
+        DataSource.EnsureWritable();
+        return TelemetryRepositoryWriter.ClearMetricsAsync(key);
     }
 
     private Task HandleSelectedDurationChangedAsync()
@@ -330,7 +335,7 @@ public partial class Metrics : IDisposable, IComponentWithTelemetry, IPageWithSe
                 if (selectedResourceKey != null)
                 {
                     // If there are more instruments than before then update the UI.
-                    var instruments = TelemetryRepository.GetInstrumentsSummaries(selectedResourceKey.Value);
+                    var instruments = TelemetryRepository.GetInstrumentSummaries(selectedResourceKey.Value);
 
                     if (PageViewModel.Instruments is null || instruments.Count != PageViewModel.Instruments.Count)
                     {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -45,7 +45,9 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
     [Inject]
     public required IDashboardClient DashboardClient { get; init; }
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
     [Inject]
     public required NavigationManager NavigationManager { get; init; }
     [Inject]
@@ -256,7 +258,7 @@ public partial class Resources : ComponentBase, IComponentWithTelemetry, IAsyncD
 
         async Task SubscribeResourcesAsync()
         {
-            var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_cts.Token);
+            var (snapshot, subscription) = await DataSource.ResourceRepository.SubscribeResourcesAsync(_cts.Token);
 
             // Apply snapshot.
             foreach (var resource in snapshot)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -3,6 +3,7 @@
 
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Components.Controls.Grid
+@using Aspire.Dashboard.Otlp.Storage
 @inject IJSRuntime JS
 @implements IDisposable
 
@@ -71,16 +72,16 @@
                                                 ResizableColumns="true"
                                                 ResizeColumnOnAllRows="false"
                                                 ItemsProvider="@GetData"
-                                                TGridItem="OtlpLogEntry"
+                                                TGridItem="LogSummary"
                                                 GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                                 ShowHover="true"
                                                 ItemKey="@(r => r.InternalId)"
                                                 OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, focusElementId: ScrollContainerId)))"
                                                 Class="main-grid enable-row-click">
                                     <ChildContent>
-                                        <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ResourceView))">
-                                            <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.ResourceView)));">
-                                                @GetResourceName(context.ResourceView)
+                                        <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.Resource))">
+                                            <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.Resource)));">
+                                                @GetResourceName(context.Resource)
                                             </span>
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@LogLevelColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
@@ -91,7 +92,7 @@
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@MessageColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]">
                                             @* Tooltip is displayed by the message GridValue instance *@
-                                            <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" IsGenAILogCallback="@IsGenAILogEntry" LaunchGenAIVisualizerCallback="@LaunchGenAIVisualizerAsync" />
+                                            <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" IsGenAILogCallback="@(log => log.HasGenAI)" LaunchGenAIVisualizerCallback="@LaunchGenAIVisualizerAsync" />
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@TraceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                             @if (!string.IsNullOrEmpty(context.TraceId))
@@ -131,8 +132,10 @@
         <FooterSection>
             <TotalItemsFooter @ref="_totalItemsFooter"
                               TotalItemCount="@_totalItemsCount"
+                              DisplayedItemCount="@_displayedItemCount"
                               SingularText="@Loc[nameof(Dashboard.Resources.StructuredLogs.TotalItemsFooterSingularText)]"
                               PluralText="@Loc[nameof(Dashboard.Resources.StructuredLogs.TotalItemsFooterPluralText)]"
+                              PartialText="@Loc[nameof(Dashboard.Resources.StructuredLogs.VirtualizedLimitText)]"
                               PauseText="@PauseText"/>
         </FooterSection>
     </AspirePageContentLayout>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -41,12 +41,13 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     private readonly CancellationTokenSource _cts = new();
     private Subscription? _resourcesSubscription;
     private Subscription? _logsSubscription;
+    private int? _displayedItemCount;
     private bool _resourceChanged;
     private string? _elementIdBeforeDetailsViewOpened;
     private string? _pendingFocusElementId;
     private AspirePageContentLayout? _contentLayout;
     private string _filter = string.Empty;
-    private FluentDataGrid<OtlpLogEntry>? _dataGrid;
+    private FluentDataGrid<LogSummary>? _dataGrid;
     private GridColumnManager _manager = null!;
     private IList<GridColumn> _gridColumns = null!;
 
@@ -58,7 +59,12 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     public StructuredLogsPageViewModel PageViewModel { get; set; } = null!;
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
+
+    [Inject]
+    public required ITelemetryRepositoryWriter TelemetryRepositoryWriter { get; init; }
 
     [Inject]
     public required StructuredLogsViewModel ViewModel { get; init; }
@@ -82,7 +88,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     public required ITelemetryErrorRecorder ErrorRecorder { get; init; }
 
     [Inject]
-    public required DimensionManager DimensionManager { get; set; }
+    public required DimensionManager DimensionManager { get; init; }
 
     [Inject]
     public required IOptions<DashboardOptions> DashboardOptions { get; init; }
@@ -122,37 +128,43 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     [SupplyParameterFromQuery]
     public long? LogEntryId { get; set; }
 
-    private async ValueTask<GridItemsProviderResult<OtlpLogEntry>> GetData(GridItemsProviderRequest<OtlpLogEntry> request)
+    private async ValueTask<GridItemsProviderResult<LogSummary>> GetData(GridItemsProviderRequest<LogSummary> request)
     {
         ViewModel.StartIndex = request.StartIndex;
         ViewModel.Count = request.Count ?? DashboardUIHelpers.DefaultDataGridResultCount;
 
-        var logs = ViewModel.GetLogs();
+        var logs = await ViewModel.GetLogsAsync(request.CancellationToken);
 
-        if (logs.IsFull && !TelemetryRepository.HasDisplayedMaxLogLimitMessage)
+        if (!TelemetryRepository.IsReadOnly)
         {
-            TelemetryRepository.MaxLogLimitMessage = await DashboardUIHelpers.DisplayMaxLimitMessageAsync(
-                MessageService,
-                Loc[nameof(Dashboard.Resources.StructuredLogs.MessageExceededLimitTitle)],
-                string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.StructuredLogs.MessageExceededLimitBody)], DashboardOptions.Value.TelemetryLimits.MaxLogCount),
-                () => TelemetryRepository.MaxLogLimitMessage = null);
+            if (logs.IsFull && !TelemetryRepository.HasDisplayedMaxLogLimitMessage)
+            {
+                TelemetryRepository.MaxLogLimitMessage = await DashboardUIHelpers.DisplayMaxLimitMessageAsync(
+                    MessageService,
+                    Loc[nameof(Dashboard.Resources.StructuredLogs.MessageExceededLimitTitle)],
+                    string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.StructuredLogs.MessageExceededLimitBody)], DashboardOptions.Value.TelemetryLimits.MaxLogCount),
+                    () => TelemetryRepository.MaxLogLimitMessage = null);
 
-            TelemetryRepository.HasDisplayedMaxLogLimitMessage = true;
+                TelemetryRepository.HasDisplayedMaxLogLimitMessage = true;
+            }
+            else if (!logs.IsFull && TelemetryRepository.MaxLogLimitMessage is { } message)
+            {
+                // Telemetry could have been cleared from the dashboard. Automatically remove full message on data update.
+                message.Close();
+            }
         }
-        else if (!logs.IsFull && TelemetryRepository.MaxLogLimitMessage is { } message)
-        {
-            // Telemetry could have been cleared from the dashboard. Automatically remove full message on data update.
-            message.Close();
-        }
+
+        var virtualizedLogCount = DashboardUIHelpers.GetVirtualizedItemCount(logs.TotalItemCount);
+        _displayedItemCount = virtualizedLogCount < logs.TotalItemCount ? virtualizedLogCount : null;
 
         // Updating the total item count as a field doesn't work because it isn't updated with the grid.
         // The workaround is to explicitly update and refresh the control.
         _totalItemsCount = logs.TotalItemCount;
-        _totalItemsFooter?.UpdateDisplayedCount(_totalItemsCount);
+        _totalItemsFooter?.UpdateDisplayedCount(_totalItemsCount, _displayedItemCount);
 
         TelemetryRepository.MarkViewedErrorLogs(ViewModel.ResourceKey);
 
-        return GridItemsProviderResult.From(logs.Items, logs.TotalItemCount);
+        return GridItemsProviderResult.From(logs.Items, virtualizedLogCount);
     }
 
     protected override void OnInitialized()
@@ -300,6 +312,12 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         }
     }
 
+    private Task OnShowPropertiesAsync(LogSummary summary, string? focusElementId)
+    {
+        var entry = TelemetryRepository.GetLog(summary.InternalId);
+        return entry is null ? Task.CompletedTask : OnShowPropertiesAsync(entry, focusElementId);
+    }
+
     private Task ClearSelectedLogEntryAsync(bool causedByUserAction = false)
     {
         PageViewModel.SelectedLogEntry = null;
@@ -321,13 +339,14 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             await _contentLayout.CloseMobileToolbarAsync();
         }
 
+        var resourceKey = PageViewModel.SelectedResource.Id?.GetResourceKey();
         await FilterHelpers.OpenFilterAsync(
             entry,
             DialogService,
             DialogService.CreateDialogCallback(this, HandleFilterDialog),
-            propertyKeys: TelemetryRepository.GetLogPropertyKeys(PageViewModel.SelectedResource.Id?.GetResourceKey()),
+            getPropertyKeysAsync: cancellationToken => TelemetryRepository.GetLogPropertyKeysAsync(resourceKey, cancellationToken),
             knownKeys: KnownStructuredLogFields.AllFields,
-            getFieldValues: TelemetryRepository.GetLogsFieldValues,
+            getFieldValuesAsync: TelemetryRepository.GetLogsFieldValuesAsync,
             FilterLoc);
     }
 
@@ -372,9 +391,9 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         }
     }
 
-    private string GetResourceName(OtlpResourceView app) => OtlpHelpers.GetResourceName(app.Resource, _resources);
+    private string GetResourceName(OtlpResource resource) => OtlpHelpers.GetResourceName(resource, _resources);
 
-    private string GetRowClass(OtlpLogEntry entry)
+    private string GetRowClass(LogSummary entry)
     {
         if (entry.InternalId == PageViewModel.SelectedLogEntry?.LogEntry.InternalId)
         {
@@ -401,7 +420,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
     {
         // Check to see whether max item count should be set on every render.
         // This is required because the data grid's virtualize component can be recreated on data change.
-        if (_dataGrid != null && FluentDataGridHelper<OtlpLogEntry>.TrySetMaxItemCount(_dataGrid, 10_000))
+        if (_dataGrid != null && FluentDataGridHelper<LogSummary>.TrySetMaxItemCount(_dataGrid, 10_000))
         {
             StateHasChanged();
         }
@@ -507,23 +526,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
         await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
     }
 
-    private bool IsGenAILogEntry(OtlpLogEntry logEntry)
-    {
-        if (string.IsNullOrEmpty(logEntry.SpanId) || string.IsNullOrEmpty(logEntry.TraceId))
-        {
-            return false;
-        }
-
-        if (GenAIHelpers.HasGenAIAttribute(logEntry.Attributes))
-        {
-            // GenAI telemetry is on the log entry.
-            return true;
-        }
-
-        return ViewModel.HasGenAISpan(logEntry.TraceId, logEntry.SpanId);
-    }
-
-    private async Task LaunchGenAIVisualizerAsync(OtlpLogEntry logEntry)
+    private async Task LaunchGenAIVisualizerAsync(LogSummary logEntry)
     {
         var available = await TraceLinkHelpers.WaitForSpanToBeAvailableAsync(
             logEntry.TraceId,
@@ -532,7 +535,7 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
             DialogService,
             InvokeAsync,
             DialogsLoc,
-            CancellationToken.None).ConfigureAwait(false);
+            _cts.Token).ConfigureAwait(false);
 
         if (available)
         {
@@ -563,14 +566,15 @@ public partial class StructuredLogs : IComponentWithTelemetry, IPageWithSessionA
                     }
 
                     return genAISpans;
-                });
+                },
+                _cts.Token);
         }
     }
 
     private Task ClearStructureLogs(ResourceKey? key)
     {
-        TelemetryRepository.ClearStructuredLogs(key);
-        return Task.CompletedTask;
+        DataSource.EnsureWritable();
+        return TelemetryRepositoryWriter.ClearStructuredLogsAsync(key);
     }
 
     public class StructuredLogsPageViewModel

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -247,13 +247,13 @@
                                                             @foreach (var item in context.SpanLogs)
                                                             {
                                                                 var buttonId = $"{context.Span.SpanId}-{item.LogEntry.InternalId}";
-                                                                var eventName = StructureLogsDetailsViewModel.GetEventName(item.LogEntry, StructuredLogsLoc);
+                                                                var eventName = item.LogEntry.EventName ?? StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)];
                                                                 var isSelected = SelectedData?.LogEntryViewModel?.LogEntry.InternalId == item.LogEntry.InternalId;
                                                                 var htmlTooltip = item.Index < 500;
                                                                 var buttonColor = item.LogEntry.IsError ? "var(--error)" : spanColor;
 
                                                                 <button id="@buttonId"
-                                                                        title="@(!htmlTooltip ? $"{eventName} - {item.LogEntry.Scope.Name}" : string.Empty)"
+                                                                        title="@(!htmlTooltip ? $"{eventName} - {item.LogEntry.ScopeName}" : string.Empty)"
                                                                         aria-label="@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)]"
                                                                         class="@($"span-log-entry-button {(isSelected ? "span-log-entry-selected" : null)} {(item.LogEntry.IsError ? "span-log-entry-error" : null)}")"
                                                                         data-span-color="@spanColor"
@@ -270,7 +270,7 @@
                                                                 {
                                                                     <FluentTooltip Anchor="@buttonId" MaxWidth="350px">
                                                                         <div class="log-tooltip-title-container">
-                                                                            <span class="log-tooltip-title">@eventName</span> <span class="log-tooltip-subtitle">@item.LogEntry.Scope.Name</span><br />
+                                                                            <span class="log-tooltip-title">@eventName</span> <span class="log-tooltip-subtitle">@item.LogEntry.ScopeName</span><br />
                                                                         </div>
                                                                         <table class="log-tooltip-table">
                                                                             <tr>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -32,8 +32,8 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     private const int RootSpanDepth = 1;
 
     private readonly CancellationTokenSource _cts = new();
-    private readonly List<IDisposable> _peerChangesSubscriptions = new();
     private OtlpTrace? _trace;
+    private long _detailViewUpdateVersion;
     private Subscription? _tracesSubscription;
     private int _maxDepth;
     private int _resourceCount;
@@ -64,10 +64,9 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
     public required ITelemetryErrorRecorder ErrorRecorder { get; init; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
 
-    [Inject]
-    public required IEnumerable<IOutgoingPeerResolver> OutgoingPeerResolvers { get; init; }
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
@@ -109,16 +108,6 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             new GridColumn(Name: TicksColumn, DesktopWidth: "12fr", MobileWidth: "12fr"),
             new GridColumn(Name: ActionsColumn, DesktopWidth: "100px", MobileWidth: null)
         ];
-
-        foreach (var resolver in OutgoingPeerResolvers)
-        {
-            _peerChangesSubscriptions.Add(resolver.OnPeerChanges(async () =>
-            {
-                UpdateDetailViewData();
-                await InvokeAsync(StateHasChanged);
-                await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
-            }));
-        }
 
         UpdateTraceActionsMenu();
 
@@ -181,12 +170,15 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     private IEnumerable<SpanWaterfallViewModel> GetVisibleSpanViewModels()
     {
-        Debug.Assert(PageViewModel.SpanWaterfallViewModels != null);
+        if (PageViewModel.SpanWaterfallViewModels is null)
+        {
+            return [];
+        }
 
         return TraceDetailPageViewModel.ApplySpanFilters(PageViewModel.SpanWaterfallViewModels, PageViewModel.Filter, PageViewModel.SelectedSpanType.Id?.Filter, PageViewModel.Filters, GetResourceName);
     }
 
-    private string? GetPageTitle()
+    internal string? GetPageTitle()
     {
         if (_trace is null)
         {
@@ -205,7 +197,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             // If the new trace has a SpanId query parameter, it will be re-opened below.
             PageViewModel.SelectedData = null;
 
-            UpdateDetailViewData();
+            await UpdateDetailViewDataAsync();
             UpdateSubscription();
 
             // If parameters change after render then the grid is automatically updated.
@@ -251,20 +243,28 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         }
     }
 
-    private void UpdateDetailViewData()
+    private async Task UpdateDetailViewDataAsync()
     {
-        _resources = TelemetryRepository.GetResources();
+        var updateVersion = Interlocked.Increment(ref _detailViewUpdateVersion);
+        var traceId = TraceId;
+        var resources = TelemetryRepository.GetResources();
+        var trace = _trace;
 
         // Copying a large trace can be expensive so only do this if required.
-        if (_trace == null || _trace.TraceId != TraceId || TelemetryRepository.HasUpdatedTrace(_trace))
+        if (trace == null || trace.TraceId != traceId || TelemetryRepository.HasUpdatedTrace(trace))
         {
-            Logger.LogInformation("Getting trace '{TraceId}'.", TraceId);
-            _trace = (TraceId != null) ? TelemetryRepository.GetTrace(TraceId) : null;
+            Logger.LogInformation("Getting trace '{TraceId}'.", traceId);
+            trace = TelemetryRepository.GetTrace(traceId);
+            // The asynchronous log query below allows an intermediate render. Publish resources before the trace so
+            // page title rendering never observes a trace without the resource list used to format its source name.
+            _resources = resources;
+            _trace = trace;
         }
 
-        if (_trace == null)
+        if (trace == null)
         {
-            Logger.LogInformation("Couldn't find trace '{TraceId}'.", TraceId);
+            Logger.LogInformation("Couldn't find trace '{TraceId}'.", traceId);
+            _resources = resources;
             PageViewModel.SpanWaterfallViewModels = null;
             _maxDepth = 0;
             _resourceCount = 0;
@@ -275,14 +275,35 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         // Get logs for the trace. Note that there isn't a limit on this query so all logs are returned.
         // There is a limit on the number of logs stored by the dashboard so this is implicitly limited.
         // If there are performance issues with displaying all logs then consider adding a limit to this query.
-        var result = TelemetryRepository.GetLogsForTrace(_trace.TraceId);
+        var result = (await TelemetryRepository.GetLogSummariesAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = KnownStructuredLogFields.TraceIdField,
+                    Condition = FilterCondition.Equals,
+                    Value = trace.TraceId
+                }
+            ]
+        }, _cts.Token)).Items;
 
-        Logger.LogInformation("Trace '{TraceId}' has {SpanCount} spans.", _trace.TraceId, _trace.Spans.Count);
-        PageViewModel.SpanWaterfallViewModels = SpanWaterfallViewModel.Create(_trace, result, new SpanWaterfallViewModel.TraceDetailState(OutgoingPeerResolvers.ToArray(), _collapsedSpanIds, _resources));
+        if (updateVersion != Volatile.Read(ref _detailViewUpdateVersion))
+        {
+            return;
+        }
+
+        _trace = trace;
+        _resources = resources;
+        Logger.LogInformation("Trace '{TraceId}' has {SpanCount} spans.", trace.TraceId, trace.Spans.Count);
+        PageViewModel.SpanWaterfallViewModels = SpanWaterfallViewModel.Create(trace, result, new SpanWaterfallViewModel.TraceDetailState(_collapsedSpanIds, resources));
         _maxDepth = PageViewModel.SpanWaterfallViewModels.Max(s => s.Depth);
 
         var apps = new HashSet<OtlpResource>();
-        foreach (var span in _trace.Spans)
+        foreach (var span in trace.Spans)
         {
             apps.Add(span.Source.Resource);
             if (span.UninstrumentedPeer != null)
@@ -332,7 +353,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
                 // Only update trace if required.
                 if (TelemetryRepository.HasUpdatedTrace(_trace))
                 {
-                    UpdateDetailViewData();
+                    await UpdateDetailViewDataAsync();
                     StateHasChanged();
                     await _dataGrid.SafeRefreshDataAsync();
                 }
@@ -384,7 +405,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     private async Task RefreshSpanViewAsync()
     {
-        UpdateDetailViewData();
+        await UpdateDetailViewDataAsync();
         UpdateTraceActionsMenu();
         await _dataGrid.SafeRefreshDataAsync();
 
@@ -488,7 +509,7 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     private string GetResourceName(OtlpResourceView app) => OtlpResource.GetResourceName(app, _resources);
 
-    private async Task ToggleSpanLogsAsync(OtlpLogEntry logEntry)
+    private async Task ToggleSpanLogsAsync(LogSummary logEntry)
     {
         if (PageViewModel.SelectedData?.LogEntryViewModel?.LogEntry.InternalId == logEntry.InternalId)
         {
@@ -496,10 +517,13 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
         }
         else
         {
-            PageViewModel.SelectedData = new TraceDetailSelectedDataViewModel
+            if (TelemetryRepository.GetLog(logEntry.InternalId) is { } fullLogEntry)
             {
-                LogEntryViewModel = new StructureLogsDetailsViewModel { LogEntry = logEntry }
-            };
+                PageViewModel.SelectedData = new TraceDetailSelectedDataViewModel
+                {
+                    LogEntryViewModel = new StructureLogsDetailsViewModel { LogEntry = fullLogEntry }
+                };
+            }
         }
     }
 
@@ -526,7 +550,8 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
                     genAISpans.Add(vm.Span);
                 }
                 return genAISpans;
-            });
+            },
+            _cts.Token);
     }
 
     private async Task OpenFilterAsync(FieldTelemetryFilter? entry)
@@ -540,9 +565,9 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             entry,
             DialogService,
             DialogService.CreateDialogCallback(this, HandleFilterDialog),
-            propertyKeys: GetTraceSpanPropertyKeys(),
+            getPropertyKeysAsync: GetTraceSpanPropertyKeysAsync,
             knownKeys: KnownTraceFields.AllFields,
-            getFieldValues: GetTraceSpanFieldValues,
+            getFieldValuesAsync: GetTraceSpanFieldValuesAsync,
             FilterLoc);
     }
 
@@ -603,11 +628,11 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     // Computed fresh on each dialog open. A single trace typically has a small number of spans,
     // so caching is unnecessary and avoids stale data if the trace is updated while the page is open.
-    private List<string> GetTraceSpanPropertyKeys()
+    private Task<List<string>> GetTraceSpanPropertyKeysAsync(CancellationToken cancellationToken)
     {
         if (_trace is null)
         {
-            return [];
+            return Task.FromResult<List<string>>([]);
         }
 
         var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -619,18 +644,19 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
             }
         }
 
-        return keys.OrderBy(k => k).ToList();
+        return Task.FromResult(keys.OrderBy(k => k).ToList());
     }
 
-    // Computed fresh on each dialog open for the same reason as GetTraceSpanPropertyKeys.
-    private Dictionary<string, int> GetTraceSpanFieldValues(string attributeName)
+    // Computed fresh on each dialog open for the same reason as GetTraceSpanPropertyKeysAsync.
+    private Task<Dictionary<string, int>> GetTraceSpanFieldValuesAsync(string attributeName, CancellationToken cancellationToken)
     {
         if (_trace is null)
         {
-            return new Dictionary<string, int>(StringComparers.OtlpAttribute);
+            return Task.FromResult(new Dictionary<string, int>(StringComparers.OtlpAttribute));
         }
 
-        return OtlpSpan.GetFieldValuesFromTraces([_trace], attributeName);
+        var fieldValues = OtlpSpan.GetFieldValuesFromTraces([_trace], attributeName);
+        return Task.FromResult(fieldValues);
     }
 
     private List<MenuButtonItem> GetFilterMenuItems()
@@ -646,11 +672,8 @@ public partial class TraceDetail : ComponentBase, IComponentWithTelemetry, IDisp
 
     public void Dispose()
     {
+        Interlocked.Increment(ref _detailViewUpdateVersion);
         _cts.Cancel();
-        foreach (var subscription in _peerChangesSubscriptions)
-        {
-            subscription.Dispose();
-        }
         _tracesSubscription?.Dispose();
         TelemetryContext.Dispose();
     }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -3,6 +3,7 @@
 
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Components.Controls.Grid
+@using Aspire.Dashboard.Otlp.Storage
 
 @inject IJSRuntime JS
 @inject IStringLocalizer<Dashboard.Resources.Traces> Loc
@@ -101,26 +102,26 @@
                                     ResizableColumns="true"
                                     ResizeColumnOnAllRows="false"
                                     ItemsProvider="@GetData"
-                                    TGridItem="OtlpTrace"
+                                    TGridItem="TraceSummary"
                                     GridTemplateColumns="@_manager.GetGridTemplateColumns()"
                                     ShowHover="true"
                                     ItemKey="@(r => r.TraceId)"
                                     OnRowClick="@(r => r.ExecuteOnDefault(d => NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(d.TraceId))))"
                                     Class="main-grid enable-row-click">
                         <ChildContent>
-                            <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
-                                @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)
+                            <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
+                                @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.StartTime, MillisecondsDisplay.Truncated)
                             </AspireTemplateColumn>
                             <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@(trace => GetNameTooltip(trace))" Class="no-ellipsis">
                                 <div class="trace-name-container">
                                     <span class="trace-name-content">
-                                        <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName((context.RootOrFirstSpan).Source)));">
+                                        <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(context.RootResource)));">
                                             <FluentHighlighter HighlightedText="@(TracesViewModel.FilterText)" Text="@(context.FullName)" />
                                         </span>
                                         <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
                                     </span>
                                     <span @onclick:stopPropagation="true">
-                                        @if (HasGenAISpans(context))
+                                        @if (context.HasGenAI)
                                         {
                                             <FluentButton Appearance="Appearance.Lightweight"
                                                           Title="@ControlsStringsLoc[nameof(ControlsStrings.GenAIDetailsTitle)]"
@@ -135,7 +136,7 @@
                             <AspireTemplateColumn ColumnId="@SpansColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Traces.TracesSpansColumnHeader)]">
                                 <FluentOverflow>
                                     <ChildContent>
-                                        @foreach (var item in TraceHelpers.GetOrderedResources(context))
+                                        @foreach (var item in context.Resources)
                                         {
                                             <FluentOverflowItem>
                                                 <span class="trace-tag trace-service-tag" title="@(GetSpansTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorVariableByKey(GetResourceName(item.Resource)));">
@@ -193,7 +194,7 @@
                             </AspireTemplateColumn>
                             <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">
                                 <div class="grid-action-container" @onclick:stopPropagation="true">
-                                    <TraceActions Trace="@context" />
+                                    <TraceActions Summary="@context" />
                                 </div>
                             </AspireTemplateColumn>
                         </ChildContent>
@@ -207,8 +208,10 @@
         <FooterSection>
             <TotalItemsFooter @ref="_totalItemsFooter"
                               TotalItemCount="@_totalItemsCount"
+                              DisplayedItemCount="@_displayedItemCount"
                               SingularText="@Loc[nameof(Dashboard.Resources.Traces.TotalItemsFooterSingularText)]"
                               PluralText="@Loc[nameof(Dashboard.Resources.Traces.TotalItemsFooterPluralText)]"
+                              PartialText="@Loc[nameof(Dashboard.Resources.Traces.VirtualizedLimitText)]"
                               PauseText="@PauseText"/>
         </FooterSection>
     </AspirePageContentLayout>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -29,11 +29,13 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     private const string SpansColumn = nameof(SpansColumn);
     private const string DurationColumn = nameof(DurationColumn);
     private const string ActionsColumn = nameof(ActionsColumn);
+    private readonly CancellationTokenSource _cts = new();
     private IList<GridColumn> _gridColumns = null!;
     private SelectViewModel<ResourceTypeDetails> _allResource = null!;
 
     private TotalItemsFooter _totalItemsFooter = default!;
     private int _totalItemsCount;
+    private int? _displayedItemCount;
     private List<SelectViewModel<SpanType>> _spanTypes = default!;
     private List<OtlpResource> _resources = default!;
     private List<SelectViewModel<ResourceTypeDetails>> _resourceViewModels = default!;
@@ -42,7 +44,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     private bool _resourceChanged;
     private string _filter = string.Empty;
     private AspirePageContentLayout? _contentLayout;
-    private FluentDataGrid<OtlpTrace> _dataGrid = null!;
+    private FluentDataGrid<TraceSummary> _dataGrid = null!;
     private GridColumnManager _manager = null!;
 
     private ColumnResizeLabels _resizeLabels = ColumnResizeLabels.Default;
@@ -56,7 +58,12 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     public string? ResourceName { get; set; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
+
+    [Inject]
+    public required ITelemetryRepositoryWriter TelemetryRepositoryWriter { get; init; }
 
     [Inject]
     public required TracesViewModel TracesViewModel { get; init; }
@@ -77,10 +84,10 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     public required ILogger<Traces> Logger { get; init; }
 
     [Inject]
-    public required NavigationManager NavigationManager { get; set; }
+    public required NavigationManager NavigationManager { get; init; }
 
     [Inject]
-    public required ISessionStorage SessionStorage { get; set; }
+    public required ISessionStorage SessionStorage { get; init; }
 
     [Inject]
     public required DimensionManager DimensionManager { get; init; }
@@ -105,7 +112,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     [SupplyParameterFromQuery(Name = "filters")]
     public string? SerializedFilters { get; set; }
 
-    private string GetNameTooltip(OtlpTrace trace)
+    private string GetNameTooltip(TraceSummary trace)
     {
         var tooltip = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.TracesFullName)], trace.FullName);
         tooltip += Environment.NewLine + string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.TracesTraceId)], trace.TraceId);
@@ -113,7 +120,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
         return tooltip;
     }
 
-    private string GetSpansTooltip(OrderedResource resourceSpans)
+    private string GetSpansTooltip(TraceResourceSummary resourceSpans)
     {
         var count = resourceSpans.TotalSpans;
         var errorCount = resourceSpans.ErroredSpans;
@@ -128,34 +135,40 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
         return tooltip;
     }
 
-    private async ValueTask<GridItemsProviderResult<OtlpTrace>> GetData(GridItemsProviderRequest<OtlpTrace> request)
+    private async ValueTask<GridItemsProviderResult<TraceSummary>> GetData(GridItemsProviderRequest<TraceSummary> request)
     {
         TracesViewModel.StartIndex = request.StartIndex;
         TracesViewModel.Count = request.Count ?? DashboardUIHelpers.DefaultDataGridResultCount;
-        var traces = TracesViewModel.GetTraces();
+        var traces = await TracesViewModel.GetTracesAsync(request.CancellationToken);
 
-        if (traces.IsFull && !TelemetryRepository.HasDisplayedMaxTraceLimitMessage)
+        if (!TelemetryRepository.IsReadOnly)
         {
-            TelemetryRepository.MaxTraceLimitMessage = await DashboardUIHelpers.DisplayMaxLimitMessageAsync(
-                MessageService,
-                Loc[nameof(Dashboard.Resources.Traces.MessageExceededLimitTitle)],
-                string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.MessageExceededLimitBody)], DashboardOptions.Value.TelemetryLimits.MaxTraceCount),
-                () => TelemetryRepository.MaxTraceLimitMessage = null);
+            if (traces.IsFull && !TelemetryRepository.HasDisplayedMaxTraceLimitMessage)
+            {
+                TelemetryRepository.MaxTraceLimitMessage = await DashboardUIHelpers.DisplayMaxLimitMessageAsync(
+                    MessageService,
+                    Loc[nameof(Dashboard.Resources.Traces.MessageExceededLimitTitle)],
+                    string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.MessageExceededLimitBody)], DashboardOptions.Value.TelemetryLimits.MaxTraceCount),
+                    () => TelemetryRepository.MaxTraceLimitMessage = null);
 
-            TelemetryRepository.HasDisplayedMaxTraceLimitMessage = true;
+                TelemetryRepository.HasDisplayedMaxTraceLimitMessage = true;
+            }
+            else if (!traces.IsFull && TelemetryRepository.MaxTraceLimitMessage is { } message)
+            {
+                // Telemetry could have been cleared from the dashboard. Automatically remove full message on data update.
+                message.Close();
+            }
         }
-        else if (!traces.IsFull && TelemetryRepository.MaxTraceLimitMessage is { } message)
-        {
-            // Telemetry could have been cleared from the dashboard. Automatically remove full message on data update.
-            message.Close();
-        }
+
+        var virtualizedTraceCount = DashboardUIHelpers.GetVirtualizedItemCount(traces.TotalItemCount);
+        _displayedItemCount = virtualizedTraceCount < traces.TotalItemCount ? virtualizedTraceCount : null;
 
         // Updating the total item count as a field doesn't work because it isn't updated with the grid.
         // The workaround is to explicitly update and refresh the control.
         _totalItemsCount = traces.TotalItemCount;
-        _totalItemsFooter.UpdateDisplayedCount(_totalItemsCount);
+        _totalItemsFooter.UpdateDisplayedCount(_totalItemsCount, _displayedItemCount);
 
-        return GridItemsProviderResult.From(traces.Items, traces.TotalItemCount);
+        return GridItemsProviderResult.From(traces.Items, virtualizedTraceCount);
     }
 
     protected override void OnInitialized()
@@ -240,11 +253,10 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     }
 
     private string GetResourceName(OtlpResource app) => OtlpHelpers.GetResourceName(app, _resources);
-    private string GetResourceName(OtlpResourceView app) => OtlpHelpers.GetResourceName(app.Resource, _resources);
 
-    private static string GetRowClass(OtlpTrace entry)
+    private static string GetRowClass(TraceSummary entry)
     {
-        if (entry.Spans.Any(span => span.Status == OtlpSpanStatusCode.Error))
+        if (entry.HasError)
         {
             return "trace-row-error";
         }
@@ -256,7 +268,7 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
     {
         // Check to see whether max item count should be set on every render.
         // This is required because the data grid's virtualize component can be recreated on data change.
-        if (_dataGrid != null && FluentDataGridHelper<OtlpTrace>.TrySetMaxItemCount(_dataGrid, 10_000))
+        if (_dataGrid != null && FluentDataGridHelper<TraceSummary>.TrySetMaxItemCount(_dataGrid, 10_000))
         {
             StateHasChanged();
         }
@@ -294,6 +306,8 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
 
     public void Dispose()
     {
+        _cts.Cancel();
+        _cts.Dispose();
         _resourcesSubscription?.Dispose();
         _tracesSubscription?.Dispose();
         DimensionManager.OnViewportInformationChanged -= OnBrowserResize;
@@ -351,13 +365,14 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
             await _contentLayout.CloseMobileToolbarAsync();
         }
 
+        var resourceKey = PageViewModel.SelectedResource.Id?.GetResourceKey();
         await FilterHelpers.OpenFilterAsync(
             entry,
             DialogService,
             DialogService.CreateDialogCallback(this, HandleFilterDialog),
-            propertyKeys: TelemetryRepository.GetTracePropertyKeys(PageViewModel.SelectedResource.Id?.GetResourceKey()),
+            getPropertyKeysAsync: cancellationToken => TelemetryRepository.GetTracePropertyKeysAsync(resourceKey, cancellationToken),
             knownKeys: KnownTraceFields.AllFields,
-            getFieldValues: TelemetryRepository.GetTraceFieldValues,
+            getFieldValuesAsync: TelemetryRepository.GetTraceFieldValuesAsync,
             FilterLoc);
     }
 
@@ -388,8 +403,8 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
 
     private Task ClearTraces(ResourceKey? key)
     {
-        TelemetryRepository.ClearTraces(key);
-        return Task.CompletedTask;
+        DataSource.EnsureWritable();
+        return TelemetryRepositoryWriter.ClearTracesAsync(key);
     }
 
     private List<MenuButtonItem> GetFilterMenuItems()
@@ -403,21 +418,14 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
             dialogsLoc: DialogsLoc);
     }
 
-    private static bool HasGenAISpans(OtlpTrace trace)
+    private async Task OnGenAIClickedAsync(TraceSummary summary)
     {
-        foreach (var span in trace.Spans)
+        var trace = TelemetryRepository.GetTrace(summary.TraceId);
+        if (trace is null)
         {
-            if (GenAIHelpers.HasGenAIAttribute(span.Attributes))
-            {
-                return true;
-            }
+            return;
         }
 
-        return false;
-    }
-
-    private async Task OnGenAIClickedAsync(OtlpTrace trace)
-    {
         var firstSpan = trace.Spans.FirstOrDefault(s => GenAIHelpers.HasGenAIAttribute(s.Attributes));
         if (firstSpan == null)
         {
@@ -439,7 +447,8 @@ public partial class Traces : IComponentWithTelemetry, IPageWithSessionAndUrlSta
                     return [];
                 }
                 return latestTrace.Spans.Where(span => GenAIHelpers.HasGenAIAttribute(span.Attributes)).ToList();
-            });
+            },
+            _cts.Token);
     }
 
     public class TracesPageViewModel

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogLevelColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogLevelColumnDisplay.razor
@@ -1,6 +1,7 @@
 ﻿@namespace Aspire.Dashboard.Components
 
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Otlp.Storage
 @using Microsoft.Extensions.Logging
 
 @if (LogEntry.IsError)
@@ -16,5 +17,5 @@ else if (LogEntry.IsWarning)
 
 @code {
     [Parameter, EditorRequired]
-    public required OtlpLogEntry LogEntry { get; set; }
+    public required LogSummary LogEntry { get; set; }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
@@ -23,6 +23,6 @@
                             Color="Color.Accent" />
             </FluentButton>
         }
-        <ExceptionDetails ExceptionText="@_exceptionText" />
+        <ExceptionDetails ExceptionText="@LogEntry.ExceptionText" />
     </ContentInButtonArea>
 </GridValue>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components;
@@ -9,23 +9,16 @@ namespace Aspire.Dashboard.Components;
 public partial class LogMessageColumnDisplay
 {
     [Parameter, EditorRequired]
-    public required OtlpLogEntry LogEntry { get; set; }
+    public required LogSummary LogEntry { get; set; }
 
     [Parameter, EditorRequired]
     public required string FilterText { get; set; }
 
     [Parameter, EditorRequired]
-    public required EventCallback<OtlpLogEntry> LaunchGenAIVisualizerCallback { get; set; }
+    public required EventCallback<LogSummary> LaunchGenAIVisualizerCallback { get; set; }
 
     [Parameter, EditorRequired]
-    public required Func<OtlpLogEntry, bool> IsGenAILogCallback { get; set; }
-
-    private string? _exceptionText;
-
-    protected override void OnInitialized()
-    {
-        _exceptionText = OtlpLogEntry.GetExceptionText(LogEntry);
-    }
+    public required Func<LogSummary, bool> IsGenAILogCallback { get; set; }
 
     private Task OnLaunchGenAIVisualizerAsync() => LaunchGenAIVisualizerCallback.InvokeAsync(LogEntry);
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
@@ -20,7 +20,9 @@ public partial class UnreadLogErrorsBadge
     public required Dictionary<ResourceKey, int>? UnviewedErrorCounts { get; set; }
 
     [Inject]
-    public required TelemetryRepository TelemetryRepository { get; init; }
+    public required DashboardDataSource DataSource { get; init; }
+
+    public ITelemetryRepository TelemetryRepository => DataSource.TelemetryRepository;
 
     protected override void OnParametersSet()
     {

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -19,6 +19,23 @@ public sealed class DashboardOptions
     public TelemetryLimitOptions TelemetryLimits { get; set; } = new();
     public DebugSessionOptions DebugSession { get; set; } = new();
     public UIOptions UI { get; set; } = new();
+    public DashboardDataOptions Data { get; set; } = new();
+}
+
+public sealed class DashboardDataOptions
+{
+    // Configure this to a location whose permissions protect persisted Dashboard data from undesirable accounts.
+    public string? Directory { get; set; }
+    public DashboardPersistenceMode PersistenceMode { get; set; }
+
+    internal string? PersistenceModeParseError { get; set; }
+}
+
+public enum DashboardPersistenceMode
+{
+    None,
+    Run,
+    Resume
 }
 
 // Don't set values after validating/parsing options.

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -26,6 +26,30 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
     {
         _logger.LogDebug($"PostConfigure {nameof(DashboardOptions)} with name '{name}'.");
 
+        if (_configuration[DashboardConfigNames.DashboardApplicationName.EnvVarName] is { Length: > 0 } applicationName)
+        {
+            options.ApplicationName = applicationName;
+        }
+
+        if (_configuration[DashboardConfigNames.DashboardDataDirectoryName.EnvVarName] is { Length: > 0 } dataDirectory)
+        {
+            options.Data.Directory = dataDirectory;
+        }
+
+        if (_configuration[DashboardConfigNames.DashboardPersistenceModeName.EnvVarName] is { Length: > 0 } persistenceMode)
+        {
+            if (Enum.TryParse<DashboardPersistenceMode>(persistenceMode, ignoreCase: true, out var parsedPersistenceMode) &&
+                Enum.IsDefined(parsedPersistenceMode))
+            {
+                options.Data.PersistenceMode = parsedPersistenceMode;
+                options.Data.PersistenceModeParseError = null;
+            }
+            else
+            {
+                options.Data.PersistenceModeParseError = $"Failed to parse dashboard persistence mode '{persistenceMode}'. Possible values: {string.Join(", ", typeof(DashboardPersistenceMode).GetEnumNames())}.";
+            }
+        }
+
         // Copy aliased config values to the strongly typed options.
         if (_configuration.GetString(DashboardConfigNames.DashboardOtlpGrpcUrlName.ConfigKey,
                                      DashboardConfigNames.Legacy.DashboardOtlpGrpcUrlName.ConfigKey, fallbackOnEmpty: true) is { } otlpGrpcUrl)

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -26,6 +26,15 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
 
         var errorMessages = new List<string>();
 
+        if (options.Data.PersistenceModeParseError is { } persistenceModeParseError)
+        {
+            errorMessages.Add(persistenceModeParseError);
+        }
+        else if (!Enum.IsDefined(options.Data.PersistenceMode))
+        {
+            errorMessages.Add($"Unexpected dashboard persistence mode: {options.Data.PersistenceMode}");
+        }
+
         if (!options.Frontend.TryParseOptions(out var frontendParseErrorMessage))
         {
             errorMessages.Add(frontendParseErrorMessage);

--- a/src/Aspire.Dashboard/DashboardActivitySource.cs
+++ b/src/Aspire.Dashboard/DashboardActivitySource.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Dashboard;
+
+/// <summary>
+/// Provides the shared activity source for dashboard operations.
+/// </summary>
+public sealed class DashboardActivitySource : IDisposable
+{
+    /// <summary>
+    /// The name of the dashboard activity source.
+    /// </summary>
+    public const string ActivitySourceName = "Aspire.Dashboard";
+
+    /// <summary>
+    /// Gets the shared activity source for dashboard operations.
+    /// </summary>
+    public ActivitySource ActivitySource { get; } = new(ActivitySourceName);
+
+    /// <inheritdoc />
+    public void Dispose() => ActivitySource.Dispose();
+}

--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -159,7 +159,7 @@ public static class DashboardEndpointsBuilder
                 return Results.Empty;
             }
 
-            var response = service.GetSpans(resource, traceId, hasError, limit, search);
+            var response = await service.GetSpansAsync(resource, traceId, hasError, limit, cancellationToken, search).ConfigureAwait(false);
             if (response is null)
             {
                 return Results.NotFound(new ProblemDetails
@@ -191,7 +191,7 @@ public static class DashboardEndpointsBuilder
                 return Results.Empty;
             }
 
-            var response = service.GetLogs(resource, traceId, severity, limit, search);
+            var response = await service.GetLogsAsync(resource, traceId, severity, limit, cancellationToken, search).ConfigureAwait(false);
             if (response is null)
             {
                 return Results.NotFound(new ProblemDetails
@@ -206,14 +206,15 @@ public static class DashboardEndpointsBuilder
 
         // GET /api/telemetry/traces - List traces in OTLP JSON format (snapshot only, no streaming)
         // Supports multiple resource names: ?resource=app1&resource=app2
-        group.MapGet("/traces", (
+        group.MapGet("/traces", async (
             TelemetryApiService service,
             [FromQuery] string[]? resource,
             [FromQuery] bool? hasError,
             [FromQuery] int? limit,
-            [FromQuery] string? search) =>
+            [FromQuery] string? search,
+            CancellationToken cancellationToken) =>
         {
-            var response = service.GetTraces(resource, hasError, limit, search);
+            var response = await service.GetTracesAsync(resource, hasError, limit, cancellationToken, search).ConfigureAwait(false);
             if (response is null)
             {
                 return Results.NotFound(new ProblemDetails

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -40,6 +40,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using OpenTelemetry.Trace;
 using OpenIdConnectOptions = Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions;
 
 namespace Aspire.Dashboard;
@@ -64,6 +65,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     private const string DashboardAuthCookieName = ".Aspire.Dashboard.Auth";
     private const string DashboardHttpAuthCookieName = ".Aspire.Dashboard.Auth.Http";
     private const string DashboardAntiForgeryCookieName = ".Aspire.Dashboard.Antiforgery";
+    private const string OtlpExporterEndpointConfigurationKey = "OTEL_EXPORTER_OTLP_ENDPOINT";
     private readonly WebApplication _app;
     private readonly ILogger<DashboardWebApplication> _logger;
     private readonly IOptionsMonitor<DashboardOptions> _dashboardOptionsMonitor;
@@ -152,6 +154,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         // Silently ignore and allow anti-forgery to automatically create a new valid cookie.
         builder.Logging.AddFilter("Microsoft.AspNetCore.Antiforgery.DefaultAntiforgery", LogLevel.None);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
+        builder.Logging.AddFilter("Microsoft.Extensions.Localization", LogLevel.Information);
         builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.None);
 #else
 
@@ -165,6 +168,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Logging.AddFilter("Aspire.Dashboard.Authentication", LogLevel.Information);
         builder.Logging.AddFilter("Aspire.Dashboard.Otlp", LogLevel.Information);
         builder.Logging.AddFilter("Microsoft", LogLevel.Information);
+        builder.Logging.AddFilter("Microsoft.Extensions.Localization", LogLevel.Information);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Cors", LogLevel.Warning);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);
@@ -277,7 +281,17 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
 
         // Data from the server.
-        builder.Services.TryAddSingleton<IDashboardClient, DashboardClient>();
+        builder.Services.TryAddSingleton<DashboardActivitySource>();
+        builder.Services.TryAddSingleton<DashboardClient>();
+        // Interactions must remain connected to the live AppHost while historical data is selected, so resolve this
+        // keyed service from DashboardClient rather than the scoped SelectedDashboardClient.
+        builder.Services.AddKeyedSingleton<IDashboardClient>(DashboardClient.LiveAppHostServiceKey,
+            (services, _) => services.GetRequiredService<DashboardClient>());
+        builder.Services.AddSingleton<DashboardDataSourcePool>();
+        builder.Services.AddHostedService<DashboardDataSourceInitializer>();
+        builder.Services.AddScoped<DashboardDataSource>();
+        builder.Services.AddScoped<IDashboardRunSelection>(services => services.GetRequiredService<DashboardDataSource>());
+        builder.Services.AddScoped<IDashboardClient, SelectedDashboardClient>();
 
         builder.Services.TryAddSingleton<INotificationService, NotificationService>();
         builder.Services.TryAddSingleton(TimeProvider.System);
@@ -291,10 +305,28 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.TryAddSingleton<IDashboardTelemetrySender, DashboardTelemetrySender>();
         builder.Services.AddSingleton<ILoggerProvider, TelemetryLoggerProvider>();
         builder.Services.AddSingleton<ITelemetryErrorRecorder, TelemetryErrorRecorder>();
+        if (!string.IsNullOrWhiteSpace(builder.Configuration[OtlpExporterEndpointConfigurationKey]))
+        {
+            builder.Services.AddOpenTelemetry()
+                .WithTracing(tracing => tracing
+                    .AddAspNetCoreInstrumentation()
+                    .AddSource(DashboardActivitySource.ActivitySourceName)
+                    .AddSource(TracingSqliteConnection.ActivitySourceName)
+                    .AddOtlpExporter());
+        }
 
         // OTLP services.
         builder.Services.AddGrpc();
-        builder.Services.AddSingleton<TelemetryRepository>();
+        builder.Services.AddSingleton<DashboardRunStore>();
+        builder.Services.AddSingleton<IDashboardRunStore>(services => services.GetRequiredService<DashboardRunStore>());
+        builder.Services.AddSingleton<IRepositoryFactory, RepositoryFactory>();
+        builder.Services.AddSingleton(services => services.GetRequiredService<DashboardDataSourcePool>().Current.TelemetryRepository);
+        // OTLP ingestion and telemetry mutations always target the current dashboard run, even when a browser circuit selects a historical run.
+        builder.Services.AddSingleton<ITelemetryRepositoryWriter>(services =>
+            (ITelemetryRepositoryWriter)services.GetRequiredService<ITelemetryRepository>());
+        builder.Services.AddSingleton(services => services.GetRequiredService<DashboardDataSourcePool>().Current.ResourceRepository);
+        builder.Services.AddSingleton<IResourceRepositoryWriter>(services =>
+            (IResourceRepositoryWriter)services.GetRequiredService<IResourceRepository>());
         builder.Services.AddTransient<StructuredLogsViewModel>();
 
         builder.Services.AddTransient<OtlpLogsService>();
@@ -305,7 +337,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddSingleton<TelemetryApiService>();
 
         builder.Services.AddTransient<TracesViewModel>();
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>());
+        builder.Services.AddSingleton<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>();
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOutgoingPeerResolver, DashboardSqliteOutgoingPeerResolver>());
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOutgoingPeerResolver, BrowserLinkOutgoingPeerResolver>());
 
         builder.Services.AddFluentUIComponents();
@@ -333,7 +366,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         // resource snapshot stream. Default impl looks up by display name and
         // replica index in IDashboardClient and connects to the consumer UDS
         // path the AppHost stamped onto the snapshot.
-        builder.Services.TryAddSingleton<Aspire.Dashboard.Terminal.ITerminalConnectionResolver, Aspire.Dashboard.Terminal.DefaultTerminalConnectionResolver>();
+        builder.Services.TryAddSingleton<Aspire.Dashboard.Terminal.ITerminalConnectionResolver>(services =>
+            new Aspire.Dashboard.Terminal.DefaultTerminalConnectionResolver(services.GetRequiredService<DashboardClient>()));
 
         builder.Services.AddScoped<DimensionManager>();
         builder.Services.AddScoped<DashboardDialogService>();
@@ -441,7 +475,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         {
             if (context.Request.Path.Equals(TargetLocationInterceptor.ResourcesPath, StringComparisons.UrlPath))
             {
-                var client = context.RequestServices.GetRequiredService<IDashboardClient>();
+                var client = context.RequestServices.GetRequiredService<DashboardClient>();
                 if (!client.IsEnabled)
                 {
                     context.Response.Redirect(TargetLocationInterceptor.StructuredLogsPath);

--- a/src/Aspire.Dashboard/Model/ConsoleLogsFetcher.cs
+++ b/src/Aspire.Dashboard/Model/ConsoleLogsFetcher.cs
@@ -11,6 +11,7 @@ namespace Aspire.Dashboard.Model;
 public sealed class ConsoleLogsFetcher
 {
     private readonly IDashboardClient _dashboardClient;
+    private readonly DashboardDataSource _dataSource;
     private readonly ConsoleLogsManager _consoleLogsManager;
 
     public bool IsEnabled => _dashboardClient.IsEnabled;
@@ -18,11 +19,13 @@ public sealed class ConsoleLogsFetcher
     /// <summary>
     /// Initializes a new instance of the <see cref="ConsoleLogsFetcher"/> class.
     /// </summary>
+    /// <param name="dataSource">The selected dashboard run data source.</param>
     /// <param name="dashboardClient">The dashboard client.</param>
     /// <param name="consoleLogsManager">The console logs manager.</param>
-    public ConsoleLogsFetcher(IDashboardClient dashboardClient, ConsoleLogsManager consoleLogsManager)
+    public ConsoleLogsFetcher(DashboardDataSource dataSource, IDashboardClient dashboardClient, ConsoleLogsManager consoleLogsManager)
     {
         _dashboardClient = dashboardClient;
+        _dataSource = dataSource;
         _consoleLogsManager = consoleLogsManager;
     }
 
@@ -31,7 +34,10 @@ public sealed class ConsoleLogsFetcher
         var logEntries = new List<LogEntry>();
         var logParser = new LogParser(ConsoleColor.Black);
 
-        await foreach (var batch in _dashboardClient.GetConsoleLogs(resourceName, cancellationToken).ConfigureAwait(false))
+        // Export uses the persisted snapshot, which can omit logs that weren't captured by a demand-driven
+        // subscription. This is a known limitation; the historical Console Logs page displays a notice when
+        // logs aren't available for the selected run. See https://github.com/microsoft/aspire/issues/18823.
+        await foreach (var batch in _dataSource.ResourceRepository.GetConsoleLogs(resourceName, cancellationToken).ConfigureAwait(false))
         {
             foreach (var logLine in batch)
             {
@@ -60,7 +66,7 @@ public sealed class ConsoleLogsFetcher
             throw new InvalidOperationException("Can't fetch console logs when the dashboard client is not enabled.");
         }
 
-        var resources = _dashboardClient.GetResources().Where(r => resourceNames.Contains(r.Name)).ToList();
+        var resources = _dataSource.ResourceRepository.GetResources().Where(r => resourceNames.Contains(r.Name)).ToList();
         var result = new Dictionary<string, List<LogEntry>>(StringComparer.OrdinalIgnoreCase);
 
         // Fetch logs for all resources in parallel

--- a/src/Aspire.Dashboard/Model/DashboardSqliteOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/DashboardSqliteOutgoingPeerResolver.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+
+namespace Aspire.Dashboard.Model;
+
+internal sealed class DashboardSqliteOutgoingPeerResolver : IOutgoingPeerResolver
+{
+    private const string SqliteSystemName = "sqlite";
+
+    public bool TryResolvePeer(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResource)
+    {
+        var isDashboardSqlite = string.Equals(attributes.GetValue(OtlpSpan.PeerServiceAttributeKey), DashboardRunStore.DatabaseFileName, StringComparison.Ordinal) &&
+            string.Equals(attributes.GetValue("db.system.name"), SqliteSystemName, StringComparison.Ordinal) &&
+            string.Equals(attributes.GetValue("db.namespace"), DashboardRunStore.DatabaseFileName, StringComparison.Ordinal);
+
+        name = isDashboardSqlite ? DashboardRunStore.DatabaseFileName : null;
+        matchedResource = null;
+        return isDashboardSqlite;
+    }
+
+    public IDisposable OnPeerChanges(Func<Task> callback) => NullDisposable.Instance;
+
+    private sealed class NullDisposable : IDisposable
+    {
+        public static NullDisposable Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Model/ExportHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ExportHelpers.cs
@@ -21,10 +21,10 @@ internal static class ExportHelpers
     /// <summary>
     /// Gets a span as a JSON export result, including associated log entries.
     /// </summary>
-    public static ExportResult GetSpanAsJson(OtlpSpan span, TelemetryRepository telemetryRepository, IOutgoingPeerResolver[] outgoingPeerResolvers)
+    public static async Task<ExportResult> GetSpanAsJsonAsync(OtlpSpan span, ITelemetryRepository telemetryRepository, CancellationToken cancellationToken)
     {
-        var logs = telemetryRepository.GetLogsForSpan(span.TraceId, span.SpanId);
-        var json = TelemetryExportService.ConvertSpanToJson(span, outgoingPeerResolvers, logs);
+        var logs = await telemetryRepository.GetLogsForSpanAsync(span.TraceId, span.SpanId, cancellationToken).ConfigureAwait(false);
+        var json = TelemetryExportService.ConvertSpanToJson(span, logs);
         var fileName = $"span-{OtlpHelpers.ToShortenedId(span.SpanId)}.json";
         return new ExportResult(json, fileName);
     }
@@ -44,10 +44,10 @@ internal static class ExportHelpers
     /// <summary>
     /// Gets all spans in a trace as a JSON export result, including associated log entries.
     /// </summary>
-    public static ExportResult GetTraceAsJson(OtlpTrace trace, TelemetryRepository telemetryRepository, IOutgoingPeerResolver[] outgoingPeerResolvers)
+    public static async Task<ExportResult> GetTraceAsJsonAsync(OtlpTrace trace, ITelemetryRepository telemetryRepository, CancellationToken cancellationToken)
     {
-        var logs = telemetryRepository.GetLogsForTrace(trace.TraceId);
-        var json = TelemetryExportService.ConvertTraceToJson(trace, outgoingPeerResolvers, logs);
+        var logs = await telemetryRepository.GetLogsForTraceAsync(trace.TraceId, cancellationToken).ConfigureAwait(false);
+        var json = TelemetryExportService.ConvertTraceToJson(trace, logs);
         var fileName = $"trace-{OtlpHelpers.ToShortenedId(trace.TraceId)}.json";
         return new ExportResult(json, fileName);
     }

--- a/src/Aspire.Dashboard/Model/FilterDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/FilterDialogViewModel.cs
@@ -9,6 +9,6 @@ public sealed class FilterDialogViewModel
 {
     public required FieldTelemetryFilter? Filter { get; init; }
     public required List<string> KnownKeys { get; init; }
-    public required List<string> PropertyKeys { get; init; }
-    public required Func<string, Dictionary<string, int>> GetFieldValues { get; init; }
+    public required Func<CancellationToken, Task<List<string>>> GetPropertyKeysAsync { get; init; }
+    public required Func<string, CancellationToken, Task<Dictionary<string, int>>> GetFieldValuesAsync { get; init; }
 }

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -47,12 +47,13 @@ public sealed class GenAIVisualizerDialogViewModel
     public int? InputTokens { get; set; }
     public int? OutputTokens { get; set; }
 
-    public static GenAIVisualizerDialogViewModel Create(
+    public static async Task<GenAIVisualizerDialogViewModel> CreateAsync(
         SpanDetailsViewModel spanDetailsViewModel,
         long? selectedLogEntryId,
         ITelemetryErrorRecorder errorRecorder,
-        TelemetryRepository telemetryRepository,
-        Func<List<OtlpSpan>> getContextGenAISpans)
+        ITelemetryRepository telemetryRepository,
+        Func<List<OtlpSpan>> getContextGenAISpans,
+        CancellationToken cancellationToken)
     {
         var resources = telemetryRepository.GetResources();
 
@@ -125,9 +126,9 @@ public sealed class GenAIVisualizerDialogViewModel
 
         try
         {
-            CreateMessages(viewModel, telemetryRepository);
+            await CreateMessagesAsync(viewModel, telemetryRepository, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // We're catching errors here to avoid it going to Blazor global error handling. But we still want to record errors from reading messages to telemetry.
             // This can be changed to just using logging once we have confidence that we're handling popular content well.
@@ -155,9 +156,9 @@ public sealed class GenAIVisualizerDialogViewModel
 
         try
         {
-            ParseEvaluations(viewModel, telemetryRepository);
+            await ParseEvaluationsAsync(viewModel, telemetryRepository, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Log error but don't fail the entire view model creation
             errorRecorder.RecordError($"Error parsing GenAI evaluation results for span {viewModel.Span.SpanId}", ex, writeToLogging: true);
@@ -277,7 +278,7 @@ public sealed class GenAIVisualizerDialogViewModel
     // - Span attributes.
     // - Log entry bodies.
     // - Span event attributes.
-    private static void CreateMessages(GenAIVisualizerDialogViewModel viewModel, TelemetryRepository telemetryRepository)
+    private static async Task CreateMessagesAsync(GenAIVisualizerDialogViewModel viewModel, ITelemetryRepository telemetryRepository, CancellationToken cancellationToken)
     {
         var currentIndex = 0;
 
@@ -311,7 +312,7 @@ public sealed class GenAIVisualizerDialogViewModel
         }
 
         // Attempt to get messages from log entries.
-        var logEntries = GetSpanLogEntries(telemetryRepository, viewModel.Span);
+        var logEntries = await GetSpanLogEntriesAsync(telemetryRepository, viewModel.Span, cancellationToken).ConfigureAwait(false);
         foreach (var (item, index) in logEntries.OrderBy(i => i.TimeStamp).Select((l, i) => (l, i)))
         {
             if (!string.IsNullOrEmpty(item.Message) && OtlpHelpers.GetEventName(item) is { } name && TryMapEventName(name, out var type))
@@ -593,7 +594,7 @@ public sealed class GenAIVisualizerDialogViewModel
         return type != null;
     }
 
-    private static List<OtlpLogEntry> GetSpanLogEntries(TelemetryRepository telemetryRepository, OtlpSpan span)
+    private static async Task<List<OtlpLogEntry>> GetSpanLogEntriesAsync(ITelemetryRepository telemetryRepository, OtlpSpan span, CancellationToken cancellationToken)
     {
         var logsContext = new GetLogsContext
         {
@@ -609,16 +610,16 @@ public sealed class GenAIVisualizerDialogViewModel
                 }
             ]
         };
-        var logsResult = telemetryRepository.GetLogs(logsContext);
+        var logsResult = await telemetryRepository.GetLogsAsync(logsContext, cancellationToken).ConfigureAwait(false);
         return logsResult.Items;
     }
 
-    private static void ParseEvaluations(GenAIVisualizerDialogViewModel viewModel, TelemetryRepository telemetryRepository)
+    private static async Task ParseEvaluationsAsync(GenAIVisualizerDialogViewModel viewModel, ITelemetryRepository telemetryRepository, CancellationToken cancellationToken)
     {
         var evaluations = new List<EvaluationResultViewModel>();
 
         // Parse evaluation results from log entries
-        var logEntries = GetSpanLogEntries(telemetryRepository, viewModel.Span);
+        var logEntries = await GetSpanLogEntriesAsync(telemetryRepository, viewModel.Span, cancellationToken).ConfigureAwait(false);
         foreach (var logEntry in logEntries)
         {
             if (OtlpHelpers.GetEventName(logEntry) == GenAIHelpers.GenAIEvaluationResultEventName)

--- a/src/Aspire.Dashboard/Model/InstrumentViewModel.cs
+++ b/src/Aspire.Dashboard/Model/InstrumentViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 
@@ -8,19 +9,34 @@ namespace Aspire.Dashboard.Model;
 
 public class InstrumentViewModel
 {
+    private ImmutableArray<Func<Task>> _dataUpdateSubscriptions = [];
+
     public OtlpInstrumentSummary? Instrument { get; private set; }
     public List<DimensionScope>? MatchedDimensions { get; private set; }
 
-    public List<Func<Task>> DataUpdateSubscriptions { get; } = [];
     public string? Theme { get; set; }
     public bool ShowCount { get; set; }
+
+    internal void AddDataUpdateSubscription(Func<Task> subscription)
+    {
+        ImmutableInterlocked.Update(ref _dataUpdateSubscriptions, static (subscriptions, subscription) => subscriptions.Add(subscription), subscription);
+    }
+
+    internal void RemoveDataUpdateSubscription(Func<Task> subscription)
+    {
+        ImmutableInterlocked.Update(ref _dataUpdateSubscriptions, static (subscriptions, subscription) => subscriptions.Remove(subscription), subscription);
+    }
 
     public async Task UpdateDataAsync(OtlpInstrumentSummary instrument, List<DimensionScope> matchedDimensions)
     {
         Instrument = instrument;
         MatchedDimensions = matchedDimensions;
 
-        foreach (var subscription in DataUpdateSubscriptions)
+        // A chart can be disposed while another subscription is awaiting a render. Invoke the immutable
+        // snapshot captured at the start so disposal can't invalidate the active enumeration.
+        var subscriptions = _dataUpdateSubscriptions;
+
+        foreach (var subscription in subscriptions)
         {
             await subscription().ConfigureAwait(false);
         }

--- a/src/Aspire.Dashboard/Model/Interaction/InteractionsInputsDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Interaction/InteractionsInputsDialogViewModel.cs
@@ -16,6 +16,7 @@ public sealed class InteractionsInputsDialogViewModel
     }
     public required Func<WatchInteractionsResponseUpdate, bool, Task> OnSubmitCallback { get; init; }
     public required string Message { get; init; }
+    public required IDashboardClient DashboardClient { get; init; }
 
     public List<InteractionInput> Inputs => Interaction.InputsDialog!.InputItems.ToList();
 

--- a/src/Aspire.Dashboard/Model/Markdown/HighlightedCodeBlockRenderer.cs
+++ b/src/Aspire.Dashboard/Model/Markdown/HighlightedCodeBlockRenderer.cs
@@ -78,7 +78,7 @@ public class HighlightedCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
 
         // Add copy attributes to the copy button.
         var rawCode = GetRawCodeText(obj);
-        var copyToClipboard = _loc[nameof(ControlsStrings.GridValueCopyToClipboard)].Value;
+        var copyToClipboard = _loc[nameof(ControlsStrings.GridValueCopyToClipboard)];
         var attributes = FluentUIExtensions.GetClipboardCopyAdditionalAttributes(rawCode, copyToClipboard, _loc[nameof(ControlsStrings.GridValueCopied)]);
         var copyButtonAttributes = new HtmlAttributes();
         copyButtonAttributes.AddClass("code-copy-button");

--- a/src/Aspire.Dashboard/Model/MenuButtonItem.cs
+++ b/src/Aspire.Dashboard/Model/MenuButtonItem.cs
@@ -12,6 +12,10 @@ public class MenuButtonItem
     public string? Text { get; set; }
     public string? Tooltip { get; set; }
     public Icon? Icon { get; set; }
+    public Icon? SecondaryActionIcon { get; set; }
+    public string? SecondaryActionAriaLabel { get; set; }
+    public Func<Task>? OnSecondaryActionClick { get; set; }
+    public bool IsSecondaryActionSelected { get; set; }
     /// <summary>
     /// Optional ARIA role for the item. Set to <see cref="MenuItemRole.MenuItemCheckbox"/> or
     /// <see cref="MenuItemRole.MenuItemRadio"/> to expose an accessible checked state (via

--- a/src/Aspire.Dashboard/Model/Otlp/SpanLogEntryViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanLogEntryViewModel.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 
 namespace Aspire.Dashboard.Model.Otlp;
 
@@ -10,6 +10,6 @@ namespace Aspire.Dashboard.Model.Otlp;
 public sealed class SpanLogEntryViewModel
 {
     public required int Index { get; init; }
-    public required OtlpLogEntry LogEntry { get; init; }
+    public required LogSummary LogEntry { get; init; }
     public required double LeftOffset { get; init; }
 }

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 
 namespace Aspire.Dashboard.Model.Otlp;
 
@@ -153,14 +154,14 @@ public sealed class SpanWaterfallViewModel
 
     private readonly record struct SpanWaterfallViewModelState(SpanWaterfallViewModel? Parent, int Depth, bool Hidden);
 
-    public sealed record TraceDetailState(IOutgoingPeerResolver[] OutgoingPeerResolvers, List<string> CollapsedSpanIds, List<OtlpResource> AllResources);
+    public sealed record TraceDetailState(List<string> CollapsedSpanIds, List<OtlpResource> AllResources);
 
     public static string GetTitle(OtlpSpan span, List<OtlpResource> allResources)
     {
         return $"{OtlpResource.GetResourceName(span.Source, allResources)}: {span.GetDisplaySummary()}";
     }
 
-    public static List<SpanWaterfallViewModel> Create(OtlpTrace trace, List<OtlpLogEntry> logs, TraceDetailState state)
+    public static List<SpanWaterfallViewModel> Create(OtlpTrace trace, List<LogSummary> logs, TraceDetailState state)
     {
         var orderedSpans = new List<SpanWaterfallViewModel>();
         var groupedLogs = logs.GroupBy(l => l.SpanId).ToDictionary(l => l.Key, g => g.ToList());
@@ -179,7 +180,7 @@ public sealed class SpanWaterfallViewModel
 
         return orderedSpans;
 
-        static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth, bool hidden, TraceDetailState state, List<OtlpLogEntry>? spanLogs, ref int currentSpanLogIndex)
+        static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth, bool hidden, TraceDetailState state, List<LogSummary>? spanLogs, ref int currentSpanLogIndex)
         {
             var traceStart = span.Trace.FirstSpan.StartTime;
             var relativeStart = span.StartTime - traceStart;
@@ -195,7 +196,7 @@ public sealed class SpanWaterfallViewModel
             // A span may indicate a call to another service but the service isn't instrumented.
             var hasPeerService = OtlpHelpers.GetPeerAddress(span.Attributes) != null;
             var isUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
-            var uninstrumentedPeer = isUninstrumentedPeer ? ResolveUninstrumentedPeerName(span, state.OutgoingPeerResolvers, state.AllResources) : null;
+            var uninstrumentedPeer = isUninstrumentedPeer ? ResolveUninstrumentedPeerName(span, state.AllResources) : null;
 
             var spanLogVms = new List<SpanLogEntryViewModel>();
             if (spanLogs != null)
@@ -248,7 +249,7 @@ public sealed class SpanWaterfallViewModel
         }
     }
 
-    private static string? ResolveUninstrumentedPeerName(OtlpSpan span, IOutgoingPeerResolver[] outgoingPeerResolvers, List<OtlpResource> allResources)
+    private static string? ResolveUninstrumentedPeerName(OtlpSpan span, List<OtlpResource> allResources)
     {
         if (span.UninstrumentedPeer != null)
         {
@@ -256,16 +257,6 @@ public sealed class SpanWaterfallViewModel
             // We are matching an address to replicas which share the same address. There isn't a way to know exactly which replica was called. The first replica instance will be chosen.
             // This shouldn't be a big issue because typically project replicas will have OTEL setup, and so a child span is recorded.
             return OtlpHelpers.GetResourceName(span.UninstrumentedPeer, allResources);
-        }
-
-        // Attempt to resolve uninstrumented peer to a friendly name from the span.
-        // This should only match non-resource returning resolves such as Browser Link.
-        foreach (var resolver in outgoingPeerResolvers)
-        {
-            if (resolver.TryResolvePeer(span.Attributes, out var name, out _))
-            {
-                return name;
-            }
         }
 
         // Fallback to the peer address.

--- a/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/ResourceMenuBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.Dialogs;
-using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
@@ -29,29 +28,32 @@ public sealed class ResourceMenuBuilder
     private static readonly Icon s_exportEnvIcon = new Icons.Regular.Size16.DocumentText();
 
     private readonly NavigationManager _navigationManager;
-    private readonly TelemetryRepository _telemetryRepository;
+    private readonly DashboardDataSource _dataSource;
     private readonly IStringLocalizer<ControlsStrings> _controlLoc;
     private readonly IStringLocalizer<Resources.Resources> _loc;
     private readonly IconResolver _iconResolver;
     private readonly DashboardDialogService _dialogService;
+    private readonly IDashboardClient _dashboardClient;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ResourceMenuBuilder"/> class.
     /// </summary>
     public ResourceMenuBuilder(
         NavigationManager navigationManager,
-        TelemetryRepository telemetryRepository,
+        DashboardDataSource dataSource,
         IStringLocalizer<ControlsStrings> controlLoc,
         IStringLocalizer<Resources.Resources> loc,
         IconResolver iconResolver,
-        DashboardDialogService dialogService)
+        DashboardDialogService dialogService,
+        IDashboardClient dashboardClient)
     {
         _navigationManager = navigationManager;
-        _telemetryRepository = telemetryRepository;
+        _dataSource = dataSource;
         _controlLoc = controlLoc;
         _loc = loc;
         _iconResolver = iconResolver;
         _dialogService = dialogService;
+        _dashboardClient = dashboardClient;
     }
 
     /// <summary>
@@ -203,7 +205,7 @@ public sealed class ResourceMenuBuilder
     private void AddTelemetryMenuItems(List<MenuButtonItem> menuItems, ResourceViewModel resource, IDictionary<string, ResourceViewModel> resourceByName)
     {
         // Show telemetry menu items if there is telemetry for the resource.
-        var telemetryResource = _telemetryRepository.GetResourceByCompositeName(resource.Name);
+        var telemetryResource = _dataSource.TelemetryRepository.GetResourceByCompositeName(resource.Name);
         if (telemetryResource != null)
         {
             menuItems.Add(new MenuButtonItem { IsDivider = true });
@@ -309,7 +311,7 @@ public sealed class ResourceMenuBuilder
                 Tooltip = command.GetDisplayDescription(),
                 Icon = _iconResolver.ResolveCommandIcon(command.IconName, command.IconVariant),
                 OnClick = () => commandSelected.InvokeAsync(command),
-                IsDisabled = command.State == CommandViewModelState.Disabled || isCommandExecuting(resource, command)
+                IsDisabled = _dashboardClient.IsReadOnly || command.State == CommandViewModelState.Disabled || isCommandExecuting(resource, command)
             };
         }
     }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -24,64 +24,84 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
     private static partial Regex HostRegex();
 
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
-    private readonly CancellationTokenSource _watchContainersTokenSource = new();
-    private readonly List<ModelSubscription> _subscriptions = [];
+    private readonly ActivitySource _activitySource;
+    private readonly ILogger<ResourceOutgoingPeerResolver> _logger;
+    private readonly CancellationTokenSource _watchContainersTokenSource;
+    private readonly CancellationToken _watchContainersToken;
+    private readonly List<PeerChangesSubscription> _subscriptions = [];
     private readonly object _lock = new();
     private readonly Task? _watchTask;
 
-    public ResourceOutgoingPeerResolver(IDashboardClient resourceService)
+    public ResourceOutgoingPeerResolver(
+        IResourceRepository resourceRepository,
+        DashboardActivitySource activitySource,
+        ILogger<ResourceOutgoingPeerResolver> logger)
     {
-        if (!resourceService.IsEnabled)
+        _activitySource = activitySource.ActivitySource;
+        _logger = logger;
+        _watchContainersTokenSource = new();
+        _watchContainersToken = _watchContainersTokenSource.Token;
+
+        if (resourceRepository is IDashboardClient { IsEnabled: false })
         {
             return;
         }
 
-        _watchTask = Task.Run(async () =>
+        // This watcher lives for the lifetime of the resolver. Don't let the request or component that
+        // causes the resolver to be constructed become the parent of that long-running operation.
+        using (ExecutionContext.SuppressFlow())
         {
-            var (snapshot, subscription) = await resourceService.SubscribeResourcesAsync(_watchContainersTokenSource.Token).ConfigureAwait(false);
+            _watchTask = Task.Run(() => WatchResourcesAsync(resourceRepository));
+        }
+    }
 
-            if (snapshot.Length > 0)
+    private async Task WatchResourcesAsync(IResourceRepository resourceRepository)
+    {
+        var (snapshot, subscription) = await resourceRepository.SubscribeResourcesAsync(_watchContainersToken).ConfigureAwait(false);
+
+        if (snapshot.Length > 0)
+        {
+            foreach (var resource in snapshot)
             {
-                foreach (var resource in snapshot)
-                {
-                    var added = _resourceByName.TryAdd(resource.Name, resource);
-                    Debug.Assert(added, "Should not receive duplicate resources in initial snapshot data.");
-                }
-
-                await RaisePeerChangesAsync().ConfigureAwait(false);
+                var added = _resourceByName.TryAdd(resource.Name, resource);
+                Debug.Assert(added, "Should not receive duplicate resources in initial snapshot data.");
             }
 
-            await foreach (var changes in subscription.WithCancellation(_watchContainersTokenSource.Token).ConfigureAwait(false))
+            await RaisePeerChangesAsync().ConfigureAwait(false);
+        }
+
+        await foreach (var changes in subscription.WithCancellation(_watchContainersToken).ConfigureAwait(false))
+        {
+            using var activity = _activitySource.StartActivity("Process resource subscription changes", ActivityKind.Consumer);
+
+            var hasPeerRelevantChanges = false;
+
+            foreach (var (changeType, resource) in changes)
             {
-                var hasPeerRelevantChanges = false;
-
-                foreach (var (changeType, resource) in changes)
+                if (changeType == ResourceViewModelChangeType.Upsert)
                 {
-                    if (changeType == ResourceViewModelChangeType.Upsert)
-                    {
-                        if (!_resourceByName.TryGetValue(resource.Name, out var existingResource) || 
-                            !ArePeerRelevantPropertiesEquivalent(resource, existingResource))
-                        {
-                            hasPeerRelevantChanges = true;
-                        }
-
-                        _resourceByName[resource.Name] = resource;
-                    }
-                    else if (changeType == ResourceViewModelChangeType.Delete)
+                    if (!_resourceByName.TryGetValue(resource.Name, out var existingResource) ||
+                        !ArePeerRelevantPropertiesEquivalent(resource, existingResource))
                     {
                         hasPeerRelevantChanges = true;
-
-                        var removed = _resourceByName.TryRemove(resource.Name, out _);
-                        Debug.Assert(removed, "Cannot remove unknown resource.");
                     }
-                }
 
-                if (hasPeerRelevantChanges)
+                    _resourceByName[resource.Name] = resource;
+                }
+                else if (changeType == ResourceViewModelChangeType.Delete)
                 {
-                    await RaisePeerChangesAsync().ConfigureAwait(false);
+                    hasPeerRelevantChanges = true;
+
+                    var removed = _resourceByName.TryRemove(resource.Name, out _);
+                    Debug.Assert(removed, "Cannot remove unknown resource.");
                 }
             }
-        });
+
+            if (hasPeerRelevantChanges)
+            {
+                await RaisePeerChangesAsync().ConfigureAwait(false);
+            }
+        }
     }
 
     private static bool ArePeerRelevantPropertiesEquivalent(ResourceViewModel resource1, ResourceViewModel resource2)
@@ -288,13 +308,13 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
     {
         lock (_lock)
         {
-            var subscription = new ModelSubscription(callback, RemoveSubscription);
+            var subscription = new PeerChangesSubscription(callback, RemoveSubscription, _logger);
             _subscriptions.Add(subscription);
             return subscription;
         }
     }
 
-    private void RemoveSubscription(ModelSubscription subscription)
+    private void RemoveSubscription(PeerChangesSubscription subscription)
     {
         lock (_lock)
         {
@@ -304,12 +324,12 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
 
     private async Task RaisePeerChangesAsync()
     {
-        if (_subscriptions.Count == 0 || _watchContainersTokenSource.IsCancellationRequested)
+        if (_watchContainersTokenSource.IsCancellationRequested)
         {
             return;
         }
 
-        ModelSubscription[] subscriptions;
+        PeerChangesSubscription[] subscriptions;
         lock (_lock)
         {
             subscriptions = _subscriptions.ToArray();
@@ -324,9 +344,57 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
     public async ValueTask DisposeAsync()
     {
         _watchContainersTokenSource.Cancel();
+
+        PeerChangesSubscription[] subscriptions;
+        lock (_lock)
+        {
+            subscriptions = _subscriptions.ToArray();
+        }
+        foreach (var subscription in subscriptions)
+        {
+            subscription.Dispose();
+        }
+
         _watchContainersTokenSource.Dispose();
 
         await TaskHelpers.WaitIgnoreCancelAsync(_watchTask).ConfigureAwait(false);
+    }
+
+    private sealed class PeerChangesSubscription : IDisposable
+    {
+        private const int StateNone = 0;
+        private const int StateDisposed = 1;
+
+        private readonly CallbackThrottler _callbackThrottler;
+        private readonly Action<PeerChangesSubscription> _onDispose;
+        private int _disposed;
+
+        public PeerChangesSubscription(
+            Func<Task> callback,
+            Action<PeerChangesSubscription> onDispose,
+            ILogger logger)
+        {
+            _callbackThrottler = new CallbackThrottler(
+                nameof(OnPeerChanges),
+                logger,
+                CallbackThrottler.DefaultMinExecuteInterval,
+                callback,
+                executionContext: null);
+            _onDispose = onDispose;
+        }
+
+        public Task ExecuteAsync() => _callbackThrottler.ExecuteAsync();
+
+        public void Dispose()
+        {
+            if (Interlocked.CompareExchange(ref _disposed, StateDisposed, StateNone) == StateDisposed)
+            {
+                return;
+            }
+
+            _onDispose(this);
+            _callbackThrottler.Dispose();
+        }
     }
 
     private sealed class PeerMatchContext(IDictionary<string, ResourceViewModel> resources, string? databaseName)

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -46,6 +46,7 @@ public sealed class ResourceViewModel
     public bool SupportsDetailedTelemetry { get; init; }
     public string? IconName { get; init; }
     public IconVariant? IconVariant { get; init; }
+    internal bool ConsoleLogsLoaded { get; set; }
     public bool IsParameter => string.Equals(ResourceType, KnownResourceTypes.Parameter, StringComparison.Ordinal);
 
     /// <summary>

--- a/src/Aspire.Dashboard/Model/SpanDetailsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/SpanDetailsViewModel.cs
@@ -19,7 +19,7 @@ public sealed class SpanDetailsViewModel
     public required string Title { get; init; }
     public required List<OtlpResource> Resources { get; init; }
 
-    public static SpanDetailsViewModel Create(OtlpSpan span, TelemetryRepository telemetryRepository, List<OtlpResource> resources)
+    public static SpanDetailsViewModel Create(OtlpSpan span, ITelemetryRepository telemetryRepository, List<OtlpResource> resources)
     {
         ArgumentNullException.ThrowIfNull(span);
         ArgumentNullException.ThrowIfNull(telemetryRepository);
@@ -59,7 +59,7 @@ public sealed class SpanDetailsViewModel
         }
     }
 
-    private static SpanLinkViewModel CreateLinkViewModel(string traceId, string spanId, KeyValuePair<string, string>[] attributes, TelemetryRepository telemetryRepository, Dictionary<string, OtlpTrace> traceCache)
+    private static SpanLinkViewModel CreateLinkViewModel(string traceId, string spanId, KeyValuePair<string, string>[] attributes, ITelemetryRepository telemetryRepository, Dictionary<string, OtlpTrace> traceCache)
     {
         ref var trace = ref CollectionsMarshal.GetValueRefOrAddDefault(traceCache, traceId, out _);
         // Adds to dictionary if not present.

--- a/src/Aspire.Dashboard/Model/SpanMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/SpanMenuBuilder.cs
@@ -4,7 +4,6 @@
 using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Model.GenAI;
 using Aspire.Dashboard.Otlp.Model;
-using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
@@ -27,8 +26,7 @@ public sealed class SpanMenuBuilder
     private readonly IStringLocalizer<ControlsStrings> _controlsLoc;
     private readonly NavigationManager _navigationManager;
     private readonly DashboardDialogService _dialogService;
-    private readonly TelemetryRepository _telemetryRepository;
-    private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers;
+    private readonly DashboardDataSource _dataSource;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SpanMenuBuilder"/> class.
@@ -37,14 +35,12 @@ public sealed class SpanMenuBuilder
         IStringLocalizer<ControlsStrings> controlsLoc,
         NavigationManager navigationManager,
         DashboardDialogService dialogService,
-        TelemetryRepository telemetryRepository,
-        IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+        DashboardDataSource dataSource)
     {
         _controlsLoc = controlsLoc;
         _navigationManager = navigationManager;
         _dialogService = dialogService;
-        _telemetryRepository = telemetryRepository;
-        _outgoingPeerResolvers = outgoingPeerResolvers.ToArray();
+        _dataSource = dataSource;
     }
 
     /// <summary>
@@ -99,7 +95,7 @@ public sealed class SpanMenuBuilder
             Icon = s_bracesIcon,
             OnClick = async () =>
             {
-                var result = ExportHelpers.GetSpanAsJson(span, _telemetryRepository, _outgoingPeerResolvers);
+                var result = await ExportHelpers.GetSpanAsJsonAsync(span, _dataSource.TelemetryRepository, CancellationToken.None).ConfigureAwait(false);
                 await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
                 {
                     DialogService = _dialogService,

--- a/src/Aspire.Dashboard/Model/SpanType.cs
+++ b/src/Aspire.Dashboard/Model/SpanType.cs
@@ -81,8 +81,16 @@ public sealed class SpanHasAttributeTelemetryFilter : TelemetryFilter
 {
     private readonly string[] _attributeNames;
 
+    internal IReadOnlyList<string> AttributeNames => _attributeNames;
+
     public SpanHasAttributeTelemetryFilter(string[] attributeNames)
     {
+        ArgumentNullException.ThrowIfNull(attributeNames);
+        if (attributeNames.Length == 0)
+        {
+            throw new ArgumentException("At least one attribute name is required.", nameof(attributeNames));
+        }
+
         _attributeNames = attributeNames;
     }
 
@@ -114,8 +122,16 @@ public sealed class SpanNoMatchTelemetryFilter : TelemetryFilter
 {
     private readonly TelemetryFilter[] _filters;
 
+    internal IReadOnlyList<TelemetryFilter> Filters => _filters;
+
     public SpanNoMatchTelemetryFilter(TelemetryFilter[] filters)
     {
+        ArgumentNullException.ThrowIfNull(filters);
+        if (filters.Length == 0)
+        {
+            throw new ArgumentException("At least one filter is required.", nameof(filters));
+        }
+
         _filters = filters;
     }
 
@@ -147,8 +163,16 @@ public sealed class SpanScopePrefixTelemetryFilter : TelemetryFilter
 {
     private readonly string[] _scopePrefixes;
 
+    internal IReadOnlyList<string> ScopePrefixes => _scopePrefixes;
+
     public SpanScopePrefixTelemetryFilter(string[] scopePrefixes)
     {
+        ArgumentNullException.ThrowIfNull(scopePrefixes);
+        if (scopePrefixes.Length == 0)
+        {
+            throw new ArgumentException("At least one scope prefix is required.", nameof(scopePrefixes));
+        }
+
         _scopePrefixes = scopePrefixes;
     }
 

--- a/src/Aspire.Dashboard/Model/StructuredLogMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/StructuredLogMenuBuilder.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
@@ -24,6 +25,7 @@ public sealed class StructuredLogMenuBuilder
     private readonly IStringLocalizer<StructuredLogs> _loc;
     private readonly IStringLocalizer<ControlsStrings> _controlsLoc;
     private readonly DashboardDialogService _dialogService;
+    private readonly DashboardDataSource _dataSource;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StructuredLogMenuBuilder"/> class.
@@ -31,11 +33,13 @@ public sealed class StructuredLogMenuBuilder
     public StructuredLogMenuBuilder(
         IStringLocalizer<StructuredLogs> loc,
         IStringLocalizer<ControlsStrings> controlsLoc,
-        DashboardDialogService dialogService)
+        DashboardDialogService dialogService,
+        DashboardDataSource dataSource)
     {
         _loc = loc;
         _controlsLoc = controlsLoc;
         _dialogService = dialogService;
+        _dataSource = dataSource;
     }
 
     /// <summary>
@@ -50,6 +54,32 @@ public sealed class StructuredLogMenuBuilder
         OtlpLogEntry logEntry,
         EventCallback onViewDetails,
         bool showViewDetails = true)
+    {
+        AddMenuItems(menuItems, logEntry.Message, () => logEntry, onViewDetails, showViewDetails);
+    }
+
+    /// <summary>
+    /// Adds menu items for a structured log summary to the provided list.
+    /// </summary>
+    /// <param name="menuItems">The list to add menu items to.</param>
+    /// <param name="summary">The log summary to create menu items for.</param>
+    /// <param name="onViewDetails">Callback when View Details is clicked. Ignored when <paramref name="showViewDetails"/> is <c>false</c>.</param>
+    /// <param name="showViewDetails">Whether to include the View Details menu item. Defaults to <c>true</c>.</param>
+    public void AddMenuItems(
+        List<MenuButtonItem> menuItems,
+        LogSummary summary,
+        EventCallback onViewDetails,
+        bool showViewDetails = true)
+    {
+        AddMenuItems(menuItems, summary.Message, () => _dataSource.TelemetryRepository.GetLog(summary.InternalId), onViewDetails, showViewDetails);
+    }
+
+    private void AddMenuItems(
+        List<MenuButtonItem> menuItems,
+        string message,
+        Func<OtlpLogEntry?> getLogEntry,
+        EventCallback onViewDetails,
+        bool showViewDetails)
     {
         if (showViewDetails)
         {
@@ -72,7 +102,7 @@ public sealed class StructuredLogMenuBuilder
                 {
                     DialogService = _dialogService,
                     ValueDescription = header,
-                    Value = logEntry.Message
+                    Value = message
                 }).ConfigureAwait(false);
             }
         });
@@ -83,6 +113,12 @@ public sealed class StructuredLogMenuBuilder
             Icon = s_bracesIcon,
             OnClick = async () =>
             {
+                var logEntry = getLogEntry();
+                if (logEntry is null)
+                {
+                    return;
+                }
+
                 var result = ExportHelpers.GetLogEntryAsJson(logEntry);
                 await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
                 {

--- a/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
@@ -1,22 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
-using Aspire.Dashboard.Model.GenAI;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
 
 namespace Aspire.Dashboard.Model;
 
 public class StructuredLogsViewModel
 {
-    private readonly TelemetryRepository _telemetryRepository;
+    private readonly DashboardDataSource _dataSource;
     private readonly List<FieldTelemetryFilter> _filters = new();
-    // Cache span lookups for GenAI attributes to avoid repeated lookups.
-    private readonly ConcurrentDictionary<SpanKey, bool> _spanGenAICache = new();
 
-    private PagedResult<OtlpLogEntry>? _logs;
+    private PagedResult<LogSummary>? _logs;
     private ResourceKey? _resourceKey;
     private string _filterText = string.Empty;
     private int _logsStartIndex;
@@ -24,41 +21,14 @@ public class StructuredLogsViewModel
     private LogLevel? _logLevel;
     private bool _currentDataHasErrors;
 
-    public StructuredLogsViewModel(TelemetryRepository telemetryRepository)
+    public StructuredLogsViewModel(DashboardDataSource dataSource)
     {
-        _telemetryRepository = telemetryRepository;
+        _dataSource = dataSource;
     }
 
     public ResourceKey? ResourceKey { get => _resourceKey; set => SetValue(ref _resourceKey, value); }
     public string FilterText { get => _filterText; set => SetValue(ref _filterText, value); }
     public IReadOnlyList<FieldTelemetryFilter> Filters => _filters;
-
-    public bool HasGenAISpan(string traceId, string spanId)
-    {
-        // Get a flag indicating whether the span has GenAI telemetry on it.
-        // This is cached to avoid repeated lookups. The cache is cleared when logs change.
-        // It's ok that this isn't completely thread safe, i.e. get and a clear happen at the same time.
-
-        var spanKey = new SpanKey(traceId, spanId);
-
-        if (_spanGenAICache.TryGetValue(spanKey, out var value))
-        {
-            return value;
-        }
-
-        var span = _telemetryRepository.GetSpan(spanKey.TraceId, spanKey.SpanId);
-        var hasGenAISpan = false;
-
-        if (span != null)
-        {
-            // Only cache a value if a span is present.
-            // We don't want to cache false if there is no span because the span may be added later.
-            hasGenAISpan = GenAIHelpers.HasGenAIAttribute(span.Attributes);
-            _spanGenAICache.TryAdd(spanKey, hasGenAISpan);
-        }
-
-        return hasGenAISpan;
-    }
 
     public void ClearFilters()
     {
@@ -106,20 +76,21 @@ public class StructuredLogsViewModel
         ClearData();
     }
 
-    public PagedResult<OtlpLogEntry> GetLogs()
+    public async Task<PagedResult<LogSummary>> GetLogsAsync(CancellationToken cancellationToken)
     {
         var logs = _logs;
         if (logs == null)
         {
             var filters = GetFilters();
 
-            logs = _telemetryRepository.GetLogs(new GetLogsContext
+            logs = await _dataSource.TelemetryRepository.GetLogSummariesAsync(new GetLogsContext
             {
                 ResourceKeys = ResourceKey is { } key ? [key] : [],
                 StartIndex = StartIndex,
                 Count = Count,
-                Filters = filters
-            });
+                Filters = filters,
+                LatestItemCount = DashboardUIHelpers.MaxVirtualizedItemCount
+            }, cancellationToken).ConfigureAwait(false);
 
             _currentDataHasErrors = logs.Items.Any(i => i.Severity >= Microsoft.Extensions.Logging.LogLevel.Error);
         }
@@ -149,31 +120,8 @@ public class StructuredLogsViewModel
         return filters;
     }
 
-    // First check if there were any errors in already available data. Avoid fetching data again.
-    public bool HasErrors() => _currentDataHasErrors || GetErrorLogs(count: 0).TotalItemCount > 0;
-
-    public PagedResult<OtlpLogEntry> GetErrorLogs(int count)
-    {
-        var filters = GetFilters();
-        filters.RemoveAll(f => f is FieldTelemetryFilter fieldFilter && fieldFilter.Field == nameof(OtlpLogEntry.Severity));
-        filters.Add(new FieldTelemetryFilter { Field = nameof(OtlpLogEntry.Severity), Condition = FilterCondition.GreaterThanOrEqual, Value = Microsoft.Extensions.Logging.LogLevel.Error.ToString() });
-
-        var errorLogs = _telemetryRepository.GetLogs(new GetLogsContext
-        {
-            ResourceKeys = ResourceKey is { } key ? [key] : [],
-            StartIndex = 0,
-            Count = count,
-            Filters = filters
-        });
-
-        return errorLogs;
-    }
-
     public void ClearData()
     {
         _logs = null;
-
-        // Clear cache whenever log data changes to prevent it growing forever.
-        _spanGenAICache.Clear();
     }
 }

--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -22,24 +22,21 @@ namespace Aspire.Dashboard.Model;
 /// </summary>
 public sealed class TelemetryExportService
 {
-    private readonly TelemetryRepository _telemetryRepository;
+    private readonly DashboardDataSource _dataSource;
     private readonly ConsoleLogsFetcher _consoleLogsFetcher;
     private readonly IDashboardClient _dashboardClient;
-    private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryExportService"/> class.
     /// </summary>
-    /// <param name="telemetryRepository">The telemetry repository.</param>
+    /// <param name="dataSource">The selected dashboard run data source.</param>
     /// <param name="consoleLogsFetcher">The console log fetcher.</param>
     /// <param name="dashboardClient">The dashboard client for fetching resources.</param>
-    /// <param name="outgoingPeerResolvers">The outgoing peer resolvers for destination name resolution.</param>
-    public TelemetryExportService(TelemetryRepository telemetryRepository, ConsoleLogsFetcher consoleLogsFetcher, IDashboardClient dashboardClient, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    public TelemetryExportService(DashboardDataSource dataSource, ConsoleLogsFetcher consoleLogsFetcher, IDashboardClient dashboardClient)
     {
-        _telemetryRepository = telemetryRepository;
+        _dataSource = dataSource;
         _consoleLogsFetcher = consoleLogsFetcher;
         _dashboardClient = dashboardClient;
-        _outgoingPeerResolvers = outgoingPeerResolvers.ToArray();
     }
 
     /// <summary>
@@ -56,14 +53,14 @@ public sealed class TelemetryExportService
 
         var exportArchive = new ExportArchive();
 
-        var allOtlpResources = _telemetryRepository.GetResources();
+        var allOtlpResources = _dataSource.TelemetryRepository.GetResources();
 
         // Get resources from dashboard client if enabled and ResourceDetails is selected
         List<ResourceViewModel> resourceDetailsResources = [];
         var hasResourceDetailsSelected = selectedResources.Any(kvp => kvp.Value.Contains(AspireDataType.ResourceDetails));
         if (_dashboardClient.IsEnabled && hasResourceDetailsSelected)
         {
-            var snapshot = _dashboardClient.GetResources();
+            var snapshot = _dataSource.ResourceRepository.GetResources();
             var resourcesByName = snapshot.ToDictionary(r => r.Name, StringComparers.ResourceName);
 
             resourceDetailsResources = selectedResources
@@ -104,19 +101,19 @@ public sealed class TelemetryExportService
         // Export structured logs (OTLP JSON)
         if (structuredLogResources.Count > 0)
         {
-            AddStructuredLogs(exportArchive, structuredLogResources);
+            await AddStructuredLogsAsync(exportArchive, structuredLogResources, cancellationToken).ConfigureAwait(false);
         }
 
         // Export traces (OTLP JSON)
         if (traceResources.Count > 0)
         {
-            AddTraces(exportArchive, traceResources);
+            await AddTracesAsync(exportArchive, traceResources, cancellationToken).ConfigureAwait(false);
         }
 
         // Export metrics (OTLP JSON)
         if (metricsResources.Count > 0)
         {
-            AddMetrics(exportArchive, metricsResources);
+            await AddMetricsAsync(exportArchive, metricsResources, cancellationToken).ConfigureAwait(false);
         }
 
         exportArchive.WriteToStream(memoryStream);
@@ -154,11 +151,11 @@ public sealed class TelemetryExportService
         }
     }
 
-    private void AddStructuredLogs(ExportArchive exportArchive, List<OtlpResource> resources)
+    private async Task AddStructuredLogsAsync(ExportArchive exportArchive, List<OtlpResource> resources, CancellationToken cancellationToken)
     {
         foreach (var resource in resources)
         {
-            var logs = _telemetryRepository.GetLogs(GetLogsContext.ForResourceKey(resource.ResourceKey));
+            var logs = await _dataSource.TelemetryRepository.GetLogsAsync(GetLogsContext.ForResourceKey(resource.ResourceKey), cancellationToken).ConfigureAwait(false);
 
             if (logs.Items.Count == 0)
             {
@@ -170,11 +167,11 @@ public sealed class TelemetryExportService
         }
     }
 
-    private void AddTraces(ExportArchive exportArchive, List<OtlpResource> resources)
+    private async Task AddTracesAsync(ExportArchive exportArchive, List<OtlpResource> resources, CancellationToken cancellationToken)
     {
         foreach (var resource in resources)
         {
-            var tracesResponse = _telemetryRepository.GetTraces(GetTracesRequest.ForResourceKey(resource.ResourceKey));
+            var tracesResponse = await _dataSource.TelemetryRepository.GetTracesAsync(GetTracesRequest.ForResourceKey(resource.ResourceKey), cancellationToken).ConfigureAwait(false);
 
             if (tracesResponse.PagedResult.Items.Count == 0)
             {
@@ -182,15 +179,15 @@ public sealed class TelemetryExportService
             }
 
             var resourceName = OtlpHelpers.GetResourceName(resource, resources);
-            exportArchive.Traces[resourceName] = ConvertTracesToOtlpJson(tracesResponse.PagedResult.Items, _outgoingPeerResolvers);
+            exportArchive.Traces[resourceName] = ConvertTracesToOtlpJson(tracesResponse.PagedResult.Items);
         }
     }
 
-    private void AddMetrics(ExportArchive exportArchive, List<OtlpResource> resources)
+    private async Task AddMetricsAsync(ExportArchive exportArchive, List<OtlpResource> resources, CancellationToken cancellationToken)
     {
         foreach (var resource in resources)
         {
-            var instrumentSummaries = _telemetryRepository.GetInstrumentsSummaries(resource.ResourceKey);
+            var instrumentSummaries = _dataSource.TelemetryRepository.GetInstrumentSummaries(resource.ResourceKey);
 
             if (instrumentSummaries.Count == 0)
             {
@@ -201,14 +198,14 @@ public sealed class TelemetryExportService
             var instrumentsData = new List<OtlpInstrumentData>();
             foreach (var summary in instrumentSummaries)
             {
-                var instrumentData = _telemetryRepository.GetInstrument(new GetInstrumentRequest
+                var instrumentData = await _dataSource.TelemetryRepository.GetInstrumentAsync(new GetInstrumentRequest
                 {
                     ResourceKey = resource.ResourceKey,
                     MeterName = summary.Parent.Name,
                     InstrumentName = summary.Name,
                     StartTime = DateTime.MinValue,
                     EndTime = DateTime.MaxValue
-                });
+                }, cancellationToken).ConfigureAwait(false);
 
                 if (instrumentData is not null)
                 {
@@ -222,7 +219,7 @@ public sealed class TelemetryExportService
             }
 
             var resourceName = OtlpHelpers.GetResourceName(resource, resources);
-            exportArchive.Metrics[resourceName] = ConvertMetricsToOtlpJson(resource, instrumentsData);
+            exportArchive.Metrics[resourceName] = ConvertMetricsToOtlpJson(instrumentsData);
         }
     }
 
@@ -272,7 +269,7 @@ public sealed class TelemetryExportService
         };
     }
 
-    internal static OtlpTelemetryDataJson ConvertSpansToOtlpJson(IReadOnlyList<OtlpSpan> spans, IOutgoingPeerResolver[] outgoingPeerResolvers)
+    internal static OtlpTelemetryDataJson ConvertSpansToOtlpJson(IReadOnlyList<OtlpSpan> spans)
     {
         // Group spans by resource and scope
         var resourceSpans = spans
@@ -288,7 +285,7 @@ public sealed class TelemetryExportService
                         .Select(scopeGroup => new OtlpScopeSpansJson
                         {
                             Scope = ConvertScope(scopeGroup.Key),
-                            Spans = scopeGroup.Select(s => ConvertSpan(s, outgoingPeerResolvers)).ToArray()
+                            Spans = scopeGroup.Select(ConvertSpan).ToArray()
                         }).ToArray()
                 };
             }).ToArray();
@@ -299,14 +296,14 @@ public sealed class TelemetryExportService
         };
     }
 
-    internal static OtlpTelemetryDataJson ConvertTracesToOtlpJson(IReadOnlyList<OtlpTrace> traces, IOutgoingPeerResolver[] outgoingPeerResolvers)
+    internal static OtlpTelemetryDataJson ConvertTracesToOtlpJson(IReadOnlyList<OtlpTrace> traces)
     {
         // Group spans by resource and scope
         var allSpans = traces.SelectMany(t => t.Spans).ToList();
-        return ConvertSpansToOtlpJson(allSpans, outgoingPeerResolvers);
+        return ConvertSpansToOtlpJson(allSpans);
     }
 
-    internal static string ConvertSpanToJson(OtlpSpan span, IOutgoingPeerResolver[] outgoingPeerResolvers, List<OtlpLogEntry>? logs = null, bool indent = true)
+    internal static string ConvertSpanToJson(OtlpSpan span, List<OtlpLogEntry>? logs = null, bool indent = true)
     {
         var data = new OtlpTelemetryDataJson
         {
@@ -320,7 +317,7 @@ public sealed class TelemetryExportService
                         new OtlpScopeSpansJson
                         {
                             Scope = ConvertScope(span.Scope),
-                            Spans = [ConvertSpan(span, outgoingPeerResolvers)]
+                            Spans = [ConvertSpan(span)]
                         }
                     ]
                 }
@@ -331,7 +328,7 @@ public sealed class TelemetryExportService
         return JsonSerializer.Serialize(data, options);
     }
 
-    internal static string ConvertTraceToJson(OtlpTrace trace, IOutgoingPeerResolver[] outgoingPeerResolvers, List<OtlpLogEntry>? logs = null)
+    internal static string ConvertTraceToJson(OtlpTrace trace, List<OtlpLogEntry>? logs = null)
     {
         // Group spans by resource and scope
         var spansByResourceAndScope = trace.Spans
@@ -347,7 +344,7 @@ public sealed class TelemetryExportService
                         .Select(scopeGroup => new OtlpScopeSpansJson
                         {
                             Scope = ConvertScope(scopeGroup.Key),
-                            Spans = scopeGroup.Select(s => ConvertSpan(s, outgoingPeerResolvers)).ToArray()
+                            Spans = scopeGroup.Select(ConvertSpan).ToArray()
                         }).ToArray()
                 };
             }).ToArray();
@@ -383,11 +380,9 @@ public sealed class TelemetryExportService
         return JsonSerializer.Serialize(data, OtlpJsonSerializerContext.IndentedOptions);
     }
 
-    private static OtlpSpanJson ConvertSpan(OtlpSpan span, IOutgoingPeerResolver[] outgoingPeerResolvers)
+    private static OtlpSpanJson ConvertSpan(OtlpSpan span)
     {
-        var destinationName = outgoingPeerResolvers.Length > 0
-            ? GetDestination(span, outgoingPeerResolvers)
-            : null;
+        var destinationName = GetDestination(span);
 
         return new OtlpSpanJson
         {
@@ -470,27 +465,23 @@ public sealed class TelemetryExportService
             }).ToArray();
     }
 
-    internal static OtlpTelemetryDataJson ConvertMetricsToOtlpJson(OtlpResource resource, List<OtlpInstrumentData> instruments)
+    internal static OtlpTelemetryDataJson ConvertMetricsToOtlpJson(List<OtlpInstrumentData> instruments)
     {
-        // Group instruments by scope
-        var instrumentsByScope = instruments.GroupBy(i => i.Summary.Parent);
-
-        var scopeMetrics = instrumentsByScope.Select(scopeGroup => new OtlpScopeMetricsJson
-        {
-            Scope = ConvertScope(scopeGroup.Key),
-            Metrics = scopeGroup.Select(ConvertInstrument).ToArray()
-        }).ToArray();
-
         return new OtlpTelemetryDataJson
         {
-            ResourceMetrics =
-            [
-                new OtlpResourceMetricsJson
+            ResourceMetrics = instruments
+                .GroupBy(instrument => instrument.Summary.ResourceView)
+                .Select(resourceGroup => new OtlpResourceMetricsJson
                 {
-                    Resource = ConvertResourceView(resource.GetViews()[0]),
-                    ScopeMetrics = scopeMetrics
-                }
-            ]
+                    Resource = ConvertResourceView(resourceGroup.Key),
+                    ScopeMetrics = resourceGroup
+                        .GroupBy(instrument => instrument.Summary.Parent)
+                        .Select(scopeGroup => new OtlpScopeMetricsJson
+                        {
+                            Scope = ConvertScope(scopeGroup.Key),
+                            Metrics = scopeGroup.Select(ConvertInstrument).ToArray()
+                        }).ToArray()
+                }).ToArray()
         };
     }
 
@@ -611,19 +602,8 @@ public sealed class TelemetryExportService
 
     private static OtlpResourceJson ConvertResourceView(OtlpResourceView resourceView)
     {
-        var attributes = new List<OtlpKeyValueJson>
-        {
-            new OtlpKeyValueJson
-            {
-                Key = OtlpResource.SERVICE_NAME,
-                Value = new OtlpAnyValueJson { StringValue = resourceView.Resource.ResourceName }
-            },
-            new OtlpKeyValueJson
-            {
-                Key = OtlpResource.SERVICE_INSTANCE_ID,
-                Value = new OtlpAnyValueJson { StringValue = resourceView.Resource.InstanceId }
-            }
-        };
+        var resource = ConvertResource(resourceView.Resource);
+        var attributes = resource.Attributes!.ToList();
 
         // Include additional properties from the resource view
         foreach (var property in resourceView.Properties)
@@ -635,9 +615,27 @@ public sealed class TelemetryExportService
             });
         }
 
+        resource.Attributes = attributes.ToArray();
+        return resource;
+    }
+
+    private static OtlpResourceJson ConvertResource(OtlpResource resource)
+    {
         return new OtlpResourceJson
         {
-            Attributes = attributes.ToArray()
+            Attributes =
+            [
+                new OtlpKeyValueJson
+                {
+                    Key = OtlpResource.SERVICE_NAME,
+                    Value = new OtlpAnyValueJson { StringValue = resource.ResourceName }
+                },
+                new OtlpKeyValueJson
+                {
+                    Key = OtlpResource.SERVICE_INSTANCE_ID,
+                    Value = new OtlpAnyValueJson { StringValue = resource.InstanceId }
+                }
+            ]
         };
     }
 
@@ -828,20 +826,10 @@ public sealed class TelemetryExportService
     }
 
     /// <summary>
-    /// Gets the destination name for a span by resolving uninstrumented peer names.
+    /// Gets the destination name stored for a span.
     /// </summary>
-    private static string? GetDestination(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    private static string? GetDestination(OtlpSpan span)
     {
-        // Attempt to resolve uninstrumented peer to a friendly name from the span.
-        foreach (var resolver in outgoingPeerResolvers)
-        {
-            if (resolver.TryResolvePeer(span.Attributes, out var name, out _))
-            {
-                return name;
-            }
-        }
-
-        // Fallback to the peer address.
-        return span.Attributes.GetPeerAddress();
+        return span.GetDestination()?.ResourceKey.GetCompositeName() ?? span.Attributes.GetPeerAddress();
     }
 }

--- a/src/Aspire.Dashboard/Model/TelemetryImportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryImportService.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json;
 using Aspire.Dashboard.Configuration;
@@ -17,9 +18,10 @@ namespace Aspire.Dashboard.Model;
 /// </summary>
 public sealed class TelemetryImportService
 {
-    private readonly TelemetryRepository _telemetryRepository;
+    private readonly ITelemetryRepositoryWriter _telemetryRepositoryWriter;
     private readonly IOptionsMonitor<DashboardOptions> _options;
     private readonly ILogger<TelemetryImportService> _logger;
+    private readonly ActivitySource _activitySource;
 
     /// <summary>
     /// Gets a value indicating whether import is enabled.
@@ -29,14 +31,20 @@ public sealed class TelemetryImportService
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryImportService"/> class.
     /// </summary>
-    /// <param name="telemetryRepository">The telemetry repository.</param>
+    /// <param name="telemetryRepositoryWriter">The telemetry repository writer.</param>
     /// <param name="options">The dashboard options.</param>
     /// <param name="logger">The logger.</param>
-    public TelemetryImportService(TelemetryRepository telemetryRepository, IOptionsMonitor<DashboardOptions> options, ILogger<TelemetryImportService> logger)
+    /// <param name="activitySource">The dashboard activity source.</param>
+    public TelemetryImportService(
+        ITelemetryRepositoryWriter telemetryRepositoryWriter,
+        IOptionsMonitor<DashboardOptions> options,
+        ILogger<TelemetryImportService> logger,
+        DashboardActivitySource activitySource)
     {
-        _telemetryRepository = telemetryRepository;
+        _telemetryRepositoryWriter = telemetryRepositoryWriter;
         _options = options;
         _logger = logger;
+        _activitySource = activitySource.ActivitySource;
     }
 
     /// <summary>
@@ -49,6 +57,8 @@ public sealed class TelemetryImportService
     /// <exception cref="InvalidOperationException">Thrown when import is disabled.</exception>
     public async Task ImportAsync(string fileName, Stream stream, CancellationToken cancellationToken)
     {
+        using var activity = _activitySource.StartActivity("Import telemetry data", ActivityKind.Internal);
+
         if (!IsImportEnabled)
         {
             throw new InvalidOperationException("Import is disabled.");
@@ -134,21 +144,21 @@ public sealed class TelemetryImportService
 
         if (telemetryData.ResourceLogs is { Length: > 0 })
         {
-            ImportLogs(telemetryData.ResourceLogs);
+            await ImportLogsAsync(telemetryData.ResourceLogs).ConfigureAwait(false);
             _logger.LogDebug("Imported logs from {FileName}", fileName);
             imported = true;
         }
 
         if (telemetryData.ResourceSpans is { Length: > 0 })
         {
-            ImportTraces(telemetryData.ResourceSpans);
+            await ImportTracesAsync(telemetryData.ResourceSpans).ConfigureAwait(false);
             _logger.LogDebug("Imported traces from {FileName}", fileName);
             imported = true;
         }
 
         if (telemetryData.ResourceMetrics is { Length: > 0 })
         {
-            ImportMetrics(telemetryData.ResourceMetrics);
+            await ImportMetricsAsync(telemetryData.ResourceMetrics).ConfigureAwait(false);
             _logger.LogDebug("Imported metrics from {FileName}", fileName);
             imported = true;
         }
@@ -159,35 +169,35 @@ public sealed class TelemetryImportService
         }
     }
 
-    private void ImportLogs(OtlpResourceLogsJson[] resourceLogs)
+    private async Task ImportLogsAsync(OtlpResourceLogsJson[] resourceLogs)
     {
         var exportRequest = new OtlpExportLogsServiceRequestJson { ResourceLogs = resourceLogs };
         var protobufRequest = OtlpJsonToProtobufConverter.ToProtobuf(exportRequest);
 
         var addContext = new AddContext();
-        _telemetryRepository.AddLogs(addContext, protobufRequest.ResourceLogs);
+        await _telemetryRepositoryWriter.AddLogsAsync(addContext, protobufRequest.ResourceLogs).ConfigureAwait(false);
 
         _logger.LogDebug("Imported logs: {SuccessCount} succeeded, {FailureCount} failed", addContext.SuccessCount, addContext.FailureCount);
     }
 
-    private void ImportTraces(OtlpResourceSpansJson[] resourceSpans)
+    private async Task ImportTracesAsync(OtlpResourceSpansJson[] resourceSpans)
     {
         var exportRequest = new OtlpExportTraceServiceRequestJson { ResourceSpans = resourceSpans };
         var protobufRequest = OtlpJsonToProtobufConverter.ToProtobuf(exportRequest);
 
         var addContext = new AddContext();
-        _telemetryRepository.AddTraces(addContext, protobufRequest.ResourceSpans);
+        await _telemetryRepositoryWriter.AddTracesAsync(addContext, protobufRequest.ResourceSpans).ConfigureAwait(false);
 
         _logger.LogDebug("Imported traces: {SuccessCount} succeeded, {FailureCount} failed", addContext.SuccessCount, addContext.FailureCount);
     }
 
-    private void ImportMetrics(OtlpResourceMetricsJson[] resourceMetrics)
+    private async Task ImportMetricsAsync(OtlpResourceMetricsJson[] resourceMetrics)
     {
         var exportRequest = new OtlpExportMetricsServiceRequestJson { ResourceMetrics = resourceMetrics };
         var protobufRequest = OtlpJsonToProtobufConverter.ToProtobuf(exportRequest);
 
         var addContext = new AddContext();
-        _telemetryRepository.AddMetrics(addContext, protobufRequest.ResourceMetrics);
+        await _telemetryRepositoryWriter.AddMetricsAsync(addContext, protobufRequest.ResourceMetrics).ConfigureAwait(false);
 
         _logger.LogDebug("Imported metrics: {SuccessCount} succeeded, {FailureCount} failed", addContext.SuccessCount, addContext.FailureCount);
     }

--- a/src/Aspire.Dashboard/Model/TraceHelpers.cs
+++ b/src/Aspire.Dashboard/Model/TraceHelpers.cs
@@ -64,7 +64,7 @@ public static class TraceHelpers
     /// </summary>
     public static IEnumerable<OrderedResource> GetOrderedResources(OtlpTrace trace)
     {
-        var resourceFirstTimes = new Dictionary<OtlpResource, OrderedResource>();
+        var resourceFirstTimes = new Dictionary<OtlpResource, OrderedResource>(OtlpResourceEqualityComparer.Instance);
 
         VisitSpans(trace, (OtlpSpan span, OrderedResourcesState state) =>
         {
@@ -83,6 +83,7 @@ public static class TraceHelpers
 
         return resourceFirstTimes.Select(kvp => kvp.Value)
             .OrderBy(s => s.FirstDateTime)
+            .ThenBy(s => s.Resource.UninstrumentedPeer)
             .ThenBy(s => s.Index);
     }
 

--- a/src/Aspire.Dashboard/Model/TraceMenuBuilder.cs
+++ b/src/Aspire.Dashboard/Model/TraceMenuBuilder.cs
@@ -25,8 +25,7 @@ public sealed class TraceMenuBuilder
     private readonly IStringLocalizer<ControlsStrings> _controlsLoc;
     private readonly NavigationManager _navigationManager;
     private readonly DashboardDialogService _dialogService;
-    private readonly TelemetryRepository _telemetryRepository;
-    private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers;
+    private readonly DashboardDataSource _dataSource;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TraceMenuBuilder"/> class.
@@ -35,14 +34,12 @@ public sealed class TraceMenuBuilder
         IStringLocalizer<ControlsStrings> controlsLoc,
         NavigationManager navigationManager,
         DashboardDialogService dialogService,
-        TelemetryRepository telemetryRepository,
-        IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+        DashboardDataSource dataSource)
     {
         _controlsLoc = controlsLoc;
         _navigationManager = navigationManager;
         _dialogService = dialogService;
-        _telemetryRepository = telemetryRepository;
-        _outgoingPeerResolvers = outgoingPeerResolvers.ToArray();
+        _dataSource = dataSource;
     }
 
     /// <summary>
@@ -56,6 +53,29 @@ public sealed class TraceMenuBuilder
         OtlpTrace trace,
         bool showViewDetails = true)
     {
+        AddMenuItems(menuItems, trace.TraceId, () => trace, showViewDetails);
+    }
+
+    /// <summary>
+    /// Adds menu items for a trace summary to the provided list.
+    /// </summary>
+    /// <param name="menuItems">The list to add menu items to.</param>
+    /// <param name="summary">The trace summary to create menu items for.</param>
+    /// <param name="showViewDetails">Whether to include the View Details menu item. Defaults to <c>true</c>.</param>
+    public void AddMenuItems(
+        List<MenuButtonItem> menuItems,
+        TraceSummary summary,
+        bool showViewDetails = true)
+    {
+        AddMenuItems(menuItems, summary.TraceId, () => _dataSource.TelemetryRepository.GetTrace(summary.TraceId), showViewDetails);
+    }
+
+    private void AddMenuItems(
+        List<MenuButtonItem> menuItems,
+        string traceId,
+        Func<OtlpTrace?> getTrace,
+        bool showViewDetails)
+    {
         if (showViewDetails)
         {
             menuItems.Add(new MenuButtonItem
@@ -64,7 +84,7 @@ public sealed class TraceMenuBuilder
                 Icon = s_viewDetailsIcon,
                 OnClick = () =>
                 {
-                    _navigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(trace.TraceId));
+                    _navigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(traceId));
                     return Task.CompletedTask;
                 }
             });
@@ -76,7 +96,7 @@ public sealed class TraceMenuBuilder
             Icon = s_structuredLogsIcon,
             OnClick = () =>
             {
-                _navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(traceId: trace.TraceId));
+                _navigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(traceId: traceId));
                 return Task.CompletedTask;
             }
         });
@@ -87,7 +107,13 @@ public sealed class TraceMenuBuilder
             Icon = s_bracesIcon,
             OnClick = async () =>
             {
-                var result = ExportHelpers.GetTraceAsJson(trace, _telemetryRepository, _outgoingPeerResolvers);
+                var trace = getTrace();
+                if (trace is null)
+                {
+                    return;
+                }
+
+                var result = await ExportHelpers.GetTraceAsJsonAsync(trace, _dataSource.TelemetryRepository, CancellationToken.None).ConfigureAwait(false);
                 await TextVisualizerDialog.OpenDialogAsync(new OpenTextVisualizerDialogOptions
                 {
                     DialogService = _dialogService,

--- a/src/Aspire.Dashboard/Model/TracesViewModel.cs
+++ b/src/Aspire.Dashboard/Model/TracesViewModel.cs
@@ -2,27 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model.Otlp;
-using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
 
 namespace Aspire.Dashboard.Model;
 
 public class TracesViewModel
 {
-    private readonly TelemetryRepository _telemetryRepository;
+    private readonly DashboardDataSource _dataSource;
     private readonly List<FieldTelemetryFilter> _filters = new();
 
-    private PagedResult<OtlpTrace>? _traces;
+    private PagedResult<TraceSummary>? _traces;
     private ResourceKey? _resourceKey;
     private string _filterText = string.Empty;
     private int _startIndex;
     private int _count;
-    private bool _currentDataHasErrors;
     private SpanType? _spanType;
 
-    public TracesViewModel(TelemetryRepository telemetryRepository)
+    public TracesViewModel(DashboardDataSource dataSource)
     {
-        _telemetryRepository = telemetryRepository;
+        _dataSource = dataSource;
     }
 
     public ResourceKey? ResourceKey { get => _resourceKey; set => SetValue(ref _resourceKey, value); }
@@ -75,55 +74,28 @@ public class TracesViewModel
         _traces = null;
     }
 
-    public PagedResult<OtlpTrace> GetTraces()
+    public async Task<PagedResult<TraceSummary>> GetTracesAsync(CancellationToken cancellationToken)
     {
         var traces = _traces;
         if (traces == null)
         {
             var filters = GetFilters();
 
-            var result = _telemetryRepository.GetTraces(new GetTracesRequest
+            var result = await _dataSource.TelemetryRepository.GetTraceSummariesAsync(new GetTracesRequest
             {
                 ResourceKeys = ResourceKey is { } key ? [key] : [],
                 StartIndex = StartIndex,
                 Count = Count,
                 Filters = filters,
-                TraceNameFilterText = FilterText
-            });
+                TraceNameFilterText = FilterText,
+                LatestItemCount = DashboardUIHelpers.MaxVirtualizedItemCount
+            }, cancellationToken).ConfigureAwait(false);
 
             traces = result.PagedResult;
             MaxDuration = result.MaxDuration;
-
-            _currentDataHasErrors = result.PagedResult.Items.Any(t => t.Spans.Any(s => s.Status == OtlpSpanStatusCode.Error));
         }
 
         return traces;
-    }
-
-    // First check if there were any errors in already available data. Avoid fetching data again.
-    public bool HasErrors() => _currentDataHasErrors || GetErrorTraces(count: 0).TotalItemCount > 0;
-
-    public PagedResult<OtlpTrace> GetErrorTraces(int count)
-    {
-        var filters = Filters.Cast<TelemetryFilter>().ToList();
-
-        if (SpanType?.Filter is { } typeFilter)
-        {
-            filters.Add(typeFilter);
-        }
-
-        filters.Add(new FieldTelemetryFilter { Field = KnownTraceFields.StatusField, Condition = FilterCondition.Equals, Value = OtlpSpanStatusCode.Error.ToString() });
-
-        var errorTraces = _telemetryRepository.GetTraces(new GetTracesRequest
-        {
-            ResourceKeys = ResourceKey is { } key ? [key] : [],
-            StartIndex = 0,
-            Count = count,
-            Filters = filters,
-            TraceNameFilterText = FilterText
-        });
-
-        return errorTraces.PagedResult;
     }
 
     private List<TelemetryFilter> GetFilters()

--- a/src/Aspire.Dashboard/Otlp/Grpc/OtlpGrpcLogsService.cs
+++ b/src/Aspire.Dashboard/Otlp/Grpc/OtlpGrpcLogsService.cs
@@ -22,6 +22,6 @@ public class OtlpGrpcLogsService : LogsService.LogsServiceBase
 
     public override Task<ExportLogsServiceResponse> Export(ExportLogsServiceRequest request, ServerCallContext context)
     {
-        return Task.FromResult(_logsService.Export(request));
+        return _logsService.ExportAsync(request);
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Grpc/OtlpGrpcMetricsService.cs
+++ b/src/Aspire.Dashboard/Otlp/Grpc/OtlpGrpcMetricsService.cs
@@ -22,6 +22,6 @@ public class OtlpGrpcMetricsService : MetricsService.MetricsServiceBase
 
     public override Task<ExportMetricsServiceResponse> Export(ExportMetricsServiceRequest request, ServerCallContext context)
     {
-        return Task.FromResult(_metricsService.Export(request));
+        return _metricsService.ExportAsync(request);
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Grpc/OtlpGrpcTraceService.cs
+++ b/src/Aspire.Dashboard/Otlp/Grpc/OtlpGrpcTraceService.cs
@@ -22,6 +22,6 @@ public class OtlpGrpcTraceService : TraceService.TraceServiceBase
 
     public override Task<ExportTraceServiceResponse> Export(ExportTraceServiceRequest request, ServerCallContext context)
     {
-        return Task.FromResult(_traceService.Export(request));
+        return _traceService.ExportAsync(request);
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Http/OtlpHttpEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/Otlp/Http/OtlpHttpEndpointsBuilder.cs
@@ -48,29 +48,29 @@ public static class OtlpHttpEndpointsBuilder
             group = group.RequireCors(CorsPolicyName);
         }
 
-        group.MapPost("logs", static (MessageBindable<ExportLogsServiceRequest> request, OtlpLogsService service) =>
+        group.MapPost("logs", static async (MessageBindable<ExportLogsServiceRequest> request, OtlpLogsService service) =>
         {
             if (request.Message is null)
             {
                 return Results.Empty;
             }
-            return OtlpResult.Response(service.Export(request.Message), request.RequestContentType);
+            return OtlpResult.Response(await service.ExportAsync(request.Message).ConfigureAwait(false), request.RequestContentType);
         });
-        group.MapPost("traces", static (MessageBindable<ExportTraceServiceRequest> request, OtlpTraceService service) =>
+        group.MapPost("traces", static async (MessageBindable<ExportTraceServiceRequest> request, OtlpTraceService service) =>
         {
             if (request.Message is null)
             {
                 return Results.Empty;
             }
-            return OtlpResult.Response(service.Export(request.Message), request.RequestContentType);
+            return OtlpResult.Response(await service.ExportAsync(request.Message).ConfigureAwait(false), request.RequestContentType);
         });
-        group.MapPost("metrics", (MessageBindable<ExportMetricsServiceRequest> request, OtlpMetricsService service) =>
+        group.MapPost("metrics", static async (MessageBindable<ExportMetricsServiceRequest> request, OtlpMetricsService service) =>
         {
             if (request.Message is null)
             {
                 return Results.Empty;
             }
-            return OtlpResult.Response(service.Export(request.Message), request.RequestContentType);
+            return OtlpResult.Response(await service.ExportAsync(request.Message).ConfigureAwait(false), request.RequestContentType);
         });
     }
 

--- a/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
@@ -31,6 +31,7 @@ public class DimensionScope
 
     public void AddPointValue(NumberDataPoint d, OtlpContext context)
     {
+        OtlpHelpers.ValidateNumberDataPoint(d);
         var start = OtlpHelpers.UnixNanoSecondsToDateTime(d.StartTimeUnixNano);
         var end = OtlpHelpers.UnixNanoSecondsToDateTime(d.TimeUnixNano);
 
@@ -81,11 +82,7 @@ public class DimensionScope
     {
         var start = OtlpHelpers.UnixNanoSecondsToDateTime(h.StartTimeUnixNano);
         var end = OtlpHelpers.UnixNanoSecondsToDateTime(h.TimeUnixNano);
-
-        if (h.BucketCounts.Count > 0 && h.ExplicitBounds.Count == 0)
-        {
-            throw new InvalidOperationException("Histogram data point has bucket counts without any explicit bounds.");
-        }
+        OtlpHelpers.ValidateHistogramDataPoint(h);
 
         var lastHistogramValue = _lastValue as HistogramValue;
         if (lastHistogramValue is not null && lastHistogramValue.Values.Length != h.BucketCounts.Count)
@@ -135,8 +132,12 @@ public class DimensionScope
                     continue;
                 }
 
-                var start = OtlpHelpers.UnixNanoSecondsToDateTime(exemplar.TimeUnixNano);
                 var exemplarValue = exemplar.HasAsDouble ? exemplar.AsDouble : exemplar.AsInt;
+                if (!double.IsFinite(exemplarValue))
+                {
+                    continue;
+                }
+                var start = OtlpHelpers.UnixNanoSecondsToDateTime(exemplar.TimeUnixNano);
 
                 var exists = false;
                 foreach (var existingExemplar in value.Exemplars)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -11,7 +11,9 @@ using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Resource.V1;
+using static OpenTelemetry.Proto.Trace.V1.Span.Types;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
@@ -24,6 +26,56 @@ public static partial class OtlpHelpers
     };
 
     // Note: ShortenedIdLength is defined in the shared OtlpHelpers.cs
+
+    internal static OtlpSpanKind ConvertSpanKind(SpanKind? kind)
+    {
+        return kind switch
+        {
+            // Unspecified to Internal is intentional.
+            // "Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED."
+            SpanKind.Unspecified => OtlpSpanKind.Internal,
+            SpanKind.Internal => OtlpSpanKind.Internal,
+            SpanKind.Client => OtlpSpanKind.Client,
+            SpanKind.Server => OtlpSpanKind.Server,
+            SpanKind.Producer => OtlpSpanKind.Producer,
+            SpanKind.Consumer => OtlpSpanKind.Consumer,
+            _ => OtlpSpanKind.Unspecified
+        };
+    }
+
+    internal static int GetMetricDataPointCount(Metric metric)
+    {
+        return metric.DataCase switch
+        {
+            Metric.DataOneofCase.Gauge => metric.Gauge.DataPoints.Count,
+            Metric.DataOneofCase.Sum => metric.Sum.DataPoints.Count,
+            Metric.DataOneofCase.Histogram => metric.Histogram.DataPoints.Count,
+            Metric.DataOneofCase.Summary => metric.Summary.DataPoints.Count,
+            Metric.DataOneofCase.ExponentialHistogram => metric.ExponentialHistogram.DataPoints.Count,
+            _ => 0,
+        };
+    }
+
+    internal static void ValidateHistogramDataPoint(HistogramDataPoint point)
+    {
+        if (!double.IsFinite(point.Sum))
+        {
+            throw new InvalidOperationException("Histogram data point sum must be finite.");
+        }
+
+        if (point.BucketCounts.Count > 0 && point.ExplicitBounds.Count == 0)
+        {
+            throw new InvalidOperationException("Histogram data point has bucket counts without any explicit bounds.");
+        }
+    }
+
+    internal static void ValidateNumberDataPoint(NumberDataPoint point)
+    {
+        if (point.ValueCase == NumberDataPoint.ValueOneofCase.AsDouble && !double.IsFinite(point.AsDouble))
+        {
+            throw new InvalidOperationException("Metric data point value must be finite.");
+        }
+    }
 
     public static ResourceKey GetResourceKey(this Resource resource)
     {
@@ -471,9 +523,9 @@ public static partial class OtlpHelpers
                 return true;
             }
 
-            if (scopes.Count >= TelemetryRepository.MaxScopeCount)
+            if (scopes.Count >= TelemetryRepositoryLimits.MaxScopeCount)
             {
-                throw new InvalidOperationException($"Scope limit of {TelemetryRepository.MaxScopeCount} reached for {telemetryType}. Scope '{name}' will not be added.");
+                throw new InvalidOperationException($"Scope limit of {TelemetryRepositoryLimits.MaxScopeCount} reached for {telemetryType}. Scope '{name}' will not be added.");
             }
 
             s = (scope != null)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
-using Aspire.Dashboard.Otlp.Storage;
-using Google.Protobuf.Collections;
-using OpenTelemetry.Proto.Common.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
@@ -20,6 +15,7 @@ public class OtlpInstrumentSummary
     public required OtlpInstrumentType Type { get; init; }
     public required OtlpAggregationTemporality AggregationTemporality { get; init; }
     public required OtlpScope Parent { get; init; }
+    public required OtlpResourceView ResourceView { get; init; }
 
     public OtlpInstrumentKey GetKey() => new(Parent.Name, Name);
 }
@@ -30,147 +26,4 @@ public class OtlpInstrumentData
     public required List<DimensionScope> Dimensions { get; init; }
     public required Dictionary<string, List<string?>> KnownAttributeValues { get; init; }
     public required bool HasOverflow { get; init; }
-}
-
-[DebuggerDisplay("Name = {Summary.Name}, Unit = {Summary.Unit}, Type = {Summary.Type}")]
-public class OtlpInstrument
-{
-    public required OtlpInstrumentSummary Summary { get; init; }
-    public required OtlpContext Context { get; init; }
-
-    public Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> Dimensions { get; } = new(ScopeAttributesComparer.Instance);
-    public Dictionary<string, List<string?>> KnownAttributeValues { get; } = new();
-    public bool HasOverflow { get; set; }
-
-    public DimensionScope FindScope(RepeatedField<KeyValue> attributes, ref KeyValuePair<string, string>[]? tempAttributes)
-    {
-        // See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute
-        // Inspect attributes before they're merged with parent attributes. "otel.metric.overflow" should be the only attribute.
-        if (!HasOverflow && attributes.Count == 1 && attributes[0].Key == "otel.metric.overflow" && attributes[0].Value.GetString() == "true")
-        {
-            HasOverflow = true;
-        }
-
-        // We want to find the dimension scope that matches the attributes, but we don't want to allocate.
-        // Copy values to a temporary reusable array.
-        //
-        // A meter can have attributes. Merge these with the data point attributes when creating a dimension.
-        OtlpHelpers.CopyKeyValuePairs(attributes, Summary.Parent.Attributes, Context, out var copyCount, ref tempAttributes);
-        Array.Sort(tempAttributes, 0, copyCount, KeyValuePairComparer.Instance);
-
-        var comparableAttributes = tempAttributes.AsMemory(0, copyCount);
-
-        // Can't use CollectionsMarshal.GetValueRefOrAddDefault here because comparableAttributes is a view over mutable data.
-        // Need to add dimensions using durable attributes instance after scope is created.
-        if (!Dimensions.TryGetValue(comparableAttributes, out var dimension))
-        {
-            if (Dimensions.Count >= TelemetryRepository.MaxDimensionCount)
-            {
-                throw new InvalidOperationException($"Dimension limit of {TelemetryRepository.MaxDimensionCount} reached for instrument '{Summary.Name}'.");
-            }
-
-            dimension = CreateDimensionScope(comparableAttributes);
-            Dimensions.Add(dimension.Attributes, dimension);
-        }
-        return dimension;
-    }
-
-    private DimensionScope CreateDimensionScope(Memory<KeyValuePair<string, string>> comparableAttributes)
-    {
-        var isFirst = Dimensions.Count == 0;
-        var durableAttributes = comparableAttributes.ToArray();
-        var dimension = new DimensionScope(Context.Options.MaxMetricsCount, durableAttributes);
-
-        var keys = KnownAttributeValues.Keys.Union(durableAttributes.Select(a => a.Key)).Distinct();
-        foreach (var key in keys)
-        {
-            ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(KnownAttributeValues, key, out var existed);
-            // Adds to dictionary if not present.
-            if (values == null)
-            {
-                if (!existed && KnownAttributeValues.Count > TelemetryRepository.MaxKnownAttributeValueCount)
-                {
-                    // Over limit. Remove the default entry that GetValueRefOrAddDefault added.
-                    KnownAttributeValues.Remove(key);
-                    continue;
-                }
-
-                values = new List<string?>();
-
-                // If the key is new and there are already dimensions, add an empty value because there are dimensions without this key.
-                if (!isFirst)
-                {
-                    TryAddValue(values, null, TelemetryRepository.MaxKnownAttributeValuesPerKey);
-                }
-            }
-
-            var currentDimensionValue = OtlpHelpers.GetValue(durableAttributes, key);
-            TryAddValue(values, currentDimensionValue, TelemetryRepository.MaxKnownAttributeValuesPerKey);
-        }
-
-        return dimension;
-
-        static void TryAddValue(List<string?> values, string? value, int maxValues)
-        {
-            if (values.Count < maxValues && !values.Contains(value))
-            {
-                values.Add(value);
-            }
-        }
-    }
-
-    public static OtlpInstrument Clone(OtlpInstrument instrument, bool cloneData, DateTime? valuesStart, DateTime? valuesEnd)
-    {
-        var newInstrument = new OtlpInstrument
-        {
-            Summary = instrument.Summary,
-            Context = instrument.Context,
-            HasOverflow = instrument.HasOverflow
-        };
-
-        if (cloneData)
-        {
-            foreach (var item in instrument.KnownAttributeValues)
-            {
-                newInstrument.KnownAttributeValues.Add(item.Key, item.Value.ToList());
-            }
-            foreach (var item in instrument.Dimensions)
-            {
-                newInstrument.Dimensions.Add(item.Key, DimensionScope.Clone(item.Value, valuesStart, valuesEnd));
-            }
-        }
-
-        return newInstrument;
-    }
-
-    private sealed class ScopeAttributesComparer : IEqualityComparer<ReadOnlyMemory<KeyValuePair<string, string>>>
-    {
-        public static readonly ScopeAttributesComparer Instance = new();
-
-        public bool Equals(ReadOnlyMemory<KeyValuePair<string, string>> x, ReadOnlyMemory<KeyValuePair<string, string>> y)
-        {
-            return x.Span.SequenceEqual(y.Span);
-        }
-
-        public int GetHashCode([DisallowNull] ReadOnlyMemory<KeyValuePair<string, string>> obj)
-        {
-            var hashcode = new HashCode();
-            foreach (KeyValuePair<string, string> pair in obj.Span)
-            {
-                hashcode.Add(pair.Key);
-                hashcode.Add(pair.Value);
-            }
-            return hashcode.ToHashCode();
-        }
-    }
-
-    private sealed class KeyValuePairComparer : IComparer<KeyValuePair<string, string>>
-    {
-        public static readonly KeyValuePairComparer Instance = new();
-
-        public int Compare(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
-        {
-            return string.Compare(x.Key, y.Key, StringComparison.Ordinal);
-        }
-    }
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -4,16 +4,12 @@
 using System.Diagnostics;
 using System.Globalization;
 using Aspire.Dashboard.Model.Otlp;
-using OpenTelemetry.Proto.Logs.V1;
-using SeverityNumberProto = OpenTelemetry.Proto.Logs.V1.SeverityNumber;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
 [DebuggerDisplay("InternalId = {InternalId}, TimeStamp = {TimeStamp}, Severity = {Severity}, Message = {Message}")]
 public class OtlpLogEntry
 {
-    private static long s_nextLogEntryId;
-
     public KeyValuePair<string, string>[] Attributes { get; }
     public DateTime TimeStamp { get; }
     public uint Flags { get; }
@@ -31,98 +27,37 @@ public class OtlpLogEntry
     public bool IsError => Severity is LogLevel.Error or LogLevel.Critical;
     public bool IsWarning => Severity is LogLevel.Warning;
 
-    public OtlpLogEntry(LogRecord record, OtlpResourceView resourceView, OtlpScope scope, OtlpContext context)
+    internal OtlpLogEntry(
+        long internalId,
+        DateTime timeStamp,
+        uint flags,
+        LogLevel severity,
+        int severityNumber,
+        string message,
+        string spanId,
+        string traceId,
+        string parentId,
+        string? originalFormat,
+        OtlpResourceView resourceView,
+        OtlpScope scope,
+        KeyValuePair<string, string>[] attributes,
+        string? eventName)
     {
-        InternalId = Interlocked.Increment(ref s_nextLogEntryId);
-        TimeStamp = ResolveTimeStamp(record);
-
-        string? originalFormat = null;
-        string? parentId = null;
-        string? eventNameFromAttribute = null;
-        Attributes = record.Attributes.ToKeyValuePairs(context, filter: attribute =>
-        {
-            switch (attribute.Key)
-            {
-                case "{OriginalFormat}":
-                    originalFormat = attribute.Value.GetString();
-                    return false;
-                case "ParentId":
-                    parentId = attribute.Value.GetString();
-                    return false;
-                case "SpanId":
-                case "TraceId":
-                case OtlpHelpers.AspireLogIdAttribute:
-                    // Explicitly ignore these
-                    return false;
-                case "logrecord.event.name":
-                case "event.name":
-                    // Capture the attribute value for fallback, but filter it out
-                    eventNameFromAttribute ??= attribute.Value.GetString();
-                    return false;
-                default:
-                    return true;
-            }
-        });
-
-        Flags = record.Flags;
-        SeverityNumber = (int)record.SeverityNumber;
-        Severity = MapSeverity(record.SeverityNumber);
-
-        Message = record.Body is { } body
-            ? OtlpHelpers.TruncateString(body.GetString(), context.Options.MaxAttributeLength)
-            : string.Empty;
+        InternalId = internalId;
+        TimeStamp = timeStamp;
+        Flags = flags;
+        Severity = severity;
+        SeverityNumber = severityNumber;
+        Message = message;
+        SpanId = spanId;
+        TraceId = traceId;
+        ParentId = parentId;
         OriginalFormat = originalFormat;
-        SpanId = record.SpanId.ToHexString();
-        TraceId = record.TraceId.ToHexString();
-        ParentId = parentId ?? string.Empty;
         ResourceView = resourceView;
         Scope = scope;
-
-        // EventName from the LogRecord field takes precedence over the legacy attribute
-        EventName = !string.IsNullOrEmpty(record.EventName) ? record.EventName : eventNameFromAttribute;
+        Attributes = attributes;
+        EventName = eventName;
     }
-
-    private static DateTime ResolveTimeStamp(LogRecord record)
-    {
-        // From proto docs:
-        //
-        // For converting OpenTelemetry log data to formats that support only one timestamp or
-        // when receiving OpenTelemetry log data by recipients that support only one timestamp
-        // internally the following logic is recommended:
-        //   - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
-        var resolvedTimeUnixNano = record.TimeUnixNano != 0 ? record.TimeUnixNano : record.ObservedTimeUnixNano;
-
-        return OtlpHelpers.UnixNanoSecondsToDateTime(resolvedTimeUnixNano);
-    }
-
-    private static LogLevel MapSeverity(SeverityNumberProto severityNumber) => severityNumber switch
-    {
-        SeverityNumberProto.Trace => LogLevel.Trace,
-        SeverityNumberProto.Trace2 => LogLevel.Trace,
-        SeverityNumberProto.Trace3 => LogLevel.Trace,
-        SeverityNumberProto.Trace4 => LogLevel.Trace,
-        SeverityNumberProto.Debug => LogLevel.Debug,
-        SeverityNumberProto.Debug2 => LogLevel.Debug,
-        SeverityNumberProto.Debug3 => LogLevel.Debug,
-        SeverityNumberProto.Debug4 => LogLevel.Debug,
-        SeverityNumberProto.Info => LogLevel.Information,
-        SeverityNumberProto.Info2 => LogLevel.Information,
-        SeverityNumberProto.Info3 => LogLevel.Information,
-        SeverityNumberProto.Info4 => LogLevel.Information,
-        SeverityNumberProto.Warn => LogLevel.Warning,
-        SeverityNumberProto.Warn2 => LogLevel.Warning,
-        SeverityNumberProto.Warn3 => LogLevel.Warning,
-        SeverityNumberProto.Warn4 => LogLevel.Warning,
-        SeverityNumberProto.Error => LogLevel.Error,
-        SeverityNumberProto.Error2 => LogLevel.Error,
-        SeverityNumberProto.Error3 => LogLevel.Error,
-        SeverityNumberProto.Error4 => LogLevel.Error,
-        SeverityNumberProto.Fatal => LogLevel.Critical,
-        SeverityNumberProto.Fatal2 => LogLevel.Critical,
-        SeverityNumberProto.Fatal3 => LogLevel.Critical,
-        SeverityNumberProto.Fatal4 => LogLevel.Critical,
-        _ => LogLevel.None
-    };
 
     public static string? GetFieldValue(OtlpLogEntry log, string field)
     {

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntryData.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntryData.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using OpenTelemetry.Proto.Logs.V1;
+using SeverityNumberProto = OpenTelemetry.Proto.Logs.V1.SeverityNumber;
+
+namespace Aspire.Dashboard.Otlp.Model;
+
+internal class OtlpLogEntryData
+{
+    internal OtlpLogEntryData(LogRecord record, OtlpResourceView resourceView, OtlpScope scope, OtlpContext context)
+    {
+        ResourceView = resourceView;
+        Scope = scope;
+        TimeStamp = ResolveTimeStamp(record);
+
+        string? originalFormat = null;
+        string? parentId = null;
+        string? eventNameFromAttribute = null;
+        Attributes = record.Attributes.ToKeyValuePairs(context, filter: attribute =>
+        {
+            switch (attribute.Key)
+            {
+                case "{OriginalFormat}":
+                    originalFormat = attribute.Value.GetString();
+                    return false;
+                case "ParentId":
+                    parentId = attribute.Value.GetString();
+                    return false;
+                case "SpanId":
+                case "TraceId":
+                case OtlpHelpers.AspireLogIdAttribute:
+                    return false;
+                case "logrecord.event.name":
+                case "event.name":
+                    eventNameFromAttribute ??= attribute.Value.GetString();
+                    return false;
+                default:
+                    return true;
+            }
+        });
+
+        Flags = record.Flags;
+        SeverityNumber = (int)record.SeverityNumber;
+        Severity = MapSeverity(record.SeverityNumber);
+        Message = record.Body is { } body
+            ? OtlpHelpers.TruncateString(body.GetString(), context.Options.MaxAttributeLength)
+            : string.Empty;
+        OriginalFormat = originalFormat;
+        SpanId = record.SpanId.ToHexString();
+        TraceId = record.TraceId.ToHexString();
+        ParentId = parentId ?? string.Empty;
+        // EventName from the LogRecord field takes precedence over the legacy attribute.
+        EventName = !string.IsNullOrEmpty(record.EventName) ? record.EventName : eventNameFromAttribute;
+    }
+
+    internal DateTime TimeStamp { get; }
+    internal uint Flags { get; }
+    internal LogLevel Severity { get; }
+    internal int SeverityNumber { get; }
+    internal string Message { get; }
+    internal string SpanId { get; }
+    internal string TraceId { get; }
+    internal string ParentId { get; }
+    internal string? OriginalFormat { get; }
+    internal OtlpResourceView ResourceView { get; }
+    internal OtlpScope Scope { get; }
+    internal KeyValuePair<string, string>[] Attributes { get; }
+    internal string? EventName { get; }
+
+    internal OtlpLogEntry CreateLogEntry(long internalId) => new(
+        internalId,
+        TimeStamp,
+        Flags,
+        Severity,
+        SeverityNumber,
+        Message,
+        SpanId,
+        TraceId,
+        ParentId,
+        OriginalFormat,
+        ResourceView,
+        Scope,
+        Attributes,
+        EventName);
+
+    private static DateTime ResolveTimeStamp(LogRecord record)
+    {
+        // OpenTelemetry recommends using time_unix_nano when present and falling back to observed_time_unix_nano.
+        // https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-timestamp
+        var resolvedTimeUnixNano = record.TimeUnixNano != 0 ? record.TimeUnixNano : record.ObservedTimeUnixNano;
+        return OtlpHelpers.UnixNanoSecondsToDateTime(resolvedTimeUnixNano);
+    }
+
+    private static LogLevel MapSeverity(SeverityNumberProto severityNumber) => severityNumber switch
+    {
+        SeverityNumberProto.Trace or SeverityNumberProto.Trace2 or SeverityNumberProto.Trace3 or SeverityNumberProto.Trace4 => LogLevel.Trace,
+        SeverityNumberProto.Debug or SeverityNumberProto.Debug2 or SeverityNumberProto.Debug3 or SeverityNumberProto.Debug4 => LogLevel.Debug,
+        SeverityNumberProto.Info or SeverityNumberProto.Info2 or SeverityNumberProto.Info3 or SeverityNumberProto.Info4 => LogLevel.Information,
+        SeverityNumberProto.Warn or SeverityNumberProto.Warn2 or SeverityNumberProto.Warn3 or SeverityNumberProto.Warn4 => LogLevel.Warning,
+        SeverityNumberProto.Error or SeverityNumberProto.Error2 or SeverityNumberProto.Error3 or SeverityNumberProto.Error4 => LogLevel.Error,
+        SeverityNumberProto.Fatal or SeverityNumberProto.Fatal2 or SeverityNumberProto.Fatal3 or SeverityNumberProto.Fatal4 => LogLevel.Critical,
+        _ => LogLevel.None
+    };
+}

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResource.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
-using OpenTelemetry.Proto.Metrics.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
@@ -43,10 +42,6 @@ public class OtlpResource : IOtlpResource
 
     public ResourceKey ResourceKey => new ResourceKey(ResourceName, InstanceId);
 
-    private readonly ReaderWriterLockSlim _metricsLock = new();
-    // Bounded by TelemetryRepository.MaxScopeCount. Cleared when metrics are cleared.
-    private readonly Dictionary<string, OtlpScope> _meters = new();
-    private readonly Dictionary<OtlpInstrumentKey, OtlpInstrument> _instruments = new();
     private readonly ConcurrentDictionary<KeyValuePair<string, string>[], OtlpResourceView> _resourceViews = new(ResourceViewKeyComparer.Instance);
 
     public OtlpResource(string name, string? instanceId, bool uninstrumentedPeer, OtlpContext context)
@@ -55,231 +50,6 @@ public class OtlpResource : IOtlpResource
         InstanceId = instanceId;
         UninstrumentedPeer = uninstrumentedPeer;
         Context = context;
-    }
-
-    public void AddMetrics(AddContext context, RepeatedField<ScopeMetrics> scopeMetrics)
-    {
-        _metricsLock.EnterWriteLock();
-
-        try
-        {
-            // Temporary attributes array to use when adding metrics to the instruments.
-            KeyValuePair<string, string>[]? tempAttributes = null;
-
-            foreach (var sm in scopeMetrics)
-            {
-                if (!OtlpHelpers.TryGetOrAddScope(_meters, sm.Scope, Context, TelemetryType.Metrics, out var scope))
-                {
-                    context.FailureCount += sm.Metrics.Sum(GetMetricDataPointCount);
-                    continue;
-                }
-
-                foreach (var metric in sm.Metrics)
-                {
-                    OtlpInstrument instrument;
-
-                    try
-                    {
-                        if (string.IsNullOrEmpty(metric.Name))
-                        {
-                            throw new InvalidOperationException("Instrument name is required.");
-                        }
-
-                        var instrumentKey = new OtlpInstrumentKey(scope.Name, metric.Name);
-                        if (_instruments.TryGetValue(instrumentKey, out var existingInstrument))
-                        {
-                            instrument = existingInstrument;
-                        }
-                        else if (_instruments.Count < TelemetryRepository.MaxInstrumentCount)
-                        {
-                            var newInstrument = new OtlpInstrument
-                            {
-                                Summary = new OtlpInstrumentSummary
-                                {
-                                    Name = metric.Name,
-                                    Description = metric.Description,
-                                    Unit = metric.Unit,
-                                    Type = MapMetricType(metric.DataCase),
-                                    AggregationTemporality = MapAggregationTemporality(metric),
-                                    Parent = scope
-                                },
-                                Context = Context
-                            };
-
-                            _instruments.Add(instrumentKey, newInstrument);
-                            instrument = newInstrument;
-
-                            Context.Logger.LogTrace("Added metric instrument '{InstrumentName}' for scope '{ScopeName}'.", instrument.Summary.Name, scope.Name);
-                        }
-                        else
-                        {
-                            throw new InvalidOperationException($"Instrument limit of {TelemetryRepository.MaxInstrumentCount} reached. Instrument '{metric.Name}' will not be added.");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        // If we can't create the instrument then all data points for it are failures.
-                        context.FailureCount += GetMetricDataPointCount(metric);
-                        Context.Logger.LogInformation(ex, "Error adding metric instrument {MetricName}.", metric.Name);
-                        continue;
-                    }
-
-                    AddMetrics(instrument, metric, context, ref tempAttributes);
-                }
-            }
-        }
-        finally
-        {
-            _metricsLock.ExitWriteLock();
-        }
-    }
-
-    internal static int GetMetricDataPointCount(Metric metric)
-    {
-        return metric.DataCase switch
-        {
-            Metric.DataOneofCase.Gauge => metric.Gauge.DataPoints.Count,
-            Metric.DataOneofCase.Sum => metric.Sum.DataPoints.Count,
-            Metric.DataOneofCase.Histogram => metric.Histogram.DataPoints.Count,
-            Metric.DataOneofCase.Summary => metric.Summary.DataPoints.Count,
-            Metric.DataOneofCase.ExponentialHistogram => metric.ExponentialHistogram.DataPoints.Count,
-            _ => 0,
-        };
-    }
-
-    private void AddMetrics(OtlpInstrument instrument, Metric metric, AddContext context, ref KeyValuePair<string, string>[]? tempAttributes)
-    {
-        switch (metric.DataCase)
-        {
-            case Metric.DataOneofCase.Gauge:
-                foreach (var d in metric.Gauge.DataPoints)
-                {
-                    try
-                    {
-                        instrument.FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Context);
-                        context.SuccessCount++;
-                    }
-                    catch (Exception ex)
-                    {
-                        context.FailureCount++;
-                        Context.Logger.LogInformation(ex, "Error adding metric.");
-                    }
-                }
-                break;
-            case Metric.DataOneofCase.Sum:
-                foreach (var d in metric.Sum.DataPoints)
-                {
-                    try
-                    {
-                        instrument.FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Context);
-                        context.SuccessCount++;
-                    }
-                    catch (Exception ex)
-                    {
-                        context.FailureCount++;
-                        Context.Logger.LogInformation(ex, "Error adding metric.");
-                    }
-                }
-                break;
-            case Metric.DataOneofCase.Histogram:
-                foreach (var d in metric.Histogram.DataPoints)
-                {
-                    try
-                    {
-                        instrument.FindScope(d.Attributes, ref tempAttributes).AddHistogramValue(d, Context);
-                        context.SuccessCount++;
-                    }
-                    catch (Exception ex)
-                    {
-                        context.FailureCount++;
-                        Context.Logger.LogInformation(ex, "Error adding metric.");
-                    }
-                }
-                break;
-            case Metric.DataOneofCase.Summary:
-                context.FailureCount += metric.Summary.DataPoints.Count;
-                Context.Logger.LogInformation("Error adding summary metrics. Summary is not supported.");
-                break;
-            case Metric.DataOneofCase.ExponentialHistogram:
-                context.FailureCount += metric.ExponentialHistogram.DataPoints.Count;
-                Context.Logger.LogInformation("Error adding exponential histogram metrics. Exponential histogram is not supported.");
-                break;
-        }
-    }
-
-    public void ClearMetrics()
-    {
-        _metricsLock.EnterWriteLock();
-
-        try
-        {
-            _instruments.Clear();
-            _meters.Clear();
-        }
-        finally
-        {
-            _metricsLock.ExitWriteLock();
-        }
-    }
-
-    private static OtlpInstrumentType MapMetricType(Metric.DataOneofCase data)
-    {
-        return data switch
-        {
-            Metric.DataOneofCase.Gauge => OtlpInstrumentType.Gauge,
-            Metric.DataOneofCase.Sum => OtlpInstrumentType.Sum,
-            Metric.DataOneofCase.Histogram => OtlpInstrumentType.Histogram,
-            _ => OtlpInstrumentType.Unsupported
-        };
-    }
-
-    private static OtlpAggregationTemporality MapAggregationTemporality(Metric metric)
-    {
-        return metric.DataCase switch
-        {
-            Metric.DataOneofCase.Sum => (OtlpAggregationTemporality)metric.Sum.AggregationTemporality,
-            Metric.DataOneofCase.Histogram => (OtlpAggregationTemporality)metric.Histogram.AggregationTemporality,
-            Metric.DataOneofCase.ExponentialHistogram => (OtlpAggregationTemporality)metric.ExponentialHistogram.AggregationTemporality,
-            _ => OtlpAggregationTemporality.Unspecified
-        };
-    }
-
-    public OtlpInstrument? GetInstrument(string meterName, string instrumentName, DateTime? valuesStart, DateTime? valuesEnd)
-    {
-        _metricsLock.EnterReadLock();
-
-        try
-        {
-            if (!_instruments.TryGetValue(new OtlpInstrumentKey(meterName, instrumentName), out var instrument))
-            {
-                return null;
-            }
-
-            return OtlpInstrument.Clone(instrument, cloneData: true, valuesStart: valuesStart, valuesEnd: valuesEnd);
-        }
-        finally
-        {
-            _metricsLock.ExitReadLock();
-        }
-    }
-
-    public List<OtlpInstrumentSummary> GetInstrumentsSummary()
-    {
-        _metricsLock.EnterReadLock();
-
-        try
-        {
-            var instruments = new List<OtlpInstrumentSummary>(_instruments.Count);
-            foreach (var instrument in _instruments)
-            {
-                instruments.Add(instrument.Value.Summary);
-            }
-            return instruments;
-        }
-        finally
-        {
-            _metricsLock.ExitReadLock();
-        }
     }
 
     public static Dictionary<string, List<OtlpResource>> GetReplicasByResourceName(IEnumerable<OtlpResource> allResources)
@@ -296,17 +66,26 @@ public class OtlpResource : IOtlpResource
 
     internal OtlpResourceView GetView(RepeatedField<KeyValue> attributes)
     {
+        return GetView(new OtlpResourceView(this, attributes));
+    }
+
+    internal OtlpResourceView GetViewFromProperties(KeyValuePair<string, string>[] properties)
+    {
+        return GetView(new OtlpResourceView(this, properties));
+    }
+
+    private OtlpResourceView GetView(OtlpResourceView view)
+    {
         // Inefficient to create this to possibly throw it away.
-        var view = new OtlpResourceView(this, attributes);
 
         if (_resourceViews.TryGetValue(view.Properties, out var resourceView))
         {
             return resourceView;
         }
 
-        if (_resourceViews.Count >= TelemetryRepository.MaxResourceViewCount)
+        if (_resourceViews.Count >= TelemetryRepositoryLimits.MaxResourceViewCount)
         {
-            throw new InvalidOperationException($"Resource view limit of {TelemetryRepository.MaxResourceViewCount} reached.");
+            throw new InvalidOperationException($"Resource view limit of {TelemetryRepositoryLimits.MaxResourceViewCount} reached.");
         }
 
         return _resourceViews.GetOrAdd(view.Properties, view);
@@ -371,4 +150,21 @@ public class OtlpResource : IOtlpResource
             return hashCode.ToHashCode();
         }
     }
+}
+
+/// <summary>
+/// Compares resources by their resource key.
+/// </summary>
+internal sealed class OtlpResourceEqualityComparer : IEqualityComparer<OtlpResource>
+{
+    public static readonly OtlpResourceEqualityComparer Instance = new();
+
+    private OtlpResourceEqualityComparer()
+    {
+    }
+
+    public bool Equals(OtlpResource? x, OtlpResource? y) =>
+        ReferenceEquals(x, y) || x is not null && y is not null && x.ResourceKey == y.ResourceKey;
+
+    public int GetHashCode(OtlpResource obj) => obj.ResourceKey.GetHashCode();
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpResourceView.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpResourceView.cs
@@ -39,6 +39,12 @@ public class OtlpResourceView
         Properties = properties;
     }
 
+    internal OtlpResourceView(OtlpResource resource, KeyValuePair<string, string>[] properties)
+    {
+        Resource = resource;
+        Properties = properties;
+    }
+
     public List<OtlpDisplayField> AllProperties()
     {
         var props = new List<OtlpDisplayField>

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -249,6 +249,10 @@ public class OtlpSpan
     public static Dictionary<string, int> GetFieldValuesFromTraces(IEnumerable<OtlpTrace> traces, string attributeName)
     {
         var attributeValues = new Dictionary<string, int>(StringComparers.OtlpAttribute);
+        if (attributeName is KnownTraceFields.DurationField or KnownTraceFields.TimestampField)
+        {
+            return attributeValues;
+        }
 
         foreach (var trace in traces)
         {

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -44,26 +44,24 @@ public class OtlpTrace
             throw new InvalidOperationException($"Duplicate span id '{span.SpanId}' detected.");
         }
 
-        var added = false;
+        var insertIndex = 0;
         for (var i = Spans.Count - 1; i >= 0; i--)
         {
             if (span.StartTime > Spans[i].StartTime)
             {
-                Spans.Insert(i + 1, span);
-                added = true;
+                insertIndex = i + 1;
                 break;
             }
         }
-        if (!added)
-        {
-            Spans.Insert(0, span);
-        }
+        Spans.Insert(insertIndex, span);
 
         if (HasCircularReference(span))
         {
             Spans.Remove(span);
             throw new InvalidOperationException($"Circular loop detected for span '{span.SpanId}' with parent '{span.ParentSpanId}'.");
         }
+
+        _duration = null;
 
         if (string.IsNullOrEmpty(span.ParentSpanId))
         {
@@ -90,7 +88,7 @@ public class OtlpTrace
             LastUpdatedDate = DateTime.UtcNow;
         }
 
-        AssertSpanOrder();
+        AssertSpanOrder(insertIndex);
 
         static string BuildFullName(OtlpSpan existingSpan)
         {
@@ -124,18 +122,13 @@ public class OtlpTrace
     }
 
     [Conditional("DEBUG")]
-    private void AssertSpanOrder()
+    private void AssertSpanOrder(int index)
     {
-        DateTime current = default;
-        for (var i = 0; i < Spans.Count; i++)
+        var span = Spans[index];
+        if ((index > 0 && span.StartTime < Spans[index - 1].StartTime) ||
+            (index < Spans.Count - 1 && span.StartTime > Spans[index + 1].StartTime))
         {
-            var span = Spans[i];
-            if (span.StartTime < current)
-            {
-                throw new InvalidOperationException($"Trace {TraceId} spans not in order at index {i}.");
-            }
-
-            current = span.StartTime;
+            throw new InvalidOperationException($"Trace {TraceId} spans not in order at index {index}.");
         }
     }
 

--- a/src/Aspire.Dashboard/Otlp/OtlpLogsService.cs
+++ b/src/Aspire.Dashboard/Otlp/OtlpLogsService.cs
@@ -12,18 +12,18 @@ namespace Aspire.Dashboard.Otlp;
 public sealed class OtlpLogsService
 {
     private readonly ILogger<OtlpLogsService> _logger;
-    private readonly TelemetryRepository _telemetryRepository;
+    private readonly ITelemetryRepositoryWriter _telemetryRepositoryWriter;
 
-    public OtlpLogsService(ILogger<OtlpLogsService> logger, TelemetryRepository telemetryRepository)
+    public OtlpLogsService(ILogger<OtlpLogsService> logger, ITelemetryRepositoryWriter telemetryRepositoryWriter)
     {
         _logger = logger;
-        _telemetryRepository = telemetryRepository;
+        _telemetryRepositoryWriter = telemetryRepositoryWriter;
     }
 
-    public ExportLogsServiceResponse Export(ExportLogsServiceRequest request)
+    public async Task<ExportLogsServiceResponse> ExportAsync(ExportLogsServiceRequest request)
     {
         var addContext = new AddContext();
-        _telemetryRepository.AddLogs(addContext, request.ResourceLogs);
+        await _telemetryRepositoryWriter.AddLogsAsync(addContext, request.ResourceLogs).ConfigureAwait(false);
 
         _logger.LogDebug("Processed logs export. Success count: {SuccessCount}, failure count: {FailureCount}", addContext.SuccessCount, addContext.FailureCount);
 

--- a/src/Aspire.Dashboard/Otlp/OtlpMetricsService.cs
+++ b/src/Aspire.Dashboard/Otlp/OtlpMetricsService.cs
@@ -12,18 +12,18 @@ namespace Aspire.Dashboard.Otlp;
 public sealed class OtlpMetricsService
 {
     private readonly ILogger<OtlpMetricsService> _logger;
-    private readonly TelemetryRepository _telemetryRepository;
+    private readonly ITelemetryRepositoryWriter _telemetryRepositoryWriter;
 
-    public OtlpMetricsService(ILogger<OtlpMetricsService> logger, TelemetryRepository telemetryRepository)
+    public OtlpMetricsService(ILogger<OtlpMetricsService> logger, ITelemetryRepositoryWriter telemetryRepositoryWriter)
     {
         _logger = logger;
-        _telemetryRepository = telemetryRepository;
+        _telemetryRepositoryWriter = telemetryRepositoryWriter;
     }
 
-    public ExportMetricsServiceResponse Export(ExportMetricsServiceRequest request)
+    public async Task<ExportMetricsServiceResponse> ExportAsync(ExportMetricsServiceRequest request)
     {
         var addContext = new AddContext();
-        _telemetryRepository.AddMetrics(addContext, request.ResourceMetrics);
+        await _telemetryRepositoryWriter.AddMetricsAsync(addContext, request.ResourceMetrics).ConfigureAwait(false);
 
         _logger.LogDebug("Processed metrics export. Success count: {SuccessCount}, failure count: {FailureCount}", addContext.SuccessCount, addContext.FailureCount);
 

--- a/src/Aspire.Dashboard/Otlp/OtlpTraceService.cs
+++ b/src/Aspire.Dashboard/Otlp/OtlpTraceService.cs
@@ -12,18 +12,18 @@ namespace Aspire.Dashboard.Otlp;
 public sealed class OtlpTraceService
 {
     private readonly ILogger<OtlpTraceService> _logger;
-    private readonly TelemetryRepository _telemetryRepository;
+    private readonly ITelemetryRepositoryWriter _telemetryRepositoryWriter;
 
-    public OtlpTraceService(ILogger<OtlpTraceService> logger, TelemetryRepository telemetryRepository)
+    public OtlpTraceService(ILogger<OtlpTraceService> logger, ITelemetryRepositoryWriter telemetryRepositoryWriter)
     {
         _logger = logger;
-        _telemetryRepository = telemetryRepository;
+        _telemetryRepositoryWriter = telemetryRepositoryWriter;
     }
 
-    public ExportTraceServiceResponse Export(ExportTraceServiceRequest request)
+    public async Task<ExportTraceServiceResponse> ExportAsync(ExportTraceServiceRequest request)
     {
         var addContext = new AddContext();
-        _telemetryRepository.AddTraces(addContext, request.ResourceSpans);
+        await _telemetryRepositoryWriter.AddTracesAsync(addContext, request.ResourceSpans).ConfigureAwait(false);
 
         _logger.LogDebug("Processed trace export. Success count: {SuccessCount}, failure count: {FailureCount}", addContext.SuccessCount, addContext.FailureCount);
 

--- a/src/Aspire.Dashboard/Otlp/Storage/GetInstrumentRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetInstrumentRequest.cs
@@ -3,11 +3,74 @@
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
+/// <summary>
+/// Specifies the instrument data to retrieve from a telemetry repository.
+/// </summary>
 public sealed class GetInstrumentRequest
 {
+    /// <summary>
+    /// Gets the instrument name.
+    /// </summary>
     public required string InstrumentName { get; init; }
+
+    /// <summary>
+    /// Gets the resource that emitted the instrument data.
+    /// </summary>
     public required ResourceKey ResourceKey { get; init; }
+
+    /// <summary>
+    /// Gets the meter name.
+    /// </summary>
     public required string MeterName { get; init; }
+
+    /// <summary>
+    /// Gets the beginning of the time range to retrieve.
+    /// </summary>
     public DateTime? StartTime { get; init; }
+
+    /// <summary>
+    /// Gets the end of the time range to retrieve.
+    /// </summary>
     public DateTime? EndTime { get; init; }
+
+    /// <summary>
+    /// Gets the dimension values to retrieve, keyed by dimension name. An empty dictionary retrieves all dimensions.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string?>> DimensionFilters { get; init; } = new Dictionary<string, IReadOnlyList<string?>>();
+
+    /// <summary>
+    /// Gets the per-dimension boundaries from which data should be refreshed. Dimensions without a cursor use <see cref="StartTime"/>.
+    /// </summary>
+    public IReadOnlyList<MetricDimensionCursor> DimensionCursors { get; init; } = [];
+
+    /// <summary>
+    /// Gets the interval used to roll up data points within each dimension. A <see langword="null"/> value returns full-fidelity data.
+    /// </summary>
+    public TimeSpan? DataPointInterval { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether exemplars should be retrieved.
+    /// </summary>
+    public bool IncludeExemplars { get; init; } = true;
+
+    /// <summary>
+    /// Gets a value indicating whether exemplar attributes should be populated.
+    /// </summary>
+    public bool PopulateExemplarAttributes { get; init; } = true;
+}
+
+/// <summary>
+/// Specifies the boundary from which one metric dimension should be refreshed.
+/// </summary>
+public sealed class MetricDimensionCursor
+{
+    /// <summary>
+    /// Gets the attributes that identify the dimension.
+    /// </summary>
+    public required KeyValuePair<string, string>[] Attributes { get; init; }
+
+    /// <summary>
+    /// Gets the inclusive beginning of the range to refresh.
+    /// </summary>
+    public required DateTime StartTime { get; init; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
@@ -13,6 +13,11 @@ public sealed class GetLogsContext
     public required List<TelemetryFilter> Filters { get; init; }
     public string[]? TextFragments { get; init; }
 
+    /// <summary>
+    /// Gets the maximum number of the latest matching logs available for paging.
+    /// </summary>
+    internal int? LatestItemCount { get; init; }
+
     public static GetLogsContext ForResourceKey(ResourceKey resourceKey) => new()
     {
         ResourceKeys = [resourceKey],

--- a/src/Aspire.Dashboard/Otlp/Storage/GetTraceSummariesResponse.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetTraceSummariesResponse.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+/// <summary>
+/// Contains a page of trace summaries and aggregate information for the matching traces.
+/// </summary>
+public sealed class GetTraceSummariesResponse
+{
+    public required PagedResult<TraceSummary> PagedResult { get; init; }
+    public required TimeSpan MaxDuration { get; init; }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
@@ -14,6 +14,11 @@ public sealed class GetTracesRequest
     public string? TraceNameFilterText { get; init; }
     public string[]? TextFragments { get; init; }
 
+    /// <summary>
+    /// Gets the maximum number of the latest matching traces available for paging.
+    /// </summary>
+    internal int? LatestItemCount { get; init; }
+
     public static GetTracesRequest ForResourceKey(ResourceKey resourceKey) => new()
     {
         ResourceKeys = [resourceKey],

--- a/src/Aspire.Dashboard/Otlp/Storage/ITelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ITelemetryRepository.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+/// <summary>
+/// Provides storage and queries for dashboard telemetry.
+/// </summary>
+public interface ITelemetryRepository : IDisposable
+{
+    /// <summary>
+    /// Gets a value indicating whether the repository is read-only.
+    /// </summary>
+    bool IsReadOnly { get; }
+
+    bool HasDisplayedMaxLogLimitMessage { get; set; }
+    Message? MaxLogLimitMessage { get; set; }
+    bool HasDisplayedMaxTraceLimitMessage { get; set; }
+    Message? MaxTraceLimitMessage { get; set; }
+
+    List<OtlpResource> GetResources(bool includeUninstrumentedPeers = false);
+    List<OtlpResource> GetResourcesByName(string name, bool includeUninstrumentedPeers = false);
+    OtlpResource? GetResourceByCompositeName(string compositeName);
+    OtlpResource? GetResource(ResourceKey key);
+    List<OtlpResource> GetResources(ResourceKey key, bool includeUninstrumentedPeers = false);
+    Dictionary<ResourceKey, int> GetResourceUnviewedErrorLogsCount();
+    void MarkViewedErrorLogs(ResourceKey? key);
+
+    Subscription OnNewResources(Func<Task> callback);
+    Subscription OnNewLogs(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback);
+    Subscription OnNewMetrics(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback);
+    Subscription OnNewTraces(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback);
+
+    Task<PagedResult<OtlpLogEntry>> GetLogsAsync(GetLogsContext context, CancellationToken cancellationToken);
+    Task<PagedResult<LogSummary>> GetLogSummariesAsync(GetLogsContext context, CancellationToken cancellationToken);
+    OtlpLogEntry? GetLog(long logId);
+    Task<List<OtlpLogEntry>> GetLogsForSpanAsync(string traceId, string spanId, CancellationToken cancellationToken);
+    Task<List<OtlpLogEntry>> GetLogsForTraceAsync(string traceId, CancellationToken cancellationToken);
+    Task<List<string>> GetLogPropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken);
+    Task<List<string>> GetTracePropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken);
+    Task<GetTracesResponse> GetTracesAsync(GetTracesRequest context, CancellationToken cancellationToken);
+    Task<GetTraceSummariesResponse> GetTraceSummariesAsync(GetTracesRequest context, CancellationToken cancellationToken);
+    Task<GetSpansResponse> GetSpansAsync(GetSpansRequest context, CancellationToken cancellationToken);
+    Task<Dictionary<string, int>> GetTraceFieldValuesAsync(string attributeName, CancellationToken cancellationToken);
+    Task<Dictionary<string, int>> GetLogsFieldValuesAsync(string attributeName, CancellationToken cancellationToken);
+    bool HasUpdatedTrace(OtlpTrace trace);
+    OtlpTrace? GetTrace(string traceId);
+    OtlpSpan? GetSpan(string traceId, string spanId);
+    OtlpResource? GetPeerResource(OtlpSpan span);
+    List<OtlpInstrumentSummary> GetInstrumentSummaries(ResourceKey key);
+
+    /// <summary>
+    /// Gets the summary for an instrument emitted by a resource.
+    /// </summary>
+    /// <param name="resourceKey">The resource that emitted the instrument.</param>
+    /// <param name="meterName">The name of the meter that contains the instrument.</param>
+    /// <param name="instrumentName">The name of the instrument.</param>
+    /// <returns>The instrument summary, or <see langword="null"/> when the instrument is not found.</returns>
+    OtlpInstrumentSummary? GetInstrumentSummary(ResourceKey resourceKey, string meterName, string instrumentName);
+
+    Task<OtlpInstrumentData?> GetInstrumentAsync(GetInstrumentRequest request, CancellationToken cancellationToken);
+    DateTime? GetInstrumentLatestEndTime(ResourceKey resourceKey, string meterName, string instrumentName);
+
+    IAsyncEnumerable<OtlpSpan> WatchSpansAsync(WatchSpansRequest request, CancellationToken cancellationToken);
+    IAsyncEnumerable<OtlpLogEntry> WatchLogsAsync(WatchLogsRequest request, CancellationToken cancellationToken);
+
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/ITelemetryRepositoryWriter.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ITelemetryRepositoryWriter.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Google.Protobuf.Collections;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Trace.V1;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+/// <summary>
+/// Adds and removes telemetry in the writable dashboard telemetry store.
+/// </summary>
+public interface ITelemetryRepositoryWriter
+{
+    /// <summary>
+    /// Asynchronously adds log records to the telemetry store.
+    /// </summary>
+    /// <param name="context">The context that records the result of adding telemetry.</param>
+    /// <param name="resourceLogs">The resource log records to add.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task AddLogsAsync(AddContext context, RepeatedField<ResourceLogs> resourceLogs);
+
+    /// <summary>
+    /// Asynchronously adds metric data to the telemetry store.
+    /// </summary>
+    /// <param name="context">The context that records the result of adding telemetry.</param>
+    /// <param name="resourceMetrics">The resource metric data to add.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task AddMetricsAsync(AddContext context, RepeatedField<ResourceMetrics> resourceMetrics);
+
+    /// <summary>
+    /// Asynchronously adds spans to the telemetry store.
+    /// </summary>
+    /// <param name="context">The context that records the result of adding telemetry.</param>
+    /// <param name="resourceSpans">The resource spans to add.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task AddTracesAsync(AddContext context, RepeatedField<ResourceSpans> resourceSpans);
+
+    /// <summary>
+    /// Asynchronously removes the selected telemetry signals for each resource.
+    /// </summary>
+    /// <param name="selectedResources">The telemetry signal types selected for removal, keyed by resource name.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task ClearSelectedSignalsAsync(Dictionary<string, HashSet<AspireDataType>> selectedResources);
+
+    /// <summary>
+    /// Asynchronously removes traces, optionally limited to a resource.
+    /// </summary>
+    /// <param name="resourceKey">The resource to clear, or <see langword="null"/> to clear all resources.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task ClearTracesAsync(ResourceKey? resourceKey = null);
+
+    /// <summary>
+    /// Asynchronously removes structured logs, optionally limited to a resource.
+    /// </summary>
+    /// <param name="resourceKey">The resource to clear, or <see langword="null"/> to clear all resources.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task ClearStructuredLogsAsync(ResourceKey? resourceKey = null);
+
+    /// <summary>
+    /// Asynchronously removes metrics, optionally limited to a resource.
+    /// </summary>
+    /// <param name="resourceKey">The resource to clear, or <see langword="null"/> to clear all resources.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task ClearMetricsAsync(ResourceKey? resourceKey = null);
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/LogSummary.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/LogSummary.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+/// <summary>
+/// Contains the log information displayed on the structured logs page.
+/// </summary>
+public sealed class LogSummary
+{
+    public required long InternalId { get; init; }
+    public required DateTime TimeStamp { get; init; }
+    public required LogLevel Severity { get; init; }
+    public required string Message { get; init; }
+    public required string SpanId { get; init; }
+    public required string TraceId { get; init; }
+    public required string ScopeName { get; init; }
+    public string? EventName { get; init; }
+    public required OtlpResource Resource { get; init; }
+    public required string? ExceptionText { get; init; }
+    public required bool HasGenAI { get; init; }
+    public bool IsError => Severity is LogLevel.Error or LogLevel.Critical;
+    public bool IsWarning => Severity is LogLevel.Warning;
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Caching.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Caching.cs
@@ -1,0 +1,857 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using System.Globalization;
+using System.Text;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Dapper;
+using Google.Protobuf.Collections;
+using Microsoft.Data.Sqlite;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public sealed partial class SqliteTelemetryRepository
+{
+    private const int MaxInstrumentBatchSize = 100;
+    private const int MaxMetadataAttributeBatchSize = 200;
+
+    private readonly object _cacheLock = new();
+    private readonly Dictionary<ResourceKey, CachedResource> _cachedResourcesByKey = [];
+    private readonly Dictionary<long, CachedResource> _cachedResourcesById = [];
+    private readonly Dictionary<string, CachedScope> _cachedScopesByName = new(StringComparer.Ordinal);
+    private readonly Dictionary<long, CachedScope> _cachedScopesById = [];
+    private bool _cachePopulated;
+
+    private CachedResource GetOrAddCachedResource(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        ResourceKey resourceKey,
+        bool uninstrumentedPeer = false)
+    {
+        lock (_cacheLock)
+        {
+            CachedResource cachedResource;
+            if (_cachedResourcesByKey.TryGetValue(resourceKey, out var existingResource))
+            {
+                cachedResource = existingResource;
+                if (cachedResource.Resource.UninstrumentedPeer && !uninstrumentedPeer)
+                {
+                    connection.Execute(
+                        "UPDATE telemetry_resources SET uninstrumented_peer = 0 WHERE resource_id = @ResourceId;",
+                        new { cachedResource.ResourceId },
+                        transaction);
+                }
+                cachedResource.Resource.SetUninstrumentedPeer(uninstrumentedPeer);
+            }
+            else
+            {
+                var record = connection.QuerySingleOrDefault<CachedResourceRecord>("""
+                    SELECT
+                        resource_id AS ResourceId,
+                        resource_name AS ResourceName,
+                        instance_id AS InstanceId,
+                        uninstrumented_peer AS UninstrumentedPeer,
+                        has_logs AS HasLogs,
+                        has_traces AS HasTraces,
+                        has_metrics AS HasMetrics
+                    FROM telemetry_resources
+                    WHERE resource_name = @ResourceName
+                      AND instance_id IS @InstanceId;
+                    """, new { ResourceName = resourceKey.Name, resourceKey.InstanceId }, transaction);
+                if (record is not null)
+                {
+                    cachedResource = GetOrAddCachedResource(record);
+                    if (cachedResource.Resource.UninstrumentedPeer && !uninstrumentedPeer)
+                    {
+                        connection.Execute(
+                            "UPDATE telemetry_resources SET uninstrumented_peer = 0 WHERE resource_id = @ResourceId;",
+                            new { cachedResource.ResourceId },
+                            transaction);
+                    }
+                    cachedResource.Resource.SetUninstrumentedPeer(uninstrumentedPeer);
+                }
+                else
+                {
+                    var resourceCount = connection.QuerySingle<int>("SELECT COUNT(*) FROM telemetry_resources;", transaction: transaction);
+                    if (resourceCount >= _otlpContext.Options.MaxResourceCount)
+                    {
+                        throw new InvalidOperationException($"Resource limit of {_otlpContext.Options.MaxResourceCount} reached. Resource '{resourceKey}' will not be added.");
+                    }
+
+                    var resourceId = connection.QuerySingle<long>("""
+                        INSERT INTO telemetry_resources (resource_name, instance_id)
+                        VALUES (@ResourceName, @InstanceId)
+                        RETURNING resource_id;
+                        """, new { ResourceName = resourceKey.Name, resourceKey.InstanceId }, transaction);
+                    cachedResource = CreateCachedResource(resourceId, resourceKey, uninstrumentedPeer);
+                }
+            }
+
+            GetOrAddCachedResourceView(connection, transaction, cachedResource, []);
+            return cachedResource;
+        }
+    }
+
+    private CachedResourceView GetOrAddCachedResourceView(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        CachedResource resource,
+        RepeatedField<KeyValue> attributes)
+    {
+        var incomingView = new OtlpResourceView(resource.Resource, attributes);
+        lock (_cacheLock)
+        {
+            if (resource.ViewsByProperties.TryGetValue(incomingView.Properties, out var cachedView))
+            {
+                return cachedView;
+            }
+
+            var parameters = new DynamicParameters();
+            parameters.Add("ResourceId", resource.ResourceId);
+            parameters.Add("PropertyCount", incomingView.Properties.Length);
+            var sql = new StringBuilder("""
+                SELECT v.resource_view_id
+                FROM telemetry_resource_views v
+                WHERE v.resource_id = @ResourceId
+                  AND (SELECT COUNT(*) FROM telemetry_resource_view_attributes a WHERE a.resource_view_id = v.resource_view_id) = @PropertyCount
+                """);
+            for (var index = 0; index < incomingView.Properties.Length; index++)
+            {
+                parameters.Add($"PropertyKey{index}", incomingView.Properties[index].Key);
+                parameters.Add($"PropertyValue{index}", incomingView.Properties[index].Value);
+                sql.Append(CultureInfo.InvariantCulture, $"""
+
+                      AND EXISTS (
+                          SELECT 1
+                          FROM telemetry_resource_view_attributes a
+                          WHERE a.resource_view_id = v.resource_view_id
+                            AND a.ordinal = {index}
+                            AND a.attribute_key = @PropertyKey{index}
+                            AND a.attribute_value = @PropertyValue{index}
+                      )
+                    """);
+            }
+            sql.Append(" LIMIT 1;");
+
+            var resourceViewId = connection.QuerySingleOrDefault<long?>(sql.ToString(), parameters, transaction);
+            if (resourceViewId is null)
+            {
+                var resourceViewCount = connection.QuerySingle<int>(
+                    "SELECT COUNT(*) FROM telemetry_resource_views WHERE resource_id = @ResourceId;",
+                    new { resource.ResourceId },
+                    transaction);
+                if (resourceViewCount >= TelemetryRepositoryLimits.MaxResourceViewCount)
+                {
+                    throw new InvalidOperationException($"Resource view limit of {TelemetryRepositoryLimits.MaxResourceViewCount} reached.");
+                }
+
+                resourceViewId = connection.QuerySingle<long>("""
+                    INSERT INTO telemetry_resource_views (resource_id)
+                    VALUES (@ResourceId)
+                    RETURNING resource_view_id;
+                    """, new { resource.ResourceId }, transaction);
+                var properties = incomingView.Properties
+                    .Select((property, ordinal) => (Ordinal: ordinal, property.Key, property.Value))
+                    .ToArray();
+                SqliteBatchInsert.BatchInsertRows(
+                    connection,
+                    transaction,
+                    properties,
+                    MaxMetadataAttributeBatchSize,
+                    "telemetry_resource_view_attributes",
+                    ["resource_view_id", "ordinal", "attribute_key", "attribute_value"],
+                    (property, parameters) =>
+                    {
+                        parameters[0].Value = resourceViewId.Value;
+                        parameters[1].Value = property.Ordinal;
+                        parameters[2].Value = property.Key;
+                        parameters[3].Value = property.Value;
+                    });
+            }
+
+            return AddCachedResourceView(resource, resourceViewId.Value, incomingView.Properties);
+        }
+    }
+
+    private CachedResourceScope GetOrAddCachedScope(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        CachedResource resource,
+        InstrumentationScope? instrumentationScope,
+        CachedTelemetryType telemetryType)
+    {
+        var incomingScope = instrumentationScope is null
+            ? OtlpScope.Empty
+            : new OtlpScope(
+                instrumentationScope.Name,
+                instrumentationScope.Version,
+                instrumentationScope.Attributes.ToKeyValuePairs(_otlpContext));
+        lock (_cacheLock)
+        {
+            if (resource.Scopes.TryGetValue(incomingScope.Name, out var resourceScope))
+            {
+                resourceScope.TelemetryTypes |= telemetryType;
+                return resourceScope;
+            }
+
+            if (!_cachedScopesByName.TryGetValue(incomingScope.Name, out var cachedScope))
+            {
+                var existingRecords = connection.Query<CachedScopeRecord>("""
+                    SELECT
+                        s.scope_id AS ScopeId,
+                        s.scope_name AS ScopeName,
+                        s.scope_version AS ScopeVersion,
+                        a.attribute_key AS AttributeKey,
+                        a.attribute_value AS AttributeValue
+                    FROM telemetry_scopes s
+                    LEFT JOIN telemetry_scope_attributes a ON a.scope_id = s.scope_id
+                    WHERE s.scope_name = @ScopeName
+                    ORDER BY a.ordinal;
+                    """, new { ScopeName = incomingScope.Name }, transaction);
+                if (existingRecords.FirstOrDefault() is { } existing)
+                {
+                    var attributes = existingRecords
+                        .Where(record => record.AttributeKey is not null)
+                        .Select(record => KeyValuePair.Create(record.AttributeKey!, record.AttributeValue!))
+                        .ToArray();
+                    cachedScope = GetOrAddCachedScope(existing.ScopeId, existing.ScopeName, existing.ScopeVersion, attributes);
+                }
+                else
+                {
+                    var scopeCount = connection.QuerySingle<int>("SELECT COUNT(*) FROM telemetry_scopes;", transaction: transaction);
+                    if (scopeCount >= TelemetryRepositoryLimits.MaxScopeCount)
+                    {
+                        throw new InvalidOperationException($"Scope limit of {TelemetryRepositoryLimits.MaxScopeCount} reached. Scope '{incomingScope.Name}' will not be added.");
+                    }
+
+                    var scopeId = connection.QuerySingle<long>("""
+                        INSERT INTO telemetry_scopes (scope_name, scope_version)
+                        VALUES (@ScopeName, @ScopeVersion)
+                        RETURNING scope_id;
+                        """, new { ScopeName = incomingScope.Name, ScopeVersion = incomingScope.Version }, transaction);
+                    var attributes = incomingScope.Attributes
+                        .Select((attribute, ordinal) => (Ordinal: ordinal, attribute.Key, attribute.Value))
+                        .ToArray();
+                    SqliteBatchInsert.BatchInsertRows(
+                        connection,
+                        transaction,
+                        attributes,
+                        MaxMetadataAttributeBatchSize,
+                        "telemetry_scope_attributes",
+                        ["scope_id", "ordinal", "attribute_key", "attribute_value"],
+                        (attribute, parameters) =>
+                        {
+                            parameters[0].Value = scopeId;
+                            parameters[1].Value = attribute.Ordinal;
+                            parameters[2].Value = attribute.Key;
+                            parameters[3].Value = attribute.Value;
+                        });
+                    cachedScope = GetOrAddCachedScope(scopeId, incomingScope.Name, incomingScope.Version, incomingScope.Attributes);
+                }
+            }
+
+            return AddCachedScope(resource, cachedScope, telemetryType);
+        }
+    }
+
+    private CachedInstrument GetOrAddCachedInstrument(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        CachedResource resource,
+        CachedResourceView resourceView,
+        CachedResourceScope resourceScope,
+        Metric metric)
+    {
+        if (string.IsNullOrEmpty(metric.Name))
+        {
+            throw new InvalidOperationException("Instrument name is required.");
+        }
+
+        lock (_cacheLock)
+        {
+            if (resourceScope.Instruments.TryGetValue(metric.Name, out var instrument))
+            {
+                return instrument;
+            }
+
+            EnsureCachedInstrumentsLoaded(connection, transaction, resource, resourceScope);
+            if (resourceScope.Instruments.TryGetValue(metric.Name, out instrument))
+            {
+                return instrument;
+            }
+
+            var instrumentCount = resource.InstrumentCount ??= connection.QuerySingle<int>(
+                    "SELECT COUNT(*) FROM telemetry_metric_instruments WHERE resource_id = @ResourceId;",
+                    new { resource.ResourceId },
+                    transaction);
+            if (instrumentCount >= TelemetryRepositoryLimits.MaxInstrumentCount)
+            {
+                throw new InvalidOperationException($"Instrument limit of {TelemetryRepositoryLimits.MaxInstrumentCount} reached. Instrument '{metric.Name}' will not be added.");
+            }
+
+            var instrumentId = connection.QuerySingle<long>("""
+                INSERT INTO telemetry_metric_instruments (
+                    resource_id, resource_view_id, scope_id, instrument_name, description, unit, instrument_type,
+                    aggregation_temporality, is_monotonic)
+                VALUES (
+                    @ResourceId, @ResourceViewId, @ScopeId, @InstrumentName, @Description, @Unit, @InstrumentType,
+                    @AggregationTemporality, @IsMonotonic)
+                RETURNING instrument_id;
+                """, new
+            {
+                resource.ResourceId,
+                resourceView.ResourceViewId,
+                ScopeId = resourceScope.Scope.ScopeId,
+                InstrumentName = metric.Name,
+                metric.Description,
+                metric.Unit,
+                InstrumentType = (int)MapMetricType(metric.DataCase),
+                AggregationTemporality = (int)MapAggregationTemporality(metric),
+                IsMonotonic = metric.DataCase == Metric.DataOneofCase.Sum && metric.Sum.IsMonotonic
+            }, transaction);
+            var record = new CachedInstrumentRecord
+            {
+                InstrumentId = instrumentId,
+                ResourceId = resource.ResourceId,
+                ResourceViewId = resourceView.ResourceViewId,
+                ScopeId = resourceScope.Scope.ScopeId,
+                InstrumentName = metric.Name,
+                Description = metric.Description,
+                Unit = metric.Unit,
+                InstrumentType = (int)MapMetricType(metric.DataCase),
+                AggregationTemporality = (int)MapAggregationTemporality(metric)
+            };
+            resource.InstrumentCount++;
+            _metricIngestionState.LoadedDimensionInstruments.Add(instrumentId);
+            _metricIngestionState.DimensionCounts[instrumentId] = 0;
+            _metricIngestionState.KnownAttributeValues[instrumentId] = new KnownAttributeValuesState();
+            return AddCachedInstrument(resource, resourceScope, record);
+        }
+    }
+
+    private void EnsureCachedInstruments(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        CachedResource resource,
+        CachedResourceView resourceView,
+        CachedResourceScope resourceScope,
+        RepeatedField<Metric> metrics)
+    {
+        lock (_cacheLock)
+        {
+            EnsureCachedInstrumentsLoaded(connection, transaction, resource, resourceScope);
+
+            var pendingMetrics = metrics
+                .Where(metric => !string.IsNullOrEmpty(metric.Name) && metric.DataCase is
+                    Metric.DataOneofCase.Gauge or Metric.DataOneofCase.Sum or Metric.DataOneofCase.Histogram)
+                .DistinctBy(metric => metric.Name, StringComparer.Ordinal)
+                .Where(metric => !resourceScope.Instruments.ContainsKey(metric.Name))
+                .ToList();
+            if (pendingMetrics.Count == 0)
+            {
+                return;
+            }
+
+            var instrumentCount = resource.InstrumentCount ??= connection.QuerySingle<int>(
+                "SELECT COUNT(*) FROM telemetry_metric_instruments WHERE resource_id = @ResourceId;",
+                new { resource.ResourceId },
+                transaction);
+            var availableCount = Math.Max(0, TelemetryRepositoryLimits.MaxInstrumentCount - instrumentCount);
+            foreach (var batch in pendingMetrics.Take(availableCount).Chunk(MaxInstrumentBatchSize))
+            {
+                var sql = new StringBuilder("""
+                    INSERT INTO telemetry_metric_instruments (
+                        resource_id, resource_view_id, scope_id, instrument_name, description, unit, instrument_type,
+                        aggregation_temporality, is_monotonic)
+                    VALUES
+                    """);
+                var parameters = new DynamicParameters();
+                parameters.Add("ResourceId", resource.ResourceId);
+                parameters.Add("ResourceViewId", resourceView.ResourceViewId);
+                parameters.Add("ScopeId", resourceScope.Scope.ScopeId);
+                for (var index = 0; index < batch.Length; index++)
+                {
+                    if (index > 0)
+                    {
+                        sql.AppendLine(",");
+                    }
+                    sql.Append(CultureInfo.InvariantCulture, $"    (@ResourceId, @ResourceViewId, @ScopeId, @InstrumentName{index}, @Description{index}, @Unit{index}, @InstrumentType{index}, @AggregationTemporality{index}, @IsMonotonic{index})");
+                    parameters.Add($"InstrumentName{index}", batch[index].Name);
+                    parameters.Add($"Description{index}", batch[index].Description);
+                    parameters.Add($"Unit{index}", batch[index].Unit);
+                    parameters.Add($"InstrumentType{index}", (int)MapMetricType(batch[index].DataCase));
+                    parameters.Add($"AggregationTemporality{index}", (int)MapAggregationTemporality(batch[index]));
+                    parameters.Add($"IsMonotonic{index}", batch[index].DataCase == Metric.DataOneofCase.Sum && batch[index].Sum.IsMonotonic);
+                }
+                sql.Append("""
+
+                    RETURNING instrument_id AS InstrumentId, instrument_name AS InstrumentName;
+                    """);
+
+                var metricsByName = batch.ToDictionary(metric => metric.Name, StringComparer.Ordinal);
+                var insertedRecords = connection.Query<InsertedInstrumentRecord>(sql.ToString(), parameters, transaction).ToList();
+
+                foreach (var insertedRecord in insertedRecords)
+                {
+                    var metric = metricsByName[insertedRecord.InstrumentName];
+                    AddCachedInstrument(resource, resourceScope, new CachedInstrumentRecord
+                    {
+                        InstrumentId = insertedRecord.InstrumentId,
+                        ResourceId = resource.ResourceId,
+                        ResourceViewId = resourceView.ResourceViewId,
+                        ScopeId = resourceScope.Scope.ScopeId,
+                        InstrumentName = metric.Name,
+                        Description = metric.Description,
+                        Unit = metric.Unit,
+                        InstrumentType = (int)MapMetricType(metric.DataCase),
+                        AggregationTemporality = (int)MapAggregationTemporality(metric)
+                    });
+                    _metricIngestionState.LoadedDimensionInstruments.Add(insertedRecord.InstrumentId);
+                    _metricIngestionState.DimensionCounts[insertedRecord.InstrumentId] = 0;
+                    _metricIngestionState.KnownAttributeValues[insertedRecord.InstrumentId] = new KnownAttributeValuesState();
+                }
+                resource.InstrumentCount += insertedRecords.Count;
+            }
+        }
+    }
+
+    private static void EnsureCachedInstrumentsLoaded(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        CachedResource resource,
+        CachedResourceScope resourceScope)
+    {
+        if (resourceScope.InstrumentsLoaded)
+        {
+            return;
+        }
+
+        var records = connection.Query<CachedInstrumentRecord>("""
+            SELECT instrument_id AS InstrumentId,
+                resource_id AS ResourceId,
+                resource_view_id AS ResourceViewId,
+                scope_id AS ScopeId,
+                instrument_name AS InstrumentName,
+                description AS Description,
+                unit AS Unit,
+                instrument_type AS InstrumentType,
+                aggregation_temporality AS AggregationTemporality
+            FROM telemetry_metric_instruments
+            WHERE resource_id = @ResourceId AND scope_id = @ScopeId;
+            """, new
+        {
+            resource.ResourceId,
+            ScopeId = resourceScope.Scope.ScopeId
+        }, transaction);
+        foreach (var loadedRecord in records)
+        {
+            AddCachedInstrument(resource, resourceScope, loadedRecord);
+        }
+        resourceScope.InstrumentsLoaded = true;
+    }
+
+    private void ClearIngestionCaches()
+    {
+        ClearMetadataCache();
+        _metricIngestionState.Clear();
+    }
+
+    private void EnsureCachePopulated()
+    {
+        lock (_cacheLock)
+        {
+            if (_cachePopulated)
+            {
+                return;
+            }
+        }
+
+        // Writers update the database and metadata caches as one operation. Wait for any active write to
+        // finish so the cache is populated from committed data instead of a partially updated state.
+        using (_database.WriteLock.Lock())
+        {
+            lock (_cacheLock)
+            {
+                if (_cachePopulated)
+                {
+                    return;
+                }
+
+                using var connection = _database.OpenConnection();
+                using var reader = connection.QueryMultiple("""
+                SELECT
+                    resource_id AS ResourceId,
+                    resource_name AS ResourceName,
+                    instance_id AS InstanceId,
+                    uninstrumented_peer AS UninstrumentedPeer,
+                    has_logs AS HasLogs,
+                    has_traces AS HasTraces,
+                    has_metrics AS HasMetrics
+                FROM telemetry_resources;
+
+                SELECT
+                    v.resource_view_id AS ResourceViewId,
+                    v.resource_id AS ResourceId,
+                    a.attribute_key AS AttributeKey,
+                    a.attribute_value AS AttributeValue
+                FROM telemetry_resource_views v
+                LEFT JOIN telemetry_resource_view_attributes a ON a.resource_view_id = v.resource_view_id
+                ORDER BY v.resource_view_id, a.ordinal;
+
+                SELECT DISTINCT
+                    u.resource_id AS ResourceId,
+                    u.scope_id AS ScopeId,
+                    u.telemetry_type AS TelemetryType,
+                    s.scope_name AS ScopeName,
+                    s.scope_version AS ScopeVersion
+                FROM (
+                    SELECT resource_id, scope_id, 1 AS telemetry_type FROM telemetry_logs
+                    UNION ALL
+                    SELECT resource_id, scope_id, 2 AS telemetry_type FROM telemetry_spans
+                    UNION ALL
+                    SELECT resource_id, scope_id, 4 AS telemetry_type FROM telemetry_metric_instruments
+                ) u
+                JOIN telemetry_scopes s ON s.scope_id = u.scope_id;
+
+                SELECT
+                    scope_id AS ScopeId,
+                    attribute_key AS AttributeKey,
+                    attribute_value AS AttributeValue
+                FROM telemetry_scope_attributes
+                ORDER BY scope_id, ordinal;
+
+                SELECT
+                    instrument_id AS InstrumentId,
+                    resource_id AS ResourceId,
+                    resource_view_id AS ResourceViewId,
+                    scope_id AS ScopeId,
+                    instrument_name AS InstrumentName,
+                    description AS Description,
+                    unit AS Unit,
+                    instrument_type AS InstrumentType,
+                    aggregation_temporality AS AggregationTemporality
+                FROM telemetry_metric_instruments
+                ORDER BY instrument_id;
+                """);
+
+                var resources = reader.Read<CachedResourceRecord>().AsList();
+                var resourceViews = reader.Read<CachedResourceViewRecord>().AsList();
+                var scopeUsages = reader.Read<CachedScopeUsageRecord>().AsList();
+                var scopeAttributes = reader.Read<CachedScopeAttributeRecord>().ToLookup(record => record.ScopeId);
+                var instruments = reader.Read<CachedInstrumentRecord>().AsList();
+
+                foreach (var record in resources)
+                {
+                    GetOrAddCachedResource(record);
+                }
+
+                foreach (var group in resourceViews.GroupBy(record => (record.ResourceId, record.ResourceViewId)))
+                {
+                    if (_cachedResourcesById.TryGetValue(group.Key.ResourceId, out var resource))
+                    {
+                        var properties = group
+                            .Where(record => record.AttributeKey is not null)
+                            .Select(record => KeyValuePair.Create(record.AttributeKey!, record.AttributeValue!))
+                            .ToArray();
+                        AddCachedResourceView(resource, group.Key.ResourceViewId, properties);
+                    }
+                }
+
+                foreach (var record in scopeUsages)
+                {
+                    if (_cachedResourcesById.TryGetValue(record.ResourceId, out var resource))
+                    {
+                        var scope = GetOrAddCachedScope(
+                            record.ScopeId,
+                            record.ScopeName,
+                            record.ScopeVersion,
+                            scopeAttributes[record.ScopeId]
+                                .Select(attribute => KeyValuePair.Create(attribute.AttributeKey, attribute.AttributeValue))
+                                .ToArray());
+                        AddCachedScope(resource, scope, (CachedTelemetryType)record.TelemetryType);
+                    }
+                }
+
+                foreach (var record in instruments)
+                {
+                    if (_cachedResourcesById.TryGetValue(record.ResourceId, out var resource) &&
+                        _cachedScopesById.TryGetValue(record.ScopeId, out var scope))
+                    {
+                        var resourceScope = AddCachedScope(resource, scope, CachedTelemetryType.Metrics);
+                        AddCachedInstrument(resource, resourceScope, record);
+                    }
+                }
+
+                foreach (var resource in _cachedResourcesById.Values)
+                {
+                    resource.InstrumentCount = resource.Scopes.Values.Sum(scope => scope.Instruments.Count);
+                    foreach (var resourceScope in resource.Scopes.Values.Where(scope => scope.TelemetryTypes.HasFlag(CachedTelemetryType.Metrics)))
+                    {
+                        resourceScope.InstrumentsLoaded = true;
+                    }
+                }
+
+                _cachePopulated = true;
+            }
+        }
+    }
+
+    private CachedResource GetOrAddCachedResource(CachedResourceRecord record)
+    {
+        var key = new ResourceKey(record.ResourceName, record.InstanceId);
+        if (!_cachedResourcesByKey.TryGetValue(key, out var cachedResource))
+        {
+            cachedResource = CreateCachedResource(record.ResourceId, key, record.UninstrumentedPeer);
+        }
+
+        cachedResource.Resource.SetUninstrumentedPeer(record.UninstrumentedPeer);
+        cachedResource.Resource.HasLogs = record.HasLogs;
+        cachedResource.Resource.HasTraces = record.HasTraces;
+        cachedResource.Resource.HasMetrics = record.HasMetrics;
+        return cachedResource;
+    }
+
+    private CachedResource CreateCachedResource(long resourceId, ResourceKey key, bool uninstrumentedPeer)
+    {
+        var resource = new OtlpResource(key.Name, key.InstanceId, uninstrumentedPeer, _otlpContext);
+        var cachedResource = new CachedResource(resourceId, resource);
+        _cachedResourcesByKey.Add(key, cachedResource);
+        _cachedResourcesById.Add(resourceId, cachedResource);
+        return cachedResource;
+    }
+
+    private static CachedResourceView AddCachedResourceView(CachedResource resource, long resourceViewId, KeyValuePair<string, string>[] properties)
+    {
+        if (resource.ViewsById.TryGetValue(resourceViewId, out var cachedView))
+        {
+            return cachedView;
+        }
+
+        var view = resource.Resource.GetViewFromProperties(properties);
+        cachedView = new CachedResourceView(resourceViewId, view);
+        resource.ViewsById.Add(resourceViewId, cachedView);
+        resource.ViewsByProperties[view.Properties] = cachedView;
+        return cachedView;
+    }
+
+    private CachedScope GetOrAddCachedScope(long scopeId, string scopeName, string scopeVersion, KeyValuePair<string, string>[] attributes)
+    {
+        if (_cachedScopesById.TryGetValue(scopeId, out var cachedScope))
+        {
+            return cachedScope;
+        }
+
+        var scope = CreateScope(scopeName, scopeVersion, attributes);
+        cachedScope = new CachedScope(scopeId, scope);
+        _cachedScopesById.Add(scopeId, cachedScope);
+        _cachedScopesByName[scope.Name] = cachedScope;
+        return cachedScope;
+    }
+
+    private static CachedResourceScope AddCachedScope(CachedResource resource, CachedScope scope, CachedTelemetryType telemetryType)
+    {
+        if (!resource.Scopes.TryGetValue(scope.Scope.Name, out var resourceScope))
+        {
+            resourceScope = new CachedResourceScope(scope);
+            resource.Scopes.Add(scope.Scope.Name, resourceScope);
+        }
+        resourceScope.TelemetryTypes |= telemetryType;
+        return resourceScope;
+    }
+
+    private static CachedInstrument AddCachedInstrument(CachedResource resource, CachedResourceScope resourceScope, CachedInstrumentRecord record)
+    {
+        if (!resourceScope.Instruments.TryGetValue(record.InstrumentName, out var instrument))
+        {
+            instrument = new CachedInstrument(
+                record.InstrumentId,
+                new OtlpInstrumentSummary
+                {
+                    Name = record.InstrumentName,
+                    Description = record.Description,
+                    Unit = record.Unit,
+                    Type = (OtlpInstrumentType)record.InstrumentType,
+                    AggregationTemporality = (OtlpAggregationTemporality)record.AggregationTemporality,
+                    Parent = resourceScope.Scope.Scope,
+                    ResourceView = resource.ViewsById[record.ResourceViewId].View
+                });
+            resourceScope.Instruments.Add(record.InstrumentName, instrument);
+        }
+        return instrument;
+    }
+
+    private List<OtlpInstrumentSummary> GetCachedInstrumentSummaries(ResourceKey key)
+    {
+        EnsureCachePopulated();
+        lock (_cacheLock)
+        {
+            return GetCachedResources(key)
+                .SelectMany(resource => resource.Scopes.Values)
+                .SelectMany(scope => scope.Instruments.Values)
+                .Select(instrument => instrument.Summary)
+                .DistinctBy(summary => summary.GetKey())
+                .ToList();
+        }
+    }
+
+    private List<CachedInstrument> GetCachedInstruments(ResourceKey resourceKey, string meterName, string instrumentName)
+    {
+        EnsureCachePopulated();
+        lock (_cacheLock)
+        {
+            return GetCachedResources(resourceKey)
+                .SelectMany(resource => resource.Scopes.Values)
+                .Where(scope => string.Equals(scope.Scope.Scope.Name, meterName, StringComparison.Ordinal))
+                .SelectMany(scope => scope.Instruments.Values)
+                .Where(instrument => string.Equals(instrument.Summary.Name, instrumentName, StringComparison.Ordinal))
+                .ToList();
+        }
+    }
+
+    private (OtlpResource Resource, OtlpResourceView View, OtlpScope Scope) GetCachedTelemetryMetadata(
+        long resourceId,
+        long resourceViewId,
+        long scopeId,
+        CachedTelemetryType telemetryType)
+    {
+        EnsureCachePopulated();
+        lock (_cacheLock)
+        {
+            var resource = _cachedResourcesById[resourceId];
+            var view = resource.ViewsById[resourceViewId];
+            var scope = _cachedScopesById[scopeId];
+            AddCachedScope(resource, scope, telemetryType);
+            return (resource.Resource, view.View, scope.Scope);
+        }
+    }
+
+    private OtlpResource? GetCachedResource(long resourceId)
+    {
+        EnsureCachePopulated();
+        lock (_cacheLock)
+        {
+            return _cachedResourcesById.TryGetValue(resourceId, out var resource) ? resource.Resource : null;
+        }
+    }
+
+    private IEnumerable<CachedResource> GetCachedResources(ResourceKey key)
+    {
+        return key.InstanceId is null
+            ? _cachedResourcesByKey.Values.Where(resource => string.Equals(resource.Resource.ResourceName, key.Name, StringComparisons.ResourceName))
+            : _cachedResourcesByKey.TryGetValue(key, out var resource) ? [resource] : [];
+    }
+
+    private void ClearMetadataCache()
+    {
+        lock (_cacheLock)
+        {
+            _cachedResourcesByKey.Clear();
+            _cachedResourcesById.Clear();
+            _cachedScopesByName.Clear();
+            _cachedScopesById.Clear();
+            _cachePopulated = false;
+        }
+    }
+
+    private sealed class CachedResource(long resourceId, OtlpResource resource)
+    {
+        public long ResourceId { get; } = resourceId;
+        public OtlpResource Resource { get; } = resource;
+        public Dictionary<long, CachedResourceView> ViewsById { get; } = [];
+        public Dictionary<KeyValuePair<string, string>[], CachedResourceView> ViewsByProperties { get; } = new(ResourceViewPropertiesComparer.Instance);
+        public Dictionary<string, CachedResourceScope> Scopes { get; } = new(StringComparer.Ordinal);
+        public int? InstrumentCount { get; set; }
+    }
+
+    private sealed record CachedResourceView(long ResourceViewId, OtlpResourceView View);
+    private sealed record CachedScope(long ScopeId, OtlpScope Scope);
+
+    private sealed class CachedResourceScope(CachedScope scope)
+    {
+        public CachedScope Scope { get; } = scope;
+        public CachedTelemetryType TelemetryTypes { get; set; }
+        public Dictionary<string, CachedInstrument> Instruments { get; } = new(StringComparer.Ordinal);
+        public bool InstrumentsLoaded { get; set; }
+    }
+
+    private sealed class CachedInstrument(long instrumentId, OtlpInstrumentSummary summary)
+    {
+        public long InstrumentId { get; } = instrumentId;
+        public OtlpInstrumentSummary Summary { get; } = summary;
+    }
+
+    [Flags]
+    private enum CachedTelemetryType
+    {
+        Logs = 1,
+        Traces = 2,
+        Metrics = 4
+    }
+
+    private sealed class CachedResourceRecord
+    {
+        public required long ResourceId { get; init; }
+        public required string ResourceName { get; init; }
+        public string? InstanceId { get; init; }
+        public required bool UninstrumentedPeer { get; init; }
+        public required bool HasLogs { get; init; }
+        public required bool HasTraces { get; init; }
+        public required bool HasMetrics { get; init; }
+    }
+
+    private sealed class CachedResourceViewRecord
+    {
+        public required long ResourceViewId { get; init; }
+        public required long ResourceId { get; init; }
+        public string? AttributeKey { get; init; }
+        public string? AttributeValue { get; init; }
+    }
+
+    private sealed class CachedScopeUsageRecord
+    {
+        public required long ResourceId { get; init; }
+        public required long ScopeId { get; init; }
+        public required int TelemetryType { get; init; }
+        public required string ScopeName { get; init; }
+        public required string ScopeVersion { get; init; }
+    }
+
+    private sealed class CachedScopeRecord
+    {
+        public required long ScopeId { get; init; }
+        public required string ScopeName { get; init; }
+        public required string ScopeVersion { get; init; }
+        public string? AttributeKey { get; init; }
+        public string? AttributeValue { get; init; }
+    }
+
+    private sealed class CachedScopeAttributeRecord
+    {
+        public required long ScopeId { get; init; }
+        public required string AttributeKey { get; init; }
+        public required string AttributeValue { get; init; }
+    }
+
+    private sealed class CachedInstrumentRecord
+    {
+        public required long InstrumentId { get; init; }
+        public required long ResourceId { get; init; }
+        public required long ResourceViewId { get; init; }
+        public required long ScopeId { get; init; }
+        public required string InstrumentName { get; init; }
+        public required string Description { get; init; }
+        public required string Unit { get; init; }
+        public required int InstrumentType { get; init; }
+        public required int AggregationTemporality { get; init; }
+    }
+
+    private sealed class InsertedInstrumentRecord
+    {
+        public required long InstrumentId { get; init; }
+        public required string InstrumentName { get; init; }
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Logs.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Logs.cs
@@ -1,0 +1,856 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using System.Globalization;
+using System.Text;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Dapper;
+using Google.Protobuf.Collections;
+using Microsoft.Data.Sqlite;
+using OpenTelemetry.Proto.Logs.V1;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public sealed partial class SqliteTelemetryRepository
+{
+    private const int MaxLogBatchSize = 50;
+    private const int MaxLogAttributeBatchSize = 200;
+    private const int MaxLogAttributeReadBatchSize = 500;
+
+    private async Task<List<OtlpLogEntry>> AddLogsToDatabaseAsync(AddContext context, RepeatedField<ResourceLogs> resourceLogs)
+    {
+        var addedLogs = new List<OtlpLogEntry>();
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            var pendingLogs = new List<PendingLog>();
+            var resourcesWithLogs = new HashSet<CachedResource>();
+
+            foreach (var resourceLogsItem in resourceLogs)
+            {
+                CachedResource cachedResource;
+                OtlpResourceView resourceView;
+                long resourceViewId;
+                try
+                {
+                    var resourceKey = resourceLogsItem.Resource.GetResourceKey();
+                    cachedResource = GetOrAddCachedResource(connection, transaction, resourceKey);
+                    var cachedView = GetOrAddCachedResourceView(connection, transaction, cachedResource, resourceLogsItem.Resource.Attributes);
+                    resourceView = cachedView.View;
+                    resourceViewId = cachedView.ResourceViewId;
+                }
+                catch (Exception exception)
+                {
+                    context.FailureCount += resourceLogsItem.ScopeLogs.Sum(scope => scope.LogRecords.Count);
+                    _otlpContext.Logger.LogInformation(exception, "Error adding resource.");
+                    continue;
+                }
+                resourcesWithLogs.Add(cachedResource);
+
+                foreach (var scopeLogs in resourceLogsItem.ScopeLogs)
+                {
+                    OtlpScope scope;
+                    long scopeId;
+                    try
+                    {
+                        var cachedScope = GetOrAddCachedScope(connection, transaction, cachedResource, scopeLogs.Scope, CachedTelemetryType.Logs);
+                        scopeId = cachedScope.Scope.ScopeId;
+                        scope = cachedScope.Scope.Scope;
+                    }
+                    catch (Exception exception)
+                    {
+                        context.FailureCount += scopeLogs.LogRecords.Count;
+                        _otlpContext.Logger.LogInformation(exception, "Error adding log scope.");
+                        continue;
+                    }
+
+                    foreach (var record in scopeLogs.LogRecords)
+                    {
+                        try
+                        {
+                            pendingLogs.Add(new PendingLog(
+                                cachedResource.ResourceId,
+                                resourceViewId,
+                                scopeId,
+                                record,
+                                resourceView,
+                                scope,
+                                _otlpContext));
+                        }
+                        catch (Exception exception)
+                        {
+                            context.FailureCount++;
+                            _otlpContext.Logger.LogInformation(exception, "Error adding log entry.");
+                        }
+                    }
+                }
+            }
+
+            InsertLogs(connection, transaction, pendingLogs, addedLogs);
+            context.SuccessCount += pendingLogs.Count;
+            MarkResourcesHaveLogs(connection, transaction, resourcesWithLogs);
+            TrimLogsToCapacity(connection, transaction);
+            transaction.Commit();
+        }
+
+        return addedLogs;
+    }
+
+    private static void InsertLogs(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        List<PendingLog> logs,
+        List<OtlpLogEntry> addedLogs)
+    {
+        var logIds = SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            logs,
+            MaxLogBatchSize,
+            "telemetry_logs",
+            [
+                "resource_id", "resource_view_id", "scope_id", "timestamp_ticks", "flags", "severity",
+                "severity_name", "severity_number", "message", "span_id", "trace_id", "parent_id", "original_format", "event_name"
+            ],
+            "log_id",
+            static (pendingLog, parameters) =>
+            {
+                parameters[0].Value = pendingLog.ResourceId;
+                parameters[1].Value = pendingLog.ResourceViewId;
+                parameters[2].Value = pendingLog.ScopeId;
+                parameters[3].Value = pendingLog.TimeStamp.Ticks;
+                parameters[4].Value = (long)pendingLog.Flags;
+                parameters[5].Value = (int)pendingLog.Severity;
+                parameters[6].Value = pendingLog.Severity.ToString();
+                parameters[7].Value = pendingLog.SeverityNumber;
+                parameters[8].Value = pendingLog.Message;
+                parameters[9].Value = pendingLog.SpanId;
+                parameters[10].Value = pendingLog.TraceId;
+                parameters[11].Value = pendingLog.ParentId;
+                parameters[12].Value = pendingLog.OriginalFormat ?? (object)DBNull.Value;
+                parameters[13].Value = pendingLog.EventName ?? (object)DBNull.Value;
+            });
+
+        InsertLogAttributes(connection, transaction, logs, logIds);
+        for (var i = 0; i < logs.Count; i++)
+        {
+            addedLogs.Add(logs[i].CreateLogEntry(logIds[i]));
+        }
+    }
+
+    private static void InsertLogAttributes(SqliteConnection connection, IDbTransaction transaction, List<PendingLog> logs, List<long> logIds)
+    {
+        var attributes = logs
+            .SelectMany((pendingLog, logIndex) => pendingLog.Attributes.Select((attribute, ordinal) => (LogId: logIds[logIndex], Ordinal: ordinal, Attribute: attribute)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            attributes,
+            MaxLogAttributeBatchSize,
+            "telemetry_log_attributes",
+            ["log_id", "ordinal", "attribute_key", "attribute_value"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.LogId;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Attribute.Key;
+                parameters[3].Value = row.Attribute.Value;
+            });
+    }
+
+    private static void MarkResourcesHaveLogs(SqliteConnection connection, IDbTransaction transaction, HashSet<CachedResource> resources)
+    {
+        var resourcesToUpdate = resources.Where(resource => !resource.Resource.HasLogs).ToArray();
+        foreach (var batch in resourcesToUpdate.Chunk(MaxLogAttributeBatchSize))
+        {
+            connection.Execute(
+                "UPDATE telemetry_resources SET has_logs = 1 WHERE resource_id IN @ResourceIds;",
+                new { ResourceIds = batch.Select(resource => resource.ResourceId).ToArray() },
+                transaction);
+        }
+        foreach (var resource in resourcesToUpdate)
+        {
+            resource.Resource.HasLogs = true;
+        }
+    }
+
+    private void TrimLogsToCapacity(SqliteConnection connection, IDbTransaction transaction)
+    {
+        connection.Execute("""
+            DELETE FROM telemetry_logs
+            WHERE log_id IN (
+                SELECT log_id
+                FROM telemetry_logs
+                ORDER BY timestamp_ticks, log_id
+                LIMIT MAX((SELECT COUNT(*) FROM telemetry_logs) - @MaxLogCount, 0)
+            );
+            """, new { _otlpContext.Options.MaxLogCount }, transaction);
+    }
+
+    private PagedResult<OtlpLogEntry> GetLogsFromDatabase(GetLogsContext context, CancellationToken cancellationToken)
+    {
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var query = BuildLogQuery(context);
+        query.Parameters.Add("StartIndex", context.StartIndex);
+        query.Parameters.Add("Count", context.Count);
+        query.Parameters.Add("LatestItemCount", Math.Max(context.LatestItemCount ?? int.MaxValue, 0));
+        var recordsWithCount = connection.Query<long, LogRecord?, (long TotalItemCount, LogRecord? Record)>(
+            $"""
+            WITH
+            filtered_logs AS (
+                SELECT
+                    l.*,
+                    r.resource_name,
+                    r.instance_id,
+                    r.uninstrumented_peer,
+                    r.has_logs,
+                    r.has_traces,
+                    r.has_metrics,
+                    s.scope_name,
+                    s.scope_version
+                {query.FromAndWhere}
+            ),
+            log_aggregate AS (
+                SELECT COUNT(*) AS TotalItemCount
+                FROM filtered_logs
+            ),
+            paged_logs AS (
+                SELECT *
+                FROM filtered_logs
+                ORDER BY timestamp_ticks, log_id DESC
+                LIMIT @Count OFFSET @StartIndex + MAX((SELECT TotalItemCount FROM log_aggregate) - @LatestItemCount, 0)
+            )
+            SELECT
+                a.TotalItemCount,
+                pl.log_id AS LogId,
+                pl.resource_id AS ResourceId,
+                pl.resource_view_id AS ResourceViewId,
+                pl.scope_id AS ScopeId,
+                pl.timestamp_ticks AS TimestampTicks,
+                pl.flags AS Flags,
+                pl.severity AS Severity,
+                pl.severity_number AS SeverityNumber,
+                pl.message AS Message,
+                pl.span_id AS SpanId,
+                pl.trace_id AS TraceId,
+                pl.parent_id AS ParentId,
+                pl.original_format AS OriginalFormat,
+                pl.event_name AS EventName,
+                pl.resource_name AS ResourceName,
+                pl.instance_id AS InstanceId,
+                pl.uninstrumented_peer AS UninstrumentedPeer,
+                pl.has_logs AS HasLogs,
+                pl.has_traces AS HasTraces,
+                pl.has_metrics AS HasMetrics,
+                pl.scope_name AS ScopeName,
+                pl.scope_version AS ScopeVersion
+            FROM log_aggregate a
+            LEFT JOIN paged_logs pl ON 1 = 1
+            ORDER BY pl.timestamp_ticks, pl.log_id DESC;
+            """,
+            static (totalItemCount, record) => (totalItemCount, record),
+            query.Parameters,
+            splitOn: "LogId").AsList();
+
+        var totalCount = checked((int)recordsWithCount[0].TotalItemCount);
+        var records = recordsWithCount
+            .Where(item => item.Record is not null)
+            .Select(item => item.Record!)
+            .ToList();
+
+        return new PagedResult<OtlpLogEntry>
+        {
+            TotalItemCount = totalCount,
+            Items = MaterializeLogs(connection, records),
+            IsFull = totalCount >= _otlpContext.Options.MaxLogCount
+        };
+    }
+
+    private PagedResult<LogSummary> GetLogSummariesFromDatabase(GetLogsContext context, CancellationToken cancellationToken)
+    {
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var query = BuildLogQuery(context);
+        query.Parameters.Add("StartIndex", Math.Max(context.StartIndex, 0));
+        query.Parameters.Add("Count", Math.Max(context.Count, 0));
+        query.Parameters.Add("LatestItemCount", Math.Max(context.LatestItemCount ?? int.MaxValue, 0));
+        query.Parameters.Add("MaxLogCount", _otlpContext.Options.MaxLogCount);
+
+        // Return the aggregate and page display data together. Only attributes that affect the
+        // message column are aggregated, avoiding the extra materialization queries for every page.
+        var records = connection.Query<LogSummaryRecord>($"""
+            WITH
+            filtered_logs AS (
+                SELECT
+                    l.*,
+                    r.resource_name,
+                    r.instance_id,
+                    r.uninstrumented_peer,
+                    s.scope_name
+                {query.FromAndWhere}
+            ),
+            log_aggregate AS (
+                SELECT COUNT(*) AS TotalItemCount
+                FROM filtered_logs
+            ),
+            paged_logs AS (
+                SELECT *
+                FROM filtered_logs
+                ORDER BY timestamp_ticks, log_id DESC
+                LIMIT @Count OFFSET @StartIndex + MAX((SELECT TotalItemCount FROM log_aggregate) - @LatestItemCount, 0)
+            ),
+            log_attribute_summaries AS (
+                SELECT
+                    a.log_id,
+                    MAX(CASE WHEN a.attribute_key = 'exception.stacktrace' THEN a.attribute_value END) AS exception_stacktrace,
+                    MAX(CASE WHEN a.attribute_key = 'exception.message' THEN a.attribute_value END) AS exception_message,
+                    MAX(CASE WHEN a.attribute_key = 'exception.type' THEN a.attribute_value END) AS exception_type,
+                    MAX(CASE WHEN a.attribute_key = 'gen_ai.system' THEN 1 ELSE 0 END) AS has_gen_ai_system,
+                    MAX(CASE WHEN a.attribute_key = 'gen_ai.system' AND LENGTH(a.attribute_value) > 0 THEN 1 ELSE 0 END) AS has_non_empty_gen_ai_system,
+                    MAX(CASE WHEN a.attribute_key = 'gen_ai.provider.name' AND LENGTH(a.attribute_value) > 0 THEN 1 ELSE 0 END) AS has_non_empty_gen_ai_provider
+                FROM telemetry_log_attributes a
+                JOIN paged_logs pl ON pl.log_id = a.log_id
+                WHERE a.attribute_key IN (
+                    'exception.stacktrace',
+                    'exception.message',
+                    'exception.type',
+                    'gen_ai.system',
+                    'gen_ai.provider.name')
+                GROUP BY a.log_id
+            )
+            SELECT
+                a.TotalItemCount,
+                (SELECT COUNT(*) FROM telemetry_logs) >= @MaxLogCount AS IsFull,
+                pl.log_id AS InternalId,
+                pl.timestamp_ticks AS TimestampTicks,
+                pl.severity AS Severity,
+                pl.message AS Message,
+                pl.span_id AS SpanId,
+                pl.trace_id AS TraceId,
+                pl.scope_name AS ScopeName,
+                pl.event_name AS EventName,
+                pl.resource_id AS ResourceId,
+                pl.resource_name AS ResourceName,
+                pl.instance_id AS InstanceId,
+                pl.uninstrumented_peer AS UninstrumentedPeer,
+                CASE
+                    WHEN LENGTH(las.exception_stacktrace) > 0 THEN las.exception_stacktrace
+                    WHEN LENGTH(las.exception_message) > 0 AND LENGTH(las.exception_type) > 0 THEN las.exception_type || ': ' || las.exception_message
+                    WHEN LENGTH(las.exception_message) > 0 THEN las.exception_message
+                END AS ExceptionText,
+                                COALESCE(
+                                        CASE WHEN las.has_gen_ai_system = 1
+                                                THEN las.has_non_empty_gen_ai_system
+                                                ELSE las.has_non_empty_gen_ai_provider
+                                        END,
+                                        0) = 1 OR
+                                CASE WHEN EXISTS (
+                                        SELECT 1
+                                        FROM telemetry_span_attributes sa
+                                        WHERE sa.trace_id = pl.trace_id
+                                            AND sa.span_id = pl.span_id
+                                            AND sa.attribute_key = 'gen_ai.system'
+                                ) THEN EXISTS (
+                                        SELECT 1
+                                        FROM telemetry_span_attributes sa
+                                        WHERE sa.trace_id = pl.trace_id
+                                            AND sa.span_id = pl.span_id
+                                            AND sa.attribute_key = 'gen_ai.system'
+                                            AND LENGTH(sa.attribute_value) > 0
+                                ) ELSE EXISTS (
+                                        SELECT 1
+                                        FROM telemetry_span_attributes sa
+                                        WHERE sa.trace_id = pl.trace_id
+                                            AND sa.span_id = pl.span_id
+                                            AND sa.attribute_key = 'gen_ai.provider.name'
+                                            AND LENGTH(sa.attribute_value) > 0
+                                ) END AS HasGenAI
+            FROM log_aggregate a
+            LEFT JOIN paged_logs pl ON 1 = 1
+            LEFT JOIN log_attribute_summaries las ON las.log_id = pl.log_id
+            ORDER BY pl.timestamp_ticks, pl.log_id DESC;
+            """, query.Parameters).AsList();
+
+        var firstRecord = records[0];
+        return new PagedResult<LogSummary>
+        {
+            Items = records
+                .Where(record => record.InternalId is not null)
+                .Select(record => new LogSummary
+                {
+                    InternalId = record.InternalId!.Value,
+                    TimeStamp = new DateTime(record.TimestampTicks!.Value, DateTimeKind.Utc),
+                    Severity = (LogLevel)record.Severity!.Value,
+                    Message = record.Message!,
+                    SpanId = record.SpanId!,
+                    TraceId = record.TraceId!,
+                    ScopeName = record.ScopeName!,
+                    EventName = record.EventName,
+                    Resource = GetCachedResource(record.ResourceId!.Value)!,
+                    ExceptionText = record.ExceptionText,
+                    HasGenAI = record.HasGenAI!.Value
+                }).ToList(),
+            TotalItemCount = firstRecord.TotalItemCount,
+            IsFull = firstRecord.IsFull
+        };
+    }
+
+    private OtlpLogEntry? GetLogFromDatabase(long logId)
+    {
+        using var connection = _database.OpenConnection();
+        var records = connection.Query<LogRecord>("""
+            SELECT
+                l.log_id AS LogId,
+                l.resource_id AS ResourceId,
+                l.resource_view_id AS ResourceViewId,
+                l.scope_id AS ScopeId,
+                l.timestamp_ticks AS TimestampTicks,
+                l.flags AS Flags,
+                l.severity AS Severity,
+                l.severity_number AS SeverityNumber,
+                l.message AS Message,
+                l.span_id AS SpanId,
+                l.trace_id AS TraceId,
+                l.parent_id AS ParentId,
+                l.original_format AS OriginalFormat,
+                l.event_name AS EventName,
+                r.resource_name AS ResourceName,
+                r.instance_id AS InstanceId,
+                r.uninstrumented_peer AS UninstrumentedPeer,
+                r.has_logs AS HasLogs,
+                r.has_traces AS HasTraces,
+                r.has_metrics AS HasMetrics,
+                s.scope_name AS ScopeName,
+                s.scope_version AS ScopeVersion
+            FROM telemetry_logs l
+            JOIN telemetry_resources r ON r.resource_id = l.resource_id
+            JOIN telemetry_scopes s ON s.scope_id = l.scope_id
+            WHERE l.log_id = @LogId;
+            """, new { LogId = logId }).AsList();
+        return records.Count == 0 ? null : MaterializeLogs(connection, records)[0];
+    }
+
+    private List<string> GetLogPropertyKeysFromDatabase(ResourceKey? resourceKey, CancellationToken cancellationToken)
+    {
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var sql = new StringBuilder("""
+            SELECT DISTINCT a.attribute_key
+            FROM telemetry_log_attributes a
+            JOIN telemetry_logs l ON l.log_id = a.log_id
+            JOIN telemetry_resources r ON r.resource_id = l.resource_id
+            """);
+        var parameters = new DynamicParameters();
+        if (resourceKey is not null)
+        {
+            sql.Append(" WHERE r.resource_name = @ResourceName COLLATE NOCASE");
+            parameters.Add("ResourceName", resourceKey.Value.Name);
+            if (resourceKey.Value.InstanceId is not null)
+            {
+                sql.Append(" AND r.instance_id = @InstanceId COLLATE NOCASE");
+                parameters.Add("InstanceId", resourceKey.Value.InstanceId);
+            }
+        }
+        sql.Append(" ORDER BY a.attribute_key;");
+        var propertyKeys = connection.Query<string>(sql.ToString(), parameters);
+        return propertyKeys.AsList();
+    }
+
+    private Dictionary<string, int> GetLogsFieldValuesFromDatabase(string attributeName, CancellationToken cancellationToken)
+    {
+        if (attributeName == KnownStructuredLogFields.TimestampField)
+        {
+            return new Dictionary<string, int>(StringComparers.OtlpAttribute);
+        }
+
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var parameters = new DynamicParameters();
+        var expression = GetLogFieldExpression(attributeName, parameters, "FieldValue", coalesceMissing: false);
+        var values = connection.Query<FieldValueRecord>($"""
+            WITH field_values AS (
+                SELECT {expression} AS FieldValue
+                FROM telemetry_logs l
+                JOIN telemetry_resources r ON r.resource_id = l.resource_id
+                JOIN telemetry_scopes s ON s.scope_id = l.scope_id
+            )
+            SELECT FieldValue, COUNT(*) AS ValueCount
+            FROM field_values
+            WHERE FieldValue IS NOT NULL
+            GROUP BY FieldValue;
+            """, parameters);
+        return values.ToDictionary(record => record.FieldValue!, record => record.ValueCount, StringComparers.OtlpAttribute);
+    }
+
+    private static LogQuery BuildLogQuery(GetLogsContext context)
+    {
+        var parameters = new DynamicParameters();
+        var predicates = new List<string>();
+        if (context.ResourceKeys.Count > 0)
+        {
+            var resourcePredicates = new List<string>();
+            for (var i = 0; i < context.ResourceKeys.Count; i++)
+            {
+                var key = context.ResourceKeys[i];
+                var predicate = $"r.resource_name = @ResourceName{i} COLLATE NOCASE";
+                parameters.Add($"ResourceName{i}", key.Name);
+                if (key.InstanceId is not null)
+                {
+                    predicate += $" AND r.instance_id = @InstanceId{i} COLLATE NOCASE";
+                    parameters.Add($"InstanceId{i}", key.InstanceId);
+                }
+                resourcePredicates.Add($"({predicate})");
+            }
+            predicates.Add($"({string.Join(" OR ", resourcePredicates)})");
+        }
+
+        var filterIndex = 0;
+        foreach (var filter in context.Filters.Where(filter => filter.Enabled))
+        {
+            if (filter is not FieldTelemetryFilter fieldFilter)
+            {
+                throw new NotSupportedException($"Unsupported log filter type '{filter.GetType().Name}'.");
+            }
+            predicates.Add(BuildLogFilterPredicate(fieldFilter, parameters, filterIndex++));
+        }
+
+        if (context.TextFragments is { Length: > 0 })
+        {
+            for (var i = 0; i < context.TextFragments.Length; i++)
+            {
+                var parameterName = $"TextFragment{i}";
+                parameters.Add(parameterName, CreateContainsLikePattern(context.TextFragments[i]));
+                predicates.Add($$"""
+                    (
+                        l.message LIKE @{{parameterName}} ESCAPE '!'
+                        OR s.scope_name LIKE @{{parameterName}} ESCAPE '!'
+                        OR l.trace_id LIKE @{{parameterName}} ESCAPE '!'
+                        OR l.span_id LIKE @{{parameterName}} ESCAPE '!'
+                        OR l.severity_name LIKE @{{parameterName}} ESCAPE '!'
+                        OR r.resource_name LIKE @{{parameterName}} ESCAPE '!'
+                        OR COALESCE(l.event_name, '') LIKE @{{parameterName}} ESCAPE '!'
+                        OR EXISTS (
+                            SELECT 1
+                            FROM telemetry_log_attributes text_attribute
+                            WHERE text_attribute.log_id = l.log_id
+                              AND (
+                                  text_attribute.attribute_key LIKE @{{parameterName}} ESCAPE '!'
+                                  OR text_attribute.attribute_value LIKE @{{parameterName}} ESCAPE '!'
+                              )
+                        )
+                    )
+                    """);
+            }
+        }
+
+        var where = predicates.Count == 0 ? string.Empty : $" WHERE {string.Join(" AND ", predicates)}";
+        return new LogQuery($"""
+            FROM telemetry_logs l
+            JOIN telemetry_resources r ON r.resource_id = l.resource_id
+            JOIN telemetry_scopes s ON s.scope_id = l.scope_id
+            {where}
+            """, parameters);
+    }
+
+    private static string BuildLogFilterPredicate(FieldTelemetryFilter filter, DynamicParameters parameters, int index)
+    {
+        var parameterName = $"FilterValue{index}";
+        if (filter.Field == nameof(OtlpLogEntry.Severity))
+        {
+            if (!Enum.TryParse<LogLevel>(filter.Value, ignoreCase: true, out var severity))
+            {
+                return "1 = 1";
+            }
+            parameters.Add(parameterName, (int)severity);
+            return BuildNumericPredicate("l.severity", filter.Condition, parameterName);
+        }
+
+        if (filter.Field == nameof(OtlpLogEntry.TimeStamp))
+        {
+            var timestamp = DateTime.Parse(filter.Value, CultureInfo.InvariantCulture);
+            parameters.Add(parameterName, timestamp.Ticks);
+            return BuildNumericPredicate("l.timestamp_ticks", filter.Condition, parameterName);
+        }
+
+        if (filter.Field == KnownStructuredLogFields.TimestampField)
+        {
+            if (!DateTime.TryParse(filter.Value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeLocal, out var timestamp))
+            {
+                return "0 = 1";
+            }
+            parameters.Add(parameterName, timestamp.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond);
+            return BuildNumericPredicate($"l.timestamp_ticks / {TimeSpan.TicksPerMillisecond}", filter.Condition, parameterName);
+        }
+
+        var expression = GetLogFieldExpression(filter.Field, parameters, $"AttributeName{index}");
+        parameters.Add(
+            parameterName,
+            filter.Condition is FilterCondition.Contains or FilterCondition.NotContains
+                ? CreateContainsLikePattern(filter.Value)
+                : filter.Value);
+        return BuildStringPredicate(expression, filter.Condition, parameterName);
+    }
+
+    private static string GetLogFieldExpression(string field, DynamicParameters parameters, string attributeParameterName, bool coalesceMissing = true)
+    {
+        return field switch
+        {
+            nameof(OtlpLogEntry.Message) or KnownStructuredLogFields.MessageField => "l.message",
+            KnownStructuredLogFields.TraceIdField => "l.trace_id",
+            KnownStructuredLogFields.SpanIdField => "l.span_id",
+            KnownStructuredLogFields.OriginalFormatField => coalesceMissing ? "COALESCE(l.original_format, '')" : "l.original_format",
+            KnownStructuredLogFields.CategoryField => "s.scope_name",
+            KnownStructuredLogFields.EventNameField => coalesceMissing ? "COALESCE(l.event_name, '')" : "l.event_name",
+            KnownStructuredLogFields.LevelField => "l.severity_name",
+            KnownStructuredLogFields.TimestampField => $"CAST(l.timestamp_ticks / {TimeSpan.TicksPerMillisecond} AS TEXT)",
+            KnownResourceFields.ServiceNameField => "r.resource_name",
+            _ => GetAttributeExpression(field, parameters, attributeParameterName, coalesceMissing)
+        };
+
+        static string GetAttributeExpression(string field, DynamicParameters parameters, string parameterName, bool coalesceMissing)
+        {
+            parameters.Add(parameterName, field);
+            var expression = $"""
+                (
+                    SELECT attribute.attribute_value
+                    FROM telemetry_log_attributes attribute
+                    WHERE attribute.log_id = l.log_id
+                      AND attribute.attribute_key = @{parameterName}
+                    LIMIT 1
+                )
+                """;
+            return coalesceMissing ? $"COALESCE({expression}, '')" : expression;
+        }
+    }
+
+    private static string BuildStringPredicate(string expression, FilterCondition condition, string parameterName)
+    {
+        return condition switch
+        {
+            FilterCondition.Equals => $"{expression} = @{parameterName} COLLATE NOCASE",
+            FilterCondition.Contains => $"{expression} LIKE @{parameterName} ESCAPE '!'",
+            FilterCondition.GreaterThan or FilterCondition.LessThan or FilterCondition.GreaterThanOrEqual or FilterCondition.LessThanOrEqual => "0 = 1",
+            FilterCondition.NotEqual => $"{expression} <> @{parameterName} COLLATE NOCASE",
+            FilterCondition.NotContains => $"{expression} NOT LIKE @{parameterName} ESCAPE '!'",
+            _ => throw new ArgumentOutOfRangeException(nameof(condition), condition, null)
+        };
+    }
+
+    private static string BuildNumericPredicate(string expression, FilterCondition condition, string parameterName)
+    {
+        var operation = condition switch
+        {
+            FilterCondition.Equals => "=",
+            FilterCondition.GreaterThan => ">",
+            FilterCondition.LessThan => "<",
+            FilterCondition.GreaterThanOrEqual => ">=",
+            FilterCondition.LessThanOrEqual => "<=",
+            FilterCondition.NotEqual => "<>",
+            FilterCondition.Contains or FilterCondition.NotContains => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(condition), condition, null)
+        };
+        return operation is null ? "0 = 1" : $"{expression} {operation} @{parameterName}";
+    }
+
+    private List<OtlpLogEntry> MaterializeLogs(SqliteConnection connection, List<LogRecord> records)
+    {
+        if (records.Count == 0)
+        {
+            return [];
+        }
+
+        var logIds = records.Select(record => record.LogId).Distinct().ToArray();
+        var attributeRecords = new List<OwnedAttributeRecord>();
+        foreach (var logIdBatch in logIds.Chunk(MaxLogAttributeReadBatchSize))
+        {
+            attributeRecords.AddRange(connection.Query<OwnedAttributeRecord>("""
+                SELECT log_id AS OwnerId, attribute_key AS AttributeKey, attribute_value AS AttributeValue
+                FROM telemetry_log_attributes
+                WHERE log_id IN @Ids
+                ORDER BY log_id, ordinal;
+                """, new { Ids = logIdBatch }));
+        }
+        var logAttributes = attributeRecords.ToLookup(record => record.OwnerId);
+        var results = new List<OtlpLogEntry>(records.Count);
+        foreach (var record in records)
+        {
+            var (_, view, scope) = GetCachedTelemetryMetadata(record.ResourceId, record.ResourceViewId, record.ScopeId, CachedTelemetryType.Logs);
+
+            results.Add(new OtlpLogEntry(
+                record.LogId,
+                new DateTime(record.TimestampTicks, DateTimeKind.Utc),
+                checked((uint)record.Flags),
+                (LogLevel)record.Severity,
+                record.SeverityNumber,
+                record.Message,
+                record.SpanId,
+                record.TraceId,
+                record.ParentId,
+                record.OriginalFormat,
+                view,
+                scope,
+                ToPairs(logAttributes[record.LogId]),
+                record.EventName));
+        }
+
+        return results;
+
+        static KeyValuePair<string, string>[] ToPairs(IEnumerable<OwnedAttributeRecord> attributes)
+        {
+            return attributes.Select(attribute => KeyValuePair.Create(attribute.AttributeKey, attribute.AttributeValue)).ToArray();
+        }
+    }
+
+    private async Task ClearSelectedLogsFromDatabaseAsync(Dictionary<string, HashSet<AspireDataType>> selectedResources)
+    {
+        EnsureWritable();
+        using var connection = _database.OpenConnection();
+        var resources = connection.Query<TelemetryResourceRecord>("""
+            SELECT resource_name AS ResourceName, instance_id AS InstanceId
+            FROM telemetry_resources;
+            """);
+        foreach (var resource in resources)
+        {
+            var key = new ResourceKey(resource.ResourceName, resource.InstanceId);
+            if (!selectedResources.TryGetValue(key.GetCompositeName(), out var dataTypes))
+            {
+                continue;
+            }
+
+            if (dataTypes.Contains(AspireDataType.Resource))
+            {
+                await DeleteTelemetryResourceFromDatabaseAsync(key).ConfigureAwait(false);
+            }
+            else if (dataTypes.Contains(AspireDataType.StructuredLogs))
+            {
+                await ClearStructuredLogsFromDatabaseAsync(key).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task ClearStructuredLogsFromDatabaseAsync(ResourceKey? resourceKey)
+    {
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            var parameters = new DynamicParameters();
+            var where = string.Empty;
+            if (resourceKey is not null)
+            {
+                where = " WHERE resource_name = @ResourceName COLLATE NOCASE";
+                parameters.Add("ResourceName", resourceKey.Value.Name);
+                if (resourceKey.Value.InstanceId is not null)
+                {
+                    where += " AND instance_id = @InstanceId COLLATE NOCASE";
+                    parameters.Add("InstanceId", resourceKey.Value.InstanceId);
+                }
+            }
+
+            connection.Execute($"""
+                DELETE FROM telemetry_logs
+                WHERE resource_id IN (SELECT resource_id FROM telemetry_resources{where});
+
+                UPDATE telemetry_resources
+                SET has_logs = EXISTS (SELECT 1 FROM telemetry_logs WHERE telemetry_logs.resource_id = telemetry_resources.resource_id);
+                """, parameters, transaction);
+            DeleteOrphanedScopes(connection, transaction);
+            transaction.Commit();
+            ClearMetadataCache();
+        }
+    }
+
+    private sealed record LogQuery(string FromAndWhere, DynamicParameters Parameters);
+
+    private sealed class PendingLog : OtlpLogEntryData
+    {
+        public PendingLog(
+            long resourceId,
+            long resourceViewId,
+            long scopeId,
+            OpenTelemetry.Proto.Logs.V1.LogRecord record,
+            OtlpResourceView resourceView,
+            OtlpScope scope,
+            OtlpContext context) : base(record, resourceView, scope, context)
+        {
+            ResourceId = resourceId;
+            ResourceViewId = resourceViewId;
+            ScopeId = scopeId;
+        }
+
+        public long ResourceId { get; }
+        public long ResourceViewId { get; }
+        public long ScopeId { get; }
+    }
+
+    private class AttributeRecord
+    {
+        public required string AttributeKey { get; init; }
+        public required string AttributeValue { get; init; }
+    }
+
+    private sealed class OwnedAttributeRecord : AttributeRecord
+    {
+        public required long OwnerId { get; init; }
+    }
+
+    private sealed class LogRecord
+    {
+        public required long LogId { get; init; }
+        public required long ResourceId { get; init; }
+        public required long ResourceViewId { get; init; }
+        public required long ScopeId { get; init; }
+        public required long TimestampTicks { get; init; }
+        public required long Flags { get; init; }
+        public required int Severity { get; init; }
+        public required int SeverityNumber { get; init; }
+        public required string Message { get; init; }
+        public required string SpanId { get; init; }
+        public required string TraceId { get; init; }
+        public required string ParentId { get; init; }
+        public string? OriginalFormat { get; init; }
+        public string? EventName { get; init; }
+        public required string ResourceName { get; init; }
+        public string? InstanceId { get; init; }
+        public required bool UninstrumentedPeer { get; init; }
+        public required bool HasLogs { get; init; }
+        public required bool HasTraces { get; init; }
+        public required bool HasMetrics { get; init; }
+        public required string ScopeName { get; init; }
+        public required string ScopeVersion { get; init; }
+    }
+
+    private sealed class LogSummaryRecord
+    {
+        public required int TotalItemCount { get; init; }
+        public required bool IsFull { get; init; }
+        public long? InternalId { get; init; }
+        public long? TimestampTicks { get; init; }
+        public int? Severity { get; init; }
+        public string? Message { get; init; }
+        public string? SpanId { get; init; }
+        public string? TraceId { get; init; }
+        public string? ScopeName { get; init; }
+        public string? EventName { get; init; }
+        public long? ResourceId { get; init; }
+        public string? ResourceName { get; init; }
+        public string? InstanceId { get; init; }
+        public bool? UninstrumentedPeer { get; init; }
+        public string? ExceptionText { get; init; }
+        public bool? HasGenAI { get; init; }
+    }
+
+    private sealed class FieldValueRecord
+    {
+        public string? FieldValue { get; init; }
+        public required int ValueCount { get; init; }
+    }
+
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Metrics.Reads.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Metrics.Reads.cs
@@ -1,0 +1,518 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Dapper;
+using Microsoft.Data.Sqlite;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public sealed partial class SqliteTelemetryRepository
+{
+    private const int MaxMetricReadBatchSize = 500;
+    private const string MetricPointRangeFilterSql = "p.start_time_ticks <= @EndTicks AND p.end_time_ticks >= r.start_time_ticks";
+    private const string MetricSourcePointRangeFilterSql = "source.start_time_ticks <= @EndTicks AND source.end_time_ticks >= r.start_time_ticks";
+    private const string SelectedMetricPointsCteSql = $"""
+        selected_metric_points AS (
+            SELECT
+                p.point_id,
+                p.dimension_id,
+                p.point_type,
+                p.start_time_ticks,
+                p.end_time_ticks,
+                p.repeat_count,
+                p.integer_value,
+                p.double_value,
+                p.histogram_sum,
+                p.histogram_count
+            FROM telemetry_metric_points p
+            JOIN metric_dimension_query_ranges r ON r.dimension_id = p.dimension_id
+            WHERE {MetricPointRangeFilterSql}
+        )
+        """;
+    private const string EffectiveMetricPointsCteSql = $"""
+        {SelectedMetricPointsCteSql},
+        ranked_metric_points AS (
+            SELECT
+                p.*,
+                ROW_NUMBER() OVER (
+                    PARTITION BY p.start_time_ticks, p.dimension_id
+                    ORDER BY p.point_id DESC) AS point_rank
+            FROM selected_metric_points p
+        ),
+        effective_metric_points AS (
+            SELECT *
+            FROM ranked_metric_points
+            WHERE point_rank = 1
+        )
+        """;
+    private static readonly string s_rolledUpMetricPointsCteSql = $"""
+        {EffectiveMetricPointsCteSql},
+        bucketed_metric_points AS (
+            SELECT
+                p.*,
+                (p.start_time_ticks / @PointIntervalTicks) * @PointIntervalTicks AS rollup_start_time_ticks
+            FROM effective_metric_points p
+        ),
+        ranked_rollup_metric_points AS (
+            SELECT
+                p.*,
+                MAX(p.end_time_ticks) OVER (
+                    PARTITION BY p.dimension_id, p.point_type, p.rollup_start_time_ticks) AS rollup_end_time_ticks,
+                SUM(p.repeat_count) OVER (
+                    PARTITION BY p.dimension_id, p.point_type, p.rollup_start_time_ticks) AS rollup_repeat_count,
+                ROW_NUMBER() OVER (
+                    PARTITION BY p.dimension_id, p.point_type, p.rollup_start_time_ticks
+                    ORDER BY
+                        CASE WHEN p.point_type = {HistogramPointType} THEN p.start_time_ticks END DESC,
+                        p.integer_value DESC,
+                        p.double_value DESC,
+                        p.point_id DESC) AS rollup_rank
+            FROM bucketed_metric_points p
+        ),
+        rolled_up_metric_points AS (
+            SELECT
+                p.point_id,
+                p.dimension_id,
+                p.point_type,
+                p.rollup_start_time_ticks AS start_time_ticks,
+                p.rollup_end_time_ticks AS end_time_ticks,
+                p.rollup_repeat_count AS repeat_count,
+                p.integer_value,
+                p.double_value,
+                p.histogram_sum,
+                p.histogram_count
+            FROM ranked_rollup_metric_points p
+            WHERE p.rollup_rank = 1
+        )
+        """;
+    private const string FullFidelityMetricPointsCteSql = $"""
+        {EffectiveMetricPointsCteSql},
+        rolled_up_metric_points AS (
+            SELECT
+                p.point_id,
+                p.dimension_id,
+                p.point_type,
+                p.start_time_ticks,
+                p.end_time_ticks,
+                p.repeat_count,
+                p.integer_value,
+                p.double_value,
+                p.histogram_sum,
+                p.histogram_count
+            FROM effective_metric_points p
+        )
+        """;
+
+    private OtlpInstrumentData? GetInstrumentFromDatabase(GetInstrumentRequest request, CancellationToken cancellationToken)
+    {
+        var instruments = GetCachedInstruments(request.ResourceKey, request.MeterName, request.InstrumentName);
+        if (instruments.Count == 0)
+        {
+            return null;
+        }
+
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var knownAttributeValues = new Dictionary<string, List<string?>>();
+        var dimensions = MaterializeMetricDimensions(
+            connection,
+            instruments,
+            request.StartTime,
+            request.EndTime,
+            request.DimensionFilters,
+            request.DimensionCursors,
+            request.DataPointInterval,
+            request.IncludeExemplars,
+            request.PopulateExemplarAttributes,
+            knownAttributeValues,
+            out var hasOverflow);
+        return new OtlpInstrumentData
+        {
+            Summary = instruments[0].Summary,
+            Dimensions = dimensions,
+            KnownAttributeValues = knownAttributeValues,
+            HasOverflow = hasOverflow
+        };
+    }
+
+    private DateTime? GetInstrumentLatestEndTimeFromDatabase(ResourceKey resourceKey, string meterName, string instrumentName)
+    {
+        using var connection = _database.OpenConnection();
+        var endTimeTicks = connection.QuerySingleOrDefault<long?>("""
+            SELECT MAX(p.end_time_ticks)
+            FROM telemetry_metric_points p
+            JOIN telemetry_metric_dimensions d ON d.dimension_id = p.dimension_id
+            JOIN telemetry_metric_instruments i ON i.instrument_id = d.instrument_id
+            JOIN telemetry_resources r ON r.resource_id = i.resource_id
+            JOIN telemetry_scopes s ON s.scope_id = i.scope_id
+            WHERE r.resource_name = @ResourceName COLLATE NOCASE
+                            AND (@InstanceId IS NULL OR r.instance_id = @InstanceId COLLATE NOCASE)
+              AND s.scope_name = @MeterName
+              AND i.instrument_name = @InstrumentName;
+            """, new { ResourceName = resourceKey.Name, resourceKey.InstanceId, MeterName = meterName, InstrumentName = instrumentName });
+        return endTimeTicks is not null ? new DateTime(endTimeTicks.Value, DateTimeKind.Utc) : null;
+    }
+
+    private List<DimensionScope> MaterializeMetricDimensions(
+        SqliteConnection connection,
+        IReadOnlyList<CachedInstrument> instruments,
+        DateTime? startTime,
+        DateTime? endTime,
+        IReadOnlyDictionary<string, IReadOnlyList<string?>> dimensionFilters,
+        IReadOnlyList<MetricDimensionCursor> dimensionCursors,
+        TimeSpan? dataPointInterval,
+        bool includeExemplars,
+        bool populateExemplarAttributes,
+        Dictionary<string, List<string?>> knownAttributeValues,
+        out bool hasOverflow)
+    {
+        if (dataPointInterval is { } interval && interval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dataPointInterval), interval, "The metric data point interval must be greater than zero.");
+        }
+
+        var dimensions = GetMetricDimensions(
+            connection,
+            instruments,
+            dimensionFilters,
+            knownAttributeValues,
+            out hasOverflow);
+        if (dimensions.Count == 0)
+        {
+            return [];
+        }
+
+        var results = dimensions
+            .Select(dimension => dimension.Scope)
+            .ToList();
+        if (startTime is null || endTime is null)
+        {
+            return results;
+        }
+
+        var queryParameters = new DynamicParameters();
+        queryParameters.Add("EndTicks", endTime.Value.Ticks);
+        queryParameters.Add("PointIntervalTicks", dataPointInterval?.Ticks ?? 0);
+        var dimensionQueryRangesCteSql = CreateMetricDimensionQueryRangesCte(
+            dimensions,
+            dimensionCursors,
+            startTime,
+            queryParameters);
+        var metricPointsCteSql = dataPointInterval is null ? FullFidelityMetricPointsCteSql : s_rolledUpMetricPointsCteSql;
+        var pointRecords = connection.Query<MetricPointDataRecord>($"""
+            WITH {dimensionQueryRangesCteSql},
+            {metricPointsCteSql}
+            SELECT
+                p.point_id AS PointId,
+                p.dimension_id AS DimensionId,
+                p.point_type AS PointType,
+                p.start_time_ticks AS StartTimeTicks,
+                p.end_time_ticks AS EndTimeTicks,
+                p.repeat_count AS RepeatCount,
+                p.integer_value AS IntegerValue,
+                p.double_value AS DoubleValue,
+                p.histogram_sum AS HistogramSum,
+                p.histogram_count AS HistogramCount,
+                stored.bucket_counts AS BucketCounts,
+                stored.explicit_bounds AS ExplicitBounds
+            FROM rolled_up_metric_points p
+            JOIN telemetry_metric_points stored ON stored.point_id = p.point_id
+            ORDER BY p.dimension_id, p.start_time_ticks, p.point_id;
+            """, queryParameters).AsList();
+        var points = pointRecords.ToLookup(record => record.DimensionId);
+        var exemplars = includeExemplars
+            ? MaterializeMetricExemplars(
+                connection,
+                dimensionQueryRangesCteSql,
+                queryParameters,
+                dataPointInterval,
+                pointRecords,
+                populateExemplarAttributes)
+            : Array.Empty<KeyValuePair<long, MetricsExemplar>>().ToLookup(pair => pair.Key, pair => pair.Value);
+
+        for (var dimensionIndex = 0; dimensionIndex < dimensions.Count; dimensionIndex++)
+        {
+            var dimensionId = dimensions[dimensionIndex].DimensionId;
+            var dimension = results[dimensionIndex];
+            foreach (var point in points[dimensionId])
+            {
+                MetricValueBase value = point.PointType switch
+                {
+                    LongPointType => new MetricValue<long>(point.IntegerValue!.Value, new DateTime(point.StartTimeTicks, DateTimeKind.Utc), new DateTime(point.EndTimeTicks, DateTimeKind.Utc)),
+                    DoublePointType => new MetricValue<double>(point.DoubleValue!.Value, new DateTime(point.StartTimeTicks, DateTimeKind.Utc), new DateTime(point.EndTimeTicks, DateTimeKind.Utc)),
+                    HistogramPointType => CreateHistogramValue(point),
+                    _ => throw new InvalidOperationException($"Unknown metric point type '{point.PointType}'.")
+                };
+                if (point.PointType != HistogramPointType)
+                {
+                    value.Count = checked((ulong)point.RepeatCount);
+                }
+                value.Exemplars.AddRange(exemplars[point.PointId]);
+                dimension.Values.Add(value);
+            }
+        }
+        return results;
+    }
+
+    private List<StoredMetricDimension> GetMetricDimensions(
+        SqliteConnection connection,
+        IReadOnlyList<CachedInstrument> instruments,
+        IReadOnlyDictionary<string, IReadOnlyList<string?>> dimensionFilters,
+        Dictionary<string, List<string?>> knownAttributeValues,
+        out bool hasOverflow)
+    {
+        var dimensionRecords = connection.Query<MetricDimensionAttributeRecord>("""
+            SELECT
+                d.dimension_id AS DimensionId,
+                d.instrument_id AS InstrumentId,
+                a.attribute_key AS AttributeKey,
+                a.attribute_value AS AttributeValue
+            FROM telemetry_metric_dimensions d
+            LEFT JOIN telemetry_metric_dimension_attributes a ON a.dimension_id = d.dimension_id
+            WHERE d.instrument_id IN @InstrumentIds
+            ORDER BY d.dimension_id, a.ordinal;
+            """, new { InstrumentIds = instruments.Select(instrument => instrument.InstrumentId) }).AsList();
+        var dimensionIds = dimensionRecords.Select(record => record.DimensionId).Distinct().ToArray();
+        var pointAttributes = dimensionRecords
+            .Where(record => record.AttributeKey is not null)
+            .Select(record => new OwnedAttributeRecord
+            {
+                OwnerId = record.DimensionId,
+                AttributeKey = record.AttributeKey!,
+                AttributeValue = record.AttributeValue!
+            })
+            .ToLookup(record => record.OwnerId);
+        hasOverflow = dimensionIds.Any(dimensionId => IsOverflowDimension(pointAttributes[dimensionId]));
+        var instrumentsById = instruments.ToDictionary(instrument => instrument.InstrumentId);
+        var instrumentIdsByDimensionId = dimensionRecords
+            .DistinctBy(record => record.DimensionId)
+            .ToDictionary(record => record.DimensionId, record => record.InstrumentId);
+        // Dimension rows store only point attributes. Scope attributes are stored once with the scope and merged here for display and filtering.
+        var attributes = dimensionIds
+            .SelectMany(dimensionId => pointAttributes[dimensionId]
+                .Select(attribute => KeyValuePair.Create(attribute.AttributeKey, attribute.AttributeValue))
+                .Concat(instrumentsById[instrumentIdsByDimensionId[dimensionId]].Summary.Parent.Attributes)
+                .Select(attribute => new OwnedAttributeRecord
+                {
+                    OwnerId = dimensionId,
+                    AttributeKey = attribute.Key,
+                    AttributeValue = attribute.Value
+                }))
+            .ToLookup(record => record.OwnerId);
+        PopulateKnownAttributeValues(dimensionIds, attributes, knownAttributeValues);
+
+        return dimensionIds
+            .Where(dimensionId => MatchesDimensionFilters(attributes[dimensionId], dimensionFilters))
+            .Select(dimensionId => new StoredMetricDimension(
+                dimensionId,
+                new DimensionScope(
+                    _otlpContext.Options.MaxMetricsCount,
+                    attributes[dimensionId].Select(attribute => KeyValuePair.Create(attribute.AttributeKey, attribute.AttributeValue)).ToArray())))
+            .ToList();
+    }
+
+    private static bool IsOverflowDimension(IEnumerable<OwnedAttributeRecord> attributes)
+    {
+        using var enumerator = attributes.GetEnumerator();
+        return enumerator.MoveNext() &&
+            enumerator.Current is { AttributeKey: "otel.metric.overflow", AttributeValue: "true" } &&
+            !enumerator.MoveNext();
+    }
+
+    private static string CreateMetricDimensionQueryRangesCte(
+        IReadOnlyList<StoredMetricDimension> dimensions,
+        IReadOnlyList<MetricDimensionCursor> dimensionCursors,
+        DateTime? defaultStartTime,
+        DynamicParameters queryParameters)
+    {
+        var sql = new StringBuilder("metric_dimension_query_ranges(dimension_id, start_time_ticks) AS (VALUES ");
+        for (var i = 0; i < dimensions.Count; i++)
+        {
+            if (i > 0)
+            {
+                sql.Append(", ");
+            }
+
+            var dimension = dimensions[i];
+            var cursor = dimensionCursors.FirstOrDefault(cursor =>
+                cursor.Attributes.SequenceEqual(dimension.Scope.Attributes));
+            queryParameters.Add($"DimensionId{i}", dimension.DimensionId);
+            queryParameters.Add($"DimensionStartTicks{i}", cursor?.StartTime.Ticks ?? defaultStartTime?.Ticks ?? 0);
+            sql.Append(CultureInfo.InvariantCulture, $"(@DimensionId{i}, @DimensionStartTicks{i})");
+        }
+        sql.Append(')');
+        return sql.ToString();
+    }
+
+    private static bool MatchesDimensionFilters(IEnumerable<OwnedAttributeRecord> attributes, IReadOnlyDictionary<string, IReadOnlyList<string?>> dimensionFilters)
+    {
+        foreach (var (key, values) in dimensionFilters)
+        {
+            var value = attributes.FirstOrDefault(attribute => attribute.AttributeKey == key)?.AttributeValue;
+            if (!values.Contains(value))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void PopulateKnownAttributeValues(
+        IReadOnlyList<long> dimensionIds,
+        ILookup<long, OwnedAttributeRecord> attributes,
+        Dictionary<string, List<string?>> knownAttributeValues)
+    {
+        // Point and scope attributes were already accepted during ingestion, so intentionally do not limit their
+        // merged key or per-key value counts while building display metadata.
+        for (var dimensionIndex = 0; dimensionIndex < dimensionIds.Count; dimensionIndex++)
+        {
+            var dimensionId = dimensionIds[dimensionIndex];
+            foreach (var key in knownAttributeValues.Keys.Union(attributes[dimensionId].Select(attribute => attribute.AttributeKey)).Distinct().ToList())
+            {
+                if (!knownAttributeValues.TryGetValue(key, out var values))
+                {
+                    values = [];
+                    knownAttributeValues.Add(key, values);
+                    if (dimensionIndex > 0)
+                    {
+                        TryAddValue(values, null);
+                    }
+                }
+                var value = attributes[dimensionId].FirstOrDefault(attribute => attribute.AttributeKey == key)?.AttributeValue;
+                TryAddValue(values, value);
+            }
+        }
+
+        static void TryAddValue(List<string?> values, string? value)
+        {
+            if (!values.Contains(value))
+            {
+                values.Add(value);
+            }
+        }
+    }
+
+    private static HistogramValue CreateHistogramValue(MetricPointDataRecord point) => new(
+        UnpackUInt64Values(point.BucketCounts!),
+        point.HistogramSum!.Value,
+        checked((ulong)point.HistogramCount!.Value),
+        new DateTime(point.StartTimeTicks, DateTimeKind.Utc),
+        new DateTime(point.EndTimeTicks, DateTimeKind.Utc),
+        UnpackDoubleValues(point.ExplicitBounds!));
+
+    private static ILookup<long, MetricsExemplar> MaterializeMetricExemplars(
+        SqliteConnection connection,
+        string dimensionQueryRangesCteSql,
+        DynamicParameters queryParameters,
+        TimeSpan? dataPointInterval,
+        IReadOnlyList<MetricPointDataRecord> points,
+        bool populateExemplarAttributes)
+    {
+        var records = connection.Query<MetricExemplarRecord>($"""
+            WITH {dimensionQueryRangesCteSql}
+            SELECT
+                e.exemplar_id AS ExemplarId,
+                source.dimension_id AS DimensionId,
+                source.point_type AS PointType,
+                source.start_time_ticks AS SourceStartTimeTicks,
+                e.start_time_ticks AS StartTimeTicks,
+                e.exemplar_value AS ExemplarValue,
+                e.span_id AS SpanId,
+                e.trace_id AS TraceId
+            FROM telemetry_metric_exemplars e
+            JOIN telemetry_metric_points source ON source.point_id = e.point_id
+            JOIN metric_dimension_query_ranges r ON r.dimension_id = source.dimension_id
+            WHERE {MetricSourcePointRangeFilterSql}
+              AND e.start_time_ticks >= r.start_time_ticks
+              AND e.start_time_ticks <= @EndTicks
+            ORDER BY source.dimension_id, source.start_time_ticks, e.exemplar_id;
+            """, queryParameters).AsList();
+        var pointIds = points.ToDictionary(
+            point => new MetricPointKey(point.DimensionId, point.PointType, point.StartTimeTicks),
+            point => point.PointId);
+        var pointIntervalTicks = dataPointInterval?.Ticks;
+        var mappedRecords = new List<(long PointId, MetricExemplarRecord Record)>();
+        foreach (var record in records)
+        {
+            var rollupStartTimeTicks = pointIntervalTicks is { } intervalTicks
+                ? (record.SourceStartTimeTicks / intervalTicks) * intervalTicks
+                : record.SourceStartTimeTicks;
+            if (pointIds.TryGetValue(new MetricPointKey(record.DimensionId, record.PointType, rollupStartTimeTicks), out var pointId))
+            {
+                mappedRecords.Add((pointId, record));
+            }
+        }
+        var attributes = populateExemplarAttributes
+            ? MaterializeMetricExemplarAttributes(connection, mappedRecords.Select(item => item.Record.ExemplarId).Distinct().ToArray())
+            : Array.Empty<OwnedAttributeRecord>().ToLookup(record => record.OwnerId);
+        return mappedRecords
+            .OrderBy(item => item.PointId)
+            .ThenBy(item => item.Record.ExemplarId)
+            .Select(item => new KeyValuePair<long, MetricsExemplar>(
+                item.PointId,
+                new MetricsExemplar
+                {
+                    Start = new DateTime(item.Record.StartTimeTicks, DateTimeKind.Utc),
+                    Value = item.Record.ExemplarValue,
+                    SpanId = item.Record.SpanId,
+                    TraceId = item.Record.TraceId,
+                    Attributes = attributes[item.Record.ExemplarId].Select(attribute => KeyValuePair.Create(attribute.AttributeKey, attribute.AttributeValue)).ToArray()
+                }))
+            .ToLookup(pair => pair.Key, pair => pair.Value);
+    }
+
+    private static ILookup<long, OwnedAttributeRecord> MaterializeMetricExemplarAttributes(
+        SqliteConnection connection,
+        IReadOnlyList<long> exemplarIds)
+    {
+        var attributes = new List<OwnedAttributeRecord>();
+        foreach (var exemplarIdBatch in exemplarIds.Chunk(MaxMetricReadBatchSize))
+        {
+            attributes.AddRange(connection.Query<OwnedAttributeRecord>("""
+                SELECT exemplar_id AS OwnerId, attribute_key AS AttributeKey, attribute_value AS AttributeValue
+                FROM telemetry_metric_exemplar_attributes
+                WHERE exemplar_id IN @ExemplarIds
+                ORDER BY exemplar_id, ordinal;
+                """, new { ExemplarIds = exemplarIdBatch }));
+        }
+        return attributes.ToLookup(record => record.OwnerId);
+    }
+
+    private sealed class MetricPointDataRecord : MetricPointRecord
+    {
+        public required long DimensionId { get; init; }
+        public required long StartTimeTicks { get; init; }
+        public required long RepeatCount { get; init; }
+        public double? HistogramSum { get; init; }
+        public byte[]? BucketCounts { get; init; }
+        public byte[]? ExplicitBounds { get; init; }
+    }
+
+    private sealed class MetricDimensionAttributeRecord
+    {
+        public required long DimensionId { get; init; }
+        public required long InstrumentId { get; init; }
+        public string? AttributeKey { get; init; }
+        public string? AttributeValue { get; init; }
+    }
+
+    private sealed class MetricExemplarRecord
+    {
+        public required long ExemplarId { get; init; }
+        public required long DimensionId { get; init; }
+        public required int PointType { get; init; }
+        public required long SourceStartTimeTicks { get; init; }
+        public required long StartTimeTicks { get; init; }
+        public required double ExemplarValue { get; init; }
+        public required string SpanId { get; init; }
+        public required string TraceId { get; init; }
+    }
+
+    private sealed record StoredMetricDimension(long DimensionId, DimensionScope Scope);
+
+    private readonly record struct MetricPointKey(long DimensionId, int PointType, long StartTimeTicks);
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Metrics.Writes.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Metrics.Writes.cs
@@ -1,0 +1,964 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Data;
+using System.Globalization;
+using System.IO.Hashing;
+using System.Text;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Dapper;
+using Google.Protobuf.Collections;
+using Microsoft.Data.Sqlite;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public sealed partial class SqliteTelemetryRepository
+{
+    private const int LongPointType = 1;
+    private const int DoublePointType = 2;
+    private const int HistogramPointType = 3;
+    private const int MaxMetricPointBatchSize = 100;
+
+    private readonly MetricIngestionState _metricIngestionState = new();
+
+    private async Task AddMetricsToDatabaseAsync(AddContext context, RepeatedField<ResourceMetrics> resourceMetrics)
+    {
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            _metricIngestionState.DimensionsToTrim.Clear();
+            _metricIngestionState.PendingDimensions.Clear();
+            _metricIngestionState.PendingDimensionAttributes.Clear();
+            try
+            {
+                using var connection = _database.OpenConnection();
+                using var transaction = connection.BeginTransaction();
+                var pointBatch = new MetricPointBatch();
+                foreach (var resourceMetricsItem in resourceMetrics)
+                {
+                    CachedResource cachedResource;
+                    CachedResourceView cachedView;
+                    try
+                    {
+                        cachedResource = GetOrAddCachedResource(connection, transaction, resourceMetricsItem.Resource.GetResourceKey());
+                        cachedView = GetOrAddCachedResourceView(connection, transaction, cachedResource, resourceMetricsItem.Resource.Attributes);
+                    }
+                    catch (Exception exception)
+                    {
+                        context.FailureCount += resourceMetricsItem.ScopeMetrics.Sum(scope => scope.Metrics.Sum(OtlpHelpers.GetMetricDataPointCount));
+                        _otlpContext.Logger.LogInformation(exception, "Error adding resource.");
+                        continue;
+                    }
+
+                    foreach (var scopeMetrics in resourceMetricsItem.ScopeMetrics)
+                    {
+                        CachedResourceScope cachedScope;
+                        try
+                        {
+                            cachedScope = GetOrAddCachedScope(connection, transaction, cachedResource, scopeMetrics.Scope, CachedTelemetryType.Metrics);
+                        }
+                        catch (Exception exception)
+                        {
+                            context.FailureCount += scopeMetrics.Metrics.Sum(OtlpHelpers.GetMetricDataPointCount);
+                            _otlpContext.Logger.LogInformation(exception, "Error adding metric scope.");
+                            continue;
+                        }
+
+                        EnsureCachedInstruments(connection, transaction, cachedResource, cachedView, cachedScope, scopeMetrics.Metrics);
+                        foreach (var metric in scopeMetrics.Metrics)
+                        {
+                            AddMetricToDatabase(connection, transaction, context, cachedResource, cachedView, cachedScope, metric, _metricIngestionState, pointBatch);
+                        }
+                    }
+
+                    if (!cachedResource.Resource.HasMetrics)
+                    {
+                        connection.Execute(
+                            "UPDATE telemetry_resources SET has_metrics = 1 WHERE resource_id = @ResourceId;",
+                            new { cachedResource.ResourceId },
+                            transaction);
+                        cachedResource.Resource.HasMetrics = true;
+                    }
+                }
+
+                InsertMetricDimensions(connection, transaction, _metricIngestionState.PendingDimensions);
+                InsertMetricDimensionAttributes(connection, transaction, _metricIngestionState.PendingDimensionAttributes);
+                ExecuteMetricPointBatch(connection, transaction, pointBatch);
+
+                TrimMetricDimensions(connection, transaction, _metricIngestionState.DimensionsToTrim);
+
+                transaction.Commit();
+                _metricIngestionState.DimensionsToTrim.Clear();
+                _metricIngestionState.PendingDimensions.Clear();
+                _metricIngestionState.PendingDimensionAttributes.Clear();
+            }
+            catch
+            {
+                // Cache entries can refer to changes that were rolled back with the transaction.
+                ClearIngestionCaches();
+                throw;
+            }
+        }
+    }
+
+    private void AddMetricToDatabase(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        AddContext context,
+        CachedResource cachedResource,
+        CachedResourceView cachedView,
+        CachedResourceScope cachedScope,
+        Metric metric,
+        MetricIngestionState ingestionState,
+        MetricPointBatch pointBatch)
+    {
+        var pointCount = OtlpHelpers.GetMetricDataPointCount(metric);
+        if (metric.DataCase is Metric.DataOneofCase.Summary or Metric.DataOneofCase.ExponentialHistogram)
+        {
+            context.FailureCount += pointCount;
+            _otlpContext.Logger.LogInformation("Error adding {MetricType} metrics. {MetricType} is not supported.", metric.DataCase, metric.DataCase);
+            return;
+        }
+        if (metric.DataCase is Metric.DataOneofCase.None)
+        {
+            return;
+        }
+
+        CachedInstrument cachedInstrument;
+        try
+        {
+            cachedInstrument = GetOrAddCachedInstrument(connection, transaction, cachedResource, cachedView, cachedScope, metric);
+        }
+        catch (Exception exception)
+        {
+            context.FailureCount += pointCount;
+            _otlpContext.Logger.LogInformation(exception, "Error adding metric instrument {MetricName}.", metric.Name);
+            return;
+        }
+
+        switch (metric.DataCase)
+        {
+            case Metric.DataOneofCase.Gauge:
+                foreach (var point in metric.Gauge.DataPoints)
+                {
+                    AddNumberMetricPoint(connection, transaction, context, cachedInstrument.InstrumentId, point, ingestionState, pointBatch);
+                }
+                break;
+            case Metric.DataOneofCase.Sum:
+                foreach (var point in metric.Sum.DataPoints)
+                {
+                    AddNumberMetricPoint(connection, transaction, context, cachedInstrument.InstrumentId, point, ingestionState, pointBatch);
+                }
+                break;
+            case Metric.DataOneofCase.Histogram:
+                foreach (var point in metric.Histogram.DataPoints)
+                {
+                    AddHistogramMetricPoint(connection, transaction, context, cachedInstrument.InstrumentId, point, ingestionState, pointBatch);
+                }
+                break;
+        }
+    }
+
+    private void AddNumberMetricPoint(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        AddContext context,
+        long instrumentId,
+        NumberDataPoint point,
+        MetricIngestionState ingestionState,
+        MetricPointBatch pointBatch)
+    {
+        try
+        {
+            OtlpHelpers.ValidateNumberDataPoint(point);
+            var pointType = point.ValueCase switch
+            {
+                NumberDataPoint.ValueOneofCase.AsInt => LongPointType,
+                NumberDataPoint.ValueOneofCase.AsDouble => DoublePointType,
+                _ => throw new InvalidOperationException("Metric data point has no value.")
+            };
+            var dimension = GetOrAddMetricDimension(connection, transaction, instrumentId, point.Attributes, ingestionState);
+            var pendingLatest = dimension.PendingPoint;
+            var latest = dimension.LatestPoint;
+            var latestPointType = pendingLatest?.PointType ?? latest?.PointType;
+            var latestEndTimeTicks = pendingLatest?.EndTimeTicks ?? latest?.EndTimeTicks;
+            var sameValue = latestPointType == pointType && (pendingLatest is not null
+                ? pointType == LongPointType ? pendingLatest.IntegerValue == point.AsInt : pendingLatest.DoubleValue == point.AsDouble
+                : pointType == LongPointType ? latest?.IntegerValue == point.AsInt : latest?.DoubleValue == point.AsDouble);
+            var endTimeTicks = OtlpHelpers.UnixNanoSecondsToDateTime(point.TimeUnixNano).Ticks;
+            if (sameValue)
+            {
+                if (pendingLatest is not null)
+                {
+                    pendingLatest.EndTimeTicks = endTimeTicks;
+                    pendingLatest.RepeatCount++;
+                    pendingLatest.SourcePointCount++;
+                    pendingLatest.Exemplars.AddRange(point.Exemplars);
+                }
+                else
+                {
+                    pointBatch.AddUpdate(latest!.PointId, endTimeTicks, incrementRepeatCount: true);
+                    latest.EndTimeTicks = endTimeTicks;
+                    QueueMetricExemplars(pointBatch, latest.PointId, point.Exemplars);
+                    context.SuccessCount++;
+                }
+            }
+            else
+            {
+                var start = OtlpHelpers.UnixNanoSecondsToDateTime(point.StartTimeUnixNano);
+                if (latestPointType == pointType)
+                {
+                    start = new DateTime(latestEndTimeTicks!.Value, DateTimeKind.Utc);
+                }
+                var pendingPoint = new PendingMetricPoint
+                {
+                    Context = context,
+                    Dimension = dimension,
+                    PointType = pointType,
+                    StartTimeTicks = start.Ticks,
+                    EndTimeTicks = endTimeTicks,
+                    RepeatCount = 1,
+                    IntegerValue = pointType == LongPointType ? point.AsInt : (long?)null,
+                    DoubleValue = pointType == DoublePointType ? point.AsDouble : (double?)null,
+                    Flags = (long)point.Flags
+                };
+                pendingPoint.Exemplars.AddRange(point.Exemplars);
+                pointBatch.Inserts.Add(pendingPoint);
+                dimension.PendingPoint = pendingPoint;
+                ingestionState.DimensionsToTrim.Add(dimension);
+            }
+        }
+        catch (Exception exception)
+        {
+            context.FailureCount++;
+            _otlpContext.Logger.LogInformation(exception, "Error adding metric.");
+        }
+    }
+
+    private void AddHistogramMetricPoint(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        AddContext context,
+        long instrumentId,
+        HistogramDataPoint point,
+        MetricIngestionState ingestionState,
+        MetricPointBatch pointBatch)
+    {
+        try
+        {
+            OtlpHelpers.ValidateHistogramDataPoint(point);
+            var dimension = GetOrAddMetricDimension(connection, transaction, instrumentId, point.Attributes, ingestionState);
+            var pendingLatest = dimension.PendingPoint;
+            var latest = dimension.LatestPoint;
+            var latestPointType = pendingLatest?.PointType ?? latest?.PointType;
+            var latestEndTimeTicks = pendingLatest?.EndTimeTicks ?? latest?.EndTimeTicks;
+            var latestBucketCountLength = pendingLatest?.HistogramBucketCounts?.Length ?? latest?.HistogramBucketCountLength;
+            if (latestPointType == HistogramPointType && latestBucketCountLength != point.BucketCounts.Count)
+            {
+                throw new InvalidOperationException("Histogram data point bucket count length changed.");
+            }
+            var histogramCount = checked((long)point.Count);
+            var sameCount = latestPointType == HistogramPointType &&
+                (pendingLatest?.HistogramCount ?? latest?.HistogramCount) == histogramCount;
+            var endTimeTicks = OtlpHelpers.UnixNanoSecondsToDateTime(point.TimeUnixNano).Ticks;
+            if (sameCount)
+            {
+                if (pendingLatest is not null)
+                {
+                    pendingLatest.EndTimeTicks = endTimeTicks;
+                    pendingLatest.SourcePointCount++;
+                    pendingLatest.Exemplars.AddRange(point.Exemplars);
+                }
+                else
+                {
+                    pointBatch.AddUpdate(latest!.PointId, endTimeTicks, incrementRepeatCount: false);
+                    latest.EndTimeTicks = endTimeTicks;
+                    QueueMetricExemplars(pointBatch, latest.PointId, point.Exemplars);
+                    context.SuccessCount++;
+                }
+            }
+            else
+            {
+                var start = OtlpHelpers.UnixNanoSecondsToDateTime(point.StartTimeUnixNano);
+                if (latestPointType == HistogramPointType)
+                {
+                    start = new DateTime(latestEndTimeTicks!.Value, DateTimeKind.Utc);
+                }
+                var pendingPoint = new PendingMetricPoint
+                {
+                    Context = context,
+                    Dimension = dimension,
+                    PointType = HistogramPointType,
+                    StartTimeTicks = start.Ticks,
+                    EndTimeTicks = endTimeTicks,
+                    RepeatCount = 1,
+                    HistogramSum = point.Sum,
+                    HistogramCount = histogramCount,
+                    Flags = (long)point.Flags,
+                    HistogramBucketCounts = point.BucketCounts.Select(count => checked((long)count)).ToArray(),
+                    HistogramExplicitBounds = point.ExplicitBounds.ToArray()
+                };
+                pendingPoint.Exemplars.AddRange(point.Exemplars);
+                pointBatch.Inserts.Add(pendingPoint);
+                dimension.PendingPoint = pendingPoint;
+                ingestionState.DimensionsToTrim.Add(dimension);
+            }
+        }
+        catch (Exception exception)
+        {
+            context.FailureCount++;
+            _otlpContext.Logger.LogInformation(exception, "Error adding metric.");
+        }
+    }
+
+    private void ExecuteMetricPointBatch(SqliteConnection connection, IDbTransaction transaction, MetricPointBatch pointBatch)
+    {
+        foreach (var updates in pointBatch.Updates.Values.Chunk(MaxMetricPointBatchSize))
+        {
+            var sql = new StringBuilder("""
+                WITH updates(point_id, end_time_ticks, repeat_delta) AS (
+                    VALUES
+                """);
+            var parameters = new DynamicParameters();
+            var index = 0;
+            foreach (var update in updates)
+            {
+                if (index > 0)
+                {
+                    sql.AppendLine(",");
+                }
+                sql.Append(CultureInfo.InvariantCulture, $"        (@PointId{index}, @EndTimeTicks{index}, @RepeatDelta{index})");
+                parameters.Add($"PointId{index}", update.PointId);
+                parameters.Add($"EndTimeTicks{index}", update.EndTimeTicks);
+                parameters.Add($"RepeatDelta{index}", update.RepeatDelta);
+                index++;
+            }
+            sql.AppendLine();
+            sql.Append("""
+                )
+                UPDATE telemetry_metric_points AS points
+                SET end_time_ticks = updates.end_time_ticks,
+                    repeat_count = points.repeat_count + updates.repeat_delta
+                FROM updates
+                WHERE points.point_id = updates.point_id;
+                """);
+            connection.Execute(sql.ToString(), parameters, transaction);
+        }
+
+        var pointIds = SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            pointBatch.Inserts,
+            MaxMetricPointBatchSize,
+            "telemetry_metric_points",
+            [
+                "dimension_id", "point_type", "start_time_ticks", "end_time_ticks", "repeat_count",
+                "integer_value", "double_value", "histogram_sum", "histogram_count", "bucket_counts", "explicit_bounds", "flags"
+            ],
+            "point_id",
+            static (point, parameters) =>
+            {
+                parameters[0].Value = point.Dimension.DimensionId;
+                parameters[1].Value = point.PointType;
+                parameters[2].Value = point.StartTimeTicks;
+                parameters[3].Value = point.EndTimeTicks;
+                parameters[4].Value = point.RepeatCount;
+                parameters[5].Value = point.IntegerValue ?? (object)DBNull.Value;
+                parameters[6].Value = point.DoubleValue ?? (object)DBNull.Value;
+                parameters[7].Value = point.HistogramSum ?? (object)DBNull.Value;
+                parameters[8].Value = point.HistogramCount ?? (object)DBNull.Value;
+                parameters[9].Value = point.HistogramBucketCounts is not null ? PackInt64Values(point.HistogramBucketCounts) : DBNull.Value;
+                parameters[10].Value = point.HistogramExplicitBounds is not null ? PackDoubleValues(point.HistogramExplicitBounds) : DBNull.Value;
+                parameters[11].Value = point.Flags;
+            });
+        for (var i = 0; i < pointBatch.Inserts.Count; i++)
+        {
+            pointBatch.Inserts[i].PointId = pointIds[i];
+        }
+
+        foreach (var point in pointBatch.Inserts)
+        {
+            QueueMetricExemplars(pointBatch, point.PointId, point.Exemplars);
+        }
+        InsertMetricExemplars(connection, transaction, pointBatch.Exemplars);
+
+        foreach (var point in pointBatch.Inserts)
+        {
+            point.Context.SuccessCount += point.SourcePointCount;
+
+            if (ReferenceEquals(point.Dimension.PendingPoint, point))
+            {
+                point.Dimension.LatestPoint = new MetricPointRecord
+                {
+                    PointId = point.PointId,
+                    PointType = point.PointType,
+                    EndTimeTicks = point.EndTimeTicks,
+                    IntegerValue = point.IntegerValue,
+                    DoubleValue = point.DoubleValue,
+                    HistogramCount = point.HistogramCount,
+                    HistogramBucketCountLength = point.HistogramBucketCounts?.Length
+                };
+                point.Dimension.PendingPoint = null;
+            }
+        }
+    }
+
+    private MetricDimensionState GetOrAddMetricDimension(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        long instrumentId,
+        RepeatedField<KeyValue> pointAttributes,
+        MetricIngestionState ingestionState)
+    {
+        var attributes = pointAttributes.ToKeyValuePairs(_otlpContext);
+        Array.Sort(attributes, MetricAttributeComparer.Instance);
+        var attributeHash = GetMetricDimensionAttributeHash(attributes);
+        var cacheKey = (instrumentId, attributeHash);
+        if (ingestionState.LoadedDimensionInstruments.Add(instrumentId))
+        {
+            var dimensions = connection.Query<MetricDimensionStateRecord>("""
+                SELECT
+                    d.dimension_id AS DimensionId,
+                    a.attribute_key AS AttributeKey,
+                    a.attribute_value AS AttributeValue,
+                    p.point_id AS PointId,
+                    p.point_type AS PointType,
+                    p.end_time_ticks AS EndTimeTicks,
+                    p.integer_value AS IntegerValue,
+                    p.double_value AS DoubleValue,
+                    p.histogram_count AS HistogramCount,
+                    p.bucket_counts AS HistogramBucketCounts
+                FROM telemetry_metric_dimensions d
+                LEFT JOIN telemetry_metric_dimension_attributes a ON a.dimension_id = d.dimension_id
+                LEFT JOIN telemetry_metric_points p ON p.point_id = (
+                    SELECT point_id
+                    FROM telemetry_metric_points
+                    WHERE dimension_id = d.dimension_id
+                    ORDER BY point_id DESC
+                    LIMIT 1
+                )
+                WHERE d.instrument_id = @InstrumentId
+                ORDER BY d.dimension_id, a.ordinal;
+                """, new { InstrumentId = instrumentId }, transaction)
+                .GroupBy(record => record.DimensionId)
+                .Select(group =>
+                {
+                    var first = group.First();
+                    return new MetricDimensionState
+                    {
+                        DimensionId = group.Key,
+                        Attributes = group
+                            .Where(record => record.AttributeKey is not null)
+                            .Select(record => KeyValuePair.Create(record.AttributeKey!, record.AttributeValue!))
+                            .ToArray(),
+                        LatestPoint = first.PointId is not null
+                            ? new MetricPointRecord
+                            {
+                                PointId = first.PointId.Value,
+                                PointType = first.PointType!.Value,
+                                EndTimeTicks = first.EndTimeTicks!.Value,
+                                IntegerValue = first.IntegerValue,
+                                DoubleValue = first.DoubleValue,
+                                HistogramCount = first.HistogramCount,
+                                HistogramBucketCountLength = first.HistogramBucketCounts?.Length / sizeof(long)
+                            }
+                            : null
+                    };
+                })
+                .ToList();
+            foreach (var loadedDimension in dimensions)
+            {
+                var dimensionCacheKey = (instrumentId, GetMetricDimensionAttributeHash(loadedDimension.Attributes));
+                if (!ingestionState.Dimensions.TryGetValue(dimensionCacheKey, out var dimensionCandidates))
+                {
+                    dimensionCandidates = [];
+                    ingestionState.Dimensions.Add(dimensionCacheKey, dimensionCandidates);
+                }
+                dimensionCandidates.Add(loadedDimension);
+            }
+            var loadedKnownAttributeValues = new KnownAttributeValuesState();
+            foreach (var loadedDimension in dimensions)
+            {
+                loadedKnownAttributeValues.LoadDimension(loadedDimension.Attributes);
+            }
+            ingestionState.KnownAttributeValues.Add(instrumentId, loadedKnownAttributeValues);
+            ingestionState.DimensionCounts[instrumentId] = dimensions.Count;
+        }
+
+        if (!ingestionState.Dimensions.TryGetValue(cacheKey, out var candidates))
+        {
+            candidates = [];
+            ingestionState.Dimensions.Add(cacheKey, candidates);
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Attributes.SequenceEqual(attributes))
+            {
+                return candidate;
+            }
+        }
+
+        var knownAttributeValues = ingestionState.KnownAttributeValues[instrumentId];
+        knownAttributeValues.ValidateDimension(attributes);
+        var dimensionCount = ingestionState.DimensionCounts[instrumentId];
+        if (dimensionCount >= TelemetryRepositoryLimits.MaxDimensionCount)
+        {
+            throw new InvalidOperationException($"Dimension limit of {TelemetryRepositoryLimits.MaxDimensionCount} reached.");
+        }
+        knownAttributeValues.AddDimension(attributes);
+        var dimension = new MetricDimensionState { Attributes = attributes };
+        ingestionState.PendingDimensions.Add(new PendingMetricDimension(instrumentId, attributeHash, dimension));
+        ingestionState.PendingDimensionAttributes.AddRange(attributes.Select((attribute, ordinal) => new PendingMetricDimensionAttribute(
+            dimension,
+            ordinal,
+            attribute.Key,
+            attribute.Value)));
+
+        candidates.Add(dimension);
+        ingestionState.DimensionCounts[instrumentId] = dimensionCount + 1;
+        return dimension;
+    }
+
+    private static void InsertMetricDimensions(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        List<PendingMetricDimension> dimensions)
+    {
+        var dimensionIds = SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            dimensions,
+            MaxMetricPointBatchSize,
+            "telemetry_metric_dimensions",
+            ["instrument_id", "attribute_hash"],
+            "dimension_id",
+            static (dimension, parameters) =>
+            {
+                parameters[0].Value = dimension.InstrumentId;
+                parameters[1].Value = dimension.AttributeHash;
+            });
+        for (var i = 0; i < dimensions.Count; i++)
+        {
+            dimensions[i].Dimension.DimensionId = dimensionIds[i];
+        }
+    }
+
+    private static void InsertMetricDimensionAttributes(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        List<PendingMetricDimensionAttribute> attributes)
+    {
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            attributes,
+            MaxMetricPointBatchSize,
+            "telemetry_metric_dimension_attributes",
+            ["dimension_id", "ordinal", "attribute_key", "attribute_value"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.Dimension.DimensionId;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Key;
+                parameters[3].Value = row.Value;
+            });
+    }
+
+    private static long GetMetricDimensionAttributeHash(ReadOnlySpan<KeyValuePair<string, string>> attributes)
+    {
+        var hash = new XxHash3();
+        foreach (var attribute in attributes)
+        {
+            AppendHashValue(hash, attribute.Key);
+            AppendHashValue(hash, attribute.Value);
+        }
+
+        return BinaryPrimitives.ReadInt64LittleEndian(hash.GetCurrentHash());
+
+        static void AppendHashValue(XxHash3 hash, string value)
+        {
+            var valueBytes = Encoding.UTF8.GetBytes(value);
+            Span<byte> lengthBytes = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(lengthBytes, valueBytes.Length);
+            hash.Append(lengthBytes);
+            hash.Append(valueBytes);
+        }
+    }
+
+    private static byte[] PackInt64Values(ReadOnlySpan<long> values)
+    {
+        var bytes = new byte[checked(values.Length * sizeof(long))];
+        for (var i = 0; i < values.Length; i++)
+        {
+            BinaryPrimitives.WriteInt64LittleEndian(bytes.AsSpan(i * sizeof(long)), values[i]);
+        }
+        return bytes;
+    }
+
+    private static byte[] PackDoubleValues(ReadOnlySpan<double> values)
+    {
+        var bytes = new byte[checked(values.Length * sizeof(double))];
+        for (var i = 0; i < values.Length; i++)
+        {
+            BinaryPrimitives.WriteInt64LittleEndian(bytes.AsSpan(i * sizeof(double)), BitConverter.DoubleToInt64Bits(values[i]));
+        }
+        return bytes;
+    }
+
+    private static ulong[] UnpackUInt64Values(ReadOnlySpan<byte> bytes)
+    {
+        ValidatePackedValueLength(bytes);
+        var values = new ulong[bytes.Length / sizeof(long)];
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = checked((ulong)BinaryPrimitives.ReadInt64LittleEndian(bytes[(i * sizeof(long))..]));
+        }
+        return values;
+    }
+
+    private static double[] UnpackDoubleValues(ReadOnlySpan<byte> bytes)
+    {
+        ValidatePackedValueLength(bytes);
+        var values = new double[bytes.Length / sizeof(double)];
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(bytes[(i * sizeof(double))..]));
+        }
+        return values;
+    }
+
+    private static void ValidatePackedValueLength(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length % sizeof(long) != 0)
+        {
+            throw new InvalidOperationException("Packed histogram data length must be a multiple of 8 bytes.");
+        }
+    }
+
+    private void QueueMetricExemplars(MetricPointBatch pointBatch, long pointId, IEnumerable<Exemplar> exemplars)
+    {
+        foreach (var exemplar in exemplars)
+        {
+            if (exemplar.TraceId is null || exemplar.SpanId is null)
+            {
+                continue;
+            }
+            var value = exemplar.HasAsDouble ? exemplar.AsDouble : exemplar.AsInt;
+            if (!double.IsFinite(value))
+            {
+                continue;
+            }
+            var startTicks = OtlpHelpers.UnixNanoSecondsToDateTime(exemplar.TimeUnixNano).Ticks;
+            pointBatch.Exemplars.TryAdd(
+                new MetricExemplarKey(pointId, startTicks, value),
+                new PendingMetricExemplar
+                {
+                    PointId = pointId,
+                    StartTimeTicks = startTicks,
+                    Value = value,
+                    SpanId = exemplar.SpanId.ToHexString(),
+                    TraceId = exemplar.TraceId.ToHexString(),
+                    Attributes = exemplar.FilteredAttributes.ToKeyValuePairs(_otlpContext)
+                });
+        }
+    }
+
+    private static void InsertMetricExemplars(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        Dictionary<MetricExemplarKey, PendingMetricExemplar> exemplars)
+    {
+        foreach (var batch in exemplars.Values.Chunk(MaxMetricPointBatchSize))
+        {
+            var sql = new StringBuilder("""
+                INSERT OR IGNORE INTO telemetry_metric_exemplars (
+                    point_id, start_time_ticks, exemplar_value, span_id, trace_id)
+                VALUES
+                """);
+            var parameters = new DynamicParameters();
+            for (var index = 0; index < batch.Length; index++)
+            {
+                if (index > 0)
+                {
+                    sql.AppendLine(",");
+                }
+                sql.Append(CultureInfo.InvariantCulture, $"    (@PointId{index}, @StartTimeTicks{index}, @Value{index}, @SpanId{index}, @TraceId{index})");
+                parameters.Add($"PointId{index}", batch[index].PointId);
+                parameters.Add($"StartTimeTicks{index}", batch[index].StartTimeTicks);
+                parameters.Add($"Value{index}", batch[index].Value);
+                parameters.Add($"SpanId{index}", batch[index].SpanId);
+                parameters.Add($"TraceId{index}", batch[index].TraceId);
+            }
+            sql.Append("""
+                RETURNING
+                    exemplar_id AS ExemplarId,
+                    point_id AS PointId,
+                    start_time_ticks AS StartTimeTicks,
+                    exemplar_value AS ExemplarValue;
+                """);
+            foreach (var inserted in connection.Query<InsertedMetricExemplarRecord>(sql.ToString(), parameters, transaction))
+            {
+                exemplars[new MetricExemplarKey(inserted.PointId, inserted.StartTimeTicks, inserted.ExemplarValue)].ExemplarId = inserted.ExemplarId;
+            }
+        }
+
+        var attributes = exemplars.Values
+            .Where(exemplar => exemplar.ExemplarId is not null)
+            .SelectMany(exemplar => exemplar.Attributes.Select((attribute, ordinal) => new PendingMetricExemplarAttribute(
+                exemplar.ExemplarId!.Value,
+                ordinal,
+                attribute.Key,
+                attribute.Value)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            attributes,
+            MaxMetricPointBatchSize,
+            "telemetry_metric_exemplar_attributes",
+            ["exemplar_id", "ordinal", "attribute_key", "attribute_value"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.ExemplarId;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Key;
+                parameters[3].Value = row.Value;
+            });
+    }
+
+    private void TrimMetricDimensions(SqliteConnection connection, IDbTransaction transaction, IEnumerable<MetricDimensionState> dimensions)
+    {
+        foreach (var batch in dimensions.Chunk(MaxMetricPointBatchSize))
+        {
+            connection.Execute("""
+                DELETE FROM telemetry_metric_points
+                WHERE point_id IN (
+                    SELECT point_id
+                    FROM (
+                        SELECT
+                            point_id,
+                            ROW_NUMBER() OVER (PARTITION BY dimension_id ORDER BY point_id DESC) AS point_rank
+                        FROM telemetry_metric_points
+                        WHERE dimension_id IN @DimensionIds
+                    )
+                    WHERE point_rank > @MaxMetricsCount
+                );
+                """, new { DimensionIds = batch.Select(dimension => dimension.DimensionId).ToArray(), _otlpContext.Options.MaxMetricsCount }, transaction);
+        }
+    }
+
+    private async Task ClearSelectedMetricsFromDatabaseAsync(Dictionary<string, HashSet<AspireDataType>> selectedResources)
+    {
+        using var connection = _database.OpenConnection();
+        foreach (var resource in connection.Query<TelemetryResourceRecord>("SELECT resource_name AS ResourceName, instance_id AS InstanceId FROM telemetry_resources;"))
+        {
+            var key = new ResourceKey(resource.ResourceName, resource.InstanceId);
+            if (selectedResources.TryGetValue(key.GetCompositeName(), out var dataTypes) && dataTypes.Contains(AspireDataType.Metrics) && !dataTypes.Contains(AspireDataType.Resource))
+            {
+                await ClearMetricsFromDatabaseAsync(key).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task ClearMetricsFromDatabaseAsync(ResourceKey? resourceKey)
+    {
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            var parameters = new DynamicParameters();
+            var where = string.Empty;
+            if (resourceKey is not null)
+            {
+                where = " WHERE resource_name = @ResourceName COLLATE NOCASE";
+                parameters.Add("ResourceName", resourceKey.Value.Name);
+                if (resourceKey.Value.InstanceId is not null)
+                {
+                    where += " AND instance_id = @InstanceId COLLATE NOCASE";
+                    parameters.Add("InstanceId", resourceKey.Value.InstanceId);
+                }
+            }
+            connection.Execute($"""
+                DELETE FROM telemetry_metric_instruments
+                WHERE resource_id IN (SELECT resource_id FROM telemetry_resources{where});
+
+                UPDATE telemetry_resources
+                SET has_metrics = EXISTS (SELECT 1 FROM telemetry_metric_instruments WHERE telemetry_metric_instruments.resource_id = telemetry_resources.resource_id);
+                """, parameters, transaction);
+            DeleteOrphanedScopes(connection, transaction);
+            transaction.Commit();
+            ClearIngestionCaches();
+        }
+    }
+
+    private static OtlpScope CreateScope(string name, string version, KeyValuePair<string, string>[] attributes)
+    {
+        return name == OtlpScope.Empty.Name && version.Length == 0 && attributes.Length == 0
+            ? OtlpScope.Empty
+            : new OtlpScope(name, version, attributes);
+    }
+
+    private static OtlpInstrumentType MapMetricType(Metric.DataOneofCase dataCase)
+    {
+        return dataCase switch
+        {
+            Metric.DataOneofCase.Gauge => OtlpInstrumentType.Gauge,
+            Metric.DataOneofCase.Sum => OtlpInstrumentType.Sum,
+            Metric.DataOneofCase.Histogram => OtlpInstrumentType.Histogram,
+            _ => OtlpInstrumentType.Unsupported
+        };
+    }
+
+    private static OtlpAggregationTemporality MapAggregationTemporality(Metric metric)
+    {
+        return metric.DataCase switch
+        {
+            Metric.DataOneofCase.Sum => (OtlpAggregationTemporality)metric.Sum.AggregationTemporality,
+            Metric.DataOneofCase.Histogram => (OtlpAggregationTemporality)metric.Histogram.AggregationTemporality,
+            Metric.DataOneofCase.ExponentialHistogram => (OtlpAggregationTemporality)metric.ExponentialHistogram.AggregationTemporality,
+            _ => OtlpAggregationTemporality.Unspecified
+        };
+    }
+
+    private sealed class MetricAttributeComparer : IComparer<KeyValuePair<string, string>>
+    {
+        public static readonly MetricAttributeComparer Instance = new();
+
+        public int Compare(KeyValuePair<string, string> x, KeyValuePair<string, string> y) => string.Compare(x.Key, y.Key, StringComparison.Ordinal);
+    }
+
+    private sealed class MetricIngestionState
+    {
+        public Dictionary<(long InstrumentId, long AttributeHash), List<MetricDimensionState>> Dimensions { get; } = [];
+        public Dictionary<long, int> DimensionCounts { get; } = [];
+        public Dictionary<long, KnownAttributeValuesState> KnownAttributeValues { get; } = [];
+        public HashSet<long> LoadedDimensionInstruments { get; } = [];
+        public HashSet<MetricDimensionState> DimensionsToTrim { get; } = [];
+        public List<PendingMetricDimension> PendingDimensions { get; } = [];
+        public List<PendingMetricDimensionAttribute> PendingDimensionAttributes { get; } = [];
+
+        public void Clear()
+        {
+            Dimensions.Clear();
+            DimensionCounts.Clear();
+            KnownAttributeValues.Clear();
+            LoadedDimensionInstruments.Clear();
+            DimensionsToTrim.Clear();
+            PendingDimensions.Clear();
+            PendingDimensionAttributes.Clear();
+        }
+    }
+
+    private sealed record PendingMetricDimension(long InstrumentId, long AttributeHash, MetricDimensionState Dimension);
+
+    private sealed record PendingMetricDimensionAttribute(MetricDimensionState Dimension, int Ordinal, string Key, string Value);
+
+    private sealed class MetricDimensionState
+    {
+        public long DimensionId { get; set; }
+        public required KeyValuePair<string, string>[] Attributes { get; init; }
+        public MetricPointRecord? LatestPoint { get; set; }
+        public PendingMetricPoint? PendingPoint { get; set; }
+    }
+
+    private sealed class MetricPointBatch
+    {
+        public Dictionary<long, MetricPointUpdate> Updates { get; } = [];
+        public List<PendingMetricPoint> Inserts { get; } = [];
+        public Dictionary<MetricExemplarKey, PendingMetricExemplar> Exemplars { get; } = [];
+
+        public void AddUpdate(long pointId, long endTimeTicks, bool incrementRepeatCount)
+        {
+            if (!Updates.TryGetValue(pointId, out var update))
+            {
+                update = new MetricPointUpdate { PointId = pointId };
+                Updates.Add(pointId, update);
+            }
+            update.EndTimeTicks = endTimeTicks;
+            if (incrementRepeatCount)
+            {
+                update.RepeatDelta++;
+            }
+        }
+    }
+
+    private readonly record struct MetricExemplarKey(long PointId, long StartTimeTicks, double Value);
+
+    private sealed class PendingMetricExemplar
+    {
+        public required long PointId { get; init; }
+        public required long StartTimeTicks { get; init; }
+        public required double Value { get; init; }
+        public required string SpanId { get; init; }
+        public required string TraceId { get; init; }
+        public required KeyValuePair<string, string>[] Attributes { get; init; }
+        public long? ExemplarId { get; set; }
+    }
+
+    private sealed record PendingMetricExemplarAttribute(long ExemplarId, int Ordinal, string Key, string Value);
+
+    private sealed class InsertedMetricExemplarRecord
+    {
+        public required long ExemplarId { get; init; }
+        public required long PointId { get; init; }
+        public required long StartTimeTicks { get; init; }
+        public required double ExemplarValue { get; init; }
+    }
+
+    private sealed class MetricPointUpdate
+    {
+        public required long PointId { get; init; }
+        public long EndTimeTicks { get; set; }
+        public long RepeatDelta { get; set; }
+    }
+
+    private sealed class PendingMetricPoint
+    {
+        public required AddContext Context { get; init; }
+        public required MetricDimensionState Dimension { get; init; }
+        public required int PointType { get; init; }
+        public required long StartTimeTicks { get; init; }
+        public required long EndTimeTicks { get; set; }
+        public required long RepeatCount { get; set; }
+        public long? IntegerValue { get; init; }
+        public double? DoubleValue { get; init; }
+        public double? HistogramSum { get; init; }
+        public long? HistogramCount { get; init; }
+        public required long Flags { get; init; }
+        public long PointId { get; set; }
+        public int SourcePointCount { get; set; } = 1;
+        public long[]? HistogramBucketCounts { get; init; }
+        public double[]? HistogramExplicitBounds { get; init; }
+        public List<Exemplar> Exemplars { get; } = [];
+    }
+
+    private sealed class MetricDimensionStateRecord
+    {
+        public required long DimensionId { get; init; }
+        public string? AttributeKey { get; init; }
+        public string? AttributeValue { get; init; }
+        public long? PointId { get; init; }
+        public int? PointType { get; init; }
+        public long? EndTimeTicks { get; init; }
+        public long? IntegerValue { get; init; }
+        public double? DoubleValue { get; init; }
+        public long? HistogramCount { get; init; }
+        public byte[]? HistogramBucketCounts { get; init; }
+    }
+
+    private class MetricPointRecord
+    {
+        public required long PointId { get; init; }
+        public required int PointType { get; init; }
+        public required long EndTimeTicks { get; set; }
+        public long? IntegerValue { get; init; }
+        public double? DoubleValue { get; init; }
+        public long? HistogramCount { get; init; }
+        public int? HistogramBucketCountLength { get; init; }
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Resources.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Resources.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using System.Text;
+using Aspire.Dashboard.Otlp.Model;
+using Dapper;
+using Microsoft.Data.Sqlite;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public sealed partial class SqliteTelemetryRepository
+{
+    public List<OtlpResource> GetResources(bool includeUninstrumentedPeers = false) => GetTelemetryResources(includeUninstrumentedPeers, name: null);
+
+    public List<OtlpResource> GetResourcesByName(string name, bool includeUninstrumentedPeers = false) => GetTelemetryResources(includeUninstrumentedPeers, name);
+
+    public OtlpResource? GetResourceByCompositeName(string compositeName) => GetResources(includeUninstrumentedPeers: true).SingleOrDefault(resource => resource.ResourceKey.EqualsCompositeName(compositeName));
+
+    public OtlpResource? GetResource(ResourceKey key) => GetResources(includeUninstrumentedPeers: true).SingleOrDefault(resource => resource.ResourceKey == key);
+
+    public List<OtlpResource> GetResources(ResourceKey key, bool includeUninstrumentedPeers = false)
+    {
+        return key.InstanceId is null
+            ? GetResourcesByName(key.Name, includeUninstrumentedPeers)
+            : GetResources(includeUninstrumentedPeers).Where(resource => resource.ResourceKey == key).ToList();
+    }
+
+    private async Task DeleteTelemetryResourceFromDatabaseAsync(ResourceKey resourceKey)
+    {
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            var sql = new StringBuilder("""
+                DELETE FROM telemetry_resources
+                WHERE resource_name = @ResourceName COLLATE NOCASE
+                """);
+            var parameters = new DynamicParameters();
+            parameters.Add("ResourceName", resourceKey.Name);
+            if (resourceKey.InstanceId is not null)
+            {
+                sql.Append(" AND instance_id = @InstanceId COLLATE NOCASE");
+                parameters.Add("InstanceId", resourceKey.InstanceId);
+            }
+            sql.Append(';');
+            // A trace can contain spans from multiple resources. Capture affected trace IDs before
+            // resource deletion cascades its spans, then delete each complete trace to avoid retaining partial trace data.
+            var affectedTraceIds = connection.Query<string>($"""
+                SELECT DISTINCT spans.trace_id
+                FROM telemetry_spans spans
+                JOIN telemetry_resources resources ON resources.resource_id = spans.resource_id
+                WHERE resources.resource_name = @ResourceName COLLATE NOCASE
+                  {(resourceKey.InstanceId is null ? string.Empty : "AND resources.instance_id = @InstanceId COLLATE NOCASE")};
+                """, parameters, transaction).AsList();
+            connection.Execute(sql.ToString(), parameters, transaction);
+            foreach (var traceBatch in affectedTraceIds.Chunk(MaxTraceBatchSize))
+            {
+                connection.Execute(
+                    "DELETE FROM telemetry_traces WHERE trace_id IN @TraceIds;",
+                    new { TraceIds = traceBatch },
+                    transaction);
+            }
+            connection.Execute("""
+                UPDATE telemetry_resources
+                SET has_traces = EXISTS (SELECT 1 FROM telemetry_spans WHERE telemetry_spans.resource_id = telemetry_resources.resource_id);
+                """, transaction: transaction);
+            DeleteOrphanedUninstrumentedPeers(connection, transaction);
+            DeleteOrphanedScopes(connection, transaction);
+            transaction.Commit();
+            ClearIngestionCaches();
+        }
+    }
+
+    /// <summary>
+    /// Deletes resources that only ever existed as the target of an outgoing span once nothing references them.
+    /// </summary>
+    /// <remarks>
+    /// Uninstrumented peers are synthesised from span attributes rather than reported by a real resource, so
+    /// nothing else deletes them. Without this they survive every clear and accumulate for the life of the
+    /// database, showing up in resource lists and peer lookups long after the spans that named them are gone.
+    /// Resources that report their own telemetry are excluded because they exist independently of any span.
+    /// </remarks>
+    private static void DeleteOrphanedUninstrumentedPeers(SqliteConnection connection, IDbTransaction transaction)
+    {
+        connection.Execute("""
+            DELETE FROM telemetry_resources
+            WHERE uninstrumented_peer = 1
+              AND NOT EXISTS (SELECT 1 FROM telemetry_spans WHERE telemetry_spans.uninstrumented_peer_resource_id = telemetry_resources.resource_id)
+              AND NOT EXISTS (SELECT 1 FROM telemetry_spans WHERE telemetry_spans.resource_id = telemetry_resources.resource_id)
+              AND NOT EXISTS (SELECT 1 FROM telemetry_logs WHERE telemetry_logs.resource_id = telemetry_resources.resource_id)
+              AND NOT EXISTS (SELECT 1 FROM telemetry_metric_instruments WHERE telemetry_metric_instruments.resource_id = telemetry_resources.resource_id);
+            """, transaction: transaction);
+    }
+
+    private static void DeleteOrphanedScopes(SqliteConnection connection, IDbTransaction transaction)
+    {
+        connection.Execute("""
+            DELETE FROM telemetry_scopes
+            WHERE NOT EXISTS (SELECT 1 FROM telemetry_logs WHERE telemetry_logs.scope_id = telemetry_scopes.scope_id)
+              AND NOT EXISTS (SELECT 1 FROM telemetry_spans WHERE telemetry_spans.scope_id = telemetry_scopes.scope_id)
+              AND NOT EXISTS (SELECT 1 FROM telemetry_metric_instruments WHERE telemetry_metric_instruments.scope_id = telemetry_scopes.scope_id);
+            """, transaction: transaction);
+    }
+
+    private List<OtlpResource> GetTelemetryResources(bool includeUninstrumentedPeers, string? name)
+    {
+        EnsureCachePopulated();
+        lock (_cacheLock)
+        {
+            return _cachedResourcesByKey.Values
+                .Select(resource => resource.Resource)
+                .Where(resource => includeUninstrumentedPeers || !resource.UninstrumentedPeer)
+                .Where(resource => name is null || string.Equals(resource.ResourceName, name, StringComparisons.ResourceName))
+                .OrderBy(resource => resource.ResourceKey)
+                .ToList();
+        }
+    }
+
+    private sealed class ResourceViewPropertiesComparer : IEqualityComparer<KeyValuePair<string, string>[]>
+    {
+        public static readonly ResourceViewPropertiesComparer Instance = new();
+
+        public bool Equals(KeyValuePair<string, string>[]? left, KeyValuePair<string, string>[]? right) =>
+            ReferenceEquals(left, right) || left is not null && right is not null && left.SequenceEqual(right);
+
+        public int GetHashCode(KeyValuePair<string, string>[] properties)
+        {
+            var hash = new HashCode();
+            foreach (var property in properties)
+            {
+                hash.Add(property);
+            }
+            return hash.ToHashCode();
+        }
+    }
+
+    private class TelemetryResourceRecord
+    {
+        public required string ResourceName { get; init; }
+        public string? InstanceId { get; init; }
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Runtime.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Runtime.cs
@@ -1,0 +1,477 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public sealed partial class SqliteTelemetryRepository
+{
+    private const int MaxWatcherSnapshotCount = 10_000;
+
+    private readonly object _subscriptionLock = new();
+    private readonly List<Subscription> _resourceSubscriptions = [];
+    private readonly List<Subscription> _logSubscriptions = [];
+    private readonly List<Subscription> _metricsSubscriptions = [];
+    private readonly List<Subscription> _tracesSubscriptions = [];
+    private readonly Dictionary<ResourceKey, int> _resourceUnviewedErrorLogs = [];
+    private TimeSpan _subscriptionMinExecuteInterval = CallbackThrottler.DefaultMinExecuteInterval;
+
+    private readonly object _watchersLock = new();
+    private List<SpanWatcher>? _spanWatchers;
+    private List<LogWatcher>? _logWatchers;
+
+    internal TimeSpan SubscriptionMinExecuteInterval
+    {
+        set => _subscriptionMinExecuteInterval = value;
+    }
+
+    /// <summary>
+    /// Gets the number of active trace subscriptions.
+    /// </summary>
+    internal int TraceSubscriptionCount
+    {
+        get
+        {
+            lock (_subscriptionLock)
+            {
+                return _tracesSubscriptions.Count;
+            }
+        }
+    }
+
+    public bool HasDisplayedMaxLogLimitMessage { get; set; }
+    public Message? MaxLogLimitMessage { get; set; }
+    public bool HasDisplayedMaxTraceLimitMessage { get; set; }
+    public Message? MaxTraceLimitMessage { get; set; }
+
+    public Dictionary<ResourceKey, int> GetResourceUnviewedErrorLogsCount()
+    {
+        lock (_subscriptionLock)
+        {
+            return _resourceUnviewedErrorLogs.ToDictionary();
+        }
+    }
+
+    public void MarkViewedErrorLogs(ResourceKey? key)
+    {
+        var changed = false;
+        lock (_subscriptionLock)
+        {
+            if (key is null)
+            {
+                changed = _resourceUnviewedErrorLogs.Count > 0;
+                _resourceUnviewedErrorLogs.Clear();
+            }
+            else if (key.Value.InstanceId is null)
+            {
+                changed = _resourceUnviewedErrorLogs.Keys
+                    .Where(resourceKey => string.Equals(resourceKey.Name, key.Value.Name, StringComparisons.ResourceName))
+                    .ToList()
+                    .Aggregate(false, (removed, resourceKey) => _resourceUnviewedErrorLogs.Remove(resourceKey) || removed);
+            }
+            else
+            {
+                changed = _resourceUnviewedErrorLogs.Remove(key.Value);
+            }
+        }
+
+        if (changed)
+        {
+            RaiseSubscriptionChanged(_logSubscriptions);
+        }
+    }
+
+    private void ClearUnviewedErrorCounts(ResourceKey? key)
+    {
+        lock (_subscriptionLock)
+        {
+            if (key is null)
+            {
+                _resourceUnviewedErrorLogs.Clear();
+                return;
+            }
+
+            foreach (var resourceKey in _resourceUnviewedErrorLogs.Keys
+                .Where(resourceKey => key.Value.InstanceId is null
+                    ? string.Equals(resourceKey.Name, key.Value.Name, StringComparisons.ResourceName)
+                    : resourceKey == key.Value)
+                .ToList())
+            {
+                _resourceUnviewedErrorLogs.Remove(resourceKey);
+            }
+        }
+    }
+
+    private void ClearUnviewedErrorCounts(Dictionary<string, HashSet<AspireDataType>> selectedResources)
+    {
+        lock (_subscriptionLock)
+        {
+            foreach (var resourceKey in _resourceUnviewedErrorLogs.Keys.ToList())
+            {
+                if (selectedResources.TryGetValue(resourceKey.GetCompositeName(), out var dataTypes) &&
+                    (dataTypes.Contains(AspireDataType.StructuredLogs) || dataTypes.Contains(AspireDataType.Resource)))
+                {
+                    _resourceUnviewedErrorLogs.Remove(resourceKey);
+                }
+            }
+        }
+    }
+
+    public Subscription OnNewResources(Func<Task> callback) =>
+        AddSubscription(nameof(OnNewResources), null, SubscriptionType.Read, callback, _resourceSubscriptions);
+
+    public Subscription OnNewLogs(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback) =>
+        AddSubscription(nameof(OnNewLogs), resourceKey, subscriptionType, callback, _logSubscriptions);
+
+    public Subscription OnNewMetrics(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback) =>
+        AddSubscription(nameof(OnNewMetrics), resourceKey, subscriptionType, callback, _metricsSubscriptions);
+
+    public Subscription OnNewTraces(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback) =>
+        AddSubscription(nameof(OnNewTraces), resourceKey, subscriptionType, callback, _tracesSubscriptions);
+
+    private Subscription AddSubscription(
+        string name,
+        ResourceKey? resourceKey,
+        SubscriptionType subscriptionType,
+        Func<Task> callback,
+        List<Subscription> subscriptions)
+    {
+        Subscription? subscription = null;
+        subscription = new Subscription(name, resourceKey, subscriptionType, callback, () =>
+        {
+            lock (_subscriptionLock)
+            {
+                subscriptions.Remove(subscription!);
+            }
+        }, ExecutionContext.Capture(), _otlpContext.Logger, _subscriptionMinExecuteInterval);
+
+        lock (_subscriptionLock)
+        {
+            subscriptions.Add(subscription);
+        }
+
+        return subscription;
+    }
+
+    private void RaiseSubscriptionChanged(List<Subscription> subscriptions)
+    {
+        Subscription[] snapshot;
+        lock (_subscriptionLock)
+        {
+            snapshot = subscriptions.ToArray();
+        }
+
+        foreach (var subscription in snapshot)
+        {
+            subscription.Execute();
+        }
+    }
+
+    private void NotifyLogsAdded(List<OtlpLogEntry> logs)
+    {
+        lock (_subscriptionLock)
+        {
+            foreach (var log in logs)
+            {
+                if (!log.IsError || _logSubscriptions.Any(subscription =>
+                    subscription.SubscriptionType == SubscriptionType.Read &&
+                    (subscription.ResourceKey is null || subscription.ResourceKey == log.ResourceView.ResourceKey)))
+                {
+                    continue;
+                }
+
+                _resourceUnviewedErrorLogs.TryGetValue(log.ResourceView.ResourceKey, out var count);
+                _resourceUnviewedErrorLogs[log.ResourceView.ResourceKey] = count + 1;
+            }
+        }
+
+        PushLogsToWatchers(logs);
+        RaiseSubscriptionChanged(_logSubscriptions);
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    private void NotifySpansAdded(List<OtlpSpan> spans)
+    {
+        PushSpansToWatchers(spans);
+        RaiseSubscriptionChanged(_tracesSubscriptions);
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    private void NotifyPeersChanged()
+    {
+        RaiseSubscriptionChanged(_tracesSubscriptions);
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    private void NotifyMetricsAdded()
+    {
+        RaiseSubscriptionChanged(_metricsSubscriptions);
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    public async IAsyncEnumerable<OtlpSpan> WatchSpansAsync(
+        WatchSpansRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var channel = Channel.CreateBounded<OtlpSpan>(new BoundedChannelOptions(1000)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true
+        });
+        var watcher = new SpanWatcher(request, channel);
+        lock (_watchersLock)
+        {
+            _spanWatchers ??= [];
+            _spanWatchers.Add(watcher);
+        }
+
+        try
+        {
+            var existingSpans = await GetSpansAsync(new GetSpansRequest
+            {
+                ResourceKeys = request.ResourceKeys,
+                StartIndex = 0,
+                Count = MaxWatcherSnapshotCount,
+                Filters = request.Filters,
+                TraceId = request.TraceId,
+                HasError = request.HasError,
+                TextFragments = request.TextFragments
+            }, cancellationToken).ConfigureAwait(false);
+            var seenSpans = new HashSet<(string TraceId, string SpanId)>();
+            foreach (var span in existingSpans.PagedResult.Items.OrderBy(span => span.StartTime))
+            {
+                seenSpans.Add((span.TraceId, span.SpanId));
+                yield return span;
+            }
+            while (channel.Reader.TryRead(out var pendingSpan))
+            {
+                if (seenSpans.Add((pendingSpan.TraceId, pendingSpan.SpanId)))
+                {
+                    yield return pendingSpan;
+                }
+            }
+
+            await foreach (var span in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return span;
+            }
+        }
+        finally
+        {
+            lock (_watchersLock)
+            {
+                _spanWatchers?.Remove(watcher);
+            }
+            channel.Writer.TryComplete();
+        }
+    }
+
+    public async IAsyncEnumerable<OtlpLogEntry> WatchLogsAsync(
+        WatchLogsRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var channel = Channel.CreateBounded<OtlpLogEntry>(new BoundedChannelOptions(1000)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true
+        });
+        var watcher = new LogWatcher(request, channel);
+        lock (_watchersLock)
+        {
+            _logWatchers ??= [];
+            _logWatchers.Add(watcher);
+        }
+
+        try
+        {
+            var existingLogs = await GetLogsAsync(new GetLogsContext
+            {
+                ResourceKeys = request.ResourceKeys,
+                StartIndex = 0,
+                Count = MaxWatcherSnapshotCount,
+                Filters = request.Filters,
+                TextFragments = request.TextFragments
+            }, cancellationToken).ConfigureAwait(false);
+            long maxYieldedLogId = 0;
+            foreach (var log in existingLogs.Items)
+            {
+                maxYieldedLogId = Math.Max(maxYieldedLogId, log.InternalId);
+                yield return log;
+            }
+            while (channel.Reader.TryRead(out var pendingLog))
+            {
+                if (pendingLog.InternalId > maxYieldedLogId)
+                {
+                    maxYieldedLogId = pendingLog.InternalId;
+                    yield return pendingLog;
+                }
+            }
+
+            await foreach (var log in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (log.InternalId > maxYieldedLogId)
+                {
+                    maxYieldedLogId = log.InternalId;
+                    yield return log;
+                }
+            }
+        }
+        finally
+        {
+            lock (_watchersLock)
+            {
+                _logWatchers?.Remove(watcher);
+            }
+            channel.Writer.TryComplete();
+        }
+    }
+
+    private void PushSpansToWatchers(List<OtlpSpan> spans)
+    {
+        SpanWatcher[] watchers;
+        lock (_watchersLock)
+        {
+            watchers = _spanWatchers?.ToArray() ?? [];
+        }
+
+        foreach (var span in spans)
+        {
+            foreach (var watcher in watchers)
+            {
+                var request = watcher.Request;
+                if (request.ResourceKeys is { Count: > 0 } keys &&
+                    !keys.Contains(span.Source.ResourceKey) &&
+                    (span.UninstrumentedPeer is null || !keys.Contains(span.UninstrumentedPeer.ResourceKey)))
+                {
+                    continue;
+                }
+                if (!MatchesSpanWatcherRequest(span, request))
+                {
+                    continue;
+                }
+                watcher.Channel.Writer.TryWrite(span);
+            }
+        }
+    }
+
+    private void PushLogsToWatchers(List<OtlpLogEntry> logs)
+    {
+        LogWatcher[] watchers;
+        lock (_watchersLock)
+        {
+            watchers = _logWatchers?.ToArray() ?? [];
+        }
+
+        foreach (var log in logs)
+        {
+            foreach (var watcher in watchers)
+            {
+                var request = watcher.Request;
+                if (request.ResourceKeys is { Count: > 0 } keys && !keys.Contains(log.ResourceView.ResourceKey))
+                {
+                    continue;
+                }
+                if (!MatchesLogWatcherRequest(log, request))
+                {
+                    continue;
+                }
+                watcher.Channel.Writer.TryWrite(log);
+            }
+        }
+    }
+
+    private static bool MatchesSpanWatcherRequest(OtlpSpan span, WatchSpansRequest request)
+    {
+        if (!string.IsNullOrEmpty(request.TraceId) && !OtlpHelpers.MatchTelemetryId(request.TraceId, span.TraceId))
+        {
+            return false;
+        }
+        if (request.HasError.HasValue && (span.Status == OtlpSpanStatusCode.Error) != request.HasError.Value)
+        {
+            return false;
+        }
+        if (request.Filters.Any(filter => filter.Enabled && !filter.Apply(span)))
+        {
+            return false;
+        }
+        return request.TextFragments is not { Length: > 0 } fragments || MatchesSpanTextFragments(span, fragments);
+    }
+
+    private static bool MatchesLogWatcherRequest(OtlpLogEntry log, WatchLogsRequest request)
+    {
+        IEnumerable<OtlpLogEntry> matches = [log];
+        foreach (var filter in request.Filters.Where(filter => filter.Enabled))
+        {
+            matches = filter.Apply(matches);
+        }
+        return matches.Any() &&
+            (request.TextFragments is not { Length: > 0 } fragments || MatchesLogTextFragments(log, fragments));
+    }
+
+    private static bool MatchesSpanTextFragments(OtlpSpan span, string[] fragments)
+    {
+        return SearchTextParser.MatchesAllFragments(fragments, span, static (candidate, fragment) =>
+            candidate.Name.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.SpanId.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.TraceId.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.Scope.Name.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.Source.Resource.ResourceName.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.Status.ToString().Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.Kind.ToString().Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.StatusMessage?.Contains(fragment, StringComparisons.FullTextSearch) == true ||
+            candidate.Attributes.Any(attribute =>
+                attribute.Key.Contains(fragment, StringComparisons.FullTextSearch) ||
+                attribute.Value.Contains(fragment, StringComparisons.FullTextSearch)) ||
+            candidate.Events.Any(spanEvent => spanEvent.Name.Contains(fragment, StringComparisons.FullTextSearch)));
+    }
+
+    private static bool MatchesLogTextFragments(OtlpLogEntry log, string[] fragments)
+    {
+        return SearchTextParser.MatchesAllFragments(fragments, log, static (candidate, fragment) =>
+            candidate.Message.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.Scope.Name.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.TraceId.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.SpanId.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.Severity.ToString().Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.ResourceView.Resource.ResourceName.Contains(fragment, StringComparisons.FullTextSearch) ||
+            candidate.EventName?.Contains(fragment, StringComparisons.FullTextSearch) == true ||
+            candidate.Attributes.Any(attribute =>
+                attribute.Key.Contains(fragment, StringComparisons.FullTextSearch) ||
+                attribute.Value.Contains(fragment, StringComparisons.FullTextSearch)));
+    }
+
+    private void DisposeWatchers()
+    {
+        lock (_watchersLock)
+        {
+            foreach (var watcher in _spanWatchers ?? [])
+            {
+                watcher.Channel.Writer.TryComplete();
+            }
+            foreach (var watcher in _logWatchers ?? [])
+            {
+                watcher.Channel.Writer.TryComplete();
+            }
+            _spanWatchers?.Clear();
+            _logWatchers?.Clear();
+        }
+    }
+
+    private sealed class SpanWatcher(WatchSpansRequest request, Channel<OtlpSpan> channel)
+    {
+        public WatchSpansRequest Request => request;
+        public Channel<OtlpSpan> Channel => channel;
+    }
+
+    private sealed class LogWatcher(WatchLogsRequest request, Channel<OtlpLogEntry> channel)
+    {
+        public WatchLogsRequest Request => request;
+        public Channel<OtlpLogEntry> Channel => channel;
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Traces.Reads.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Traces.Reads.cs
@@ -1,0 +1,913 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using System.Globalization;
+using System.Text;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using Dapper;
+using Microsoft.Data.Sqlite;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public sealed partial class SqliteTelemetryRepository
+{
+    private GetTracesResponse GetTracesFromDatabase(GetTracesRequest context, CancellationToken cancellationToken)
+    {
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var query = BuildTraceQuery(context);
+        var aggregate = connection.QuerySingle<TraceAggregateRecord>($"""
+            SELECT COUNT(*) AS TotalItemCount, COALESCE(MAX(t.duration_ticks), 0) AS MaxDurationTicks
+            {query.FromAndWhere};
+            """, query.Parameters);
+        var hiddenItemCount = context.LatestItemCount is { } latestItemCount
+            ? Math.Max(aggregate.TotalItemCount - Math.Max(latestItemCount, 0), 0)
+            : 0;
+        query.Parameters.Add("StartIndex", (long)Math.Max(context.StartIndex, 0) + hiddenItemCount);
+        query.Parameters.Add("Count", Math.Max(context.Count, 0));
+        var records = connection.Query<TraceSummaryRecord>($"""
+            SELECT
+                t.trace_id AS TraceId,
+                t.last_updated_timestamp_ticks AS LastUpdatedTimestampTicks
+            {query.FromAndWhere}
+            ORDER BY t.first_span_timestamp_ticks, t.trace_id
+            LIMIT @Count OFFSET @StartIndex;
+            """, query.Parameters).AsList();
+        var traces = new List<OtlpTrace>(records.Count);
+        foreach (var batch in records.Chunk(MaxTraceBatchSize))
+        {
+            var tracesById = MaterializeTraces(connection, batch.Select(record => record.TraceId).ToArray());
+            traces.AddRange(batch.Select(record => tracesById[record.TraceId]));
+        }
+        return new GetTracesResponse
+        {
+            PagedResult = new PagedResult<OtlpTrace>
+            {
+                Items = traces,
+                TotalItemCount = aggregate.TotalItemCount,
+                IsFull = connection.QuerySingle<int>("SELECT COUNT(*) FROM telemetry_traces;") >= _otlpContext.Options.MaxTraceCount
+            },
+            MaxDuration = TimeSpan.FromTicks(aggregate.MaxDurationTicks)
+        };
+    }
+
+    private GetTraceSummariesResponse GetTraceSummariesFromDatabase(GetTracesRequest context, CancellationToken cancellationToken)
+    {
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var query = BuildTraceQuery(context);
+        query.Parameters.Add("StartIndex", Math.Max(context.StartIndex, 0));
+        query.Parameters.Add("Count", Math.Max(context.Count, 0));
+        query.Parameters.Add("LatestItemCount", Math.Max(context.LatestItemCount ?? int.MaxValue, 0));
+        query.Parameters.Add("MaxTraceCount", _otlpContext.Options.MaxTraceCount);
+
+        // Build the page and its pre-aggregated resource groups in one query.
+        var records = connection.Query<TracePageSummaryRecord>($"""
+            WITH
+            filtered_traces AS (
+                SELECT t.*
+                {query.FromAndWhere}
+            ),
+            trace_aggregate AS (
+                SELECT COUNT(*) AS TotalItemCount, COALESCE(MAX(duration_ticks), 0) AS MaxDurationTicks
+                FROM filtered_traces
+            ),
+            paged_traces AS (
+                SELECT *
+                FROM filtered_traces
+                ORDER BY first_span_timestamp_ticks, trace_id
+                LIMIT @Count OFFSET @StartIndex + MAX((SELECT TotalItemCount FROM trace_aggregate) - @LatestItemCount, 0)
+            ),
+            resource_summaries AS (
+                SELECT
+                    tr.trace_id,
+                    r.resource_name,
+                    r.instance_id,
+                    r.uninstrumented_peer,
+                    tr.resource_order_ticks,
+                    tr.total_spans,
+                    tr.errored_spans
+                FROM telemetry_trace_resources tr
+                JOIN paged_traces pt ON pt.trace_id = tr.trace_id
+                JOIN telemetry_resources r ON r.resource_id = tr.resource_id
+                WHERE tr.total_spans > 0
+            ),
+            trace_summaries AS (
+                SELECT
+                    pt.trace_id,
+                    pt.full_name,
+                    pt.first_span_timestamp_ticks,
+                    pt.duration_ticks,
+                    r.resource_name AS root_resource_name,
+                    r.instance_id AS root_instance_id,
+                    r.uninstrumented_peer AS root_uninstrumented_peer,
+                    pt.has_error,
+                    pt.has_gen_ai,
+                    pt.first_span_timestamp_ticks AS trace_order_ticks
+                FROM paged_traces pt
+                JOIN telemetry_spans s ON s.trace_id = pt.trace_id AND s.span_id = pt.primary_span_id
+                JOIN telemetry_resources r ON r.resource_id = s.resource_id
+            )
+            SELECT
+                a.TotalItemCount,
+                a.MaxDurationTicks,
+                (SELECT COUNT(*) FROM telemetry_traces) >= @MaxTraceCount AS IsFull,
+                ts.trace_id AS TraceId,
+                ts.full_name AS FullName,
+                ts.first_span_timestamp_ticks AS StartTimeTicks,
+                ts.duration_ticks AS DurationTicks,
+                ts.root_resource_name AS RootResourceName,
+                ts.root_instance_id AS RootInstanceId,
+                ts.root_uninstrumented_peer AS RootUninstrumentedPeer,
+                ts.has_error AS HasError,
+                ts.has_gen_ai AS HasGenAI,
+                rs.resource_name AS ResourceName,
+                rs.instance_id AS InstanceId,
+                rs.uninstrumented_peer AS UninstrumentedPeer,
+                rs.total_spans AS TotalSpans,
+                rs.errored_spans AS ErroredSpans
+            FROM trace_aggregate a
+            LEFT JOIN trace_summaries ts ON 1 = 1
+            LEFT JOIN resource_summaries rs ON rs.trace_id = ts.trace_id
+            ORDER BY ts.trace_order_ticks, ts.trace_id, rs.resource_order_ticks DESC, rs.uninstrumented_peer, rs.resource_name, rs.instance_id;
+            """, query.Parameters).AsList();
+
+        var firstRecord = records[0];
+        var summaries = records
+            .Where(record => record.TraceId is not null)
+            .GroupBy(record => record.TraceId!, StringComparer.Ordinal)
+            .Select(group =>
+            {
+                var trace = group.First();
+                return new TraceSummary
+                {
+                    TraceId = trace.TraceId!,
+                    FullName = trace.FullName!,
+                    StartTime = new DateTime(trace.StartTimeTicks!.Value, DateTimeKind.Utc),
+                    Duration = TimeSpan.FromTicks(trace.DurationTicks!.Value),
+                    RootResource = CreateSummaryResource(trace.RootResourceName!, trace.RootInstanceId, trace.RootUninstrumentedPeer!.Value),
+                    Resources = group.Select(resource => new TraceResourceSummary
+                    {
+                        Resource = CreateSummaryResource(resource.ResourceName!, resource.InstanceId, resource.UninstrumentedPeer!.Value),
+                        TotalSpans = resource.TotalSpans!.Value,
+                        ErroredSpans = resource.ErroredSpans!.Value
+                    }).ToList(),
+                    HasError = trace.HasError!.Value,
+                    HasGenAI = trace.HasGenAI!.Value
+                };
+            }).ToList();
+
+        return new GetTraceSummariesResponse
+        {
+            PagedResult = new PagedResult<TraceSummary>
+            {
+                Items = summaries,
+                TotalItemCount = firstRecord.TotalItemCount,
+                IsFull = firstRecord.IsFull
+            },
+            MaxDuration = TimeSpan.FromTicks(firstRecord.MaxDurationTicks)
+        };
+
+        OtlpResource CreateSummaryResource(string resourceName, string? instanceId, bool uninstrumentedPeer) =>
+            new(resourceName, instanceId, uninstrumentedPeer, _otlpContext);
+    }
+
+    private static TraceQuery BuildTraceQuery(GetTracesRequest context)
+    {
+        var sql = new StringBuilder("FROM telemetry_traces t WHERE 1 = 1");
+        var parameters = new DynamicParameters();
+        if (context.ResourceKeys.Count > 0)
+        {
+            var resourcePredicates = new List<string>(context.ResourceKeys.Count);
+            for (var index = 0; index < context.ResourceKeys.Count; index++)
+            {
+                var key = context.ResourceKeys[index];
+                parameters.Add($"ResourceName{index}", key.Name);
+                var resourcePredicate = $"r.resource_name = @ResourceName{index} COLLATE NOCASE";
+                if (key.InstanceId is not null)
+                {
+                    parameters.Add($"InstanceId{index}", key.InstanceId);
+                    resourcePredicate += $" AND r.instance_id = @InstanceId{index} COLLATE NOCASE";
+                }
+                resourcePredicates.Add($"({resourcePredicate})");
+            }
+            sql.Append(" AND EXISTS (SELECT 1 FROM telemetry_trace_resources tr JOIN telemetry_resources r ON r.resource_id = tr.resource_id WHERE tr.trace_id = t.trace_id AND tr.total_spans > 0 AND (");
+            sql.AppendJoin(" OR ", resourcePredicates);
+            sql.Append("))");
+        }
+        if (!string.IsNullOrWhiteSpace(context.TraceNameFilterText))
+        {
+            sql.Append(" AND t.full_name LIKE @TraceNameFilterText ESCAPE '!'");
+            parameters.Add("TraceNameFilterText", CreateContainsLikePattern(context.TraceNameFilterText));
+        }
+
+        var positivePredicates = new List<string>();
+        var filterIndex = 0;
+        foreach (var filter in context.Filters.Where(filter => filter.Enabled))
+        {
+            if (filter is SpanHasAttributeTelemetryFilter or SpanScopePrefixTelemetryFilter or SpanNoMatchTelemetryFilter)
+            {
+                positivePredicates.Add(BuildSpanTypePredicate(filter, parameters, ref filterIndex));
+                continue;
+            }
+            if (filter is not FieldTelemetryFilter fieldFilter)
+            {
+                continue;
+            }
+
+            if (fieldFilter.Field == KnownTraceFields.DurationField)
+            {
+                sql.Append(" AND ");
+                sql.Append(BuildTraceDurationPredicate(fieldFilter, parameters, filterIndex++));
+                continue;
+            }
+
+            if (fieldFilter.Condition is FilterCondition.NotEqual or FilterCondition.NotContains)
+            {
+                sql.Append(" AND NOT EXISTS (SELECT 1 FROM telemetry_spans s JOIN telemetry_resources r ON r.resource_id = s.resource_id JOIN telemetry_scopes sc ON sc.scope_id = s.scope_id JOIN telemetry_span_kinds sk ON sk.kind = s.kind JOIN telemetry_span_statuses ss ON ss.status = s.status LEFT JOIN telemetry_resources pr ON pr.resource_id = s.uninstrumented_peer_resource_id WHERE s.trace_id = t.trace_id AND ");
+                sql.Append(BuildSpanFieldPredicate(fieldFilter, parameters, filterIndex++, invertNegative: true));
+                sql.Append(')');
+            }
+            else
+            {
+                positivePredicates.Add(BuildSpanFieldPredicate(fieldFilter, parameters, filterIndex++, invertNegative: false));
+            }
+        }
+        if (positivePredicates.Count > 0)
+        {
+            sql.Append(" AND EXISTS (SELECT 1 FROM telemetry_spans s JOIN telemetry_resources r ON r.resource_id = s.resource_id JOIN telemetry_scopes sc ON sc.scope_id = s.scope_id JOIN telemetry_span_kinds sk ON sk.kind = s.kind JOIN telemetry_span_statuses ss ON ss.status = s.status LEFT JOIN telemetry_resources pr ON pr.resource_id = s.uninstrumented_peer_resource_id WHERE s.trace_id = t.trace_id AND ");
+            sql.AppendJoin(" AND ", positivePredicates);
+            sql.Append(')');
+        }
+
+        if (context.TextFragments is { Length: > 0 })
+        {
+            var fullNamePredicates = new List<string>(context.TextFragments.Length);
+            var spanPredicates = new List<string>(context.TextFragments.Length);
+            for (var index = 0; index < context.TextFragments.Length; index++)
+            {
+                var parameterName = $"TextFragment{index}";
+                parameters.Add(parameterName, CreateContainsLikePattern(context.TextFragments[index]));
+                fullNamePredicates.Add($"t.full_name LIKE @{parameterName} ESCAPE '!'");
+                spanPredicates.Add($"""
+                    (
+                        s.name LIKE @{parameterName} ESCAPE '!' OR
+                        s.span_id LIKE @{parameterName} ESCAPE '!' OR
+                        s.trace_id LIKE @{parameterName} ESCAPE '!' OR
+                        sc.scope_name LIKE @{parameterName} ESCAPE '!' OR
+                        r.resource_name LIKE @{parameterName} ESCAPE '!' OR
+                        ss.status_name LIKE @{parameterName} ESCAPE '!' OR
+                        sk.kind_name LIKE @{parameterName} ESCAPE '!' OR
+                        COALESCE(s.status_message, '') LIKE @{parameterName} ESCAPE '!' OR
+                        EXISTS (SELECT 1 FROM telemetry_span_attributes a WHERE a.trace_id = s.trace_id AND a.span_id = s.span_id AND (a.attribute_key LIKE @{parameterName} ESCAPE '!' OR a.attribute_value LIKE @{parameterName} ESCAPE '!')) OR
+                        EXISTS (SELECT 1 FROM telemetry_span_events e WHERE e.trace_id = s.trace_id AND e.span_id = s.span_id AND e.event_name LIKE @{parameterName} ESCAPE '!')
+                    )
+                    """);
+            }
+            sql.Append(" AND ((");
+            sql.AppendJoin(" AND ", fullNamePredicates);
+            sql.Append(") OR EXISTS (SELECT 1 FROM telemetry_spans s JOIN telemetry_resources r ON r.resource_id = s.resource_id JOIN telemetry_scopes sc ON sc.scope_id = s.scope_id JOIN telemetry_span_kinds sk ON sk.kind = s.kind JOIN telemetry_span_statuses ss ON ss.status = s.status WHERE s.trace_id = t.trace_id AND ");
+            sql.AppendJoin(" AND ", spanPredicates);
+            sql.Append("))");
+        }
+        return new TraceQuery(sql.ToString(), parameters);
+    }
+
+    private static string BuildSpanTypePredicate(TelemetryFilter filter, DynamicParameters parameters, ref int filterIndex)
+    {
+        switch (filter)
+        {
+            case SpanHasAttributeTelemetryFilter attributeFilter:
+                var attributePredicates = new List<string>(attributeFilter.AttributeNames.Count);
+                foreach (var attributeName in attributeFilter.AttributeNames)
+                {
+                    var parameterName = $"SpanTypeAttribute{filterIndex++}";
+                    parameters.Add(parameterName, attributeName);
+                    attributePredicates.Add($"a.attribute_key = @{parameterName}");
+                }
+                return $"EXISTS (SELECT 1 FROM telemetry_span_attributes a WHERE a.trace_id = s.trace_id AND a.span_id = s.span_id AND LENGTH(a.attribute_value) > 0 AND ({string.Join(" OR ", attributePredicates)}))";
+            case SpanScopePrefixTelemetryFilter scopeFilter:
+                var scopePredicates = new List<string>(scopeFilter.ScopePrefixes.Count);
+                foreach (var scopePrefix in scopeFilter.ScopePrefixes)
+                {
+                    var parameterName = $"SpanTypeScope{filterIndex++}";
+                    parameters.Add(parameterName, scopePrefix);
+                    parameters.Add($"{parameterName}Prefix", $"{EscapeLikePattern(scopePrefix)}.%");
+                    scopePredicates.Add($"(sc.scope_name = @{parameterName} COLLATE NOCASE OR sc.scope_name LIKE @{parameterName}Prefix ESCAPE '!')");
+                }
+                return $"({string.Join(" OR ", scopePredicates)})";
+            case SpanNoMatchTelemetryFilter noMatchFilter:
+                var matchPredicates = new List<string>(noMatchFilter.Filters.Count);
+                foreach (var nestedFilter in noMatchFilter.Filters)
+                {
+                    matchPredicates.Add(BuildSpanTypePredicate(nestedFilter, parameters, ref filterIndex));
+                }
+                return $"NOT ({string.Join(" OR ", matchPredicates)})";
+            default:
+                throw new InvalidOperationException($"Unsupported span type filter: {filter.GetType().FullName}");
+        }
+    }
+
+    private static string BuildTraceDurationPredicate(FieldTelemetryFilter filter, DynamicParameters parameters, int filterIndex)
+    {
+        var parameterName = $"TraceDuration{filterIndex}";
+        if (!double.TryParse(filter.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var milliseconds) || !double.IsFinite(milliseconds))
+        {
+            return "0 = 1";
+        }
+
+        parameters.Add(parameterName, milliseconds);
+        return BuildNumericPredicate($"(CAST(t.duration_ticks AS REAL) / {TimeSpan.TicksPerMillisecond})", filter.Condition, parameterName);
+    }
+
+    private static string BuildSpanFieldPredicate(
+        FieldTelemetryFilter filter,
+        DynamicParameters parameters,
+        int filterIndex,
+        bool invertNegative)
+    {
+        var parameterName = $"TraceFilter{filterIndex}";
+        var condition = invertNegative
+            ? filter.Condition switch
+            {
+                FilterCondition.NotEqual => FilterCondition.Equals,
+                FilterCondition.NotContains => FilterCondition.Contains,
+                _ => filter.Condition
+            }
+            : filter.Condition;
+        parameters.Add(
+            parameterName,
+            condition is FilterCondition.Contains or FilterCondition.NotContains
+                ? CreateContainsLikePattern(filter.Value)
+                : filter.Value);
+
+        var expression = filter.Field switch
+        {
+            KnownResourceFields.ServiceNameField => null,
+            KnownTraceFields.TraceIdField => "s.trace_id",
+            KnownTraceFields.SpanIdField => "s.span_id",
+            KnownTraceFields.NameField => "s.name",
+            KnownTraceFields.KindField => "sk.kind_name",
+            KnownTraceFields.StatusField => "ss.status_name",
+            KnownSourceFields.NameField => "sc.scope_name",
+            KnownTraceFields.TimestampField => "s.start_time_ticks / 10000",
+            _ => null
+        };
+        if (filter.Field == KnownTraceFields.TimestampField)
+        {
+            if (!DateTime.TryParse(filter.Value, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeLocal, out var date))
+            {
+                return "0 = 1";
+            }
+            parameters.Add(parameterName, date.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond);
+            return BuildNumericPredicate(expression!, condition, parameterName);
+        }
+        if (expression is not null)
+        {
+            return BuildStringPredicate(expression, condition, parameterName);
+        }
+        if (filter.Field == KnownResourceFields.ServiceNameField)
+        {
+            var sourcePredicate = BuildStringPredicate("r.resource_name", condition, parameterName);
+            var peerPredicate = BuildStringPredicate("pr.resource_name", condition, parameterName);
+            return $"({sourcePredicate} OR (pr.resource_id IS NOT NULL AND {peerPredicate}))";
+        }
+
+        var attributePredicate = BuildStringPredicate("a.attribute_value", condition, parameterName);
+        parameters.Add($"TraceField{filterIndex}", filter.Field);
+        return $"EXISTS (SELECT 1 FROM telemetry_span_attributes a WHERE a.trace_id = s.trace_id AND a.span_id = s.span_id AND a.attribute_key = @TraceField{filterIndex} COLLATE NOCASE AND {attributePredicate})";
+    }
+
+    private GetSpansResponse GetSpansFromDatabase(GetSpansRequest context, CancellationToken cancellationToken)
+    {
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var query = BuildSpanQuery(context);
+        var totalCount = connection.QuerySingle<int>($"SELECT COUNT(*) {query.FromAndWhere};", query.Parameters);
+        query.Parameters.Add("StartIndex", Math.Max(context.StartIndex, 0));
+        query.Parameters.Add("Count", Math.Max(context.Count, 0));
+        var identities = connection.Query<SpanIdentityRecord>($"""
+            SELECT s.trace_id AS TraceId, s.span_id AS SpanId
+            {query.FromAndWhere}
+            ORDER BY t.first_span_timestamp_ticks, t.trace_id, s.start_time_ticks, s.span_id
+            LIMIT @Count OFFSET @StartIndex;
+            """, query.Parameters).AsList();
+        var traces = identities.Select(identity => identity.TraceId).Distinct(StringComparer.Ordinal)
+            .ToDictionary(traceId => traceId, traceId => MaterializeTrace(connection, traceId)!, StringComparer.Ordinal);
+        return new GetSpansResponse
+        {
+            PagedResult = new PagedResult<OtlpSpan>
+            {
+                Items = identities.Select(identity => traces[identity.TraceId].Spans.Single(span => span.SpanId == identity.SpanId)).ToList(),
+                TotalItemCount = totalCount,
+                IsFull = connection.QuerySingle<int>("SELECT COUNT(*) FROM telemetry_traces;") >= _otlpContext.Options.MaxTraceCount
+            }
+        };
+    }
+
+    private static TraceQuery BuildSpanQuery(GetSpansRequest context)
+    {
+        var sql = new StringBuilder("""
+            FROM telemetry_spans s
+            JOIN telemetry_traces t ON t.trace_id = s.trace_id
+            JOIN telemetry_resources r ON r.resource_id = s.resource_id
+            JOIN telemetry_scopes sc ON sc.scope_id = s.scope_id
+            JOIN telemetry_span_kinds sk ON sk.kind = s.kind
+            JOIN telemetry_span_statuses ss ON ss.status = s.status
+            LEFT JOIN telemetry_resources pr ON pr.resource_id = s.uninstrumented_peer_resource_id
+            WHERE 1 = 1
+            """);
+        var parameters = new DynamicParameters();
+        if (context.ResourceKeys.Count > 0)
+        {
+            var predicates = new List<string>(context.ResourceKeys.Count);
+            for (var index = 0; index < context.ResourceKeys.Count; index++)
+            {
+                var key = context.ResourceKeys[index];
+                parameters.Add($"SpanResourceName{index}", key.Name);
+                var source = $"r.resource_name = @SpanResourceName{index} COLLATE NOCASE";
+                var peer = $"pr.resource_name = @SpanResourceName{index} COLLATE NOCASE";
+                if (key.InstanceId is not null)
+                {
+                    parameters.Add($"SpanInstanceId{index}", key.InstanceId);
+                    source += $" AND r.instance_id = @SpanInstanceId{index} COLLATE NOCASE";
+                    peer += $" AND pr.instance_id = @SpanInstanceId{index} COLLATE NOCASE";
+                }
+                predicates.Add($"(({source}) OR ({peer}))");
+            }
+            sql.Append(" AND (");
+            sql.AppendJoin(" OR ", predicates);
+            sql.Append(')');
+        }
+        if (!string.IsNullOrEmpty(context.TraceId))
+        {
+            parameters.Add(
+                "SpanTraceId",
+                context.TraceId.Length >= OtlpHelpers.ShortenedIdLength
+                    ? CreateStartsWithLikePattern(context.TraceId)
+                    : context.TraceId);
+            sql.Append(context.TraceId.Length >= OtlpHelpers.ShortenedIdLength
+                ? " AND s.trace_id LIKE @SpanTraceId ESCAPE '!'"
+                : " AND s.trace_id = @SpanTraceId COLLATE NOCASE");
+        }
+        if (context.HasError is not null)
+        {
+            parameters.Add("SpanErrorStatus", (int)OtlpSpanStatusCode.Error);
+            sql.Append(context.HasError.Value ? " AND s.status = @SpanErrorStatus" : " AND s.status <> @SpanErrorStatus");
+        }
+
+        var filterIndex = 0;
+        foreach (var filter in context.Filters.Where(filter => filter.Enabled))
+        {
+            if (filter is not FieldTelemetryFilter fieldFilter)
+            {
+                continue;
+            }
+            if (fieldFilter.Field == KnownTraceFields.DurationField)
+            {
+                var parameterName = $"SpanDuration{filterIndex++}";
+                if (!double.TryParse(fieldFilter.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var milliseconds) || !double.IsFinite(milliseconds))
+                {
+                    sql.Append(" AND 0 = 1");
+                    continue;
+                }
+                parameters.Add(parameterName, milliseconds);
+                sql.Append(" AND ");
+                sql.Append(BuildNumericPredicate($"(CAST(s.end_time_ticks - s.start_time_ticks AS REAL) / {TimeSpan.TicksPerMillisecond})", fieldFilter.Condition, parameterName));
+                continue;
+            }
+
+            if (fieldFilter.Condition is FilterCondition.NotEqual or FilterCondition.NotContains &&
+                fieldFilter.Field is not (KnownResourceFields.ServiceNameField or KnownTraceFields.TraceIdField or KnownTraceFields.SpanIdField or KnownTraceFields.NameField or KnownTraceFields.KindField or KnownTraceFields.StatusField or KnownSourceFields.NameField or KnownTraceFields.TimestampField))
+            {
+                var violationFilter = new FieldTelemetryFilter
+                {
+                    Field = fieldFilter.Field,
+                    Condition = fieldFilter.Condition == FilterCondition.NotEqual ? FilterCondition.Equals : FilterCondition.Contains,
+                    Value = fieldFilter.Value
+                };
+                sql.Append(" AND NOT ");
+                sql.Append(BuildSpanFieldPredicate(violationFilter, parameters, filterIndex++, invertNegative: false));
+            }
+            else
+            {
+                sql.Append(" AND ");
+                sql.Append(BuildSpanFieldPredicate(fieldFilter, parameters, filterIndex++, invertNegative: false));
+            }
+        }
+
+        if (context.TextFragments is { Length: > 0 })
+        {
+            for (var index = 0; index < context.TextFragments.Length; index++)
+            {
+                var parameterName = $"SpanTextFragment{index}";
+                parameters.Add(parameterName, CreateContainsLikePattern(context.TextFragments[index]));
+                 sql.Append(CultureInfo.InvariantCulture, $"""
+                     AND (
+                        s.name LIKE @{parameterName} ESCAPE '!' OR
+                        s.span_id LIKE @{parameterName} ESCAPE '!' OR
+                        s.trace_id LIKE @{parameterName} ESCAPE '!' OR
+                        sc.scope_name LIKE @{parameterName} ESCAPE '!' OR
+                        r.resource_name LIKE @{parameterName} ESCAPE '!' OR
+                        ss.status_name LIKE @{parameterName} ESCAPE '!' OR
+                        sk.kind_name LIKE @{parameterName} ESCAPE '!' OR
+                        COALESCE(s.status_message, '') LIKE @{parameterName} ESCAPE '!' OR
+                        EXISTS (SELECT 1 FROM telemetry_span_attributes a WHERE a.trace_id = s.trace_id AND a.span_id = s.span_id AND (a.attribute_key LIKE @{parameterName} ESCAPE '!' OR a.attribute_value LIKE @{parameterName} ESCAPE '!')) OR
+                        EXISTS (SELECT 1 FROM telemetry_span_events e WHERE e.trace_id = s.trace_id AND e.span_id = s.span_id AND e.event_name LIKE @{parameterName} ESCAPE '!')
+                    )
+                    """);
+            }
+        }
+        return new TraceQuery(sql.ToString(), parameters);
+    }
+
+    private List<string> GetTracePropertyKeysFromDatabase(ResourceKey? resourceKey, CancellationToken cancellationToken)
+    {
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var parameters = new DynamicParameters();
+        var resourceWhere = string.Empty;
+        if (resourceKey is not null)
+        {
+            resourceWhere = " AND r.resource_name = @ResourceName COLLATE NOCASE";
+            parameters.Add("ResourceName", resourceKey.Value.Name);
+            if (resourceKey.Value.InstanceId is not null)
+            {
+                resourceWhere += " AND r.instance_id = @InstanceId COLLATE NOCASE";
+                parameters.Add("InstanceId", resourceKey.Value.InstanceId);
+            }
+        }
+        var propertyKeys = connection.Query<string>($"""
+            SELECT DISTINCT a.attribute_key
+            FROM telemetry_span_attributes a
+            JOIN telemetry_spans s ON s.trace_id = a.trace_id AND s.span_id = a.span_id
+            JOIN telemetry_resources r ON r.resource_id = s.resource_id
+            WHERE 1 = 1{resourceWhere}
+            ORDER BY a.attribute_key;
+            """, parameters);
+        return propertyKeys.AsList();
+    }
+
+    private Dictionary<string, int> GetTraceFieldValuesFromDatabase(string attributeName, CancellationToken cancellationToken)
+    {
+        if (attributeName is KnownTraceFields.DurationField or KnownTraceFields.TimestampField)
+        {
+            return new Dictionary<string, int>(StringComparers.OtlpAttribute);
+        }
+
+        using var connection = _database.OpenConnection();
+        using var interrupt = connection.RegisterInterrupt(cancellationToken);
+        var values = attributeName switch
+        {
+            KnownResourceFields.ServiceNameField => Query("""
+                SELECT resource_name AS FieldValue, COUNT(*) AS ValueCount
+                FROM (
+                    SELECT r.resource_name
+                    FROM telemetry_spans s
+                    JOIN telemetry_resources r ON r.resource_id = s.resource_id
+                    UNION ALL
+                    SELECT r.resource_name
+                    FROM telemetry_spans s
+                    JOIN telemetry_resources r ON r.resource_id = s.uninstrumented_peer_resource_id
+                )
+                GROUP BY resource_name;
+                """),
+            KnownTraceFields.TraceIdField => QueryFieldValues("trace_id", "telemetry_spans"),
+            KnownTraceFields.SpanIdField => QueryFieldValues("span_id", "telemetry_spans"),
+            KnownTraceFields.KindField => Query("""
+                SELECT sk.kind_name AS FieldValue, COUNT(*) AS ValueCount
+                FROM telemetry_spans s
+                JOIN telemetry_span_kinds sk ON sk.kind = s.kind
+                GROUP BY sk.kind, sk.kind_name;
+                """),
+            KnownTraceFields.StatusField => Query("""
+                SELECT ss.status_name AS FieldValue, COUNT(*) AS ValueCount
+                FROM telemetry_spans s
+                JOIN telemetry_span_statuses ss ON ss.status = s.status
+                GROUP BY ss.status, ss.status_name;
+                """),
+            KnownSourceFields.NameField => Query("""
+                SELECT sc.scope_name AS FieldValue, COUNT(*) AS ValueCount
+                FROM telemetry_spans s
+                JOIN telemetry_scopes sc ON sc.scope_id = s.scope_id
+                GROUP BY sc.scope_name;
+                """),
+            KnownTraceFields.NameField => QueryFieldValues("name", "telemetry_spans"),
+            _ => Query("""
+                SELECT attribute_value AS FieldValue, COUNT(*) AS ValueCount
+                FROM telemetry_span_attributes
+                WHERE attribute_key = @AttributeName COLLATE NOCASE
+                GROUP BY attribute_value;
+                """, new { AttributeName = attributeName })
+        };
+        return values.ToDictionary(record => record.FieldValue!, record => record.ValueCount, StringComparers.OtlpAttribute);
+
+        IEnumerable<FieldValueRecord> Query(string sql, object? parameters = null)
+        {
+            return connection.Query<FieldValueRecord>(sql, parameters);
+        }
+
+        IEnumerable<FieldValueRecord> QueryFieldValues(string expression, string table)
+        {
+            return Query($"""
+                SELECT {expression} AS FieldValue, COUNT(*) AS ValueCount
+                FROM {table}
+                GROUP BY {expression};
+                """);
+        }
+    }
+
+    private bool HasUpdatedTraceInDatabase(OtlpTrace trace)
+    {
+        using var connection = _database.OpenConnection();
+        var lastUpdatedTicks = connection.QuerySingleOrDefault<long?>("""
+            SELECT last_updated_timestamp_ticks
+            FROM telemetry_traces
+            WHERE trace_id = @TraceId;
+            """, new { trace.TraceId });
+        return lastUpdatedTicks is null || lastUpdatedTicks.Value > trace.LastUpdatedDate.Ticks;
+    }
+
+    private OtlpTrace? GetTraceFromDatabase(string traceId)
+    {
+        using var connection = _database.OpenConnection();
+        var usePrefix = traceId.Length >= OtlpHelpers.ShortenedIdLength;
+        var storedTraceId = connection.QueryFirstOrDefault<string>(usePrefix
+            ? "SELECT trace_id FROM telemetry_traces WHERE trace_id LIKE @TraceId ESCAPE '!' ORDER BY first_span_timestamp_ticks, trace_id LIMIT 1;"
+            : "SELECT trace_id FROM telemetry_traces WHERE trace_id = @TraceId COLLATE NOCASE ORDER BY first_span_timestamp_ticks, trace_id LIMIT 1;", new { TraceId = usePrefix ? CreateStartsWithLikePattern(traceId) : traceId });
+        return storedTraceId is null ? null : MaterializeTrace(connection, storedTraceId);
+    }
+
+    private OtlpSpan? GetSpanFromDatabase(string traceId, string spanId)
+    {
+        var trace = GetTraceFromDatabase(traceId);
+        return trace?.Spans.FirstOrDefault(span => span.SpanId == spanId);
+    }
+
+    private OtlpTrace? MaterializeTrace(SqliteConnection connection, string traceId, IDbTransaction? transaction = null)
+    {
+        return MaterializeTraces(connection, [traceId], transaction).GetValueOrDefault(traceId);
+    }
+
+    private Dictionary<string, OtlpTrace> MaterializeTraces(SqliteConnection connection, IReadOnlyList<string> traceIds, IDbTransaction? transaction = null)
+    {
+        var records = connection.Query<SpanRecord>("""
+            SELECT
+                s.trace_id AS TraceId,
+                s.span_id AS SpanId,
+                s.parent_span_id AS ParentSpanId,
+                s.resource_id AS ResourceId,
+                s.resource_view_id AS ResourceViewId,
+                s.scope_id AS ScopeId,
+                s.name AS Name,
+                s.kind AS Kind,
+                s.start_time_ticks AS StartTimeTicks,
+                s.end_time_ticks AS EndTimeTicks,
+                s.status AS Status,
+                s.status_message AS StatusMessage,
+                s.trace_state AS State,
+                s.uninstrumented_peer_resource_id AS PeerResourceId,
+                t.last_updated_timestamp_ticks AS LastUpdatedTimestampTicks,
+                r.resource_name AS ResourceName,
+                r.instance_id AS InstanceId,
+                r.uninstrumented_peer AS UninstrumentedPeer,
+                r.has_logs AS HasLogs,
+                r.has_traces AS HasTraces,
+                r.has_metrics AS HasMetrics,
+                sc.scope_name AS ScopeName,
+                sc.scope_version AS ScopeVersion,
+                pr.resource_name AS PeerResourceName,
+                pr.instance_id AS PeerInstanceId
+            FROM telemetry_spans s
+            JOIN telemetry_traces t ON t.trace_id = s.trace_id
+            JOIN telemetry_resources r ON r.resource_id = s.resource_id
+            JOIN telemetry_scopes sc ON sc.scope_id = s.scope_id
+            LEFT JOIN telemetry_resources pr ON pr.resource_id = s.uninstrumented_peer_resource_id
+            WHERE s.trace_id IN @TraceIds
+            ORDER BY s.trace_id, s.start_time_ticks, s.span_id;
+            """, new { TraceIds = traceIds }, transaction).AsList();
+        if (records.Count == 0)
+        {
+            return new Dictionary<string, OtlpTrace>(StringComparer.Ordinal);
+        }
+
+        var spanAttributes = connection.Query<TraceOwnedAttributeRecord>("""
+            SELECT trace_id AS TraceId, span_id AS OwnerId, attribute_key AS AttributeKey, attribute_value AS AttributeValue
+            FROM telemetry_span_attributes
+            WHERE trace_id IN @TraceIds
+            ORDER BY trace_id, span_id, ordinal;
+            """, new { TraceIds = traceIds }, transaction).ToLookup(record => (record.TraceId, record.OwnerId));
+        var eventRecords = connection.Query<SpanEventRecord>("""
+            SELECT trace_id AS TraceId, event_id AS EventId, span_id AS SpanId, event_name AS EventName, event_time_ticks AS EventTimeTicks
+            FROM telemetry_span_events
+            WHERE trace_id IN @TraceIds
+            ORDER BY trace_id, span_id, ordinal;
+            """, new { TraceIds = traceIds }, transaction).AsList();
+        var eventAttributeRecords = new List<TextOwnedAttributeRecord>();
+        foreach (var eventIdBatch in eventRecords.Select(record => record.EventId).Chunk(MaxSpanDetailBatchSize))
+        {
+            eventAttributeRecords.AddRange(connection.Query<TextOwnedAttributeRecord>("""
+                SELECT event_id AS OwnerId, attribute_key AS AttributeKey, attribute_value AS AttributeValue
+                FROM telemetry_span_event_attributes
+                WHERE event_id IN @Ids
+                ORDER BY event_id, ordinal;
+                """, new { Ids = eventIdBatch }, transaction));
+        }
+        var eventAttributes = eventAttributeRecords.ToLookup(record => record.OwnerId);
+        var events = eventRecords.ToLookup(record => (record.TraceId, record.SpanId));
+        var linkRecords = connection.Query<SpanLinkRecord>("""
+            SELECT
+                link_id AS LinkId,
+                source_trace_id AS SourceTraceId,
+                source_span_id AS SourceSpanId,
+                target_trace_id AS TraceId,
+                target_span_id AS SpanId,
+                trace_state AS TraceState
+            FROM telemetry_span_links
+            WHERE source_trace_id IN @TraceIds OR target_trace_id IN @TraceIds
+            ORDER BY link_id;
+            """, new { TraceIds = traceIds }, transaction).AsList();
+        var linkAttributeRecords = new List<LongOwnedAttributeRecord>();
+        foreach (var linkIdBatch in linkRecords.Select(record => record.LinkId).Chunk(MaxSpanDetailBatchSize))
+        {
+            linkAttributeRecords.AddRange(connection.Query<LongOwnedAttributeRecord>("""
+                SELECT link_id AS OwnerId, attribute_key AS AttributeKey, attribute_value AS AttributeValue
+                FROM telemetry_span_link_attributes
+                WHERE link_id IN @Ids
+                ORDER BY link_id, ordinal;
+                """, new { Ids = linkIdBatch }, transaction));
+        }
+        var linkAttributes = linkAttributeRecords.ToLookup(record => record.OwnerId);
+        var outgoingLinks = linkRecords.ToLookup(record => (record.SourceTraceId, record.SourceSpanId));
+        var incomingLinks = linkRecords.ToLookup(record => (record.TraceId, record.SpanId));
+
+        var traces = new Dictionary<string, OtlpTrace>(StringComparer.Ordinal);
+        foreach (var traceRecords in records.GroupBy(record => record.TraceId, StringComparer.Ordinal))
+        {
+            var traceId = traceRecords.Key;
+            var firstRecord = traceRecords.First();
+            var trace = new OtlpTrace(Convert.FromHexString(traceId), new DateTime(firstRecord.LastUpdatedTimestampTicks, DateTimeKind.Utc));
+            foreach (var record in traceRecords)
+            {
+                var (_, view, scope) = GetCachedTelemetryMetadata(record.ResourceId, record.ResourceViewId, record.ScopeId, CachedTelemetryType.Traces);
+
+                var modelSpan = new OtlpSpan(view, trace, scope)
+                {
+                    SpanId = record.SpanId,
+                    ParentSpanId = record.ParentSpanId,
+                    Name = record.Name,
+                    Kind = (OtlpSpanKind)record.Kind,
+                    StartTime = new DateTime(record.StartTimeTicks, DateTimeKind.Utc),
+                    EndTime = new DateTime(record.EndTimeTicks, DateTimeKind.Utc),
+                    Status = (OtlpSpanStatusCode)record.Status,
+                    StatusMessage = record.StatusMessage,
+                    State = record.State,
+                    Attributes = ToPairs(spanAttributes[(traceId, record.SpanId)]),
+                    Events = [],
+                    Links = outgoingLinks[(traceId, record.SpanId)].Select(CreateLink).ToList(),
+                    BackLinks = incomingLinks[(traceId, record.SpanId)].Select(CreateLink).ToList()
+                };
+                if (record.PeerResourceId is not null)
+                {
+                    modelSpan.SetUninstrumentedPeer(GetCachedResource(record.PeerResourceId.Value));
+                }
+                modelSpan.Events.AddRange(events[(traceId, record.SpanId)].Select(spanEvent => new OtlpSpanEvent(modelSpan)
+                {
+                    InternalId = Guid.Parse(spanEvent.EventId),
+                    Name = spanEvent.EventName,
+                    Time = new DateTime(spanEvent.EventTimeTicks, DateTimeKind.Utc),
+                    Attributes = ToPairs(eventAttributes[spanEvent.EventId])
+                }));
+                trace.AddSpan(modelSpan, skipLastUpdatedDate: true);
+            }
+            traces.Add(traceId, trace);
+        }
+        return traces;
+
+        OtlpSpanLink CreateLink(SpanLinkRecord link)
+        {
+            return new OtlpSpanLink
+            {
+                SourceTraceId = link.SourceTraceId,
+                SourceSpanId = link.SourceSpanId,
+                TraceId = link.TraceId,
+                SpanId = link.SpanId,
+                TraceState = link.TraceState,
+                Attributes = ToPairs(linkAttributes[link.LinkId])
+            };
+        }
+
+        static KeyValuePair<string, string>[] ToPairs(IEnumerable<AttributeRecord> attributes)
+        {
+            return attributes.Select(attribute => KeyValuePair.Create(attribute.AttributeKey, attribute.AttributeValue)).ToArray();
+        }
+    }
+
+    private sealed record TraceQuery(string FromAndWhere, DynamicParameters Parameters);
+
+    private sealed class TraceAggregateRecord
+    {
+        public required int TotalItemCount { get; init; }
+        public required long MaxDurationTicks { get; init; }
+    }
+
+    private sealed class TraceSummaryRecord
+    {
+        public required string TraceId { get; init; }
+        public required long LastUpdatedTimestampTicks { get; init; }
+    }
+
+    private sealed class TracePageSummaryRecord
+    {
+        public required int TotalItemCount { get; init; }
+        public required long MaxDurationTicks { get; init; }
+        public required bool IsFull { get; init; }
+        public string? TraceId { get; init; }
+        public string? FullName { get; init; }
+        public long? StartTimeTicks { get; init; }
+        public long? DurationTicks { get; init; }
+        public string? RootResourceName { get; init; }
+        public string? RootInstanceId { get; init; }
+        public bool? RootUninstrumentedPeer { get; init; }
+        public bool? HasError { get; init; }
+        public bool? HasGenAI { get; init; }
+        public string? ResourceName { get; init; }
+        public string? InstanceId { get; init; }
+        public bool? UninstrumentedPeer { get; init; }
+        public int? TotalSpans { get; init; }
+        public int? ErroredSpans { get; init; }
+    }
+
+    private sealed class SpanIdentityRecord
+    {
+        public required string TraceId { get; init; }
+        public required string SpanId { get; init; }
+    }
+
+    private sealed class TraceOwnedAttributeRecord : AttributeRecord
+    {
+        public required string TraceId { get; init; }
+        public required string OwnerId { get; init; }
+    }
+
+    private sealed class TextOwnedAttributeRecord : AttributeRecord
+    {
+        public required string OwnerId { get; init; }
+    }
+
+    private sealed class LongOwnedAttributeRecord : AttributeRecord
+    {
+        public required long OwnerId { get; init; }
+    }
+
+    private sealed class SpanEventRecord
+    {
+        public required string TraceId { get; init; }
+        public required string EventId { get; init; }
+        public required string SpanId { get; init; }
+        public required string EventName { get; init; }
+        public required long EventTimeTicks { get; init; }
+    }
+
+    private sealed class SpanLinkRecord
+    {
+        public required long LinkId { get; init; }
+        public required string SourceTraceId { get; init; }
+        public required string SourceSpanId { get; init; }
+        public required string TraceId { get; init; }
+        public required string SpanId { get; init; }
+        public required string TraceState { get; init; }
+    }
+
+    private sealed class SpanRecord
+    {
+        public required string TraceId { get; init; }
+        public required string SpanId { get; init; }
+        public string? ParentSpanId { get; init; }
+        public required long ResourceId { get; init; }
+        public required long ResourceViewId { get; init; }
+        public required long ScopeId { get; init; }
+        public required string Name { get; init; }
+        public required int Kind { get; init; }
+        public required long StartTimeTicks { get; init; }
+        public required long EndTimeTicks { get; init; }
+        public required int Status { get; init; }
+        public string? StatusMessage { get; init; }
+        public string? State { get; init; }
+        public long? PeerResourceId { get; init; }
+        public required long LastUpdatedTimestampTicks { get; init; }
+        public required string ResourceName { get; init; }
+        public string? InstanceId { get; init; }
+        public required bool UninstrumentedPeer { get; init; }
+        public required bool HasLogs { get; init; }
+        public required bool HasTraces { get; init; }
+        public required bool HasMetrics { get; init; }
+        public required string ScopeName { get; init; }
+        public required string ScopeVersion { get; init; }
+        public string? PeerResourceName { get; init; }
+        public string? PeerInstanceId { get; init; }
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Traces.Writes.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Traces.Writes.cs
@@ -1231,7 +1231,7 @@ public sealed partial class SqliteTelemetryRepository
                 DELETE FROM telemetry_traces
                 WHERE @ClearAll OR trace_id IN (
                     SELECT DISTINCT trace_id
-                    FROM telemetry_spans
+                    FROM telemetry_trace_resources
                     WHERE resource_id IN (SELECT resource_id FROM telemetry_resources{where})
                 );
 

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Traces.Writes.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.Traces.Writes.cs
@@ -1,0 +1,1352 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using System.Globalization;
+using System.Text;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
+using Dapper;
+using Google.Protobuf.Collections;
+using Microsoft.Data.Sqlite;
+using OpenTelemetry.Proto.Trace.V1;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public sealed partial class SqliteTelemetryRepository
+{
+    private const int MaxTraceBatchSize = 100;
+    // Microsoft.Data.Sqlite resolves every named parameter when binding. Reusing prepared commands avoids
+    // repeated preparation, while these batch sizes keep each binding pass small enough to avoid nonlinear cost.
+    private const int MaxSpanBatchSize = 25;
+    private const int MaxSpanDetailBatchSize = 50;
+
+    private async Task<List<OtlpSpan>> AddTracesToDatabaseAsync(AddContext context, RepeatedField<ResourceSpans> resourceSpans)
+    {
+        var addedSpans = new List<OtlpSpan>();
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            var incomingSpans = resourceSpans
+                .SelectMany(resource => resource.ScopeSpans)
+                .SelectMany(scope => scope.Spans)
+                .Select(span => new IncomingSpanIdentity(
+                    span.TraceId.ToHexString(),
+                    span.SpanId.ToHexString(),
+                    span.ParentSpanId.IsEmpty ? null : span.ParentSpanId.ToHexString()))
+                .ToArray();
+            var traceIds = incomingSpans
+                .Select(span => span.TraceId)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            var ingestionState = LoadTraceIngestionState(connection, transaction, incomingSpans, traceIds);
+            var traces = new Dictionary<string, OtlpTrace>(StringComparer.Ordinal);
+            var pendingSpans = new List<PendingSpan>();
+            var latestReceivedTimestampTicks = new Dictionary<string, long>(StringComparer.Ordinal);
+            var resourcesWithTraces = new HashSet<CachedResource>();
+
+            foreach (var resourceSpansItem in resourceSpans)
+            {
+                OtlpResourceView resourceView;
+                CachedResource cachedResource;
+                long resourceId;
+                long resourceViewId;
+                try
+                {
+                    var resourceKey = resourceSpansItem.Resource.GetResourceKey();
+                    cachedResource = GetOrAddCachedResource(connection, transaction, resourceKey);
+                    resourceId = cachedResource.ResourceId;
+                    var cachedView = GetOrAddCachedResourceView(connection, transaction, cachedResource, resourceSpansItem.Resource.Attributes);
+                    resourceView = cachedView.View;
+                    resourceViewId = cachedView.ResourceViewId;
+                }
+                catch (Exception exception)
+                {
+                    context.FailureCount += resourceSpansItem.ScopeSpans.Sum(scope => scope.Spans.Count);
+                    _otlpContext.Logger.LogInformation(exception, "Error adding resource.");
+                    continue;
+                }
+                resourcesWithTraces.Add(cachedResource);
+
+                foreach (var scopeSpans in resourceSpansItem.ScopeSpans)
+                {
+                    OtlpScope scope;
+                    long scopeId;
+                    try
+                    {
+                        var cachedScope = GetOrAddCachedScope(connection, transaction, cachedResource, scopeSpans.Scope, CachedTelemetryType.Traces);
+                        scopeId = cachedScope.Scope.ScopeId;
+                        scope = cachedScope.Scope.Scope;
+                    }
+                    catch (Exception exception)
+                    {
+                        context.FailureCount += scopeSpans.Spans.Count;
+                        _otlpContext.Logger.LogInformation(exception, "Error adding trace scope.");
+                        continue;
+                    }
+
+                    foreach (var span in scopeSpans.Spans)
+                    {
+                        try
+                        {
+                            var pendingSpan = PrepareSpan(
+                                traces,
+                                ingestionState,
+                                latestReceivedTimestampTicks,
+                                resourceId,
+                                resourceViewId,
+                                resourceView,
+                                scopeId,
+                                scope,
+                                span);
+                            pendingSpans.Add(pendingSpan);
+                            addedSpans.Add(pendingSpan.Span);
+                            context.SuccessCount++;
+                        }
+                        catch (Exception exception)
+                        {
+                            context.FailureCount++;
+                            _otlpContext.Logger.LogInformation(exception, "Error adding span.");
+                        }
+                    }
+                }
+
+            }
+
+            var traceResourceDeltas = PrepareUninstrumentedPeers(connection, transaction, pendingSpans, ingestionState);
+            UpsertTraces(connection, transaction, traces.Values, ingestionState.ExistingTraces, latestReceivedTimestampTicks);
+            InsertSpans(connection, transaction, pendingSpans);
+            InsertSpanDetails(connection, transaction, pendingSpans);
+            UpdateTraceResourceSummaries(connection, transaction, pendingSpans, traceResourceDeltas);
+            MarkResourcesHaveTraces(connection, transaction, resourcesWithTraces);
+            TrimTracesToCapacity(connection, transaction);
+            transaction.Commit();
+        }
+
+        return addedSpans;
+    }
+
+    private static TraceIngestionState LoadTraceIngestionState(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        IReadOnlyList<IncomingSpanIdentity> incomingSpans,
+        IReadOnlyList<string> traceIds)
+    {
+        var existingTraces = new Dictionary<string, IngestionTraceRecord>(StringComparer.Ordinal);
+        foreach (var batch in traceIds.Chunk(MaxTraceBatchSize))
+        {
+            foreach (var record in connection.Query<IngestionTraceRecord>("""
+                SELECT
+                    t.trace_id AS TraceId,
+                    t.first_span_timestamp_ticks AS FirstSpanTimestampTicks,
+                    t.last_span_end_timestamp_ticks AS LastSpanEndTimestampTicks,
+                    t.last_updated_timestamp_ticks AS LastUpdatedTimestampTicks,
+                    t.full_name AS FullName,
+                    t.primary_span_id AS PrimarySpanId,
+                    t.has_error AS HasError,
+                    t.has_gen_ai AS HasGenAI,
+                    p.parent_span_id AS PrimaryParentSpanId,
+                    p.start_time_ticks AS PrimaryStartTimeTicks
+                FROM telemetry_traces t
+                JOIN telemetry_spans p ON p.trace_id = t.trace_id AND p.span_id = t.primary_span_id
+                WHERE t.trace_id IN @TraceIds;
+                """, new { TraceIds = batch }, transaction))
+            {
+                existingTraces.Add(record.TraceId, record);
+            }
+        }
+
+        var existingSpans = new Dictionary<(string TraceId, string SpanId), IngestionExistingSpanRecord>();
+        var existingParentReferences = new HashSet<(string TraceId, string ParentSpanId)>();
+        var circularSpanIds = new HashSet<(string TraceId, string SpanId)>();
+        if (existingTraces.Count == 0)
+        {
+            return new TraceIngestionState
+            {
+                ExistingTraces = existingTraces,
+                ExistingSpans = existingSpans,
+                ExistingParentReferences = existingParentReferences,
+                CircularSpanIds = circularSpanIds
+            };
+        }
+
+        var incomingSpansForExistingTraces = incomingSpans
+            .Where(span => existingTraces.ContainsKey(span.TraceId))
+            .ToArray();
+        var incomingIdentities = incomingSpansForExistingTraces
+            .Select(span => (span.TraceId, span.SpanId))
+            .ToHashSet();
+        var parentIdentities = incomingSpansForExistingTraces
+            .Where(span => span.ParentSpanId is not null)
+            .Select(span => (span.TraceId, SpanId: span.ParentSpanId!))
+            .ToHashSet();
+        var ancestors = new List<IngestionAncestorRecord>();
+        foreach (var traceBatch in existingTraces.Keys.Chunk(MaxTraceBatchSize))
+        {
+            var traceIdSet = traceBatch.ToHashSet(StringComparer.Ordinal);
+            var traceIncomingSpans = incomingSpansForExistingTraces
+                .Where(span => traceIdSet.Contains(span.TraceId))
+                .ToArray();
+
+            var relevantSpanIds = traceIncomingSpans
+                .Select(span => span.SpanId)
+                .Concat(traceIncomingSpans.Where(span => span.ParentSpanId is not null).Select(span => span.ParentSpanId!))
+                .Distinct(StringComparer.Ordinal);
+            foreach (var spanIdBatch in relevantSpanIds.Chunk(MaxSpanDetailBatchSize))
+            {
+                foreach (var record in connection.Query<IngestionExistingSpanRecord>("""
+                    SELECT
+                        s.trace_id AS TraceId,
+                        s.span_id AS SpanId,
+                        s.status AS Status,
+                        s.uninstrumented_peer_resource_id AS UninstrumentedPeerResourceId
+                    FROM telemetry_spans s
+                    WHERE s.trace_id IN @TraceIds AND s.span_id IN @SpanIds;
+                    """, new { TraceIds = traceBatch, SpanIds = spanIdBatch }, transaction))
+                {
+                    var identity = (record.TraceId, record.SpanId);
+                    if (incomingIdentities.Contains(identity) || parentIdentities.Contains(identity))
+                    {
+                        existingSpans.TryAdd(identity, record);
+                    }
+                }
+            }
+
+            foreach (var spanIdBatch in traceIncomingSpans
+                .Select(span => span.SpanId)
+                .Distinct(StringComparer.Ordinal)
+                .Chunk(MaxSpanDetailBatchSize))
+            {
+                foreach (var record in connection.Query<IngestionParentReferenceRecord>("""
+                    SELECT
+                        s.trace_id AS TraceId,
+                        s.parent_span_id AS ParentSpanId
+                    FROM telemetry_spans s
+                    WHERE s.trace_id IN @TraceIds AND s.parent_span_id IN @ParentSpanIds;
+                    """, new { TraceIds = traceBatch, ParentSpanIds = spanIdBatch }, transaction))
+                {
+                    var parentIdentity = (record.TraceId, record.ParentSpanId);
+                    if (incomingIdentities.Contains(parentIdentity))
+                    {
+                        existingParentReferences.Add(parentIdentity);
+                    }
+                }
+            }
+
+            foreach (var parentSpanIdBatch in traceIncomingSpans
+                .Where(span => span.ParentSpanId is not null)
+                .Select(span => span.ParentSpanId!)
+                .Distinct(StringComparer.Ordinal)
+                .Chunk(MaxSpanDetailBatchSize))
+            {
+                ancestors.AddRange(connection.Query<IngestionAncestorRecord>("""
+                    WITH RECURSIVE ancestors(trace_id, span_id, parent_span_id) AS (
+                        SELECT s.trace_id, s.span_id, s.parent_span_id
+                        FROM telemetry_spans s
+                        WHERE s.trace_id IN @TraceIds AND s.span_id IN @ParentSpanIds
+                        UNION
+                        SELECT parent.trace_id, parent.span_id, parent.parent_span_id
+                        FROM ancestors child
+                        JOIN telemetry_spans parent ON parent.trace_id = child.trace_id AND parent.span_id = child.parent_span_id
+                    )
+                    SELECT
+                        trace_id AS TraceId,
+                        span_id AS SpanId,
+                        parent_span_id AS ParentSpanId
+                    FROM ancestors;
+                    """, new { TraceIds = traceBatch, ParentSpanIds = parentSpanIdBatch }, transaction));
+            }
+        }
+
+        var parentSpanIds = new Dictionary<(string TraceId, string SpanId), string?>();
+        foreach (var ancestor in ancestors)
+        {
+            parentSpanIds.TryAdd((ancestor.TraceId, ancestor.SpanId), ancestor.ParentSpanId);
+        }
+        foreach (var span in incomingSpansForExistingTraces)
+        {
+            var identity = (span.TraceId, span.SpanId);
+            if (span.ParentSpanId is null || existingSpans.ContainsKey(identity) || !parentSpanIds.TryAdd(identity, span.ParentSpanId))
+            {
+                continue;
+            }
+
+            // Persisted and incoming edges can jointly complete a cycle. Add incoming edges in ingestion order so
+            // only the edge that closes the cycle is rejected, matching OtlpTrace.AddSpan's partial-batch behavior.
+            var visitedSpanIds = new HashSet<string>(StringComparer.Ordinal);
+            var parentSpanId = span.ParentSpanId;
+            while (parentSpanId is not null && visitedSpanIds.Add(parentSpanId))
+            {
+                if (string.Equals(parentSpanId, span.SpanId, StringComparison.Ordinal))
+                {
+                    circularSpanIds.Add(identity);
+                    parentSpanIds.Remove(identity);
+                    break;
+                }
+
+                parentSpanIds.TryGetValue((span.TraceId, parentSpanId), out parentSpanId);
+            }
+        }
+
+        return new TraceIngestionState
+        {
+            ExistingTraces = existingTraces,
+            ExistingSpans = existingSpans,
+            ExistingParentReferences = existingParentReferences,
+            CircularSpanIds = circularSpanIds
+        };
+    }
+
+    private PendingSpan PrepareSpan(
+        Dictionary<string, OtlpTrace> traces,
+        TraceIngestionState ingestionState,
+        Dictionary<string, long> latestReceivedTimestampTicks,
+        long resourceId,
+        long resourceViewId,
+        OtlpResourceView resourceView,
+        long scopeId,
+        OtlpScope scope,
+        Span span)
+    {
+        var traceId = span.TraceId.ToHexString();
+        var spanId = span.SpanId.ToHexString();
+        if (ingestionState.ExistingSpans.ContainsKey((traceId, spanId)))
+        {
+            throw new InvalidOperationException($"Duplicate span id '{spanId}' detected.");
+        }
+        if (ingestionState.CircularSpanIds.Contains((traceId, spanId)))
+        {
+            throw new InvalidOperationException($"Circular loop detected for span '{spanId}' with parent '{span.ParentSpanId.ToHexString()}'.");
+        }
+
+        var previousReceivedTimestampTicks = latestReceivedTimestampTicks.GetValueOrDefault(
+            traceId,
+            ingestionState.ExistingTraces.GetValueOrDefault(traceId)?.LastUpdatedTimestampTicks ?? 0);
+        var receivedTimestampTicks = Math.Max(_timeProvider.GetUtcNow().Ticks, previousReceivedTimestampTicks + 1);
+        latestReceivedTimestampTicks[traceId] = receivedTimestampTicks;
+
+        var registerTrace = false;
+        if (!traces.TryGetValue(traceId, out var trace))
+        {
+            var lastUpdatedDate = ingestionState.ExistingTraces.TryGetValue(traceId, out var existingTrace)
+                ? new DateTime(existingTrace.LastUpdatedTimestampTicks, DateTimeKind.Utc)
+                : DateTime.UtcNow;
+            trace = new OtlpTrace(span.TraceId.Memory, lastUpdatedDate);
+            registerTrace = true;
+        }
+        var modelSpan = CreateSqliteSpan(resourceView, trace, scope, span);
+        trace.AddSpan(modelSpan);
+        if (registerTrace)
+        {
+            traces.Add(traceId, trace);
+        }
+
+        return new PendingSpan(resourceId, resourceViewId, scopeId, receivedTimestampTicks, modelSpan);
+    }
+
+    private static void UpsertTraces(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        IEnumerable<OtlpTrace> traces,
+        IReadOnlyDictionary<string, IngestionTraceRecord> existingTraces,
+        IReadOnlyDictionary<string, long> latestReceivedTimestampTicks)
+    {
+        foreach (var batch in traces
+            .Select(trace => CreateTraceUpsertRecord(
+                trace,
+                existingTraces.GetValueOrDefault(trace.TraceId),
+                latestReceivedTimestampTicks[trace.TraceId]))
+            .Chunk(MaxTraceBatchSize))
+        {
+            var sql = new StringBuilder("""
+                INSERT INTO telemetry_traces (
+                    trace_id, first_span_timestamp_ticks, last_span_end_timestamp_ticks, duration_ticks, last_updated_timestamp_ticks, full_name,
+                    primary_span_id, has_error, has_gen_ai)
+                VALUES
+                """);
+            var parameters = new DynamicParameters();
+            for (var index = 0; index < batch.Length; index++)
+            {
+                if (index > 0)
+                {
+                    sql.AppendLine(",");
+                }
+                var trace = batch[index];
+                sql.Append(CultureInfo.InvariantCulture, $"    (@TraceId{index}, @FirstSpanTimestampTicks{index}, @LastSpanEndTimestampTicks{index}, @DurationTicks{index}, @LastUpdatedTimestampTicks{index}, @FullName{index}, @PrimarySpanId{index}, @HasError{index}, @HasGenAI{index})");
+                parameters.Add($"TraceId{index}", trace.TraceId);
+                parameters.Add($"FirstSpanTimestampTicks{index}", trace.FirstSpanTimestampTicks);
+                parameters.Add($"LastSpanEndTimestampTicks{index}", trace.LastSpanEndTimestampTicks);
+                parameters.Add($"DurationTicks{index}", trace.LastSpanEndTimestampTicks - trace.FirstSpanTimestampTicks);
+                parameters.Add($"LastUpdatedTimestampTicks{index}", trace.LastUpdatedTimestampTicks);
+                parameters.Add($"FullName{index}", trace.FullName);
+                parameters.Add($"PrimarySpanId{index}", trace.PrimarySpanId);
+                parameters.Add($"HasError{index}", trace.HasError);
+                parameters.Add($"HasGenAI{index}", trace.HasGenAI);
+            }
+            sql.Append("""
+                ON CONFLICT(trace_id) DO UPDATE SET
+                    first_span_timestamp_ticks = excluded.first_span_timestamp_ticks,
+                    last_span_end_timestamp_ticks = excluded.last_span_end_timestamp_ticks,
+                    duration_ticks = excluded.duration_ticks,
+                    last_updated_timestamp_ticks = excluded.last_updated_timestamp_ticks,
+                    full_name = excluded.full_name,
+                    primary_span_id = excluded.primary_span_id,
+                    has_error = excluded.has_error,
+                    has_gen_ai = excluded.has_gen_ai;
+                """);
+            connection.Execute(sql.ToString(), parameters, transaction);
+        }
+    }
+
+    private static TraceUpsertRecord CreateTraceUpsertRecord(
+        OtlpTrace trace,
+        IngestionTraceRecord? existingTrace,
+        long latestReceivedTimestampTicks)
+    {
+        var incomingPrimarySpan = GetPrimarySpan(trace);
+        var lastUpdatedTimestampTicks = Math.Max(trace.LastUpdatedDate.Ticks, latestReceivedTimestampTicks);
+        if (existingTrace is null)
+        {
+            return new TraceUpsertRecord(
+                trace.TraceId,
+                trace.TimeStamp.Ticks,
+                trace.Spans.Max(span => span.EndTime.Ticks),
+                lastUpdatedTimestampTicks,
+                trace.FullName,
+                incomingPrimarySpan.SpanId,
+                trace.Spans.Any(span => span.Status == OtlpSpanStatusCode.Error),
+                HasGenAI(trace.Spans));
+        }
+
+        var existingPrimaryIsRoot = string.IsNullOrEmpty(existingTrace.PrimaryParentSpanId);
+        var incomingPrimaryIsRoot = string.IsNullOrEmpty(incomingPrimarySpan.ParentSpanId);
+        var useIncomingPrimary = IsPreferredPrimarySpan(
+            incomingPrimaryIsRoot,
+            incomingPrimarySpan.StartTime.Ticks,
+            incomingPrimarySpan.SpanId,
+            existingPrimaryIsRoot,
+            existingTrace.PrimaryStartTimeTicks,
+            existingTrace.PrimarySpanId);
+        return new TraceUpsertRecord(
+            trace.TraceId,
+            Math.Min(existingTrace.FirstSpanTimestampTicks, trace.TimeStamp.Ticks),
+            Math.Max(existingTrace.LastSpanEndTimestampTicks, trace.Spans.Max(span => span.EndTime.Ticks)),
+            lastUpdatedTimestampTicks,
+            useIncomingPrimary
+                ? $"{incomingPrimarySpan.Source.Resource.ResourceName}: {incomingPrimarySpan.Name}"
+                : existingTrace.FullName,
+            useIncomingPrimary ? incomingPrimarySpan.SpanId : existingTrace.PrimarySpanId,
+            existingTrace.HasError || trace.Spans.Any(span => span.Status == OtlpSpanStatusCode.Error),
+            existingTrace.HasGenAI || HasGenAI(trace.Spans));
+
+        static bool HasGenAI(IEnumerable<OtlpSpan> spans) => spans.Any(span => span.Attributes.Any(attribute =>
+            (attribute.Key is "gen_ai.system" or "gen_ai.provider.name") && attribute.Value.Length > 0));
+    }
+
+    private static OtlpSpan GetPrimarySpan(OtlpTrace trace)
+    {
+        var primarySpan = trace.Spans[0];
+        foreach (var span in trace.Spans.Skip(1))
+        {
+            if (IsPreferredPrimarySpan(
+                string.IsNullOrEmpty(span.ParentSpanId),
+                span.StartTime.Ticks,
+                span.SpanId,
+                string.IsNullOrEmpty(primarySpan.ParentSpanId),
+                primarySpan.StartTime.Ticks,
+                primarySpan.SpanId))
+            {
+                primarySpan = span;
+            }
+        }
+
+        return primarySpan;
+    }
+
+    private static bool IsPreferredPrimarySpan(
+        bool candidateIsRoot,
+        long candidateStartTimeTicks,
+        string candidateSpanId,
+        bool currentIsRoot,
+        long currentStartTimeTicks,
+        string currentSpanId)
+    {
+        if (candidateIsRoot != currentIsRoot)
+        {
+            return candidateIsRoot;
+        }
+
+        if (candidateStartTimeTicks != currentStartTimeTicks)
+        {
+            return candidateStartTimeTicks < currentStartTimeTicks;
+        }
+
+        // Equal-time spans are inserted before existing spans by OtlpTrace, so the last span ID in
+        // database order becomes primary when a trace is materialized.
+        return string.CompareOrdinal(candidateSpanId, currentSpanId) > 0;
+    }
+
+    private static void InsertSpans(SqliteConnection connection, IDbTransaction transaction, List<PendingSpan> spans)
+    {
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            spans,
+            MaxSpanBatchSize,
+            "telemetry_spans",
+            [
+                "trace_id", "span_id", "parent_span_id", "resource_id", "resource_view_id", "scope_id", "name", "kind",
+                "start_time_ticks", "end_time_ticks", "status", "status_message", "trace_state", "uninstrumented_peer_resource_id"
+            ],
+            static (pendingSpan, parameters) =>
+            {
+                var span = pendingSpan.Span;
+                parameters[0].Value = span.TraceId;
+                parameters[1].Value = span.SpanId;
+                parameters[2].Value = span.ParentSpanId ?? (object)DBNull.Value;
+                parameters[3].Value = pendingSpan.ResourceId;
+                parameters[4].Value = pendingSpan.ResourceViewId;
+                parameters[5].Value = pendingSpan.ScopeId;
+                parameters[6].Value = span.Name;
+                parameters[7].Value = (int)span.Kind;
+                parameters[8].Value = span.StartTime.Ticks;
+                parameters[9].Value = span.EndTime.Ticks;
+                parameters[10].Value = (int)span.Status;
+                parameters[11].Value = span.StatusMessage ?? (object)DBNull.Value;
+                parameters[12].Value = span.State ?? (object)DBNull.Value;
+                parameters[13].Value = pendingSpan.PeerResourceId ?? (object)DBNull.Value;
+            });
+    }
+
+    private static void MarkResourcesHaveTraces(SqliteConnection connection, IDbTransaction transaction, HashSet<CachedResource> resources)
+    {
+        var resourcesToUpdate = resources.Where(resource => !resource.Resource.HasTraces).ToArray();
+        foreach (var batch in resourcesToUpdate.Chunk(MaxTraceBatchSize))
+        {
+            connection.Execute(
+                "UPDATE telemetry_resources SET has_traces = 1 WHERE resource_id IN @ResourceIds;",
+                new { ResourceIds = batch.Select(resource => resource.ResourceId).ToArray() },
+                transaction);
+        }
+        foreach (var resource in resourcesToUpdate)
+        {
+            resource.Resource.HasTraces = true;
+        }
+    }
+
+    private List<TraceResourceDelta> PrepareUninstrumentedPeers(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        IReadOnlyList<PendingSpan> pendingSpans,
+        TraceIngestionState ingestionState)
+    {
+        var incomingParentReferences = pendingSpans
+            .Select(pendingSpan => pendingSpan.Span)
+            .Where(span => span.ParentSpanId is not null)
+            .Select(span => (span.TraceId, ParentSpanId: span.ParentSpanId!))
+            .ToHashSet();
+        var peerResourceIds = new HashSet<long>();
+        var existingParentUpdates = new List<PeerSpanUpdateRecord>();
+        var updatedExistingParents = new HashSet<(string TraceId, string SpanId)>();
+        var traceResourceDeltas = new List<TraceResourceDelta>();
+        foreach (var pendingSpan in pendingSpans)
+        {
+            var span = pendingSpan.Span;
+            OtlpResource? peer = null;
+            var hasPeerAddress = OtlpHelpers.GetPeerAddress(span.Attributes) is not null;
+            var hasChildren = incomingParentReferences.Contains((span.TraceId, span.SpanId)) ||
+                ingestionState.ExistingParentReferences.Contains((span.TraceId, span.SpanId));
+            if (hasPeerAddress && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !hasChildren)
+            {
+                if (TryResolvePeerResourceKey(span.Attributes, out var peerKey))
+                {
+                    var cachedPeerResource = GetOrAddCachedResource(connection, transaction, peerKey, uninstrumentedPeer: true);
+                    pendingSpan.PeerResourceId = cachedPeerResource.ResourceId;
+                    // A peer key can identify a real resource that reports its own telemetry. The cache refuses to
+                    // downgrade that resource, so only persist the peer flag when it remains synthetic.
+                    if (cachedPeerResource.Resource.UninstrumentedPeer)
+                    {
+                        peerResourceIds.Add(cachedPeerResource.ResourceId);
+                    }
+                    peer = cachedPeerResource.Resource;
+                }
+            }
+            span.SetUninstrumentedPeer(peer);
+
+            if (span.ParentSpanId is not null &&
+                ingestionState.ExistingSpans.TryGetValue((span.TraceId, span.ParentSpanId), out var existingParent) &&
+                existingParent.UninstrumentedPeerResourceId is { } peerResourceId &&
+                updatedExistingParents.Add((span.TraceId, span.ParentSpanId)))
+            {
+                existingParentUpdates.Add(new PeerSpanUpdateRecord
+                {
+                    PeerResourceId = null,
+                    TraceId = span.TraceId,
+                    SpanId = span.ParentSpanId
+                });
+                traceResourceDeltas.Add(new TraceResourceDelta(
+                    span.TraceId,
+                    peerResourceId,
+                    long.MinValue,
+                    TotalSpans: -1,
+                    ErroredSpans: existingParent.Status == (int)OtlpSpanStatusCode.Error ? -1 : 0));
+            }
+        }
+
+        if (peerResourceIds.Count > 0)
+        {
+            connection.Execute(
+                "UPDATE telemetry_resources SET uninstrumented_peer = 1 WHERE resource_id IN @ResourceIds;",
+                new { ResourceIds = peerResourceIds.ToArray() },
+                transaction);
+        }
+
+        UpdatePeerSpans(connection, transaction, existingParentUpdates);
+        return traceResourceDeltas;
+    }
+
+    private static void UpdatePeerSpans(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<PeerSpanUpdateRecord> spanUpdates)
+    {
+        foreach (var batch in spanUpdates.Chunk(MaxSpanDetailBatchSize))
+        {
+            var sql = new StringBuilder("""
+                WITH peer_updates(trace_id, span_id, peer_resource_id) AS (
+                    VALUES
+                """);
+            var parameters = new DynamicParameters();
+            for (var index = 0; index < batch.Length; index++)
+            {
+                if (index > 0)
+                {
+                    sql.AppendLine(",");
+                }
+                sql.Append(CultureInfo.InvariantCulture, $"        (@TraceId{index}, @SpanId{index}, @PeerResourceId{index})");
+                parameters.Add($"TraceId{index}", batch[index].TraceId);
+                parameters.Add($"SpanId{index}", batch[index].SpanId);
+                parameters.Add($"PeerResourceId{index}", batch[index].PeerResourceId);
+            }
+            sql.Append("""
+                )
+                UPDATE telemetry_spans AS spans
+                SET uninstrumented_peer_resource_id = peer_updates.peer_resource_id
+                FROM peer_updates
+                WHERE spans.trace_id = peer_updates.trace_id
+                  AND spans.span_id = peer_updates.span_id;
+                """);
+            connection.Execute(sql.ToString(), parameters, transaction);
+        }
+    }
+
+    private static void UpdateTraceResourceSummaries(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        IReadOnlyList<PendingSpan> pendingSpans,
+        List<TraceResourceDelta> traceResourceDeltas)
+    {
+        foreach (var pendingSpan in pendingSpans)
+        {
+            var span = pendingSpan.Span;
+            var resourceOrderTicks = GetResourceOrderTicks(span.ParentSpanId, span.StartTime.Ticks, pendingSpan.ReceivedTimestampTicks);
+            var erroredSpans = span.Status == OtlpSpanStatusCode.Error ? 1 : 0;
+            traceResourceDeltas.Add(new TraceResourceDelta(
+                span.TraceId,
+                pendingSpan.ResourceId,
+                resourceOrderTicks,
+                TotalSpans: 1,
+                ErroredSpans: erroredSpans));
+            if (pendingSpan.PeerResourceId is { } peerResourceId)
+            {
+                traceResourceDeltas.Add(new TraceResourceDelta(
+                    span.TraceId,
+                    peerResourceId,
+                    resourceOrderTicks,
+                    TotalSpans: 1,
+                    ErroredSpans: erroredSpans));
+            }
+        }
+
+        ApplyTraceResourceDeltas(connection, transaction, traceResourceDeltas);
+    }
+
+    private static void ApplyTraceResourceDeltas(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        IEnumerable<TraceResourceDelta> deltas)
+    {
+        var aggregateDeltas = deltas
+            .GroupBy(delta => (delta.TraceId, delta.ResourceId))
+            .Select(group => new AggregateTraceResourceDelta(
+                group.Key.TraceId,
+                group.Key.ResourceId,
+                group.Max(delta => delta.ResourceOrderTicks),
+                group.Sum(delta => delta.TotalSpans),
+                group.Sum(delta => delta.ErroredSpans),
+                RequiresExistingRow: group.Any(delta => delta.TotalSpans < 0 || delta.ErroredSpans < 0)))
+            .ToArray();
+
+        ApplyExistingTraceResourceDeltas(connection, transaction, aggregateDeltas.Where(delta => delta.RequiresExistingRow));
+        UpsertNewTraceResourceDeltas(connection, transaction, aggregateDeltas.Where(delta => !delta.RequiresExistingRow));
+    }
+
+    private static void ApplyExistingTraceResourceDeltas(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        IEnumerable<AggregateTraceResourceDelta> deltas)
+    {
+        foreach (var deltaBatch in deltas.Chunk(MaxSpanDetailBatchSize))
+        {
+            var sql = new StringBuilder("WITH resource_deltas(trace_id, resource_id, resource_order_ticks, total_spans, errored_spans) AS (VALUES\n");
+            var parameters = new DynamicParameters();
+            AppendTraceResourceDeltaValues(sql, parameters, deltaBatch);
+            sql.Append("""
+                )
+                UPDATE telemetry_trace_resources AS resources
+                SET resource_order_ticks = MAX(resources.resource_order_ticks, resource_deltas.resource_order_ticks),
+                    total_spans = resources.total_spans + resource_deltas.total_spans,
+                    errored_spans = resources.errored_spans + resource_deltas.errored_spans
+                FROM resource_deltas
+                WHERE resources.trace_id = resource_deltas.trace_id
+                  AND resources.resource_id = resource_deltas.resource_id;
+                """);
+            connection.Execute(sql.ToString(), parameters, transaction);
+        }
+    }
+
+    private static void UpsertNewTraceResourceDeltas(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        IEnumerable<AggregateTraceResourceDelta> deltas)
+    {
+        foreach (var deltaBatch in deltas.Chunk(MaxSpanDetailBatchSize))
+        {
+            var sql = new StringBuilder("WITH resource_deltas(trace_id, resource_id, resource_order_ticks, total_spans, errored_spans) AS (VALUES\n");
+            var parameters = new DynamicParameters();
+            AppendTraceResourceDeltaValues(sql, parameters, deltaBatch);
+            sql.Append("""
+                )
+                INSERT INTO telemetry_trace_resources (
+                    trace_id, resource_id, resource_order_ticks, total_spans, errored_spans)
+                SELECT trace_id, resource_id, resource_order_ticks, total_spans, errored_spans
+                FROM resource_deltas
+                WHERE true
+                ON CONFLICT(trace_id, resource_id) DO UPDATE SET
+                    resource_order_ticks = MAX(telemetry_trace_resources.resource_order_ticks, excluded.resource_order_ticks),
+                    total_spans = telemetry_trace_resources.total_spans + excluded.total_spans,
+                    errored_spans = telemetry_trace_resources.errored_spans + excluded.errored_spans;
+                """);
+            connection.Execute(sql.ToString(), parameters, transaction);
+        }
+    }
+
+    private static void AppendTraceResourceDeltaValues(
+        StringBuilder sql,
+        DynamicParameters parameters,
+        AggregateTraceResourceDelta[] deltaBatch)
+    {
+        for (var index = 0; index < deltaBatch.Length; index++)
+        {
+            if (index > 0)
+            {
+                sql.AppendLine(",");
+            }
+            var delta = deltaBatch[index];
+            sql.Append(CultureInfo.InvariantCulture, $"    (@TraceId{index}, @ResourceId{index}, @ResourceOrderTicks{index}, @TotalSpans{index}, @ErroredSpans{index})");
+            parameters.Add($"TraceId{index}", delta.TraceId);
+            parameters.Add($"ResourceId{index}", delta.ResourceId);
+            parameters.Add($"ResourceOrderTicks{index}", delta.ResourceOrderTicks);
+            parameters.Add($"TotalSpans{index}", delta.TotalSpans);
+            parameters.Add($"ErroredSpans{index}", delta.ErroredSpans);
+        }
+    }
+
+    private static long GetResourceOrderTicks(string? parentSpanId, long startTimeTicks, long receivedTimestampTicks) =>
+        string.IsNullOrEmpty(parentSpanId) ? long.MaxValue - receivedTimestampTicks : -startTimeTicks;
+
+    private static void InsertSpanDetails(SqliteConnection connection, IDbTransaction transaction, List<PendingSpan> pendingSpans)
+    {
+        InsertSpanAttributes(connection, transaction, pendingSpans);
+
+        var events = pendingSpans
+            .SelectMany(pendingSpan => pendingSpan.Span.Events.Select((spanEvent, ordinal) => new PendingSpanEvent(
+                spanEvent.InternalId.ToString("D"),
+                pendingSpan.Span.TraceId,
+                pendingSpan.Span.SpanId,
+                ordinal,
+                spanEvent)))
+            .ToArray();
+        InsertSpanEvents(connection, transaction, events);
+        InsertSpanEventAttributes(connection, transaction, events);
+
+        var links = pendingSpans
+            .SelectMany(pendingSpan => pendingSpan.Span.Links.Select(link => new PendingSpanLink(link)))
+            .ToArray();
+        InsertSpanLinks(connection, transaction, links);
+        InsertSpanLinkAttributes(connection, transaction, links);
+    }
+
+    private static void InsertSpanAttributes(SqliteConnection connection, IDbTransaction transaction, List<PendingSpan> pendingSpans)
+    {
+        var attributes = pendingSpans
+            .SelectMany(pendingSpan => pendingSpan.Span.Attributes.Select((attribute, ordinal) => new
+            {
+                pendingSpan.Span.TraceId,
+                pendingSpan.Span.SpanId,
+                Ordinal = ordinal,
+                attribute.Key,
+                attribute.Value
+            }))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            attributes,
+            MaxSpanDetailBatchSize,
+            "telemetry_span_attributes",
+            ["trace_id", "span_id", "ordinal", "attribute_key", "attribute_value"],
+            static (attribute, parameters) =>
+            {
+                parameters[0].Value = attribute.TraceId;
+                parameters[1].Value = attribute.SpanId;
+                parameters[2].Value = attribute.Ordinal;
+                parameters[3].Value = attribute.Key;
+                parameters[4].Value = attribute.Value;
+            });
+    }
+
+    private static void InsertSpanEvents(SqliteConnection connection, IDbTransaction transaction, PendingSpanEvent[] events)
+    {
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            events,
+            MaxSpanDetailBatchSize,
+            "telemetry_span_events",
+            ["event_id", "trace_id", "span_id", "ordinal", "event_name", "event_time_ticks"],
+            static (spanEvent, parameters) =>
+            {
+                parameters[0].Value = spanEvent.EventId;
+                parameters[1].Value = spanEvent.TraceId;
+                parameters[2].Value = spanEvent.SpanId;
+                parameters[3].Value = spanEvent.Ordinal;
+                parameters[4].Value = spanEvent.Event.Name;
+                parameters[5].Value = spanEvent.Event.Time.Ticks;
+            });
+    }
+
+    private static void InsertSpanEventAttributes(SqliteConnection connection, IDbTransaction transaction, PendingSpanEvent[] events)
+    {
+        var attributes = events
+            .SelectMany(spanEvent => spanEvent.Event.Attributes.Select((attribute, ordinal) => new
+            {
+                spanEvent.EventId,
+                Ordinal = ordinal,
+                attribute.Key,
+                attribute.Value
+            }))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            attributes,
+            MaxSpanDetailBatchSize,
+            "telemetry_span_event_attributes",
+            ["event_id", "ordinal", "attribute_key", "attribute_value"],
+            static (attribute, parameters) =>
+            {
+                parameters[0].Value = attribute.EventId;
+                parameters[1].Value = attribute.Ordinal;
+                parameters[2].Value = attribute.Key;
+                parameters[3].Value = attribute.Value;
+            });
+    }
+
+    private static void InsertSpanLinks(SqliteConnection connection, IDbTransaction transaction, PendingSpanLink[] links)
+    {
+        var linkIds = SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            links,
+            MaxSpanDetailBatchSize,
+            "telemetry_span_links",
+            ["source_trace_id", "source_span_id", "target_trace_id", "target_span_id", "trace_state"],
+            "link_id",
+            static (pendingLink, parameters) =>
+            {
+                var link = pendingLink.Link;
+                parameters[0].Value = link.SourceTraceId;
+                parameters[1].Value = link.SourceSpanId;
+                parameters[2].Value = link.TraceId;
+                parameters[3].Value = link.SpanId;
+                parameters[4].Value = link.TraceState;
+            });
+        for (var i = 0; i < links.Length; i++)
+        {
+            links[i].LinkId = linkIds[i];
+        }
+    }
+
+    private static void InsertSpanLinkAttributes(SqliteConnection connection, IDbTransaction transaction, PendingSpanLink[] links)
+    {
+        var attributes = links
+            .SelectMany(link => link.Link.Attributes.Select((attribute, ordinal) => new
+            {
+                link.LinkId,
+                Ordinal = ordinal,
+                attribute.Key,
+                attribute.Value
+            }))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            attributes,
+            MaxSpanDetailBatchSize,
+            "telemetry_span_link_attributes",
+            ["link_id", "ordinal", "attribute_key", "attribute_value"],
+            static (attribute, parameters) =>
+            {
+                parameters[0].Value = attribute.LinkId;
+                parameters[1].Value = attribute.Ordinal;
+                parameters[2].Value = attribute.Key;
+                parameters[3].Value = attribute.Value;
+            });
+    }
+
+    private OtlpSpan CreateSqliteSpan(OtlpResourceView resourceView, OtlpTrace trace, OtlpScope scope, Span span)
+    {
+        var spanId = span.SpanId?.ToHexString();
+        if (spanId is null)
+        {
+            throw new ArgumentException("Span has no SpanId");
+        }
+
+        var modelSpan = new OtlpSpan(resourceView, trace, scope)
+        {
+            SpanId = spanId,
+            ParentSpanId = span.ParentSpanId?.ToHexString(),
+            Name = span.Name,
+            Kind = OtlpHelpers.ConvertSpanKind(span.Kind),
+            StartTime = OtlpHelpers.UnixNanoSecondsToDateTime(span.StartTimeUnixNano),
+            EndTime = OtlpHelpers.UnixNanoSecondsToDateTime(span.EndTimeUnixNano),
+            Status = ConvertSqliteStatus(span.Status),
+            StatusMessage = span.Status?.Message,
+            Attributes = span.Attributes.ToKeyValuePairs(_otlpContext, filter: attribute => attribute.Key != OtlpHelpers.AspireDestinationNameAttribute),
+            State = !string.IsNullOrEmpty(span.TraceState) ? span.TraceState : null,
+            Events = [],
+            Links = [],
+            BackLinks = []
+        };
+
+        foreach (var spanEvent in span.Events.OrderBy(spanEvent => spanEvent.TimeUnixNano).Take(_otlpContext.Options.MaxSpanEventCount))
+        {
+            modelSpan.Events.Add(new OtlpSpanEvent(modelSpan)
+            {
+                InternalId = Guid.NewGuid(),
+                Name = spanEvent.Name,
+                Time = OtlpHelpers.UnixNanoSecondsToDateTime(spanEvent.TimeUnixNano),
+                Attributes = spanEvent.Attributes.ToKeyValuePairs(_otlpContext)
+            });
+        }
+
+        foreach (var link in span.Links)
+        {
+            modelSpan.Links.Add(new OtlpSpanLink
+            {
+                SourceSpanId = spanId,
+                SourceTraceId = trace.TraceId,
+                TraceState = link.TraceState,
+                SpanId = link.SpanId.ToHexString(),
+                TraceId = link.TraceId.ToHexString(),
+                Attributes = link.Attributes.ToKeyValuePairs(_otlpContext)
+            });
+        }
+
+        return modelSpan;
+    }
+
+    private static OtlpSpanStatusCode ConvertSqliteStatus(Status? status)
+    {
+        return status?.Code switch
+        {
+            Status.Types.StatusCode.Ok => OtlpSpanStatusCode.Ok,
+            Status.Types.StatusCode.Error => OtlpSpanStatusCode.Error,
+            _ => OtlpSpanStatusCode.Unset
+        };
+    }
+
+    private void TrimTracesToCapacity(SqliteConnection connection, IDbTransaction transaction)
+    {
+        connection.Execute("""
+            DELETE FROM telemetry_traces
+            WHERE trace_id IN (
+                SELECT trace_id
+                FROM telemetry_traces
+                ORDER BY first_span_timestamp_ticks, trace_id
+                LIMIT MAX((SELECT COUNT(*) FROM telemetry_traces) - @MaxTraceCount, 0)
+            );
+            """, new { _otlpContext.Options.MaxTraceCount }, transaction);
+    }
+
+    private async Task ClearSelectedTracesFromDatabaseAsync(Dictionary<string, HashSet<AspireDataType>> selectedResources)
+    {
+        using var connection = _database.OpenConnection();
+        var resources = connection.Query<TelemetryResourceRecord>("""
+            SELECT resource_name AS ResourceName, instance_id AS InstanceId
+            FROM telemetry_resources;
+            """);
+        foreach (var resource in resources)
+        {
+            var key = new ResourceKey(resource.ResourceName, resource.InstanceId);
+            if (selectedResources.TryGetValue(key.GetCompositeName(), out var dataTypes) &&
+                dataTypes.Contains(AspireDataType.Traces) &&
+                !dataTypes.Contains(AspireDataType.Resource))
+            {
+                await ClearTracesFromDatabaseAsync(key).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task RecalculateUninstrumentedPeersAsync()
+    {
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            using var writeConnection = _database.OpenConnection();
+            using var transaction = writeConnection.BeginTransaction();
+            using var readConnection = _database.OpenConnection();
+            // Return one row per span attribute (or one row with null attributes for spans without any).
+            // The parents CTE marks spans that have children so processing below can restrict peer
+            // resolution to client/producer leaf spans that have a peer address. Ordering keeps every
+            // span's attributes contiguous, which lets the loop finalize one span when its identity
+            // changes instead of buffering all spans and attributes. A separate connection keeps the
+            // unbuffered reader open while completed spans are written in batches through the transaction.
+            var rows = readConnection.Query<PeerRecalculationRowRecord>("""
+                WITH parents AS (
+                    SELECT DISTINCT trace_id, parent_span_id AS span_id
+                    FROM telemetry_spans
+                    WHERE parent_span_id IS NOT NULL
+                )
+                SELECT
+                    spans.trace_id AS TraceId,
+                    spans.span_id AS SpanId,
+                    spans.kind AS Kind,
+                    spans.parent_span_id AS ParentSpanId,
+                    spans.start_time_ticks AS StartTimeTicks,
+                    spans.status AS Status,
+                    spans.uninstrumented_peer_resource_id AS UninstrumentedPeerResourceId,
+                    traces.last_updated_timestamp_ticks AS TraceLastUpdatedTimestampTicks,
+                    parents.span_id IS NOT NULL AS HasChildren,
+                    attributes.attribute_key AS AttributeKey,
+                    attributes.attribute_value AS AttributeValue
+                FROM telemetry_spans AS spans
+                JOIN telemetry_traces AS traces ON traces.trace_id = spans.trace_id
+                LEFT JOIN parents
+                    ON parents.trace_id = spans.trace_id
+                   AND parents.span_id = spans.span_id
+                LEFT JOIN telemetry_span_attributes AS attributes
+                    ON attributes.trace_id = spans.trace_id
+                   AND attributes.span_id = spans.span_id
+                ORDER BY spans.trace_id, spans.span_id, attributes.ordinal;
+                """, buffered: false);
+            var spanUpdates = new List<PeerSpanUpdateRecord>(MaxSpanDetailBatchSize);
+            var traceResourceDeltas = new List<TraceResourceDelta>(MaxSpanDetailBatchSize * 2);
+            var uninstrumentedPeerResourceIds = new HashSet<long>();
+            var latestReceivedTimestampTicks = new Dictionary<string, long>(StringComparer.Ordinal);
+            var spanAttributes = new List<KeyValuePair<string, string>>();
+            PeerRecalculationRowRecord? currentSpan = null;
+
+            foreach (var row in rows)
+            {
+                if (currentSpan is not null &&
+                    (!string.Equals(currentSpan.TraceId, row.TraceId, StringComparison.Ordinal) ||
+                     !string.Equals(currentSpan.SpanId, row.SpanId, StringComparison.Ordinal)))
+                {
+                    ProcessSpan(currentSpan, spanAttributes);
+                    spanAttributes.Clear();
+                }
+
+                currentSpan = row;
+                if (row.AttributeKey is not null)
+                {
+                    spanAttributes.Add(KeyValuePair.Create(row.AttributeKey, row.AttributeValue!));
+                }
+            }
+            if (currentSpan is not null)
+            {
+                ProcessSpan(currentSpan, spanAttributes);
+            }
+            FlushSpanUpdates();
+
+            if (uninstrumentedPeerResourceIds.Count > 0)
+            {
+                writeConnection.Execute(
+                    "UPDATE telemetry_resources SET uninstrumented_peer = 1 WHERE resource_id IN @ResourceIds;",
+                    new { ResourceIds = uninstrumentedPeerResourceIds.ToArray() },
+                    transaction);
+            }
+            var lastUpdatedTimestampTicks = Math.Max(
+                _timeProvider.GetUtcNow().Ticks,
+                latestReceivedTimestampTicks.Values.DefaultIfEmpty(0).Max());
+            writeConnection.Execute("""
+                UPDATE telemetry_traces
+                SET last_updated_timestamp_ticks = MAX(last_updated_timestamp_ticks, @LastUpdatedTimestampTicks)
+                WHERE trace_id IN (SELECT trace_id FROM telemetry_spans);
+                """, new
+            {
+                LastUpdatedTimestampTicks = lastUpdatedTimestampTicks
+            }, transaction);
+            transaction.Commit();
+
+            void ProcessSpan(PeerRecalculationRowRecord span, IReadOnlyList<KeyValuePair<string, string>> attributes)
+            {
+                long? peerResourceId = null;
+                if ((OtlpSpanKind)span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer &&
+                    !span.HasChildren &&
+                    attributes.Count > 0)
+                {
+                    var attributeArray = attributes.ToArray();
+                    if (attributeArray.GetPeerAddress() is not null &&
+                        TryResolvePeerResourceKey(attributeArray, out var peerKey))
+                    {
+                        var cachedPeerResource = GetOrAddCachedResource(writeConnection, transaction, peerKey, uninstrumentedPeer: true);
+                        peerResourceId = cachedPeerResource.ResourceId;
+                        // Preserve the classification of real resources that are also destinations of outgoing spans.
+                        if (cachedPeerResource.Resource.UninstrumentedPeer)
+                        {
+                            uninstrumentedPeerResourceIds.Add(cachedPeerResource.ResourceId);
+                        }
+                    }
+                }
+
+                if (peerResourceId == span.UninstrumentedPeerResourceId)
+                {
+                    return;
+                }
+
+                spanUpdates.Add(new PeerSpanUpdateRecord
+                {
+                    PeerResourceId = peerResourceId,
+                    TraceId = span.TraceId,
+                    SpanId = span.SpanId
+                });
+                var erroredSpans = span.Status == (int)OtlpSpanStatusCode.Error ? 1 : 0;
+                if (span.UninstrumentedPeerResourceId is { } previousPeerResourceId)
+                {
+                    traceResourceDeltas.Add(new TraceResourceDelta(
+                        span.TraceId,
+                        previousPeerResourceId,
+                        long.MinValue,
+                        TotalSpans: -1,
+                        ErroredSpans: -erroredSpans));
+                }
+                if (peerResourceId is { } newPeerResourceId)
+                {
+                    var receivedTimestampTicks = GetNextReceivedTimestampTicks(span);
+                    traceResourceDeltas.Add(new TraceResourceDelta(
+                        span.TraceId,
+                        newPeerResourceId,
+                        GetResourceOrderTicks(span.ParentSpanId, span.StartTimeTicks, receivedTimestampTicks),
+                        TotalSpans: 1,
+                        ErroredSpans: erroredSpans));
+                }
+                if (spanUpdates.Count == MaxSpanDetailBatchSize)
+                {
+                    FlushSpanUpdates();
+                }
+            }
+
+            void FlushSpanUpdates()
+            {
+                if (spanUpdates.Count == 0)
+                {
+                    return;
+                }
+
+                UpdatePeerSpans(writeConnection, transaction, spanUpdates);
+                ApplyTraceResourceDeltas(writeConnection, transaction, traceResourceDeltas);
+                spanUpdates.Clear();
+                traceResourceDeltas.Clear();
+            }
+
+            long GetNextReceivedTimestampTicks(PeerRecalculationRowRecord span)
+            {
+                var previousReceivedTimestampTicks = latestReceivedTimestampTicks.GetValueOrDefault(
+                    span.TraceId,
+                    span.TraceLastUpdatedTimestampTicks);
+                var receivedTimestampTicks = Math.Max(_timeProvider.GetUtcNow().Ticks, previousReceivedTimestampTicks + 1);
+                latestReceivedTimestampTicks[span.TraceId] = receivedTimestampTicks;
+                return receivedTimestampTicks;
+            }
+        }
+    }
+
+    private bool TryResolvePeerResourceKey(KeyValuePair<string, string>[] attributes, out ResourceKey peerKey)
+    {
+        foreach (var resolver in _outgoingPeerResolvers)
+        {
+            if (!resolver.TryResolvePeer(attributes, out var name, out var matchedResource))
+            {
+                continue;
+            }
+
+            if (matchedResource is not null)
+            {
+                peerKey = ResourceKey.Create(matchedResource.DisplayName, matchedResource.Name);
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                peerKey = new ResourceKey(name, InstanceId: null);
+                return true;
+            }
+        }
+
+        peerKey = default;
+        return false;
+    }
+
+    private async Task ClearTracesFromDatabaseAsync(ResourceKey? resourceKey)
+    {
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            var parameters = new DynamicParameters();
+            var where = string.Empty;
+            if (resourceKey is not null)
+            {
+                where = " WHERE resource_name = @ResourceName COLLATE NOCASE";
+                parameters.Add("ResourceName", resourceKey.Value.Name);
+                if (resourceKey.Value.InstanceId is not null)
+                {
+                    where += " AND instance_id = @InstanceId COLLATE NOCASE";
+                    parameters.Add("InstanceId", resourceKey.Value.InstanceId);
+                }
+            }
+            parameters.Add("ClearAll", resourceKey is null);
+
+            connection.Execute($"""
+                DELETE FROM telemetry_traces
+                WHERE @ClearAll OR trace_id IN (
+                    SELECT DISTINCT trace_id
+                    FROM telemetry_spans
+                    WHERE resource_id IN (SELECT resource_id FROM telemetry_resources{where})
+                );
+
+                UPDATE telemetry_resources
+                SET has_traces = EXISTS (SELECT 1 FROM telemetry_spans WHERE telemetry_spans.resource_id = telemetry_resources.resource_id);
+                """, parameters, transaction);
+            DeleteOrphanedUninstrumentedPeers(connection, transaction);
+            DeleteOrphanedScopes(connection, transaction);
+            transaction.Commit();
+            ClearMetadataCache();
+        }
+    }
+
+    private sealed record PendingSpan(long ResourceId, long ResourceViewId, long ScopeId, long ReceivedTimestampTicks, OtlpSpan Span)
+    {
+        public long? PeerResourceId { get; set; }
+    }
+
+    private readonly record struct IncomingSpanIdentity(string TraceId, string SpanId, string? ParentSpanId);
+
+    private sealed record PendingSpanEvent(string EventId, string TraceId, string SpanId, int Ordinal, OtlpSpanEvent Event);
+
+    private sealed record TraceResourceDelta(
+        string TraceId,
+        long ResourceId,
+        long ResourceOrderTicks,
+        long TotalSpans,
+        long ErroredSpans);
+
+    private sealed record AggregateTraceResourceDelta(
+        string TraceId,
+        long ResourceId,
+        long ResourceOrderTicks,
+        long TotalSpans,
+        long ErroredSpans,
+        bool RequiresExistingRow);
+
+    private sealed class TraceIngestionState
+    {
+        public required IReadOnlyDictionary<string, IngestionTraceRecord> ExistingTraces { get; init; }
+        public required IReadOnlyDictionary<(string TraceId, string SpanId), IngestionExistingSpanRecord> ExistingSpans { get; init; }
+        public required IReadOnlySet<(string TraceId, string ParentSpanId)> ExistingParentReferences { get; init; }
+        public required IReadOnlySet<(string TraceId, string SpanId)> CircularSpanIds { get; init; }
+    }
+
+    private sealed class IngestionTraceRecord
+    {
+        public required string TraceId { get; init; }
+        public required long FirstSpanTimestampTicks { get; init; }
+        public required long LastSpanEndTimestampTicks { get; init; }
+        public required long LastUpdatedTimestampTicks { get; init; }
+        public required string FullName { get; init; }
+        public required string PrimarySpanId { get; init; }
+        public required bool HasError { get; init; }
+        public required bool HasGenAI { get; init; }
+        public string? PrimaryParentSpanId { get; init; }
+        public required long PrimaryStartTimeTicks { get; init; }
+    }
+
+    private sealed class IngestionExistingSpanRecord
+    {
+        public required string TraceId { get; init; }
+        public required string SpanId { get; init; }
+        public required int Status { get; init; }
+        public long? UninstrumentedPeerResourceId { get; init; }
+    }
+
+    private sealed class IngestionParentReferenceRecord
+    {
+        public required string TraceId { get; init; }
+        public required string ParentSpanId { get; init; }
+    }
+
+    private sealed class IngestionAncestorRecord
+    {
+        public required string TraceId { get; init; }
+        public required string SpanId { get; init; }
+        public string? ParentSpanId { get; init; }
+    }
+
+    private sealed record TraceUpsertRecord(
+        string TraceId,
+        long FirstSpanTimestampTicks,
+        long LastSpanEndTimestampTicks,
+        long LastUpdatedTimestampTicks,
+        string FullName,
+        string PrimarySpanId,
+        bool HasError,
+        bool HasGenAI);
+
+    private sealed class PendingSpanLink(OtlpSpanLink link)
+    {
+        public OtlpSpanLink Link { get; } = link;
+        public long LinkId { get; set; }
+    }
+
+    private sealed class PeerRecalculationRowRecord
+    {
+        public required string TraceId { get; init; }
+        public required string SpanId { get; init; }
+        public required int Kind { get; init; }
+        public string? ParentSpanId { get; init; }
+        public required long StartTimeTicks { get; init; }
+        public required int Status { get; init; }
+        public long? UninstrumentedPeerResourceId { get; init; }
+        public required long TraceLastUpdatedTimestampTicks { get; init; }
+        public required bool HasChildren { get; init; }
+        public string? AttributeKey { get; init; }
+        public string? AttributeValue { get; init; }
+    }
+
+    private sealed class PeerSpanUpdateRecord
+    {
+        public required string TraceId { get; init; }
+        public required string SpanId { get; init; }
+        public long? PeerResourceId { get; init; }
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/SqliteTelemetryRepository.cs
@@ -1,0 +1,292 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using System.Diagnostics;
+using Google.Protobuf.Collections;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using SQLitePCL;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+/// <summary>
+/// Persists telemetry to SQLite and exposes it through the dashboard telemetry model.
+/// </summary>
+public sealed partial class SqliteTelemetryRepository : ITelemetryRepository, ITelemetryRepositoryWriter
+{
+    private readonly DashboardSqliteDatabase _database;
+    private readonly OtlpContext _otlpContext;
+    private readonly PauseManager _pauseManager;
+    private readonly TimeProvider _timeProvider;
+    private readonly IReadOnlyList<IOutgoingPeerResolver> _outgoingPeerResolvers;
+    private readonly List<IDisposable> _outgoingPeerSubscriptions = [];
+    private int _disposed;
+
+    private static string CreateContainsLikePattern(string value) => $"%{EscapeLikePattern(value)}%";
+
+    private static string CreateStartsWithLikePattern(string value) => $"{EscapeLikePattern(value)}%";
+
+    public bool IsReadOnly => _database.IsReadOnly;
+
+    private static string EscapeLikePattern(string value)
+    {
+        return value
+            .Replace("!", "!!", StringComparison.Ordinal)
+            .Replace("%", "!%", StringComparison.Ordinal)
+            .Replace("_", "!_", StringComparison.Ordinal);
+    }
+
+    internal ActivitySource SqlActivitySource => _database.ActivitySource;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqliteTelemetryRepository"/> class.
+    /// </summary>
+    /// <param name="database">The dashboard database used to persist telemetry.</param>
+    /// <param name="loggerFactory">The logger factory.</param>
+    /// <param name="dashboardOptions">The dashboard options.</param>
+    /// <param name="pauseManager">The telemetry pause manager.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    /// <param name="outgoingPeerResolvers">The resolvers used to identify outgoing peer resources.</param>
+    public SqliteTelemetryRepository(
+        DashboardSqliteDatabase database,
+        ILoggerFactory loggerFactory,
+        IOptions<DashboardOptions> dashboardOptions,
+        PauseManager pauseManager,
+        TimeProvider timeProvider,
+        IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    {
+        _database = database;
+        _pauseManager = pauseManager;
+        _timeProvider = timeProvider;
+        _outgoingPeerResolvers = outgoingPeerResolvers.ToList();
+        _otlpContext = new OtlpContext
+        {
+            Logger = loggerFactory.CreateLogger<SqliteTelemetryRepository>(),
+            Options = dashboardOptions.Value.TelemetryLimits
+        };
+
+        if (!database.IsReadOnly)
+        {
+            foreach (var resolver in _outgoingPeerResolvers)
+            {
+                _outgoingPeerSubscriptions.Add(resolver.OnPeerChanges(async () =>
+                {
+                    await RecalculateUninstrumentedPeersAsync().ConfigureAwait(false);
+                    NotifyPeersChanged();
+                }));
+            }
+        }
+
+    }
+
+    public async Task AddLogsAsync(AddContext context, RepeatedField<ResourceLogs> resourceLogs)
+    {
+        if (_pauseManager.AreStructuredLogsPaused(out _))
+        {
+            _otlpContext.Logger.LogTrace("{Count} incoming structured log resource(s) ignored because of an active pause.", resourceLogs.Count);
+            return;
+        }
+
+        EnsureWritable();
+        try
+        {
+            NotifyLogsAdded(await AddLogsToDatabaseAsync(context, resourceLogs).ConfigureAwait(false));
+        }
+        catch
+        {
+            using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+            {
+                ClearIngestionCaches();
+            }
+            throw;
+        }
+    }
+
+    public async Task AddMetricsAsync(AddContext context, RepeatedField<ResourceMetrics> resourceMetrics)
+    {
+        if (_pauseManager.AreMetricsPaused(out _))
+        {
+            _otlpContext.Logger.LogTrace("{Count} incoming metric resource(s) ignored because of an active pause.", resourceMetrics.Count);
+            return;
+        }
+
+        EnsureWritable();
+        var successCount = context.SuccessCount;
+        await AddMetricsToDatabaseAsync(context, resourceMetrics).ConfigureAwait(false);
+        if (context.SuccessCount > successCount)
+        {
+            NotifyMetricsAdded();
+        }
+    }
+
+    public async Task AddTracesAsync(AddContext context, RepeatedField<ResourceSpans> resourceSpans)
+    {
+        if (_pauseManager.AreTracesPaused(out _))
+        {
+            _otlpContext.Logger.LogTrace("{Count} incoming trace resource(s) ignored because of an active pause.", resourceSpans.Count);
+            return;
+        }
+
+        EnsureWritable();
+        try
+        {
+            NotifySpansAdded(await AddTracesToDatabaseAsync(context, resourceSpans).ConfigureAwait(false));
+        }
+        catch
+        {
+            using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+            {
+                ClearIngestionCaches();
+            }
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Runs a cancellable database read on the thread pool.
+    /// </summary>
+    /// <remarks>
+    /// The read registers <c>sqlite3_interrupt</c> for <paramref name="cancellationToken"/>, which surfaces as
+    /// a <see cref="SqliteException"/> with <c>SQLITE_INTERRUPT</c> rather than an <see cref="OperationCanceledException"/>.
+    /// Translate it here so callers see normal cancellation semantics.
+    /// </remarks>
+    internal static Task<T> RunReadAsync<T>(Func<CancellationToken, T> read, CancellationToken cancellationToken) =>
+        Task.Run(() =>
+        {
+            try
+            {
+                return read(cancellationToken);
+            }
+            catch (SqliteException ex) when (ex.SqliteErrorCode == raw.SQLITE_INTERRUPT)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
+        }, cancellationToken);
+
+    // SQLite database access is always synchronous. Potentially slow repository reads use Task.Run
+    // to avoid blocking the Blazor UI thread.
+    public Task<PagedResult<OtlpLogEntry>> GetLogsAsync(GetLogsContext context, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetLogsFromDatabase(context, token), cancellationToken);
+    public Task<PagedResult<LogSummary>> GetLogSummariesAsync(GetLogsContext context, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetLogSummariesFromDatabase(context, token), cancellationToken);
+    public OtlpLogEntry? GetLog(long logId) => GetLogFromDatabase(logId);
+    public async Task<List<OtlpLogEntry>> GetLogsForSpanAsync(string traceId, string spanId, CancellationToken cancellationToken)
+    {
+        var result = await GetLogsAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters =
+            [
+                new FieldTelemetryFilter { Field = KnownStructuredLogFields.TraceIdField, Condition = FilterCondition.Equals, Value = traceId },
+                new FieldTelemetryFilter { Field = KnownStructuredLogFields.SpanIdField, Condition = FilterCondition.Equals, Value = spanId }
+            ]
+        }, cancellationToken).ConfigureAwait(false);
+        return result.Items;
+    }
+    public async Task<List<OtlpLogEntry>> GetLogsForTraceAsync(string traceId, CancellationToken cancellationToken)
+    {
+        var result = await GetLogsAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters =
+            [
+                new FieldTelemetryFilter { Field = KnownStructuredLogFields.TraceIdField, Condition = FilterCondition.Equals, Value = traceId }
+            ]
+        }, cancellationToken).ConfigureAwait(false);
+        return result.Items;
+    }
+    public Task<List<string>> GetLogPropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetLogPropertyKeysFromDatabase(resourceKey, token), cancellationToken);
+    public Task<List<string>> GetTracePropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetTracePropertyKeysFromDatabase(resourceKey, token), cancellationToken);
+    public Task<GetTracesResponse> GetTracesAsync(GetTracesRequest context, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetTracesFromDatabase(context, token), cancellationToken);
+    public Task<GetTraceSummariesResponse> GetTraceSummariesAsync(GetTracesRequest context, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetTraceSummariesFromDatabase(context, token), cancellationToken);
+    public Task<GetSpansResponse> GetSpansAsync(GetSpansRequest context, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetSpansFromDatabase(context, token), cancellationToken);
+    public Task<Dictionary<string, int>> GetTraceFieldValuesAsync(string attributeName, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetTraceFieldValuesFromDatabase(attributeName, token), cancellationToken);
+    public Task<Dictionary<string, int>> GetLogsFieldValuesAsync(string attributeName, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetLogsFieldValuesFromDatabase(attributeName, token), cancellationToken);
+    public bool HasUpdatedTrace(OtlpTrace trace) => HasUpdatedTraceInDatabase(trace);
+    public OtlpTrace? GetTrace(string traceId) => GetTraceFromDatabase(traceId);
+    public OtlpSpan? GetSpan(string traceId, string spanId) => GetSpanFromDatabase(traceId, spanId);
+    public OtlpResource? GetPeerResource(OtlpSpan span) => span.UninstrumentedPeer;
+    public List<OtlpInstrumentSummary> GetInstrumentSummaries(ResourceKey key) => GetCachedInstrumentSummaries(key);
+    public OtlpInstrumentSummary? GetInstrumentSummary(ResourceKey resourceKey, string meterName, string instrumentName) =>
+        GetCachedInstruments(resourceKey, meterName, instrumentName).FirstOrDefault()?.Summary;
+    public Task<OtlpInstrumentData?> GetInstrumentAsync(GetInstrumentRequest request, CancellationToken cancellationToken) =>
+        RunReadAsync(token => GetInstrumentFromDatabase(request, token), cancellationToken);
+    public DateTime? GetInstrumentLatestEndTime(ResourceKey resourceKey, string meterName, string instrumentName) =>
+        GetInstrumentLatestEndTimeFromDatabase(resourceKey, meterName, instrumentName);
+    public async Task ClearSelectedSignalsAsync(Dictionary<string, HashSet<AspireDataType>> selectedResources)
+    {
+        EnsureWritable();
+        await ClearSelectedLogsFromDatabaseAsync(selectedResources).ConfigureAwait(false);
+        await ClearSelectedTracesFromDatabaseAsync(selectedResources).ConfigureAwait(false);
+        await ClearSelectedMetricsFromDatabaseAsync(selectedResources).ConfigureAwait(false);
+        ClearUnviewedErrorCounts(selectedResources);
+        RaiseSubscriptionChanged(_logSubscriptions);
+        RaiseSubscriptionChanged(_tracesSubscriptions);
+        RaiseSubscriptionChanged(_metricsSubscriptions);
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    public async Task ClearTracesAsync(ResourceKey? resourceKey = null)
+    {
+        EnsureWritable();
+        await ClearTracesFromDatabaseAsync(resourceKey).ConfigureAwait(false);
+        RaiseSubscriptionChanged(_tracesSubscriptions);
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    public async Task ClearStructuredLogsAsync(ResourceKey? resourceKey = null)
+    {
+        EnsureWritable();
+        await ClearStructuredLogsFromDatabaseAsync(resourceKey).ConfigureAwait(false);
+        ClearUnviewedErrorCounts(resourceKey);
+        RaiseSubscriptionChanged(_logSubscriptions);
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    public async Task ClearMetricsAsync(ResourceKey? resourceKey = null)
+    {
+        EnsureWritable();
+        await ClearMetricsFromDatabaseAsync(resourceKey).ConfigureAwait(false);
+        RaiseSubscriptionChanged(_metricsSubscriptions);
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    private void EnsureWritable()
+    {
+        _database.EnsureWritable("Historical dashboard telemetry is read-only.");
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        foreach (var subscription in _outgoingPeerSubscriptions)
+        {
+            subscription.Dispose();
+        }
+        DisposeWatchers();
+    }
+
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
@@ -24,12 +24,12 @@ public sealed class Subscription : IDisposable
     public SubscriptionType SubscriptionType { get; }
     public string Name { get; }
 
-    public Subscription(string name, ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback, Action unsubscribe, ExecutionContext? executionContext, TelemetryRepository telemetryRepository)
+    public Subscription(string name, ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback, Action unsubscribe, ExecutionContext? executionContext, ILogger logger, TimeSpan minExecuteInterval)
     {
         Name = name;
         ResourceKey = resourceKey;
         SubscriptionType = subscriptionType;
-        _callbackThrottler = new CallbackThrottler(name, telemetryRepository._otlpContext.Logger, telemetryRepository._subscriptionMinExecuteInterval, callback, executionContext);
+        _callbackThrottler = new CallbackThrottler(name, logger, minExecuteInterval, callback, executionContext);
         _unsubscribe = unsubscribe;
     }
 

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepositoryLimits.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepositoryLimits.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+internal static class TelemetryRepositoryLimits
+{
+    public const int MaxResourceViewCount = 10_000;
+    public const int MaxInstrumentCount = 10_000;
+    public const int MaxScopeCount = 10_000;
+    public const int MaxDimensionCount = 10_000;
+    public const int MaxKnownAttributeValueCount = 10_000;
+    public const int MaxKnownAttributeValuesPerKey = 10_000;
+}
+
+internal sealed class KnownAttributeValuesState
+{
+    private readonly Dictionary<string, HashSet<string>> _values = new(StringComparer.Ordinal);
+
+    public void LoadDimension(IReadOnlyList<KeyValuePair<string, string>> attributes)
+    {
+        AddDimension(attributes);
+    }
+
+    public void ValidateDimension(IReadOnlyList<KeyValuePair<string, string>> attributes)
+    {
+        var dimensionValues = GetDimensionValues(attributes);
+        var newKeyCount = dimensionValues.Keys.Count(key => !_values.ContainsKey(key));
+        if (_values.Count + newKeyCount > TelemetryRepositoryLimits.MaxKnownAttributeValueCount)
+        {
+            throw new InvalidOperationException($"Known attribute key limit of {TelemetryRepositoryLimits.MaxKnownAttributeValueCount} reached.");
+        }
+
+        foreach (var (key, value) in dimensionValues)
+        {
+            if (_values.TryGetValue(key, out var values) &&
+                !values.Contains(value) &&
+                values.Count >= TelemetryRepositoryLimits.MaxKnownAttributeValuesPerKey)
+            {
+                throw new InvalidOperationException($"Known attribute value limit of {TelemetryRepositoryLimits.MaxKnownAttributeValuesPerKey} reached for key '{key}'.");
+            }
+        }
+    }
+
+    public void AddDimension(IReadOnlyList<KeyValuePair<string, string>> attributes)
+    {
+        foreach (var (key, value) in GetDimensionValues(attributes))
+        {
+            if (!_values.TryGetValue(key, out var values))
+            {
+                values = [];
+                _values.Add(key, values);
+            }
+            values.Add(value);
+        }
+    }
+
+    private static Dictionary<string, string> GetDimensionValues(IReadOnlyList<KeyValuePair<string, string>> attributes)
+    {
+        var dimensionValues = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var attribute in attributes)
+        {
+            dimensionValues.TryAdd(attribute.Key, attribute.Value);
+        }
+        return dimensionValues;
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/TraceSummary.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TraceSummary.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+/// <summary>
+/// Contains the trace information displayed on the traces page.
+/// </summary>
+public sealed class TraceSummary
+{
+    public required string TraceId { get; init; }
+    public required string FullName { get; init; }
+    public required DateTime StartTime { get; init; }
+    public required TimeSpan Duration { get; init; }
+    public required OtlpResource RootResource { get; init; }
+    public required IReadOnlyList<TraceResourceSummary> Resources { get; init; }
+    public required bool HasError { get; init; }
+    public required bool HasGenAI { get; init; }
+}
+
+/// <summary>
+/// Contains the resource information displayed for a trace on the traces page.
+/// </summary>
+public sealed class TraceResourceSummary
+{
+    public required OtlpResource Resource { get; init; }
+    public required int TotalSpans { get; init; }
+    public required int ErroredSpans { get; init; }
+}

--- a/src/Aspire.Dashboard/Properties/launchSettings.json
+++ b/src/Aspire.Dashboard/Properties/launchSettings.json
@@ -8,6 +8,23 @@
       },
       "applicationUrl": "https://localhost:15888"
     },
+    "https (browser only + telemetry)": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+        "Dashboard__TelemetryLimits__MaxLogCount": "2147483647",
+        "Dashboard__TelemetryLimits__MaxTraceCount": "2147483647",
+        "Dashboard__TelemetryLimits__MaxMetricsCount": "2147483647",
+        "Dashboard__TelemetryLimits__MaxAttributeCount": "2147483647",
+        "Dashboard__TelemetryLimits__MaxAttributeLength": "2147483647",
+        "Dashboard__TelemetryLimits__MaxSpanEventCount": "2147483647",
+        "Dashboard__TelemetryLimits__MaxResourceCount": "2147483647"
+      },
+      "applicationUrl": "https://localhost:15888"
+    },
     "http (browser only)": {
       "commandName": "Project",
       "launchBrowser": true,

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
@@ -74,6 +74,12 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ConsoleLogsNoLogsFound", resourceCulture);
             }
         }
+
+        public static string ConsoleLogsNotCapturedForRun {
+            get {
+                return ResourceManager.GetString("ConsoleLogsNotCapturedForRun", resourceCulture);
+            }
+        }
         
         public static string ConsoleLogsNoLogsMatchFilter {
             get {

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
@@ -133,6 +133,9 @@
   <data name="ConsoleLogsNoLogsFound" xml:space="preserve">
     <value>No logs found</value>
   </data>
+  <data name="ConsoleLogsNotCapturedForRun" xml:space="preserve">
+    <value>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</value>
+  </data>
   <data name="ConsoleLogsNoLogsMatchFilter" xml:space="preserve">
     <value>No logs match the filter</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -1117,7 +1117,7 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("SettingsDialogDashboardLogsAndTelemetry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Runtime: {0}.
         /// </summary>

--- a/src/Aspire.Dashboard/Resources/Layout.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Layout.Designer.cs
@@ -59,7 +59,52 @@ namespace Aspire.Dashboard.Resources {
                 resourceCulture = value;
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select dashboard run.
+        /// </summary>
+        public static string DashboardRunSelectTitle {
+            get {
+                return ResourceManager.GetString("DashboardRunSelectTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select run: {0}.
+        /// </summary>
+        public static string DashboardRunSelectAccessibleLabel {
+            get {
+                return ResourceManager.GetString("DashboardRunSelectAccessibleLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Live run.
+        /// </summary>
+        public static string DashboardRunSelectCurrent {
+            get {
+                return ResourceManager.GetString("DashboardRunSelectCurrent", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Pin run.
+        /// </summary>
+        public static string DashboardRunSelectPin {
+            get {
+                return ResourceManager.GetString("DashboardRunSelectPin", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Unpin run.
+        /// </summary>
+        public static string DashboardRunSelectUnpin {
+            get {
+                return ResourceManager.GetString("DashboardRunSelectUnpin", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Aspire.
         /// </summary>

--- a/src/Aspire.Dashboard/Resources/Layout.resx
+++ b/src/Aspire.Dashboard/Resources/Layout.resx
@@ -186,4 +186,19 @@
   <data name="MainLayoutLaunchAIAgents" xml:space="preserve">
     <value>AI agents</value>
   </data>
+  <data name="DashboardRunSelectTitle" xml:space="preserve">
+    <value>Select dashboard run</value>
+  </data>
+  <data name="DashboardRunSelectAccessibleLabel" xml:space="preserve">
+    <value>Select run: {0}</value>
+  </data>
+  <data name="DashboardRunSelectCurrent" xml:space="preserve">
+    <value>Live run</value>
+  </data>
+  <data name="DashboardRunSelectPin" xml:space="preserve">
+    <value>Pin run</value>
+  </data>
+  <data name="DashboardRunSelectUnpin" xml:space="preserve">
+    <value>Unpin run</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/StructuredLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/StructuredLogs.Designer.cs
@@ -85,6 +85,15 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("MessageExceededLimitTitle", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results.
+        /// </summary>
+        public static string VirtualizedLimitText {
+            get {
+                return ResourceManager.GetString("VirtualizedLimitText", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Structured logs capture paused at {0}.

--- a/src/Aspire.Dashboard/Resources/StructuredLogs.resx
+++ b/src/Aspire.Dashboard/Resources/StructuredLogs.resx
@@ -166,6 +166,10 @@
   <data name="MessageExceededLimitTitle" xml:space="preserve">
     <value>Exceeded structured log limit</value>
   </data>
+  <data name="VirtualizedLimitText" xml:space="preserve">
+    <value>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</value>
+    <comment>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</comment>
+  </data>
   <data name="ActionLogMessageText" xml:space="preserve">
     <value>Log message</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Traces.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Traces.Designer.cs
@@ -122,6 +122,15 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("TotalItemsFooterSingularText", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results.
+        /// </summary>
+        public static string VirtualizedLimitText {
+            get {
+                return ResourceManager.GetString("VirtualizedLimitText", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Name: {0}.

--- a/src/Aspire.Dashboard/Resources/Traces.resx
+++ b/src/Aspire.Dashboard/Resources/Traces.resx
@@ -168,6 +168,10 @@
     <value>Showing &lt;strong&gt;{0} traces&lt;/strong&gt;</value>
     <comment>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
+  <data name="VirtualizedLimitText" xml:space="preserve">
+    <value>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</value>
+    <comment>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</comment>
+  </data>
   <data name="SpanTypeLabel" xml:space="preserve">
     <value>Type</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Nezalamovat řádky protokolu</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">Protokoly konzoly aplikace {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Protokollzeilen nicht umbrechen</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">{0} Konsolenprotokolle</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">No ajustar líneas de registro</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">Registros de consola de {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Ne pas envelopper les lignes de journal</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">Journaux de console {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Non eseguire il wrapping delle righe di log</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">{0} log della console</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">ログ行を折り返さない</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">{0} のコンソール ログ</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">로그 줄 래핑 안 함</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">{0} 콘솔 로그</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Nie zawijaj wierszy dziennika</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">Dzienniki konsoli: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Não empacotar linhas de log</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">{0} logs do console</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Не переносить строки в журнале</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">Журналов консоли: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Günlük satırlarını sarmalama</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">{0} konsol günlükleri</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">不将日志换行</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">{0} 控制台日志</target>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">不要自動換行</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConsoleLogsNotCapturedForRun">
+        <source>Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</source>
+        <target state="new">Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ConsoleLogsPageTitle">
         <source>{0} console logs</source>
         <target state="translated">{0} 主控台記錄</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Layout.resx">
     <body>
+      <trans-unit id="DashboardRunSelectAccessibleLabel">
+        <source>Select run: {0}</source>
+        <target state="new">Select run: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectCurrent">
+        <source>Live run</source>
+        <target state="new">Live run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectTitle">
+        <source>Select dashboard run</source>
+        <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MainLayoutAspire">
         <source>Aspire</source>
         <target state="translated">Aspire</target>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.cs.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Počet zobrazovaných &lt;strong&gt; strukturovaných protokolů: {0}&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.de.xlf
@@ -97,6 +97,11 @@
         <target state="translated">&lt;strong&gt;{0} Strukturiertes Protokoll&lt;/strong&gt; wird angezeigt</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.es.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Mostrando &lt;strong&gt;{0} registro estructurado&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.fr.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Affichage &lt;strong&gt;{0} de journal structuré&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.it.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Visualizzazione di &lt;strong&gt;{0} log strutturato&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.ja.xlf
@@ -97,6 +97,11 @@
         <target state="translated">&lt;strong&gt;{0} 個の構造化ログを表示中&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.ko.xlf
@@ -97,6 +97,11 @@
         <target state="translated">&lt;strong&gt;{0}개의 구조적 로그를 표시하는 중&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.pl.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Wyświetlanie &lt;strong&gt;{0} dziennika ze strukturą&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.pt-BR.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Mostrando log &lt;strong&gt;{0} estruturado&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.ru.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Отображение &lt;strong&gt;{0} структурированного журнала&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.tr.xlf
@@ -97,6 +97,11 @@
         <target state="translated">&lt;strong&gt;{0} yapılandırılmış günlük&lt;/strong&gt; gösteriliyor</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.zh-Hans.xlf
@@ -97,6 +97,11 @@
         <target state="translated">正在显示 &lt;strong&gt;{0} 个结构化日志&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/StructuredLogs.zh-Hant.xlf
@@ -97,6 +97,11 @@
         <target state="translated">正在顯示 &lt;strong&gt;{0} 結構化記錄&lt;/strong&gt;</target>
         <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} logs&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.cs.xlf
@@ -87,6 +87,11 @@
         <target state="translated">ID trasování: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.de.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Ablaufverfolgungs-ID: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.es.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Id. de seguimiento: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.fr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">ID de trace : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.it.xlf
@@ -87,6 +87,11 @@
         <target state="translated">ID traccia: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.ja.xlf
@@ -87,6 +87,11 @@
         <target state="translated">トレース ID: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.ko.xlf
@@ -87,6 +87,11 @@
         <target state="translated">추적 ID: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.pl.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Identyfikator śledzenia: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.pt-BR.xlf
@@ -87,6 +87,11 @@
         <target state="translated">ID de rastreamento: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.ru.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Идентификатор трассировки: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.tr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">İzleme Kimliği: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.zh-Hans.xlf
@@ -87,6 +87,11 @@
         <target state="translated">跟踪 ID: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/Traces.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Traces.zh-Hant.xlf
@@ -87,6 +87,11 @@
         <target state="translated">追蹤識別碼 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="VirtualizedLimitText">
+        <source>Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</source>
+        <target state="new">Showing &lt;strong&gt;{0} of {1} traces&lt;/strong&gt;. Use filters to narrow the results</target>
+        <note>{0} is the displayed count. {1} is the total count. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -36,7 +36,7 @@ namespace Aspire.Dashboard.ServiceClient;
 /// <para>
 /// If the <c>ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL</c> environment variable is not specified, then there's
 /// no known endpoint to connect to, and this dashboard client will be disabled. Calls to
-/// <see cref="IDashboardClient.SubscribeResourcesAsync"/> and <see cref="IDashboardClient.SubscribeConsoleLogs"/>
+/// <see cref="IResourceRepository.SubscribeResourcesAsync"/> and <see cref="IResourceRepository.SubscribeConsoleLogs"/>
 /// will throw if <see cref="IDashboardClient.IsEnabled"/> is <see langword="false"/>. Callers should
 /// check this property first, before calling these methods.
 /// </para>
@@ -45,12 +45,14 @@ internal sealed class DashboardClient : IDashboardClient
 {
     private const string ApiKeyHeaderName = "x-resource-service-api-key";
     private const string TroubleshootingUrl = "https://aka.ms/aspire/dashboard-apphost-connection-failed";
+    internal const string LiveAppHostServiceKey = "LiveAppHost";
 
     // The dashboard's own version, extracted from its assembly at startup. Used to compare against
     // the minimum version required by the AppHost.
     private static readonly SemVersion? s_dashboardVersion = GetDashboardVersion();
 
     private readonly Dictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
+    private readonly ActivitySource _activitySource;
     private readonly InteractionCollection _pendingInteractionCollection = new();
     private readonly CancellationTokenSource _cts = new();
     private readonly CancellationToken _clientCancellationToken;
@@ -66,6 +68,7 @@ internal sealed class DashboardClient : IDashboardClient
     private readonly DashboardOptions _dashboardOptions;
     private readonly IStringLocalizer<DashboardResources> _loc;
     private readonly ILogger<DashboardClient> _logger;
+    private readonly IResourceRepositoryWriter _resourceRepositoryWriter;
 
     private ImmutableHashSet<Channel<IReadOnlyList<ResourceViewModelChange>>> _outgoingResourceChannels = [];
     private ImmutableHashSet<Channel<WatchInteractionsResponseUpdate>> _outgoingInteractionChannels = [];
@@ -90,17 +93,21 @@ internal sealed class DashboardClient : IDashboardClient
     private Task? _connection;
 
     public DashboardClient(
+        DashboardActivitySource activitySource,
         ILoggerFactory loggerFactory,
         IConfiguration configuration,
         IOptions<DashboardOptions> dashboardOptions,
         IKnownPropertyLookup knownPropertyLookup,
         IStringLocalizer<DashboardResources> loc,
+        IResourceRepositoryWriter resourceRepositoryWriter,
         Action<SocketsHttpHandler>? configureHttpHandler = null)
     {
+        _activitySource = activitySource.ActivitySource;
         _loggerFactory = loggerFactory;
         _knownPropertyLookup = knownPropertyLookup;
         _dashboardOptions = dashboardOptions.Value;
         _loc = loc;
+        _resourceRepositoryWriter = resourceRepositoryWriter;
 
         // Take a copy of the token and always use it to avoid race between disposal of CTS and usage of token.
         _clientCancellationToken = _cts.Token;
@@ -324,7 +331,12 @@ internal sealed class DashboardClient : IDashboardClient
         }
 
         SetConnectionState(DashboardConnectionState.Connecting);
-        _connection = Task.Run(() => ConnectAndWatchAsync(_clientCancellationToken), _clientCancellationToken);
+        // The connection watches resources for the lifetime of the dashboard. Don't let the request or
+        // component that first accesses the client become the parent of that long-running operation.
+        using (ExecutionContext.SuppressFlow())
+        {
+            _connection = Task.Run(() => ConnectAndWatchAsync(_clientCancellationToken), _clientCancellationToken);
+        }
     }
 
     async Task ConnectAndWatchAsync(CancellationToken cancellationToken)
@@ -551,6 +563,9 @@ internal sealed class DashboardClient : IDashboardClient
 
         await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
         {
+            using var activity = _activitySource.StartActivity("Process resource update", ActivityKind.Consumer);
+            activity?.SetTag("aspire.dashboard.resource_update.type", response.KindCase.ToString());
+
             List<ResourceViewModelChange>? changes = null;
             ImmutableHashSet<Channel<IReadOnlyList<ResourceViewModelChange>>> resourceChannels = [];
             var shouldUpdateConnectionState = false;
@@ -566,6 +581,11 @@ internal sealed class DashboardClient : IDashboardClient
 
                 if (response.KindCase == WatchResourcesUpdate.KindOneofCase.InitialData)
                 {
+                    var resourcesWithLoadedConsoleLogs = _resourceByName.Values
+                        .Where(resource => resource.ConsoleLogsLoaded)
+                        .Select(resource => resource.Name)
+                        .ToHashSet(StringComparers.ResourceName);
+
                     // Populate our map using the initial data.
                     _resourceByName.Clear();
 
@@ -575,6 +595,7 @@ internal sealed class DashboardClient : IDashboardClient
                     {
                         // Add to map.
                         var viewModel = resource.ToViewModel(CalculateReplicaIndex(resource.DisplayName), _knownPropertyLookup, _logger);
+                        viewModel.ConsoleLogsLoaded = resourcesWithLoadedConsoleLogs.Contains(resource.Name);
                         _resourceByName[resource.Name] = viewModel;
 
                         // Send this update to any subscribers too.
@@ -595,6 +616,10 @@ internal sealed class DashboardClient : IDashboardClient
                         {
                             // Upsert (i.e. add or replace)
                             var viewModel = change.Upsert.ToViewModel(CalculateReplicaIndex(change.Upsert.DisplayName), _knownPropertyLookup, _logger);
+                            if (_resourceByName.TryGetValue(change.Upsert.Name, out var existingResource))
+                            {
+                                viewModel.ConsoleLogsLoaded = existingResource.ConsoleLogsLoaded;
+                            }
                             _resourceByName[change.Upsert.Name] = viewModel;
                             changes.Add(new(ResourceViewModelChangeType.Upsert, viewModel));
                         }
@@ -633,6 +658,15 @@ internal sealed class DashboardClient : IDashboardClient
                     // point receives the updated model in its initial snapshot and must not also receive this change.
                     resourceChannels = _outgoingResourceChannels;
                 }
+            }
+
+            if (response.KindCase == WatchResourcesUpdate.KindOneofCase.InitialData)
+            {
+                await _resourceRepositoryWriter.ReplaceResourcesAsync(response.InitialData.Resources).ConfigureAwait(false);
+            }
+            else if (response.KindCase == WatchResourcesUpdate.KindOneofCase.Changes)
+            {
+                await _resourceRepositoryWriter.ApplyChangesAsync(response.Changes.Value).ConfigureAwait(false);
             }
 
             // Update connection state outside the lock to avoid potential deadlocks
@@ -899,6 +933,12 @@ internal sealed class DashboardClient : IDashboardClient
     {
         EnsureInitialized();
 
+        // Console-log persistence is demand-driven rather than always-on. This known limitation means
+        // historical runs can omit logs for resources that were never viewed or exported. The historical
+        // Console Logs page checks this capture state and displays a notice when logs aren't available.
+        // See https://github.com/microsoft/aspire/issues/18823.
+        await MarkConsoleLogsLoadedAsync(resourceName).ConfigureAwait(false);
+
         // It's ok to dispose CTS with using because this method exits after it is finished being used.
         using var combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(_clientCancellationToken, cancellationToken);
 
@@ -918,6 +958,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: combinedTokens.Token).ConfigureAwait(false))
                 {
+                    await _resourceRepositoryWriter.AddConsoleLogsAsync(resourceName, response.LogLines).ConfigureAwait(false);
                     // Channel is unbound so TryWrite always succeeds.
                     channel.Writer.TryWrite(CreateLogLines(response.LogLines));
                 }
@@ -940,6 +981,8 @@ internal sealed class DashboardClient : IDashboardClient
     {
         EnsureInitialized();
 
+        await MarkConsoleLogsLoadedAsync(resourceName).ConfigureAwait(false);
+
         using var combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(_clientCancellationToken, cancellationToken);
 
         var call = _client!.WatchResourceConsoleLogs(
@@ -949,8 +992,26 @@ internal sealed class DashboardClient : IDashboardClient
 
         await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: combinedTokens.Token).ConfigureAwait(false))
         {
+            await _resourceRepositoryWriter.AddConsoleLogsAsync(resourceName, response.LogLines).ConfigureAwait(false);
             yield return CreateLogLines(response.LogLines);
         }
+    }
+
+    /// <inheritdoc/>
+    public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate) =>
+        _resourceRepositoryWriter.ClearConsoleLogsAsync(resourceNames, clearDate);
+
+    private async Task MarkConsoleLogsLoadedAsync(string resourceName)
+    {
+        lock (_lock)
+        {
+            if (_resourceByName.TryGetValue(resourceName, out var resource))
+            {
+                resource.ConsoleLogsLoaded = true;
+            }
+        }
+
+        await _resourceRepositoryWriter.MarkConsoleLogsLoadedAsync(resourceName).ConfigureAwait(false);
     }
 
     private static ResourceLogLine[] CreateLogLines(IList<ConsoleLogLine> logLines)

--- a/src/Aspire.Dashboard/ServiceClient/DashboardDataSource.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardDataSource.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Storage;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Controls the dashboard run selected in the current scope.
+/// </summary>
+public interface IDashboardRunSelection
+{
+    /// <summary>
+    /// Gets the selected dashboard run.
+    /// </summary>
+    DashboardRunDescriptor SelectedRun { get; }
+
+    /// <summary>
+    /// Selects the dashboard run with the specified identifier.
+    /// </summary>
+    /// <param name="runId">The run identifier, or <see langword="null"/> to select the current run.</param>
+    void SelectRun(string? runId);
+}
+
+/// <summary>
+/// Provides repositories for the dashboard run selected in the current scope.
+/// </summary>
+public sealed class DashboardDataSource : IDashboardRunSelection, IDisposable
+{
+    private readonly IDashboardRunStore _runStore;
+    private readonly ILogger<DashboardDataSource> _logger;
+    private readonly DashboardDataSourcePool _dataSourcePool;
+
+    private DashboardDataSourcePool.Lease? _historicalDataSourceLease;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DashboardDataSource"/> class.
+    /// </summary>
+    /// <param name="runStore">The store that provides available dashboard runs.</param>
+    /// <param name="logger">The logger used to record dashboard run selection.</param>
+    /// <param name="dataSourcePool">The caller-owned pool that provides dashboard run data sources.</param>
+    public DashboardDataSource(
+        IDashboardRunStore runStore,
+        ILogger<DashboardDataSource> logger,
+        DashboardDataSourcePool dataSourcePool)
+    {
+        _runStore = runStore;
+        _logger = logger;
+        _dataSourcePool = dataSourcePool;
+
+        SelectRun(runId: null);
+    }
+
+    internal DashboardRunDescriptor SelectedRun { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets the telemetry repository for the selected dashboard run.
+    /// </summary>
+    public ITelemetryRepository TelemetryRepository { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets the resource repository for the selected dashboard run.
+    /// </summary>
+    public IResourceRepository ResourceRepository { get; private set; } = null!;
+
+    internal bool IsReadOnly { get; private set; }
+
+    internal void EnsureWritable()
+    {
+        if (IsReadOnly)
+        {
+            throw new InvalidOperationException("Historical dashboard data is read-only.");
+        }
+    }
+
+    DashboardRunDescriptor IDashboardRunSelection.SelectedRun => SelectedRun;
+
+    void IDashboardRunSelection.SelectRun(string? runId) => SelectRun(runId);
+
+    internal void SelectRun(string? runId)
+    {
+        var currentRun = _runStore.GetCurrentRun();
+        var selectedRun = runId is not null ? _runStore.GetRunById(runId) : null;
+        if (selectedRun is null)
+        {
+            if (!string.IsNullOrEmpty(runId))
+            {
+                _logger.LogWarning("Failed to switch to dashboard run '{RunId}' because it is no longer available.", runId);
+            }
+
+            selectedRun = currentRun;
+        }
+
+        if (SelectedRun?.RunId == selectedRun.RunId)
+        {
+            return;
+        }
+
+        var previousRun = SelectedRun;
+
+        if (!selectedRun.IsCurrent)
+        {
+            DashboardDataSourcePool.Lease? historicalDataSourceLease;
+            try
+            {
+                historicalDataSourceLease = _dataSourcePool.TryAcquire(selectedRun);
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(exception, "Failed to switch to dashboard run '{RunId}'.", selectedRun.RunId);
+                throw;
+            }
+
+            if (historicalDataSourceLease is null)
+            {
+                _logger.LogWarning("Failed to switch to dashboard run '{RunId}' because it is no longer available.", selectedRun.RunId);
+                return;
+            }
+
+            var previousHistoricalDataSourceLease = _historicalDataSourceLease;
+            _historicalDataSourceLease = historicalDataSourceLease;
+            TelemetryRepository = historicalDataSourceLease.TelemetryRepository;
+            ResourceRepository = historicalDataSourceLease.ResourceRepository;
+            IsReadOnly = true;
+            SelectedRun = selectedRun;
+            previousHistoricalDataSourceLease?.Dispose();
+        }
+        else
+        {
+            var previousHistoricalDataSourceLease = _historicalDataSourceLease;
+            _historicalDataSourceLease = null;
+            SelectCurrentRun(selectedRun);
+            previousHistoricalDataSourceLease?.Dispose();
+        }
+
+        LogRunSwitch(previousRun, selectedRun);
+    }
+
+    public void Dispose()
+    {
+        DisposeHistoricalDataSource();
+    }
+
+    private void DisposeHistoricalDataSource()
+    {
+        _historicalDataSourceLease?.Dispose();
+        _historicalDataSourceLease = null;
+    }
+
+    private void SelectCurrentRun(DashboardRunDescriptor currentRun)
+    {
+        var currentDataSource = _dataSourcePool.Current;
+        TelemetryRepository = currentDataSource.TelemetryRepository;
+        ResourceRepository = currentDataSource.ResourceRepository;
+        IsReadOnly = false;
+        SelectedRun = currentRun;
+    }
+
+    private void LogRunSwitch(DashboardRunDescriptor? previousRun, DashboardRunDescriptor selectedRun)
+    {
+        if (previousRun is not null && !string.Equals(previousRun.RunId, selectedRun.RunId, StringComparison.Ordinal))
+        {
+            _logger.LogDebug(
+                "Switched dashboard run from '{PreviousRunId}' to '{RunId}'.",
+                previousRun.RunId,
+                selectedRun.RunId);
+        }
+    }
+}

--- a/src/Aspire.Dashboard/ServiceClient/DashboardDataSourceInitializer.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardDataSourceInitializer.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.ServiceClient;
+
+internal sealed class DashboardDataSourceInitializer(
+    DashboardDataSourcePool dataSourcePool,
+    IHostApplicationLifetime applicationLifetime,
+    ILogger<DashboardDataSourceInitializer> logger) : IHostedService, IDisposable
+{
+    private CancellationTokenRegistration _startedRegistration;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await dataSourcePool.InitializeAsync(cancellationToken).ConfigureAwait(false);
+
+        // Publishing from ApplicationStarted ensures a failed Kestrel bind doesn't leave an empty attempted run
+        // in history. It is safe to publish this late because the current run is created from in-memory metadata;
+        // run.json is only needed by a later Dashboard process to discover this run as historical. Pruning is slower
+        // file system housekeeping, so keep that work off the startup callback.
+        _startedRegistration = applicationLifetime.ApplicationStarted.Register(static state =>
+        {
+            var (pool, log) = ((DashboardDataSourcePool, ILogger))state!;
+            pool.PublishRun();
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    pool.PruneExpiredRuns();
+                }
+                catch (Exception ex)
+                {
+                    // Nothing awaits this, so an unhandled exception would crash the process.
+                    log.LogWarning(ex, "Failed to prune expired dashboard runs.");
+                }
+            });
+        }, (dataSourcePool, (ILogger)logger));
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public void Dispose() => _startedRegistration.Dispose();
+}

--- a/src/Aspire.Dashboard/ServiceClient/DashboardDataSourcePool.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardDataSourcePool.cs
@@ -1,0 +1,280 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Storage;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Manages dashboard data sources and shares historical databases across dashboard circuits.
+/// </summary>
+public sealed class DashboardDataSourcePool : IDisposable
+{
+    private static readonly StringComparer s_pathComparer = OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    private readonly object _lock = new();
+    private readonly Dictionary<string, Entry> _entries = new(s_pathComparer);
+    private readonly IDashboardRunStore _runStore;
+    private readonly IRepositoryFactory _repositoryFactory;
+    private Lease? _current;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DashboardDataSourcePool"/> class.
+    /// </summary>
+    /// <param name="runStore">The dashboard run store used to locate and lease dashboard runs.</param>
+    /// <param name="repositoryFactory">The factory used to create repositories for dashboard runs.</param>
+    public DashboardDataSourcePool(IDashboardRunStore runStore, IRepositoryFactory repositoryFactory)
+    {
+        _runStore = runStore;
+        _repositoryFactory = repositoryFactory;
+    }
+
+    /// <summary>
+    /// Gets the pool-owned data source lease for the current dashboard run.
+    /// </summary>
+    /// <remarks>
+    /// Callers must not dispose the returned lease. It is shared by all callers and disposed with the pool.
+    /// </remarks>
+    public Lease Current
+    {
+        get
+        {
+            lock (_lock)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+
+                var currentRun = _runStore.GetCurrentRun();
+                if (_current is null)
+                {
+                    var database = new DashboardSqliteDatabase(currentRun.DatabasePath);
+                    _current = new Lease(
+                        database,
+                        () => _repositoryFactory.CreateTelemetryRepository(database),
+                        () => _repositoryFactory.CreateResourceRepository(database),
+                        () =>
+                        {
+                            database.ClearPool();
+                            database.Dispose();
+                        });
+                }
+
+                return _current;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Attempts to acquire a shared data source lease for the specified dashboard run.
+    /// </summary>
+    /// <param name="run">The dashboard run to acquire.</param>
+    /// <returns>A shared data source lease, or <see langword="null"/> when the run is no longer available.</returns>
+    public Lease? TryAcquire(DashboardRunDescriptor run)
+    {
+        lock (_lock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            var databasePath = Path.GetFullPath(run.DatabasePath);
+            if (!_entries.TryGetValue(databasePath, out var entry))
+            {
+                var runLease = _runStore.TryAcquireRunLease(run);
+                if (runLease is null)
+                {
+                    return null;
+                }
+
+                DashboardSqliteDatabase? database = null;
+                try
+                {
+                    database = new DashboardSqliteDatabase(databasePath, readOnly: true);
+                    entry = new Entry(database, runLease);
+                    _entries.Add(databasePath, entry);
+                }
+                catch
+                {
+                    database?.ClearPool();
+                    database?.Dispose();
+                    runLease.Dispose();
+                    throw;
+                }
+            }
+
+            entry.ReferenceCount++;
+            try
+            {
+                if (!entry.Database.ValidateSchemaVersion(run.SchemaVersion))
+                {
+                    throw new InvalidOperationException(
+                        $"Dashboard database for run '{run.RunId}' does not match run metadata schema version '{run.SchemaVersion}'.");
+                }
+            }
+            catch
+            {
+                Release(entry);
+                throw;
+            }
+
+            var lease = new Lease(
+                entry.Database,
+                () => _repositoryFactory.CreateTelemetryRepository(entry.Database),
+                () => _repositoryFactory.CreateResourceRepository(entry.Database),
+                () => Release(entry));
+            try
+            {
+                _ = lease.TelemetryRepository;
+                _ = lease.ResourceRepository;
+                return lease;
+            }
+            catch
+            {
+                lease.Dispose();
+                throw;
+            }
+        }
+    }
+
+    internal async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        await Current.Database.InitializeSchemaAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    internal void PublishRun()
+    {
+        _runStore.PublishRun();
+    }
+
+    internal void PruneExpiredRuns()
+    {
+        _runStore.PruneExpiredRuns();
+    }
+
+    private void Release(Entry entry)
+    {
+        lock (_lock)
+        {
+            if (entry.IsDisposed)
+            {
+                return;
+            }
+
+            entry.ReferenceCount--;
+            if (entry.ReferenceCount == 0)
+            {
+                _entries.Remove(entry.Database.DatabasePath);
+                DisposeEntry(entry);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            foreach (var entry in _entries.Values)
+            {
+                DisposeEntry(entry);
+            }
+            _entries.Clear();
+            _current?.Dispose();
+        }
+    }
+
+    private static void DisposeEntry(Entry entry)
+    {
+        entry.IsDisposed = true;
+        try
+        {
+            entry.Database.ClearPool();
+            entry.Database.Dispose();
+        }
+        finally
+        {
+            entry.RunLease.Dispose();
+        }
+    }
+
+    private sealed class Entry(DashboardSqliteDatabase database, IDisposable runLease)
+    {
+        public DashboardSqliteDatabase Database { get; } = database;
+        public IDisposable RunLease { get; } = runLease;
+        public int ReferenceCount { get; set; }
+        public bool IsDisposed { get; set; }
+    }
+
+    /// <summary>
+    /// Keeps repositories and their shared dashboard database available until the lease is disposed.
+    /// </summary>
+    public sealed class Lease : IDisposable
+    {
+        private readonly Lazy<ITelemetryRepository> _telemetryRepository;
+        private readonly Lazy<IResourceRepository> _resourceRepository;
+        private readonly Action _release;
+        private int _disposed;
+
+        internal Lease(
+            DashboardSqliteDatabase database,
+            Func<ITelemetryRepository> telemetryRepositoryFactory,
+            Func<IResourceRepository> resourceRepositoryFactory,
+            Action release)
+        {
+            Database = database;
+            _telemetryRepository = new(telemetryRepositoryFactory);
+            _resourceRepository = new(resourceRepositoryFactory);
+            _release = release;
+        }
+
+        /// <summary>
+        /// Gets the shared dashboard database.
+        /// </summary>
+        public DashboardSqliteDatabase Database { get; }
+
+        /// <summary>
+        /// Gets the telemetry repository for the leased dashboard run.
+        /// </summary>
+        public ITelemetryRepository TelemetryRepository => _telemetryRepository.Value;
+
+        /// <summary>
+        /// Gets the resource repository for the leased dashboard run.
+        /// </summary>
+        public IResourceRepository ResourceRepository => _resourceRepository.Value;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                try
+                {
+                    if (_telemetryRepository.IsValueCreated)
+                    {
+                        _telemetryRepository.Value.Dispose();
+                    }
+                }
+                finally
+                {
+                    try
+                    {
+                        if (_resourceRepository.IsValueCreated)
+                        {
+                            (_resourceRepository.Value as IDisposable)?.Dispose();
+                        }
+                    }
+                    finally
+                    {
+                        _release();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -1,0 +1,660 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.IO.Hashing;
+using System.Text;
+using System.Text.Json;
+using Aspire.Dashboard.Configuration;
+using Aspire.Shared;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Provides the dashboard runs available for selection.
+/// </summary>
+public interface IDashboardRunStore
+{
+    /// <summary>
+    /// Gets a value indicating whether historical dashboard runs can be selected.
+    /// </summary>
+    bool SupportsRunSelection { get; }
+
+    /// <summary>
+    /// Gets the current and historical dashboard runs available for selection.
+    /// </summary>
+    /// <returns>The available dashboard runs.</returns>
+    IReadOnlyList<DashboardRunDescriptor> GetRuns();
+
+    /// <summary>
+    /// Gets the current dashboard run.
+    /// </summary>
+    /// <returns>The current dashboard run.</returns>
+    DashboardRunDescriptor GetCurrentRun();
+
+    /// <summary>
+    /// Gets the dashboard run with the specified ID.
+    /// </summary>
+    /// <param name="runId">The ID of the dashboard run.</param>
+    /// <returns>The dashboard run, or <see langword="null"/> when the run is not available.</returns>
+    DashboardRunDescriptor? GetRunById(string runId);
+
+    /// <summary>
+    /// Pins or unpins the specified dashboard run.
+    /// </summary>
+    /// <param name="run">The dashboard run to update.</param>
+    /// <param name="isPinned"><see langword="true"/> to pin the dashboard run; <see langword="false"/> to unpin it.</param>
+    void SetRunPinned(DashboardRunDescriptor run, bool isPinned);
+
+    /// <summary>
+    /// Attempts to acquire a lease that keeps the specified dashboard run available while it is selected.
+    /// </summary>
+    /// <param name="run">The dashboard run to lease.</param>
+    /// <returns>A lease for the dashboard run, or <see langword="null"/> when the run is no longer available.</returns>
+    IDisposable? TryAcquireRunLease(DashboardRunDescriptor run);
+
+    /// <summary>
+    /// Publishes the current dashboard run so it can be discovered by future dashboard processes.
+    /// </summary>
+    void PublishRun();
+
+    /// <summary>
+    /// Deletes dashboard runs beyond the retention limit.
+    /// </summary>
+    void PruneExpiredRuns();
+}
+
+internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
+{
+    private const string TemporaryDirectoryPrefix = "aspire-dashboard-";
+
+    internal const string DatabaseFileName = "dashboard.db";
+    internal const int MaxApplicationDirectoryNameLength = 80;
+    internal const int MaxRuns = 10;
+    internal const int SchemaVersion = DashboardSqliteDatabase.SchemaVersion;
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    private readonly string? _runsDirectory;
+    private readonly string? _metadataPath;
+    private readonly string? _temporaryDirectory;
+    private readonly FileLock? _runLock;
+    private DashboardRunMetadata _metadata;
+    private readonly ILogger<DashboardRunStore> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly Action<string> _deleteRunDirectory;
+    private readonly Lazy<IReadOnlyList<DashboardRunDescriptor>> _runs;
+    private readonly object _runStateLock = new();
+    private bool _metadataPublished;
+
+    public DashboardRunStore(IOptions<DashboardOptions> options, ILogger<DashboardRunStore> logger, TimeProvider timeProvider)
+        : this(options, logger, timeProvider, static directory => Directory.Delete(directory, recursive: true))
+    {
+    }
+
+    internal DashboardRunStore(
+        IOptions<DashboardOptions> options,
+        ILogger<DashboardRunStore> logger,
+        TimeProvider timeProvider,
+        Action<string> deleteRunDirectory)
+    {
+        _logger = logger;
+        _timeProvider = timeProvider;
+        _deleteRunDirectory = deleteRunDirectory;
+        var applicationName = string.IsNullOrWhiteSpace(options.Value.ApplicationName) ? "Aspire" : options.Value.ApplicationName;
+        var startedAt = timeProvider.GetUtcNow();
+        // A millisecond timestamp collision is very unlikely. The exclusive run lock below also ensures that if two
+        // Dashboard instances resolve the same run ID concurrently, the second fails instead of sharing the database.
+        // Format invariantly. This value is a durable directory name and the ordinal sort key used by
+        // PruneRuns, so a non-Gregorian current culture (th-TH, ar-SA) would produce IDs that sort
+        // against previous runs incorrectly and let retention delete newer runs.
+        var runId = startedAt.ToString("yyyyMMddTHHmmssfffZ", CultureInfo.InvariantCulture);
+        PersistenceMode = options.Value.Data.PersistenceMode;
+
+        // Persistent data can contain environment variables, telemetry, and console logs. Restrict the
+        // application directory so the database, WAL, shared-memory, and metadata files aren't exposed
+        // to other local users even when the data root was created with a permissive umask.
+        switch (PersistenceMode)
+        {
+            case DashboardPersistenceMode.None:
+                _temporaryDirectory = Directory.CreateTempSubdirectory(TemporaryDirectoryPrefix).FullName;
+                RunDirectory = _temporaryDirectory;
+                DatabasePath = Path.Combine(RunDirectory, DatabaseFileName);
+                _runLock = OpenRunLock(RunDirectory);
+                DeleteAbandonedTemporaryDirectories(deleteRunDirectory);
+                break;
+            case DashboardPersistenceMode.Run:
+                var applicationDirectory = GetApplicationDirectory(options.Value.Data.Directory, applicationName);
+                DirectoryHelper.CreateWithOwnerOnlyPermissions(applicationDirectory);
+                _runsDirectory = Path.Combine(applicationDirectory, "runs");
+                RunDirectory = Path.Combine(_runsDirectory, runId);
+                DatabasePath = Path.Combine(RunDirectory, DatabaseFileName);
+                Directory.CreateDirectory(RunDirectory);
+                _runLock = OpenRequiredRunLock(
+                    RunDirectory,
+                    $"Dashboard run '{runId}' is already in use by another dashboard process.");
+                _metadataPath = Path.Combine(RunDirectory, "run.json");
+                break;
+            case DashboardPersistenceMode.Resume:
+                RunDirectory = GetApplicationDirectory(options.Value.Data.Directory, applicationName);
+                DatabasePath = Path.Combine(RunDirectory, DatabaseFileName);
+                DirectoryHelper.CreateWithOwnerOnlyPermissions(RunDirectory);
+                var resumeRunLock = OpenRequiredRunLock(
+                    RunDirectory,
+                    $"Dashboard data for application '{applicationName}' is already in use by another dashboard process. Database path: '{DatabasePath}'.");
+                try
+                {
+                    if (!File.Exists(DatabasePath))
+                    {
+                        _logger.LogDebug("Creating dashboard database at '{DatabasePath}'.", DatabasePath);
+                    }
+                    else if (!DashboardSqliteDatabase.IsCompatible(DatabasePath))
+                    {
+                        _logger.LogInformation(
+                            "Existing dashboard database at '{DatabasePath}' is incompatible with schema version {SchemaVersion} and will be replaced.",
+                            DatabasePath,
+                            SchemaVersion);
+                        DeleteDatabaseFiles(DatabasePath);
+                    }
+                    else
+                    {
+                        _logger.LogDebug("Resuming dashboard database at '{DatabasePath}'.", DatabasePath);
+                    }
+
+                    _runLock = resumeRunLock;
+                }
+                catch
+                {
+                    resumeRunLock.Dispose();
+                    throw;
+                }
+                break;
+            default:
+                throw new InvalidOperationException($"Unexpected dashboard persistence mode: {PersistenceMode}");
+        }
+
+        _metadata = new DashboardRunMetadata
+        {
+            SchemaVersion = SchemaVersion,
+            RunId = runId,
+            StartedAtUtc = startedAt,
+            ApplicationName = options.Value.ApplicationName,
+            DatabaseFileName = Path.GetFileName(DatabasePath)
+        };
+        _runs = new(LoadRuns);
+
+        _logger.LogDebug(
+            "Dashboard run store initialized with persistence mode '{PersistenceMode}'. Run directory: '{RunDirectory}'. Database path: '{DatabasePath}'.",
+            PersistenceMode,
+            RunDirectory,
+            DatabasePath);
+    }
+
+    private void DeleteAbandonedTemporaryDirectories(Action<string> deleteRunDirectory)
+    {
+        var temporaryRoot = Directory.GetParent(RunDirectory)!.FullName;
+        foreach (var directory in Directory.EnumerateDirectories(temporaryRoot, $"{TemporaryDirectoryPrefix}*"))
+        {
+            if (string.Equals(directory, RunDirectory, StringComparison.OrdinalIgnoreCase) ||
+                !File.Exists(Path.Combine(directory, DatabaseFileName)))
+            {
+                continue;
+            }
+
+            using var runLock = TryOpenRunLock(directory);
+            if (runLock is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                deleteRunDirectory(directory);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "Failed to delete abandoned dashboard temporary directory '{RunDirectory}'. The directory may still be in use by another dashboard process.",
+                    directory);
+            }
+        }
+    }
+
+    public string RunDirectory { get; }
+    public string DatabasePath { get; }
+    public string RunId => _metadata.RunId;
+    public DashboardPersistenceMode PersistenceMode { get; }
+    public bool SupportsRunSelection => PersistenceMode == DashboardPersistenceMode.Run;
+
+    public IReadOnlyList<DashboardRunDescriptor> GetRuns()
+    {
+        var runs = _runs.Value;
+        return runs.Any(run => run.IsPruned || !run.IsSelectable)
+            ? runs.Where(run => !run.IsPruned && run.IsSelectable).ToArray()
+            : runs;
+    }
+
+    public DashboardRunDescriptor GetCurrentRun() => GetRuns().Single(run => run.IsCurrent);
+
+    public DashboardRunDescriptor? GetRunById(string runId) =>
+        GetRuns().SingleOrDefault(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+
+    public void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
+    {
+        var storedRun = GetRunById(run.RunId);
+        if (storedRun is null)
+        {
+            throw new InvalidOperationException($"Dashboard run '{run.RunId}' is no longer available.");
+        }
+
+        var runDirectory = Path.GetDirectoryName(storedRun.DatabasePath)!;
+        lock (_runStateLock)
+        {
+            // The current run has the store's lifetime lock, and a selected historical run has a lease.
+            // Only an unselected historical run needs a temporary lock while its metadata is updated.
+            using var runLock = storedRun.IsCurrent || storedRun.IsLeased
+                ? null
+                : TryOpenRunLock(runDirectory)
+                    ?? throw new InvalidOperationException($"Dashboard run '{storedRun.RunId}' is no longer available.");
+            UpdatePinnedState(storedRun, runDirectory, isPinned);
+        }
+    }
+
+    private void UpdatePinnedState(DashboardRunDescriptor run, string runDirectory, bool isPinned)
+    {
+        var metadataPath = Path.Combine(runDirectory, "run.json");
+        var metadata = JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath));
+        if (metadata is not { SchemaVersion: SchemaVersion } ||
+            !string.Equals(metadata.RunId, run.RunId, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Dashboard run metadata for '{run.RunId}' is invalid.");
+        }
+
+        var updatedMetadata = metadata with { IsPinned = isPinned };
+        WriteMetadata(updatedMetadata, metadataPath);
+        if (string.Equals(run.RunId, RunId, StringComparison.Ordinal))
+        {
+            _metadata = updatedMetadata;
+        }
+
+        run.IsPinned = isPinned;
+    }
+
+    public void PublishRun()
+    {
+        if (_metadataPath is null || _metadataPublished)
+        {
+            return;
+        }
+
+        WriteMetadata(_metadata);
+        _metadataPublished = true;
+    }
+
+    /// <summary>
+    /// Deletes run directories beyond the retention limit.
+    /// </summary>
+    /// <remarks>
+    /// Kept separate from <see cref="PublishRun"/> because pruning walks every run directory, takes a cross-process
+    /// lock on each, and recursively deletes it. On a slow or contended file system it can take a long time, so
+    /// pruning is background housekeeping and must not hold up the dashboard accepting requests.
+    /// </remarks>
+    public void PruneExpiredRuns()
+    {
+        if (!_metadataPublished || _runsDirectory is null || !Directory.Exists(_runsDirectory))
+        {
+            return;
+        }
+
+        PruneRuns(_deleteRunDirectory);
+    }
+
+    public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run)
+    {
+        var storedRun = GetRunById(run.RunId);
+        if (storedRun is null)
+        {
+            return null;
+        }
+
+        var runDirectory = Path.GetDirectoryName(storedRun.DatabasePath)!;
+        lock (_runStateLock)
+        {
+            var runLock = TryOpenRunLock(runDirectory);
+            if (runLock is null)
+            {
+                return null;
+            }
+
+            storedRun.IsLeased = true;
+            return new RunLease(this, storedRun, runLock);
+        }
+    }
+
+    private IReadOnlyList<DashboardRunDescriptor> LoadRuns()
+    {
+        var runs = new List<DashboardRunDescriptor>
+        {
+            CreateDescriptor(_metadata, RunDirectory, isCurrent: true)
+        };
+
+        if (SupportsRunSelection && Directory.Exists(_runsDirectory))
+        {
+            foreach (var directory in Directory.EnumerateDirectories(_runsDirectory))
+            {
+                if (string.Equals(directory, RunDirectory, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var metadataPath = Path.Combine(directory, "run.json");
+                try
+                {
+                    var metadata = JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath));
+                    if (metadata is { SchemaVersion: SchemaVersion })
+                    {
+                        var run = CreateDescriptor(metadata, directory, isCurrent: false);
+                        // Filter out in-progress runs that are owned by other Dashboard instances.
+                        using var runLock = TryOpenRunLock(directory);
+                        run.IsSelectable = runLock is not null;
+                        runs.Add(run);
+                    }
+                }
+                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+                {
+                    // Ignore incomplete or unreadable run metadata.
+                }
+            }
+        }
+
+        var orderedRuns = runs
+            .OrderByDescending(run => run.IsCurrent)
+            .ThenByDescending(run => run.IsPinned)
+            .ThenByDescending(run => run.StartedAtUtc)
+            .ToArray();
+        _logger.LogDebug(
+            "Dashboard run discovery completed in directory '{RunsDirectory}'. Run count: {RunCount}. Run IDs: {RunIds}.",
+            _runsDirectory ?? RunDirectory,
+            orderedRuns.Length,
+            string.Join(", ", orderedRuns.Select(run => run.RunId)));
+
+        return orderedRuns;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (_metadataPublished)
+            {
+                WriteMetadata(_metadata with { EndedAtUtc = _timeProvider.GetUtcNow(), CleanShutdown = true });
+            }
+            else if (_temporaryDirectory is not null && Directory.Exists(_temporaryDirectory))
+            {
+                Directory.Delete(_temporaryDirectory, recursive: true);
+            }
+            else if (PersistenceMode == DashboardPersistenceMode.Run && Directory.Exists(RunDirectory))
+            {
+                // Run metadata is published only after the host starts listening. If startup fails first, remove
+                // the initialized database so the attempted run never appears as empty historical data.
+                _deleteRunDirectory(RunDirectory);
+            }
+        }
+        finally
+        {
+            _runLock?.Dispose();
+        }
+    }
+
+    private void WriteMetadata(DashboardRunMetadata metadata) => WriteMetadata(metadata, _metadataPath!);
+
+    private static void WriteMetadata(DashboardRunMetadata metadata, string metadataPath)
+    {
+        // Write to a sibling temp file and rename over the target. Overwriting run.json in place means a
+        // crash or power loss part-way through leaves a truncated file and the run becomes unreadable on
+        // the next start. A rename within the same directory is atomic on both Windows and Unix.
+        var temporaryPath = $"{metadataPath}.tmp";
+
+        try
+        {
+            File.WriteAllText(temporaryPath, JsonSerializer.Serialize(metadata, s_jsonOptions));
+            File.Move(temporaryPath, metadataPath, overwrite: true);
+        }
+        catch
+        {
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                // Best effort. A leftover temp file doesn't affect run discovery, which only reads run.json.
+            }
+
+            throw;
+        }
+    }
+
+    private void PruneRuns(Action<string> deleteRunDirectory)
+    {
+        foreach (var run in _runs.Value.Where(run => !run.IsPinned).Skip(MaxRuns))
+        {
+            var directory = Path.GetDirectoryName(run.DatabasePath)!;
+            using var runLock = TryOpenRunLock(directory);
+            // Pinning can happen after the candidate list is created. Recheck while holding the same lock used by
+            // SetRunPinned so a successful pin always completes before pruning decides whether to delete the run.
+            if (runLock is null || IsPinnedRunDirectory(directory))
+            {
+                continue;
+            }
+
+            try
+            {
+                deleteRunDirectory(directory);
+                run.IsPruned = true;
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "Failed to delete expired dashboard run directory '{RunDirectory}'. The directory may still be in use by another dashboard process.",
+                    directory);
+            }
+        }
+    }
+
+    private static bool IsPinnedRunDirectory(string runDirectory)
+    {
+        try
+        {
+            var metadataPath = Path.Combine(runDirectory, "run.json");
+            return JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath))?.IsPinned == true;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            // Run metadata is written locally by DashboardRunStore and is assumed to be reliable during normal usage.
+            // Treat unreadable metadata as unpinned so incomplete or abandoned run directories can still be pruned.
+            return false;
+        }
+    }
+
+    private static FileLock OpenRunLock(string runDirectory)
+    {
+        // Keep the lock beside the run directory so pruning can hold it while recursively deleting the directory on Windows.
+        return FileLock.Acquire(GetRunLockPath(runDirectory));
+    }
+
+    private static FileLock OpenRequiredRunLock(string runDirectory, string errorMessage)
+    {
+        try
+        {
+            return OpenRunLock(runDirectory);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            throw new InvalidOperationException(errorMessage, exception);
+        }
+    }
+
+    private static FileLock? TryOpenRunLock(string runDirectory)
+    {
+        var runLock = FileLock.TryAcquire(GetRunLockPath(runDirectory));
+        if (runLock is null)
+        {
+            return null;
+        }
+
+        // The lock file is adjacent to the run directory, so OpenOrCreate can recreate it after pruning has already
+        // deleted the directory. Check after acquiring the lock to avoid racing with a cooperating pruner.
+        if (!Directory.Exists(runDirectory))
+        {
+            runLock.Dispose();
+            return null;
+        }
+
+        return runLock;
+    }
+
+    internal static string GetRunLockPath(string runDirectory) => $"{runDirectory}.lock";
+
+    private static DashboardRunDescriptor CreateDescriptor(DashboardRunMetadata metadata, string runDirectory, bool isCurrent)
+    {
+        return new DashboardRunDescriptor(
+            metadata.RunId,
+            metadata.SchemaVersion,
+            metadata.StartedAtUtc,
+            metadata.EndedAtUtc,
+            metadata.CleanShutdown,
+            metadata.ApplicationName,
+            Path.Combine(runDirectory, metadata.DatabaseFileName),
+            isCurrent)
+        {
+            IsPinned = metadata.IsPinned
+        };
+    }
+
+    internal static string GetApplicationDirectory(string? dataRoot, string applicationName)
+    {
+        if (string.IsNullOrWhiteSpace(dataRoot))
+        {
+            dataRoot = Path.Combine(AspireHomeDirectory.GetDefault(), "dashboard");
+        }
+
+        return Path.Combine(Path.GetFullPath(dataRoot), GetApplicationDirectoryName(applicationName));
+    }
+
+    private static void DeleteDatabaseFiles(string databasePath)
+    {
+        foreach (var path in new[] { databasePath, $"{databasePath}-wal", $"{databasePath}-shm" })
+        {
+            File.Delete(path);
+        }
+    }
+
+    internal static string GetApplicationDirectoryName(string applicationName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(applicationName);
+
+        const int hashLength = 16;
+        const int separatorLength = 1;
+        var maxPrefixLength = MaxApplicationDirectoryNameLength - separatorLength - hashLength;
+        var prefixBuilder = new StringBuilder(Math.Min(applicationName.Length, maxPrefixLength));
+
+        foreach (var character in applicationName)
+        {
+            if (prefixBuilder.Length == maxPrefixLength)
+            {
+                break;
+            }
+
+            prefixBuilder.Append(character is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9') or '-' or '_'
+                ? character
+                : '-');
+        }
+
+        var prefix = prefixBuilder.ToString().Trim('-', '_');
+        if (prefix.Length == 0)
+        {
+            prefix = "dashboard";
+        }
+
+        var hash = Convert.ToHexString(XxHash3.Hash(Encoding.UTF8.GetBytes(applicationName))).ToLowerInvariant();
+        return $"{prefix}-{hash}";
+    }
+
+    private sealed class RunLease(DashboardRunStore owner, DashboardRunDescriptor run, FileLock runLock) : IDisposable
+    {
+        private FileLock? _runLock = runLock;
+
+        public void Dispose()
+        {
+            lock (owner._runStateLock)
+            {
+                var runLock = Interlocked.Exchange(ref _runLock, null);
+                if (runLock is not null)
+                {
+                    try
+                    {
+                        runLock.Dispose();
+                    }
+                    finally
+                    {
+                        run.IsLeased = false;
+                    }
+                }
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    private sealed record DashboardRunMetadata
+    {
+        public required int SchemaVersion { get; init; }
+        public required string RunId { get; init; }
+        public required DateTimeOffset StartedAtUtc { get; init; }
+        public DateTimeOffset? EndedAtUtc { get; init; }
+        public bool CleanShutdown { get; init; }
+        public string? ApplicationName { get; init; }
+        public required string DatabaseFileName { get; init; }
+        public bool IsPinned { get; init; }
+    }
+}
+
+/// <summary>
+/// Describes a dashboard run available for selection.
+/// </summary>
+/// <param name="RunId">The unique identifier for the dashboard run.</param>
+/// <param name="SchemaVersion">The dashboard database schema version used by the run.</param>
+/// <param name="StartedAtUtc">The time at which the run started.</param>
+/// <param name="EndedAtUtc">The time at which the run ended, or <see langword="null"/> when it has not ended.</param>
+/// <param name="CleanShutdown">A value indicating whether the run shut down cleanly.</param>
+/// <param name="ApplicationName">The application name associated with the run.</param>
+/// <param name="DatabasePath">The path to the dashboard database for the run.</param>
+/// <param name="IsCurrent">A value indicating whether this is the current dashboard run.</param>
+public sealed record DashboardRunDescriptor(
+    string RunId,
+    int SchemaVersion,
+    DateTimeOffset StartedAtUtc,
+    DateTimeOffset? EndedAtUtc,
+    bool CleanShutdown,
+    string? ApplicationName,
+    string DatabasePath,
+    bool IsCurrent)
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the dashboard run was pruned.
+    /// </summary>
+    public bool IsPruned { get; set; }
+
+    internal bool IsSelectable { get; set; } = true;
+
+    /// <summary>
+    /// Gets a value indicating whether the dashboard run is pinned.
+    /// </summary>
+    public bool IsPinned { get; internal set; }
+
+    internal bool IsLeased { get; set; }
+}

--- a/src/Aspire.Dashboard/ServiceClient/DashboardSqliteDatabase.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardSqliteDatabase.cs
@@ -1,0 +1,248 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Dapper;
+using System.Data;
+using System.Diagnostics;
+using System.Globalization;
+using Aspire.Dashboard.Utils;
+using Microsoft.Data.Sqlite;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Creates consistently configured connections to a dashboard run database.
+/// </summary>
+public sealed class DashboardSqliteDatabase : IDisposable
+{
+    private const string SchemaResourcePrefix = "Aspire.Dashboard.ServiceClient.DatabaseSchema.";
+
+    internal const int SchemaVersion = 17;
+
+    private static readonly Lazy<IReadOnlyList<string>> s_schemaScripts = new(LoadSchemaScripts);
+
+    private readonly string _connectionString;
+    private readonly ActivitySource _activitySource = new(TracingSqliteConnection.ActivitySourceName);
+    private bool _schemaInitialized;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DashboardSqliteDatabase"/> class.
+    /// </summary>
+    /// <param name="databasePath">The path to the dashboard database.</param>
+    /// <param name="readOnly">A value indicating whether the database is opened for read-only access.</param>
+    /// <param name="pooling">A value indicating whether SQLite connection pooling is enabled.</param>
+    public DashboardSqliteDatabase(string databasePath, bool readOnly = false, bool pooling = true)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(databasePath);
+
+        DatabasePath = Path.GetFullPath(databasePath);
+        IsReadOnly = readOnly;
+
+        if (!readOnly)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(DatabasePath)!);
+        }
+
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = DatabasePath,
+            Mode = readOnly ? SqliteOpenMode.ReadOnly : SqliteOpenMode.ReadWriteCreate,
+            Pooling = pooling,
+            ForeignKeys = true,
+            DefaultTimeout = 5
+        }.ToString();
+    }
+
+    /// <summary>
+    /// Gets the full path to the dashboard database.
+    /// </summary>
+    public string DatabasePath { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the database is opened for read-only access.
+    /// </summary>
+    public bool IsReadOnly { get; }
+
+    internal ActivitySource ActivitySource => _activitySource;
+
+    /// <summary>
+    /// Gets the lock that serializes writes to this database.
+    /// </summary>
+    internal AsyncLock WriteLock { get; } = new();
+
+    /// <summary>
+    /// Determines whether a dashboard database uses the current schema version.
+    /// </summary>
+    /// <param name="databasePath">The path to the dashboard database.</param>
+    /// <returns><see langword="true"/> when the database is compatible; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="SqliteException">The database schema version could not be read.</exception>
+    public static bool IsCompatible(string databasePath)
+    {
+        if (!File.Exists(databasePath))
+        {
+            return false;
+        }
+
+        using var database = new DashboardSqliteDatabase(databasePath, readOnly: true, pooling: false);
+        using var connection = database.OpenConnection();
+        return ValidateSchemaVersion(connection, transaction: null, SchemaVersion);
+    }
+
+    internal TracingSqliteConnection OpenConnection()
+    {
+        var connection = new TracingSqliteConnection(_connectionString, DatabasePath, _activitySource);
+        connection.Open();
+
+        // synchronous is scoped to the native connection and is not stored in the database. A pooled native
+        // connection retains its value, but Microsoft.Data.Sqlite doesn't expose whether Open created a new
+        // native connection or leased one from the pool, so apply it after every logical open. NORMAL avoids
+        // syncing the WAL after every commit while preserving database consistency, although a power loss can
+        // discard the most recent transactions.
+        // See https://sqlite.org/pragma.html#pragma_synchronous.
+        connection.ConfigureSynchronousNormal();
+
+        return connection;
+    }
+
+    internal bool ValidateSchemaVersion(int metadataSchemaVersion)
+    {
+        using var connection = OpenConnection();
+        return ValidateSchemaVersion(connection, transaction: null, metadataSchemaVersion);
+    }
+
+    /// <summary>
+    /// Clears pooled SQLite connections associated with this database.
+    /// </summary>
+    public void ClearPool()
+    {
+        using var connection = new SqliteConnection(_connectionString);
+        SqliteConnection.ClearPool(connection);
+    }
+
+    public void Dispose() => _activitySource.Dispose();
+
+    /// <summary>
+    /// Initializes the dashboard database schema when it has not already been initialized.
+    /// </summary>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    public async Task InitializeSchemaAsync(CancellationToken cancellationToken)
+    {
+        EnsureWritable("Historical dashboard data is read-only.");
+
+        using (await WriteLock.LockAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (_schemaInitialized)
+            {
+                return;
+            }
+
+            using var connection = OpenConnection();
+            // Unlike synchronous, WAL journal mode is stored in the database and persists across connections
+            // and process restarts, so it only needs to be set during database initialization rather than on
+            // every open. WAL appends writes sequentially and allows readers to continue while a writer commits.
+            // See https://sqlite.org/pragma.html#pragma_journal_mode.
+            connection.Execute("PRAGMA journal_mode = WAL;");
+
+            var schemaTableExists = connection.QuerySingle<long>("""
+                SELECT COUNT(*)
+                FROM sqlite_schema
+                WHERE type = 'table' AND name = 'dashboard_schema';
+                """) != 0;
+            if (schemaTableExists)
+            {
+                var existingSchemaVersion = GetSchemaVersion(connection, transaction: null);
+                if (existingSchemaVersion != SchemaVersion)
+                {
+                    throw new InvalidOperationException($"The dashboard database schema version {FormatSchemaVersion(existingSchemaVersion)} does not match the expected version {SchemaVersion}.");
+                }
+            }
+
+            using var transaction = connection.BeginTransaction();
+            foreach (var script in s_schemaScripts.Value)
+            {
+                connection.Execute(script, new { SchemaVersion }, transaction);
+            }
+
+            var initializedSchemaVersion = GetSchemaVersion(connection, transaction);
+            if (initializedSchemaVersion != SchemaVersion)
+            {
+                throw new InvalidOperationException($"The dashboard database schema was initialized to version {FormatSchemaVersion(initializedSchemaVersion)} instead of the expected version {SchemaVersion}.");
+            }
+            transaction.Commit();
+            _schemaInitialized = true;
+        }
+    }
+
+    /// <summary>
+    /// Throws an exception with the specified message when the database is read-only.
+    /// </summary>
+    /// <param name="message">The exception message used when the database is read-only.</param>
+    /// <exception cref="InvalidOperationException">The database is read-only.</exception>
+    public void EnsureWritable(string message)
+    {
+        if (IsReadOnly)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private static IReadOnlyList<string> LoadSchemaScripts()
+    {
+        var assembly = typeof(DashboardSqliteDatabase).Assembly;
+        // Numeric filename prefixes define execution order because later schema domains reference tables created by earlier scripts.
+        var resourceNames = assembly.GetManifestResourceNames()
+            .Where(name => name.StartsWith(SchemaResourcePrefix, StringComparison.Ordinal) && name.EndsWith(".sql", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        if (resourceNames.Length == 0)
+        {
+            throw new InvalidOperationException("No embedded dashboard database schema scripts were found.");
+        }
+
+        var scripts = new List<string>(resourceNames.Length);
+        foreach (var resourceName in resourceNames)
+        {
+            using var stream = assembly.GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException($"Embedded dashboard database schema script '{resourceName}' was not found.");
+            using var reader = new StreamReader(stream);
+            scripts.Add(reader.ReadToEnd());
+        }
+
+        return scripts;
+    }
+
+    private static bool ValidateSchemaVersion(SqliteConnection connection, IDbTransaction? transaction, int expectedVersion)
+    {
+        // Opening the database and setting WAL creates a valid SQLite file before the schema transaction
+        // commits, so an interrupted first initialization leaves a file with no dashboard_schema table.
+        // Querying it directly throws "no such table: dashboard_schema", and because Resume only replaces
+        // the database when this returns false, every later start would keep crashing.
+        //
+        // Probe sqlite_master first so a missing schema table reports "not compatible" while genuine IO,
+        // locking, and corruption failures still surface as exceptions.
+        // See https://www.sqlite.org/schematab.html
+        var schemaTableCount = connection.QuerySingle<long>("""
+            SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'dashboard_schema';
+            """, transaction: transaction);
+        if (schemaTableCount == 0)
+        {
+            return false;
+        }
+
+        return GetSchemaVersion(connection, transaction) == expectedVersion;
+    }
+
+    private static int? GetSchemaVersion(SqliteConnection connection, IDbTransaction? transaction)
+    {
+        return connection.QuerySingleOrDefault<int?>("""
+            SELECT CASE
+                WHEN COUNT(*) = 1 THEN MAX(version)
+                ELSE NULL
+            END
+            FROM dashboard_schema;
+            """, transaction: transaction);
+    }
+
+    private static string FormatSchemaVersion(int? version) => version?.ToString(CultureInfo.InvariantCulture) ?? "unknown";
+}

--- a/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/001.Core.sql
+++ b/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/001.Core.sql
@@ -1,0 +1,11 @@
+-- Licensed to the .NET Foundation under one or more agreements.
+-- The .NET Foundation licenses this file to you under the MIT license.
+-- IMPORTANT: Increment DashboardSqliteDatabase.SchemaVersion when changing the database schema.
+
+CREATE TABLE IF NOT EXISTS dashboard_schema (
+    version INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO dashboard_schema (version)
+SELECT @SchemaVersion
+WHERE NOT EXISTS (SELECT 1 FROM dashboard_schema);

--- a/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/002.Resources.sql
+++ b/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/002.Resources.sql
@@ -1,0 +1,157 @@
+-- Licensed to the .NET Foundation under one or more agreements.
+-- The .NET Foundation licenses this file to you under the MIT license.
+-- IMPORTANT: Increment DashboardSqliteDatabase.SchemaVersion when changing the database schema.
+
+CREATE TABLE IF NOT EXISTS dashboard_resources (
+    resource_name TEXT PRIMARY KEY,
+    replica_index INTEGER NOT NULL,
+    resource_type TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    uid TEXT NOT NULL,
+    state TEXT NULL,
+    created_at_seconds INTEGER NULL,
+    created_at_nanos INTEGER NULL,
+    state_style TEXT NULL,
+    started_at_seconds INTEGER NULL,
+    started_at_nanos INTEGER NULL,
+    stopped_at_seconds INTEGER NULL,
+    stopped_at_nanos INTEGER NULL,
+    is_hidden INTEGER NOT NULL,
+    supports_detailed_telemetry INTEGER NOT NULL,
+    icon_name TEXT NULL,
+    icon_variant INTEGER NULL,
+    console_logs_loaded INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_environment (
+    resource_name TEXT NOT NULL REFERENCES dashboard_resources(resource_name) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    value TEXT NULL,
+    is_from_spec INTEGER NOT NULL,
+    PRIMARY KEY (resource_name, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_urls (
+    resource_name TEXT NOT NULL REFERENCES dashboard_resources(resource_name) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    endpoint_name TEXT NULL,
+    full_url TEXT NOT NULL,
+    is_internal INTEGER NOT NULL,
+    is_inactive INTEGER NOT NULL,
+    display_sort_order INTEGER NOT NULL,
+    display_name TEXT NOT NULL,
+    PRIMARY KEY (resource_name, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_volumes (
+    resource_name TEXT NOT NULL REFERENCES dashboard_resources(resource_name) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    mount_type TEXT NOT NULL,
+    is_read_only INTEGER NOT NULL,
+    PRIMARY KEY (resource_name, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_health_reports (
+    resource_name TEXT NOT NULL REFERENCES dashboard_resources(resource_name) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    status INTEGER NULL,
+    key TEXT NOT NULL,
+    description TEXT NOT NULL,
+    exception TEXT NOT NULL,
+    last_run_at_seconds INTEGER NULL,
+    last_run_at_nanos INTEGER NULL,
+    PRIMARY KEY (resource_name, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_relationships (
+    resource_name TEXT NOT NULL REFERENCES dashboard_resources(resource_name) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    related_resource_name TEXT NOT NULL,
+    relationship_type TEXT NOT NULL,
+    PRIMARY KEY (resource_name, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_properties (
+    resource_name TEXT NOT NULL REFERENCES dashboard_resources(resource_name) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    display_name TEXT NULL,
+    value TEXT NOT NULL CHECK (json_valid(value)),
+    is_sensitive INTEGER NULL,
+    is_highlighted INTEGER NOT NULL,
+    sort_order INTEGER NULL,
+    PRIMARY KEY (resource_name, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_commands (
+    resource_name TEXT NOT NULL REFERENCES dashboard_resources(resource_name) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    confirmation_message TEXT NULL,
+    parameter_value TEXT NULL CHECK (parameter_value IS NULL OR json_valid(parameter_value)),
+    is_highlighted INTEGER NOT NULL,
+    icon_name TEXT NULL,
+    icon_variant INTEGER NULL,
+    display_description TEXT NULL,
+    state INTEGER NOT NULL,
+    PRIMARY KEY (resource_name, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_command_inputs (
+    resource_name TEXT NOT NULL,
+    command_ordinal INTEGER NOT NULL,
+    ordinal INTEGER NOT NULL,
+    label TEXT NOT NULL,
+    placeholder TEXT NOT NULL,
+    input_type INTEGER NOT NULL,
+    required INTEGER NOT NULL,
+    value TEXT NOT NULL,
+    description TEXT NOT NULL,
+    enable_description_markdown INTEGER NOT NULL,
+    max_length INTEGER NOT NULL,
+    allow_custom_choice INTEGER NOT NULL,
+    loading INTEGER NOT NULL,
+    update_state_on_change INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    disabled INTEGER NOT NULL,
+    max_file_size INTEGER NOT NULL,
+    allow_multiple_files INTEGER NOT NULL,
+    file_filter TEXT NOT NULL,
+    PRIMARY KEY (resource_name, command_ordinal, ordinal),
+    FOREIGN KEY (resource_name, command_ordinal) REFERENCES dashboard_resource_commands(resource_name, ordinal) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_command_input_options (
+    resource_name TEXT NOT NULL,
+    command_ordinal INTEGER NOT NULL,
+    input_ordinal INTEGER NOT NULL,
+    option_key TEXT NOT NULL,
+    option_value TEXT NOT NULL,
+    PRIMARY KEY (resource_name, command_ordinal, input_ordinal, option_key),
+    FOREIGN KEY (resource_name, command_ordinal, input_ordinal) REFERENCES dashboard_resource_command_inputs(resource_name, command_ordinal, ordinal) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dashboard_resource_command_input_validation_errors (
+    resource_name TEXT NOT NULL,
+    command_ordinal INTEGER NOT NULL,
+    input_ordinal INTEGER NOT NULL,
+    ordinal INTEGER NOT NULL,
+    validation_error TEXT NOT NULL,
+    PRIMARY KEY (resource_name, command_ordinal, input_ordinal, ordinal),
+    FOREIGN KEY (resource_name, command_ordinal, input_ordinal) REFERENCES dashboard_resource_command_inputs(resource_name, command_ordinal, ordinal) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS console_logs (
+    console_log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_name TEXT NOT NULL,
+    line_number INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    is_stderr INTEGER NOT NULL
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS ix_console_logs_resource_id
+ON console_logs(resource_name, console_log_id);

--- a/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/003.Logs.sql
+++ b/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/003.Logs.sql
@@ -1,0 +1,91 @@
+-- Licensed to the .NET Foundation under one or more agreements.
+-- The .NET Foundation licenses this file to you under the MIT license.
+-- IMPORTANT: Increment DashboardSqliteDatabase.SchemaVersion when changing the database schema.
+
+CREATE TABLE IF NOT EXISTS telemetry_resources (
+    resource_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_name TEXT NOT NULL,
+    instance_id TEXT NULL,
+    uninstrumented_peer INTEGER NOT NULL DEFAULT 0,
+    has_logs INTEGER NOT NULL DEFAULT 0,
+    has_traces INTEGER NOT NULL DEFAULT 0,
+    has_metrics INTEGER NOT NULL DEFAULT 0
+) STRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_telemetry_resources_name_without_instance
+    ON telemetry_resources(resource_name)
+    WHERE instance_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS ix_telemetry_resources_name_with_instance
+    ON telemetry_resources(resource_name, instance_id)
+    WHERE instance_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS telemetry_resource_views (
+    resource_view_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL REFERENCES telemetry_resources(resource_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS ix_telemetry_resource_views_resource
+    ON telemetry_resource_views(resource_id);
+
+CREATE TABLE IF NOT EXISTS telemetry_resource_view_attributes (
+    resource_view_id INTEGER NOT NULL REFERENCES telemetry_resource_views(resource_view_id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    attribute_key TEXT NOT NULL,
+    attribute_value TEXT NOT NULL,
+    PRIMARY KEY (resource_view_id, ordinal)
+) STRICT;
+
+-- Scope identity intentionally uses the name only. Scope attributes aren't used by the Dashboard today,
+-- so the version and attributes from the first observed scope are retained for later telemetry with the same name.
+CREATE TABLE IF NOT EXISTS telemetry_scopes (
+    scope_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    scope_name TEXT NOT NULL UNIQUE,
+    scope_version TEXT NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_scope_attributes (
+    scope_id INTEGER NOT NULL REFERENCES telemetry_scopes(scope_id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    attribute_key TEXT NOT NULL,
+    attribute_value TEXT NOT NULL,
+    PRIMARY KEY (scope_id, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_logs (
+    log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL REFERENCES telemetry_resources(resource_id) ON DELETE CASCADE,
+    resource_view_id INTEGER NOT NULL REFERENCES telemetry_resource_views(resource_view_id) ON DELETE CASCADE,
+    scope_id INTEGER NOT NULL REFERENCES telemetry_scopes(scope_id),
+    timestamp_ticks INTEGER NOT NULL,
+    flags INTEGER NOT NULL,
+    severity INTEGER NOT NULL,
+    severity_name TEXT NOT NULL,
+    severity_number INTEGER NOT NULL,
+    message TEXT NOT NULL,
+    span_id TEXT NOT NULL,
+    trace_id TEXT NOT NULL,
+    parent_id TEXT NOT NULL,
+    original_format TEXT NULL,
+    event_name TEXT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_log_attributes (
+    log_id INTEGER NOT NULL REFERENCES telemetry_logs(log_id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    attribute_key TEXT NOT NULL,
+    attribute_value TEXT NOT NULL,
+    PRIMARY KEY (log_id, ordinal)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS ix_telemetry_logs_resource_order
+    ON telemetry_logs(resource_id, timestamp_ticks, log_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_logs_order
+    ON telemetry_logs(timestamp_ticks, log_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_logs_trace_span_order
+    ON telemetry_logs(trace_id, span_id, timestamp_ticks, log_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_logs_trace_order
+    ON telemetry_logs(trace_id, timestamp_ticks, log_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_log_attributes_owner_key
+    ON telemetry_log_attributes(log_id, attribute_key);
+CREATE INDEX IF NOT EXISTS ix_telemetry_log_attributes_key_value_owner
+    ON telemetry_log_attributes(attribute_key COLLATE NOCASE, attribute_value COLLATE NOCASE, log_id);

--- a/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/004.Traces.sql
+++ b/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/004.Traces.sql
@@ -1,0 +1,131 @@
+-- Licensed to the .NET Foundation under one or more agreements.
+-- The .NET Foundation licenses this file to you under the MIT license.
+-- IMPORTANT: Increment DashboardSqliteDatabase.SchemaVersion when changing the database schema.
+
+CREATE TABLE IF NOT EXISTS telemetry_traces (
+    trace_id TEXT PRIMARY KEY,
+    first_span_timestamp_ticks INTEGER NOT NULL,
+    last_span_end_timestamp_ticks INTEGER NOT NULL,
+    duration_ticks INTEGER NOT NULL,
+    last_updated_timestamp_ticks INTEGER NOT NULL,
+    full_name TEXT NOT NULL,
+    primary_span_id TEXT NOT NULL,
+    has_error INTEGER NOT NULL CHECK (has_error IN (0, 1)),
+    has_gen_ai INTEGER NOT NULL CHECK (has_gen_ai IN (0, 1))
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_span_kinds (
+    kind INTEGER PRIMARY KEY,
+    kind_name TEXT NOT NULL UNIQUE
+) STRICT;
+
+INSERT OR IGNORE INTO telemetry_span_kinds (kind, kind_name)
+VALUES
+    (0, 'Unspecified'),
+    (1, 'Internal'),
+    (2, 'Server'),
+    (3, 'Client'),
+    (4, 'Producer'),
+    (5, 'Consumer');
+
+CREATE TABLE IF NOT EXISTS telemetry_span_statuses (
+    status INTEGER PRIMARY KEY,
+    status_name TEXT NOT NULL UNIQUE
+) STRICT;
+
+INSERT OR IGNORE INTO telemetry_span_statuses (status, status_name)
+VALUES
+    (0, 'Unset'),
+    (1, 'Ok'),
+    (2, 'Error');
+
+CREATE TABLE IF NOT EXISTS telemetry_spans (
+    trace_id TEXT NOT NULL REFERENCES telemetry_traces(trace_id) ON DELETE CASCADE,
+    span_id TEXT NOT NULL,
+    parent_span_id TEXT NULL,
+    resource_id INTEGER NOT NULL REFERENCES telemetry_resources(resource_id) ON DELETE CASCADE,
+    resource_view_id INTEGER NOT NULL REFERENCES telemetry_resource_views(resource_view_id) ON DELETE CASCADE,
+    scope_id INTEGER NOT NULL REFERENCES telemetry_scopes(scope_id),
+    name TEXT NOT NULL,
+    kind INTEGER NOT NULL REFERENCES telemetry_span_kinds(kind),
+    start_time_ticks INTEGER NOT NULL,
+    end_time_ticks INTEGER NOT NULL,
+    status INTEGER NOT NULL REFERENCES telemetry_span_statuses(status),
+    status_message TEXT NULL,
+    trace_state TEXT NULL,
+    uninstrumented_peer_resource_id INTEGER NULL REFERENCES telemetry_resources(resource_id) ON DELETE SET NULL,
+    PRIMARY KEY (trace_id, span_id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_trace_resources (
+    trace_id TEXT NOT NULL REFERENCES telemetry_traces(trace_id) ON DELETE CASCADE,
+    resource_id INTEGER NOT NULL REFERENCES telemetry_resources(resource_id) ON DELETE CASCADE,
+    resource_order_ticks INTEGER NOT NULL,
+    total_spans INTEGER NOT NULL CHECK (total_spans >= 0),
+    errored_spans INTEGER NOT NULL CHECK (errored_spans >= 0 AND errored_spans <= total_spans),
+    PRIMARY KEY (trace_id, resource_id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_span_attributes (
+    trace_id TEXT NOT NULL,
+    span_id TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    attribute_key TEXT NOT NULL,
+    attribute_value TEXT NOT NULL,
+    PRIMARY KEY (trace_id, span_id, ordinal),
+    FOREIGN KEY (trace_id, span_id) REFERENCES telemetry_spans(trace_id, span_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_span_events (
+    event_id TEXT PRIMARY KEY,
+    trace_id TEXT NOT NULL,
+    span_id TEXT NOT NULL,
+    ordinal INTEGER NOT NULL,
+    event_name TEXT NOT NULL,
+    event_time_ticks INTEGER NOT NULL,
+    UNIQUE (trace_id, span_id, ordinal),
+    FOREIGN KEY (trace_id, span_id) REFERENCES telemetry_spans(trace_id, span_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_span_event_attributes (
+    event_id TEXT NOT NULL REFERENCES telemetry_span_events(event_id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    attribute_key TEXT NOT NULL,
+    attribute_value TEXT NOT NULL,
+    PRIMARY KEY (event_id, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_span_links (
+    link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_trace_id TEXT NOT NULL,
+    source_span_id TEXT NOT NULL,
+    target_trace_id TEXT NOT NULL,
+    target_span_id TEXT NOT NULL,
+    trace_state TEXT NOT NULL,
+    FOREIGN KEY (source_trace_id, source_span_id) REFERENCES telemetry_spans(trace_id, span_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_span_link_attributes (
+    link_id INTEGER NOT NULL REFERENCES telemetry_span_links(link_id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    attribute_key TEXT NOT NULL,
+    attribute_value TEXT NOT NULL,
+    PRIMARY KEY (link_id, ordinal)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS ix_telemetry_traces_order
+    ON telemetry_traces(first_span_timestamp_ticks, trace_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_spans_resource_order
+    ON telemetry_spans(resource_id, start_time_ticks, trace_id, span_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_spans_trace_order
+    ON telemetry_spans(trace_id, start_time_ticks, span_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_spans_parent
+    ON telemetry_spans(trace_id, parent_span_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_trace_resources_order
+    ON telemetry_trace_resources(trace_id, resource_order_ticks, resource_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_span_attributes_owner_key
+    ON telemetry_span_attributes(trace_id, span_id, attribute_key);
+CREATE INDEX IF NOT EXISTS ix_telemetry_span_attributes_key_value_owner
+    ON telemetry_span_attributes(attribute_key COLLATE NOCASE, attribute_value COLLATE NOCASE, trace_id, span_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_span_links_target
+    ON telemetry_span_links(target_trace_id, target_span_id);

--- a/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/005.Metrics.sql
+++ b/src/Aspire.Dashboard/ServiceClient/DatabaseSchema/005.Metrics.sql
@@ -1,0 +1,81 @@
+-- Licensed to the .NET Foundation under one or more agreements.
+-- The .NET Foundation licenses this file to you under the MIT license.
+-- IMPORTANT: Increment DashboardSqliteDatabase.SchemaVersion when changing the database schema.
+
+CREATE TABLE IF NOT EXISTS telemetry_metric_instruments (
+    instrument_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resource_id INTEGER NOT NULL REFERENCES telemetry_resources(resource_id) ON DELETE CASCADE,
+    resource_view_id INTEGER NOT NULL REFERENCES telemetry_resource_views(resource_view_id) ON DELETE CASCADE,
+    scope_id INTEGER NOT NULL REFERENCES telemetry_scopes(scope_id),
+    instrument_name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    unit TEXT NOT NULL,
+    instrument_type INTEGER NOT NULL,
+    aggregation_temporality INTEGER NOT NULL,
+    is_monotonic INTEGER NOT NULL,
+    UNIQUE (resource_id, scope_id, instrument_name)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_metric_dimensions (
+    dimension_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    instrument_id INTEGER NOT NULL REFERENCES telemetry_metric_instruments(instrument_id) ON DELETE CASCADE,
+    attribute_hash INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_metric_dimension_attributes (
+    dimension_id INTEGER NOT NULL REFERENCES telemetry_metric_dimensions(dimension_id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    attribute_key TEXT NOT NULL,
+    attribute_value TEXT NOT NULL,
+    PRIMARY KEY (dimension_id, ordinal)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_metric_points (
+    point_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dimension_id INTEGER NOT NULL REFERENCES telemetry_metric_dimensions(dimension_id) ON DELETE CASCADE,
+    point_type INTEGER NOT NULL,
+    start_time_ticks INTEGER NOT NULL,
+    end_time_ticks INTEGER NOT NULL,
+    repeat_count INTEGER NOT NULL,
+    integer_value INTEGER NULL,
+    double_value REAL NULL,
+    histogram_sum REAL NULL,
+    histogram_count INTEGER NULL,
+    bucket_counts BLOB NULL,
+    explicit_bounds BLOB NULL,
+    flags INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_metric_exemplars (
+    exemplar_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    point_id INTEGER NOT NULL REFERENCES telemetry_metric_points(point_id) ON DELETE CASCADE,
+    start_time_ticks INTEGER NOT NULL,
+    exemplar_value REAL NOT NULL,
+    span_id TEXT NOT NULL,
+    trace_id TEXT NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS telemetry_metric_exemplar_attributes (
+    exemplar_id INTEGER NOT NULL REFERENCES telemetry_metric_exemplars(exemplar_id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL,
+    attribute_key TEXT NOT NULL,
+    attribute_value TEXT NOT NULL,
+    PRIMARY KEY (exemplar_id, ordinal)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS ix_telemetry_metric_instruments_lookup
+    ON telemetry_metric_instruments(resource_id, scope_id, instrument_name);
+CREATE INDEX IF NOT EXISTS ix_telemetry_metric_dimensions_instrument
+    ON telemetry_metric_dimensions(instrument_id, dimension_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_metric_dimensions_hash
+    ON telemetry_metric_dimensions(instrument_id, attribute_hash);
+CREATE INDEX IF NOT EXISTS ix_telemetry_metric_points_dimension_order
+    ON telemetry_metric_points(dimension_id, point_id);
+CREATE INDEX IF NOT EXISTS ix_telemetry_metric_points_time
+    ON telemetry_metric_points(dimension_id, start_time_ticks, end_time_ticks);
+CREATE INDEX IF NOT EXISTS ix_telemetry_metric_points_end_time
+    ON telemetry_metric_points(dimension_id, end_time_ticks, start_time_ticks, point_id);
+-- Exemplar identity intentionally omits span/trace IDs and filtered attributes. Distinct exemplars that share a
+-- point, timestamp, and value can be collapsed, but that combination is unlikely to occur in real-world telemetry.
+CREATE UNIQUE INDEX IF NOT EXISTS ix_telemetry_metric_exemplars_identity
+    ON telemetry_metric_exemplars(point_id, start_time_ticks, exemplar_value);

--- a/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
@@ -11,7 +11,7 @@ namespace Aspire.Dashboard.ServiceClient;
 /// <summary>
 /// Provides data about active resources to external components, such as the dashboard.
 /// </summary>
-public interface IDashboardClient : IAsyncDisposable
+public interface IDashboardClient : IResourceRepository, IAsyncDisposable
 {
     Task WhenConnected { get; }
 
@@ -23,6 +23,11 @@ public interface IDashboardClient : IAsyncDisposable
     /// any other members of this interface, to avoid exceptions.
     /// </remarks>
     bool IsEnabled { get; }
+
+    /// <summary>
+    /// Gets whether the selected dashboard data source is read-only.
+    /// </summary>
+    bool IsReadOnly => false;
 
     /// <summary>
     /// Gets the current connection state of the client to the resource service.
@@ -53,44 +58,9 @@ public interface IDashboardClient : IAsyncDisposable
     /// </summary>
     string? MinRequiredVersion { get; }
 
-    /// <summary>
-    /// Gets the current set of resources and a stream of updates.
-    /// </summary>
-    /// <remarks>
-    /// The returned subscription will not complete on its own.
-    /// Callers are required to manage the lifetime of the subscription,
-    /// using cancellation during enumeration.
-    /// </remarks>
-    Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Gets a resource matching the specified name. This resource won't be updated with changes after it is fetched.
-    /// </summary>
-    ResourceViewModel? GetResource(string resourceName);
-
-    /// <summary>
-    /// Get the current resources.
-    /// </summary>
-    /// <returns></returns>
-    IReadOnlyList<ResourceViewModel> GetResources();
-
     IAsyncEnumerable<WatchInteractionsResponseUpdate> SubscribeInteractionsAsync(CancellationToken cancellationToken);
 
     Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Gets a stream of console log messages for the specified resource.
-    /// Includes messages logged both before and after this method call.
-    /// </summary>
-    /// <remarks>
-    /// <para>The returned sequence may end when the resource terminates.
-    /// It is up to the implementation.</para>
-    /// </remarks>
-    /// <para>It is important that callers trigger <paramref name="cancellationToken"/>
-    /// so that resources owned by the sequence and its consumers can be freed.</para>
-    IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken);
-
-    IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken);
 
     Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken);
 

--- a/src/Aspire.Dashboard/ServiceClient/IRepositoryFactory.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IRepositoryFactory.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Storage;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Creates repositories for current and historical dashboard run databases.
+/// </summary>
+public interface IRepositoryFactory
+{
+    /// <summary>
+    /// Creates a telemetry repository for the specified database.
+    /// </summary>
+    /// <param name="database">The dashboard database used by the repository.</param>
+    /// <returns>A telemetry repository for the specified database.</returns>
+    ITelemetryRepository CreateTelemetryRepository(DashboardSqliteDatabase database);
+
+    /// <summary>
+    /// Creates a resource repository for the specified database.
+    /// </summary>
+    /// <param name="database">The dashboard database used by the repository.</param>
+    /// <returns>A resource repository for the specified database.</returns>
+    IResourceRepository CreateResourceRepository(DashboardSqliteDatabase database);
+}

--- a/src/Aspire.Dashboard/ServiceClient/IResourceRepository.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IResourceRepository.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Provides dashboard resource snapshots, updates, and console logs.
+/// </summary>
+public interface IResourceRepository
+{
+    /// <summary>
+    /// Gets the current set of resources and a stream of updates.
+    /// </summary>
+    Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a resource matching the specified name.
+    /// </summary>
+    ResourceViewModel? GetResource(string resourceName);
+
+    /// <summary>
+    /// Gets the current resources.
+    /// </summary>
+    IReadOnlyList<ResourceViewModel> GetResources();
+
+    /// <summary>
+    /// Gets existing and incoming console log messages for a resource.
+    /// </summary>
+    IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets existing console log messages for a resource.
+    /// </summary>
+    IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes persisted console log messages for the specified resources.
+    /// </summary>
+    /// <param name="resourceNames">The names of the resources whose console logs should be deleted.</param>
+    /// <param name="clearDate">The timestamp through which replayed console logs should remain deleted.</param>
+    /// <returns>A task that represents the asynchronous delete operation.</returns>
+    Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate);
+}

--- a/src/Aspire.Dashboard/ServiceClient/IResourceRepositoryWriter.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IResourceRepositoryWriter.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.DashboardService.Proto.V1;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+internal interface IResourceRepositoryWriter
+{
+    Task ReplaceResourcesAsync(IReadOnlyList<Resource> resources);
+    Task ApplyChangesAsync(IReadOnlyList<WatchResourcesChange> changes);
+    Task MarkConsoleLogsLoadedAsync(string resourceName);
+    Task AddConsoleLogsAsync(string resourceName, IReadOnlyList<ConsoleLogLine> logLines);
+    Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate);
+}

--- a/src/Aspire.Dashboard/ServiceClient/RepositoryFactory.cs
+++ b/src/Aspire.Dashboard/ServiceClient/RepositoryFactory.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Creates telemetry and resource repositories for dashboard run databases.
+/// </summary>
+// IServiceProvider is required to defer resolving IOutgoingPeerResolver until a telemetry repository is created.
+// Constructor injection would create a cycle through ResourceOutgoingPeerResolver and IResourceRepository.
+internal sealed class RepositoryFactory(IServiceProvider serviceProvider) : IRepositoryFactory
+{
+    public ITelemetryRepository CreateTelemetryRepository(DashboardSqliteDatabase database) =>
+        new SqliteTelemetryRepository(
+            database,
+            serviceProvider.GetRequiredService<ILoggerFactory>(),
+            serviceProvider.GetRequiredService<IOptions<DashboardOptions>>(),
+            serviceProvider.GetRequiredService<PauseManager>(),
+            serviceProvider.GetRequiredService<TimeProvider>(),
+            serviceProvider.GetServices<IOutgoingPeerResolver>());
+
+    public IResourceRepository CreateResourceRepository(DashboardSqliteDatabase database) =>
+        new SqliteResourceRepository(
+            database,
+            serviceProvider.GetRequiredService<IKnownPropertyLookup>(),
+            serviceProvider.GetRequiredService<ILoggerFactory>());
+}

--- a/src/Aspire.Dashboard/ServiceClient/SelectedDashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/SelectedDashboardClient.cs
@@ -64,10 +64,10 @@ internal sealed class SelectedDashboardClient(DashboardClient currentClient, Das
         return currentClient.ExecuteResourceCommandAsync(resourceName, resourceType, command, options, cancellationToken);
     }
 
-    public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, CancellationToken cancellationToken)
+    public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken)
     {
         EnsureWritable();
-        return currentClient.UploadFileAsync(fileStream, fileName, expectedSize, cancellationToken);
+        return currentClient.UploadFileAsync(fileStream, fileName, expectedSize, interactionId, inputName, cancellationToken);
     }
 
     private void EnsureWritable()

--- a/src/Aspire.Dashboard/ServiceClient/SelectedDashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/SelectedDashboardClient.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.DashboardService.Proto.V1;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+internal sealed class SelectedDashboardClient(DashboardClient currentClient, DashboardDataSource dataSource) : IDashboardClient
+{
+    public Task WhenConnected => IsReadOnly ? Task.CompletedTask : currentClient.WhenConnected;
+    public bool IsEnabled => IsReadOnly || currentClient.IsEnabled;
+    public bool IsReadOnly => dataSource.IsReadOnly;
+    public DashboardConnectionState ConnectionState => IsReadOnly ? DashboardConnectionState.Connected : currentClient.ConnectionState;
+    public string ApplicationName => dataSource.SelectedRun.ApplicationName ?? currentClient.ApplicationName;
+    public string? MinRequiredVersion => IsReadOnly ? null : currentClient.MinRequiredVersion;
+
+    public event Action<DashboardConnectionState>? ConnectionStateChanged
+    {
+        add
+        {
+            if (!IsReadOnly)
+            {
+                currentClient.ConnectionStateChanged += value;
+            }
+        }
+        remove
+        {
+            currentClient.ConnectionStateChanged -= value;
+        }
+    }
+
+    public Task ReconnectAsync() => IsReadOnly ? Task.CompletedTask : currentClient.ReconnectAsync();
+    public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => dataSource.ResourceRepository.SubscribeResourcesAsync(cancellationToken);
+    public ResourceViewModel? GetResource(string resourceName) => dataSource.ResourceRepository.GetResource(resourceName);
+    public IReadOnlyList<ResourceViewModel> GetResources() => dataSource.ResourceRepository.GetResources();
+    public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) =>
+        IsReadOnly
+            ? dataSource.ResourceRepository.SubscribeConsoleLogs(resourceName, cancellationToken)
+            : currentClient.SubscribeConsoleLogs(resourceName, cancellationToken);
+    public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) =>
+        IsReadOnly
+            ? dataSource.ResourceRepository.GetConsoleLogs(resourceName, cancellationToken)
+            : currentClient.GetConsoleLogs(resourceName, cancellationToken);
+
+    public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate)
+    {
+        EnsureWritable();
+        return dataSource.ResourceRepository.ClearConsoleLogsAsync(resourceNames, clearDate);
+    }
+
+    public IAsyncEnumerable<WatchInteractionsResponseUpdate> SubscribeInteractionsAsync(CancellationToken cancellationToken) =>
+        IsReadOnly ? EmptyInteractionsAsync() : currentClient.SubscribeInteractionsAsync(cancellationToken);
+
+    public Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken)
+    {
+        EnsureWritable();
+        return currentClient.SendInteractionRequestAsync(request, cancellationToken);
+    }
+
+    public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken)
+    {
+        EnsureWritable();
+        return currentClient.ExecuteResourceCommandAsync(resourceName, resourceType, command, options, cancellationToken);
+    }
+
+    public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, CancellationToken cancellationToken)
+    {
+        EnsureWritable();
+        return currentClient.UploadFileAsync(fileStream, fileName, expectedSize, cancellationToken);
+    }
+
+    private void EnsureWritable()
+    {
+        if (IsReadOnly)
+        {
+            throw new InvalidOperationException("Historical dashboard data is read-only.");
+        }
+    }
+
+    private static async IAsyncEnumerable<WatchInteractionsResponseUpdate> EmptyInteractionsAsync()
+    {
+        await Task.CompletedTask.ConfigureAwait(false);
+        yield break;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/src/Aspire.Dashboard/ServiceClient/SqliteResourceRepository.Storage.cs
+++ b/src/Aspire.Dashboard/ServiceClient/SqliteResourceRepository.Storage.cs
@@ -1,0 +1,773 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using Aspire.Dashboard.Utils;
+using Aspire.DashboardService.Proto.V1;
+using Dapper;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Data.Sqlite;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+public sealed partial class SqliteResourceRepository
+{
+    private const int MaxWriteBatchSize = 100;
+
+    private static void InsertResources(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<ResourceToSave> resources)
+    {
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            resources,
+            MaxWriteBatchSize,
+            "dashboard_resources",
+            [
+                "resource_name", "replica_index", "resource_type", "display_name", "uid", "state",
+                "created_at_seconds", "created_at_nanos", "state_style",
+                "started_at_seconds", "started_at_nanos", "stopped_at_seconds", "stopped_at_nanos",
+                "is_hidden", "supports_detailed_telemetry", "icon_name", "icon_variant", "console_logs_loaded"
+            ],
+            static (resourceToSave, parameters) =>
+            {
+                var resource = resourceToSave.Resource;
+                parameters[0].Value = resource.Name;
+                parameters[1].Value = resourceToSave.ReplicaIndex;
+                parameters[2].Value = resource.ResourceType;
+                parameters[3].Value = resource.DisplayName;
+                parameters[4].Value = resource.Uid;
+                parameters[5].Value = resource.HasState ? resource.State : DBNull.Value;
+                parameters[6].Value = resource.CreatedAt?.Seconds ?? (object)DBNull.Value;
+                parameters[7].Value = resource.CreatedAt?.Nanos ?? (object)DBNull.Value;
+                parameters[8].Value = resource.HasStateStyle ? resource.StateStyle : DBNull.Value;
+                parameters[9].Value = resource.StartedAt?.Seconds ?? (object)DBNull.Value;
+                parameters[10].Value = resource.StartedAt?.Nanos ?? (object)DBNull.Value;
+                parameters[11].Value = resource.StoppedAt?.Seconds ?? (object)DBNull.Value;
+                parameters[12].Value = resource.StoppedAt?.Nanos ?? (object)DBNull.Value;
+                parameters[13].Value = resource.IsHidden;
+                parameters[14].Value = resource.SupportsDetailedTelemetry;
+                parameters[15].Value = resource.HasIconName ? resource.IconName : DBNull.Value;
+                parameters[16].Value = resource.HasIconVariant ? (int)resource.IconVariant : DBNull.Value;
+                parameters[17].Value = resourceToSave.ConsoleLogsLoaded;
+            });
+
+        var resourceModels = resources.Select(resource => resource.Resource).ToArray();
+        InsertEnvironment(connection, transaction, resourceModels);
+        InsertUrls(connection, transaction, resourceModels);
+        InsertVolumes(connection, transaction, resourceModels);
+        InsertHealthReports(connection, transaction, resourceModels);
+        InsertRelationships(connection, transaction, resourceModels);
+        var properties = new List<PropertyToSave>();
+        var commands = new List<CommandToSave>();
+        foreach (var resource in resourceModels)
+        {
+            foreach (var (property, ordinal) in resource.Properties.Select((item, ordinal) => (item, ordinal)))
+            {
+                properties.Add(new(resource.Name, ordinal, property));
+            }
+
+#pragma warning disable CS0612 // ResourceCommand.Parameter must be persisted for compatibility with older AppHosts.
+            foreach (var (command, ordinal) in resource.Commands.Select((item, ordinal) => (item, ordinal)))
+            {
+                var parameterJsonValue = command.Parameter is not null ? JsonFormatter.Default.Format(command.Parameter) : null;
+                commands.Add(new(resource.Name, ordinal, command, parameterJsonValue));
+            }
+#pragma warning restore CS0612
+        }
+
+        InsertProperties(connection, transaction, properties);
+        InsertCommands(connection, transaction, commands);
+    }
+
+    private static void InsertConsoleLogs(
+        SqliteConnection connection,
+        IDbTransaction transaction,
+        string resourceName,
+        IReadOnlyList<ConsoleLogToInsert> consoleLogs)
+    {
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            consoleLogs,
+            MaxWriteBatchSize,
+            "console_logs",
+            ["resource_name", "line_number", "content", "is_stderr"],
+            (consoleLog, parameters) =>
+            {
+                parameters[0].Value = resourceName;
+                parameters[1].Value = consoleLog.LineNumber;
+                parameters[2].Value = consoleLog.Content;
+                parameters[3].Value = consoleLog.IsStdErr;
+            });
+    }
+
+    private static void InsertEnvironment(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<Resource> resources)
+    {
+        var rows = resources
+            .SelectMany(resource => resource.Environment.Select((item, ordinal) => (ResourceName: resource.Name, Ordinal: ordinal, Item: item)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            rows,
+            MaxWriteBatchSize,
+            "dashboard_resource_environment",
+            ["resource_name", "ordinal", "name", "value", "is_from_spec"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.ResourceName;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Item.Name;
+                parameters[3].Value = row.Item.HasValue ? row.Item.Value : DBNull.Value;
+                parameters[4].Value = row.Item.IsFromSpec;
+            });
+    }
+
+    private static void InsertUrls(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<Resource> resources)
+    {
+        var rows = resources
+            .SelectMany(resource => resource.Urls.Select((item, ordinal) => (ResourceName: resource.Name, Ordinal: ordinal, Item: item)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            rows,
+            MaxWriteBatchSize,
+            "dashboard_resource_urls",
+            ["resource_name", "ordinal", "endpoint_name", "full_url", "is_internal", "is_inactive", "display_sort_order", "display_name"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.ResourceName;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Item.HasEndpointName ? row.Item.EndpointName : DBNull.Value;
+                parameters[3].Value = row.Item.FullUrl;
+                parameters[4].Value = row.Item.IsInternal;
+                parameters[5].Value = row.Item.IsInactive;
+                parameters[6].Value = row.Item.DisplayProperties.SortOrder;
+                parameters[7].Value = row.Item.DisplayProperties.DisplayName;
+            });
+    }
+
+    private static void InsertVolumes(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<Resource> resources)
+    {
+        var rows = resources
+            .SelectMany(resource => resource.Volumes.Select((item, ordinal) => (ResourceName: resource.Name, Ordinal: ordinal, Item: item)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            rows,
+            MaxWriteBatchSize,
+            "dashboard_resource_volumes",
+            ["resource_name", "ordinal", "source", "target", "mount_type", "is_read_only"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.ResourceName;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Item.Source;
+                parameters[3].Value = row.Item.Target;
+                parameters[4].Value = row.Item.MountType;
+                parameters[5].Value = row.Item.IsReadOnly;
+            });
+    }
+
+    private static void InsertHealthReports(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<Resource> resources)
+    {
+        var rows = resources
+            .SelectMany(resource => resource.HealthReports.Select((item, ordinal) => (ResourceName: resource.Name, Ordinal: ordinal, Item: item)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            rows,
+            MaxWriteBatchSize,
+            "dashboard_resource_health_reports",
+            ["resource_name", "ordinal", "status", "key", "description", "exception", "last_run_at_seconds", "last_run_at_nanos"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.ResourceName;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Item.HasStatus ? (int)row.Item.Status : DBNull.Value;
+                parameters[3].Value = row.Item.Key;
+                parameters[4].Value = row.Item.Description;
+                parameters[5].Value = row.Item.Exception;
+                parameters[6].Value = row.Item.LastRunAt?.Seconds ?? (object)DBNull.Value;
+                parameters[7].Value = row.Item.LastRunAt?.Nanos ?? (object)DBNull.Value;
+            });
+    }
+
+    private static void InsertRelationships(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<Resource> resources)
+    {
+        var rows = resources
+            .SelectMany(resource => resource.Relationships.Select((item, ordinal) => (ResourceName: resource.Name, Ordinal: ordinal, Item: item)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            rows,
+            MaxWriteBatchSize,
+            "dashboard_resource_relationships",
+            ["resource_name", "ordinal", "related_resource_name", "relationship_type"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.ResourceName;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Item.ResourceName;
+                parameters[3].Value = row.Item.Type;
+            });
+    }
+
+    private static void InsertProperties(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<PropertyToSave> properties)
+    {
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            properties,
+            MaxWriteBatchSize,
+            "dashboard_resource_properties",
+            ["resource_name", "ordinal", "name", "display_name", "value", "is_sensitive", "is_highlighted", "sort_order"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.ResourceName;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = row.Property.Name;
+                parameters[3].Value = row.Property.HasDisplayName ? row.Property.DisplayName : DBNull.Value;
+                parameters[4].Value = JsonFormatter.Default.Format(row.Property.Value);
+                parameters[5].Value = row.Property.HasIsSensitive ? row.Property.IsSensitive : DBNull.Value;
+                parameters[6].Value = row.Property.IsHighlighted;
+                parameters[7].Value = row.Property.HasSortOrder ? row.Property.SortOrder : DBNull.Value;
+            });
+    }
+
+    private static void InsertCommands(SqliteConnection connection, IDbTransaction transaction, IReadOnlyList<CommandToSave> commands)
+    {
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            commands,
+            MaxWriteBatchSize,
+            "dashboard_resource_commands",
+            [
+                "resource_name", "ordinal", "name", "display_name", "confirmation_message", "parameter_value",
+                "is_highlighted", "icon_name", "icon_variant", "display_description", "state"
+            ],
+            static (row, parameters) =>
+            {
+                var command = row.Command;
+                parameters[0].Value = row.ResourceName;
+                parameters[1].Value = row.Ordinal;
+                parameters[2].Value = command.Name;
+                parameters[3].Value = command.DisplayName;
+                parameters[4].Value = command.HasConfirmationMessage ? command.ConfirmationMessage : DBNull.Value;
+                parameters[5].Value = row.ParameterJsonValue ?? (object)DBNull.Value;
+                parameters[6].Value = command.IsHighlighted;
+                parameters[7].Value = command.HasIconName ? command.IconName : DBNull.Value;
+                parameters[8].Value = command.HasIconVariant ? (int)command.IconVariant : DBNull.Value;
+                parameters[9].Value = command.HasDisplayDescription ? command.DisplayDescription : DBNull.Value;
+                parameters[10].Value = (int)command.State;
+            });
+
+        var inputs = commands.SelectMany(command => command.Command.ArgumentInputs.Select((input, ordinal) => (Command: command, Ordinal: ordinal, Input: input))).ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            inputs,
+            MaxWriteBatchSize,
+            "dashboard_resource_command_inputs",
+            [
+                "resource_name", "command_ordinal", "ordinal", "label", "placeholder", "input_type", "required", "value",
+                "description", "enable_description_markdown", "max_length", "allow_custom_choice", "loading",
+                "update_state_on_change", "name", "disabled", "max_file_size", "allow_multiple_files", "file_filter"
+            ],
+            static (row, parameters) =>
+            {
+                var input = row.Input;
+                parameters[0].Value = row.Command.ResourceName;
+                parameters[1].Value = row.Command.Ordinal;
+                parameters[2].Value = row.Ordinal;
+                parameters[3].Value = input.Label;
+                parameters[4].Value = input.Placeholder;
+                parameters[5].Value = (int)input.InputType;
+                parameters[6].Value = input.Required;
+                parameters[7].Value = input.Value;
+                parameters[8].Value = input.Description;
+                parameters[9].Value = input.EnableDescriptionMarkdown;
+                parameters[10].Value = input.MaxLength;
+                parameters[11].Value = input.AllowCustomChoice;
+                parameters[12].Value = input.Loading;
+                parameters[13].Value = input.UpdateStateOnChange;
+                parameters[14].Value = input.Name;
+                parameters[15].Value = input.Disabled;
+                parameters[16].Value = input.MaxFileSize;
+                parameters[17].Value = input.AllowMultipleFiles;
+                parameters[18].Value = input.FileFilter;
+            });
+
+        var options = inputs
+            .SelectMany(row => row.Input.Options.Select(option => (row.Command, InputOrdinal: row.Ordinal, Option: option)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            options,
+            MaxWriteBatchSize,
+            "dashboard_resource_command_input_options",
+            ["resource_name", "command_ordinal", "input_ordinal", "option_key", "option_value"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.Command.ResourceName;
+                parameters[1].Value = row.Command.Ordinal;
+                parameters[2].Value = row.InputOrdinal;
+                parameters[3].Value = row.Option.Key;
+                parameters[4].Value = row.Option.Value;
+            });
+
+        var validationErrors = inputs
+            .SelectMany(row => row.Input.ValidationErrors.Select((validationError, ordinal) => (row.Command, InputOrdinal: row.Ordinal, Ordinal: ordinal, ValidationError: validationError)))
+            .ToArray();
+        SqliteBatchInsert.BatchInsertRows(
+            connection,
+            transaction,
+            validationErrors,
+            MaxWriteBatchSize,
+            "dashboard_resource_command_input_validation_errors",
+            ["resource_name", "command_ordinal", "input_ordinal", "ordinal", "validation_error"],
+            static (row, parameters) =>
+            {
+                parameters[0].Value = row.Command.ResourceName;
+                parameters[1].Value = row.Command.Ordinal;
+                parameters[2].Value = row.InputOrdinal;
+                parameters[3].Value = row.Ordinal;
+                parameters[4].Value = row.ValidationError;
+            });
+    }
+
+    private static IEnumerable<StoredResource> LoadResourceRecords(SqliteConnection connection)
+    {
+        using var reader = connection.QueryMultiple("""
+            SELECT
+                resource_name AS ResourceName,
+                replica_index AS ReplicaIndex,
+                resource_type AS ResourceType,
+                display_name AS DisplayName,
+                uid AS Uid,
+                state AS State,
+                created_at_seconds AS CreatedAtSeconds,
+                created_at_nanos AS CreatedAtNanos,
+                state_style AS StateStyle,
+                started_at_seconds AS StartedAtSeconds,
+                started_at_nanos AS StartedAtNanos,
+                stopped_at_seconds AS StoppedAtSeconds,
+                stopped_at_nanos AS StoppedAtNanos,
+                is_hidden AS IsHidden,
+                supports_detailed_telemetry AS SupportsDetailedTelemetry,
+                icon_name AS IconName,
+                icon_variant AS IconVariant,
+                console_logs_loaded AS ConsoleLogsLoaded
+            FROM dashboard_resources
+            ORDER BY rowid;
+
+            SELECT resource_name AS ResourceName, name AS Name, value AS Value, is_from_spec AS IsFromSpec
+            FROM dashboard_resource_environment
+            ORDER BY resource_name, ordinal;
+
+            SELECT resource_name AS ResourceName, endpoint_name AS EndpointName, full_url AS FullUrl,
+                is_internal AS IsInternal, is_inactive AS IsInactive, display_sort_order AS DisplaySortOrder, display_name AS DisplayName
+            FROM dashboard_resource_urls
+            ORDER BY resource_name, ordinal;
+
+            SELECT resource_name AS ResourceName, source AS Source, target AS Target, mount_type AS MountType, is_read_only AS IsReadOnly
+            FROM dashboard_resource_volumes
+            ORDER BY resource_name, ordinal;
+
+            SELECT resource_name AS ResourceName, status AS Status, key AS Key, description AS Description,
+                exception AS Exception, last_run_at_seconds AS LastRunAtSeconds, last_run_at_nanos AS LastRunAtNanos
+            FROM dashboard_resource_health_reports
+            ORDER BY resource_name, ordinal;
+
+            SELECT resource_name AS ResourceName, related_resource_name AS RelatedResourceName, relationship_type AS RelationshipType
+            FROM dashboard_resource_relationships
+            ORDER BY resource_name, ordinal;
+
+            SELECT resource_name AS ResourceName, name AS Name, display_name AS DisplayName, value AS JsonValue,
+                is_sensitive AS IsSensitive, is_highlighted AS IsHighlighted, sort_order AS SortOrder
+            FROM dashboard_resource_properties
+            ORDER BY resource_name, ordinal;
+
+            SELECT resource_name AS ResourceName, ordinal AS Ordinal, name AS Name, display_name AS DisplayName,
+                confirmation_message AS ConfirmationMessage, parameter_value AS ParameterJsonValue,
+                is_highlighted AS IsHighlighted, icon_name AS IconName, icon_variant AS IconVariant,
+                display_description AS DisplayDescription, state AS State
+            FROM dashboard_resource_commands
+            ORDER BY resource_name, ordinal;
+
+            SELECT resource_name AS ResourceName, command_ordinal AS CommandOrdinal, ordinal AS Ordinal,
+                label AS Label, placeholder AS Placeholder, input_type AS InputType, required AS Required,
+                value AS Value, description AS Description, enable_description_markdown AS EnableDescriptionMarkdown,
+                max_length AS MaxLength, allow_custom_choice AS AllowCustomChoice, loading AS Loading,
+                update_state_on_change AS UpdateStateOnChange, name AS Name, disabled AS Disabled,
+                max_file_size AS MaxFileSize, allow_multiple_files AS AllowMultipleFiles, file_filter AS FileFilter
+            FROM dashboard_resource_command_inputs
+            ORDER BY resource_name, command_ordinal, ordinal;
+
+            SELECT resource_name AS ResourceName, command_ordinal AS CommandOrdinal, input_ordinal AS InputOrdinal,
+                option_key AS OptionKey, option_value AS OptionValue
+            FROM dashboard_resource_command_input_options
+            ORDER BY resource_name, command_ordinal, input_ordinal, option_key;
+
+            SELECT resource_name AS ResourceName, command_ordinal AS CommandOrdinal, input_ordinal AS InputOrdinal,
+                validation_error AS ValidationError
+            FROM dashboard_resource_command_input_validation_errors
+            ORDER BY resource_name, command_ordinal, input_ordinal, ordinal;
+
+            """);
+
+        var resourceRecords = reader.Read<ResourceRecord>().AsList();
+        var environments = reader.Read<EnvironmentRecord>().ToLookup(record => record.ResourceName, StringComparers.ResourceName);
+        var urls = reader.Read<UrlRecord>().ToLookup(record => record.ResourceName, StringComparers.ResourceName);
+        var volumes = reader.Read<VolumeRecord>().ToLookup(record => record.ResourceName, StringComparers.ResourceName);
+        var healthReports = reader.Read<HealthReportRecord>().ToLookup(record => record.ResourceName, StringComparers.ResourceName);
+        var relationships = reader.Read<RelationshipRecord>().ToLookup(record => record.ResourceName, StringComparers.ResourceName);
+        var properties = reader.Read<PropertyRecord>().ToLookup(record => record.ResourceName, StringComparers.ResourceName);
+        var commands = reader.Read<CommandRecord>().ToLookup(record => record.ResourceName, StringComparers.ResourceName);
+        var inputs = reader.Read<InputRecord>().ToLookup(record => (record.ResourceName, record.CommandOrdinal));
+        var options = reader.Read<OptionRecord>().ToLookup(record => (record.ResourceName, record.CommandOrdinal, record.InputOrdinal));
+        var validationErrors = reader.Read<ValidationErrorRecord>().ToLookup(record => (record.ResourceName, record.CommandOrdinal, record.InputOrdinal));
+
+        foreach (var record in resourceRecords)
+        {
+            var resource = new Resource
+            {
+                Name = record.ResourceName,
+                ResourceType = record.ResourceType,
+                DisplayName = record.DisplayName,
+                Uid = record.Uid,
+                IsHidden = record.IsHidden,
+                SupportsDetailedTelemetry = record.SupportsDetailedTelemetry
+            };
+
+            SetOptionalResourceFields(resource, record);
+            foreach (var environment in environments[record.ResourceName])
+            {
+                var item = new EnvironmentVariable { Name = environment.Name, IsFromSpec = environment.IsFromSpec };
+                if (environment.Value is not null)
+                {
+                    item.Value = environment.Value;
+                }
+                resource.Environment.Add(item);
+            }
+            foreach (var url in urls[record.ResourceName])
+            {
+                var item = new Url
+                {
+                    FullUrl = url.FullUrl,
+                    IsInternal = url.IsInternal,
+                    IsInactive = url.IsInactive,
+                    DisplayProperties = new UrlDisplayProperties { SortOrder = url.DisplaySortOrder, DisplayName = url.DisplayName }
+                };
+                if (url.EndpointName is not null)
+                {
+                    item.EndpointName = url.EndpointName;
+                }
+                resource.Urls.Add(item);
+            }
+            resource.Volumes.Add(volumes[record.ResourceName].Select(volume => new Volume
+            {
+                Source = volume.Source,
+                Target = volume.Target,
+                MountType = volume.MountType,
+                IsReadOnly = volume.IsReadOnly
+            }));
+            foreach (var healthReport in healthReports[record.ResourceName])
+            {
+                var item = new HealthReport { Key = healthReport.Key, Description = healthReport.Description, Exception = healthReport.Exception };
+                if (healthReport.Status is not null)
+                {
+                    item.Status = (HealthStatus)healthReport.Status.Value;
+                }
+                if (healthReport.LastRunAtSeconds is not null)
+                {
+                    item.LastRunAt = CreateTimestamp(healthReport.LastRunAtSeconds.Value, healthReport.LastRunAtNanos);
+                }
+                resource.HealthReports.Add(item);
+            }
+            resource.Relationships.Add(relationships[record.ResourceName].Select(relationship => new ResourceRelationship
+            {
+                ResourceName = relationship.RelatedResourceName,
+                Type = relationship.RelationshipType
+            }));
+            foreach (var property in properties[record.ResourceName])
+            {
+                var item = new ResourceProperty
+                {
+                    Name = property.Name,
+                    Value = MaterializeValue(property.JsonValue),
+                    IsHighlighted = property.IsHighlighted
+                };
+                if (property.DisplayName is not null)
+                {
+                    item.DisplayName = property.DisplayName;
+                }
+                if (property.IsSensitive is not null)
+                {
+                    item.IsSensitive = property.IsSensitive.Value;
+                }
+                if (property.SortOrder is not null)
+                {
+                    item.SortOrder = property.SortOrder.Value;
+                }
+                resource.Properties.Add(item);
+            }
+
+#pragma warning disable CS0612 // ResourceCommand.Parameter must be restored for compatibility with older AppHosts.
+            foreach (var commandRecord in commands[record.ResourceName])
+            {
+                var command = new ResourceCommand
+                {
+                    Name = commandRecord.Name,
+                    DisplayName = commandRecord.DisplayName,
+                    IsHighlighted = commandRecord.IsHighlighted,
+                    State = (ResourceCommandState)commandRecord.State
+                };
+                if (commandRecord.ConfirmationMessage is not null)
+                {
+                    command.ConfirmationMessage = commandRecord.ConfirmationMessage;
+                }
+                if (commandRecord.ParameterJsonValue is not null)
+                {
+                    command.Parameter = MaterializeValue(commandRecord.ParameterJsonValue);
+                }
+                if (commandRecord.IconName is not null)
+                {
+                    command.IconName = commandRecord.IconName;
+                }
+                if (commandRecord.IconVariant is not null)
+                {
+                    command.IconVariant = (IconVariant)commandRecord.IconVariant.Value;
+                }
+                if (commandRecord.DisplayDescription is not null)
+                {
+                    command.DisplayDescription = commandRecord.DisplayDescription;
+                }
+
+                foreach (var inputRecord in inputs[(record.ResourceName, commandRecord.Ordinal)])
+                {
+                    var input = new InteractionInput
+                    {
+                        Label = inputRecord.Label,
+                        Placeholder = inputRecord.Placeholder,
+                        InputType = (InputType)inputRecord.InputType,
+                        Required = inputRecord.Required,
+                        Value = inputRecord.Value,
+                        Description = inputRecord.Description,
+                        EnableDescriptionMarkdown = inputRecord.EnableDescriptionMarkdown,
+                        MaxLength = inputRecord.MaxLength,
+                        AllowCustomChoice = inputRecord.AllowCustomChoice,
+                        Loading = inputRecord.Loading,
+                        UpdateStateOnChange = inputRecord.UpdateStateOnChange,
+                        Name = inputRecord.Name,
+                        Disabled = inputRecord.Disabled,
+                        MaxFileSize = inputRecord.MaxFileSize,
+                        AllowMultipleFiles = inputRecord.AllowMultipleFiles,
+                        FileFilter = inputRecord.FileFilter
+                    };
+                    foreach (var option in options[(record.ResourceName, commandRecord.Ordinal, inputRecord.Ordinal)])
+                    {
+                        input.Options.Add(option.OptionKey, option.OptionValue);
+                    }
+                    input.ValidationErrors.Add(validationErrors[(record.ResourceName, commandRecord.Ordinal, inputRecord.Ordinal)].Select(error => error.ValidationError));
+                    command.ArgumentInputs.Add(input);
+                }
+                resource.Commands.Add(command);
+            }
+#pragma warning restore CS0612
+
+            yield return new StoredResource(resource, record.ReplicaIndex, record.ConsoleLogsLoaded);
+        }
+    }
+
+    private static Value MaterializeValue(string jsonValue) => JsonParser.Default.Parse<Value>(jsonValue);
+
+    private static void SetOptionalResourceFields(Resource resource, ResourceRecord record)
+    {
+        if (record.State is not null)
+        {
+            resource.State = record.State;
+        }
+        if (record.CreatedAtSeconds is not null)
+        {
+            resource.CreatedAt = CreateTimestamp(record.CreatedAtSeconds.Value, record.CreatedAtNanos);
+        }
+        if (record.StateStyle is not null)
+        {
+            resource.StateStyle = record.StateStyle;
+        }
+        if (record.StartedAtSeconds is not null)
+        {
+            resource.StartedAt = CreateTimestamp(record.StartedAtSeconds.Value, record.StartedAtNanos);
+        }
+        if (record.StoppedAtSeconds is not null)
+        {
+            resource.StoppedAt = CreateTimestamp(record.StoppedAtSeconds.Value, record.StoppedAtNanos);
+        }
+        if (record.IconName is not null)
+        {
+            resource.IconName = record.IconName;
+        }
+        if (record.IconVariant is not null)
+        {
+            resource.IconVariant = (IconVariant)record.IconVariant.Value;
+        }
+    }
+
+    private static Timestamp CreateTimestamp(long seconds, int? nanos)
+    {
+        return new Timestamp { Seconds = seconds, Nanos = nanos ?? 0 };
+    }
+
+    private sealed record ResourceToSave(Resource Resource, int ReplicaIndex, bool ConsoleLogsLoaded);
+
+    private sealed record ConsoleLogToInsert(int LineNumber, string Content, bool IsStdErr);
+
+    private sealed record PropertyToSave(string ResourceName, int Ordinal, ResourceProperty Property);
+
+    private sealed record CommandToSave(string ResourceName, int Ordinal, ResourceCommand Command, string? ParameterJsonValue);
+
+    private sealed record StoredResource(Resource Resource, int ReplicaIndex, bool ConsoleLogsLoaded);
+
+    private sealed class ResourceRecord
+    {
+        public required string ResourceName { get; init; }
+        public required int ReplicaIndex { get; init; }
+        public required string ResourceType { get; init; }
+        public required string DisplayName { get; init; }
+        public required string Uid { get; init; }
+        public string? State { get; init; }
+        public long? CreatedAtSeconds { get; init; }
+        public int? CreatedAtNanos { get; init; }
+        public string? StateStyle { get; init; }
+        public long? StartedAtSeconds { get; init; }
+        public int? StartedAtNanos { get; init; }
+        public long? StoppedAtSeconds { get; init; }
+        public int? StoppedAtNanos { get; init; }
+        public required bool IsHidden { get; init; }
+        public required bool SupportsDetailedTelemetry { get; init; }
+        public string? IconName { get; init; }
+        public int? IconVariant { get; init; }
+        public required bool ConsoleLogsLoaded { get; init; }
+    }
+
+    private sealed class EnvironmentRecord
+    {
+        public required string ResourceName { get; init; }
+        public required string Name { get; init; }
+        public string? Value { get; init; }
+        public required bool IsFromSpec { get; init; }
+    }
+
+    private sealed class UrlRecord
+    {
+        public required string ResourceName { get; init; }
+        public string? EndpointName { get; init; }
+        public required string FullUrl { get; init; }
+        public required bool IsInternal { get; init; }
+        public required bool IsInactive { get; init; }
+        public required int DisplaySortOrder { get; init; }
+        public required string DisplayName { get; init; }
+    }
+
+    private sealed class VolumeRecord
+    {
+        public required string ResourceName { get; init; }
+        public required string Source { get; init; }
+        public required string Target { get; init; }
+        public required string MountType { get; init; }
+        public required bool IsReadOnly { get; init; }
+    }
+
+    private sealed class HealthReportRecord
+    {
+        public required string ResourceName { get; init; }
+        public int? Status { get; init; }
+        public required string Key { get; init; }
+        public required string Description { get; init; }
+        public required string Exception { get; init; }
+        public long? LastRunAtSeconds { get; init; }
+        public int? LastRunAtNanos { get; init; }
+    }
+
+    private sealed class PropertyRecord
+    {
+        public required string ResourceName { get; init; }
+        public required string Name { get; init; }
+        public string? DisplayName { get; init; }
+        public required string JsonValue { get; init; }
+        public bool? IsSensitive { get; init; }
+        public required bool IsHighlighted { get; init; }
+        public int? SortOrder { get; init; }
+    }
+
+    private sealed class CommandRecord
+    {
+        public required string ResourceName { get; init; }
+        public required int Ordinal { get; init; }
+        public required string Name { get; init; }
+        public required string DisplayName { get; init; }
+        public string? ConfirmationMessage { get; init; }
+        public string? ParameterJsonValue { get; init; }
+        public required bool IsHighlighted { get; init; }
+        public string? IconName { get; init; }
+        public int? IconVariant { get; init; }
+        public string? DisplayDescription { get; init; }
+        public required int State { get; init; }
+    }
+
+    private sealed class InputRecord
+    {
+        public required string ResourceName { get; init; }
+        public required int CommandOrdinal { get; init; }
+        public required int Ordinal { get; init; }
+        public required string Label { get; init; }
+        public required string Placeholder { get; init; }
+        public required int InputType { get; init; }
+        public required bool Required { get; init; }
+        public required string Value { get; init; }
+        public required string Description { get; init; }
+        public required bool EnableDescriptionMarkdown { get; init; }
+        public required int MaxLength { get; init; }
+        public required bool AllowCustomChoice { get; init; }
+        public required bool Loading { get; init; }
+        public required bool UpdateStateOnChange { get; init; }
+        public required string Name { get; init; }
+        public required bool Disabled { get; init; }
+        public required long MaxFileSize { get; init; }
+        public required bool AllowMultipleFiles { get; init; }
+        public required string FileFilter { get; init; }
+    }
+
+    private sealed class OptionRecord
+    {
+        public required string ResourceName { get; init; }
+        public required int CommandOrdinal { get; init; }
+        public required int InputOrdinal { get; init; }
+        public required string OptionKey { get; init; }
+        public required string OptionValue { get; init; }
+    }
+
+    private sealed class RelationshipRecord
+    {
+        public required string ResourceName { get; init; }
+        public required string RelatedResourceName { get; init; }
+        public required string RelationshipType { get; init; }
+    }
+
+    private sealed class ValidationErrorRecord
+    {
+        public required string ResourceName { get; init; }
+        public required int CommandOrdinal { get; init; }
+        public required int InputOrdinal { get; init; }
+        public required string ValidationError { get; init; }
+    }
+
+}

--- a/src/Aspire.Dashboard/ServiceClient/SqliteResourceRepository.cs
+++ b/src/Aspire.Dashboard/ServiceClient/SqliteResourceRepository.cs
@@ -1,0 +1,558 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Aspire.Dashboard.Model;
+using Aspire.DashboardService.Proto.V1;
+using Aspire.Shared.ConsoleLogs;
+using Dapper;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Stores dashboard resources and console logs in SQLite.
+/// </summary>
+public sealed partial class SqliteResourceRepository : IResourceRepository, IResourceRepositoryWriter, IDisposable
+{
+    private readonly DashboardSqliteDatabase _database;
+    private readonly IKnownPropertyLookup _knownPropertyLookup;
+    private readonly ILogger _logger;
+    private readonly object _stateLock = new();
+    private readonly Dictionary<string, ResourceState> _resourceStates = new(StringComparers.ResourceName);
+    private ImmutableHashSet<Channel<IReadOnlyList<ResourceViewModelChange>>> _resourceChannels = [];
+    private readonly Dictionary<string, ImmutableHashSet<Channel<IReadOnlyList<ResourceLogLine>>>> _consoleChannels = new(StringComparers.ResourceName);
+    private int _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqliteResourceRepository"/> class.
+    /// </summary>
+    /// <param name="database">The dashboard database used to persist resources and console logs.</param>
+    /// <param name="knownPropertyLookup">The lookup for known resource properties.</param>
+    /// <param name="loggerFactory">The logger factory.</param>
+    public SqliteResourceRepository(
+        DashboardSqliteDatabase database,
+        IKnownPropertyLookup knownPropertyLookup,
+        ILoggerFactory loggerFactory)
+    {
+        _database = database;
+        _knownPropertyLookup = knownPropertyLookup;
+        _logger = loggerFactory.CreateLogger<SqliteResourceRepository>();
+
+        LoadResources();
+    }
+
+    public ResourceViewModel? GetResource(string resourceName)
+    {
+        ThrowIfDisposed();
+        lock (_stateLock)
+        {
+            return _resourceStates.GetValueOrDefault(resourceName)?.Resource;
+        }
+    }
+
+    public IReadOnlyList<ResourceViewModel> GetResources()
+    {
+        ThrowIfDisposed();
+        lock (_stateLock)
+        {
+            return _resourceStates.Values.Select(state => state.Resource).ToList();
+        }
+    }
+
+    public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        var channel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>(new UnboundedChannelOptions
+        {
+            AllowSynchronousContinuations = false,
+            SingleReader = true,
+            SingleWriter = false
+        });
+        ImmutableArray<ResourceViewModel> initialState;
+        lock (_stateLock)
+        {
+            _resourceChannels = _resourceChannels.Add(channel);
+            initialState = _resourceStates.Values.Select(state => state.Resource).ToImmutableArray();
+        }
+
+        return Task.FromResult(new ResourceViewModelSubscription(
+            initialState,
+            ReadResourceUpdatesAsync(channel, cancellationToken)));
+    }
+
+    public async IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(
+        string resourceName,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ResourceLogLine[] lines;
+        ThrowIfDisposed();
+        using var connection = _database.OpenConnection();
+        lines = connection.Query<ConsoleLogRecord>("""
+            SELECT line_number AS LineNumber, content AS Content, is_stderr AS IsStdErr
+            FROM console_logs
+            WHERE resource_name = @ResourceName
+            ORDER BY console_log_id;
+            """, new { ResourceName = resourceName })
+            .Select(line => new ResourceLogLine(line.LineNumber, line.Content, line.IsStdErr))
+            .ToArray();
+
+        cancellationToken.ThrowIfCancellationRequested();
+        if (lines.Length > 0)
+        {
+            yield return lines;
+        }
+    }
+
+    public async IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(
+        string resourceName,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ResourceLogLine[] initialLines;
+        Channel<IReadOnlyList<ResourceLogLine>> channel;
+        ThrowIfDisposed();
+        // Keep the initial query and channel registration atomic with console-log writes. Otherwise, a write
+        // could commit after the query but before registration, causing the subscriber to miss those lines.
+        using (await _database.WriteLock.LockAsync(cancellationToken).ConfigureAwait(false))
+        {
+            using var connection = _database.OpenConnection();
+            initialLines = connection.Query<ConsoleLogRecord>("""
+                SELECT line_number AS LineNumber, content AS Content, is_stderr AS IsStdErr
+                FROM console_logs
+                WHERE resource_name = @ResourceName
+                ORDER BY console_log_id;
+                """, new { ResourceName = resourceName })
+                .Select(line => new ResourceLogLine(line.LineNumber, line.Content, line.IsStdErr))
+                .ToArray();
+
+            channel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>(new UnboundedChannelOptions
+            {
+                AllowSynchronousContinuations = false,
+                SingleReader = true,
+                SingleWriter = false
+            });
+            lock (_stateLock)
+            {
+                _consoleChannels[resourceName] = (_consoleChannels.GetValueOrDefault(resourceName) ?? []).Add(channel);
+            }
+        }
+
+        try
+        {
+            if (initialLines.Length > 0)
+            {
+                yield return initialLines;
+            }
+
+            await foreach (var lines in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return lines;
+            }
+        }
+        finally
+        {
+            lock (_stateLock)
+            {
+                if (_consoleChannels.TryGetValue(resourceName, out var channels))
+                {
+                    channels = channels.Remove(channel);
+                    if (channels.Count == 0)
+                    {
+                        _consoleChannels.Remove(resourceName);
+                    }
+                    else
+                    {
+                        _consoleChannels[resourceName] = channels;
+                    }
+                }
+            }
+        }
+    }
+
+    async Task IResourceRepositoryWriter.ReplaceResourcesAsync(IReadOnlyList<Resource> resources)
+    {
+        EnsureWritable();
+        ThrowIfDisposed();
+        List<ResourceViewModelChange> changes = [];
+
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            Dictionary<string, ResourceViewModel> currentResources;
+            lock (_stateLock)
+            {
+                currentResources = _resourceStates.ToDictionary(entry => entry.Key, entry => entry.Value.Resource, StringComparers.ResourceName);
+            }
+
+            var replacementResources = new Dictionary<string, ResourceViewModel>(StringComparers.ResourceName);
+            var resourcesToSave = new List<ResourceToSave>(resources.Count);
+            var replacementResourceNames = resources.Select(resource => resource.Name).ToHashSet(StringComparers.ResourceName);
+            foreach (var (resourceName, viewModel) in currentResources)
+            {
+                if (!replacementResourceNames.Contains(resourceName))
+                {
+                    changes.Add(new ResourceViewModelChange(ResourceViewModelChangeType.Delete, viewModel));
+                }
+            }
+            var resourcesWithLoadedConsoleLogs = currentResources.Values
+                .Where(resource => resource.ConsoleLogsLoaded)
+                .Select(resource => resource.Name)
+                .ToHashSet(StringComparers.ResourceName);
+
+            foreach (var resource in resources)
+            {
+                var viewModel = CreateViewModel(resource, replacementResources);
+                viewModel.ConsoleLogsLoaded = resourcesWithLoadedConsoleLogs.Contains(resource.Name);
+                resourcesToSave.Add(new(resource, viewModel.ReplicaIndex, viewModel.ConsoleLogsLoaded));
+                replacementResources[resource.Name] = viewModel;
+                changes.Add(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, viewModel));
+            }
+
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            connection.Execute("DELETE FROM dashboard_resources;", transaction: transaction);
+            InsertResources(connection, transaction, resourcesToSave);
+            transaction.Commit();
+
+            lock (_stateLock)
+            {
+                UpdateResourceStates(replacementResources);
+            }
+        }
+
+        PublishResourceChanges(changes);
+    }
+
+    async Task IResourceRepositoryWriter.ApplyChangesAsync(IReadOnlyList<WatchResourcesChange> changes)
+    {
+        EnsureWritable();
+        ThrowIfDisposed();
+        List<ResourceViewModelChange> viewModelChanges = [];
+
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            var affectedResourceNames = changes
+                .Select(change => change.KindCase switch
+                {
+                    WatchResourcesChange.KindOneofCase.Upsert => change.Upsert.Name,
+                    WatchResourcesChange.KindOneofCase.Delete => change.Delete.ResourceName,
+                    _ => null
+                })
+                .Where(name => name is not null)
+                .Distinct(StringComparers.ResourceName)
+                .ToArray();
+            var resourcesToSave = new Dictionary<string, ResourceToSave>(StringComparers.ResourceName);
+            Dictionary<string, ResourceViewModel> updatedResources;
+
+            lock (_stateLock)
+            {
+                updatedResources = _resourceStates.ToDictionary(entry => entry.Key, entry => entry.Value.Resource, StringComparers.ResourceName);
+            }
+            foreach (var change in changes)
+            {
+                if (change.KindCase == WatchResourcesChange.KindOneofCase.Upsert)
+                {
+                    var resource = change.Upsert;
+                    var viewModel = CreateViewModel(resource, updatedResources);
+                    resourcesToSave[resource.Name] = new(resource, viewModel.ReplicaIndex, viewModel.ConsoleLogsLoaded);
+                    updatedResources[resource.Name] = viewModel;
+                    viewModelChanges.Add(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, viewModel));
+                }
+                else if (change.KindCase == WatchResourcesChange.KindOneofCase.Delete && updatedResources.Remove(change.Delete.ResourceName, out var removed))
+                {
+                    resourcesToSave.Remove(change.Delete.ResourceName);
+                    viewModelChanges.Add(new ResourceViewModelChange(ResourceViewModelChangeType.Delete, removed));
+                }
+            }
+
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            connection.Execute("DELETE FROM dashboard_resources WHERE resource_name IN @ResourceNames;", new { ResourceNames = affectedResourceNames }, transaction);
+            InsertResources(connection, transaction, resourcesToSave.Values.ToArray());
+            transaction.Commit();
+
+            lock (_stateLock)
+            {
+                UpdateResourceStates(updatedResources);
+            }
+        }
+
+        PublishResourceChanges(viewModelChanges);
+    }
+
+    async Task IResourceRepositoryWriter.MarkConsoleLogsLoadedAsync(string resourceName)
+    {
+        EnsureWritable();
+        ThrowIfDisposed();
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            using var connection = _database.OpenConnection();
+            connection.Execute("""
+                UPDATE dashboard_resources
+                SET console_logs_loaded = 1
+                WHERE resource_name = @ResourceName;
+                """, new { ResourceName = resourceName });
+            lock (_stateLock)
+            {
+                if (_resourceStates.TryGetValue(resourceName, out var state))
+                {
+                    state.Resource.ConsoleLogsLoaded = true;
+                }
+            }
+        }
+    }
+
+    async Task IResourceRepositoryWriter.AddConsoleLogsAsync(string resourceName, IReadOnlyList<ConsoleLogLine> logLines)
+    {
+        EnsureWritable();
+        ThrowIfDisposed();
+        if (logLines.Count == 0)
+        {
+            return;
+        }
+
+        var viewModelLines = logLines.Select(line => new ResourceLogLine(line.LineNumber, line.Text, line.IsStdErr)).ToArray();
+        Channel<IReadOnlyList<ResourceLogLine>>[] channels;
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            int lastLineNumber;
+            DateTime? clearDate;
+            lock (_stateLock)
+            {
+                var state = _resourceStates.GetValueOrDefault(resourceName);
+                lastLineNumber = state?.LastConsoleLogLineNumber ?? int.MinValue;
+                clearDate = state?.ConsoleLogsClearDate;
+            }
+
+            // A response can overlap a previously persisted response or repeat a line number within the
+            // same batch. Persist only new line numbers and keep the latest content for an in-batch repeat.
+            var consoleLogsToInsert = new List<ConsoleLogToInsert>(logLines.Count);
+            var consoleLogToInsertIndexes = new Dictionary<int, int>();
+            foreach (var line in logLines)
+            {
+                if (line.LineNumber <= lastLineNumber)
+                {
+                    continue;
+                }
+
+                // AppHost subscriptions replay lines in this raw shape:
+                //   2025-02-08T10:16:08Z Application started.
+                // A resource can emit lines while the Console Logs page is closed, so its line number can
+                // be new even though its timestamp predates a clear operation performed from Manage Data.
+                if (clearDate is not null &&
+                    TimestampParser.TryParseConsoleTimestamp(line.Text, out var timestamp) &&
+                    timestamp.Value.Timestamp.UtcDateTime <= clearDate)
+                {
+                    continue;
+                }
+
+                if (consoleLogToInsertIndexes.TryGetValue(line.LineNumber, out var index))
+                {
+                    consoleLogsToInsert[index] = new(line.LineNumber, line.Text, line.IsStdErr);
+                }
+                else
+                {
+                    consoleLogToInsertIndexes.Add(line.LineNumber, consoleLogsToInsert.Count);
+                    consoleLogsToInsert.Add(new(line.LineNumber, line.Text, line.IsStdErr));
+                }
+            }
+
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            connection.Execute("""
+                UPDATE dashboard_resources
+                SET console_logs_loaded = 1
+                WHERE resource_name = @ResourceName;
+                """, new { ResourceName = resourceName }, transaction);
+            InsertConsoleLogs(connection, transaction, resourceName, consoleLogsToInsert);
+            transaction.Commit();
+
+            lock (_stateLock)
+            {
+                if (_resourceStates.TryGetValue(resourceName, out var state))
+                {
+                    state.LastConsoleLogLineNumber = Math.Max(state.LastConsoleLogLineNumber, logLines.Max(line => line.LineNumber));
+                    state.Resource.ConsoleLogsLoaded = true;
+                }
+                channels = (_consoleChannels.GetValueOrDefault(resourceName) ?? []).ToArray();
+            }
+        }
+
+        foreach (var channel in channels)
+        {
+            channel.Writer.TryWrite(viewModelLines);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate)
+    {
+        EnsureWritable();
+        ThrowIfDisposed();
+        if (resourceNames.Count == 0)
+        {
+            return;
+        }
+
+        using (await _database.WriteLock.LockAsync().ConfigureAwait(false))
+        {
+            // Keep the in-memory line-number watermark so an AppHost retry cannot repopulate rows
+            // the user cleared. New lines with higher numbers continue to be persisted normally.
+            using var connection = _database.OpenConnection();
+            connection.Execute(
+                "DELETE FROM console_logs WHERE resource_name IN @ResourceNames;",
+                new { ResourceNames = resourceNames });
+
+            lock (_stateLock)
+            {
+                foreach (var resourceName in resourceNames)
+                {
+                    if (_resourceStates.TryGetValue(resourceName, out var state))
+                    {
+                        state.ConsoleLogsClearDate = clearDate;
+                    }
+                }
+            }
+        }
+    }
+
+    private ResourceViewModel CreateViewModel(Resource resource, IReadOnlyDictionary<string, ResourceViewModel> resources)
+    {
+        if (resources.TryGetValue(resource.Name, out var existingResource))
+        {
+            var viewModel = resource.ToViewModel(existingResource.ReplicaIndex, _knownPropertyLookup, _logger);
+            viewModel.ConsoleLogsLoaded = existingResource.ConsoleLogsLoaded;
+            return viewModel;
+        }
+
+        var replicaIndex = resources.Values.Count(r => string.Equals(r.DisplayName, resource.DisplayName, StringComparisons.ResourceName)) + 1;
+        return resource.ToViewModel(replicaIndex, _knownPropertyLookup, _logger);
+    }
+
+    private void LoadResources()
+    {
+        using var connection = _database.OpenConnection();
+        foreach (var storedResource in LoadResourceRecords(connection))
+        {
+            var viewModel = storedResource.Resource.ToViewModel(storedResource.ReplicaIndex, _knownPropertyLookup, _logger);
+            viewModel.ConsoleLogsLoaded = storedResource.ConsoleLogsLoaded;
+            _resourceStates[storedResource.Resource.Name] = new ResourceState(viewModel);
+        }
+
+        // Console line numbers restart at 1 for a new AppHost generation. After a Dashboard restart,
+        // the repository cannot distinguish that new data from a same-generation replay, so Resume
+        // favors preserving new logs and may duplicate a replay from an AppHost that remained running.
+        // Repeat watches within this Dashboard process are still suppressed by the in-memory high-water mark.
+    }
+
+    private void UpdateResourceStates(IReadOnlyDictionary<string, ResourceViewModel> resources)
+    {
+        var updatedStates = new Dictionary<string, ResourceState>(StringComparers.ResourceName);
+        foreach (var (resourceName, resource) in resources)
+        {
+            if (_resourceStates.TryGetValue(resourceName, out var state))
+            {
+                state.Resource = resource;
+            }
+            else
+            {
+                state = new ResourceState(resource);
+            }
+            updatedStates.Add(resourceName, state);
+        }
+
+        _resourceStates.Clear();
+        foreach (var (resourceName, state) in updatedStates)
+        {
+            _resourceStates.Add(resourceName, state);
+        }
+    }
+
+    private async IAsyncEnumerable<IReadOnlyList<ResourceViewModelChange>> ReadResourceUpdatesAsync(
+        Channel<IReadOnlyList<ResourceViewModelChange>> channel,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var changes in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return changes;
+            }
+        }
+        finally
+        {
+            lock (_stateLock)
+            {
+                _resourceChannels = _resourceChannels.Remove(channel);
+            }
+        }
+    }
+
+    private void PublishResourceChanges(IReadOnlyList<ResourceViewModelChange> changes)
+    {
+        if (changes.Count == 0)
+        {
+            return;
+        }
+
+        Channel<IReadOnlyList<ResourceViewModelChange>>[] channels;
+        lock (_stateLock)
+        {
+            channels = _resourceChannels.ToArray();
+        }
+        foreach (var channel in channels)
+        {
+            channel.Writer.TryWrite(changes);
+        }
+    }
+
+    private void EnsureWritable()
+    {
+        _database.EnsureWritable("Historical dashboard resources are read-only.");
+    }
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+    public void Dispose()
+    {
+        using (_database.WriteLock.Lock())
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            Channel<IReadOnlyList<ResourceViewModelChange>>[] resourceChannels;
+            Channel<IReadOnlyList<ResourceLogLine>>[] consoleChannels;
+            lock (_stateLock)
+            {
+                resourceChannels = _resourceChannels.ToArray();
+                consoleChannels = _consoleChannels.Values.SelectMany(channels => channels).ToArray();
+            }
+
+            foreach (var channel in resourceChannels)
+            {
+                channel.Writer.TryComplete();
+            }
+            foreach (var channel in consoleChannels)
+            {
+                channel.Writer.TryComplete();
+            }
+
+        }
+    }
+
+    private sealed class ConsoleLogRecord
+    {
+        public required int LineNumber { get; init; }
+        public required string Content { get; init; }
+        public required bool IsStdErr { get; init; }
+    }
+
+    private sealed class ResourceState(ResourceViewModel resource)
+    {
+        public ResourceViewModel Resource { get; set; } = resource;
+        public int LastConsoleLogLineNumber { get; set; } = int.MinValue;
+        public DateTime? ConsoleLogsClearDate { get; set; }
+    }
+}

--- a/src/Aspire.Dashboard/ServiceClient/TracingSqliteConnection.cs
+++ b/src/Aspire.Dashboard/ServiceClient/TracingSqliteConnection.cs
@@ -1,0 +1,511 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Dashboard.Otlp.Model;
+using Microsoft.Data.Sqlite;
+using SQLitePCL;
+
+namespace Aspire.Dashboard.ServiceClient;
+
+/// <summary>
+/// Adds tracing to commands executed by Dapper through a SQLite connection.
+/// </summary>
+internal sealed class TracingSqliteConnection(string connectionString, string databasePath, ActivitySource activitySource) : SqliteConnection(connectionString)
+{
+    internal const string ActivitySourceName = "Aspire.Dashboard.Sqlite";
+
+    internal new TracingSqliteTransaction BeginTransaction() =>
+        new(base.BeginTransaction(), Path.GetFileName(databasePath), activitySource);
+
+    internal new TracingSqliteTransaction BeginTransaction(IsolationLevel isolationLevel) =>
+        new(base.BeginTransaction(isolationLevel), Path.GetFileName(databasePath), activitySource);
+
+    protected override DbCommand CreateDbCommand() => new TracingDbCommand(base.CreateDbCommand(), Path.GetFileName(databasePath), activitySource);
+
+    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => BeginTransaction(isolationLevel);
+
+    internal void ConfigureSynchronousNormal()
+    {
+        using var command = base.CreateDbCommand();
+        command.CommandText = "PRAGMA synchronous = NORMAL;";
+        command.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Aborts any statement running on this connection when <paramref name="cancellationToken"/> is canceled.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Microsoft.Data.Sqlite's <see cref="SqliteCommand.Cancel"/> is documented as doing nothing, so neither
+    /// Dapper's <c>CommandDefinition</c> token nor <c>ExecuteReaderAsync</c> can stop a scan that has already
+    /// started. Without this, canceling a query only discards its result while the scan runs to completion,
+    /// holding a thread-pool thread and a connection the whole time.
+    /// </para>
+    /// <para>
+    /// <c>sqlite3_interrupt</c> is SQLite's supported mechanism for this. It causes the in-progress statement
+    /// on this connection to fail with <c>SQLITE_INTERRUPT</c>. It is explicitly safe to call from another
+    /// thread while the connection is in use. See https://www.sqlite.org/c3ref/interrupt.html.
+    /// </para>
+    /// <para>
+    /// Dispose the returned registration before closing the connection. <see cref="CancellationTokenRegistration.Dispose"/>
+    /// waits for a concurrently running callback to finish, so the handle can't be used after it is released.
+    /// </para>
+    /// </remarks>
+    internal CancellationTokenRegistration RegisterInterrupt(CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            return default;
+        }
+
+        return cancellationToken.Register(static state =>
+        {
+            var connection = (TracingSqliteConnection)state!;
+            if (connection.Handle is { } handle)
+            {
+                raw.sqlite3_interrupt(handle);
+            }
+        }, this);
+    }
+
+    private static Activity? StartActivity(string query, string databaseName, ActivitySource activitySource)
+    {
+        var operationName = GetOperationName(query);
+        var activity = activitySource.StartActivity(
+            operationName is null ? "sqlite query" : $"{operationName} sqlite",
+            ActivityKind.Client);
+        if (activity is not null)
+        {
+            activity.SetTag("db.system.name", "sqlite");
+            activity.SetTag(OtlpSpan.PeerServiceAttributeKey, databaseName);
+            activity.SetTag("db.namespace", databaseName);
+            activity.SetTag("db.query.text", query);
+            activity.SetTag("db.operation.name", operationName);
+        }
+
+        return activity;
+    }
+
+    private static string? GetOperationName(string query)
+    {
+        var querySpan = query.AsSpan();
+        while (true)
+        {
+            querySpan = querySpan.TrimStart();
+
+            // Embedded schema scripts start with license comments before the first SQL statement.
+            if (querySpan.StartsWith("--"))
+            {
+                var lineEndIndex = querySpan.IndexOfAny('\r', '\n');
+                if (lineEndIndex < 0)
+                {
+                    return null;
+                }
+
+                querySpan = querySpan[(lineEndIndex + 1)..];
+                continue;
+            }
+
+            if (querySpan.StartsWith("/*"))
+            {
+                var commentEndIndex = querySpan.IndexOf("*/");
+                if (commentEndIndex < 0)
+                {
+                    return null;
+                }
+
+                querySpan = querySpan[(commentEndIndex + 2)..];
+                continue;
+            }
+
+            break;
+        }
+
+        var separatorIndex = querySpan.IndexOfAny(" \t\r\n;");
+        var operationSpan = separatorIndex >= 0 ? querySpan[..separatorIndex] : querySpan;
+        return operationSpan.IsEmpty ? null : operationSpan.ToString().ToUpperInvariant();
+    }
+
+    private static void RecordException(Activity? activity, Exception exception)
+    {
+        activity?.SetTag("error.type", exception.GetType().FullName);
+        activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+    }
+
+    internal sealed class TracingSqliteTransaction(SqliteTransaction transaction, string databaseName, ActivitySource activitySource) : DbTransaction
+    {
+        internal SqliteTransaction InnerTransaction => transaction;
+
+        public override IsolationLevel IsolationLevel => transaction.IsolationLevel;
+
+        protected override DbConnection? DbConnection => transaction.Connection;
+
+        public override bool SupportsSavepoints => transaction.SupportsSavepoints;
+
+        public override void Commit() => ExecuteWithActivity("COMMIT;", transaction.Commit);
+
+        public override Task CommitAsync(CancellationToken cancellationToken = default) =>
+            ExecuteWithActivityAsync("COMMIT;", () => transaction.CommitAsync(cancellationToken));
+
+        public override void Rollback() => ExecuteWithActivity("ROLLBACK;", transaction.Rollback);
+
+        public override Task RollbackAsync(CancellationToken cancellationToken = default) =>
+            ExecuteWithActivityAsync("ROLLBACK;", () => transaction.RollbackAsync(cancellationToken));
+
+        public override void Save(string savepointName) => transaction.Save(savepointName);
+
+        public override Task SaveAsync(string savepointName, CancellationToken cancellationToken = default) =>
+            transaction.SaveAsync(savepointName, cancellationToken);
+
+        public override void Rollback(string savepointName) => transaction.Rollback(savepointName);
+
+        public override Task RollbackAsync(string savepointName, CancellationToken cancellationToken = default) =>
+            transaction.RollbackAsync(savepointName, cancellationToken);
+
+        public override void Release(string savepointName) => transaction.Release(savepointName);
+
+        public override Task ReleaseAsync(string savepointName, CancellationToken cancellationToken = default) =>
+            transaction.ReleaseAsync(savepointName, cancellationToken);
+
+        public override ValueTask DisposeAsync() => transaction.DisposeAsync();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                transaction.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void ExecuteWithActivity(string query, Action execute)
+        {
+            using var activity = StartActivity(query, databaseName, activitySource);
+            try
+            {
+                execute();
+            }
+            catch (Exception exception)
+            {
+                RecordException(activity, exception);
+                throw;
+            }
+        }
+
+        private async Task ExecuteWithActivityAsync(string query, Func<Task> execute)
+        {
+            using var activity = StartActivity(query, databaseName, activitySource);
+            try
+            {
+                await execute().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                RecordException(activity, exception);
+                throw;
+            }
+        }
+    }
+
+    private sealed class TracingDbCommand(DbCommand command, string databaseName, ActivitySource activitySource) : DbCommand
+    {
+        private DbTransaction? _transaction;
+
+        [AllowNull]
+        public override string CommandText
+        {
+            get => command.CommandText;
+            set => command.CommandText = value;
+        }
+
+        public override int CommandTimeout
+        {
+            get => command.CommandTimeout;
+            set => command.CommandTimeout = value;
+        }
+
+        public override CommandType CommandType
+        {
+            get => command.CommandType;
+            set => command.CommandType = value;
+        }
+
+        public override bool DesignTimeVisible
+        {
+            get => command.DesignTimeVisible;
+            set => command.DesignTimeVisible = value;
+        }
+
+        public override UpdateRowSource UpdatedRowSource
+        {
+            get => command.UpdatedRowSource;
+            set => command.UpdatedRowSource = value;
+        }
+
+        protected override DbConnection? DbConnection
+        {
+            get => command.Connection;
+            set => command.Connection = value;
+        }
+
+        protected override DbParameterCollection DbParameterCollection => command.Parameters;
+
+        protected override DbTransaction? DbTransaction
+        {
+            get => _transaction ?? command.Transaction;
+            set
+            {
+                _transaction = value;
+                command.Transaction = value is TracingSqliteTransaction tracingTransaction
+                    ? tracingTransaction.InnerTransaction
+                    : value;
+            }
+        }
+
+        public override void Cancel() => command.Cancel();
+
+        public override int ExecuteNonQuery() => ExecuteWithActivity(command.ExecuteNonQuery);
+
+        public override object? ExecuteScalar() => ExecuteWithActivity(command.ExecuteScalar);
+
+        public override void Prepare() => command.Prepare();
+
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken) =>
+            ExecuteWithActivityAsync(() => command.ExecuteNonQueryAsync(cancellationToken));
+
+        public override Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken) =>
+            ExecuteWithActivityAsync(() => command.ExecuteScalarAsync(cancellationToken));
+
+        public override Task PrepareAsync(CancellationToken cancellationToken = default) => command.PrepareAsync(cancellationToken);
+
+        public override ValueTask DisposeAsync() => command.DisposeAsync();
+
+        protected override DbParameter CreateDbParameter() => command.CreateParameter();
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            var activity = StartActivity();
+            try
+            {
+                var reader = command.ExecuteReader(behavior);
+                return activity is null ? reader : new TracingDbDataReader(reader, activity);
+            }
+            catch (Exception exception)
+            {
+                RecordException(activity, exception);
+                activity?.Dispose();
+                throw;
+            }
+        }
+
+        protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        {
+            var activity = StartActivity();
+            try
+            {
+                var reader = await command.ExecuteReaderAsync(behavior, cancellationToken).ConfigureAwait(false);
+                return activity is null ? reader : new TracingDbDataReader(reader, activity);
+            }
+            catch (Exception exception)
+            {
+                RecordException(activity, exception);
+                activity?.Dispose();
+                throw;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                command.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private T ExecuteWithActivity<T>(Func<T> execute)
+        {
+            using var activity = StartActivity();
+            try
+            {
+                return execute();
+            }
+            catch (Exception exception)
+            {
+                RecordException(activity, exception);
+                throw;
+            }
+        }
+
+        private async Task<T> ExecuteWithActivityAsync<T>(Func<Task<T>> execute)
+        {
+            using var activity = StartActivity();
+            try
+            {
+                return await execute().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                RecordException(activity, exception);
+                throw;
+            }
+        }
+
+        private Activity? StartActivity() => TracingSqliteConnection.StartActivity(CommandText, databaseName, activitySource);
+
+        private sealed class TracingDbDataReader(DbDataReader reader, Activity activity) : DbDataReader
+        {
+            private Activity? _activity = activity;
+
+            public override object this[int ordinal] => reader[ordinal];
+            public override object this[string name] => reader[name];
+            public override int Depth => reader.Depth;
+            public override int FieldCount => reader.FieldCount;
+            public override bool HasRows => reader.HasRows;
+            public override bool IsClosed => reader.IsClosed;
+            public override int RecordsAffected => reader.RecordsAffected;
+            public override int VisibleFieldCount => reader.VisibleFieldCount;
+
+            public override void Close()
+            {
+                try
+                {
+                    reader.Close();
+                }
+                catch (Exception exception)
+                {
+                    RecordException(_activity, exception);
+                    throw;
+                }
+                finally
+                {
+                    CompleteActivity();
+                }
+            }
+
+            public override bool GetBoolean(int ordinal) => reader.GetBoolean(ordinal);
+            public override byte GetByte(int ordinal) => reader.GetByte(ordinal);
+            public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => reader.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+            public override char GetChar(int ordinal) => reader.GetChar(ordinal);
+            public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => reader.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
+            public override string GetDataTypeName(int ordinal) => reader.GetDataTypeName(ordinal);
+            public override DateTime GetDateTime(int ordinal) => reader.GetDateTime(ordinal);
+            public override decimal GetDecimal(int ordinal) => reader.GetDecimal(ordinal);
+            public override double GetDouble(int ordinal) => reader.GetDouble(ordinal);
+            public override IEnumerator GetEnumerator() => reader.GetEnumerator();
+            public override Type GetFieldType(int ordinal) => reader.GetFieldType(ordinal);
+            public override T GetFieldValue<T>(int ordinal) => reader.GetFieldValue<T>(ordinal);
+            public override float GetFloat(int ordinal) => reader.GetFloat(ordinal);
+            public override Guid GetGuid(int ordinal) => reader.GetGuid(ordinal);
+            public override short GetInt16(int ordinal) => reader.GetInt16(ordinal);
+            public override int GetInt32(int ordinal) => reader.GetInt32(ordinal);
+            public override long GetInt64(int ordinal) => reader.GetInt64(ordinal);
+            public override string GetName(int ordinal) => reader.GetName(ordinal);
+            public override int GetOrdinal(string name) => reader.GetOrdinal(name);
+            public override Type GetProviderSpecificFieldType(int ordinal) => reader.GetProviderSpecificFieldType(ordinal);
+            public override object GetProviderSpecificValue(int ordinal) => reader.GetProviderSpecificValue(ordinal);
+            public override int GetProviderSpecificValues(object[] values) => reader.GetProviderSpecificValues(values);
+            public override DataTable? GetSchemaTable() => reader.GetSchemaTable();
+            public override Stream GetStream(int ordinal) => reader.GetStream(ordinal);
+            public override string GetString(int ordinal) => reader.GetString(ordinal);
+            public override TextReader GetTextReader(int ordinal) => reader.GetTextReader(ordinal);
+            public override object GetValue(int ordinal) => reader.GetValue(ordinal);
+            public override int GetValues(object[] values) => reader.GetValues(values);
+            public override bool IsDBNull(int ordinal) => reader.IsDBNull(ordinal);
+
+            public override bool NextResult() => ExecuteReaderOperation(reader.NextResult);
+
+            public override Task<bool> NextResultAsync(CancellationToken cancellationToken) =>
+                ExecuteReaderOperationAsync(() => reader.NextResultAsync(cancellationToken));
+
+            public override bool Read() => ExecuteReaderOperation(reader.Read);
+
+            public override Task<bool> ReadAsync(CancellationToken cancellationToken) =>
+                ExecuteReaderOperationAsync(() => reader.ReadAsync(cancellationToken));
+
+            public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken) =>
+                reader.GetFieldValueAsync<T>(ordinal, cancellationToken);
+
+            public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken) =>
+                reader.IsDBNullAsync(ordinal, cancellationToken);
+
+            public override async ValueTask DisposeAsync()
+            {
+                try
+                {
+                    await reader.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    RecordException(_activity, exception);
+                    throw;
+                }
+                finally
+                {
+                    CompleteActivity();
+                }
+
+                GC.SuppressFinalize(this);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    try
+                    {
+                        reader.Dispose();
+                    }
+                    catch (Exception exception)
+                    {
+                        RecordException(_activity, exception);
+                        throw;
+                    }
+                    finally
+                    {
+                        CompleteActivity();
+                    }
+                }
+
+                base.Dispose(disposing);
+            }
+
+            private T ExecuteReaderOperation<T>(Func<T> operation)
+            {
+                try
+                {
+                    return operation();
+                }
+                catch (Exception exception)
+                {
+                    RecordException(_activity, exception);
+                    CompleteActivity();
+                    throw;
+                }
+            }
+
+            private async Task<T> ExecuteReaderOperationAsync<T>(Func<Task<T>> operation)
+            {
+                try
+                {
+                    return await operation().ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    RecordException(_activity, exception);
+                    CompleteActivity();
+                    throw;
+                }
+            }
+
+            private void CompleteActivity() => Interlocked.Exchange(ref _activity, null)?.Dispose();
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Utils/AsyncLock.cs
+++ b/src/Aspire.Dashboard/Utils/AsyncLock.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Utils;
+
+/// <summary>
+/// Provides mutual exclusion with asynchronous lock acquisition.
+/// </summary>
+internal sealed class AsyncLock
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    /// <summary>
+    /// Acquires the lock synchronously.
+    /// </summary>
+    /// <returns>A handle that releases the lock when disposed.</returns>
+    public IDisposable Lock()
+    {
+        _semaphore.Wait();
+        return new Releaser(_semaphore);
+    }
+
+    /// <summary>
+    /// Acquires the lock asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A handle that releases the lock when disposed.</returns>
+    public async ValueTask<IDisposable> LockAsync(CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new Releaser(_semaphore);
+    }
+
+    private sealed class Releaser(SemaphoreSlim semaphore) : IDisposable
+    {
+        private SemaphoreSlim? _semaphore = semaphore;
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _semaphore, null)?.Release();
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
+++ b/src/Aspire.Dashboard/Utils/BrowserStorageKeys.cs
@@ -23,6 +23,7 @@ internal static class BrowserStorageKeys
     public const string ResourcesShowResourceTypes = "Aspire_Resources_ShowResourceTypes";
 
     public const string DashboardTelemetrySettings = "Aspire_Settings_DashboardTelemetry";
+    public const string SelectedDashboardRunId = "Aspire_Settings_SelectedDashboardRunId";
     public const string ResourcesShowHiddenResources = "Aspire_Resources_ShowHiddenResources";
 
     public const string NavMenuExpanded = "Aspire_NavMenu_Expanded";

--- a/src/Aspire.Dashboard/Utils/CallbackThrottler.cs
+++ b/src/Aspire.Dashboard/Utils/CallbackThrottler.cs
@@ -8,6 +8,9 @@ namespace Aspire.Dashboard.Utils;
 [DebuggerDisplay("Name = {Name}")]
 public sealed class CallbackThrottler
 {
+    // This interval balances responsiveness with the performance cost of repeatedly executing callbacks.
+    public static readonly TimeSpan DefaultMinExecuteInterval = TimeSpan.FromMilliseconds(500);
+
     private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
     private DateTime? _lastExecute;
 
@@ -89,7 +92,7 @@ public sealed class CallbackThrottler
         }
     }
 
-    private async Task ExecuteAsync()
+    public async Task ExecuteAsync()
     {
         // Try to queue the subscription callback.
         // If another caller is already in the queue then exit without calling the callback.

--- a/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
@@ -13,6 +13,11 @@ namespace Aspire.Dashboard.Utils;
 
 internal static class DashboardUIHelpers
 {
+    // Virtualize represents unloaded rows with CSS spacers. Browser engines clamp very tall
+    // elements, causing the spacer observer to report inconsistent measurements and render forever.
+    // At the dashboard's 46px grid row height, 200,000 items use a 9.2 million pixel spacer.
+    public const int MaxVirtualizedItemCount = 200_000;
+
     public const string MessageBarSection = "MessagesTop";
 
     // Blazor SectionOutlet/SectionContent name used to teleport the current page's title
@@ -38,6 +43,8 @@ internal static class DashboardUIHelpers
     // If there is no count then default to a limit to avoid getting all data.
     // Given the size of rows on dashboard grids, 100 rows should always fill the grid on the screen.
     public const int DefaultDataGridResultCount = 100;
+
+    public static int GetVirtualizedItemCount(int totalItemCount) => Math.Min(totalItemCount, MaxVirtualizedItemCount);
 
     // Don't attempt to display more than 2 highlighted commands. Many commands will take up too much space.
     public const int MaxHighlightedCommands = 2;

--- a/src/Aspire.Dashboard/Utils/FilterHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FilterHelpers.cs
@@ -98,9 +98,9 @@ public static class FilterHelpers
         FieldTelemetryFilter? entry,
         DashboardDialogService dialogService,
         EventCallback<DialogResult> onDialogResult,
-        List<string> propertyKeys,
+        Func<CancellationToken, Task<List<string>>> getPropertyKeysAsync,
         List<string> knownKeys,
-        Func<string, Dictionary<string, int>> getFieldValues,
+        Func<string, CancellationToken, Task<Dictionary<string, int>>> getFieldValuesAsync,
         IStringLocalizer<StructuredFiltering> filterLoc)
     {
         var title = entry is not null ? filterLoc[nameof(StructuredFiltering.DialogTitleEditFilter)] : filterLoc[nameof(StructuredFiltering.DialogTitleAddFilter)];
@@ -116,9 +116,9 @@ public static class FilterHelpers
         var data = new FilterDialogViewModel
         {
             Filter = entry,
-            PropertyKeys = propertyKeys,
+            GetPropertyKeysAsync = getPropertyKeysAsync,
             KnownKeys = knownKeys,
-            GetFieldValues = getFieldValues
+            GetFieldValuesAsync = getFieldValuesAsync
         };
         await dialogService.ShowPanelAsync<FilterDialog>(data, parameters).ConfigureAwait(false);
     }

--- a/src/Aspire.Dashboard/Utils/SqliteBatchInsert.cs
+++ b/src/Aspire.Dashboard/Utils/SqliteBatchInsert.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+
+namespace Aspire.Dashboard.Utils;
+
+internal static class SqliteBatchInsert
+{
+    internal static DbCommand CreateBatchInsertCommand(
+        DbConnection connection,
+        IDbTransaction transaction,
+        int rowCount,
+        string tableName,
+        IReadOnlyList<string> columnNames,
+        string? returningColumnName = null)
+    {
+        var command = connection.CreateCommand();
+        command.Transaction = (DbTransaction)transaction;
+        var sql = new StringBuilder("INSERT INTO ");
+        sql.Append(tableName);
+        sql.Append(" (\n    ");
+        sql.AppendJoin(", ", columnNames);
+        sql.Append("\n)\nVALUES\n");
+        for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
+        {
+            if (rowIndex > 0)
+            {
+                sql.AppendLine(",");
+            }
+
+            sql.Append("    (");
+            for (var parameterIndex = 0; parameterIndex < columnNames.Count; parameterIndex++)
+            {
+                if (parameterIndex > 0)
+                {
+                    sql.Append(", ");
+                }
+
+                var parameterName = string.Create(CultureInfo.InvariantCulture, $"@param_{columnNames[parameterIndex]}_{rowIndex + 1}");
+                sql.Append(parameterName);
+                var parameter = command.CreateParameter();
+                parameter.ParameterName = parameterName;
+                command.Parameters.Add(parameter);
+            }
+            sql.Append(')');
+        }
+        if (returningColumnName is not null)
+        {
+            sql.Append("\nRETURNING ");
+            sql.Append(returningColumnName);
+        }
+        sql.Append(';');
+        command.CommandText = sql.ToString();
+        command.Prepare();
+        return command;
+    }
+
+    internal static void BatchInsertRows<T>(
+        DbConnection connection,
+        IDbTransaction transaction,
+        IReadOnlyList<T> data,
+        int batchSize,
+        string tableName,
+        IReadOnlyList<string> columnNames,
+        BindRowParameters<T> bindRowParameters)
+    {
+        BatchInsertRows(
+            data,
+            batchSize,
+            columnNames.Count,
+            rowCount => CreateBatchInsertCommand(connection, transaction, rowCount, tableName, columnNames),
+            bindRowParameters);
+    }
+
+    internal static List<long> BatchInsertRows<T>(
+        DbConnection connection,
+        IDbTransaction transaction,
+        IReadOnlyList<T> data,
+        int batchSize,
+        string tableName,
+        IReadOnlyList<string> columnNames,
+        string returningColumnName,
+        BindRowParameters<T> bindRowParameters)
+    {
+        var generatedIds = new List<long>(data.Count);
+        BatchInsertRows(
+            data,
+            batchSize,
+            columnNames.Count,
+            rowCount => CreateBatchInsertCommand(connection, transaction, rowCount, tableName, columnNames, returningColumnName),
+            bindRowParameters,
+            command =>
+            {
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    generatedIds.Add(reader.GetInt64(0));
+                }
+            });
+        if (generatedIds.Count != data.Count)
+        {
+            throw new InvalidOperationException($"The batch insert returned {generatedIds.Count} generated IDs; expected {data.Count}.");
+        }
+
+        // SQLite doesn't guarantee RETURNING row order. Generated IDs increase with the input rows,
+        // so sorting restores source-row order before callers correlate IDs by index.
+        generatedIds.Sort();
+        return generatedIds;
+    }
+
+    internal static void BatchInsertRows<T>(
+        IReadOnlyList<T> data,
+        int batchSize,
+        int parametersPerRow,
+        Func<int, DbCommand> commandFactory,
+        BindRowParameters<T> bindRowParameters)
+    {
+        BatchInsertRows(data, batchSize, parametersPerRow, commandFactory, bindRowParameters, static command => command.ExecuteNonQuery());
+    }
+
+    private static void BatchInsertRows<T>(
+        IReadOnlyList<T> data,
+        int batchSize,
+        int parametersPerRow,
+        Func<int, DbCommand> commandFactory,
+        BindRowParameters<T> bindRowParameters,
+        Action<DbCommand> executeCommand)
+    {
+        DbCommand? command = null;
+        DbParameter[] parameters = [];
+        try
+        {
+            for (var batchStart = 0; batchStart < data.Count; batchStart += batchSize)
+            {
+                var rowCount = Math.Min(batchSize, data.Count - batchStart);
+                var parameterCount = checked(rowCount * parametersPerRow);
+                if (command is null || parameters.Length != parameterCount)
+                {
+                    command?.Dispose();
+                    command = commandFactory(rowCount);
+                    parameters = command.Parameters.Cast<DbParameter>().ToArray();
+                    if (parameters.Length != parameterCount)
+                    {
+                        throw new InvalidOperationException($"The batch insert command has {parameters.Length} parameters; expected {parameterCount}.");
+                    }
+                }
+
+                for (var rowIndex = 0; rowIndex < rowCount; rowIndex++)
+                {
+                    bindRowParameters(
+                        data[batchStart + rowIndex],
+                        parameters.AsSpan(rowIndex * parametersPerRow, parametersPerRow));
+                }
+
+                executeCommand(command);
+            }
+        }
+        finally
+        {
+            command?.Dispose();
+        }
+    }
+}
+
+internal delegate void BindRowParameters<in T>(T row, ReadOnlySpan<DbParameter> parameters);

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -2022,6 +2022,10 @@ fluent-tooltip[anchor="dialog_close"] > div {
     text-overflow: ellipsis;
 }
 
+.aspire-menu-container fluent-menu-item.indent-1[role="menuitemradio"]:has(> span[slot="end"]) {
+    grid-template-columns: minmax(32px, auto) auto 1fr minmax(32px, auto);
+}
+
 .aspire-menu-container.mobile-nav-menu fluent-menu-item {
     scroll-margin-block: var(--mobile-nav-menu-focus-padding);
 }

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="CircularBuffer.cs" />
     <Compile Include="$(SharedDir)CompareHelpers.cs" Link="Utils\CompareHelpers.cs" />
     <Compile Include="$(SharedDir)CustomResourceSnapshotExtensions.cs" Link="CustomResourceSnapshotExtensions.cs" />
+    <Compile Include="$(SharedDir)DirectoryHelper.cs" Link="Utils\DirectoryHelper.cs" />
     <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Dashboard\KnownProperties.cs" />
     <Compile Include="$(SharedDir)Model\KnownResourceTypes.cs" Link="Dashboard\KnownResourceTypes.cs" />
     <Compile Include="$(SharedDir)Model\KnownRelationshipTypes.cs" Link="Dashboard\KnownRelationshipTypes.cs" />

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -607,6 +607,20 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
 
         context.EnvironmentVariables[KnownAspNetCoreConfigNames.Environment] = environment;
         context.EnvironmentVariables[DashboardConfigNames.ResourceServiceUrlName.EnvVarName] = resourceServiceUrl;
+        SetEnvironmentVariableWithFallback(
+            context,
+            DashboardConfigNames.DashboardApplicationName,
+            "AppHost:DashboardApplicationName",
+            transform: DashboardService.GetDashboardApplicationName);
+        SetEnvironmentVariableWithFallback(
+            context,
+            DashboardConfigNames.DashboardDataDirectoryName,
+            DashboardConfigNames.DashboardDataDirectoryName.ConfigKey);
+        SetEnvironmentVariableWithFallback(
+            context,
+            DashboardConfigNames.DashboardPersistenceModeName,
+            "Aspire:Dashboard:PersistenceMode",
+            defaultValue: "Run");
 
         PopulateDashboardUrls(context);
 
@@ -717,7 +731,34 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
         {
             context.EnvironmentVariables[DashboardConfigNames.DebugSessionTelemetryOptOutName.EnvVarName] = optOutValue;
         }
+    }
 
+    private void SetEnvironmentVariableWithFallback(
+        EnvironmentCallbackContext context,
+        ConfigName configName,
+        string fallbackConfigurationKey,
+        string? defaultValue = null,
+        Func<string, string>? transform = null)
+    {
+        if (!string.IsNullOrWhiteSpace(configuration[configName.EnvVarName]))
+        {
+            return;
+        }
+
+        var value = configuration[fallbackConfigurationKey];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            value = defaultValue;
+        }
+        else if (transform is not null)
+        {
+            value = transform(value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            context.EnvironmentVariables[configName.EnvVarName] = value;
+        }
     }
 
     private class EndpointGenerationContext

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -52,18 +52,18 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
         return Task.FromResult(new ApplicationInformationResponse
         {
-            ApplicationName = ComputeApplicationName(applicationName),
+            ApplicationName = GetDashboardApplicationName(applicationName),
             MinDashboardVersion = MinRequiredDashboardVersion
         });
+    }
 
-        static string ComputeApplicationName(string applicationName)
+    internal static string GetDashboardApplicationName(string applicationName)
+    {
+        return ApplicationNameRegex().Match(applicationName) switch
         {
-            return ApplicationNameRegex().Match(applicationName) switch
-            {
-                Match { Success: true } match => match.Groups["name"].Value,
-                _ => applicationName
-            };
-        }
+            Match { Success: true } match => match.Groups["name"].Value,
+            _ => applicationName
+        };
     }
 
     public override async Task WatchInteractions(IAsyncStreamReader<WatchInteractionsRequestUpdate> requestStream, IServerStreamWriter<WatchInteractionsResponseUpdate> responseStream, ServerCallContext context)

--- a/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
@@ -61,7 +61,7 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
 
                 try
                 {
-                    await foreach (var batch in channel.GetBatchesAsync(cancellationToken: linked.Token).ConfigureAwait(false))
+                    await foreach (var batch in channel.GetBatchesAsync(cancellationToken: linked.Token, minReadInterval: TimeSpan.FromMilliseconds(100)).ConfigureAwait(false))
                     {
                         yield return batch;
                     }

--- a/src/Aspire.Hosting/Dcp/DcpHost.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHost.cs
@@ -427,14 +427,7 @@ internal sealed class DcpHost
         var directoryName = Path.GetDirectoryName(socketPath);
         if (!string.IsNullOrEmpty(directoryName))
         {
-            if (OperatingSystem.IsWindows())
-            {
-                Directory.CreateDirectory(directoryName);
-            }
-            else
-            {
-                Directory.CreateDirectory(directoryName, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
-            }
+            DirectoryHelper.CreateWithOwnerOnlyPermissions(directoryName);
         }
 
         var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Model;
+using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Model;
-using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 

--- a/src/Aspire.Hosting/DeveloperCertificateService.cs
+++ b/src/Aspire.Hosting/DeveloperCertificateService.cs
@@ -5,6 +5,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
+using Aspire.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Collections.Immutable;
@@ -390,14 +391,7 @@ internal class DeveloperCertificateService : IDeveloperCertificateService
     {
         try
         {
-            if (OperatingSystem.IsWindows())
-            {
-                Directory.CreateDirectory(s_userDevCertificateLocation);
-            }
-            else
-            {
-                Directory.CreateDirectory(s_userDevCertificateLocation, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
-            }
+            DirectoryHelper.CreateWithOwnerOnlyPermissions(s_userDevCertificateLocation);
 
             File.WriteAllText(certFileName, certificate.ExportCertificatePem());
 

--- a/src/Aspire.Hosting/Pipelines/Internal/FileDeploymentStateManager.cs
+++ b/src/Aspire.Hosting/Pipelines/Internal/FileDeploymentStateManager.cs
@@ -6,6 +6,7 @@
 
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
+using Aspire.Shared;
 using Aspire.Shared.UserSecrets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -104,35 +105,7 @@ internal sealed partial class FileDeploymentStateManager(
 
             var flattenedSecrets = JsonFlattener.FlattenJsonObject(state);
             var deploymentStateDirectory = Path.GetDirectoryName(deploymentStatePath)!;
-            if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
-            {
-                Directory.CreateDirectory(deploymentStateDirectory);
-            }
-            else
-            {
-                var expectedMode = UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead;
-                // Always call CreateDirectory first to avoid race conditions.
-                // CreateDirectory is a no-op if the directory already exists but won't change existing permissions.
-                Directory.CreateDirectory(deploymentStateDirectory, expectedMode);
-
-                try
-                {
-                    var currentMode = File.GetUnixFileMode(deploymentStateDirectory);
-                    if ((currentMode & (UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
-                                        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute)) != 0)
-                    {
-                        logger.LogWarning(
-                            "Deployment state directory '{Directory}' has permissions that allow access to other users. " +
-                            "Consider restricting permissions to the current user only by running: chmod 700 {Directory}",
-                            deploymentStateDirectory,
-                            deploymentStateDirectory);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogDebug(ex, "Unable to check permissions on deployment state directory '{Directory}'.", deploymentStateDirectory);
-                }
-            }
+            DirectoryHelper.CreateWithOwnerOnlyPermissions(deploymentStateDirectory);
             await File.WriteAllTextAsync(
                 deploymentStatePath,
                 flattenedSecrets.ToJsonString(UserSecretsJsonOptions.s_instance),

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -539,7 +539,13 @@ public static class ProjectResourceBuilderExtensions
             builder.WithEnvironment(KnownOtelConfigNames.DotnetExperimentalHttpClientDisableUrlQueryRedaction, "true");
         }
 
-        builder.WithOtlpExporter();
+        // The dashboard generates telemetry while processing received telemetry, so automatically exporting
+        // that telemetry back to the dashboard would create a loop. Dashboard telemetry export is opt-in.
+        if (!string.Equals(builder.Resource.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName))
+        {
+            builder.WithOtlpExporter();
+        }
+
         builder.ConfigureConsoleLogs();
 
         if (OperatingSystem.IsWindows())

--- a/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Lifecycle;
 using Aspire.Shared.TerminalHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -188,21 +187,15 @@ public static class TerminalResourceBuilderExtensions
         // 0700 on Unix so other local users cannot enumerate which terminals exist on
         // this machine. On Windows the user-profile ACLs (per-user by default) make this
         // a no-op; CreateDirectory is idempotent.
-        Directory.CreateDirectory(trmnlDirectory);
-        if (!OperatingSystem.IsWindows())
+        try
         {
-            try
-            {
-                File.SetUnixFileMode(
-                    trmnlDirectory,
-                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-            }
-            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
-            {
-                // Best-effort: directory may already have stricter perms or be on a filesystem
-                // that does not support chmod (e.g. some FAT-formatted home dirs). Per-socket
-                // 0600 in TerminalHostControlListener still protects each endpoint.
-            }
+            DirectoryHelper.CreateWithOwnerOnlyPermissions(trmnlDirectory);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            // Best-effort: directory may already have stricter perms or be on a filesystem
+            // that does not support chmod (e.g. some FAT-formatted home dirs). Per-socket
+            // 0600 in TerminalHostControlListener still protects each endpoint.
         }
 
         var terminalHosts = new TerminalHostResource[replicaCount];

--- a/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
@@ -5,6 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
+using Aspire.Shared;
 using Aspire.Shared.TerminalHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Aspire.Managed/Aspire.Managed.csproj
+++ b/src/Aspire.Managed/Aspire.Managed.csproj
@@ -19,8 +19,9 @@
     <!-- Don't generate web.config or include IIS hosting -->
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
 
-    <!-- Self-contained single-file publish settings (applied only during publish via Bundle.proj) -->
+    <!-- CreateLayout copies only the managed executable, so native dependencies must be embedded in the single file. -->
     <PublishSingleFile>true</PublishSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
 
     <!-- Locate the SDK's trustedroots directory for NuGet signature verification certificates -->
     <_SdkTrustedRootsDir>$([System.IO.Path]::Combine($([System.IO.Path]::GetDirectoryName($(BundledRuntimeIdentifierGraphFile))), 'trustedroots'))</_SdkTrustedRootsDir>
@@ -75,6 +76,11 @@
       <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="$([System.String]::Copy('%(RelativePath)').EndsWith('.runtimeconfig.json'))" />
       <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="$([System.String]::Copy('%(RelativePath)').EndsWith('.staticwebassets.endpoints.json'))" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="ValidateSingleFilePublishConfiguration" BeforeTargets="PrepareForPublish">
+    <Error Condition="'$(PublishSingleFile)' == 'true' and '$(IncludeNativeLibrariesForSelfExtract)' != 'true'"
+           Text="Aspire.Managed single-file publishing must embed native libraries because CreateLayout copies only the managed executable." />
   </Target>
 
 </Project>

--- a/src/Shared/AspireHomeDirectory.cs
+++ b/src/Shared/AspireHomeDirectory.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Shared;
+
+/// <summary>
+/// Resolves the default home directory used by Aspire tools.
+/// </summary>
+internal static class AspireHomeDirectory
+{
+    /// <summary>
+    /// The environment variable that overrides the default Aspire home directory.
+    /// </summary>
+    internal const string EnvironmentVariable = "ASPIRE_HOME";
+
+    /// <summary>
+    /// Gets the configured Aspire home directory, or the default directory in the current user's profile.
+    /// </summary>
+    internal static string GetDefault()
+    {
+        return GetDefault(
+            Environment.GetEnvironmentVariable(EnvironmentVariable),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+    }
+
+    /// <summary>
+    /// Gets the configured Aspire home directory, or the default directory in <paramref name="userProfileDirectory"/>.
+    /// </summary>
+    internal static string GetDefault(string? configuredAspireHome, string userProfileDirectory)
+    {
+        return string.IsNullOrWhiteSpace(configuredAspireHome)
+            ? Path.Combine(userProfileDirectory, ".aspire")
+            : configuredAspireHome;
+    }
+}

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -16,6 +16,9 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardAspireApiDisabledName = new(KnownConfigNames.DashboardApiDisabled);
     public static readonly ConfigName ResourceServiceUrlName = new(KnownConfigNames.ResourceServiceEndpointUrl);
     public static readonly ConfigName ForwardedHeaders = new(KnownConfigNames.DashboardForwardedHeadersEnabled);
+    public static readonly ConfigName DashboardApplicationName = new("Dashboard:ApplicationName", "ASPIRE_DASHBOARD_APPLICATION_NAME");
+    public static readonly ConfigName DashboardDataDirectoryName = new("Dashboard:Data:Directory", "ASPIRE_DASHBOARD_DATA_DIRECTORY");
+    public static readonly ConfigName DashboardPersistenceModeName = new("Dashboard:Data:PersistenceMode", "ASPIRE_DASHBOARD_PERSISTENCE_MODE");
 
     public static readonly ConfigName DashboardOtlpAuthModeName = new("Dashboard:Otlp:AuthMode", "DASHBOARD__OTLP__AUTHMODE");
     public static readonly ConfigName DashboardOtlpPrimaryApiKeyName = new("Dashboard:Otlp:PrimaryApiKey", "DASHBOARD__OTLP__PRIMARYAPIKEY");

--- a/src/Shared/DirectoryHelper.cs
+++ b/src/Shared/DirectoryHelper.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Shared;
+
+/// <summary>
+/// Provides helpers for creating directories with secure platform-specific permissions.
+/// </summary>
+internal static class DirectoryHelper
+{
+    // Unix 0700: only the owner can list entries, create or remove entries, and traverse the directory.
+    // Directories require execute permission for traversal, including access to files within them.
+    private const UnixFileMode OwnerOnlyMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
+    /// <summary>
+    /// Creates a directory and restricts access to the current user on Unix.
+    /// </summary>
+    internal static DirectoryInfo CreateWithOwnerOnlyPermissions(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return Directory.CreateDirectory(path);
+        }
+
+        // Apply 0700 while creating a new directory so there is no window with permissions derived from
+        // the process umask. CreateDirectory doesn't change the mode when the directory already exists,
+        // so SetUnixFileMode is also required to repair an existing permissive directory.
+        var directory = Directory.CreateDirectory(path, OwnerOnlyMode);
+        File.SetUnixFileMode(path, OwnerOnlyMode);
+        return directory;
+    }
+}

--- a/src/Shared/FileLock.cs
+++ b/src/Shared/FileLock.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Cli.Utils;
+namespace Aspire.Shared;
 
 /// <summary>
 /// A cross-process file-based lock that is safe to use with async/await.
@@ -30,6 +30,7 @@ internal sealed class FileLock : IDisposable
     // Short delay keeps latency low under contention without busy-spinning.
     // Matches the delay used by NuGet.Common.ConcurrencyUtilities.
     private static readonly TimeSpan s_defaultRetryDelay = TimeSpan.FromMilliseconds(10);
+    private static readonly TimeSpan s_defaultTimeout = TimeSpan.FromMinutes(5);
 
     private readonly FileStream _stream;
 
@@ -39,9 +40,29 @@ internal sealed class FileLock : IDisposable
     }
 
     /// <summary>
-    /// Default maximum time to wait for the lock before giving up.
+    /// Acquires an exclusive file lock without waiting.
     /// </summary>
-    private static readonly TimeSpan s_defaultTimeout = TimeSpan.FromMinutes(5);
+    public static FileLock Acquire(string lockPath)
+    {
+        CreateLockDirectory(lockPath);
+
+        return new FileLock(CreateLockStream(lockPath));
+    }
+
+    /// <summary>
+    /// Attempts to acquire an exclusive file lock without waiting.
+    /// </summary>
+    public static FileLock? TryAcquire(string lockPath)
+    {
+        try
+        {
+            return Acquire(lockPath);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
 
     /// <summary>
     /// Acquires an exclusive file lock, retrying on contention.
@@ -57,11 +78,7 @@ internal sealed class FileLock : IDisposable
         var effectiveTimeout = timeout ?? s_defaultTimeout;
         var deadline = DateTime.UtcNow + effectiveTimeout;
 
-        var directory = Path.GetDirectoryName(lockPath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
+        CreateLockDirectory(lockPath);
 
         while (true)
         {
@@ -99,6 +116,15 @@ internal sealed class FileLock : IDisposable
     public void Dispose()
     {
         _stream.Dispose();
+    }
+
+    private static void CreateLockDirectory(string lockPath)
+    {
+        var directory = Path.GetDirectoryName(lockPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
     }
 
     /// <summary>

--- a/src/Shared/FormatHelpers.cs
+++ b/src/Shared/FormatHelpers.cs
@@ -76,7 +76,7 @@ internal static class FormatHelpers
         var local = timeProvider.ToLocal(value);
 
         // If the date is today then only return time, otherwise return entire date time text.
-        if (local.Date == DateTime.Now.Date)
+        if (local.Date == timeProvider.GetLocalNow().Date)
         {
             // e.g. "08:57:44" (based on user's culture and preferences)
             // Don't include milliseconds as resource server returned time stamp is second precision.

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -65,6 +65,9 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [InlineData("--otlp-grpc-url http://localhost:4317")]
     [InlineData("--otlp-http-url http://localhost:4318")]
     [InlineData("--allow-anonymous")]
+    [InlineData("--application-name TestApp")]
+    [InlineData("--persistence Run")]
+    [InlineData("--persistence Resume")]
     [InlineData("--config-file-path /path/to/config.json")]
     public void DashboardRunCommand_ParsesOptionsWithoutErrors(string args)
     {
@@ -233,6 +236,9 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     [InlineData("--otlp-grpc-url http://localhost:9317", "--ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:9317")]
     [InlineData("--otlp-http-url http://localhost:9318", "--ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://localhost:9318")]
     [InlineData("--allow-anonymous", "--ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true")]
+    [InlineData("--application-name TestApp", "--ASPIRE_DASHBOARD_APPLICATION_NAME=TestApp")]
+    [InlineData("--persistence Run", "--ASPIRE_DASHBOARD_PERSISTENCE_MODE=Run")]
+    [InlineData("--persistence Resume", "--ASPIRE_DASHBOARD_PERSISTENCE_MODE=Resume")]
     [InlineData("--config-file-path /path/to/config.json", "--ASPIRE_DASHBOARD_CONFIG_FILE_PATH=/path/to/config.json")]
     public async Task DashboardRunCommand_IndividualOption_PassesCorrectArgToProcess(string cliArgs, string expectedArg)
     {
@@ -278,6 +284,26 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DashboardRunCommand_ConfiguresDashboardDebugLogging()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        IDictionary<string, string>? capturedEnv = null;
+        var (services, _, executionFactory) = CreateServicesWithLayout(workspace);
+        executionFactory.AssertionCallback = (_, env, _, _) => { capturedEnv = env; };
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.NotNull(capturedEnv);
+        Assert.Equal("Debug", capturedEnv["Logging__LogLevel__Default"]);
+    }
+
+    [Fact]
     public async Task DashboardRunCommand_UnmatchedTokens_ForwardedToProcess()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -314,7 +340,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse("dashboard run --frontend-url http://localhost:5000 --otlp-grpc-url http://localhost:9317 --otlp-http-url http://localhost:9318 --allow-anonymous --config-file-path /my/config.json");
+        var result = command.Parse("dashboard run --frontend-url http://localhost:5000 --otlp-grpc-url http://localhost:9317 --otlp-http-url http://localhost:9318 --allow-anonymous --application-name TestApp --persistence Run --config-file-path /my/config.json");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -326,6 +352,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
             arg => Assert.Equal("--ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:9317", arg),
             arg => Assert.Equal("--ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL=http://localhost:9318", arg),
             arg => Assert.Equal("--ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true", arg),
+            arg => Assert.Equal("--ASPIRE_DASHBOARD_APPLICATION_NAME=TestApp", arg),
+            arg => Assert.Equal("--ASPIRE_DASHBOARD_PERSISTENCE_MODE=Run", arg),
             arg => Assert.Equal("--ASPIRE_DASHBOARD_API_ENABLED=true", arg),
             arg => Assert.Equal("--ASPIRE_DASHBOARD_CONFIG_FILE_PATH=/my/config.json", arg));
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
+++ b/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <DefineConstants>$(DefineConstants);ASPIRE_DASHBOARD_COMPONENT_TESTS</DefineConstants>
     <!--
       CS8002: Referenced assembly does not have a strong name
     -->
@@ -11,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
     <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="bUnit" />
   </ItemGroup>
 
@@ -29,7 +31,8 @@
     <Compile Include="$(TestsSharedDir)TestDialogService.cs" Link="shared/TestDialogService.cs" />
     <Compile Include="$(TestsSharedDir)TestSessionStorage.cs" Link="shared/TestSessionStorage.cs" />
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
-    <Compile Include="$(TestsSharedDir)Telemetry\*.cs" LinkBase="shared/Telemetry" />
+    <Compile Include="$(TestsSharedDir)TemporaryWorkspace.cs" Link="shared/TemporaryWorkspace.cs" />
+    <Compile Include="$(TestsSharedDir)Telemetry\TelemetryTestHelpers.cs" Link="shared/Telemetry/TelemetryTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
     <Compile Include="$(TestsSharedDir)DashboardModel\*.cs" LinkBase="shared/DashboardModel" />
     <Compile Include="..\Aspire.Dashboard.Tests\Model\MockKnownPropertyLookup.cs" Link="Shared\MockKnownPropertyLookup.cs" />

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Tests.Shared;
+using Aspire.DashboardService.Proto.V1;
 using Bunit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -68,9 +69,12 @@ public class ApplicationNameTests : DashboardTestContext
         Services.AddLocalization();
         Services.AddSingleton<IConfiguration>(new ConfigurationManager());
         Services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        Services.AddSingleton<DashboardActivitySource>();
+        // Use the real client intentionally to verify ApplicationName and DashboardClient work together.
         Services.AddSingleton<IDashboardClient, DashboardClient>();
         Services.AddSingleton<BrowserTimeProvider>();
         Services.AddSingleton<IKnownPropertyLookup>(new MockKnownPropertyLookup());
+        Services.AddSingleton<IResourceRepositoryWriter, NoopResourceRepositoryWriter>();
     }
 
     private sealed class TestStringLocalizer<T> : IStringLocalizer<T>
@@ -79,5 +83,14 @@ public class ApplicationNameTests : DashboardTestContext
         public LocalizedString this[string name, params object[] arguments] => new LocalizedString(name, $"Localized:{name}:" + string.Join("+", arguments));
 
         public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+    }
+
+    private sealed class NoopResourceRepositoryWriter : IResourceRepositoryWriter
+    {
+        public Task ReplaceResourcesAsync(IReadOnlyList<Resource> resources) => Task.CompletedTask;
+        public Task ApplyChangesAsync(IReadOnlyList<WatchResourcesChange> changes) => Task.CompletedTask;
+        public Task MarkConsoleLogsLoadedAsync(string resourceName) => Task.CompletedTask;
+        public Task AddConsoleLogsAsync(string resourceName, IReadOnlyList<ConsoleLogLine> logLines) => Task.CompletedTask;
+        public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate) => Task.CompletedTask;
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
@@ -13,6 +13,22 @@ namespace Aspire.Dashboard.Components.Tests.Controls;
 public class AspireMenuButtonTests : DashboardTestContext
 {
     [Fact]
+    public void Disabled_DisablesButton()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+
+        var cut = RenderComponent<AspireMenuButton>(builder => builder
+            .Add(component => component.MenuButtonId, "disabled-menu-button")
+            .Add(component => component.ItemsProvider, () => [new MenuButtonItem { Text = "Item" }])
+            .Add(component => component.Disabled, true));
+
+        Assert.True(cut.FindComponent<FluentButton>().Instance.Disabled);
+    }
+
+    [Fact]
     public void Render_AddsMenuPopupAriaWithoutExpandedState()
     {
         FluentUISetupHelpers.SetupFluentUIComponents(this);

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
@@ -5,13 +5,65 @@ using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Tests.Controls;
 
 public class AspireMenuTests : DashboardTestContext
 {
+    [Fact]
+    public async Task ClickSecondaryAction_RefreshesOpenMenu()
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+
+        var item = new MenuButtonItem
+        {
+            Text = "Historical run",
+            SecondaryActionIcon = new Icons.Regular.Size16.Pin(),
+            SecondaryActionAriaLabel = "Pin run"
+        };
+        item.OnSecondaryActionClick = () =>
+        {
+            item.SecondaryActionIcon = new Icons.Filled.Size16.Pin();
+            item.SecondaryActionAriaLabel = "Unpin run";
+            item.IsSecondaryActionSelected = true;
+            return Task.CompletedTask;
+        };
+
+        var menuService = Services.GetRequiredService<IMenuService>();
+        var provider = RenderComponent<FluentMenuProvider>();
+        var menuHost = RenderComponent<CascadingValue<bool>>(builder =>
+        {
+            builder.Add(p => p.Value, false);
+            builder.AddChildContent<AspireMenu>(menuBuilder =>
+            {
+                menuBuilder.Add(p => p.Anchor, "menu-anchor");
+                menuBuilder.Add(p => p.Open, true);
+                menuBuilder.Add(p => p.Items, new[] { item });
+            });
+        });
+        var menu = menuHost.FindComponent<FluentMenu>().Instance;
+        await menuHost.InvokeAsync(() => menuService.RefreshMenuAsync(menu.Id!, isOpen: true));
+
+        var pinButton = provider.WaitForElement("fluent-button[aria-label='Pin run']");
+        Assert.Equal("false", pinButton.GetAttribute("aria-pressed"));
+        pinButton.Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            Assert.Single(provider.FindComponents<FluentMenu>());
+            var unpinButton = provider.Find("fluent-button[aria-label='Unpin run']");
+            Assert.Equal("true", unpinButton.GetAttribute("aria-pressed"));
+        });
+    }
+
     [Fact]
     public void UnanchoredAspireMenu_RendersFluentMenu()
     {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
@@ -176,12 +176,14 @@ public class ChartFiltersTests : DashboardTestContext
         Assert.Equal(["DELETE", "GET", "POST"], ordered);
     }
 
-    private IRenderedComponent<ChartFilters> RenderChartFilters(DimensionFilterViewModel dimensionFilter, Action<DimensionFilterViewModel>? onDimensionValuesChanged = null)
+    private IRenderedComponent<ChartFilters> RenderChartFilters(
+        DimensionFilterViewModel dimensionFilter,
+        Action<DimensionFilterViewModel>? onDimensionValuesChanged = null)
     {
         return RenderComponent<ChartFilters>(builder =>
         {
-            builder.Add(p => p.Instrument, CreateInstrument());
-            builder.Add(p => p.InstrumentViewModel, new InstrumentViewModel());
+            builder.Add(p => p.InstrumentType, OtlpInstrumentType.Sum);
+            builder.Add(p => p.ShowCount, false);
             builder.Add(p => p.DimensionFilters, [dimensionFilter]);
             if (onDimensionValuesChanged is not null)
             {
@@ -209,22 +211,4 @@ public class ChartFiltersTests : DashboardTestContext
         return dimensionFilter;
     }
 
-    private static OtlpInstrumentData CreateInstrument()
-    {
-        return new OtlpInstrumentData
-        {
-            Summary = new OtlpInstrumentSummary
-            {
-                Name = "request-duration",
-                Description = string.Empty,
-                Unit = "ms",
-                Type = OtlpInstrumentType.Sum,
-                AggregationTemporality = OtlpAggregationTemporality.Cumulative,
-                Parent = new OtlpScope("meter", string.Empty, [])
-            },
-            Dimensions = [],
-            KnownAttributeValues = [],
-            HasOverflow = false
-        };
-    }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/GenAIVisualizerDialogTests.cs
@@ -41,10 +41,11 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             dialogService: dialogService,
             span: CreateOtlpSpan(resource, trace, scope, spanId: "abc", parentSpanId: null, startDate: s_testTime),
             selectedLogEntryId: null,
-            telemetryRepository: Services.GetRequiredService<TelemetryRepository>(),
+            telemetryRepository: Services.GetRequiredService<SqliteTelemetryRepository>(),
             errorRecorder: new TestTelemetryErrorRecorder(),
             resources: [],
-            getContextGenAISpans: () => []
+            getContextGenAISpans: () => [],
+            cancellationToken: CancellationToken.None
             );
 
         var instance = cut.FindComponent<GenAIVisualizerDialog>().Instance;
@@ -107,10 +108,11 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             dialogService: dialogService,
             span: span,
             selectedLogEntryId: null,
-            telemetryRepository: Services.GetRequiredService<TelemetryRepository>(),
+            telemetryRepository: Services.GetRequiredService<SqliteTelemetryRepository>(),
             errorRecorder: new TestTelemetryErrorRecorder(),
             resources: [],
-            getContextGenAISpans: () => []
+            getContextGenAISpans: () => [],
+            cancellationToken: CancellationToken.None
             );
 
         var instance = cut.FindComponent<GenAIVisualizerDialog>().Instance;
@@ -129,8 +131,8 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         var span = CreateOtlpSpan(resource, trace, scope, spanId: GetHexId("abc"), parentSpanId: null, startDate: s_testTime);
 
         var cut = SetUpDialog(out var dialogService);
-        var repository = Services.GetRequiredService<TelemetryRepository>();
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        var repository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -152,7 +154,7 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
                 }
             }
         });
-        var selectedLogEntryId = repository.GetLogsForSpan(trace.TraceId, span.SpanId).Single().InternalId;
+        var selectedLogEntryId = (await repository.GetLogsForSpanAsync(trace.TraceId, span.SpanId, CancellationToken.None)).Single().InternalId;
 
         await GenAIVisualizerDialog.OpenDialogAsync(
             dialogService: dialogService,
@@ -161,7 +163,8 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             telemetryRepository: repository,
             errorRecorder: new TestTelemetryErrorRecorder(),
             resources: [],
-            getContextGenAISpans: () => []
+            getContextGenAISpans: () => [],
+            cancellationToken: CancellationToken.None
             );
 
         var copyButton = cut.Find("fluent-button.message-copy-button");
@@ -177,11 +180,11 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
     {
         // Arrange - Setup dialog infrastructure and repository
         var cut = SetUpDialog(out var dialogService);
-        var repository = Services.GetRequiredService<TelemetryRepository>();
+        var repository = Services.GetRequiredService<SqliteTelemetryRepository>();
         
         // Add initial trace to repository for the dialog to display
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -203,13 +206,13 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         // Get the resource and trace
         var resources = repository.GetResources();
         var resource = resources[0];
-        var tracesResult = repository.GetTraces(new GetTracesRequest
+        var tracesResult = await repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, CancellationToken.None);
         var trace = tracesResult.PagedResult.Items[0];
         var span = trace.Spans[0];
 
@@ -221,14 +224,15 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             telemetryRepository: repository,
             errorRecorder: new TestTelemetryErrorRecorder(),
             resources: resources,
-            getContextGenAISpans: () => []
+            getContextGenAISpans: () => [],
+            cancellationToken: CancellationToken.None
         );
 
         var instance = cut.FindComponent<GenAIVisualizerDialog>().Instance;
         var originalContent = instance.Content;
 
         // Act - Add a DIFFERENT trace to the repository
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -260,11 +264,11 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
     {
         // Arrange - Setup dialog infrastructure and repository
         var cut = SetUpDialog(out var dialogService);
-        var repository = Services.GetRequiredService<TelemetryRepository>();
+        var repository = Services.GetRequiredService<SqliteTelemetryRepository>();
         
         // Add initial trace to repository for the dialog to display
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -286,26 +290,20 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
         // Get the resource and trace
         var resources = repository.GetResources();
         var resource = resources[0];
-        var tracesResult = repository.GetTraces(new GetTracesRequest
+        var tracesResult = await repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, CancellationToken.None);
         var trace = tracesResult.PagedResult.Items[0];
         var span = trace.Spans[0];
 
         // Create a function that retrieves the current list of spans from the trace
         List<OtlpSpan> GetContextGenAISpans()
         {
-            var currentTrace = repository.GetTraces(new GetTracesRequest
-            {
-                ResourceKeys = [resource.ResourceKey],
-                StartIndex = 0,
-                Count = 10,
-                Filters = []
-            }).PagedResult.Items.FirstOrDefault(t => t.TraceId == trace.TraceId);
+            var currentTrace = repository.GetTrace(trace.TraceId);
             
             return currentTrace?.Spans.ToList() ?? [];
         }
@@ -318,14 +316,15 @@ public class GenAIVisualizerDialogTests : DashboardTestContext
             telemetryRepository: repository,
             errorRecorder: new TestTelemetryErrorRecorder(),
             resources: resources,
-            getContextGenAISpans: GetContextGenAISpans
+            getContextGenAISpans: GetContextGenAISpans,
+            cancellationToken: CancellationToken.None
         );
 
         var instance = cut.FindComponent<GenAIVisualizerDialog>().Instance;
         var originalContent = instance.Content;
 
         // Act - Add a new span to the SAME trace that the dialog is displaying
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -61,18 +61,16 @@ public class PlotlyChartTests : DashboardTestContext
         var options = new TelemetryLimitOptions();
         var logger = NullLogger.Instance;
         var context = new OtlpContext { Options = options, Logger = logger };
-        var instrument = new OtlpInstrument
+        var resource = new OtlpResource("resource", instanceId: null, uninstrumentedPeer: false, context);
+        var instrumentSummary = new OtlpInstrumentSummary
         {
-            Summary = new OtlpInstrumentSummary
-            {
-                Name = "Name-<b>Bold</b>",
-                Unit = "Unit-<b>Bold</b>",
-                Description = "Description-<b>Bold</b>",
-                Parent = new OtlpScope("Parent-Name-<b>Bold</b>", string.Empty, []),
-                Type = OtlpInstrumentType.Sum,
-                AggregationTemporality = OtlpAggregationTemporality.Cumulative
-            },
-            Context = context
+            Name = "Name-<b>Bold</b>",
+            Unit = "Unit-<b>Bold</b>",
+            Description = "Description-<b>Bold</b>",
+            Parent = new OtlpScope("Parent-Name-<b>Bold</b>", string.Empty, []),
+            Type = OtlpInstrumentType.Sum,
+            AggregationTemporality = OtlpAggregationTemporality.Cumulative,
+            ResourceView = new OtlpResourceView(resource, Array.Empty<KeyValuePair<string, string>>())
         };
 
         var model = new InstrumentViewModel();
@@ -84,7 +82,7 @@ public class PlotlyChartTests : DashboardTestContext
             TimeUnixNano = long.MaxValue
         }, context);
 
-        await model.UpdateDataAsync(instrument.Summary, [dimension]);
+        await model.UpdateDataAsync(instrumentSummary, [dimension]);
 
         // Act
         var cut = RenderComponent<PlotlyChart>(builder =>
@@ -114,5 +112,39 @@ public class PlotlyChartTests : DashboardTestContext
                 });
                 Assert.Equal(expectedPlotlyTimeFormat, Assert.IsType<PlotlyUserLocale>(i.Arguments[5]).Time);
             });
+    }
+
+    [Fact]
+    public async Task UpdateDataAsync_SubscriptionRemovedDuringUpdate_CompletesSuccessfully()
+    {
+        var model = new InstrumentViewModel();
+        var firstSubscriptionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueFirstSubscription = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSubscriptionCalled = false;
+
+        async Task FirstSubscription()
+        {
+            firstSubscriptionStarted.SetResult();
+            await continueFirstSubscription.Task;
+        }
+
+        Task SecondSubscription()
+        {
+            secondSubscriptionCalled = true;
+            return Task.CompletedTask;
+        }
+
+        model.AddDataUpdateSubscription(FirstSubscription);
+        model.AddDataUpdateSubscription(SecondSubscription);
+
+        var updateTask = model.UpdateDataAsync(null!, []);
+        await firstSubscriptionStarted.Task;
+
+        model.RemoveDataUpdateSubscription(SecondSubscription);
+        continueFirstSubscription.SetResult();
+
+        await updateTask;
+
+        Assert.True(secondSubscriptionCalled);
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/StructuredLogDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/StructuredLogDetailsTests.cs
@@ -32,7 +32,7 @@ public class StructuredLogDetailsTests : DashboardTestContext
         });
         var model = new StructureLogsDetailsViewModel
         {
-            LogEntry = new OtlpLogEntry(
+            LogEntry = TelemetryTestHelpers.CreateOtlpLogEntry(
                 record: TelemetryTestHelpers.CreateLogRecord(attributes:
                 [
                     KeyValuePair.Create("Message", "value1"),

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/TotalItemsFooterTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/TotalItemsFooterTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Tests.Shared;
+using Bunit;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Controls;
+
+public class TotalItemsFooterTests : DashboardTestContext
+{
+    [Fact]
+    public async Task UpdateDisplayedCount_WithDisplayedItemCount_DisplaysPartialCount()
+    {
+        var cut = RenderComponent<TotalItemsFooter>(builder => builder
+            .Add(p => p.TotalItemCount, 0)
+            .Add(p => p.SingularText, "Showing <strong>{0} item</strong>")
+            .Add(p => p.PluralText, "Showing <strong>{0} items</strong>")
+            .Add(p => p.PartialText, "Showing <strong>{0} of {1} logs</strong>. Use filters to narrow the results"));
+
+        await cut.InvokeAsync(() => cut.Instance.UpdateDisplayedCount(totalItemCount: 600_000, displayedItemCount: 200_000));
+
+        Assert.Equal("Showing 200000 of 600000 logs. Use filters to narrow the results", cut.Find(".result-count").TextContent.Trim());
+        Assert.Equal("200000 of 600000 logs", cut.Find(".result-count strong").TextContent);
+
+        await cut.InvokeAsync(() => cut.Instance.UpdateDisplayedCount(totalItemCount: 100, displayedItemCount: null));
+
+        Assert.Equal("Showing 100 items", cut.Find(".result-count").TextContent);
+
+        await cut.InvokeAsync(() => cut.Instance.UpdateDisplayedCount(totalItemCount: 100, displayedItemCount: 100));
+
+        Assert.Equal("Showing 100 items", cut.Find(".result-count").TextContent);
+    }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/FilterDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/FilterDialogTests.cs
@@ -58,6 +58,8 @@ public class FilterDialogTests : DashboardTestContext
 
         Assert.Empty(cut.FindComponents<FluentNumberField<double?>>());
         Assert.Contains("fluent-combobox", cut.Markup);
+        Assert.Equal(3, cut.FindAll(".filter-input-container > label").Count);
+        Assert.Empty(cut.FindAll(".input-line-container label"));
 
         var conditionSelect = Assert.Single(cut.FindComponents<FluentSelect<SelectViewModel<FilterCondition>>>());
         Assert.Collection(conditionSelect.Instance.Items!,
@@ -65,6 +67,294 @@ public class FilterDialogTests : DashboardTestContext
             item => Assert.Equal(FilterCondition.Contains, item.Id),
             item => Assert.Equal(FilterCondition.NotEqual, item.Id),
             item => Assert.Equal(FilterCondition.NotContains, item.Id));
+    }
+
+    [Fact]
+    public async Task Render_PropertyKeysLoading_DisablesParameterSelectAndDisplaysProgressRing()
+    {
+        SetupFilterDialogServices();
+        var loadingStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var propertyKeys = new TaskCompletionSource<List<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var content = CreateContent(new FieldTelemetryFilter
+        {
+            Field = KnownTraceFields.NameField,
+            Condition = FilterCondition.Contains,
+            Value = "request"
+        });
+        content = new FilterDialogViewModel
+        {
+            Filter = content.Filter,
+            KnownKeys = content.KnownKeys,
+            GetPropertyKeysAsync = _ =>
+            {
+                loadingStarted.SetResult();
+                return propertyKeys.Task;
+            },
+            GetFieldValuesAsync = content.GetFieldValuesAsync
+        };
+
+        var cut = RenderComponent<FilterDialog>(builder => builder.Add(p => p.Content, content));
+        await loadingStarted.Task.WaitAsync(DefaultWaitTimeout);
+
+        Assert.True(cut.FindComponent<FluentSelect<SelectViewModel<string>>>().Instance.Disabled);
+        Assert.Single(cut.FindComponents<FluentProgressRing>());
+        Assert.NotNull(cut.Find(".input-line-container .input-progress"));
+
+        propertyKeys.SetResult(["custom.attribute"]);
+
+        cut.WaitForAssertion(() =>
+        {
+            var parameterSelect = cut.FindComponent<FluentSelect<SelectViewModel<string>>>();
+            Assert.False(parameterSelect.Instance.Disabled);
+            Assert.Empty(cut.FindComponents<FluentProgressRing>());
+            Assert.Contains(parameterSelect.Instance.Items!, item => item.Id == "custom.attribute");
+        });
+    }
+
+    [Fact]
+    public async Task Render_FieldValuesLoading_DisablesValueComboboxAndDisplaysProgressRing()
+    {
+        SetupFilterDialogServices();
+        var loadingStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fieldValues = new TaskCompletionSource<Dictionary<string, int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var content = CreateContent(new FieldTelemetryFilter
+        {
+            Field = KnownTraceFields.NameField,
+            Condition = FilterCondition.Contains,
+            Value = "request"
+        });
+        content = new FilterDialogViewModel
+        {
+            Filter = content.Filter,
+            KnownKeys = content.KnownKeys,
+            GetPropertyKeysAsync = content.GetPropertyKeysAsync,
+            GetFieldValuesAsync = (_, _) =>
+            {
+                loadingStarted.SetResult();
+                return fieldValues.Task;
+            }
+        };
+
+        var cut = RenderComponent<FilterDialog>(builder => builder.Add(p => p.Content, content));
+        await loadingStarted.Task.WaitAsync(DefaultWaitTimeout);
+
+        Assert.True(cut.Find("fluent-combobox").HasAttribute("disabled"));
+        Assert.Single(cut.FindAll("fluent-combobox + fluent-progress-ring"));
+
+        fieldValues.SetResult(new Dictionary<string, int> { ["request"] = 1 });
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.False(cut.Find("fluent-combobox").HasAttribute("disabled"));
+            Assert.Empty(cut.FindAll("fluent-combobox + fluent-progress-ring"));
+        });
+    }
+
+    [Fact]
+    public async Task Render_ChangingStringFieldAfterValuesLoad_LoadsNewValues()
+    {
+        SetupFilterDialogServices();
+        var loadedFields = new List<string>();
+        var content = new FilterDialogViewModel
+        {
+            Filter = new FieldTelemetryFilter
+            {
+                Field = KnownTraceFields.NameField,
+                Condition = FilterCondition.Contains,
+                Value = "request"
+            },
+            KnownKeys = [KnownTraceFields.NameField, KnownTraceFields.TraceIdField],
+            GetPropertyKeysAsync = static _ => Task.FromResult<List<string>>([]),
+            GetFieldValuesAsync = (field, _) =>
+            {
+                loadedFields.Add(field);
+                return Task.FromResult<Dictionary<string, int>>([]);
+            }
+        };
+
+        var cut = RenderComponent<FilterDialog>(builder => builder.Add(p => p.Content, content));
+        var parameterSelect = cut.FindComponent<FluentSelect<SelectViewModel<string>>>();
+        var traceIdOption = parameterSelect.Instance.Items!.Single(item => item.Id == KnownTraceFields.TraceIdField);
+
+        await parameterSelect.InvokeAsync(() => parameterSelect.Instance.SelectedOptionChanged.InvokeAsync(traceIdOption));
+
+        Assert.Collection(loadedFields,
+            field => Assert.Equal(KnownTraceFields.NameField, field),
+            field => Assert.Equal(KnownTraceFields.TraceIdField, field));
+        Assert.False(cut.Find("fluent-combobox").HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public async Task Render_FieldValueReadsCompleteOutOfOrder_LatestValuesDisplayed()
+    {
+        SetupFilterDialogServices();
+        var firstLoadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondLoadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstFieldValues = new TaskCompletionSource<Dictionary<string, int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondFieldValues = new TaskCompletionSource<Dictionary<string, int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var content = new FilterDialogViewModel
+        {
+            Filter = new FieldTelemetryFilter
+            {
+                Field = KnownTraceFields.NameField,
+                Condition = FilterCondition.Contains,
+                Value = "request"
+            },
+            KnownKeys = [KnownTraceFields.NameField, KnownTraceFields.TraceIdField, KnownTraceFields.SpanIdField],
+            GetPropertyKeysAsync = static _ => Task.FromResult<List<string>>([]),
+            GetFieldValuesAsync = (field, _) => field switch
+            {
+                KnownTraceFields.NameField => Task.FromResult<Dictionary<string, int>>([]),
+                KnownTraceFields.TraceIdField => StartLoad(firstLoadStarted, firstFieldValues),
+                KnownTraceFields.SpanIdField => StartLoad(secondLoadStarted, secondFieldValues),
+                _ => throw new InvalidOperationException($"Unexpected field '{field}'.")
+            }
+        };
+
+        var cut = RenderComponent<FilterDialog>(builder => builder.Add(p => p.Content, content));
+        var parameterSelect = cut.FindComponent<FluentSelect<SelectViewModel<string>>>();
+        var traceIdOption = parameterSelect.Instance.Items!.Single(item => item.Id == KnownTraceFields.TraceIdField);
+        var spanIdOption = parameterSelect.Instance.Items!.Single(item => item.Id == KnownTraceFields.SpanIdField);
+
+        var firstChangeTask = parameterSelect.InvokeAsync(() => parameterSelect.Instance.SelectedOptionChanged.InvokeAsync(traceIdOption));
+        await firstLoadStarted.Task.WaitAsync(DefaultWaitTimeout);
+        var secondChangeTask = parameterSelect.InvokeAsync(() => parameterSelect.Instance.SelectedOptionChanged.InvokeAsync(spanIdOption));
+        await secondLoadStarted.Task.WaitAsync(DefaultWaitTimeout);
+
+        secondFieldValues.SetResult(new Dictionary<string, int> { ["latest-value"] = 1 });
+        await secondChangeTask;
+        firstFieldValues.SetResult(new Dictionary<string, int> { ["stale-value"] = 1 });
+        await firstChangeTask;
+
+        cut.WaitForAssertion(() =>
+        {
+            var options = cut.Find("fluent-combobox").QuerySelectorAll("fluent-option");
+            var option = Assert.Single(options);
+            Assert.Contains("latest-value", option.TextContent, StringComparison.Ordinal);
+        });
+
+        static Task<Dictionary<string, int>> StartLoad(
+            TaskCompletionSource loadStarted,
+            TaskCompletionSource<Dictionary<string, int>> fieldValues)
+        {
+            loadStarted.SetResult();
+            return fieldValues.Task;
+        }
+    }
+
+    [Fact]
+    public async Task Render_PropertyKeysReadFails_ClearsLoadingState()
+    {
+        SetupFilterDialogServices();
+        var loadingStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var propertyKeys = new TaskCompletionSource<List<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var content = CreateContent(new FieldTelemetryFilter
+        {
+            Field = KnownTraceFields.NameField,
+            Condition = FilterCondition.Contains,
+            Value = "request"
+        });
+        content = new FilterDialogViewModel
+        {
+            Filter = content.Filter,
+            KnownKeys = content.KnownKeys,
+            GetPropertyKeysAsync = _ =>
+            {
+                loadingStarted.SetResult();
+                return propertyKeys.Task;
+            },
+            GetFieldValuesAsync = content.GetFieldValuesAsync
+        };
+
+        var cut = RenderComponent<FilterDialog>(builder => builder.Add(p => p.Content, content));
+        await loadingStarted.Task.WaitAsync(DefaultWaitTimeout);
+        Assert.Single(cut.FindComponents<FluentProgressRing>());
+
+        propertyKeys.SetException(new InvalidOperationException("Database read failed."));
+
+        // A failed read must still clear the loading state. Otherwise the parameter select stays disabled behind a
+        // spinner for the life of the dialog and the user cannot pick a different field.
+        cut.WaitForAssertion(() =>
+        {
+            Assert.False(cut.FindComponent<FluentSelect<SelectViewModel<string>>>().Instance.Disabled);
+            Assert.Empty(cut.FindComponents<FluentProgressRing>());
+        });
+    }
+
+    [Fact]
+    public async Task Render_FieldValuesReadFails_ClearsLoadingState()
+    {
+        SetupFilterDialogServices();
+        var loadingStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fieldValues = new TaskCompletionSource<Dictionary<string, int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var content = CreateContent(new FieldTelemetryFilter
+        {
+            Field = KnownTraceFields.NameField,
+            Condition = FilterCondition.Contains,
+            Value = "request"
+        });
+        content = new FilterDialogViewModel
+        {
+            Filter = content.Filter,
+            KnownKeys = content.KnownKeys,
+            GetPropertyKeysAsync = content.GetPropertyKeysAsync,
+            GetFieldValuesAsync = (_, _) =>
+            {
+                loadingStarted.SetResult();
+                return fieldValues.Task;
+            }
+        };
+
+        var cut = RenderComponent<FilterDialog>(builder => builder.Add(p => p.Content, content));
+        await loadingStarted.Task.WaitAsync(DefaultWaitTimeout);
+        Assert.True(cut.Find("fluent-combobox").HasAttribute("disabled"));
+
+        fieldValues.SetException(new InvalidOperationException("Database read failed."));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.False(cut.Find("fluent-combobox").HasAttribute("disabled"));
+            Assert.Empty(cut.FindAll("fluent-combobox + fluent-progress-ring"));
+        });
+    }
+
+    [Fact]
+    public async Task DisposeAsync_InFlightRead_CancelsToken()
+    {
+        SetupFilterDialogServices();
+        var loadingStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var propertyKeys = new TaskCompletionSource<List<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var readCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var content = CreateContent(new FieldTelemetryFilter
+        {
+            Field = KnownTraceFields.NameField,
+            Condition = FilterCondition.Contains,
+            Value = "request"
+        });
+        content = new FilterDialogViewModel
+        {
+            Filter = content.Filter,
+            KnownKeys = content.KnownKeys,
+            GetPropertyKeysAsync = cancellationToken =>
+            {
+                cancellationToken.Register(() => readCancelled.TrySetResult());
+                loadingStarted.SetResult();
+                return propertyKeys.Task;
+            },
+            GetFieldValuesAsync = content.GetFieldValuesAsync
+        };
+
+        var cut = RenderComponent<FilterDialog>(builder => builder.Add(p => p.Content, content));
+        await loadingStarted.Task.WaitAsync(DefaultWaitTimeout);
+
+        // Telemetry reads run against SQLite on the thread pool. Closing the dialog must cancel them so a scan
+        // started for a dialog nobody is looking at does not keep running.
+        await cut.Instance.DisposeAsync();
+
+        await readCancelled.Task.WaitAsync(DefaultWaitTimeout);
+
+        // Complete the read so the component's initialization task does not stay pending past the test.
+        propertyKeys.SetResult([]);
     }
 
     private void SetupFilterDialogServices()
@@ -84,10 +374,10 @@ public class FilterDialogTests : DashboardTestContext
         {
             Filter = filter,
             KnownKeys = [KnownTraceFields.NameField, KnownTraceFields.DurationField],
-            PropertyKeys = [],
-            GetFieldValues = field => field == KnownTraceFields.NameField
+            GetPropertyKeysAsync = static _ => Task.FromResult<List<string>>([]),
+            GetFieldValuesAsync = static (field, _) => Task.FromResult(field == KnownTraceFields.NameField
                 ? new Dictionary<string, int> { ["request"] = 1 }
-                : []
+                : [])
         };
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/InteractionsInputDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/InteractionsInputDialogTests.cs
@@ -37,6 +37,7 @@ public sealed class InteractionsInputDialogTests : DashboardTestContext
         {
             Interaction = interaction,
             Message = string.Empty,
+            DashboardClient = new TestDashboardClient(),
             OnSubmitCallback = (_, _) => Task.CompletedTask
         };
 
@@ -121,8 +122,6 @@ public sealed class InteractionsInputDialogTests : DashboardTestContext
 
     private IRenderedFragment SetUpDialog(out IDialogService dialogService)
     {
-        Services.AddSingleton<IDashboardClient>(new TestDashboardClient());
-
         FluentUISetupHelpers.SetupDialogInfrastructure(this);
         FluentUISetupHelpers.SetupFluentInputLabel(this);
         FluentUISetupHelpers.SetupFluentTextField(this);
@@ -156,6 +155,7 @@ public sealed class InteractionsInputDialogTests : DashboardTestContext
         {
             Interaction = interaction,
             Message = string.Empty,
+            DashboardClient = new TestDashboardClient(),
             OnSubmitCallback = (_, _) => Task.CompletedTask
         };
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/InteractionsInputDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/InteractionsInputDialogTests.cs
@@ -93,6 +93,7 @@ public sealed class InteractionsInputDialogTests : DashboardTestContext
         {
             Interaction = interaction,
             Message = string.Empty,
+            DashboardClient = new TestDashboardClient(),
             OnSubmitCallback = (_, _) => Task.CompletedTask
         };
         await dialogService.ShowDialogAsync<InteractionsInputDialog>(viewModel, new DialogParameters

--- a/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Dialogs/ManageDataDialogTests.cs
@@ -152,15 +152,17 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         Assert.Equal(0, clickCount);
     }
 
-    [Fact]
-    public async Task Render_ClearedSignals_PrunesSelectionsAndSupportsRemovingEmptyResource()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Render_ClearedSignals_PrunesSelectionsAndSupportsRemovingEmptyResource(bool dashboardClientIsReadOnly)
     {
-        var dashboardClient = new TestDashboardClient(isEnabled: false, initialResources: []);
+        var dashboardClient = new TestDashboardClient(isEnabled: false, initialResources: [], isReadOnly: dashboardClientIsReadOnly);
         SetupManageDataDialogServices(dashboardClient);
 
-        var repository = Services.GetRequiredService<TelemetryRepository>();
+        var repository = Services.GetRequiredService<SqliteTelemetryRepository>();
         var resourceKey = new ResourceKey("orphan", "instance");
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -176,7 +178,7 @@ public sealed class ManageDataDialogTests : DashboardTestContext
             }
         });
         var timestamp = DateTime.UnixEpoch;
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -205,7 +207,7 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         cut.WaitForAssertion(() => AssertSelectionCheckbox(cut, "Structured logs for orphan", "true"));
         await ClickSelectionCheckboxAsync(cut, "Structured logs for orphan", "true");
 
-        repository.ClearTraces(resourceKey);
+        await repository.ClearTracesAsync(resourceKey);
 
         cut.WaitForAssertion(() =>
         {
@@ -215,7 +217,7 @@ public sealed class ManageDataDialogTests : DashboardTestContext
             AssertButtonDisabled(cut, "Remove selected", expectedDisabled: true);
         });
 
-        repository.ClearStructuredLogs(resourceKey);
+        await repository.ClearStructuredLogsAsync(resourceKey);
 
         cut.WaitForAssertion(() =>
         {
@@ -241,6 +243,35 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         cut.WaitForAssertion(() => Assert.Empty(repository.GetResources()));
     }
 
+    [Fact]
+    public void RemoveSelected_ConsoleLogs_ClearsPersistenceAndUpdatesFilter()
+    {
+        var resource = ModelTestHelpers.CreateResource(
+            resourceName: "api",
+            displayName: "API service",
+            state: KnownResourceState.Running);
+        var resourcesChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            initialResources: [resource],
+            resourceChannelProvider: () => resourcesChannel);
+        SetupManageDataDialogServices(dashboardClient);
+
+        var cut = RenderComponent<ManageDataDialog>();
+        cut.WaitForAssertion(() => AssertButtonDisabled(cut, "Remove selected", expectedDisabled: false));
+
+        cut.Find("fluent-button[aria-label='Remove selected']").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var clearedConsoleLogs = Assert.Single(dashboardClient.ClearedConsoleLogs);
+            Assert.Collection(
+                clearedConsoleLogs.ResourceNames,
+                resourceName => Assert.Equal("api", resourceName));
+            Assert.Equal(clearedConsoleLogs.ClearDate, Services.GetRequiredService<ConsoleLogsManager>().GetFilterDate("api"));
+        });
+    }
+
     private void SetupManageDataDialogServices(TestDashboardClient dashboardClient)
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
@@ -249,8 +280,9 @@ public sealed class ManageDataDialogTests : DashboardTestContext
         Services.AddSingleton<IDashboardClient>(dashboardClient);
         Services.AddSingleton<IconResolver>();
         Services.AddSingleton<ConsoleLogsManager>();
-        Services.AddSingleton<ConsoleLogsFetcher>();
-        Services.AddSingleton<TelemetryExportService>();
+        Services.AddScoped<ConsoleLogsFetcher>();
+        Services.AddScoped<TelemetryExportService>();
+        Services.AddSingleton<DashboardActivitySource>();
         Services.AddSingleton<TelemetryImportService>();
 
         FluentUISetupHelpers.SetupFluentUIComponents(this);

--- a/tests/Aspire.Dashboard.Components.Tests/Interactions/InteractionsProviderTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Interactions/InteractionsProviderTests.cs
@@ -81,6 +81,57 @@ public partial class InteractionsProviderTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task Initialize_InteractionsUseLiveDashboardClientAsync()
+    {
+        var liveInteractionsChannel = Channel.CreateUnbounded<WatchInteractionsResponseUpdate>();
+        var liveRequestsChannel = Channel.CreateUnbounded<WatchInteractionsRequestUpdate>();
+        var selectedInteractionsChannel = Channel.CreateUnbounded<WatchInteractionsResponseUpdate>();
+        var selectedRequestsChannel = Channel.CreateUnbounded<WatchInteractionsRequestUpdate>();
+        var liveSubscriptionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var liveSubscriptionCount = 0;
+        var selectedSubscriptionCount = 0;
+
+        var liveDashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            interactionChannelProvider: () =>
+            {
+                Interlocked.Increment(ref liveSubscriptionCount);
+                liveSubscriptionStarted.TrySetResult();
+                return liveInteractionsChannel;
+            },
+            sendInteractionUpdateChannel: liveRequestsChannel);
+        var selectedDashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            interactionChannelProvider: () =>
+            {
+                Interlocked.Increment(ref selectedSubscriptionCount);
+                return selectedInteractionsChannel;
+            },
+            sendInteractionUpdateChannel: selectedRequestsChannel,
+            isReadOnly: true);
+
+        SetupInteractionProviderServices(liveDashboardClient, selectedDashboardClient: selectedDashboardClient);
+
+        var cut = RenderComponent<Components.Interactions.InteractionsProvider>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        Assert.Same(liveDashboardClient, cut.Instance.DashboardClient);
+        await liveSubscriptionStarted.Task.DefaultTimeout();
+        Assert.Equal(1, Volatile.Read(ref liveSubscriptionCount));
+        Assert.Equal(0, Volatile.Read(ref selectedSubscriptionCount));
+
+        var request = new WatchInteractionsRequestUpdate();
+        await cut.Instance.DashboardClient.SendInteractionRequestAsync(request, CancellationToken.None);
+
+        Assert.Same(request, await liveRequestsChannel.Reader.ReadAsync().AsTask().DefaultTimeout());
+        Assert.False(selectedRequestsChannel.Reader.TryRead(out _));
+
+        await cut.Instance.DisposeAsync().DefaultTimeout();
+    }
+
+    [Fact]
     public async Task ReceiveData_MessageBoxOpen_OpenDialog()
     {
         // Arrange
@@ -289,6 +340,7 @@ public partial class InteractionsProviderTests : DashboardTestContext
         // Act 2
         Assert.NotNull(dialogParameters);
         Assert.NotNull(vm);
+        Assert.Same(dashboardClient, vm.DashboardClient);
 
         await vm.OnSubmitCallback(response, false).DefaultTimeout();
 
@@ -622,7 +674,11 @@ public partial class InteractionsProviderTests : DashboardTestContext
         await instance.DisposeAsync().DefaultTimeout();
     }
 
-    private void SetupInteractionProviderServices(TestDashboardClient? dashboardClient = null, TestDialogService? dialogService = null, TestMessageService? messageService = null)
+    private void SetupInteractionProviderServices(
+        TestDashboardClient? dashboardClient = null,
+        TestDialogService? dialogService = null,
+        TestMessageService? messageService = null,
+        TestDashboardClient? selectedDashboardClient = null)
     {
         var loggerFactory = IntegrationTestHelpers.CreateLoggerFactory(_testOutputHelper);
 
@@ -631,7 +687,8 @@ public partial class InteractionsProviderTests : DashboardTestContext
 
         Services.AddSingleton<IDialogService>(dialogService ?? new TestDialogService());
         Services.AddSingleton<IMessageService>(messageService ?? new TestMessageService());
-        Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient());
+        Services.AddSingleton<IDashboardClient>(selectedDashboardClient ?? new TestDashboardClient());
+        Services.AddKeyedSingleton<IDashboardClient>(DashboardClient.LiveAppHostServiceKey, dashboardClient ?? new TestDashboardClient());
         Services.AddSingleton<DashboardTelemetryService>();
         Services.AddSingleton<IDashboardTelemetrySender, TestDashboardTelemetrySender>();
         Services.AddSingleton<ComponentTelemetryContextProvider>();

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -1,11 +1,13 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.BrowserStorage;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Utils;
 using Aspire.Tests.Shared;
@@ -13,10 +15,13 @@ using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Components.Tooltip;
 using Microsoft.JSInterop;
 using Xunit;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Tests.Layout;
 
@@ -282,6 +287,672 @@ public partial class MainLayoutTests : DashboardTestContext
     }
 
     [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DashboardRunSelect_Supported_IsDisplayedBeforeHeaderButtons(bool isDesktop)
+    {
+        SetupMainLayoutServices();
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: isDesktop, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        var existingButtonId = isDesktop ? "dashboard-help-button" : "dashboard-navigation-button";
+
+        Assert.Single(cut.FindComponents<DashboardRunSelect>());
+        Assert.Contains("class=\"application-run-select\"", cut.Markup, StringComparison.Ordinal);
+        Assert.True(
+            cut.Markup.IndexOf("class=\"application-run-select\"", StringComparison.Ordinal) <
+            cut.Markup.IndexOf($"id=\"{existingButtonId}\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DashboardRunSelect_PrunedHistoricalRunIsNotDisplayed()
+    {
+        var historicalRun = new DashboardRunDescriptor(
+            RunId: "historical",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: DateTimeOffset.UnixEpoch,
+            EndedAtUtc: DateTimeOffset.UnixEpoch,
+            CleanShutdown: true,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: false);
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
+        [
+            new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: true),
+            historicalRun
+        ]);
+        SetupMainLayoutServices(dashboardRunStore: runStore);
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(
+                component => component.ViewportInformation,
+                new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        historicalRun.IsPruned = true;
+        var runSelect = cut.FindComponent<DashboardRunSelect>();
+        runSelect.Find("fluent-button").Click();
+
+        var menuItem = Assert.Single(runSelect.FindComponent<AspireMenu>().Instance.Items);
+        Assert.Equal("Live run", menuItem.Text);
+        Assert.True(menuItem.Checked);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DashboardRunSelect_Unsupported_IsHiddenAndStaleSelectionIsIgnored(bool isDesktop)
+    {
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
+        [
+            new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: true)
+        ],
+        supportsRunSelection: false);
+        var sessionStorage = new TestSessionStorage
+        {
+            OnGetAsync = _ => throw new InvalidOperationException("Run selection should not be read.")
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore, sessionStorage: sessionStorage);
+        var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
+        var getRunsCallCount = runStore.GetRunsCallCount;
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(
+                component => component.ViewportInformation,
+                new ViewportInformation(IsDesktop: isDesktop, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        Assert.Empty(cut.FindComponents<DashboardRunSelect>());
+        Assert.Equal(getRunsCallCount, runStore.GetRunsCallCount);
+        Assert.Null(runSelection.SelectedRunId);
+    }
+
+    [Fact]
+    public async Task DashboardRunSelect_ChangeStoresAndAppliesSelectionWithoutNavigation()
+    {
+        var historicalRun = new DashboardRunDescriptor(
+            RunId: "historical",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: new DateTimeOffset(2025, 1, 2, 12, 30, 0, TimeSpan.Zero),
+            EndedAtUtc: new DateTimeOffset(2025, 1, 2, 13, 30, 0, TimeSpan.Zero),
+            CleanShutdown: true,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: false);
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
+        [
+            new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: true),
+            historicalRun
+        ]);
+        string? storedRunId = null;
+        var sessionStorage = new TestSessionStorage
+        {
+            OnSetAsync = (_, value) => storedRunId = Assert.IsType<string>(value)
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore, sessionStorage: sessionStorage);
+        var expectedHistoricalRunText = FormatHelpers.FormatTimeWithOptionalDate(
+            Services.GetRequiredService<BrowserTimeProvider>(),
+            historicalRun.StartedAtUtc.UtcDateTime);
+        JSInterop.SetupVoid("focusElement", _ => true).SetVoidResult();
+        var initializedCount = 0;
+        var disposedCount = 0;
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(component => component.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+            builder.Add(component => component.Body, bodyBuilder =>
+            {
+                bodyBuilder.OpenComponent<LifecycleTestComponent>(0);
+                bodyBuilder.AddComponentParameter(1, nameof(LifecycleTestComponent.Initialized), (Action)(() => initializedCount++));
+                bodyBuilder.AddComponentParameter(2, nameof(LifecycleTestComponent.Disposed), (Action)(() => disposedCount++));
+                bodyBuilder.CloseComponent();
+            });
+        });
+
+        var runSelect = cut.FindComponent<DashboardRunSelect>();
+        var menuButton = runSelect.FindComponent<AspireMenuButton>();
+        var statusIcon = runSelect.Find(".application-run-status");
+        Assert.Equal("start", statusIcon.GetAttribute("slot"));
+        Assert.Contains("fill: var(--success)", statusIcon.GetAttribute("style"), StringComparison.Ordinal);
+        Assert.Equal("Live run", menuButton.Instance.Text);
+        Assert.True(menuButton.Instance.HideIcon);
+        Assert.Empty(menuButton.FindComponents<AspireMenu>());
+        var menuButtonElement = runSelect.Find("fluent-button");
+        var menuButtonId = menuButtonElement.Id;
+        Assert.Equal("Select run: Live run", menuButtonElement.GetAttribute("aria-label"));
+
+        var navigationOccurred = false;
+        Services.GetRequiredService<NavigationManager>().LocationChanged += (_, _) => navigationOccurred = true;
+        runSelect.Find("fluent-button").Click();
+        Assert.Collection(
+            menuButton.FindComponent<AspireMenu>().Instance.Items,
+            item =>
+            {
+                Assert.Equal("Live run", item.Text);
+                Assert.Equal(MenuItemRole.MenuItemRadio, item.Role);
+                Assert.True(item.Checked);
+                Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
+                Assert.IsType<Icons.Regular.Size16.Pin>(item.SecondaryActionIcon);
+                Assert.Equal("Pin run", item.SecondaryActionAriaLabel);
+                Assert.False(item.IsSecondaryActionSelected);
+            },
+            item => Assert.True(item.IsDivider),
+            item =>
+            {
+                Assert.Equal(expectedHistoricalRunText, item.Text);
+                Assert.Equal(MenuItemRole.MenuItemRadio, item.Role);
+                Assert.False(item.Checked);
+                Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
+                Assert.IsType<Icons.Regular.Size16.Pin>(item.SecondaryActionIcon);
+                Assert.Equal("Pin run", item.SecondaryActionAriaLabel);
+                Assert.False(item.IsSecondaryActionSelected);
+            });
+
+        var menuItems = cut.WaitForElements("fluent-menu-item");
+        Assert.Single(cut.FindAll("fluent-divider"));
+        Assert.Empty(menuItems[0].QuerySelectorAll("span[slot='start']"));
+        Assert.Empty(menuItems[1].QuerySelectorAll("span[slot='start']"));
+        Assert.Single(menuItems[0].QuerySelectorAll("[slot='radio-indicator']"));
+        Assert.Single(menuItems[1].QuerySelectorAll("[slot='radio-indicator']"));
+        Assert.Equal("menuitemradio", menuItems[0].GetAttribute("role"));
+        Assert.True(menuItems[0].HasAttribute("checked"));
+        Assert.Equal("menuitemradio", menuItems[1].GetAttribute("role"));
+        Assert.False(menuItems[1].HasAttribute("checked"));
+        var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
+        var currentRun = runStore.GetRuns().Single(run => run.IsCurrent);
+        Assert.Single(menuItems[0].QuerySelectorAll("fluent-button")).Click();
+
+        Assert.True(currentRun.IsPinned);
+        Assert.Null(runSelection.SelectedRunId);
+        Assert.True(runSelect.FindComponent<AspireMenu>().Instance.Open);
+        menuButton = runSelect.FindComponent<AspireMenuButton>();
+        Assert.IsType<Icons.Filled.Size16.Pin>(menuButton.Instance.Items[0].SecondaryActionIcon);
+        Assert.True(menuButton.Instance.Items[0].IsSecondaryActionSelected);
+
+        menuItems = cut.WaitForElements("fluent-menu-item");
+        var pinButton = Assert.Single(menuItems[1].QuerySelectorAll("fluent-button"));
+        pinButton.Click();
+
+        Assert.True(historicalRun.IsPinned);
+        Assert.Null(storedRunId);
+        Assert.Null(runSelection.SelectedRunId);
+        Assert.True(runSelect.FindComponent<AspireMenu>().Instance.Open);
+        menuButton = runSelect.FindComponent<AspireMenuButton>();
+        var historicalItem = menuButton.Instance.Items[2];
+        Assert.IsType<Icons.Filled.Size16.Pin>(historicalItem.SecondaryActionIcon);
+        Assert.Equal("Unpin run", historicalItem.SecondaryActionAriaLabel);
+        Assert.True(historicalItem.IsSecondaryActionSelected);
+
+        menuItems = cut.WaitForElements("fluent-menu-item");
+        menuItems[1].Click();
+
+        Assert.Equal("historical", storedRunId);
+        Assert.Equal("historical", runSelection.SelectedRunId);
+        Assert.False(navigationOccurred);
+        Assert.Equal(2, initializedCount);
+        Assert.Equal(1, disposedCount);
+        runSelect = cut.FindComponent<DashboardRunSelect>();
+        menuButton = runSelect.FindComponent<AspireMenuButton>();
+        statusIcon = runSelect.Find(".application-run-status");
+        Assert.Contains("fill: var(--warning)", statusIcon.GetAttribute("style"), StringComparison.Ordinal);
+        Assert.Equal(expectedHistoricalRunText, menuButton.Instance.Text);
+        Assert.False(menuButton.FindComponent<AspireMenu>().Instance.Open);
+        Assert.Equal(menuButtonId, runSelect.Find("fluent-button").Id);
+        Assert.Equal($"Select run: {expectedHistoricalRunText}", runSelect.Find("fluent-button").GetAttribute("aria-label"));
+        Assert.Contains(
+            JSInterop.Invocations,
+            invocation => invocation.Identifier == "focusElement" && invocation.Arguments.Single() is string id && id == menuButtonId);
+
+        runSelect.Find("fluent-button").Click();
+        Assert.Collection(
+            menuButton.FindComponent<AspireMenu>().Instance.Items,
+            item =>
+            {
+                Assert.False(item.Checked);
+                Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
+            },
+            item => Assert.True(item.IsDivider),
+            item =>
+            {
+                Assert.True(item.Checked);
+                Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
+            });
+        menuItems = cut.WaitForElements("fluent-menu-item");
+        Assert.Single(cut.FindAll("fluent-divider"));
+        Assert.Empty(menuItems[0].QuerySelectorAll("span[slot='start']"));
+        Assert.Empty(menuItems[1].QuerySelectorAll("span[slot='start']"));
+        menuItems[0].Click();
+
+        Assert.Equal(string.Empty, storedRunId);
+        Assert.Null(runSelection.SelectedRunId);
+        Assert.False(navigationOccurred);
+        Assert.Equal(3, initializedCount);
+        Assert.Equal(2, disposedCount);
+        runSelect = cut.FindComponent<DashboardRunSelect>();
+        menuButton = runSelect.FindComponent<AspireMenuButton>();
+        statusIcon = runSelect.Find(".application-run-status");
+        Assert.Contains("fill: var(--success)", statusIcon.GetAttribute("style"), StringComparison.Ordinal);
+        Assert.Equal("Live run", menuButton.Instance.Text);
+        Assert.False(menuButton.FindComponent<AspireMenu>().Instance.Open);
+    }
+
+    [Fact]
+    public void DashboardRunSelect_SelectionFailure_KeepsCurrentRunAndCircuitActive()
+    {
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
+        [
+            new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: true),
+            new(
+                RunId: "historical",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: DateTimeOffset.UnixEpoch,
+                CleanShutdown: true,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: false)
+        ]);
+        string? storedRunId = null;
+        var sessionStorage = new TestSessionStorage
+        {
+            OnSetAsync = (_, value) => storedRunId = Assert.IsType<string>(value)
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore, sessionStorage: sessionStorage);
+        JSInterop.SetupVoid("focusElement", _ => true).SetVoidResult();
+        var testSink = new TestSink();
+        Services.AddSingleton<ILogger<MainLayout>>(new TestLogger<MainLayout>(new TestLoggerFactory(testSink, enabled: true)));
+        var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
+        var exception = new InvalidOperationException("The historical database could not be opened.");
+        runSelection.OnSelectRun = runId =>
+        {
+            if (runId == "historical")
+            {
+                throw exception;
+            }
+        };
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(component => component.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+            builder.Add(component => component.Body, bodyBuilder => bodyBuilder.AddMarkupContent(0, "<div id=\"body-content\"></div>"));
+        });
+        var runSelect = cut.FindComponent<DashboardRunSelect>();
+        runSelect.Find("fluent-button").Click();
+
+        cut.WaitForElements("fluent-menu-item")[1].Click();
+
+        Assert.NotNull(cut.Find("#body-content"));
+        Assert.True(runSelection.SelectedRun.IsCurrent);
+        Assert.Equal(string.Empty, storedRunId);
+        Assert.Equal("Live run", cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>().Instance.Text);
+        var errorLog = Assert.Single(testSink.Writes);
+        Assert.Equal(LogLevel.Error, errorLog.LogLevel);
+        Assert.Equal("Failed to switch to dashboard run 'historical'. Keeping dashboard run 'current' selected.", errorLog.Message);
+        Assert.Same(exception, errorLog.Exception);
+    }
+
+    [Fact]
+    public void DashboardRunSelect_PinningFailure_KeepsMenuAndCircuitActive()
+    {
+        var currentRun = new DashboardRunDescriptor(
+            RunId: "current",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: DateTimeOffset.UnixEpoch,
+            EndedAtUtc: null,
+            CleanShutdown: false,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: true);
+        var historicalRun = new DashboardRunDescriptor(
+            RunId: "historical",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: DateTimeOffset.UnixEpoch,
+            EndedAtUtc: DateTimeOffset.UnixEpoch,
+            CleanShutdown: true,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: false);
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore([currentRun, historicalRun]);
+        var exception = new IOException("The run metadata could not be written.");
+        runStore.OnSetRunPinned = (run, _) =>
+        {
+            if (run.RunId == historicalRun.RunId)
+            {
+                throw exception;
+            }
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore);
+        var testSink = new TestSink();
+        Services.AddSingleton<ILogger<DashboardRunSelect>>(new TestLogger<DashboardRunSelect>(new TestLoggerFactory(testSink, enabled: true)));
+        var provider = RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<DashboardRunSelect>(builder =>
+        {
+            builder.Add(component => component.SelectedRunId, currentRun.RunId);
+            builder.Add(component => component.SelectedRunIsCurrent, true);
+            builder.Add(component => component.SelectedRunStartedAtUtc, currentRun.StartedAtUtc);
+        });
+        cut.Find("fluent-button").Click();
+
+        var historicalMenuItem = provider.WaitForElements("fluent-menu-item")[1];
+        Assert.Single(historicalMenuItem.QuerySelectorAll("fluent-button")).Click();
+
+        Assert.False(historicalRun.IsPinned);
+        Assert.True(cut.FindComponent<AspireMenu>().Instance.Open);
+        Assert.NotNull(cut.Find("fluent-button"));
+        var errorLog = Assert.Single(testSink.Writes);
+        Assert.Equal(LogLevel.Error, errorLog.LogLevel);
+        Assert.Equal("Failed to update the pinned state of dashboard run 'historical'.", errorLog.Message);
+        Assert.Same(exception, errorLog.Exception);
+    }
+
+    [Fact]
+    public void DashboardRunSelect_SortsHistoricalRunsByPinnedThenDateDescendingAndUpdatesOrderWhenPinned()
+    {
+        var currentRun = new DashboardRunDescriptor(
+            RunId: "current",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: DateTimeOffset.UnixEpoch,
+            EndedAtUtc: null,
+            CleanShutdown: false,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: true);
+        var historicalRuns = new[]
+        {
+            new DashboardRunDescriptor("unpinned-b", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 12, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false),
+            new DashboardRunDescriptor("pinned-b", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 11, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false),
+            new DashboardRunDescriptor("unpinned-a", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 9, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false),
+            new DashboardRunDescriptor("pinned-a", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 10, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false)
+        };
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore([currentRun, .. historicalRuns]);
+        runStore.SetRunPinned(historicalRuns[1], isPinned: true);
+        runStore.SetRunPinned(historicalRuns[3], isPinned: true);
+        SetupMainLayoutServices(dashboardRunStore: runStore);
+        var browserTimeProvider = Services.GetRequiredService<BrowserTimeProvider>();
+        var expectedHistoricalTexts = historicalRuns
+            .OrderByDescending(run => run.IsPinned)
+            .ThenByDescending(run => run.StartedAtUtc)
+            .Select(run => FormatHelpers.FormatTimeWithOptionalDate(browserTimeProvider, run.StartedAtUtc.UtcDateTime))
+            .ToArray();
+        var provider = RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<DashboardRunSelect>(builder =>
+        {
+            builder.Add(component => component.SelectedRunId, currentRun.RunId);
+            builder.Add(component => component.SelectedRunIsCurrent, true);
+            builder.Add(component => component.SelectedRunStartedAtUtc, currentRun.StartedAtUtc);
+        });
+
+        cut.Find("fluent-button").Click();
+
+        var items = cut.FindComponent<AspireMenuButton>().Instance.Items;
+        Assert.Equal("Live run", items[0].Text);
+        Assert.IsType<Icons.Regular.Size16.Pin>(items[0].SecondaryActionIcon);
+        Assert.False(items[0].IsSecondaryActionSelected);
+        Assert.True(items[1].IsDivider);
+        Assert.Equal(expectedHistoricalTexts, items.Skip(2).Select(item => item.Text));
+        Assert.All(items.Skip(2).Take(2), item => Assert.True(item.IsSecondaryActionSelected));
+        Assert.All(items.Skip(4), item => Assert.False(item.IsSecondaryActionSelected));
+
+        var menuItems = provider.WaitForElements("fluent-menu-item");
+        Assert.Single(menuItems[3].QuerySelectorAll("fluent-button")).Click();
+
+        expectedHistoricalTexts = historicalRuns
+            .OrderByDescending(run => run.IsPinned)
+            .ThenByDescending(run => run.StartedAtUtc)
+            .Select(run => FormatHelpers.FormatTimeWithOptionalDate(browserTimeProvider, run.StartedAtUtc.UtcDateTime))
+            .ToArray();
+        items = cut.FindComponent<AspireMenuButton>().Instance.Items;
+        Assert.Equal(expectedHistoricalTexts, items.Skip(2).Select(item => item.Text));
+        Assert.All(items.Skip(2).Take(3), item => Assert.True(item.IsSecondaryActionSelected));
+        Assert.False(items[5].IsSecondaryActionSelected);
+    }
+
+    [Fact]
+    public async Task RunSelectionPending_RendersCurrentRunWithoutLoadingRuns()
+    {
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
+        [
+            new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: true)
+        ]);
+        var runSelectionSource = new TaskCompletionSource<(bool Success, object? Value)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionStorage = new TestSessionStorage
+        {
+            OnGetTaskAsync = _ => runSelectionSource.Task
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore, sessionStorage: sessionStorage);
+        var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
+        var getRunsCallCount = runStore.GetRunsCallCount;
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+            builder.Add(p => p.Body, bodyBuilder => bodyBuilder.AddMarkupContent(0, "<div id=\"body-content\"></div>"));
+        });
+
+        Assert.NotNull(cut.Find("#body-content"));
+        Assert.True(runSelection.SelectedRun.IsCurrent);
+        var runSelect = cut.FindComponent<DashboardRunSelect>();
+        var menuButton = runSelect.FindComponent<AspireMenuButton>();
+        Assert.Equal("Live run", menuButton.Instance.Text);
+        Assert.Empty(menuButton.FindComponents<AspireMenu>());
+        Assert.Equal(getRunsCallCount, runStore.GetRunsCallCount);
+
+        runSelect.Find("fluent-button").Click();
+
+        Assert.Single(cut.WaitForElements("fluent-menu-item"));
+        Assert.Equal(getRunsCallCount + 1, runStore.GetRunsCallCount);
+
+        await cut.InvokeAsync(() => runSelectionSource.SetResult((false, null)));
+    }
+
+    [Fact]
+    public async Task RunSelectionPending_StoredHistoricalRunReplacesCurrentRun()
+    {
+        var historicalRun = new DashboardRunDescriptor(
+            RunId: "historical",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: new DateTimeOffset(2025, 1, 2, 12, 30, 0, TimeSpan.Zero),
+            EndedAtUtc: new DateTimeOffset(2025, 1, 2, 13, 30, 0, TimeSpan.Zero),
+            CleanShutdown: true,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: false);
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
+        [
+            new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: true),
+            historicalRun
+        ]);
+        var runSelectionSource = new TaskCompletionSource<(bool Success, object? Value)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionStorage = new TestSessionStorage
+        {
+            OnGetTaskAsync = _ => runSelectionSource.Task
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore, sessionStorage: sessionStorage);
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+            builder.Add(p => p.Body, bodyBuilder => bodyBuilder.AddMarkupContent(0, "<div id=\"body-content\"></div>"));
+        });
+
+        Assert.Equal("Live run", cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>().Instance.Text);
+
+        await cut.InvokeAsync(() => runSelectionSource.SetResult((true, "historical")));
+
+        var expectedHistoricalRunText = FormatHelpers.FormatTimeWithOptionalDate(
+            Services.GetRequiredService<BrowserTimeProvider>(),
+            historicalRun.StartedAtUtc.UtcDateTime);
+        cut.WaitForAssertion(() =>
+        {
+            var menuButton = cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>();
+            Assert.Equal(expectedHistoricalRunText, menuButton.Instance.Text);
+        });
+    }
+
+    [Fact]
+    public void StoredHistoricalRunFailure_FallsBackToCurrentRunAndClearsSelection()
+    {
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
+        [
+            new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: true),
+            new(
+                RunId: "historical",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: DateTimeOffset.UnixEpoch,
+                CleanShutdown: true,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: false)
+        ]);
+        string? storedRunId = null;
+        var sessionStorage = new TestSessionStorage
+        {
+            OnGetAsync = _ => (true, "historical"),
+            OnSetAsync = (_, value) => storedRunId = Assert.IsType<string>(value)
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore, sessionStorage: sessionStorage);
+        var testSink = new TestSink();
+        Services.AddSingleton<ILogger<MainLayout>>(new TestLogger<MainLayout>(new TestLoggerFactory(testSink, enabled: true)));
+        var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
+        var selectedRunIds = new List<string?>();
+        var exception = new InvalidOperationException("The historical database could not be opened.");
+        runSelection.OnSelectRun = runId =>
+        {
+            selectedRunIds.Add(runId);
+            if (runId == "historical")
+            {
+                throw exception;
+            }
+        };
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        Assert.Equal(["historical", null], selectedRunIds);
+        Assert.True(runSelection.SelectedRun.IsCurrent);
+        Assert.Null(runSelection.SelectedRunId);
+        Assert.Equal(string.Empty, storedRunId);
+        Assert.Equal("Live run", cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>().Instance.Text);
+        var errorLog = Assert.Single(testSink.Writes);
+        Assert.Equal(LogLevel.Error, errorLog.LogLevel);
+        Assert.Equal("Failed to restore dashboard run 'historical'. Falling back to the current run.", errorLog.Message);
+        Assert.Same(exception, errorLog.Exception);
+    }
+
+    [Fact]
+    public async Task RunSelectionPending_UserSelectionWinsOverStoredSelection()
+    {
+        var historicalRun = new DashboardRunDescriptor(
+            RunId: "historical",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: new DateTimeOffset(2025, 1, 2, 12, 30, 0, TimeSpan.Zero),
+            EndedAtUtc: new DateTimeOffset(2025, 1, 2, 13, 30, 0, TimeSpan.Zero),
+            CleanShutdown: true,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: false);
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore(
+        [
+            new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: string.Empty,
+                IsCurrent: true),
+            historicalRun
+        ]);
+        var runSelectionSource = new TaskCompletionSource<(bool Success, object? Value)>(TaskCreationOptions.RunContinuationsAsynchronously);
+        string? storedRunId = null;
+        var sessionStorage = new TestSessionStorage
+        {
+            OnGetTaskAsync = _ => runSelectionSource.Task,
+            OnSetAsync = (_, value) => storedRunId = Assert.IsType<string>(value)
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore, sessionStorage: sessionStorage);
+        JSInterop.SetupVoid("focusElement", _ => true).SetVoidResult();
+
+        var cut = RenderComponent<MainLayout>(builder =>
+        {
+            builder.Add(p => p.ViewportInformation, new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+        var runSelect = cut.FindComponent<DashboardRunSelect>();
+        runSelect.Find("fluent-button").Click();
+        cut.WaitForElements("fluent-menu-item")[0].Click();
+
+        Assert.Equal(string.Empty, storedRunId);
+        await cut.InvokeAsync(() => runSelectionSource.SetResult((true, "historical")));
+
+        var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
+        Assert.True(runSelection.SelectedRun.IsCurrent);
+        Assert.Equal("Live run", cut.FindComponent<DashboardRunSelect>().FindComponent<AspireMenuButton>().Instance.Text);
+    }
+
+    [Theory]
     [InlineData(true, false, "dashboard-help-button", "HelpDialog", "dashboard-navigation-button")]
     [InlineData(true, false, "dashboard-settings-button", "SettingsDialog", "dashboard-navigation-button")]
     [InlineData(false, true, "dashboard-navigation-button", "HelpDialog", "dashboard-help-button")]
@@ -385,9 +1056,18 @@ public partial class MainLayoutTests : DashboardTestContext
         TestLocalStorage? localStorage = null,
         MessageService? messageService = null,
         Action<DashboardOptions>? configureOptions = null,
-        IDialogService? dialogService = null)
+        IDialogService? dialogService = null,
+        BrowserTimeProvider? browserTimeProvider = null,
+        IDashboardRunStore? dashboardRunStore = null,
+        ISessionStorage? sessionStorage = null)
     {
-        FluentUISetupHelpers.AddCommonDashboardServices(this, localStorage: localStorage, messageService: messageService);
+        FluentUISetupHelpers.AddCommonDashboardServices(
+            this,
+            localStorage: localStorage,
+            messageService: messageService,
+            browserTimeProvider: browserTimeProvider,
+            dashboardRunStore: dashboardRunStore,
+            sessionStorage: sessionStorage);
 
         if (dialogService is not null)
         {
@@ -396,7 +1076,9 @@ public partial class MainLayoutTests : DashboardTestContext
 
         Services.AddOptions();
         Services.AddSingleton<IThemeResolver, TestThemeResolver>();
-        Services.AddSingleton<IDashboardClient, TestDashboardClient>();
+        var dashboardClient = new TestDashboardClient();
+        Services.AddSingleton<IDashboardClient>(dashboardClient);
+        Services.AddKeyedSingleton<IDashboardClient>(DashboardClient.LiveAppHostServiceKey, dashboardClient);
         Services.AddSingleton<ITooltipService, TooltipService>();
         Services.AddSingleton<IToastService, ToastService>();
         Services.Configure<DashboardOptions>(o =>
@@ -416,6 +1098,11 @@ public partial class MainLayoutTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentMenu(this);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
         FluentUISetupHelpers.SetupFluentDivider(this);
+        FluentUISetupHelpers.SetupFluentInputLabel(this);
+        FluentUISetupHelpers.SetupFluentList(this);
+        FluentUISetupHelpers.SetupFluentCombobox(this);
+        FluentUISetupHelpers.SetupAspireMenuButtonModule(this);
+        FluentUISetupHelpers.SetupMenuService(this);
 
         var themeModule = JSInterop.SetupModule("/js/app-theme.js");
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTerminalTests.cs
@@ -345,6 +345,48 @@ public partial class ConsoleLogsTests
     }
 
     [Fact]
+    public async Task HistoricalTerminalResource_Selected_DoesNotRenderTerminalView()
+    {
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var subscriptionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var terminalResource = CreateTerminalResource("terminal-resource", replicaIndex: 0, replicaCount: 1);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            isReadOnly: true,
+            consoleLogsChannelProvider: _ =>
+            {
+                subscriptionStarted.TrySetResult();
+                return consoleLogsChannel;
+            },
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [terminalResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+        SetupTerminalViewJsInterop();
+
+        var navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: "terminal-resource"));
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "terminal-resource");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        await subscriptionStarted.Task.WaitAsync(DefaultWaitTimeout);
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Empty(cut.FindComponents<TerminalView>());
+            Assert.Single(cut.FindComponents<LogViewer>());
+        });
+    }
+
+    [Fact]
     public async Task SwitchingFromTerminalToNonTerminalResource_TearsDownTerminalView()
     {
         var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -374,6 +374,68 @@ public partial class ConsoleLogsTests : DashboardTestContext
         cut.WaitForState(() => instance._logEntries.EntriesCount > 0);
     }
 
+    [Fact]
+    public async Task CurrentRun_SubscribesToLiveConsoleLogs()
+    {
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        var liveSubscriptionTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var liveConsoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var repositoryConsoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var repositorySubscriptionCount = 0;
+        var liveClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: resourceName =>
+            {
+                liveSubscriptionTcs.TrySetResult(resourceName);
+                return liveConsoleLogsChannel;
+            },
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+        var currentResourceRepository = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ =>
+            {
+                Interlocked.Increment(ref repositorySubscriptionCount);
+                return repositoryConsoleLogsChannel;
+            },
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+
+        SetupConsoleLogsServices(liveClient, resourceRepository: currentResourceRepository);
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var cut = RenderConsoleLogsPage(viewport, testResource.Name);
+
+        Assert.Equal(testResource.Name, await liveSubscriptionTcs.Task.DefaultTimeout());
+        Assert.Equal(0, Volatile.Read(ref repositorySubscriptionCount));
+
+        liveConsoleLogsChannel.Writer.TryWrite([new ResourceLogLine(1, "Live log", IsErrorMessage: false)]);
+        cut.WaitForState(() => cut.Instance._logEntries.EntriesCount == 1);
+        Assert.Equal("Live log", Assert.Single(cut.Instance._logEntries.GetEntries()).RawContent);
+    }
+
+    [Theory]
+    [InlineData(false, "Console logs weren't captured for this run. Console logs are only captured if this page is visited while the AppHost is running.")]
+    [InlineData(true, "No logs found")]
+    public void HistoricalRun_NoLogs_DisplaysCaptureStatus(bool consoleLogsWereLoaded, string expectedMessage)
+    {
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        testResource.ConsoleLogsLoaded = consoleLogsWereLoaded;
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>(),
+            resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>,
+            initialResources: [testResource],
+            isReadOnly: true);
+        SetupConsoleLogsServices(dashboardClient);
+
+        var cut = RenderConsoleLogsPage(CreateViewport(isDesktop: true), testResource.Name);
+
+        var emptyMessage = cut.WaitForElement(".console-empty-message", TimeSpan.FromSeconds(3));
+        Assert.Equal(expectedMessage, emptyMessage.TextContent.Trim());
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -596,10 +658,52 @@ public partial class ConsoleLogsTests : DashboardTestContext
         cut.Render();
 
         cut.WaitForState(() => instance._logEntries.EntriesCount == 0);
+        var clearedConsoleLogs = Assert.Single(dashboardClient.ClearedConsoleLogs);
+        Assert.Collection(
+            clearedConsoleLogs.ResourceNames,
+            resourceName => Assert.Equal(testResource.Name, resourceName));
+        Assert.Equal(timeProvider.UtcNow.UtcDateTime, clearedConsoleLogs.ClearDate);
 
         logger.LogInformation("New log results are added to log viewer.");
         consoleLogsChannel.Writer.TryWrite([new ResourceLogLine(2, "2025-03-08T10:16:08Z Hello world", IsErrorMessage: false)]);
         cut.WaitForState(() => instance._logEntries.EntriesCount > 0);
+    }
+
+    [Fact]
+    public async Task ClearLogEntries_SelectedResource_DeletesPersistedLogsAndUpdatesFilter()
+    {
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var selectedResource = ModelTestHelpers.CreateResource(resourceName: "selected-resource", state: KnownResourceState.Running);
+        var otherResource = ModelTestHelpers.CreateResource(resourceName: "other-resource", state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [selectedResource, otherResource]);
+        var timeProvider = new TestTimeProvider
+        {
+            UtcNow = new DateTime(2025, 2, 8, 10, 16, 8, DateTimeKind.Utc)
+        };
+        SetupConsoleLogsServices(dashboardClient, timeProvider: timeProvider);
+
+        var cut = RenderConsoleLogsPage(CreateViewport(isDesktop: true), selectedResource.Name);
+        cut.WaitForState(() => cut.Instance.PageViewModel.SelectedResource.Id?.InstanceId == selectedResource.Name);
+
+        cut.Find(".clear-button").Click();
+        _menuProvider!.WaitForElement("#clear-menu-resource");
+        var clearMenu = cut.FindComponents<AspireMenu>().Single(menu => menu.Instance.Items.Any(item => item.Id == "clear-menu-resource"));
+        var clearResourceMenuItem = clearMenu.Instance.Items.Single(item => item.Id == "clear-menu-resource");
+        Assert.NotNull(clearResourceMenuItem.OnClick);
+        await cut.InvokeAsync(clearResourceMenuItem.OnClick);
+
+        var clearedConsoleLogs = Assert.Single(dashboardClient.ClearedConsoleLogs);
+        Assert.Collection(
+            clearedConsoleLogs.ResourceNames,
+            resourceName => Assert.Equal(selectedResource.Name, resourceName));
+        Assert.Equal(timeProvider.UtcNow.UtcDateTime, clearedConsoleLogs.ClearDate);
+        Assert.Equal(timeProvider.UtcNow.UtcDateTime, Services.GetRequiredService<ConsoleLogsManager>().GetFilterDate(selectedResource.Name));
+        Assert.Null(Services.GetRequiredService<ConsoleLogsManager>().GetFilterDate(otherResource.Name));
     }
 
     [Fact]
@@ -656,6 +760,41 @@ public partial class ConsoleLogsTests : DashboardTestContext
         logger.LogInformation("New log results are added to log viewer.");
         consoleLogsChannel.Writer.TryWrite([new ResourceLogLine(2, "2025-03-08T10:16:08Z Hello world", IsErrorMessage: false)]);
         cut.WaitForState(() => instance._logEntries.EntriesCount > 0);
+    }
+
+    [Fact]
+    public async Task NavigateBack_AfterLogsDeleted_ReplayedLogsBeforeClearDateRemainFiltered()
+    {
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+        SetupConsoleLogsServices(dashboardClient);
+
+        var clearDate = new DateTime(2025, 2, 8, 10, 16, 8, DateTimeKind.Utc);
+        await dashboardClient.ClearConsoleLogsAsync([testResource.Name], clearDate);
+        var consoleLogsManager = Services.GetRequiredService<ConsoleLogsManager>();
+        await consoleLogsManager.UpdateFiltersAsync(ConsoleLogsFilters.Default.WithResourceCleared(testResource.Name, clearDate));
+
+        var cut = RenderConsoleLogsPage(CreateViewport(isDesktop: true), testResource.Name);
+        cut.WaitForState(() => cut.Instance.PageViewModel.SelectedResource.Id?.InstanceId == testResource.Name);
+
+        var clearedLog = "2025-02-08T10:16:08Z Cleared log";
+        var newLog = "2025-02-08T10:16:09Z New log";
+        consoleLogsChannel.Writer.TryWrite([
+            new ResourceLogLine(1, clearedLog, IsErrorMessage: false),
+            new ResourceLogLine(2, newLog, IsErrorMessage: false)
+        ]);
+
+        cut.WaitForAssertion(() =>
+        {
+            var logEntry = Assert.Single(cut.Instance._logEntries.GetEntries());
+            Assert.Equal(newLog, logEntry.RawContent);
+        });
     }
 
     [Fact]
@@ -719,6 +858,53 @@ public partial class ConsoleLogsTests : DashboardTestContext
         {
             var highlightedCommands = cut.FindAll(".highlighted-command");
             Assert.Empty(highlightedCommands);
+        });
+    }
+
+    [Fact]
+    public void DashboardReadOnly_DisablesCommandButNotTelemetryActions()
+    {
+        var resource = ModelTestHelpers.CreateResource(
+            resourceName: "test-resource",
+            state: KnownResourceState.Running,
+            commands:
+            [
+                new CommandViewModel(
+                    "test-command",
+                    CommandViewModelState.Enabled,
+                    "Test command",
+                    "Test command description",
+                    confirmationMessage: "",
+                    argumentInputs: [],
+                    isHighlighted: true,
+                    iconName: string.Empty,
+                    iconVariant: IconVariant.Regular)
+            ]);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>(),
+            resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>,
+            initialResources: [resource],
+            isReadOnly: true);
+        SetupConsoleLogsServices(dashboardClient);
+        var viewport = CreateViewport(isDesktop: true);
+
+        var cut = RenderConsoleLogsPage(viewport, resource.Name);
+
+        cut.WaitForAssertion(() =>
+        {
+            var commandButton = Assert.Single(
+                cut.FindComponents<FluentButton>(),
+                button => string.Equals(button.Instance.Class, "highlighted-command", StringComparison.Ordinal));
+            Assert.True(commandButton.Instance.Disabled);
+
+            var clearButton = Assert.Single(
+                cut.FindComponents<FluentButton>(),
+                button => string.Equals(button.Instance.Class, "clear-button", StringComparison.Ordinal));
+            Assert.False(clearButton.Instance.Disabled);
+
+            var pauseButton = Assert.Single(cut.FindComponents<PauseIncomingDataSwitch>());
+            Assert.False(pauseButton.Instance.Disabled);
         });
     }
 
@@ -921,7 +1107,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         }
     }
 
-    private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null, TestTimeProvider? timeProvider = null)
+    private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null, TestTimeProvider? timeProvider = null, IResourceRepository? resourceRepository = null)
     {
         FluentUISetupHelpers.SetupFluentDialogProvider(this);
         FluentUISetupHelpers.SetupFluentDivider(this);
@@ -948,6 +1134,12 @@ public partial class ConsoleLogsTests : DashboardTestContext
         Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient());
         Services.AddScoped<DashboardCommandExecutor>();
         Services.AddSingleton<ConsoleLogsManager>();
+
+        if (resourceRepository is not null)
+        {
+            // Registered after AddCommonDashboardServices, which otherwise forwards IResourceRepository to IDashboardClient.
+            Services.AddSingleton(resourceRepository);
+        }
 
         FluentUISetupHelpers.SetupFluentUIComponents(this);
         _menuProvider = RenderComponent<FluentMenuProvider>();

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -1,14 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using System.Web;
 using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Utils;
@@ -18,8 +22,10 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Time.Testing;
 using Microsoft.FluentUI.AspNetCore.Components;
 using OpenTelemetry.Proto.Metrics.V1;
+using Aspire.Tests;
 using Xunit;
 using static Aspire.Dashboard.Components.Pages.Metrics;
 using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
@@ -31,10 +37,25 @@ public partial class MetricsTests : DashboardTestContext
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-    [Fact]
-    public void ChangeResource_MeterAndInstrumentOnNewResource_InstrumentSet()
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public async Task SignalActions_UseTelemetryRepositoryReadOnlyState(bool telemetryRepositoryIsReadOnly, bool dashboardClientIsReadOnly)
     {
-        ChangeResourceAndAssertInstrument(
+        MetricsSetupHelpers.SetupMetricsPage(this);
+        Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isReadOnly: dashboardClientIsReadOnly));
+        await FluentUISetupHelpers.ConfigureTelemetryRepository(this, telemetryRepositoryIsReadOnly, _ => Task.CompletedTask);
+
+        var cut = RenderComponent<Metrics>(builder => builder.AddCascadingValue(new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false)));
+
+        Assert.Equal(telemetryRepositoryIsReadOnly, cut.FindComponent<PauseIncomingDataSwitch>().Instance.Disabled);
+        Assert.Equal(telemetryRepositoryIsReadOnly, cut.FindComponent<ClearSignalsButton>().FindComponent<AspireMenuButton>().Instance.Disabled);
+    }
+
+    [Fact]
+    public async Task ChangeResource_MeterAndInstrumentOnNewResource_InstrumentSet()
+    {
+        await ChangeResourceAndAssertInstrument(
             app1InstrumentName: "test1",
             app2InstrumentName: "test1",
             expectedMeterNameAfterChange: "test-meter",
@@ -42,13 +63,290 @@ public partial class MetricsTests : DashboardTestContext
     }
 
     [Fact]
-    public void ChangeResource_MeterAndInstrumentNotOnNewResources_InstrumentCleared()
+    public async Task ChangeResource_MeterAndInstrumentNotOnNewResources_InstrumentCleared()
     {
-        ChangeResourceAndAssertInstrument(
+        await ChangeResourceAndAssertInstrument(
             app1InstrumentName: "test1",
             app2InstrumentName: "test2",
             expectedMeterNameAfterChange: null,
             expectedInstrumentNameAfterChange: null);
+    }
+
+    [Fact]
+    public async Task ChartContainer_ParametersAndActiveView_OnlyRefreshAndRenderWhenChanged()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        MetricsSetupHelpers.SetupMetricsPage(this);
+        var chartTimeProvider = new TestTimeProvider { UtcNow = DateTimeOffset.UtcNow };
+        Services.AddSingleton<BrowserTimeProvider>(chartTimeProvider);
+
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        var metricTime = chartTimeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1);
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "TestApp"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(
+                                metricName: "test-instrument",
+                                startTime: metricTime,
+                                attributes: [new KeyValuePair<string, string>("http.method", "GET")])
+                        }
+                    }
+                }
+            }
+        });
+
+        var resource = telemetryRepository.GetResources().Single();
+
+        var cut = RenderComponent<ChartContainer>(builder =>
+        {
+            builder.Add(component => component.ResourceKey, resource.ResourceKey);
+            builder.Add(component => component.MeterName, "test-meter");
+            builder.Add(component => component.InstrumentName, "test-instrument");
+            builder.Add(component => component.Duration, TimeSpan.FromMinutes(5));
+            builder.Add(component => component.ActiveView, MetricViewKind.Graph);
+            builder.Add(component => component.OnViewChangedAsync, _ => Task.CompletedTask);
+            builder.Add(component => component.Resources, [resource]);
+            builder.Add(component => component.PauseText, null);
+        });
+        cut.WaitForAssertion(() =>
+        {
+            var dimensionFilter = Assert.Single(cut.Instance.DimensionFilters);
+            Assert.Equal("GET", Assert.Single(dimensionFilter.SelectedValues).Value);
+            Assert.Single(cut.FindComponents<PlotlyChart>());
+            Assert.Empty(cut.FindComponents<MetricTable>());
+        });
+        var dimensionFilters = cut.Instance.DimensionFilters;
+
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(telemetryRepository.SqlActivitySource, onActivityStopped: activities.Enqueue);
+
+        cut.SetParametersAndRender(builder => builder.Add(component => component.ActiveView, MetricViewKind.Table));
+
+        Assert.Empty(cut.FindComponents<PlotlyChart>());
+        Assert.Single(cut.FindComponents<MetricTable>());
+        if (cut.FindAll(".empty-content-cell") is [var emptyContentCell])
+        {
+            Assert.Equal("Loading...", emptyContentCell.TextContent.Trim());
+        }
+        cut.WaitForAssertion(() => Assert.Contains("1Value increased", cut.FindAll("[role='gridcell']").Select(cell => cell.TextContent.Trim())));
+        Assert.Empty(activities);
+
+        cut.SetParametersAndRender(builder => builder.Add(component => component.ActiveView, MetricViewKind.Graph));
+
+        Assert.Single(cut.FindComponents<PlotlyChart>());
+        Assert.Empty(cut.FindComponents<MetricTable>());
+        Assert.Empty(activities);
+
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "TestApp"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(
+                                metricName: "test-instrument",
+                                startTime: metricTime,
+                                attributes: [new KeyValuePair<string, string>("http.method", "POST")])
+                        }
+                    }
+                }
+            }
+        });
+        activities.Clear();
+
+        cut.SetParametersAndRender(builder => builder.Add(component => component.Duration, TimeSpan.FromMinutes(5)));
+
+        Assert.Empty(activities);
+
+        cut.SetParametersAndRender(builder => builder.Add(component => component.Duration, TimeSpan.FromMinutes(1)));
+
+        cut.WaitForAssertion(() =>
+        {
+            var updatedFilter = Assert.Single(cut.Instance.DimensionFilters);
+            Assert.NotSame(dimensionFilters, cut.Instance.DimensionFilters);
+            Assert.Collection(
+                updatedFilter.SelectedValues.Select(value => value.Value).Order(),
+                value => Assert.Equal("GET", value),
+                value => Assert.Equal("POST", value));
+
+            var chart = cut.FindComponent<PlotlyChart>();
+            var dimensions = chart.Instance.InstrumentViewModel.MatchedDimensions!;
+            Assert.Equal(2, dimensions.Count);
+            Assert.All(dimensions, dimension => Assert.Equal(1, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value));
+            Assert.Contains(activities, activity => ((string?)activity.GetTagItem("db.query.text"))?.Contains("telemetry_metric_points", StringComparison.Ordinal) == true);
+        });
+    }
+
+    [Fact]
+    public async Task ChartContainer_InstrumentChanged_TableUpdates()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        MetricsSetupHelpers.SetupMetricsPage(this);
+        await FluentUISetupHelpers.ConfigureTelemetryRepository(this, readOnly: true, telemetryRepository => telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "TestApp"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "instrument-1", startTime: s_testTime.AddMinutes(1), value: 0),
+                            CreateSumMetric(metricName: "instrument-1", startTime: s_testTime.AddMinutes(2), value: 1),
+                            CreateSumMetric(metricName: "instrument-2", startTime: s_testTime.AddMinutes(1), value: 0),
+                            CreateSumMetric(metricName: "instrument-2", startTime: s_testTime.AddMinutes(2), value: 2)
+                        }
+                    }
+                }
+            }
+        }));
+
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        var resource = telemetryRepository.GetResources().Single();
+        var cut = RenderComponent<ChartContainer>(builder =>
+        {
+            builder.Add(component => component.ResourceKey, resource.ResourceKey);
+            builder.Add(component => component.MeterName, "test-meter");
+            builder.Add(component => component.InstrumentName, "instrument-1");
+            builder.Add(component => component.Duration, TimeSpan.FromMinutes(5));
+            builder.Add(component => component.ActiveView, MetricViewKind.Table);
+            builder.Add(component => component.OnViewChangedAsync, _ => Task.CompletedTask);
+            builder.Add(component => component.Resources, [resource]);
+            builder.Add(component => component.PauseText, null);
+        });
+
+        cut.WaitForState(() => cut.FindComponents<MetricTable>().Count == 1);
+        var table = cut.FindComponent<MetricTable>();
+        table.Render();
+        table.WaitForAssertion(() => Assert.Contains("1Value increased", table.FindAll("[role='gridcell']").Select(cell => cell.TextContent.Trim())));
+
+        cut.SetParametersAndRender(builder => builder.Add(component => component.InstrumentName, "instrument-2"));
+
+        cut.WaitForAssertion(() =>
+        {
+            var updatedTable = cut.FindComponent<MetricTable>();
+            Assert.Equal("instrument-2", updatedTable.Instance.InstrumentViewModel.Instrument?.Name);
+            Assert.NotEmpty(updatedTable.Instance.InstrumentViewModel.MatchedDimensions!);
+        });
+        cut.WaitForAssertion(() => Assert.Contains("2Value increased", cut.FindAll("[role='gridcell']").Select(cell => cell.TextContent.Trim())));
+    }
+
+    [Fact]
+    public async Task ChartContainer_TickUpdate_PreservesComponentCultureAndStopsOnDispose()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        MetricsSetupHelpers.SetupMetricsPage(this);
+        var timeProvider = new SignalingFakeTimeProvider();
+        Services.AddSingleton<TimeProvider>(timeProvider);
+
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        var metric = CreateSumMetric(metricName: "test-instrument", startTime: DateTime.UtcNow);
+        // End in the current SQLite query window while spanning the fixed browser time used by the rendered chart.
+        metric.Sum.DataPoints.Single().StartTimeUnixNano = 0;
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "TestApp"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            metric
+                        }
+                    }
+                }
+            }
+        });
+        var resource = telemetryRepository.GetResources().Single();
+
+        var activitySource = Services.GetRequiredService<DashboardActivitySource>();
+        var tickActivityCount = 0;
+        var activityStarted = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var activityStopped = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var listener = ActivityListenerHelper.Create(
+            activitySource.ActivitySource,
+            onActivityStarted: activity =>
+            {
+                if (activity.OperationName == "Update metric chart data from tick")
+                {
+                    Interlocked.Increment(ref tickActivityCount);
+                    activityStarted.TrySetResult(activity);
+                }
+            },
+            onActivityStopped: activity =>
+            {
+                if (activity.OperationName == "Update metric chart data from tick")
+                {
+                    activityStopped.TrySetResult(activity);
+                }
+            });
+
+        var componentCulture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
+        componentCulture.DateTimeFormat.AMDesignator = "am";
+        var originalCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = componentCulture;
+            var cut = RenderComponent<ChartContainer>(builder =>
+            {
+                builder.Add(component => component.ResourceKey, resource.ResourceKey);
+                builder.Add(component => component.MeterName, "test-meter");
+                builder.Add(component => component.InstrumentName, "test-instrument");
+                builder.Add(component => component.Duration, TimeSpan.FromSeconds(1));
+                builder.Add(component => component.ActiveView, MetricViewKind.Table);
+                builder.Add(component => component.OnViewChangedAsync, _ => Task.CompletedTask);
+                builder.Add(component => component.Resources, [resource]);
+                builder.Add(component => component.PauseText, null);
+            });
+
+            cut.WaitForAssertion(() => Assert.Single(cut.FindComponents<MetricTable>()));
+            await timeProvider.TimerCreated.Task.DefaultTimeout();
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+            var started = await activityStarted.Task.WaitAsync(DefaultWaitTimeout);
+            var activity = await activityStopped.Task.WaitAsync(DefaultWaitTimeout);
+
+            Assert.Same(started, activity);
+            Assert.Equal(ActivityKind.Internal, activity.Kind);
+            Assert.Null(activity.ParentId);
+            cut.WaitForAssertion(() =>
+            {
+                Assert.Equal("12:59:57 am", cut.Find("[role='gridcell']").TextContent.Trim(), ignoreWhiteSpaceDifferences: true);
+            });
+
+            await cut.Instance.DisposeAsync().DefaultTimeout();
+            var activityCountAfterDispose = Volatile.Read(ref tickActivityCount);
+            timeProvider.Advance(TimeSpan.FromSeconds(10));
+
+            Assert.Equal(activityCountAfterDispose, Volatile.Read(ref tickActivityCount));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     [Fact]
@@ -66,8 +364,8 @@ public partial class MetricsTests : DashboardTestContext
             return ValueTask.CompletedTask;
         });
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -98,7 +396,7 @@ public partial class MetricsTests : DashboardTestContext
     }
 
     [Fact]
-    public void InitialLoad_HasSessionState_RedirectUsingState()
+    public async Task InitialLoad_HasSessionState_RedirectUsingState()
     {
         // Arrange
         var testSessionStorage = new TestSessionStorage
@@ -135,8 +433,8 @@ public partial class MetricsTests : DashboardTestContext
             loadRedirect = new Uri(a.Location);
         };
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -253,13 +551,13 @@ public partial class MetricsTests : DashboardTestContext
     }
 
     [Fact]
-    public void MetricsTree_MetricsAdded_TreeUpdated()
+    public async Task MetricsTree_MetricsAdded_TreeUpdated()
     {
         // Arrange
         MetricsSetupHelpers.SetupMetricsPage(this);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -304,7 +602,7 @@ public partial class MetricsTests : DashboardTestContext
 
         // Act 2
         // New instruments added
-        telemetryRepository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -348,7 +646,52 @@ public partial class MetricsTests : DashboardTestContext
         });
     }
 
-    private void ChangeResourceAndAssertInstrument(string app1InstrumentName, string app2InstrumentName, string? expectedMeterNameAfterChange, string? expectedInstrumentNameAfterChange)
+    [Fact]
+    public async Task ReadOnly_ChartEndsAtLatestMetricTime()
+    {
+        MetricsSetupHelpers.SetupMetricsPage(this);
+
+        await FluentUISetupHelpers.ConfigureTelemetryRepository(this, readOnly: true, telemetryRepository => telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "TestApp"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test-instrument", startTime: s_testTime.AddMinutes(1)),
+                            CreateSumMetric(metricName: "test-instrument", startTime: s_testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        }));
+        Services.GetRequiredService<PauseManager>().SetMetricsPaused(true);
+        Services.GetRequiredService<NavigationManager>().NavigateTo(
+            DashboardUrls.MetricsUrl(resource: "TestApp", meter: "test-meter", instrument: "test-instrument", duration: 5, view: MetricViewKind.Graph.ToString()));
+
+        var cut = RenderComponent<Metrics>(builder =>
+        {
+            builder.Add(m => m.ResourceName, "TestApp");
+            builder.AddCascadingValue(new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        cut.WaitForAssertion(() => Assert.Single(cut.FindComponents<PlotlyChart>()));
+        var chart = cut.FindComponent<PlotlyChart>().Instance;
+        var expectedEndTime = new DateTimeOffset(s_testTime.AddMinutes(2));
+        Assert.Equal(expectedEndTime, chart.DataEndTime);
+        cut.WaitForAssertion(() =>
+        {
+            var initializeChart = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "initializeChart");
+            Assert.Equal(chart.TimeProvider.ToLocal(expectedEndTime), Assert.IsType<DateTime>(initializeChart.Arguments[3]));
+        });
+    }
+
+    private async Task ChangeResourceAndAssertInstrument(string app1InstrumentName, string app2InstrumentName, string? expectedMeterNameAfterChange, string? expectedInstrumentNameAfterChange)
     {
         // Arrange
         MetricsSetupHelpers.SetupMetricsPage(this);
@@ -356,8 +699,8 @@ public partial class MetricsTests : DashboardTestContext
         var navigationManager = Services.GetRequiredService<NavigationManager>();
         navigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: "TestApp", meter: "test-meter", instrument: app1InstrumentName, duration: 720, view: MetricViewKind.Table.ToString()));
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -427,5 +770,17 @@ public partial class MetricsTests : DashboardTestContext
 
         Assert.Equal(MetricViewKind.Table, viewModel.SelectedViewKind);
         Assert.Equal(TimeSpan.FromMinutes(720), viewModel.SelectedDuration.Id);
+    }
+
+    private sealed class SignalingFakeTimeProvider : FakeTimeProvider
+    {
+        public TaskCompletionSource TimerCreated { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = base.CreateTimer(callback, state, dueTime, period);
+            TimerCreated.TrySetResult();
+            return timer;
+        }
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsTests.cs
@@ -115,7 +115,6 @@ public partial class MetricsTests : DashboardTestContext
             builder.Add(component => component.ActiveView, MetricViewKind.Graph);
             builder.Add(component => component.OnViewChangedAsync, _ => Task.CompletedTask);
             builder.Add(component => component.Resources, [resource]);
-            builder.Add(component => component.PauseText, null);
         });
         cut.WaitForAssertion(() =>
         {
@@ -230,7 +229,6 @@ public partial class MetricsTests : DashboardTestContext
             builder.Add(component => component.ActiveView, MetricViewKind.Table);
             builder.Add(component => component.OnViewChangedAsync, _ => Task.CompletedTask);
             builder.Add(component => component.Resources, [resource]);
-            builder.Add(component => component.PauseText, null);
         });
 
         cut.WaitForState(() => cut.FindComponents<MetricTable>().Count == 1);
@@ -319,7 +317,6 @@ public partial class MetricsTests : DashboardTestContext
                 builder.Add(component => component.ActiveView, MetricViewKind.Table);
                 builder.Add(component => component.OnViewChangedAsync, _ => Task.CompletedTask);
                 builder.Add(component => component.Resources, [resource]);
-                builder.Add(component => component.PauseText, null);
             });
 
             cut.WaitForAssertion(() => Assert.Single(cut.FindComponents<MetricTable>()));
@@ -486,12 +483,12 @@ public partial class MetricsTests : DashboardTestContext
     }
 
     [Fact]
-    public void PauseIncomingData_DisplaysPauseWarningInPageFooter()
+    public async Task PauseIncomingData_DisplaysPauseWarningInPageFooter()
     {
         MetricsSetupHelpers.SetupMetricsPage(this);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -12,6 +12,7 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Utils;
+using Aspire.Tests.Shared.DashboardModel;
 using Bunit;
 using ProtobufValue = Google.Protobuf.WellKnownTypes.Value;
 using Google.Protobuf.Collections;
@@ -29,6 +30,47 @@ namespace Aspire.Dashboard.Components.Tests.Pages;
 [UseCulture("en-US")]
 public partial class ResourcesTests : DashboardTestContext
 {
+    [Fact]
+    public void ReadOnly_HighlightedCommandIsVisibleAndDisabled()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var resource = ModelTestHelpers.CreateResource(
+            resourceName: "test-resource",
+            state: KnownResourceState.Running,
+            commands:
+            [
+                new CommandViewModel(
+                    "test-command",
+                    CommandViewModelState.Enabled,
+                    "Test command",
+                    "Test command description",
+                    confirmationMessage: "",
+                    argumentInputs: [],
+                    isHighlighted: true,
+                    iconName: string.Empty,
+                    iconVariant: IconVariant.Regular)
+            ]);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            initialResources: [resource],
+            resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>,
+            isReadOnly: true);
+        ResourceSetupHelpers.SetupResourcesPage(this, viewport, dashboardClient);
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        cut.WaitForAssertion(() =>
+        {
+            var commandButton = Assert.Single(
+                cut.FindComponents<FluentButton>(),
+                button => string.Equals(button.Instance.Title, "Test command description", StringComparison.Ordinal));
+            Assert.True(commandButton.Instance.Disabled);
+        });
+    }
+
     [Fact]
     public void UpdateResources_FiltersUpdated()
     {
@@ -490,14 +532,14 @@ public partial class ResourcesTests : DashboardTestContext
     }
 
     [Fact]
-    public void UnreadLogErrorsBadge_StopsKeyboardPropagation()
+    public async Task UnreadLogErrorsBadge_StopsKeyboardPropagation()
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         FluentUISetupHelpers.SetupFluentUIComponents(this);
         FluentUISetupHelpers.SetupFluentAnchor(this);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        AddErrorLog(telemetryRepository, resourceName: "Resource1");
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await AddErrorLog(telemetryRepository, resourceName: "Resource1");
         var unviewedErrorCounts = telemetryRepository.GetResourceUnviewedErrorLogsCount();
         var resourceKey = Assert.Single(unviewedErrorCounts.Keys);
         var resource = CreateResource(resourceKey.GetCompositeName(), "Type1", "Running", null);
@@ -548,7 +590,7 @@ public partial class ResourcesTests : DashboardTestContext
         };
     }
 
-    private static void AddErrorLog(TelemetryRepository repository, string resourceName)
+    private static async Task AddErrorLog(SqliteTelemetryRepository repository, string resourceName)
     {
         var addContext = new AddContext();
         var logs = new RepeatedField<ResourceLogs>();
@@ -571,7 +613,7 @@ public partial class ResourcesTests : DashboardTestContext
             }
         });
 
-        repository.AddLogs(addContext, logs);
+        await repository.AddLogsAsync(addContext, logs);
 
         Assert.Equal(0, addContext.FailureCount);
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -5,6 +5,7 @@ using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
@@ -18,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 using OpenTelemetry.Proto.Logs.V1;
 using Xunit;
@@ -29,13 +31,13 @@ namespace Aspire.Dashboard.Components.Tests.Pages;
 public partial class StructuredLogsTests : DashboardTestContext
 {
     [Fact]
-    public void Render_ResourceInstanceHasDashes_AppKeyResolvedCorrectly()
+    public async Task Render_ResourceInstanceHasDashes_AppKeyResolvedCorrectly()
     {
         // Arrange
         SetupStructureLogsServices();
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -71,7 +73,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         });
 
         // Assert
-        var viewModel = Services.GetRequiredService<StructuredLogsViewModel>();
+        var viewModel = cut.Instance.ViewModel;
 
         Assert.NotNull(viewModel.ResourceKey);
         Assert.Equal("TestApp", viewModel.ResourceKey.Value.Name);
@@ -100,7 +102,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         });
 
         // Assert
-        var viewModel = Services.GetRequiredService<StructuredLogsViewModel>();
+        var viewModel = cut.Instance.ViewModel;
 
         Assert.Collection(viewModel.Filters,
             f =>
@@ -140,7 +142,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         });
 
         // Assert
-        var viewModel = Services.GetRequiredService<StructuredLogsViewModel>();
+        var viewModel = cut.Instance.ViewModel;
 
         Assert.Collection(viewModel.Filters,
             f =>
@@ -178,7 +180,7 @@ public partial class StructuredLogsTests : DashboardTestContext
         });
 
         // Assert
-        var viewModel = Services.GetRequiredService<StructuredLogsViewModel>();
+        var viewModel = cut.Instance.ViewModel;
 
         Assert.Collection(viewModel.Filters,
             f =>
@@ -269,8 +271,55 @@ public partial class StructuredLogsTests : DashboardTestContext
 
         cut.FindComponent<PauseIncomingDataSwitch>().WaitForElement("fluent-button").Click();
 
-        Assert.True(Services.GetRequiredService<PauseManager>().AreStructuredLogsPaused(out _));
-        Assert.Contains("Capture paused", cut.Markup);
+        // The click handler flows through PauseManager and then re-renders the page, so the pause state and the
+        // warning banner do not both land in the same render pass. Waiting avoids asserting on an interim render.
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(Services.GetRequiredService<PauseManager>().AreStructuredLogsPaused(out _));
+            Assert.Contains("Capture paused", cut.Markup);
+        });
+    }
+
+    [Theory]
+    [InlineData(false, 1)]
+    [InlineData(true, 0)]
+    public async Task Render_AtLogLimit_LimitMessageOnlyDisplayedForLiveRun(bool isReadOnly, int expectedMessageCount)
+    {
+        var messageCount = 0;
+        var messageService = new TestMessageService(_ =>
+        {
+            messageCount++;
+            return Task.FromResult(new Message());
+        });
+
+        SetupStructureLogsServices();
+        Services.AddSingleton<IMessageService>(messageService);
+        Services.AddSingleton<IOptions<DashboardOptions>>(Options.Create(new DashboardOptions
+        {
+            TelemetryLimits = { MaxLogCount = 1 }
+        }));
+
+        await FluentUISetupHelpers.ConfigureTelemetryRepository(this, isReadOnly, telemetryRepository => telemetryRepository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(),
+                        LogRecords = { CreateLogRecord() }
+                    }
+                }
+            }
+        }));
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        Services.GetRequiredService<DimensionManager>().InvokeOnViewportInformationChanged(viewport);
+        var cut = RenderComponent<StructuredLogs>(builder => builder.Add(p => p.ViewportInformation, viewport));
+
+        cut.WaitForAssertion(() => Assert.Equal(expectedMessageCount, messageCount));
     }
 
     private void SetupStructureLogsServices()
@@ -290,6 +339,6 @@ public partial class StructuredLogsTests : DashboardTestContext
 
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         Services.AddSingleton<ILogger<StructuredLogs>>(NullLogger<StructuredLogs>.Instance);
-        Services.AddSingleton<StructuredLogsViewModel>();
+        Services.AddTransient<StructuredLogsViewModel>();
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -36,7 +36,7 @@ public partial class TraceDetailsTests : DashboardTestContext
     }
 
     [Fact]
-    public void Render_HasTrace_SubscriptionRemovedOnDispose()
+    public async Task Render_HasTrace_SubscriptionRemovedOnDispose()
     {
         // Arrange
         SetupTraceDetailsServices();
@@ -46,8 +46,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -76,18 +76,74 @@ public partial class TraceDetailsTests : DashboardTestContext
         });
 
         // Assert
-        Assert.Collection(telemetryRepository.TracesSubscriptions, t =>
-        {
-            Assert.Equal(nameof(TelemetryRepository.OnNewTraces), t.Name);
-        });
+        cut.WaitForAssertion(() => Assert.Equal(3, cut.FindComponent<FluentDataGrid<SpanWaterfallViewModel>>().FindAll(".fluent-data-grid-row").Count));
+        cut.WaitForAssertion(() => Assert.Equal(1, telemetryRepository.TraceSubscriptionCount));
 
         DisposeComponents();
 
-        Assert.Empty(telemetryRepository.TracesSubscriptions);
+        Assert.Equal(0, telemetryRepository.TraceSubscriptionCount);
     }
 
     [Fact]
-    public void Render_FocusesAccessibleScrollContainerOnInitialRender()
+    public async Task Render_LogQueryPending_PageTitleRendered()
+    {
+        SetupTraceDetailsServices();
+
+        var queryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueQuery = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Services.AddSingleton<ITelemetryRepository>(services =>
+        {
+            var inner = services.GetRequiredService<SqliteTelemetryRepository>();
+            return new TestTelemetryRepository(inner)
+            {
+                GetLogSummariesAsyncHandler = async (context, cancellationToken) =>
+                {
+                    queryStarted.SetResult();
+                    await continueQuery.Task.WaitAsync(cancellationToken);
+                    return await inner.GetLogSummariesAsync(context, cancellationToken);
+                }
+            };
+        });
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        Services.GetRequiredService<DimensionManager>().InvokeOnViewportInformationChanged(viewport);
+
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10))
+                        }
+                    }
+                }
+            }
+        });
+
+        var traceId = Convert.ToHexString(Encoding.UTF8.GetBytes("1"));
+        var cut = RenderComponent<TraceDetail>(builder =>
+        {
+            builder.Add(p => p.TraceId, traceId);
+            builder.AddCascadingValue(viewport);
+        });
+
+        await queryStarted.Task.WaitAsync(DefaultWaitTimeout);
+        Assert.NotEmpty(Assert.IsType<string>(cut.Instance.GetPageTitle()));
+
+        continueQuery.SetResult();
+        cut.WaitForAssertion(() => Assert.Equal(2, cut.FindComponent<FluentDataGrid<SpanWaterfallViewModel>>().FindAll(".fluent-data-grid-row").Count));
+    }
+
+    [Fact]
+    public async Task Render_FocusesAccessibleScrollContainerOnInitialRender()
     {
         SetupTraceDetailsServices();
 
@@ -96,8 +152,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -162,8 +218,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -230,8 +286,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -269,7 +325,7 @@ public partial class TraceDetailsTests : DashboardTestContext
             return rows.Count == 3;
         }, "Expected rows to be rendered.", logger);
 
-        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -312,8 +368,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -352,7 +408,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         }, "Expected rows to be rendered.", logger);
 
         logger.LogInformation($"Adding span for difference trace");
-        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -389,8 +445,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(),
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(),
             new RepeatedField<ResourceSpans>
             {
                 new ResourceSpans
@@ -436,6 +492,7 @@ public partial class TraceDetailsTests : DashboardTestContext
             builder.AddCascadingValue(viewport);
         });
 
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Instance.PageViewModel.SpanWaterfallViewModels));
         var data = await cut.Instance.GetData(new GridItemsProviderRequest<SpanWaterfallViewModel>());
 
         // Assert
@@ -457,8 +514,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(),
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(),
             new RepeatedField<ResourceSpans>
             {
                 new ResourceSpans
@@ -507,6 +564,7 @@ public partial class TraceDetailsTests : DashboardTestContext
             builder.AddCascadingValue(viewport);
         });
 
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Instance.PageViewModel.SpanWaterfallViewModels));
         var unfilteredData = await cut.Instance.GetData(new GridItemsProviderRequest<SpanWaterfallViewModel>());
 
         // Duration >= 10ms only matches 1-3. Its parent chain (1-1, 1-2) stays visible
@@ -582,8 +640,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(),
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(),
             new RepeatedField<ResourceSpans>
             {
                 new ResourceSpans
@@ -629,6 +687,7 @@ public partial class TraceDetailsTests : DashboardTestContext
             builder.AddCascadingValue(viewport);
         });
 
+        cut.WaitForAssertion(() => Assert.NotNull(cut.Instance.PageViewModel.SpanWaterfallViewModels));
         var unfilteredData = await cut.Instance.GetData(new GridItemsProviderRequest<SpanWaterfallViewModel>());
 
         var filteredItems = TraceDetail.TraceDetailPageViewModel.ApplySpanFilters(
@@ -656,7 +715,7 @@ public partial class TraceDetailsTests : DashboardTestContext
     }
 
     [Fact]
-    public void ToggleCollapse_SpanStateChanges()
+    public async Task ToggleCollapse_SpanStateChanges()
     {
         // Arrange
         SetupTraceDetailsServices();
@@ -665,8 +724,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(),
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(),
             new RepeatedField<ResourceSpans>
             {
                 new ResourceSpans
@@ -739,7 +798,7 @@ public partial class TraceDetailsTests : DashboardTestContext
     }
 
     [Fact]
-    public void CollapseAllSpans_CollapsesAllSpans()
+    public async Task CollapseAllSpans_CollapsesAllSpans()
     {
         // Arrange
         SetupTraceDetailsServices();
@@ -748,8 +807,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(),
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(),
             new RepeatedField<ResourceSpans>
             {
                 new ResourceSpans
@@ -790,7 +849,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         var menuButton = cut.FindComponent<AspireMenuButton>();
         var collapseAllMenuItem = menuButton.Instance.ItemsProvider().FirstOrDefault(item => item.Text == "Collapse all"); // Locate by text since ID was removed
         Assert.NotNull(collapseAllMenuItem);
-        cut.InvokeAsync(() => collapseAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
+        await cut.InvokeAsync(() => collapseAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -814,7 +873,7 @@ public partial class TraceDetailsTests : DashboardTestContext
     }
 
     [Fact]
-    public void ExpandAllSpans_ExpandsAllSpans()
+    public async Task ExpandAllSpans_ExpandsAllSpans()
     {
         // Arrange
         SetupTraceDetailsServices();
@@ -823,8 +882,8 @@ public partial class TraceDetailsTests : DashboardTestContext
         var dimensionManager = Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);
 
-        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
-        telemetryRepository.AddTraces(new AddContext(),
+        var telemetryRepository = Services.GetRequiredService<SqliteTelemetryRepository>();
+        await telemetryRepository.AddTracesAsync(new AddContext(),
             new RepeatedField<ResourceSpans>
             {
                 new ResourceSpans
@@ -865,7 +924,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         var menuButton = cut.FindComponent<AspireMenuButton>();
         var collapseAllMenuItem = menuButton.Instance.ItemsProvider().FirstOrDefault(item => item.Text == "Collapse all"); // Locate by text since ID was removed
         Assert.NotNull(collapseAllMenuItem);
-        cut.InvokeAsync(() => collapseAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
+        await cut.InvokeAsync(() => collapseAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
 
         // Wait for spans to collapse
         cut.WaitForAssertion(() =>
@@ -878,7 +937,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         // Act - Click "Expand All"
         var expandAllMenuItem = menuButton.Instance.ItemsProvider().FirstOrDefault(item => item.Text == "Expand all"); // Locate by text since ID was removed
         Assert.NotNull(expandAllMenuItem);
-        cut.InvokeAsync(() => expandAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
+        await cut.InvokeAsync(() => expandAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
 
         // Assert
         cut.WaitForAssertion(() =>

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TracesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TracesTests.cs
@@ -4,13 +4,20 @@
 using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
 using Bunit;
+using Google.Protobuf.Collections;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.FluentUI.AspNetCore.Components;
+using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Components.Tests.Pages;
 
@@ -48,6 +55,49 @@ public class TracesTests : DashboardTestContext
         });
     }
 
+    [Theory]
+    [InlineData(false, 1)]
+    [InlineData(true, 0)]
+    public async Task Render_AtTraceLimit_LimitMessageOnlyDisplayedForLiveRun(bool isReadOnly, int expectedMessageCount)
+    {
+        var messageCount = 0;
+        var messageService = new TestMessageService(_ =>
+        {
+            messageCount++;
+            return Task.FromResult(new Message());
+        });
+
+        SetupTracesServices();
+        Services.AddSingleton<IMessageService>(messageService);
+        Services.AddSingleton<IOptions<DashboardOptions>>(Options.Create(new DashboardOptions
+        {
+            TelemetryLimits = { MaxTraceCount = 1 }
+        }));
+
+        var timestamp = DateTime.UnixEpoch;
+        await FluentUISetupHelpers.ConfigureTelemetryRepository(this, isReadOnly, telemetryRepository => telemetryRepository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan(traceId: "trace", spanId: "span", startTime: timestamp, endTime: timestamp.AddSeconds(1)) }
+                    }
+                }
+            }
+        }));
+
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        Services.GetRequiredService<DimensionManager>().InvokeOnViewportInformationChanged(viewport);
+        var cut = RenderComponent<Traces>(builder => builder.AddCascadingValue(viewport));
+
+        cut.WaitForAssertion(() => Assert.Equal(expectedMessageCount, messageCount));
+    }
+
     private void SetupTracesServices()
     {
         FluentUISetupHelpers.SetupFluentOverflow(this);
@@ -67,6 +117,6 @@ public class TracesTests : DashboardTestContext
 
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         Services.AddSingleton<ILogger<Traces>>(NullLogger<Traces>.Instance);
-        Services.AddSingleton<TracesViewModel>();
+        Services.AddTransient<TracesViewModel>();
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
@@ -7,11 +7,14 @@ using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.BrowserStorage;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.ServiceClient;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Dashboard.Tests;
+using Aspire.Tests.Utils;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 
@@ -144,26 +147,90 @@ internal static class FluentUISetupHelpers
         comboboxModule.SetupVoid("setControlAttribute", _ => true);
     }
 
+    public static async Task ConfigureTelemetryRepository(
+        TestContext context,
+        bool readOnly,
+        Func<ITelemetryRepositoryWriter, Task> seed)
+    {
+        context.Services.AddSingleton(new TelemetryRepositoryConfiguration(readOnly));
+
+        var databasePath = Path.Combine(context.Services.GetRequiredService<TemporaryWorkspace>().Path, "dashboard.db");
+        var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+        var options = context.Services.GetRequiredService<IOptions<DashboardOptions>>();
+        var outgoingPeerResolvers = context.Services.GetServices<IOutgoingPeerResolver>();
+
+        using var database = new DashboardSqliteDatabase(databasePath, pooling: false);
+        await database.InitializeSchemaAsync(CancellationToken.None);
+        using var writer = new SqliteTelemetryRepository(
+            database,
+            loggerFactory,
+            options,
+            new PauseManager(),
+            context.Services.GetRequiredService<TimeProvider>(),
+            outgoingPeerResolvers);
+        await seed(writer);
+    }
+
     public static void AddCommonDashboardServices(
         TestContext context,
         ILocalStorage? localStorage = null,
         ISessionStorage? sessionStorage = null,
         ThemeManager? themeManager = null,
         IMessageService? messageService = null,
-        BrowserTimeProvider? browserTimeProvider = null)
+        BrowserTimeProvider? browserTimeProvider = null,
+        IDashboardRunStore? dashboardRunStore = null)
     {
         context.Services.AddLocalization();
         context.Services.AddSingleton<BrowserTimeProvider>(browserTimeProvider ?? new TestTimeProvider());
-        context.Services.AddSingleton<TelemetryRepository>();
+        context.Services.AddSingleton(TimeProvider.System);
+        context.Services.AddSingleton(_ => TemporaryWorkspace.Create(
+            global::Xunit.TestContext.Current.TestOutputHelper ?? throw new InvalidOperationException("An active test output helper is required.")));
+        context.Services.AddSingleton(services =>
+        {
+            var databasePath = Path.Combine(services.GetRequiredService<TemporaryWorkspace>().Path, "dashboard.db");
+            var configuration = services.GetService<TelemetryRepositoryConfiguration>();
+            var database = new DashboardSqliteDatabase(databasePath, readOnly: configuration?.ReadOnly == true, pooling: false);
+            if (!database.IsReadOnly)
+            {
+                database.InitializeSchemaAsync(CancellationToken.None).GetAwaiter().GetResult();
+            }
+            return database;
+        });
+        context.Services.AddSingleton<SqliteTelemetryRepository>(services =>
+        {
+            var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+            var options = services.GetRequiredService<IOptions<DashboardOptions>>();
+            var pauseManager = services.GetRequiredService<PauseManager>();
+            var outgoingPeerResolvers = services.GetServices<IOutgoingPeerResolver>();
+
+            return new SqliteTelemetryRepository(
+                services.GetRequiredService<DashboardSqliteDatabase>(),
+                loggerFactory,
+                options,
+                pauseManager,
+                services.GetRequiredService<TimeProvider>(),
+                outgoingPeerResolvers);
+        });
+        context.Services.AddSingleton<ITelemetryRepository>(services => services.GetRequiredService<SqliteTelemetryRepository>());
+        context.Services.AddSingleton<ITelemetryRepositoryWriter>(services => services.GetRequiredService<SqliteTelemetryRepository>());
         context.Services.AddSingleton<PauseManager>();
         context.Services.AddSingleton<IDialogService, DialogService>();
         context.Services.AddSingleton<ILocalStorage>(localStorage ?? new TestLocalStorage());
         context.Services.AddSingleton<ISessionStorage>(sessionStorage ?? new TestSessionStorage());
+        context.Services.AddSingleton<IDashboardRunStore>(services => dashboardRunStore ?? new TestDashboardRunStore(
+            databasePath: Path.Combine(services.GetRequiredService<TemporaryWorkspace>().Path, "dashboard.db")));
+        context.Services.AddSingleton<IDashboardRunSelection, TestDashboardRunSelection>();
+        context.Services.AddSingleton<IDashboardClient, TestDashboardClient>();
+        context.Services.AddSingleton<IResourceRepository>(services => services.GetRequiredService<IDashboardClient>());
+        context.Services.AddSingleton<IRepositoryFactory, TestRepositoryFactory>();
+        context.Services.AddSingleton<DashboardDataSourcePool>();
+        context.Services.AddScoped<DashboardDataSource>();
         context.Services.AddSingleton<ShortcutManager>();
         context.Services.AddSingleton<LibraryConfiguration>();
         context.Services.AddSingleton<IKeyCodeService, KeyCodeService>();
         context.Services.AddSingleton<IMessageService>(messageService ?? new MessageService());
         context.Services.AddSingleton<DashboardTelemetryService>();
+        context.Services.AddSingleton<DashboardActivitySource>();
         context.Services.AddSingleton<IDashboardTelemetrySender, TestDashboardTelemetrySender>();
         context.Services.AddSingleton<ComponentTelemetryContextProvider>();
         context.Services.AddSingleton<ITelemetryErrorRecorder, TestTelemetryErrorRecorder>();
@@ -180,22 +247,118 @@ internal static class FluentUISetupHelpers
         context.Services.AddSingleton<IOptions<DashboardOptions>>(Options.Create(new DashboardOptions()));
     }
 
+    internal sealed class TestDashboardRunStore(
+        IEnumerable<DashboardRunDescriptor>? runs = null,
+        bool supportsRunSelection = true,
+        string? databasePath = null) : IDashboardRunStore
+    {
+        private readonly IReadOnlyList<DashboardRunDescriptor> _runs = (runs ??
+            [
+                new(
+                RunId: "current",
+                SchemaVersion: DashboardRunStore.SchemaVersion,
+                StartedAtUtc: DateTimeOffset.UnixEpoch,
+                EndedAtUtc: null,
+                CleanShutdown: false,
+                ApplicationName: "TestApp",
+                DatabasePath: databasePath ?? string.Empty,
+                IsCurrent: true)
+            ]).ToArray();
+
+        public int GetRunsCallCount { get; private set; }
+
+        public Action<DashboardRunDescriptor, bool>? OnSetRunPinned { get; set; }
+
+        public IReadOnlyList<DashboardRunDescriptor> GetRuns()
+        {
+            GetRunsCallCount++;
+            return _runs;
+        }
+
+        public DashboardRunDescriptor GetCurrentRun() => _runs.Single(run => run.IsCurrent);
+
+        public DashboardRunDescriptor? GetRunById(string runId) =>
+            _runs.SingleOrDefault(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+
+        public void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
+        {
+            OnSetRunPinned?.Invoke(run, isPinned);
+            _runs.Single(candidate => string.Equals(candidate.RunId, run.RunId, StringComparison.Ordinal)).IsPinned = isPinned;
+        }
+
+        public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run) => null;
+
+        public void PublishRun()
+        {
+        }
+
+        public void PruneExpiredRuns()
+        {
+        }
+
+        public bool SupportsRunSelection => supportsRunSelection;
+    }
+
+    internal sealed class TestDashboardRunSelection(IDashboardRunStore runStore) : IDashboardRunSelection
+    {
+        public DashboardRunDescriptor SelectedRun { get; private set; } = runStore.GetCurrentRun();
+
+        public string? SelectedRunId { get; private set; }
+
+        public Action<string?>? OnSelectRun { get; set; }
+
+        public void SelectRun(string? runId)
+        {
+            OnSelectRun?.Invoke(runId);
+            SelectedRun = runId is not null ? runStore.GetRunById(runId) ?? runStore.GetCurrentRun() : runStore.GetCurrentRun();
+            SelectedRunId = SelectedRun.IsCurrent ? null : SelectedRun.RunId;
+        }
+    }
+
+    private sealed class TestRepositoryFactory(
+        ITelemetryRepository telemetryRepository,
+        IDashboardClient dashboardClient) : IRepositoryFactory
+    {
+        public ITelemetryRepository CreateTelemetryRepository(DashboardSqliteDatabase database) => telemetryRepository;
+        public IResourceRepository CreateResourceRepository(DashboardSqliteDatabase database) => dashboardClient;
+    }
+
     public static void SetupFluentUIComponents(TestContext context, bool setupAspireMenuButtonModule = true)
     {
         context.Services.AddFluentUIComponents();
 
         if (setupAspireMenuButtonModule)
         {
-            var menuButtonModule = context.JSInterop.SetupModule("./Components/Controls/AspireMenuButton.razor.js");
-            menuButtonModule.SetupVoid("prepareForFluentMenuInitialization", _ => true).SetVoidResult();
-            menuButtonModule.SetupVoid("waitForFluentMenuInitialization", _ => true).SetVoidResult();
-            menuButtonModule.SetupVoid("cancelFluentMenuInitialization", _ => true).SetVoidResult();
+            SetupAspireMenuButtonModule(context);
         }
 
         // Setting a provider ID on menu service is required to simulate <FluentMenuProvider> on the page.
         // This makes FluentMenu render without error.
-        var menuService = context.Services.GetRequiredService<IMenuService>();
-        menuService.ProviderId = "Test";
+        SetupMenuService(context);
+    }
+
+    /// <summary>
+    /// Registers the FluentUI menu service and simulates a <c>FluentMenuProvider</c> being present on the page.
+    /// Tests that configure FluentUI piecemeal (rather than calling <see cref="SetupFluentUIComponents"/>) still
+    /// need this because <see cref="AspireMenu"/> injects <see cref="IMenuService"/>.
+    /// </summary>
+    public static void SetupMenuService(TestContext context)
+    {
+        // Register a pre-configured instance rather than resolving one from the provider. Resolving here would
+        // seal bUnit's service collection, and callers add more services after this setup runs.
+        context.Services.AddSingleton<IMenuService>(new MenuService { ProviderId = "Test" });
+    }
+
+    /// <summary>
+    /// Registers the JS module <see cref="AspireMenuButton"/> imports when its menu is first opened.
+    /// Tests that click a menu button need this even when they configure FluentUI piecemeal.
+    /// </summary>
+    public static void SetupAspireMenuButtonModule(TestContext context)
+    {
+        var menuButtonModule = context.JSInterop.SetupModule("./Components/Controls/AspireMenuButton.razor.js");
+        menuButtonModule.SetupVoid("prepareForFluentMenuInitialization", _ => true).SetVoidResult();
+        menuButtonModule.SetupVoid("waitForFluentMenuInitialization", _ => true).SetVoidResult();
+        menuButtonModule.SetupVoid("cancelFluentMenuInitialization", _ => true).SetVoidResult();
     }
 
     public static void SetupDialogInfrastructure(
@@ -216,4 +379,6 @@ internal static class FluentUISetupHelpers
             builder.CloseComponent();
         });
     }
+
+    private sealed record TelemetryRepositoryConfiguration(bool ReadOnly);
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/LifecycleTestComponent.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/LifecycleTestComponent.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+
+internal sealed class LifecycleTestComponent : ComponentBase, IDisposable
+{
+    [Parameter, EditorRequired]
+    public required Action Initialized { get; init; }
+
+    [Parameter, EditorRequired]
+    public required Action Disposed { get; init; }
+
+    protected override void OnInitialized()
+    {
+        Initialized();
+    }
+
+    public void Dispose()
+    {
+        Disposed();
+    }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/MetricsSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/MetricsSetupHelpers.cs
@@ -20,7 +20,8 @@ internal static class MetricsSetupHelpers
 {
     public static void SetupChartContainer(TestContext context)
     {
-        _ = context.JSInterop.SetupModule("/Components/Controls/Chart/MetricTable.razor.js");
+        var metricTableModule = context.JSInterop.SetupModule("/Components/Controls/Chart/MetricTable.razor.js");
+        metricTableModule.SetupVoid("announceDataGridRows", _ => true);
 
         FluentUISetupHelpers.SetupFluentTab(context);
         FluentUISetupHelpers.SetupFluentOverflow(context);

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -61,7 +61,7 @@ internal static class ResourceSetupHelpers
         context.JSInterop.SetupVoid("focusElement", _ => true);
         context.Services.AddSingleton<IconResolver>();
         context.Services.AddSingleton<ILogger<StructuredLogs>>(NullLogger<StructuredLogs>.Instance);
-        context.Services.AddSingleton<StructuredLogsViewModel>();
+        context.Services.AddTransient<StructuredLogsViewModel>();
         context.Services.AddScoped<DashboardCommandExecutor, DashboardCommandExecutor>();
         context.Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient(isEnabled: true, initialResources: [], resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>));
 

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestTelemetryRepository.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestTelemetryRepository.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+
+internal sealed class TestTelemetryRepository(ITelemetryRepository inner) : ITelemetryRepository
+{
+    public Func<GetLogsContext, CancellationToken, Task<PagedResult<LogSummary>>>? GetLogSummariesAsyncHandler { get; init; }
+
+    public bool IsReadOnly => inner.IsReadOnly;
+    public bool HasDisplayedMaxLogLimitMessage { get => inner.HasDisplayedMaxLogLimitMessage; set => inner.HasDisplayedMaxLogLimitMessage = value; }
+    public Message? MaxLogLimitMessage { get => inner.MaxLogLimitMessage; set => inner.MaxLogLimitMessage = value; }
+    public bool HasDisplayedMaxTraceLimitMessage { get => inner.HasDisplayedMaxTraceLimitMessage; set => inner.HasDisplayedMaxTraceLimitMessage = value; }
+    public Message? MaxTraceLimitMessage { get => inner.MaxTraceLimitMessage; set => inner.MaxTraceLimitMessage = value; }
+
+    public List<OtlpResource> GetResources(bool includeUninstrumentedPeers = false) => inner.GetResources(includeUninstrumentedPeers);
+    public List<OtlpResource> GetResourcesByName(string name, bool includeUninstrumentedPeers = false) => inner.GetResourcesByName(name, includeUninstrumentedPeers);
+    public OtlpResource? GetResourceByCompositeName(string compositeName) => inner.GetResourceByCompositeName(compositeName);
+    public OtlpResource? GetResource(ResourceKey key) => inner.GetResource(key);
+    public List<OtlpResource> GetResources(ResourceKey key, bool includeUninstrumentedPeers = false) => inner.GetResources(key, includeUninstrumentedPeers);
+    public Dictionary<ResourceKey, int> GetResourceUnviewedErrorLogsCount() => inner.GetResourceUnviewedErrorLogsCount();
+    public void MarkViewedErrorLogs(ResourceKey? key) => inner.MarkViewedErrorLogs(key);
+
+    public Subscription OnNewResources(Func<Task> callback) => inner.OnNewResources(callback);
+    public Subscription OnNewLogs(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback) => inner.OnNewLogs(resourceKey, subscriptionType, callback);
+    public Subscription OnNewMetrics(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback) => inner.OnNewMetrics(resourceKey, subscriptionType, callback);
+    public Subscription OnNewTraces(ResourceKey? resourceKey, SubscriptionType subscriptionType, Func<Task> callback) => inner.OnNewTraces(resourceKey, subscriptionType, callback);
+
+    public Task<PagedResult<OtlpLogEntry>> GetLogsAsync(GetLogsContext context, CancellationToken cancellationToken) => inner.GetLogsAsync(context, cancellationToken);
+    public Task<PagedResult<LogSummary>> GetLogSummariesAsync(GetLogsContext context, CancellationToken cancellationToken) =>
+        GetLogSummariesAsyncHandler?.Invoke(context, cancellationToken) ?? inner.GetLogSummariesAsync(context, cancellationToken);
+    public OtlpLogEntry? GetLog(long logId) => inner.GetLog(logId);
+    public Task<List<OtlpLogEntry>> GetLogsForSpanAsync(string traceId, string spanId, CancellationToken cancellationToken) => inner.GetLogsForSpanAsync(traceId, spanId, cancellationToken);
+    public Task<List<OtlpLogEntry>> GetLogsForTraceAsync(string traceId, CancellationToken cancellationToken) => inner.GetLogsForTraceAsync(traceId, cancellationToken);
+    public Task<List<string>> GetLogPropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken) => inner.GetLogPropertyKeysAsync(resourceKey, cancellationToken);
+    public Task<List<string>> GetTracePropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken) => inner.GetTracePropertyKeysAsync(resourceKey, cancellationToken);
+    public Task<GetTracesResponse> GetTracesAsync(GetTracesRequest context, CancellationToken cancellationToken) => inner.GetTracesAsync(context, cancellationToken);
+    public Task<GetTraceSummariesResponse> GetTraceSummariesAsync(GetTracesRequest context, CancellationToken cancellationToken) => inner.GetTraceSummariesAsync(context, cancellationToken);
+    public Task<GetSpansResponse> GetSpansAsync(GetSpansRequest context, CancellationToken cancellationToken) => inner.GetSpansAsync(context, cancellationToken);
+    public Task<Dictionary<string, int>> GetTraceFieldValuesAsync(string attributeName, CancellationToken cancellationToken) => inner.GetTraceFieldValuesAsync(attributeName, cancellationToken);
+    public Task<Dictionary<string, int>> GetLogsFieldValuesAsync(string attributeName, CancellationToken cancellationToken) => inner.GetLogsFieldValuesAsync(attributeName, cancellationToken);
+    public bool HasUpdatedTrace(OtlpTrace trace) => inner.HasUpdatedTrace(trace);
+    public OtlpTrace? GetTrace(string traceId) => inner.GetTrace(traceId);
+    public OtlpSpan? GetSpan(string traceId, string spanId) => inner.GetSpan(traceId, spanId);
+    public OtlpResource? GetPeerResource(OtlpSpan span) => inner.GetPeerResource(span);
+    public List<OtlpInstrumentSummary> GetInstrumentSummaries(ResourceKey key) => inner.GetInstrumentSummaries(key);
+    public OtlpInstrumentSummary? GetInstrumentSummary(ResourceKey resourceKey, string meterName, string instrumentName) => inner.GetInstrumentSummary(resourceKey, meterName, instrumentName);
+    public Task<OtlpInstrumentData?> GetInstrumentAsync(GetInstrumentRequest request, CancellationToken cancellationToken) => inner.GetInstrumentAsync(request, cancellationToken);
+    public DateTime? GetInstrumentLatestEndTime(ResourceKey resourceKey, string meterName, string instrumentName) => inner.GetInstrumentLatestEndTime(resourceKey, meterName, instrumentName);
+
+    public IAsyncEnumerable<OtlpSpan> WatchSpansAsync(WatchSpansRequest request, CancellationToken cancellationToken) => inner.WatchSpansAsync(request, cancellationToken);
+    public IAsyncEnumerable<OtlpLogEntry> WatchLogsAsync(WatchLogsRequest request, CancellationToken cancellationToken) => inner.WatchLogsAsync(request, cancellationToken);
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="$(TestsSharedDir)TestDashboardClient.cs" Link="shared/TestDashboardClient.cs" />
     <Compile Include="$(TestsSharedDir)TestSessionStorage.cs" Link="shared/TestSessionStorage.cs" />
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
+    <Compile Include="$(TestsSharedDir)TemporaryWorkspace.cs" Link="shared/TemporaryWorkspace.cs" />
     <Compile Include="$(TestsSharedDir)TestCertificateLoader.cs" Link="shared/TestCertificateLoader.cs" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
     <Compile Include="$(TestsSharedDir)Telemetry\*.cs" LinkBase="shared/Telemetry" />
@@ -54,6 +55,7 @@
 
   <ItemGroup>
     <Using Include="Aspire.Dashboard.ServiceClient" />
+    <Using Include="Aspire.Tests.Utils" />
   </ItemGroup>
 
   <Import Project="..\Shared\Playwright\Playwright.targets" />

--- a/tests/Aspire.Dashboard.Tests/ChartDataCalculatorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ChartDataCalculatorTests.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.Controls.Chart;
+using Aspire.Dashboard.Components;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Metrics.V1;
 using Xunit;
@@ -167,6 +169,40 @@ public class ChartDataCalculatorTests
     }
 
     [Fact]
+    public void TryCalculatePoint_StaggeredDimensionChanges_SumsCurrentValues()
+    {
+        var context = CreateContext();
+        var stableDimension = new DimensionScope(capacity: 100, []);
+        var changingDimension = new DimensionScope(capacity: 100, []);
+        var start = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+        for (var minute = 1; minute <= 3; minute++)
+        {
+            stableDimension.AddPointValue(new NumberDataPoint
+            {
+                AsInt = 10,
+                StartTimeUnixNano = ToNanos(start),
+                TimeUnixNano = ToNanos(start.AddMinutes(minute))
+            }, context);
+            changingDimension.AddPointValue(new NumberDataPoint
+            {
+                AsInt = 15 + (minute * 5),
+                StartTimeUnixNano = ToNanos(start),
+                TimeUnixNano = ToNanos(start.AddMinutes(minute))
+            }, context);
+        }
+
+        var result = ChartDataCalculator.TryCalculatePoint(
+            [stableDimension, changingDimension],
+            start.AddMinutes(3).AddSeconds(-1),
+            start.AddMinutes(3),
+            out var pointValue);
+
+        Assert.True(result);
+        Assert.Equal(40, pointValue);
+    }
+
+    [Fact]
     public void TryCalculatePoint_MultipleMetricsInDimension_TakesMax()
     {
         var context = CreateContext();
@@ -298,6 +334,60 @@ public class ChartDataCalculatorTests
     }
 
     [Fact]
+    public void TryCalculateHistogramPoints_StaggeredDimensionChanges_CombinesObservationDeltas()
+    {
+        var context = CreateContext();
+        var stableDimension = new DimensionScope(capacity: 100, []);
+        var changingDimension = new DimensionScope(capacity: 100, []);
+        var start = new DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+        for (var minute = 1; minute <= 3; minute++)
+        {
+            stableDimension.AddHistogramValue(CreateHistogramPoint(start, minute, 10, [10, 0, 0]), context);
+            changingDimension.AddHistogramValue(CreateHistogramPoint(start, minute, checked((ulong)(15 + (minute * 5))), [0, 0, checked((ulong)(15 + (minute * 5)))]), context);
+        }
+
+        var traces = new Dictionary<int, ChartTrace>
+        {
+            [25] = new ChartTrace { Name = "P25", Percentile = 25 }
+        };
+        var exemplars = new List<ChartExemplar>();
+
+        var firstResult = ChartDataCalculator.TryCalculateHistogramPoints(
+            [stableDimension, changingDimension],
+            start,
+            start,
+            traces,
+            exemplars,
+            ToLocal);
+        var secondResult = ChartDataCalculator.TryCalculateHistogramPoints(
+            [stableDimension, changingDimension],
+            start.AddMinutes(1),
+            start.AddMinutes(1),
+            traces,
+            exemplars,
+            ToLocal);
+
+        Assert.True(firstResult);
+        Assert.True(secondResult);
+        Assert.Equal([10, 100], traces[25].Values);
+
+        static HistogramDataPoint CreateHistogramPoint(DateTimeOffset start, int minute, ulong count, ulong[] bucketCounts)
+        {
+            var point = new HistogramDataPoint
+            {
+                StartTimeUnixNano = ToNanos(start),
+                TimeUnixNano = ToNanos(start.AddMinutes(minute)),
+                Count = count,
+                Sum = count
+            };
+            point.ExplicitBounds.AddRange([10, 100]);
+            point.BucketCounts.AddRange(bucketCounts);
+            return point;
+        }
+    }
+
+    [Fact]
     public void CalculateHistogramValues_XValuesInChronologicalOrder()
     {
         var context = CreateContext();
@@ -345,6 +435,112 @@ public class ChartDataCalculatorTests
         var data = calculator.CalculateChartValues([dimension], s_startTime, toLocalWithOffset, "Count");
 
         Assert.All(data.XValues, x => Assert.Equal(offset, x.Offset));
+    }
+
+    [Fact]
+    public void MetricInstrumentDataCache_Merge_ReplacesTailAndAddsDimension()
+    {
+        var start = s_startTime.UtcDateTime;
+        KeyValuePair<string, string>[] firstAttributes = [KeyValuePair.Create("dimension", "first")];
+        KeyValuePair<string, string>[] secondAttributes = [KeyValuePair.Create("dimension", "second")];
+        var cachedDimension = new DimensionScope(capacity: 100, firstAttributes);
+        cachedDimension.Values.Add(new MetricValue<long>(1, start, start.AddSeconds(1)));
+        cachedDimension.Values.Add(new MetricValue<long>(2, start.AddSeconds(1), start.AddSeconds(2)));
+
+        var refreshedDimension = new DimensionScope(capacity: 100, firstAttributes);
+        refreshedDimension.Values.Add(new MetricValue<long>(1, start, start.AddSeconds(1)));
+        refreshedDimension.Values.Add(new MetricValue<long>(2, start.AddSeconds(1), start.AddSeconds(3)));
+        refreshedDimension.Values.Add(new MetricValue<long>(3, start.AddSeconds(3), start.AddSeconds(4)));
+        var newDimension = new DimensionScope(capacity: 100, secondAttributes);
+        newDimension.Values.Add(new MetricValue<long>(4, start.AddSeconds(3), start.AddSeconds(4)));
+
+        var cached = CreateInstrumentData([cachedDimension]);
+        var refreshed = CreateInstrumentData([refreshedDimension, newDimension]);
+        var cursors = new List<MetricDimensionCursor>
+        {
+            new() { Attributes = firstAttributes, StartTime = start.AddSeconds(1) }
+        };
+
+        var merged = MetricInstrumentDataCache.Merge(cached, refreshed, cursors, start);
+
+        Assert.Collection(
+            merged.Dimensions[0].Values.Cast<MetricValue<long>>(),
+            value => Assert.Equal((1L, start.AddSeconds(1)), (value.Value, value.End)),
+            value => Assert.Equal((2L, start.AddSeconds(3)), (value.Value, value.End)),
+            value => Assert.Equal((3L, start.AddSeconds(4)), (value.Value, value.End)));
+        Assert.Equal(4, Assert.IsType<MetricValue<long>>(Assert.Single(merged.Dimensions[1].Values)).Value);
+    }
+
+    [Fact]
+    public void MetricInstrumentDataCache_Merge_ReplacesLateArrivingValue()
+    {
+        var start = s_startTime.UtcDateTime;
+        KeyValuePair<string, string>[] attributes = [KeyValuePair.Create("dimension", "first")];
+        var cachedDimension = new DimensionScope(capacity: 100, attributes);
+        cachedDimension.Values.Add(new MetricValue<long>(1, start, start.AddSeconds(5)));
+        cachedDimension.Values.Add(new MetricValue<long>(2, start.AddSeconds(14), start.AddSeconds(15)));
+        cachedDimension.Values.Add(new MetricValue<long>(3, start.AddSeconds(29), start.AddSeconds(30)));
+
+        var refreshedDimension = new DimensionScope(capacity: 100, attributes);
+        refreshedDimension.Values.Add(new MetricValue<long>(20, start.AddSeconds(14), start.AddSeconds(15)));
+        refreshedDimension.Values.Add(new MetricValue<long>(3, start.AddSeconds(29), start.AddSeconds(30)));
+
+        var cached = CreateInstrumentData([cachedDimension]);
+        var refreshed = CreateInstrumentData([refreshedDimension]);
+        var cursors = MetricInstrumentDataCache.CreateCursors(cached, TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(1));
+
+        Assert.Equal(start.AddSeconds(10), Assert.Single(cursors).StartTime);
+
+        var merged = MetricInstrumentDataCache.Merge(cached, refreshed, cursors, start);
+
+        Assert.Collection(
+            Assert.Single(merged.Dimensions).Values.Cast<MetricValue<long>>(),
+            value => Assert.Equal((1L, start.AddSeconds(5)), (value.Value, value.End)),
+            value => Assert.Equal((20L, start.AddSeconds(15)), (value.Value, value.End)),
+            value => Assert.Equal((3L, start.AddSeconds(30)), (value.Value, value.End)));
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(5, 1)]
+    [InlineData(6, 2)]
+    [InlineData(15, 2)]
+    [InlineData(16, 5)]
+    [InlineData(30, 5)]
+    [InlineData(31, 10)]
+    [InlineData(60, 10)]
+    [InlineData(61, 30)]
+    [InlineData(180, 30)]
+    [InlineData(181, 60)]
+    [InlineData(360, 60)]
+    [InlineData(361, 120)]
+    [InlineData(720, 120)]
+    [InlineData(721, 300)]
+    public void MetricDataPointInterval_Get_ReturnsDurationResolution(int durationMinutes, int expectedSeconds)
+    {
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), MetricDataPointInterval.Get(TimeSpan.FromMinutes(durationMinutes)));
+    }
+
+    private static OtlpInstrumentData CreateInstrumentData(List<DimensionScope> dimensions)
+    {
+        var resource = new OtlpResource("resource", instanceId: null, uninstrumentedPeer: false, CreateContext());
+
+        return new OtlpInstrumentData
+        {
+            Summary = new OtlpInstrumentSummary
+            {
+                Name = "test",
+                Description = "test",
+                Unit = "items",
+                Type = OtlpInstrumentType.Gauge,
+                AggregationTemporality = OtlpAggregationTemporality.Cumulative,
+                Parent = OtlpScope.Empty,
+                ResourceView = new OtlpResourceView(resource, Array.Empty<KeyValuePair<string, string>>())
+            },
+            Dimensions = dimensions,
+            KnownAttributeValues = [],
+            HasOverflow = false
+        };
     }
 
     private static ulong ToNanos(DateTimeOffset dt) => (ulong)(dt.ToUnixTimeMilliseconds() * 1_000_000);

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -43,6 +43,51 @@ public sealed class DashboardOptionsTests
 
         Assert.Null(result.FailureMessage);
         Assert.True(result.Succeeded);
+        Assert.Equal(DashboardPersistenceMode.None, GetValidOptions().Data.PersistenceMode);
+    }
+
+    [Fact]
+    public void PostConfigure_MapsDashboardRunStorageEnvironmentAliases()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [DashboardConfigNames.DashboardApplicationName.EnvVarName] = "My Dashboard",
+                [DashboardConfigNames.DashboardDataDirectoryName.EnvVarName] = "/data/.aspire/dashboard",
+                [DashboardConfigNames.DashboardPersistenceModeName.EnvVarName] = "resume"
+            })
+            .Build();
+        var options = new DashboardOptions
+        {
+            ApplicationName = "Section Name",
+            Data = new DashboardDataOptions { Directory = "/section/path" }
+        };
+
+        new PostConfigureDashboardOptions(configuration).PostConfigure(null, options);
+
+        Assert.Equal("My Dashboard", options.ApplicationName);
+        Assert.Equal("/data/.aspire/dashboard", options.Data.Directory);
+        Assert.Equal(DashboardPersistenceMode.Resume, options.Data.PersistenceMode);
+    }
+
+    [Fact]
+    public void PostConfigure_InvalidDashboardPersistenceMode_IsInvalid()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [DashboardConfigNames.DashboardPersistenceModeName.EnvVarName] = "invalid"
+            })
+            .Build();
+        var options = GetValidOptions();
+
+        new PostConfigureDashboardOptions(configuration).PostConfigure(null, options);
+        var result = new ValidateDashboardOptions().Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(
+            "Failed to parse dashboard persistence mode 'invalid'. Possible values: None, Run, Resume.",
+            result.FailureMessage);
     }
 
     #region Frontend options

--- a/tests/Aspire.Dashboard.Tests/DashboardSqliteOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardSqliteOutgoingPeerResolverTests.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class DashboardSqliteOutgoingPeerResolverTests
+{
+    [Fact]
+    public void TryResolvePeer_DashboardSqlite_ReturnsDatabaseName()
+    {
+        var resolver = new DashboardSqliteOutgoingPeerResolver();
+
+        var result = resolver.TryResolvePeer(CreateAttributes(), out var name, out var resource);
+
+        Assert.True(result);
+        Assert.Equal("dashboard.db", name);
+        Assert.Null(resource);
+    }
+
+    [Theory]
+    [InlineData(OtlpSpan.PeerServiceAttributeKey, "postgresql")]
+    [InlineData("db.system.name", "postgresql")]
+    [InlineData("db.namespace", "application.db")]
+    public void TryResolvePeer_NonDashboardSqlite_ReturnsFalse(string attributeName, string attributeValue)
+    {
+        var resolver = new DashboardSqliteOutgoingPeerResolver();
+        var attributes = CreateAttributes();
+        var attributeIndex = Array.FindIndex(attributes, attribute => attribute.Key == attributeName);
+        attributes[attributeIndex] = KeyValuePair.Create(attributeName, attributeValue);
+
+        var result = resolver.TryResolvePeer(attributes, out var name, out var resource);
+
+        Assert.False(result);
+        Assert.Null(name);
+        Assert.Null(resource);
+    }
+
+    private static KeyValuePair<string, string>[] CreateAttributes() =>
+    [
+        KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "dashboard.db"),
+        KeyValuePair.Create("db.system.name", "sqlite"),
+        KeyValuePair.Create("db.namespace", "dashboard.db")
+    ];
+}

--- a/tests/Aspire.Dashboard.Tests/DashboardUIHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardUIHelpersTests.cs
@@ -9,6 +9,14 @@ namespace Aspire.Dashboard.Tests;
 public class DashboardUIHelpersTests
 {
     [Theory]
+    [InlineData(200_000, 200_000)]
+    [InlineData(600_000, 200_000)]
+    public void GetVirtualizedItemCount_LimitsLargeResultSets(int totalItemCount, int expected)
+    {
+        Assert.Equal(expected, DashboardUIHelpers.GetVirtualizedItemCount(totalItemCount));
+    }
+
+    [Theory]
     [InlineData(0, 0)]
     [InlineData(1000, 1000)]
     [InlineData(1.5, 1)]

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -176,6 +176,17 @@ public class FormatHelpersTests
     }
 
     [Theory]
+    [InlineData("2025-12-20T13:45:30.0000000Z", "1:45:30 PM")]
+    [InlineData("2025-12-19T13:45:30.0000000Z", "12/19/2025 1:45:30 PM")]
+    public void FormatTimeWithOptionalDate_UsesTimeProviderCurrentDate(string value, string expected)
+    {
+        var provider = new FixedTimeProvider(new DateTimeOffset(2025, 12, 20, 23, 59, 59, TimeSpan.Zero));
+        var date = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+        Assert.Equal(expected, FormatHelpers.FormatTimeWithOptionalDate(provider, date, cultureInfo: CultureInfo.GetCultureInfo("en-US")), ignoreWhiteSpaceDifferences: true);
+    }
+
+    [Theory]
     [InlineData("fi-FI", TimeFormat.TwentyFourHour, MillisecondsDisplay.None, "15.6.2009 13.45.30")]
     [InlineData("fi-FI", TimeFormat.TwentyFourHour, MillisecondsDisplay.Truncated, "15.6.2009 13.45.30,123")]
     [InlineData("fi-FI", TimeFormat.TwelveHour, MillisecondsDisplay.None, "15.6.2009 1.45.30 ip.")]
@@ -265,5 +276,12 @@ public class FormatHelpersTests
     private static BrowserTimeProvider CreateTimeProvider()
     {
         return new BrowserTimeProvider(NullLoggerFactory.Instance);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+
+        public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
@@ -37,9 +37,10 @@ public sealed class DashboardClientAuthTests
     [InlineData(false)]
     public async Task ConnectsToResourceService_Unsecured(bool useHttps)
     {
+        using var activitySource = new DashboardActivitySource();
         var loggerFactory = IntegrationTestHelpers.CreateLoggerFactory(_testOutputHelper);
         await using var server = await CreateResourceServiceServerAsync(loggerFactory, useHttps).DefaultTimeout();
-        await using var client = await CreateDashboardClientAsync(loggerFactory, server.Url, authMode: ResourceClientAuthMode.Unsecured).DefaultTimeout();
+        await using var client = await CreateDashboardClientAsync(activitySource, loggerFactory, server.Url, authMode: ResourceClientAuthMode.Unsecured).DefaultTimeout();
 
         var call = await server.Calls.ResourceInformationCallsChannel.Reader.ReadAsync().DefaultTimeout();
 
@@ -53,9 +54,10 @@ public sealed class DashboardClientAuthTests
     [InlineData(false)]
     public async Task ConnectsToResourceService_ApiKey(bool useHttps)
     {
+        using var activitySource = new DashboardActivitySource();
         var loggerFactory = IntegrationTestHelpers.CreateLoggerFactory(_testOutputHelper);
         await using var server = await CreateResourceServiceServerAsync(loggerFactory, useHttps).DefaultTimeout();
-        await using var client = await CreateDashboardClientAsync(loggerFactory, server.Url, authMode: ResourceClientAuthMode.ApiKey, configureOptions: options => options.ResourceServiceClient.ApiKey = "TestApiKey!").DefaultTimeout();
+        await using var client = await CreateDashboardClientAsync(activitySource, loggerFactory, server.Url, authMode: ResourceClientAuthMode.ApiKey, configureOptions: options => options.ResourceServiceClient.ApiKey = "TestApiKey!").DefaultTimeout();
 
         var call = await server.Calls.ResourceInformationCallsChannel.Reader.ReadAsync().DefaultTimeout();
 
@@ -106,6 +108,7 @@ public sealed class DashboardClientAuthTests
     }
 
     private static async Task<DashboardClient> CreateDashboardClientAsync(
+        DashboardActivitySource activitySource,
         ILoggerFactory loggerFactory,
         string serverAddress,
         ResourceClientAuthMode authMode = ResourceClientAuthMode.Unsecured,
@@ -125,11 +128,13 @@ public sealed class DashboardClientAuthTests
         options.ResourceServiceClient.TryParseOptions(out _);
 
         var client = new DashboardClient(
+            activitySource: activitySource,
             loggerFactory: loggerFactory,
             configuration: new ConfigurationManager(),
             dashboardOptions: Options.Create(options),
             knownPropertyLookup: new MockKnownPropertyLookup(),
             loc: new Aspire.Dashboard.Tests.TestStringLocalizer<Dashboard.Resources.Resources>(),
+            resourceRepositoryWriter: new NoopResourceRepositoryWriter(),
             configureHttpHandler: handler => handler.SslOptions.RemoteCertificateValidationCallback = (sender, cert, chain, sslPolicyErrors) => true);
 
         var iClient = (IDashboardClient)client;
@@ -137,6 +142,15 @@ public sealed class DashboardClientAuthTests
         await iClient.WhenConnected;
 
         return client;
+    }
+
+    private sealed class NoopResourceRepositoryWriter : IResourceRepositoryWriter
+    {
+        public Task ReplaceResourcesAsync(IReadOnlyList<Resource> resources) => Task.CompletedTask;
+        public Task ApplyChangesAsync(IReadOnlyList<WatchResourcesChange> changes) => Task.CompletedTask;
+        public Task AddConsoleLogsAsync(string resourceName, IReadOnlyList<ConsoleLogLine> logLines) => Task.CompletedTask;
+        public Task MarkConsoleLogsLoadedAsync(string resourceName) => Task.CompletedTask;
+        public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate) => Task.CompletedTask;
     }
 
     private sealed class ResourceServiceServer(WebApplication serverApp, TestCalls testCalls) : IAsyncDisposable

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -161,6 +161,7 @@ public class FrontendBrowserTokenAuthTests
         Assert.DoesNotContain("; secure", httpCookie, StringComparison.OrdinalIgnoreCase);
     }
 
+#if DEBUG
     [Fact]
     public async Task Get_Signout_HttpsEndpointWithHttpAndHttpsCookies_DeletesBothCookies()
     {
@@ -210,6 +211,7 @@ public class FrontendBrowserTokenAuthTests
                 Assert.Contains("expires=Thu, 01 Jan 1970", c, StringComparison.OrdinalIgnoreCase);
             });
     }
+        #endif
 
     [Fact]
     public async Task Get_LoginPage_ValidToken_HttpEndpointWithHttpsEndpoint_RedirectToApp()

--- a/tests/Aspire.Dashboard.Tests/Integration/HealthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/HealthTests.cs
@@ -1,25 +1,28 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Net;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.InternalTesting;
-using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Integration;
 
-public class HealthTests(ITestOutputHelper testOutputHelper)
+public class HealthTests(HealthTests.Fixture fixture) : IClassFixture<HealthTests.Fixture>
 {
+    private const string TestActivitySourceName = "Aspire.Dashboard.Tests.Integration.HealthTests";
+
     [Fact]
     public async Task HealthEndpoint_SendRequest_200Response()
     {
-        // Arrange
-        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
-        await app.StartAsync().DefaultTimeout();
-
-        await MakeRequestAndAssert($"http://{app.FrontendSingleEndPointAccessor().EndPoint}", HttpVersion.Version11).DefaultTimeout();
-        await MakeRequestAndAssert($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}", HttpVersion.Version11).DefaultTimeout();
-        await MakeRequestAndAssert($"http://{app.OtlpServiceGrpcEndPointAccessor().EndPoint}", HttpVersion.Version20).DefaultTimeout();
+        await MakeRequestAndAssert($"http://{fixture.App.FrontendSingleEndPointAccessor().EndPoint}", HttpVersion.Version11).DefaultTimeout();
+        await MakeRequestAndAssert($"http://{fixture.App.OtlpServiceHttpEndPointAccessor().EndPoint}", HttpVersion.Version11).DefaultTimeout();
+        await MakeRequestAndAssert($"http://{fixture.App.OtlpServiceGrpcEndPointAccessor().EndPoint}", HttpVersion.Version20).DefaultTimeout();
 
         static async Task MakeRequestAndAssert(string basePath, Version httpVersion)
         {
@@ -34,6 +37,131 @@ public class HealthTests(ITestOutputHelper testOutputHelper)
 
             // Assert 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task HealthEndpoint_OtlpExporterConfigured_ExportsAspNetCoreActivity()
+    {
+        using var testActivity = fixture.TestActivitySource.StartActivity(nameof(HealthEndpoint_OtlpExporterConfigured_ExportsAspNetCoreActivity));
+        Assert.NotNull(testActivity);
+        using var observation = fixture.Exporter.ObserveNext(
+            testActivity.TraceId,
+            activity => activity.Source.Name == "Microsoft.AspNetCore" && activity.Kind == ActivityKind.Server);
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{fixture.App.FrontendSingleEndPointAccessor().EndPoint}") };
+        var response = await client.GetAsync($"/{DashboardUrls.HealthBasePath}").DefaultTimeout();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var activity = await observation.Task.DefaultTimeout();
+        Assert.Equal(testActivity.TraceId, activity.TraceId);
+        Assert.Equal("Microsoft.AspNetCore", activity.Source.Name);
+        Assert.Equal(ActivityKind.Server, activity.Kind);
+    }
+
+    [Fact]
+    public async Task OtlpExporterConfigured_ExportsResourceServiceActivity()
+    {
+        using var testActivity = fixture.TestActivitySource.StartActivity(nameof(OtlpExporterConfigured_ExportsResourceServiceActivity));
+        Assert.NotNull(testActivity);
+        using var observation = fixture.Exporter.ObserveNext(
+            testActivity.TraceId,
+            activity => activity.Source.Name == DashboardActivitySource.ActivitySourceName);
+        var activitySource = fixture.App.Services.GetRequiredService<DashboardActivitySource>();
+
+        using (var activity = activitySource.ActivitySource.StartActivity("Test resource update", ActivityKind.Consumer))
+        {
+            Assert.NotNull(activity);
+        }
+
+        var exported = await observation.Task.DefaultTimeout();
+        Assert.Equal(testActivity.TraceId, exported.TraceId);
+        Assert.Equal(DashboardActivitySource.ActivitySourceName, exported.Source.Name);
+        Assert.Equal(ActivityKind.Consumer, exported.Kind);
+    }
+
+    public sealed class Fixture : IAsyncLifetime
+    {
+        public DashboardWebApplication App { get; private set; } = null!;
+        internal TestActivityExporter Exporter { get; } = new();
+        internal ActivitySource TestActivitySource { get; } = new(TestActivitySourceName);
+
+        public async ValueTask InitializeAsync()
+        {
+            App = IntegrationTestHelpers.CreateDashboardWebApplication(
+                NullLoggerFactory.Instance,
+                config => config["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://127.0.0.1:1",
+                builder => builder.Services.AddOpenTelemetry()
+                    .WithTracing(tracing => tracing
+                        .AddSource(TestActivitySourceName)
+                        .AddProcessor(new SimpleActivityExportProcessor(Exporter))));
+            await App.StartAsync().DefaultTimeout();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await App.DisposeAsync();
+            TestActivitySource.Dispose();
+        }
+    }
+
+    internal sealed class TestActivityExporter : BaseExporter<Activity>
+    {
+        private readonly object _lock = new();
+        private Observation? _observation;
+
+        public Observation ObserveNext(ActivityTraceId traceId, Func<Activity, bool> predicate)
+        {
+            var observation = new Observation(this, traceId, predicate);
+            lock (_lock)
+            {
+                Assert.Null(_observation);
+                _observation = observation;
+            }
+            return observation;
+        }
+
+        public override ExportResult Export(in Batch<Activity> batch)
+        {
+            foreach (var activity in batch)
+            {
+                lock (_lock)
+                {
+                    if (_observation is { } observation &&
+                        observation.TraceId == activity.TraceId &&
+                        observation.Predicate(activity))
+                    {
+                        _observation = null;
+                        observation.TrySetResult(activity);
+                    }
+                }
+            }
+
+            return ExportResult.Success;
+        }
+
+        private void Remove(Observation observation)
+        {
+            lock (_lock)
+            {
+                if (ReferenceEquals(_observation, observation))
+                {
+                    _observation = null;
+                }
+            }
+        }
+
+        internal sealed class Observation(TestActivityExporter exporter, ActivityTraceId traceId, Func<Activity, bool> predicate) : IDisposable
+        {
+            private readonly TaskCompletionSource<Activity> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public ActivityTraceId TraceId { get; } = traceId;
+            public Func<Activity, bool> Predicate { get; } = predicate;
+            public Task<Activity> Task => _completion.Task;
+
+            public void Dispose() => exporter.Remove(this);
+
+            public void TrySetResult(Activity activity) => _completion.TrySetResult(activity);
         }
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpJsonTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpJsonTests.cs
@@ -485,7 +485,7 @@ public class OtlpHttpJsonTests
         _testOutputHelper = testOutputHelper;
     }
 
-    private static OtlpResource AssertMyServiceResource(TelemetryRepository telemetryRepository)
+    private static OtlpResource AssertMyServiceResource(ITelemetryRepository telemetryRepository)
     {
         var resources = telemetryRepository.GetResourcesByName("my.service");
         var resource = Assert.Single(resources);
@@ -521,16 +521,16 @@ public class OtlpHttpJsonTests
         Assert.NotNull(response);
 
         // Verify data was stored in the repository
-        var telemetryRepository = app.Services.GetRequiredService<TelemetryRepository>();
+        var telemetryRepository = app.Services.GetRequiredService<ITelemetryRepository>();
         var resource = AssertMyServiceResource(telemetryRepository);
 
-        var traces = telemetryRepository.GetTraces(new GetTracesRequest
+        var traces = await telemetryRepository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.NotEmpty(traces.PagedResult.Items);
 
         var trace = traces.PagedResult.Items.First();
@@ -581,16 +581,16 @@ public class OtlpHttpJsonTests
         Assert.NotNull(response);
 
         // Verify data was stored in the repository
-        var telemetryRepository = app.Services.GetRequiredService<TelemetryRepository>();
+        var telemetryRepository = app.Services.GetRequiredService<ITelemetryRepository>();
         var resource = AssertMyServiceResource(telemetryRepository);
 
-        var logs = telemetryRepository.GetLogs(new GetLogsContext
+        var logs = await telemetryRepository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.NotEmpty(logs.Items);
 
         var log = logs.Items.First();
@@ -658,16 +658,16 @@ public class OtlpHttpJsonTests
         Assert.NotNull(response);
 
         // Verify data was stored in the repository (events are stored as logs)
-        var telemetryRepository = app.Services.GetRequiredService<TelemetryRepository>();
+        var telemetryRepository = app.Services.GetRequiredService<ITelemetryRepository>();
         var resource = AssertMyServiceResource(telemetryRepository);
 
-        var logs = telemetryRepository.GetLogs(new GetLogsContext
+        var logs = await telemetryRepository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.NotEmpty(logs.Items);
 
         var log = logs.Items.First();
@@ -708,10 +708,10 @@ public class OtlpHttpJsonTests
         Assert.NotNull(response);
 
         // Verify data was stored in the repository
-        var telemetryRepository = app.Services.GetRequiredService<TelemetryRepository>();
+        var telemetryRepository = app.Services.GetRequiredService<ITelemetryRepository>();
         var resource = AssertMyServiceResource(telemetryRepository);
 
-        var instruments = resource.GetInstrumentsSummary();
+        var instruments = telemetryRepository.GetInstrumentSummaries(resource.ResourceKey);
         Assert.Collection(instruments,
             counter =>
             {
@@ -758,22 +758,22 @@ public class OtlpHttpJsonTests
         var response = System.Text.Json.JsonSerializer.Deserialize(responseBody, OtlpJsonSerializerContext.Default.OtlpExportMetricsServiceResponseJson);
         Assert.NotNull(response);
 
-        var telemetryRepository = app.Services.GetRequiredService<TelemetryRepository>();
+        var telemetryRepository = app.Services.GetRequiredService<ITelemetryRepository>();
         var resources = telemetryRepository.GetResourcesByName("copilot-chat");
         var resource = Assert.Single(resources);
 
-        var instruments = resource.GetInstrumentsSummary();
+        var instruments = telemetryRepository.GetInstrumentSummaries(resource.ResourceKey);
         var summary = Assert.Single(instruments);
         Assert.Equal("copilot_chat.tool.call.duration", summary.Name);
 
-        var instrumentData = telemetryRepository.GetInstrument(new GetInstrumentRequest
+        var instrumentData = await telemetryRepository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource.ResourceKey,
             InstrumentName = "copilot_chat.tool.call.duration",
             MeterName = "copilot-chat",
             StartTime = DateTime.MinValue,
             EndTime = DateTime.MaxValue
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.NotNull(instrumentData);
 
         var dimension = Assert.Single(instrumentData.Dimensions);

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
@@ -41,7 +41,10 @@ public class OtlpHttpServiceTests
 
         using var httpClient = IntegrationTestHelpers.CreateHttpClient($"http://{app.OtlpServiceHttpEndPointAccessor().EndPoint}");
 
-        var request = CreateExportLogsServiceRequest(logRecordsCount: 10000);
+        // One hundred 40,000-character messages keep the record count low while producing a protobuf payload
+        // just below the 4 MiB request limit, so the test targets request size rather than log insertion volume.
+        var request = CreateExportLogsServiceRequest(logRecordsCount: 100, messageLength: 40_000);
+        Assert.InRange(request.CalculateSize(), 3_900_000, (4 * 1024 * 1024) - 1);
 
         var content = new ByteArrayContent(request.ToByteArray());
         content.Headers.TryAddWithoutValidation("content-type", OtlpHttpEndpointsBuilder.ProtobufContentType);
@@ -79,15 +82,18 @@ public class OtlpHttpServiceTests
         Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
     }
 
-    private static ExportLogsServiceRequest CreateExportLogsServiceRequest(int logRecordsCount)
+    private static ExportLogsServiceRequest CreateExportLogsServiceRequest(int logRecordsCount, int? messageLength = null)
     {
         var scopeLogs = new ScopeLogs
         {
             Scope = TelemetryTestHelpers.CreateScope("TestLogger")
         };
+        var message = messageLength is { } length
+            ? new string('x', length)
+            : "The quick brown fox jumped over the lazy dog. Peter Pipper picked a patch of pickled peppers.";
         for (var i = 0; i < logRecordsCount; i++)
         {
-            scopeLogs.LogRecords.Add(TelemetryTestHelpers.CreateLogRecord(message: $"This is the test log message {i}. The quick brown fox jumped over the lazy dog. Peter Pipper picked a patch of pickled peppers."));
+            scopeLogs.LogRecords.Add(TelemetryTestHelpers.CreateLogRecord(message: $"This is the test log message {i}. {message}"));
         }
 
         var request = new ExportLogsServiceRequest();

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -53,6 +53,9 @@ public sealed class MockDashboardClient : IDashboardClient
     public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
     public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
 
+    /// <inheritdoc/>
+    public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate) => Task.CompletedTask;
+
     public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult(new ResourceViewModelSubscription(

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Nodes;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Http;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Telemetry;
 using Aspire.Hosting;
 using Aspire.Tests.Shared.Telemetry;
@@ -32,6 +33,36 @@ namespace Aspire.Dashboard.Tests.Integration;
 
 public class StartupTests(ITestOutputHelper testOutputHelper)
 {
+    [Fact]
+    public async Task Construction_ValidatesServiceDescriptorsAndScopes()
+    {
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(
+            testOutputHelper,
+            preConfigureBuilder: builder => builder.WebHost.UseDefaultServiceProvider(options =>
+            {
+                options.ValidateOnBuild = true;
+                options.ValidateScopes = true;
+            }));
+    }
+
+    [Fact]
+    public async Task Construction_CurrentDataSourceIsManagedByPool()
+    {
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper);
+
+        var databasePool = app.Services.GetRequiredService<DashboardDataSourcePool>();
+        await databasePool.InitializeAsync(CancellationToken.None);
+        var currentRun = app.Services.GetRequiredService<IDashboardRunStore>().GetRuns().Single(run => run.IsCurrent);
+        var telemetryRepository = Assert.IsType<SqliteTelemetryRepository>(app.Services.GetRequiredService<ITelemetryRepository>());
+
+        Assert.Equal(currentRun.DatabasePath, databasePool.Current.Database.DatabasePath);
+        Assert.False(databasePool.Current.Database.IsReadOnly);
+        Assert.Same(databasePool.Current.Database.ActivitySource, telemetryRepository.SqlActivitySource);
+        Assert.Same(databasePool.Current.TelemetryRepository, telemetryRepository);
+        Assert.Same(databasePool.Current.ResourceRepository, app.Services.GetRequiredService<IResourceRepository>());
+        Assert.Null(app.Services.GetService<DashboardSqliteDatabase>());
+    }
+
     [Fact]
     public async Task EndPointAccessors_AppStarted_EndPointPortsAssigned()
     {
@@ -1036,8 +1067,14 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         using var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        const string applicationName = "Failed startup";
+        var runsDirectory = Path.Combine(
+            DashboardRunStore.GetApplicationDirectory(workspace.Path, applicationName),
+            "runs");
 
-        await using var app = new DashboardWebApplication(preConfigureBuilder: builder =>
+        int exitCode;
+        await using (var app = new DashboardWebApplication(preConfigureBuilder: builder =>
         {
             RemoveEnvironmentVariableSources(builder);
             builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
@@ -1047,12 +1084,19 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 [DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://127.0.0.1:0",
                 [DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = nameof(OtlpAuthMode.Unsecured),
                 [DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.Unsecured),
+                [DashboardConfigNames.DashboardApplicationName.ConfigKey] = applicationName,
+                [DashboardConfigNames.DashboardDataDirectoryName.ConfigKey] = workspace.Path,
+                [DashboardConfigNames.DashboardPersistenceModeName.ConfigKey] = nameof(DashboardPersistenceMode.Run),
             });
-        });
+        }))
+        {
+            exitCode = app.Run();
 
-        var exitCode = app.Run();
+            Assert.Empty(Directory.GetFiles(runsDirectory, "run.json", SearchOption.AllDirectories));
+        }
 
         Assert.Equal(DashboardWebApplication.ExitCodeAddressInUse, exitCode);
+        Assert.Empty(Directory.GetDirectories(runsDirectory));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Integration/TelemetryApiTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/TelemetryApiTests.cs
@@ -354,7 +354,7 @@ public class TelemetryApiTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         try
         {
-            var response = await httpClient.GetAsync("/api/telemetry/spans?follow=true", HttpCompletionOption.ResponseHeadersRead, cts.Token).DefaultTimeout();
+            using var response = await httpClient.GetAsync("/api/telemetry/spans?follow=true", HttpCompletionOption.ResponseHeadersRead, cts.Token).DefaultTimeout();
 
             // Assert - should have NDJSON content type and streaming headers
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Markdown/MarkdownProcessorTests.cs
@@ -147,25 +147,8 @@ public class MarkdownProcessorTests
 
         // Assert
         Assert.Contains("language-csharp", html);
+        Assert.Contains("aria-label=\"Localized:GridValueCopyToClipboard\"", html);
         Assert.Contains("</code>", html);
-    }
-
-    [Fact]
-    public void ToHtml_FencedCodeBlock_CopyButtonHasLocalizedAccessibleName()
-    {
-        var processor = CreateMarkdownProcessor();
-
-        var markdown =
-            """
-            ```csharp
-            Console.WriteLine("Hello");
-            ```
-            """;
-
-        var html = processor.ToHtml(markdown, inCompleteDocument: true);
-
-        var copyButton = Regex.Match(html, """<button[^>]* (?<accessibleName>aria-label="[^"]+")[^>]*>""");
-        Assert.Equal("aria-label=\"Localized:GridValueCopyToClipboard\"", copyButton.Groups["accessibleName"].Value);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -1,16 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Aspire.DashboardService.Proto.V1;
+using Aspire.Tests;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Semver;
@@ -19,27 +21,13 @@ using DashboardResources = Aspire.Dashboard.Resources.Resources;
 
 namespace Aspire.Dashboard.Tests.Model;
 
-public sealed class DashboardClientTests
+public sealed class DashboardClientTests(ITestOutputHelper testOutputHelper) : IDisposable
 {
-    private readonly IConfiguration _configuration;
-    private readonly IOptions<DashboardOptions> _dashboardOptions;
-
-    public DashboardClientTests()
+    private readonly ILoggerFactory _loggerFactory = LoggerFactory.Create(builder =>
     {
-        _configuration = new ConfigurationManager();
-
-        var options = new DashboardOptions
-        {
-            ResourceServiceClient =
-            {
-                AuthMode = ResourceClientAuthMode.Unsecured,
-                Url = "http://localhost:12345"
-            }
-        };
-        options.ResourceServiceClient.TryParseOptions(out _);
-
-        _dashboardOptions = Options.Create(options);
-    }
+        builder.AddXunit(testOutputHelper, LogLevel.Trace, DateTimeOffset.UtcNow);
+        builder.SetMinimumLevel(LogLevel.Trace);
+    });
 
     [Fact]
     public async Task SubscribeResources_OnCancel_ChannelRemoved()
@@ -154,6 +142,39 @@ public sealed class DashboardClientTests
     }
 
     [Fact]
+    public async Task SubscribeConsoleLogs_ReceivesAndPersistsLogs()
+    {
+        var repositoryWriter = new RecordingResourceRepositoryWriter();
+        await using var instance = CreateResourceServiceClient(resourceRepositoryWriter: repositoryWriter);
+        instance.SetDashboardServiceClient(new MockDashboardServiceClient
+        {
+            ConsoleLogUpdates =
+            [
+                new WatchResourceConsoleLogsUpdate
+                {
+                    LogLines =
+                    {
+                        new ConsoleLogLine { LineNumber = 1, Text = "Hello", IsStdErr = false }
+                    }
+                }
+            ]
+        });
+
+        var batches = new List<IReadOnlyList<ResourceLogLine>>();
+        await foreach (var batch in instance.SubscribeConsoleLogs("api", CancellationToken.None))
+        {
+            batches.Add(batch);
+        }
+
+        var line = Assert.Single(Assert.Single(batches));
+        Assert.Equal(new ResourceLogLine(1, "Hello", false), line);
+        var persistedLogs = Assert.Single(repositoryWriter.ConsoleLogs);
+        Assert.Equal("api", persistedLogs.ResourceName);
+        Assert.Equal("Hello", Assert.Single(persistedLogs.LogLines).Text);
+        Assert.Equal("api", Assert.Single(repositoryWriter.LoadedConsoleLogs));
+    }
+
+    [Fact]
     public async Task SubscribeInteractions_OnCancel_ChannelRemoved()
     {
         await using var instance = CreateResourceServiceClient();
@@ -256,6 +277,62 @@ public sealed class DashboardClientTests
         IDashboardClient client = instance;
 
         Assert.Equal(DashboardConnectionState.Connecting, client.ConnectionState);
+    }
+
+    [Fact]
+    public async Task WhenConnected_AmbientActivity_DoesNotFlowToConnection()
+    {
+        await using var instance = CreateResourceServiceClient();
+        var serviceClient = new MockDashboardServiceClient();
+        instance.SetDashboardServiceClient(serviceClient);
+
+        using var activity = new Activity("request").Start();
+
+        await instance.WhenConnected.DefaultTimeout();
+
+        Assert.Null(serviceClient.ActivityOnGetApplicationInformation);
+    }
+
+    [Fact]
+    public async Task WatchResources_ResponseCreatesActivity()
+    {
+        using var activitySource = new DashboardActivitySource();
+        await using var instance = CreateResourceServiceClient(activitySource);
+        instance.SetDashboardServiceClient(new MockDashboardServiceClient
+        {
+            ResourceUpdates =
+            [
+                new WatchResourcesUpdate { InitialData = new InitialResourceData() },
+                new WatchResourcesUpdate { Changes = new WatchResourcesChanges() }
+            ]
+        });
+        var activities = new ConcurrentQueue<Activity>();
+        var activitiesReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var listener = ActivityListenerHelper.Create(activitySource.ActivitySource, onActivityStopped: activity =>
+        {
+            activities.Enqueue(activity);
+            if (activities.Count == 2)
+            {
+                activitiesReceived.TrySetResult();
+            }
+        });
+
+        _ = instance.WhenConnected;
+        await activitiesReceived.Task.DefaultTimeout();
+        await instance.DisposeAsync().DefaultTimeout();
+
+        Assert.Collection(
+            activities,
+            activity => AssertActivity(activity, WatchResourcesUpdate.KindOneofCase.InitialData),
+            activity => AssertActivity(activity, WatchResourcesUpdate.KindOneofCase.Changes));
+
+        static void AssertActivity(Activity activity, WatchResourcesUpdate.KindOneofCase kind)
+        {
+            Assert.Equal(DashboardActivitySource.ActivitySourceName, activity.Source.Name);
+            Assert.Equal("Process resource update", activity.OperationName);
+            Assert.Equal(ActivityKind.Consumer, activity.Kind);
+            Assert.Equal(kind.ToString(), activity.GetTagItem("aspire.dashboard.resource_update.type"));
+        }
     }
 
     [Fact]
@@ -374,9 +451,9 @@ public sealed class DashboardClientTests
     public async Task ConnectWithRetry_LogsErrorWithTroubleshootingLink()
     {
         var testSink = new TestSink();
-        var loggerFactory = LoggerFactory.Create(b => b.AddProvider(new TestLoggerProvider(testSink)));
+        _loggerFactory.AddProvider(new TestLoggerProvider(testSink));
 
-        await using var instance = new DashboardClient(loggerFactory, _configuration, _dashboardOptions, new MockKnownPropertyLookup(), new TestStringLocalizer<DashboardResources>());
+        await using var instance = CreateResourceServiceClient();
         instance.SetDashboardServiceClient(new MockDashboardServiceClient { FailOnGetApplicationInformation = true });
 
         IDashboardClient client = instance;
@@ -522,6 +599,20 @@ public sealed class DashboardClientTests
         public bool FailOnExecuteResourceCommand { get; init; }
         public bool CancelExecuteResourceCommandOnCallCancellation { get; init; }
         public string MinDashboardVersion { get; init; } = "";
+        public IReadOnlyList<WatchResourceConsoleLogsUpdate> ConsoleLogUpdates { get; init; } = [];
+        public IReadOnlyList<WatchResourcesUpdate> ResourceUpdates { get; init; } = [];
+        public Activity? ActivityOnGetApplicationInformation { get; private set; }
+        private int _resourceUpdatesReturned;
+
+        public override AsyncServerStreamingCall<WatchResourceConsoleLogsUpdate> WatchResourceConsoleLogs(WatchResourceConsoleLogsRequest request, CallOptions options)
+        {
+            return new AsyncServerStreamingCall<WatchResourceConsoleLogsUpdate>(
+                new AsyncStreamReader<WatchResourceConsoleLogsUpdate>(ConsoleLogUpdates),
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
 
         public override AsyncDuplexStreamingCall<WatchInteractionsRequestUpdate, WatchInteractionsResponseUpdate> WatchInteractions(CallOptions options)
         {
@@ -536,6 +627,7 @@ public sealed class DashboardClientTests
 
         public override AsyncUnaryCall<ApplicationInformationResponse> GetApplicationInformationAsync(ApplicationInformationRequest request, CallOptions options)
         {
+            ActivityOnGetApplicationInformation = Activity.Current;
             if (FailOnGetApplicationInformation)
             {
                 return new AsyncUnaryCall<ApplicationInformationResponse>(
@@ -609,7 +701,7 @@ public sealed class DashboardClientTests
         {
             var reader = FailOnWatchResources
                 ? (IAsyncStreamReader<WatchResourcesUpdate>)new FailingAsyncStreamReader<WatchResourcesUpdate>()
-                : new AsyncStreamReader<WatchResourcesUpdate>();
+                : new AsyncStreamReader<WatchResourcesUpdate>(Interlocked.Exchange(ref _resourceUpdatesReturned, 1) == 0 ? ResourceUpdates : []);
 
             return new AsyncServerStreamingCall<WatchResourcesUpdate>(
                 reader,
@@ -632,12 +724,55 @@ public sealed class DashboardClientTests
 
     private sealed class AsyncStreamReader<T> : IAsyncStreamReader<T>
     {
-        public T Current { get; } = default!;
+        private readonly Queue<T> _items;
+
+        public AsyncStreamReader(IEnumerable<T>? items = null)
+        {
+            _items = new Queue<T>(items ?? []);
+        }
+
+        public T Current { get; private set; } = default!;
 
         public Task<bool> MoveNext(CancellationToken cancellationToken)
         {
+            if (_items.TryDequeue(out var item))
+            {
+                Current = item;
+                return Task.FromResult(true);
+            }
+
             return Task.FromResult(false);
         }
+    }
+
+    private sealed class RecordingResourceRepositoryWriter : IResourceRepositoryWriter
+    {
+        public List<(string ResourceName, IReadOnlyList<ConsoleLogLine> LogLines)> ConsoleLogs { get; } = [];
+        public List<string> LoadedConsoleLogs { get; } = [];
+
+        public Task ReplaceResourcesAsync(IReadOnlyList<Resource> resources)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task ApplyChangesAsync(IReadOnlyList<WatchResourcesChange> changes)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task MarkConsoleLogsLoadedAsync(string resourceName)
+        {
+            LoadedConsoleLogs.Add(resourceName);
+            return Task.CompletedTask;
+        }
+
+        public Task AddConsoleLogsAsync(string resourceName, IReadOnlyList<ConsoleLogLine> logLines)
+        {
+            ConsoleLogs.Add((resourceName, logLines));
+            return Task.CompletedTask;
+        }
+
+        public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate) => Task.CompletedTask;
     }
 
     private sealed class ClientStreamWriter<T> : IClientStreamWriter<T>
@@ -655,9 +790,41 @@ public sealed class DashboardClientTests
         }
     }
 
-    private DashboardClient CreateResourceServiceClient()
+    private DashboardClient CreateResourceServiceClient(
+        DashboardActivitySource? activitySource = null,
+        IResourceRepositoryWriter? resourceRepositoryWriter = null)
     {
-        return new DashboardClient(NullLoggerFactory.Instance, _configuration, _dashboardOptions, new MockKnownPropertyLookup(), new TestStringLocalizer<DashboardResources>());
+        return CreateResourceServiceClient(_loggerFactory, activitySource, resourceRepositoryWriter);
+    }
+
+    private static DashboardClient CreateResourceServiceClient(
+        ILoggerFactory loggerFactory,
+        DashboardActivitySource? activitySource,
+        IResourceRepositoryWriter? resourceRepositoryWriter)
+    {
+        var options = new DashboardOptions
+        {
+            ResourceServiceClient =
+            {
+                AuthMode = ResourceClientAuthMode.Unsecured,
+                Url = "http://localhost:12345"
+            }
+        };
+        options.ResourceServiceClient.TryParseOptions(out _);
+
+        return new DashboardClient(
+            activitySource ?? new DashboardActivitySource(),
+            loggerFactory,
+            new ConfigurationManager(),
+            Options.Create(options),
+            new MockKnownPropertyLookup(),
+            new TestStringLocalizer<DashboardResources>(),
+            resourceRepositoryWriter: resourceRepositoryWriter ?? new RecordingResourceRepositoryWriter());
+    }
+
+    public void Dispose()
+    {
+        _loggerFactory.Dispose();
     }
 
     private static CommandViewModel CreateCommand()

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
@@ -1,0 +1,1349 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.DashboardService.Proto.V1;
+using Aspire.Dashboard.Tests.Shared;
+using Aspire.Shared;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Proto.Logs.V1;
+using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void RunDirectory_IsNestedUnderApplicationDirectoryAndRuns()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, "My Dashboard");
+
+        using var runStore = CreateRunStore(options);
+
+        var applicationDirectoryName = DashboardRunStore.GetApplicationDirectoryName("My Dashboard");
+        var expectedRunsDirectory = Path.Combine(workspace.Path, applicationDirectoryName, "runs");
+        Assert.Equal(expectedRunsDirectory, Directory.GetParent(runStore.RunDirectory)!.FullName);
+    }
+
+    [Fact]
+    public void ApplicationDirectory_WithoutDataDirectory_UsesDashboardDirectoryInAspireHome()
+    {
+        var applicationDirectoryName = DashboardRunStore.GetApplicationDirectoryName("My Dashboard");
+        var expectedDirectory = Path.Combine(
+            AspireHomeDirectory.GetDefault(),
+            "dashboard",
+            applicationDirectoryName);
+
+        Assert.Equal(expectedDirectory, DashboardRunStore.GetApplicationDirectory(dataRoot: null, "My Dashboard"));
+    }
+
+    [Theory]
+    [InlineData(DashboardPersistenceMode.Run)]
+    [InlineData(DashboardPersistenceMode.Resume)]
+    public void PersistentApplicationDirectory_HasOwnerOnlyPermissionsOnUnix(DashboardPersistenceMode persistenceMode)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var applicationDirectory = DashboardRunStore.GetApplicationDirectory(workspace.Path, "My Dashboard");
+        Directory.CreateDirectory(applicationDirectory);
+        File.SetUnixFileMode(
+            applicationDirectory,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        using var runStore = CreateRunStore(CreateOptions(workspace, "My Dashboard", persistenceMode));
+
+        Assert.Equal(
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+            File.GetUnixFileMode(applicationDirectory));
+    }
+
+    [Fact]
+    public void RunId_IsUtcTimestampWithMillisecondPrecision()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var timeProvider = new FixedTimeProvider(new DateTimeOffset(2026, 7, 20, 12, 34, 56, 789, TimeSpan.Zero));
+
+        using var runStore = CreateRunStore(CreateOptions(workspace), timeProvider);
+
+        Assert.Equal("20260720T123456789Z", runStore.RunId);
+        Assert.Equal(runStore.RunId, Path.GetFileName(runStore.RunDirectory));
+    }
+
+    [Fact]
+    public void RunMode_RejectsConcurrentTimestampCollision()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var timeProvider = new FixedTimeProvider(new DateTimeOffset(2026, 7, 20, 12, 34, 56, 789, TimeSpan.Zero));
+        var options = CreateOptions(workspace);
+        using var firstRunStore = CreateRunStore(options, timeProvider);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CreateRunStore(options, timeProvider));
+
+        Assert.Equal($"Dashboard run '{firstRunStore.RunId}' is already in use by another dashboard process.", exception.Message);
+    }
+
+    [Fact]
+    public async Task RunMetadata_IsPublishedAfterApplicationStarted()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        using var runStore = CreateRunStore(options);
+        var metadataPath = Path.Combine(runStore.RunDirectory, "run.json");
+        using var lifetime = new TestHostApplicationLifetime();
+
+        Assert.False(File.Exists(metadataPath));
+
+        using var dataSourcePool = new DashboardDataSourcePool(runStore, CreateRepositoryFactory(options));
+        using var initializer = new DashboardDataSourceInitializer(
+            dataSourcePool,
+            lifetime,
+            NullLogger<DashboardDataSourceInitializer>.Instance);
+        await initializer.StartAsync(CancellationToken.None);
+
+        Assert.False(File.Exists(metadataPath));
+
+        lifetime.NotifyStarted();
+
+        using var metadata = JsonDocument.Parse(File.ReadAllText(metadataPath));
+
+        Assert.Equal(DashboardRunStore.SchemaVersion, metadata.RootElement.GetProperty("SchemaVersion").GetInt32());
+        Assert.Equal(DashboardRunStore.SchemaVersion, Assert.Single(runStore.GetRuns()).SchemaVersion);
+    }
+
+    [Fact]
+    public async Task CurrentRun_PinPersistsWhenRunBecomesHistorical()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero);
+        string pinnedRunId;
+
+        using (var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt)))
+        {
+            await InitializeAndPublishRunAsync(currentRunStore);
+            var currentRun = Assert.Single(currentRunStore.GetRuns());
+            Assert.False(currentRun.IsPinned);
+
+            currentRunStore.SetRunPinned(currentRun, isPinned: true);
+
+            Assert.True(currentRun.IsPinned);
+            using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(currentRunStore.RunDirectory, "run.json")));
+            Assert.True(metadata.RootElement.GetProperty("IsPinned").GetBoolean());
+            pinnedRunId = currentRun.RunId;
+        }
+
+        using var nextRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(1)));
+        var historicalRun = nextRunStore.GetRuns().Single(run => string.Equals(run.RunId, pinnedRunId, StringComparison.Ordinal));
+        Assert.False(historicalRun.IsCurrent);
+        Assert.True(historicalRun.IsPinned);
+    }
+
+    [Fact]
+    public async Task RunMetadata_SchemaInitializationFailure_DoesNotPublishRun()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        using var runStore = CreateRunStore(options);
+        using (var connection = new SqliteConnection($"Data Source={runStore.DatabasePath};Pooling=False"))
+        {
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "CREATE TABLE dashboard_schema (version INTEGER NOT NULL); INSERT INTO dashboard_schema VALUES (1);";
+            command.ExecuteNonQuery();
+        }
+        using var dataSourcePool = new DashboardDataSourcePool(runStore, CreateRepositoryFactory(options));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => dataSourcePool.InitializeAsync(CancellationToken.None));
+
+        Assert.False(File.Exists(Path.Combine(runStore.RunDirectory, "run.json")));
+    }
+
+    [Fact]
+    public void ConstructionAndGetRuns_LogResolvedStorageAndDiscoveredRuns()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var testSink = new TestSink();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(new TestLoggerProvider(testSink));
+        });
+        using var runStore = new DashboardRunStore(
+            CreateOptions(workspace),
+            loggerFactory.CreateLogger<DashboardRunStore>(),
+            TimeProvider.System);
+
+        Assert.Single(runStore.GetRuns());
+
+        Assert.Collection(
+            testSink.Writes,
+            initializationLog =>
+            {
+                Assert.Equal(LogLevel.Debug, initializationLog.LogLevel);
+                Assert.Equal(
+                    $"Dashboard run store initialized with persistence mode 'Run'. Run directory: '{runStore.RunDirectory}'. Database path: '{runStore.DatabasePath}'.",
+                    initializationLog.Message);
+            },
+            discoveryLog =>
+            {
+                Assert.Equal(LogLevel.Debug, discoveryLog.LogLevel);
+                Assert.Equal(
+                    $"Dashboard run discovery completed in directory '{Directory.GetParent(runStore.RunDirectory)!.FullName}'. Run count: 1. Run IDs: {runStore.RunId}.",
+                    discoveryLog.Message);
+            });
+    }
+
+    [Fact]
+    public async Task NoneMode_UsesTemporaryDatabaseAndDeletesItOnDispose()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, persistenceMode: DashboardPersistenceMode.None);
+        string runDirectory;
+        string databasePath;
+
+        using (var runStore = CreateRunStore(options))
+        {
+            runDirectory = runStore.RunDirectory;
+            databasePath = runStore.DatabasePath;
+            using var database = new DashboardSqliteDatabase(databasePath, pooling: false);
+            await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+
+            Assert.False(runStore.SupportsRunSelection);
+            Assert.False(runDirectory.StartsWith(workspace.Path, StringComparison.OrdinalIgnoreCase));
+            Assert.Collection(runStore.GetRuns(), run => Assert.True(run.IsCurrent));
+            Assert.True(File.Exists(databasePath));
+        }
+
+        Assert.False(Directory.Exists(runDirectory));
+        Assert.False(File.Exists(databasePath));
+    }
+
+    [Theory]
+    [InlineData(DashboardPersistenceMode.None)]
+    [InlineData(DashboardPersistenceMode.Run)]
+    [InlineData(DashboardPersistenceMode.Resume)]
+    public async Task ServiceProviderDisposal_ReleasesDatabaseAndDeletesUnpublishedDirectory(DashboardPersistenceMode persistenceMode)
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, $"Dispose-{Guid.NewGuid():N}", persistenceMode);
+        var services = new ServiceCollection()
+            .AddSingleton(options)
+            .AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance)
+            .AddSingleton<ILogger<DashboardRunStore>>(NullLogger<DashboardRunStore>.Instance)
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<PauseManager>()
+            .AddSingleton<IKnownPropertyLookup, MockKnownPropertyLookup>()
+            .AddSingleton<DashboardRunStore>()
+            .AddSingleton<IDashboardRunStore>(serviceProvider => serviceProvider.GetRequiredService<DashboardRunStore>())
+            .AddSingleton<IRepositoryFactory, RepositoryFactory>()
+            .AddSingleton<DashboardDataSourcePool>();
+
+        string? runDirectory = null;
+        try
+        {
+            using (var serviceProvider = services.BuildServiceProvider())
+            {
+                var runStore = serviceProvider.GetRequiredService<DashboardRunStore>();
+                // Starting the pool creates its current lease after the run store, so DI disposes the pool first.
+                // Schema initialization leaves a physical connection in the SQLite provider pool to be cleared.
+                await serviceProvider.GetRequiredService<DashboardDataSourcePool>().InitializeAsync(CancellationToken.None);
+                runDirectory = runStore.RunDirectory;
+            }
+
+            // None mode owns its temporary directory, and an unpublished Run directory represents a failed startup.
+            // Resume mode retains its storage. Deleting it here also verifies that SQLite released the database.
+            Assert.Equal(persistenceMode == DashboardPersistenceMode.Resume, Directory.Exists(runDirectory));
+
+            if (Directory.Exists(runDirectory))
+            {
+                Directory.Delete(runDirectory, recursive: true);
+            }
+            Assert.False(Directory.Exists(runDirectory));
+        }
+        finally
+        {
+            if (runDirectory is not null && Directory.Exists(runDirectory))
+            {
+                Directory.Delete(runDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void NoneMode_DeletesAbandonedTemporaryDirectories()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var abandonedDirectory = Directory.CreateTempSubdirectory("aspire-dashboard-").FullName;
+        File.WriteAllText(Path.Combine(abandonedDirectory, "dashboard.db"), string.Empty);
+
+        try
+        {
+            using var runStore = CreateRunStore(CreateOptions(workspace, persistenceMode: DashboardPersistenceMode.None));
+
+            Assert.False(Directory.Exists(abandonedDirectory));
+        }
+        finally
+        {
+            if (Directory.Exists(abandonedDirectory))
+            {
+                Directory.Delete(abandonedDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task NoneMode_DoesNotDeleteActiveTemporaryDirectories()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, persistenceMode: DashboardPersistenceMode.None);
+        using var activeRunStore = CreateRunStore(options);
+        using var database = new DashboardSqliteDatabase(activeRunStore.DatabasePath, pooling: false);
+        await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+
+        using var secondRunStore = CreateRunStore(options);
+
+        Assert.True(Directory.Exists(activeRunStore.RunDirectory));
+        Assert.True(Directory.Exists(secondRunStore.RunDirectory));
+    }
+
+    [Fact]
+    public void NoneMode_DoesNotDeleteTemporaryDirectoriesWithOtherNames()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var otherDirectory = Directory.CreateTempSubdirectory("unrelated-").FullName;
+        File.WriteAllText(Path.Combine(otherDirectory, "dashboard.db"), string.Empty);
+
+        try
+        {
+            using var runStore = CreateRunStore(CreateOptions(workspace, persistenceMode: DashboardPersistenceMode.None));
+
+            Assert.True(Directory.Exists(otherDirectory));
+        }
+        finally
+        {
+            if (Directory.Exists(otherDirectory))
+            {
+                Directory.Delete(otherDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ResumeMode_LogsCreatingDatabase()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var testSink = new TestSink();
+        var logger = new TestLogger<DashboardRunStore>(new TestLoggerFactory(testSink, enabled: true));
+
+        using var runStore = new DashboardRunStore(
+            CreateOptions(workspace, $"Create-{Guid.NewGuid():N}", DashboardPersistenceMode.Resume),
+            logger,
+            TimeProvider.System);
+
+        var creationLog = Assert.Single(
+            testSink.Writes,
+            write => write.Message == $"Creating dashboard database at '{runStore.DatabasePath}'.");
+        Assert.Equal(LogLevel.Debug, creationLog.LogLevel);
+    }
+
+    [Fact]
+    public async Task ResumeMode_ReusesApplicationDatabaseWithoutRunSelection()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, "My Dashboard", DashboardPersistenceMode.Resume);
+        string firstDatabasePath;
+
+        using (var firstRunStore = CreateRunStore(options))
+        {
+            firstDatabasePath = firstRunStore.DatabasePath;
+            using var database = new DashboardSqliteDatabase(firstDatabasePath);
+            await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+        }
+
+        var testSink = new TestSink();
+        var logger = new TestLogger<DashboardRunStore>(new TestLoggerFactory(testSink, enabled: true));
+        using var secondRunStore = new DashboardRunStore(options, logger, TimeProvider.System);
+
+        Assert.Equal(firstDatabasePath, secondRunStore.DatabasePath);
+        Assert.False(secondRunStore.SupportsRunSelection);
+        Assert.Collection(secondRunStore.GetRuns(), run => Assert.True(run.IsCurrent));
+        Assert.True(DashboardSqliteDatabase.IsCompatible(secondRunStore.DatabasePath));
+        var resumeLog = Assert.Single(
+            testSink.Writes,
+            write => write.Message == $"Resuming dashboard database at '{secondRunStore.DatabasePath}'.");
+        Assert.Equal(LogLevel.Debug, resumeLog.LogLevel);
+    }
+
+    [Fact]
+    public void ResumeMode_RejectsConcurrentDashboardForApplication()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, "My Dashboard", DashboardPersistenceMode.Resume);
+        using var firstRunStore = CreateRunStore(options);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CreateRunStore(options));
+
+        Assert.Equal(
+            $"Dashboard data for application 'My Dashboard' is already in use by another dashboard process. Database path: '{firstRunStore.DatabasePath}'.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task ResumeMode_DeletesIncompatibleDatabase()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, persistenceMode: DashboardPersistenceMode.Resume);
+        string databasePath;
+
+        using (var firstRunStore = CreateRunStore(options))
+        {
+            databasePath = firstRunStore.DatabasePath;
+            using var connection = new SqliteConnection($"Data Source={databasePath};Pooling=False");
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "CREATE TABLE dashboard_schema (version INTEGER NOT NULL); INSERT INTO dashboard_schema VALUES (1);";
+            command.ExecuteNonQuery();
+        }
+
+        var testSink = new TestSink();
+        var logger = new TestLogger<DashboardRunStore>(new TestLoggerFactory(testSink, enabled: true));
+        using var secondRunStore = new DashboardRunStore(options, logger, TimeProvider.System);
+
+        Assert.Equal(databasePath, secondRunStore.DatabasePath);
+        Assert.False(File.Exists(databasePath));
+        var incompatibleLog = Assert.Single(
+            testSink.Writes,
+            write => write.Message == $"Existing dashboard database at '{databasePath}' is incompatible with schema version {DashboardRunStore.SchemaVersion} and will be replaced.");
+        Assert.Equal(LogLevel.Information, incompatibleLog.LogLevel);
+        using var database = new DashboardSqliteDatabase(databasePath);
+        await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+        Assert.True(DashboardSqliteDatabase.IsCompatible(databasePath));
+    }
+
+    [Fact]
+    public void ResumeMode_PreservesDatabaseWhenCompatibilityProbeFails()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace, persistenceMode: DashboardPersistenceMode.Resume);
+        string databasePath;
+
+        using (var firstRunStore = CreateRunStore(options))
+        {
+            databasePath = firstRunStore.DatabasePath;
+        }
+
+        var databaseContents = "not a SQLite database"u8.ToArray();
+        var walContents = "existing WAL data"u8.ToArray();
+        var sharedMemoryContents = "existing shared-memory data"u8.ToArray();
+        File.WriteAllBytes(databasePath, databaseContents);
+        File.WriteAllBytes($"{databasePath}-wal", walContents);
+        File.WriteAllBytes($"{databasePath}-shm", sharedMemoryContents);
+
+        Assert.Throws<SqliteException>(() => CreateRunStore(options));
+
+        Assert.Equal(databaseContents, File.ReadAllBytes(databasePath));
+        Assert.True(File.Exists($"{databasePath}-wal"));
+        Assert.True(File.Exists($"{databasePath}-shm"));
+        // A second probe reaches SQLite instead of failing because the first constructor leaked the run lock.
+        Assert.Throws<SqliteException>(() => CreateRunStore(options));
+    }
+
+    [Fact]
+    public void IsCompatible_ReturnsFalseForMultipleSchemaVersions()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = Path.Combine(workspace.Path, $"malformed-{Guid.NewGuid():N}.db");
+        using (var connection = new SqliteConnection($"Data Source={databasePath};Pooling=False"))
+        {
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "CREATE TABLE dashboard_schema (version INTEGER NOT NULL) STRICT; INSERT INTO dashboard_schema VALUES (8), (8);";
+            command.ExecuteNonQuery();
+        }
+
+        Assert.False(DashboardSqliteDatabase.IsCompatible(databasePath));
+    }
+
+    [Fact]
+    public void ApplicationDirectoryName_IsSafeBoundedAndUnique()
+    {
+        var firstName = new string('a', 300) + "/dashboard";
+        var secondName = new string('a', 300) + ":dashboard";
+
+        var firstDirectoryName = DashboardRunStore.GetApplicationDirectoryName(firstName);
+        var secondDirectoryName = DashboardRunStore.GetApplicationDirectoryName(secondName);
+
+        Assert.Equal(DashboardRunStore.MaxApplicationDirectoryNameLength, firstDirectoryName.Length);
+        Assert.Equal(DashboardRunStore.MaxApplicationDirectoryNameLength, secondDirectoryName.Length);
+        Assert.Matches("^[A-Za-z0-9_-]+-[0-9a-f]{16}$", firstDirectoryName);
+        Assert.Matches("^[A-Za-z0-9_-]+-[0-9a-f]{16}$", secondDirectoryName);
+        Assert.NotEqual(firstDirectoryName, secondDirectoryName);
+        Assert.Equal(firstDirectoryName, DashboardRunStore.GetApplicationDirectoryName(firstName));
+    }
+
+    [Fact]
+    public async Task GetRuns_ReturnsCurrentThenCompletedHistoricalRun()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        string historicalRunId;
+
+        using (var historicalRunStore = CreateRunStore(options))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            using var telemetryContext = await CreateTelemetryRepositoryAsync(historicalRunStore.DatabasePath, options);
+            historicalRunStore.PublishRun();
+        }
+
+        using var currentRunStore = CreateRunStore(options);
+        using var currentTelemetryContext = await CreateTelemetryRepositoryAsync(currentRunStore.DatabasePath, options);
+
+        Assert.Collection(
+            currentRunStore.GetRuns(),
+            currentRun =>
+            {
+                Assert.True(currentRun.IsCurrent);
+                Assert.Equal(currentRunStore.RunId, currentRun.RunId);
+            },
+            historicalRun =>
+            {
+                Assert.False(historicalRun.IsCurrent);
+                Assert.True(historicalRun.CleanShutdown);
+                Assert.NotNull(historicalRun.EndedAtUtc);
+                Assert.Equal(historicalRunId, historicalRun.RunId);
+            });
+    }
+
+    [Fact]
+    public void GetRuns_ReusesLazySnapshot()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var runStore = CreateRunStore(CreateOptions(workspace));
+
+        var first = runStore.GetRuns();
+        var second = runStore.GetRuns();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetCurrentRunAndGetRunById_ReturnSnapshotDescriptors()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var runStore = CreateRunStore(CreateOptions(workspace));
+
+        var currentRun = runStore.GetCurrentRun();
+
+        Assert.True(currentRun.IsCurrent);
+        Assert.Same(currentRun, runStore.GetRunById(currentRun.RunId));
+        Assert.Null(runStore.GetRunById("missing"));
+    }
+
+    [Fact]
+    public async Task GetRuns_ExcludesRunOwnedByAnotherDashboard()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        string historicalRunId;
+
+        using (var historicalRunStore = CreateRunStore(options))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            using var historicalTelemetryContext = await CreateTelemetryRepositoryAsync(historicalRunStore.DatabasePath, options);
+            historicalRunStore.PublishRun();
+        }
+
+        using var activeRunStore = CreateRunStore(options);
+        using var activeTelemetryContext = await CreateTelemetryRepositoryAsync(activeRunStore.DatabasePath, options);
+        activeRunStore.PublishRun();
+        using var currentRunStore = CreateRunStore(options);
+        using var currentTelemetryContext = await CreateTelemetryRepositoryAsync(currentRunStore.DatabasePath, options);
+
+        Assert.Collection(
+            currentRunStore.GetRuns(),
+            currentRun =>
+            {
+                Assert.True(currentRun.IsCurrent);
+                Assert.Equal(currentRunStore.RunId, currentRun.RunId);
+            },
+            historicalRun =>
+            {
+                Assert.False(historicalRun.IsCurrent);
+                Assert.Equal(historicalRunId, historicalRun.RunId);
+                Assert.NotEqual(activeRunStore.RunId, historicalRun.RunId);
+            });
+    }
+
+    [Fact]
+    public async Task RunMode_DeletesOldestRunWhenLimitIsExceeded()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 5, 12, 34, 56, TimeSpan.Zero);
+        var historicalRunDirectories = new List<string>();
+
+        foreach (var index in Enumerable.Range(1, DashboardRunStore.MaxRuns))
+        {
+            using var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(-index)));
+            historicalRunDirectories.Add(historicalRunStore.RunDirectory);
+            await InitializeAndPublishRunWithoutPruningAsync(historicalRunStore);
+        }
+
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
+        await InitializeAndPublishRunAsync(currentRunStore);
+
+        var runsDirectory = Path.GetDirectoryName(currentRunStore.RunDirectory)!;
+        Assert.Equal(DashboardRunStore.MaxRuns, Directory.GetDirectories(runsDirectory).Length);
+        Assert.False(Directory.Exists(historicalRunDirectories[^1]));
+        Assert.All(historicalRunDirectories[..^1], directory => Assert.True(Directory.Exists(directory)));
+        Assert.True(Directory.Exists(currentRunStore.RunDirectory));
+    }
+
+    [Fact]
+    public async Task RunMode_DoesNotListRunsBeyondRetentionLimitWhenDiscoveredBeforePruning()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 5, 12, 34, 56, TimeSpan.Zero);
+        var activeRunCount = 4;
+
+        foreach (var index in Enumerable.Range(0, DashboardRunStore.MaxRuns - activeRunCount))
+        {
+            using var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMilliseconds(index)));
+            await InitializeAndPublishRunAsync(historicalRunStore);
+        }
+
+        var activeRunStores = new List<DashboardRunStore>();
+        foreach (var index in Enumerable.Range(DashboardRunStore.MaxRuns - activeRunCount, activeRunCount))
+        {
+            var activeRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMilliseconds(index)));
+            using var database = new DashboardSqliteDatabase(activeRunStore.DatabasePath, pooling: false);
+            await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+            activeRunStore.PublishRun();
+            activeRunStores.Add(activeRunStore);
+        }
+
+        using var currentRunStore = CreateRunStore(
+            options,
+            new FixedTimeProvider(startedAt.AddMilliseconds(DashboardRunStore.MaxRuns)));
+        var runsBeforePruning = currentRunStore.GetRuns();
+
+        await InitializeAndPublishRunAsync(currentRunStore);
+
+        foreach (var activeRunStore in activeRunStores)
+        {
+            activeRunStore.Dispose();
+        }
+
+        var prunedRun = Assert.Single(runsBeforePruning, run => run.IsPruned);
+        Assert.False(File.Exists(prunedRun.DatabasePath));
+
+        var selectableRuns = currentRunStore.GetRuns();
+        Assert.Equal(DashboardRunStore.MaxRuns - activeRunCount, selectableRuns.Count);
+        Assert.All(selectableRuns, run => Assert.True(File.Exists(run.DatabasePath)));
+    }
+
+    [Fact]
+    public async Task RunMode_PinnedRunsDoNotCountTowardHistoricalLimitAndReloadFromMetadata()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var pinnedRunIds = new List<string>();
+        var pinnedRunDirectories = new List<string>();
+        var runIndex = 0;
+
+        for (var index = 0; index < 3; index++)
+        {
+            string runId;
+            using (var runStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(runIndex++))))
+            {
+                runId = runStore.RunId;
+                await InitializeAndPublishRunAsync(runStore);
+            }
+
+            using var pinningRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(runIndex++)));
+            await InitializeAndPublishRunAsync(pinningRunStore);
+            var run = pinningRunStore.GetRuns().Single(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+            pinningRunStore.SetRunPinned(run, isPinned: true);
+            pinnedRunIds.Add(runId);
+            pinnedRunDirectories.Add(Path.GetDirectoryName(run.DatabasePath)!);
+
+            using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(pinnedRunDirectories[^1], "run.json")));
+            Assert.True(metadata.RootElement.GetProperty("IsPinned").GetBoolean());
+        }
+
+        for (var index = 0; index < DashboardRunStore.MaxRuns - 1; index++)
+        {
+            using var runStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(runIndex++)));
+            await InitializeAndPublishRunAsync(runStore);
+        }
+
+        using var finalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(runIndex)));
+        await InitializeAndPublishRunAsync(finalRunStore);
+        var runs = finalRunStore.GetRuns();
+        Assert.Equal(
+            runs.OrderByDescending(run => run.IsCurrent).ThenByDescending(run => run.IsPinned).ThenByDescending(run => run.StartedAtUtc),
+            runs);
+        Assert.Single(runs, run => run.IsCurrent);
+        Assert.Equal(3, runs.Count(run => !run.IsCurrent && run.IsPinned));
+        Assert.Equal(DashboardRunStore.MaxRuns - 1, runs.Count(run => !run.IsCurrent && !run.IsPinned));
+        Assert.All(pinnedRunIds, runId => Assert.True(finalRunStore.GetRuns().Single(run => string.Equals(run.RunId, runId, StringComparison.Ordinal)).IsPinned));
+        Assert.All(pinnedRunDirectories, directory => Assert.True(Directory.Exists(directory)));
+    }
+
+    [Fact]
+    public async Task RunMode_DoesNotDeleteActiveExpiredRun()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 5, 12, 34, 56, TimeSpan.Zero);
+
+        foreach (var index in Enumerable.Range(1, DashboardRunStore.MaxRuns - 1))
+        {
+            using var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(-index)));
+            await InitializeAndPublishRunWithoutPruningAsync(historicalRunStore);
+        }
+
+        using var activeRunStore = CreateRunStore(
+            options,
+            new FixedTimeProvider(startedAt.AddDays(-DashboardRunStore.MaxRuns)));
+        await InitializeAndPublishRunWithoutPruningAsync(activeRunStore);
+
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt));
+        await InitializeAndPublishRunAsync(currentRunStore);
+
+        var runsDirectory = Path.GetDirectoryName(currentRunStore.RunDirectory)!;
+        Assert.True(Directory.Exists(activeRunStore.RunDirectory));
+        Assert.Equal(DashboardRunStore.MaxRuns + 1, Directory.GetDirectories(runsDirectory).Length);
+    }
+
+    [Fact]
+    public async Task SelectedHistoricalRun_HoldsLeaseUntilSelectionChanges()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 7, 26, 12, 34, 56, TimeSpan.Zero);
+        string historicalRunId;
+        string historicalRunDirectory;
+
+        using (var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt)))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            historicalRunDirectory = historicalRunStore.RunDirectory;
+            using var historicalTelemetryContext = await CreateTelemetryRepositoryAsync(historicalRunStore.DatabasePath, options);
+            historicalRunStore.PublishRun();
+        }
+
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMilliseconds(1)));
+        var repositoryFactory = CreateRepositoryFactory(options);
+        using var dataSourcePool = new DashboardDataSourcePool(currentRunStore, repositoryFactory);
+        using var dataSource = CreateDataSource(currentRunStore, dataSourcePool);
+        dataSource.SelectRun(historicalRunId);
+
+        foreach (var index in Enumerable.Range(1, DashboardRunStore.MaxRuns - 2))
+        {
+            using var additionalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(index)));
+            await InitializeAndPublishRunWithoutPruningAsync(additionalRunStore);
+        }
+
+        var deletedRunDirectories = new List<string>();
+        using var pruningRunStore = new DashboardRunStore(
+            options,
+            NullLogger<DashboardRunStore>.Instance,
+            new FixedTimeProvider(startedAt.AddMilliseconds(2)),
+            deletedRunDirectories.Add);
+        await InitializeAndPublishRunAsync(pruningRunStore);
+
+        Assert.Empty(deletedRunDirectories);
+        Assert.True(Directory.Exists(historicalRunDirectory));
+
+        dataSource.SelectRun(runId: null);
+        using var nextPruningRunStore = new DashboardRunStore(
+            options,
+            NullLogger<DashboardRunStore>.Instance,
+            new FixedTimeProvider(startedAt.AddMilliseconds(3)),
+            deletedRunDirectories.Add);
+        await InitializeAndPublishRunAsync(nextPruningRunStore);
+
+        Assert.Equal(historicalRunDirectory, Assert.Single(deletedRunDirectories));
+    }
+
+    [Fact]
+    public async Task SelectedHistoricalRun_SharesDatabaseAcrossDataSources()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        string historicalRunId;
+
+        using (var historicalRunStore = CreateRunStore(options))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            using var historicalTelemetryContext = await CreateTelemetryRepositoryAsync(historicalRunStore.DatabasePath, options);
+            historicalRunStore.PublishRun();
+        }
+
+        using var currentRunStore = CreateRunStore(options);
+        var historicalRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));
+        var innerRepositoryFactory = CreateRepositoryFactory(options);
+        var repositoryFactory = new RecordingRepositoryFactory(innerRepositoryFactory);
+        using var dataSourcePool = new DashboardDataSourcePool(currentRunStore, repositoryFactory);
+        using var firstDataSource = CreateDataSource(currentRunStore, dataSourcePool);
+        using var secondDataSource = CreateDataSource(currentRunStore, dataSourcePool);
+
+        firstDataSource.SelectRun(historicalRunId);
+        secondDataSource.SelectRun(historicalRunId);
+
+        Assert.True(historicalRun.IsLeased);
+        var historicalDatabases = repositoryFactory.Databases.Where(database => database.IsReadOnly).ToList();
+        var sharedDatabase = Assert.IsType<DashboardSqliteDatabase>(historicalDatabases[0]);
+        Assert.Equal(4, historicalDatabases.Count);
+        Assert.All(historicalDatabases, database => Assert.Same(sharedDatabase, database));
+        Assert.All(historicalDatabases, database => Assert.Same(sharedDatabase.WriteLock, database.WriteLock));
+        Assert.Null(currentRunStore.TryAcquireRunLease(historicalRun));
+
+        firstDataSource.SelectRun(runId: null);
+
+        Assert.True(historicalRun.IsLeased);
+        Assert.Empty(secondDataSource.TelemetryRepository.GetResources());
+        Assert.Null(currentRunStore.TryAcquireRunLease(historicalRun));
+
+        secondDataSource.SelectRun(runId: null);
+
+        Assert.False(historicalRun.IsLeased);
+        using (var releasedRunLease = currentRunStore.TryAcquireRunLease(historicalRun))
+        {
+            Assert.NotNull(releasedRunLease);
+            Assert.True(historicalRun.IsLeased);
+        }
+        Assert.False(historicalRun.IsLeased);
+    }
+
+    [Fact]
+    public async Task SelectedHistoricalRun_CanBePinned()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        string historicalRunId;
+
+        using (var historicalRunStore = CreateRunStore(options))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            using var historicalTelemetryContext = await CreateTelemetryRepositoryAsync(historicalRunStore.DatabasePath, options);
+            historicalRunStore.PublishRun();
+        }
+
+        using var currentRunStore = CreateRunStore(options);
+        var historicalRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));
+        using var dataSourcePool = new DashboardDataSourcePool(currentRunStore, CreateRepositoryFactory(options));
+        using var dataSource = CreateDataSource(currentRunStore, dataSourcePool);
+        dataSource.SelectRun(historicalRunId);
+
+        Assert.True(historicalRun.IsLeased);
+        currentRunStore.SetRunPinned(historicalRun, isPinned: true);
+
+        Assert.True(historicalRun.IsPinned);
+        Assert.True(historicalRun.IsLeased);
+        using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(Path.GetDirectoryName(historicalRun.DatabasePath)!, "run.json")));
+        Assert.True(metadata.RootElement.GetProperty("IsPinned").GetBoolean());
+    }
+
+    [Fact]
+    public async Task RunMode_DeleteExpiredRunFails_LogsWarningAndContinues()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 8, 5, 12, 34, 56, TimeSpan.Zero);
+        var historicalRunDirectories = new List<string>();
+
+        foreach (var index in Enumerable.Range(1, DashboardRunStore.MaxRuns))
+        {
+            using var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(-index)));
+            historicalRunDirectories.Add(historicalRunStore.RunDirectory);
+            await InitializeAndPublishRunWithoutPruningAsync(historicalRunStore);
+        }
+
+        var testSink = new TestSink();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new TestLoggerProvider(testSink)));
+        var logger = loggerFactory.CreateLogger<DashboardRunStore>();
+        var expiredRunDirectory = historicalRunDirectories[^1];
+
+        using var currentRunStore = new DashboardRunStore(
+            options,
+            logger,
+            new FixedTimeProvider(startedAt),
+            directory => throw new IOException($"The directory '{directory}' is in use."));
+        await InitializeAndPublishRunAsync(currentRunStore);
+
+        var warning = Assert.Single(testSink.Writes);
+        Assert.Equal(LogLevel.Warning, warning.LogLevel);
+        Assert.Equal(typeof(DashboardRunStore).FullName, warning.LoggerName);
+        Assert.Contains(expiredRunDirectory, warning.Message, StringComparison.Ordinal);
+        Assert.IsType<IOException>(warning.Exception);
+        Assert.True(Directory.Exists(expiredRunDirectory));
+        Assert.True(Directory.Exists(currentRunStore.RunDirectory));
+    }
+
+    [Fact]
+    public void SelectedHistoricalRun_SchemaValidationThrows_ReleasesRunLease()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        string malformedDatabasePath;
+        string malformedRunId;
+
+        using (var malformedRunStore = CreateRunStore(options))
+        {
+            malformedDatabasePath = malformedRunStore.DatabasePath;
+            malformedRunId = malformedRunStore.RunId;
+            using var connection = new SqliteConnection($"Data Source={malformedDatabasePath};Pooling=False");
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "CREATE TABLE unrelated (value INTEGER NOT NULL);";
+            command.ExecuteNonQuery();
+            malformedRunStore.PublishRun();
+        }
+
+        using var currentRunStore = CreateRunStore(options);
+        var currentRun = Assert.Single(currentRunStore.GetRuns(), run => run.IsCurrent);
+        var malformedRun = currentRun with
+        {
+            RunId = malformedRunId,
+            DatabasePath = malformedDatabasePath,
+            IsCurrent = false
+        };
+        var runStore = new TestDashboardRunStore(
+            [currentRun, malformedRun],
+            TryOpenTestRunLease);
+        var repositoryFactory = CreateRepositoryFactory(options);
+        using var dataSourcePool = new DashboardDataSourcePool(runStore, repositoryFactory);
+        using var dataSource = CreateDataSource(runStore, dataSourcePool);
+
+        // A run directory whose database was never fully initialized has no dashboard_schema table. That is an
+        // incompatible database, not an internal error, so it must not surface the raw SQLite failure.
+        var exception = Assert.Throws<InvalidOperationException>(() => dataSource.SelectRun(malformedRunId));
+        Assert.Contains("does not match run metadata schema version", exception.Message, StringComparison.Ordinal);
+
+        using var runLease = Assert.IsType<FileStream>(TryOpenTestRunLease(malformedRun));
+
+        var malformedRunDirectory = Path.GetDirectoryName(malformedDatabasePath)!;
+        Directory.Delete(malformedRunDirectory, recursive: true);
+        Assert.False(Directory.Exists(malformedRunDirectory));
+    }
+
+    [Fact]
+    public async Task SelectedHistoricalRun_ReplacementValidationThrows_PreservesPreviousSelection()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        using var currentRunStore = CreateRunStore(options);
+
+        var historicalDirectory = Path.Combine(workspace.Path, "historical");
+        var historicalDatabasePath = Path.Combine(historicalDirectory, DashboardRunStore.DatabaseFileName);
+        using (var historicalTelemetryContext = await CreateTelemetryRepositoryAsync(historicalDatabasePath, options))
+        {
+        }
+
+        var malformedDirectory = Path.Combine(workspace.Path, "malformed");
+        var malformedDatabasePath = Path.Combine(malformedDirectory, DashboardRunStore.DatabaseFileName);
+        Directory.CreateDirectory(malformedDirectory);
+        using (var connection = new SqliteConnection($"Data Source={malformedDatabasePath};Pooling=False"))
+        {
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "CREATE TABLE unrelated (value INTEGER NOT NULL);";
+            command.ExecuteNonQuery();
+        }
+
+        var currentRun = Assert.Single(currentRunStore.GetRuns());
+        var historicalRun = currentRun with
+        {
+            RunId = "historical",
+            DatabasePath = historicalDatabasePath,
+            IsCurrent = false
+        };
+        var malformedRun = currentRun with
+        {
+            RunId = "malformed",
+            DatabasePath = malformedDatabasePath,
+            IsCurrent = false
+        };
+        var unavailableRun = currentRun with
+        {
+            RunId = "unavailable",
+            DatabasePath = Path.Combine(workspace.Path, "unavailable", DashboardRunStore.DatabaseFileName),
+            IsCurrent = false
+        };
+        var runStore = new TestDashboardRunStore(
+            [currentRun, historicalRun, malformedRun, unavailableRun],
+            TryOpenTestRunLease);
+        var repositoryFactory = CreateRepositoryFactory(options);
+        using var dataSourcePool = new DashboardDataSourcePool(runStore, repositoryFactory);
+        using var dataSource = CreateDataSource(runStore, dataSourcePool);
+
+        dataSource.SelectRun(historicalRun.RunId);
+        var historicalTelemetryRepository = dataSource.TelemetryRepository;
+        var historicalResourceRepository = dataSource.ResourceRepository;
+
+        Assert.Throws<InvalidOperationException>(() => dataSource.SelectRun(malformedRun.RunId));
+
+        Assert.Equal(historicalRun, dataSource.SelectedRun);
+        Assert.Same(historicalTelemetryRepository, dataSource.TelemetryRepository);
+        Assert.Same(historicalResourceRepository, dataSource.ResourceRepository);
+        Assert.Null(TryOpenTestRunLease(historicalRun));
+
+        dataSource.SelectRun(unavailableRun.RunId);
+
+        Assert.Equal(historicalRun, dataSource.SelectedRun);
+        Assert.Same(historicalTelemetryRepository, dataSource.TelemetryRepository);
+        Assert.Same(historicalResourceRepository, dataSource.ResourceRepository);
+        Assert.Null(TryOpenTestRunLease(historicalRun));
+    }
+
+    [Fact]
+    public void SqliteDatabase_ConfiguresLikeAndForeignKeys()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var database = new DashboardSqliteDatabase(Path.Combine(workspace.Path, "connection.db"));
+        using (var connection = database.OpenConnection())
+        using (var command = connection.CreateCommand())
+        {
+            Assert.True(new SqliteConnectionStringBuilder(connection.ConnectionString).Pooling);
+            Assert.Equal(5, connection.DefaultTimeout);
+            Assert.Equal(5, command.CommandTimeout);
+
+            command.CommandText = """
+                SELECT
+                    'Dashboard' = 'dashboard' COLLATE NOCASE,
+                    'CAFE au lait' LIKE '%fe AU%',
+                    'Delta' LIKE 'dE%',
+                    (SELECT foreign_keys FROM pragma_foreign_keys());
+                """;
+            using var reader = command.ExecuteReader();
+
+            Assert.True(reader.Read());
+            Assert.Equal(1, reader.GetInt64(0));
+            Assert.Equal(1, reader.GetInt64(1));
+            Assert.Equal(1, reader.GetInt64(2));
+            Assert.Equal(1, reader.GetInt64(3));
+        }
+
+        database.ClearPool();
+    }
+
+    [Fact]
+    public async Task SelectedHistoricalRun_ReplaysDataAndRejectsMutation()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        string historicalRunId;
+
+        using (var historicalRunStore = CreateRunStore(options))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            using var telemetryContext = await CreateTelemetryRepositoryAsync(historicalRunStore.DatabasePath, options);
+            await telemetryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(),
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            Scope = CreateScope("HistoricalLogger"),
+                            LogRecords = { CreateLogRecord() }
+                        }
+                    }
+                }
+            });
+            using var resourceContext = CreateResourceRepository(historicalRunStore.DatabasePath);
+            await ((IResourceRepositoryWriter)resourceContext.Repository).ReplaceResourcesAsync([new Resource
+            {
+                Name = "api",
+                DisplayName = "API",
+                ResourceType = "Project",
+                CreatedAt = Timestamp.FromDateTime(DateTime.UnixEpoch)
+            }]);
+            historicalRunStore.PublishRun();
+        }
+
+        using var currentRunStore = CreateRunStore(options);
+        var repositoryFactory = CreateRepositoryFactory(options);
+        var testSink = new TestSink();
+        var logger = new TestLogger<DashboardDataSource>(new TestLoggerFactory(testSink, enabled: true));
+        using var dataSourcePool = new DashboardDataSourcePool(currentRunStore, repositoryFactory);
+        using var dataSource = CreateDataSource(currentRunStore, dataSourcePool, logger);
+        var currentTelemetryRepository = dataSource.TelemetryRepository;
+        var currentResourceRepository = dataSource.ResourceRepository;
+        Assert.Empty(dataSource.TelemetryRepository.GetResources());
+        Assert.False(dataSource.TelemetryRepository.IsReadOnly);
+
+        dataSource.SelectRun(historicalRunId);
+
+        var switchLog = Assert.Single(testSink.Writes);
+        Assert.Equal(LogLevel.Debug, switchLog.LogLevel);
+        Assert.Equal($"Switched dashboard run from '{currentRunStore.RunId}' to '{historicalRunId}'.", switchLog.Message);
+
+        Assert.True(dataSource.IsReadOnly);
+        Assert.True(dataSource.TelemetryRepository.IsReadOnly);
+        Assert.Equal(historicalRunId, dataSource.SelectedRun.RunId);
+        Assert.Equal("api", Assert.Single(dataSource.ResourceRepository.GetResources()).Name);
+        Assert.Equal("TestService", Assert.Single(dataSource.TelemetryRepository.GetResources()).ResourceName);
+        Assert.Equal("Test Value!", Assert.Single((await dataSource.TelemetryRepository.GetLogsAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).Items).Message);
+        Assert.Empty(currentTelemetryRepository.GetResources());
+        Assert.Empty(currentResourceRepository.GetResources());
+
+        var exception = Assert.Throws<InvalidOperationException>(dataSource.EnsureWritable);
+        Assert.Equal("Historical dashboard data is read-only.", exception.Message);
+
+        using var activitySource = new DashboardActivitySource();
+        await using var currentClient = new DashboardClient(
+            activitySource,
+            NullLoggerFactory.Instance,
+            new ConfigurationManager(),
+            options,
+            new MockKnownPropertyLookup(),
+            new TestStringLocalizer<Resources.Resources>(),
+            (IResourceRepositoryWriter)currentResourceRepository);
+        IDashboardClient selectedClient = new SelectedDashboardClient(currentClient, dataSource);
+        var connectionStateChangedCount = 0;
+        selectedClient.ConnectionStateChanged += _ => connectionStateChangedCount++;
+
+        currentClient.SetConnectionStateForTesting(DashboardConnectionState.Disconnected);
+
+        Assert.True(selectedClient.IsEnabled);
+        Assert.True(selectedClient.WhenConnected.IsCompletedSuccessfully);
+        Assert.Equal(DashboardConnectionState.Connected, selectedClient.ConnectionState);
+        Assert.Equal(0, connectionStateChangedCount);
+        await selectedClient.ReconnectAsync();
+        var clearException = await Assert.ThrowsAsync<InvalidOperationException>(() => selectedClient.ClearConsoleLogsAsync(["api"], DateTime.UtcNow));
+        Assert.Equal("Historical dashboard data is read-only.", clearException.Message);
+
+        dataSource.SelectRun(runId: null);
+
+        Assert.Empty(dataSource.TelemetryRepository.GetResources());
+        Assert.False(dataSource.IsReadOnly);
+        Assert.False(dataSource.TelemetryRepository.IsReadOnly);
+
+        Action<DashboardConnectionState> handler = _ => connectionStateChangedCount++;
+        selectedClient.ConnectionStateChanged += handler;
+        dataSource.SelectRun(historicalRunId);
+        selectedClient.ConnectionStateChanged -= handler;
+
+        currentClient.SetConnectionStateForTesting(DashboardConnectionState.Connected);
+        Assert.Equal(0, connectionStateChangedCount);
+    }
+
+    [Fact]
+    public void UnknownRunId_SelectsCurrentRun()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        using var currentRunStore = CreateRunStore(options);
+        var repositoryFactory = CreateRepositoryFactory(options);
+        using var dataSourcePool = new DashboardDataSourcePool(currentRunStore, repositoryFactory);
+        using var dataSource = CreateDataSource(currentRunStore, dataSourcePool);
+        var currentTelemetryRepository = dataSource.TelemetryRepository;
+        var currentResourceRepository = dataSource.ResourceRepository;
+        dataSource.SelectRun("missing");
+
+        Assert.False(dataSource.IsReadOnly);
+        Assert.True(dataSource.SelectedRun.IsCurrent);
+        Assert.Equal(currentRunStore.RunId, dataSource.SelectedRun.RunId);
+        Assert.Same(currentResourceRepository, dataSource.ResourceRepository);
+        Assert.Same(currentTelemetryRepository, dataSource.TelemetryRepository);
+    }
+
+    [Fact]
+    public void UnavailableHistoricalRun_SelectsCurrentRun()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var historicalRunTime = new DateTimeOffset(2026, 7, 20, 12, 34, 56, TimeSpan.Zero);
+        string historicalRunId;
+
+        using (var historicalRunStore = CreateRunStore(options, new FixedTimeProvider(historicalRunTime)))
+        {
+            historicalRunId = historicalRunStore.RunId;
+        }
+
+        using var currentRunStore = CreateRunStore(options, new FixedTimeProvider(historicalRunTime.AddMilliseconds(1)));
+        var runStore = new TestDashboardRunStore(currentRunStore.GetRuns(), tryAcquireRunLease: _ => null);
+        var repositoryFactory = CreateRepositoryFactory(options);
+        var testSink = new TestSink();
+        var logger = new TestLogger<DashboardDataSource>(new TestLoggerFactory(testSink, enabled: true));
+        using var dataSourcePool = new DashboardDataSourcePool(runStore, repositoryFactory);
+        using var dataSource = CreateDataSource(runStore, dataSourcePool, logger);
+        var currentTelemetryRepository = dataSource.TelemetryRepository;
+        var currentResourceRepository = dataSource.ResourceRepository;
+
+        dataSource.SelectRun(historicalRunId);
+
+        Assert.False(dataSource.IsReadOnly);
+        Assert.True(dataSource.SelectedRun.IsCurrent);
+        Assert.Equal(currentRunStore.RunId, dataSource.SelectedRun.RunId);
+        Assert.Same(currentResourceRepository, dataSource.ResourceRepository);
+        Assert.Same(currentTelemetryRepository, dataSource.TelemetryRepository);
+        var failureLog = Assert.Single(testSink.Writes);
+        Assert.Equal(LogLevel.Warning, failureLog.LogLevel);
+        Assert.Equal($"Failed to switch to dashboard run '{historicalRunId}' because it is no longer available.", failureLog.Message);
+    }
+
+    private static IOptions<DashboardOptions> CreateOptions(
+        TemporaryWorkspace workspace,
+        string applicationName = "TestApp",
+        DashboardPersistenceMode persistenceMode = DashboardPersistenceMode.Run)
+    {
+        return Options.Create(new DashboardOptions
+        {
+            ApplicationName = applicationName,
+            Data = new DashboardDataOptions
+            {
+                Directory = workspace.Path,
+                PersistenceMode = persistenceMode
+            }
+        });
+    }
+
+    private static async Task<SqliteRepositoryTestContext<SqliteTelemetryRepository>> CreateTelemetryRepositoryAsync(
+        string databasePath,
+        IOptions<DashboardOptions> options)
+    {
+        var context = await SqliteRepositoryTestHelpers.CreateTelemetryRepositoryAsync(
+            databasePath,
+            pooling: true,
+            dashboardOptions: options);
+        return context;
+    }
+
+    private static async Task InitializeAndPublishRunAsync(DashboardRunStore runStore)
+    {
+        await InitializeAndPublishRunWithoutPruningAsync(runStore);
+
+        // Production defers pruning until the host has started so slow file system work stays off the startup
+        // path. Tests run both steps here so they observe the same end state.
+        runStore.PruneExpiredRuns();
+    }
+
+    private static async Task InitializeAndPublishRunWithoutPruningAsync(DashboardRunStore runStore)
+    {
+        using var database = new DashboardSqliteDatabase(runStore.DatabasePath, pooling: false);
+        await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+        runStore.PublishRun();
+    }
+
+    private static SqliteRepositoryTestContext<SqliteResourceRepository> CreateResourceRepository(
+        string databasePath)
+    {
+        var context = SqliteRepositoryTestHelpers.CreateResourceRepository(
+            databasePath,
+            new MockKnownPropertyLookup(),
+            pooling: true);
+        return context;
+    }
+
+    private static DashboardRunStore CreateRunStore(IOptions<DashboardOptions> options, TimeProvider? timeProvider = null)
+    {
+        return new DashboardRunStore(options, NullLogger<DashboardRunStore>.Instance, timeProvider ?? TimeProvider.System);
+    }
+
+    private static DashboardDataSource CreateDataSource(
+        IDashboardRunStore runStore,
+        DashboardDataSourcePool dataSourcePool,
+        ILogger<DashboardDataSource>? logger = null)
+    {
+        dataSourcePool.InitializeAsync(CancellationToken.None).GetAwaiter().GetResult();
+        return new DashboardDataSource(
+            runStore,
+            logger ?? NullLogger<DashboardDataSource>.Instance,
+            dataSourcePool);
+    }
+
+    private static FileStream? TryOpenTestRunLease(DashboardRunDescriptor run)
+    {
+        var runDirectory = Path.GetDirectoryName(run.DatabasePath)!;
+        try
+        {
+            var runLock = new FileStream(
+                DashboardRunStore.GetRunLockPath(runDirectory),
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                bufferSize: 1,
+                FileOptions.DeleteOnClose);
+            if (!Directory.Exists(runDirectory))
+            {
+                runLock.Dispose();
+                return null;
+            }
+
+            return runLock;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static RepositoryFactory CreateRepositoryFactory(IOptions<DashboardOptions> options)
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance)
+            .AddSingleton(options)
+            .AddSingleton<PauseManager>()
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<IKnownPropertyLookup, MockKnownPropertyLookup>()
+            .BuildServiceProvider();
+
+        return new RepositoryFactory(serviceProvider);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class RecordingRepositoryFactory(IRepositoryFactory inner) : IRepositoryFactory
+    {
+        public List<DashboardSqliteDatabase> Databases { get; } = [];
+
+        public ITelemetryRepository CreateTelemetryRepository(DashboardSqliteDatabase database)
+        {
+            Databases.Add(database);
+            return inner.CreateTelemetryRepository(database);
+        }
+
+        public IResourceRepository CreateResourceRepository(DashboardSqliteDatabase database)
+        {
+            Databases.Add(database);
+            return inner.CreateResourceRepository(database);
+        }
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardSqliteDatabaseTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardSqliteDatabaseTests.cs
@@ -1,0 +1,220 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Diagnostics;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Tests;
+using Dapper;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class DashboardSqliteDatabaseTests(ITestOutputHelper testOutputHelper) : IDisposable
+{
+    private readonly TemporaryWorkspace _workspace = TemporaryWorkspace.Create(testOutputHelper);
+
+    [Fact]
+    public void OpenConnection_ConfiguresSynchronousNormal()
+    {
+        using var database = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "dashboard.db"), pooling: false);
+        using var firstConnection = database.OpenConnection();
+        using var secondConnection = database.OpenConnection();
+
+        Assert.Equal(1, firstConnection.QuerySingle<int>("PRAGMA synchronous;"));
+        Assert.Equal(1, secondConnection.QuerySingle<int>("PRAGMA synchronous;"));
+    }
+
+    [Fact]
+    public async Task InitializeSchema_IncompatibleVersionReportsExistingAndExpectedVersions()
+    {
+        var databasePath = Path.Combine(_workspace.Path, "dashboard.db");
+        using (var connection = new SqliteConnection($"Data Source={databasePath};Pooling=False"))
+        {
+            connection.Open();
+            connection.Execute("CREATE TABLE dashboard_schema (version INTEGER NOT NULL) STRICT; INSERT INTO dashboard_schema VALUES (1);");
+        }
+        using var database = new DashboardSqliteDatabase(databasePath, pooling: false);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => database.InitializeSchemaAsync(CancellationToken.None));
+
+        Assert.Equal(
+            $"The dashboard database schema version 1 does not match the expected version {DashboardSqliteDatabase.SchemaVersion}.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task InitializeSchema_HistogramValuesUseBlobStorage()
+    {
+        using var database = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "dashboard.db"), pooling: false);
+        await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+        using var connection = database.OpenConnection();
+
+        var histogramCountColumnType = connection.QuerySingle<string>("SELECT type FROM pragma_table_info('telemetry_metric_points') WHERE name = 'histogram_count';");
+        var histogramColumnTypes = connection.Query<(string Name, string Type)>("SELECT name, type FROM pragma_table_info('telemetry_metric_points') WHERE name IN ('bucket_counts', 'explicit_bounds') ORDER BY name;");
+
+        Assert.Equal("INTEGER", histogramCountColumnType);
+        Assert.Collection(
+            histogramColumnTypes,
+            column => Assert.Equal(("bucket_counts", "BLOB"), column),
+            column => Assert.Equal(("explicit_bounds", "BLOB"), column));
+        Assert.Equal(0, connection.QuerySingle<int>("SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'telemetry_metric_histograms';"));
+    }
+
+    [Fact]
+    public async Task RepositoryWrites_ShareDatabaseWriteLock()
+    {
+        using var database = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "dashboard.db"), pooling: false);
+        await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+        using var telemetryRepository = new SqliteTelemetryRepository(
+            database,
+            NullLoggerFactory.Instance,
+            Options.Create(new DashboardOptions()),
+            new PauseManager(),
+            TimeProvider.System,
+            []);
+        using var resourceRepository = new SqliteResourceRepository(database, new MockKnownPropertyLookup(), NullLoggerFactory.Instance);
+
+        Task telemetryWriteTask;
+        Task resourceWriteTask;
+        using (await database.WriteLock.LockAsync())
+        {
+            telemetryWriteTask = ((ITelemetryRepositoryWriter)telemetryRepository).ClearMetricsAsync();
+            resourceWriteTask = ((IResourceRepositoryWriter)resourceRepository).ReplaceResourcesAsync([]);
+
+            Assert.False(telemetryWriteTask.IsCompleted);
+            Assert.False(resourceWriteTask.IsCompleted);
+        }
+
+        await Task.WhenAll(telemetryWriteTask, resourceWriteTask);
+    }
+
+    [Fact]
+    public async Task DapperQuery_CreatesActivityWithQueryInformation()
+    {
+        using var database = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "dashboard.db"), pooling: false);
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(database.ActivitySource, onActivityStopped: activities.Enqueue);
+        using var connection = database.OpenConnection();
+        var query = $"-- {Guid.NewGuid():N}{Environment.NewLine}SELECT 42;";
+
+        var result = await connection.QuerySingleAsync<int>(query);
+
+        Assert.Equal(42, result);
+        var activity = Assert.Single(activities, activity => Equals(activity.GetTagItem("db.query.text"), query));
+        Assert.Equal(TracingSqliteConnection.ActivitySourceName, activity.Source.Name);
+        Assert.Equal("SELECT sqlite", activity.OperationName);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
+        Assert.Equal("sqlite", activity.GetTagItem("db.system.name"));
+        Assert.Equal("dashboard.db", activity.GetTagItem(OtlpSpan.PeerServiceAttributeKey));
+        Assert.Equal("dashboard.db", activity.GetTagItem("db.namespace"));
+        Assert.Equal("SELECT", activity.GetTagItem("db.operation.name"));
+        Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+    }
+
+    [Fact]
+    public void DapperFailure_SetsActivityErrorInformation()
+    {
+        using var database = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "dashboard.db"), pooling: false);
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(database.ActivitySource, onActivityStopped: activities.Enqueue);
+        using var connection = database.OpenConnection();
+        var query = $"SELECT * FROM missing_{Guid.NewGuid():N};";
+
+        var exception = Assert.Throws<SqliteException>(() => connection.Query(query));
+
+        var activity = Assert.Single(activities, activity => Equals(activity.GetTagItem("db.query.text"), query));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal(exception.Message, activity.StatusDescription);
+        Assert.Equal(typeof(SqliteException).FullName, activity.GetTagItem("error.type"));
+    }
+
+    [Fact]
+    public void DataReader_ActivityStopsWhenReaderIsDisposed()
+    {
+        using var database = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "dashboard.db"), pooling: false);
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(database.ActivitySource, onActivityStopped: activities.Enqueue);
+        using DbConnection connection = database.OpenConnection();
+        using var command = connection.CreateCommand();
+        var query = $"SELECT '{Guid.NewGuid():N}';";
+        command.CommandText = query;
+
+        var reader = command.ExecuteReader();
+
+        Assert.DoesNotContain(activities, activity => Equals(activity.GetTagItem("db.query.text"), query));
+        Assert.True(reader.Read());
+        reader.Dispose();
+        Assert.Single(activities, activity => Equals(activity.GetTagItem("db.query.text"), query));
+    }
+
+    [Fact]
+    public void DapperQueryMultiple_ActivitySpansAllResultSets()
+    {
+        using var database = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "dashboard.db"), pooling: false);
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(database.ActivitySource, onActivityStopped: activities.Enqueue);
+        using var connection = database.OpenConnection();
+        var query = $"SELECT '{Guid.NewGuid():N}'; SELECT '{Guid.NewGuid():N}';";
+
+        using (var results = connection.QueryMultiple(query))
+        {
+            Assert.DoesNotContain(activities, activity => Equals(activity.GetTagItem("db.query.text"), query));
+            Assert.NotEmpty(results.ReadSingle<string>());
+            Assert.DoesNotContain(activities, activity => Equals(activity.GetTagItem("db.query.text"), query));
+            Assert.NotEmpty(results.ReadSingle<string>());
+        }
+
+        Assert.Single(activities, activity => Equals(activity.GetTagItem("db.query.text"), query));
+    }
+
+    [Fact]
+    public void CommitTransaction_CreatesActivityWithDatabaseInformation()
+    {
+        using var database = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "dashboard.db"), pooling: false);
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(database.ActivitySource, onActivityStopped: activities.Enqueue);
+        using var connection = database.OpenConnection();
+        using var transaction = connection.BeginTransaction();
+
+        connection.Execute("SELECT 1;", transaction: transaction);
+        transaction.Commit();
+
+        var activity = Assert.Single(activities, activity => Equals(activity.GetTagItem("db.query.text"), "COMMIT;"));
+        Assert.Equal("COMMIT sqlite", activity.OperationName);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
+        Assert.Equal("sqlite", activity.GetTagItem("db.system.name"));
+        Assert.Equal("dashboard.db", activity.GetTagItem(OtlpSpan.PeerServiceAttributeKey));
+        Assert.Equal("dashboard.db", activity.GetTagItem("db.namespace"));
+        Assert.Equal("COMMIT", activity.GetTagItem("db.operation.name"));
+    }
+
+    [Fact]
+    public void ActivityListener_DoesNotCaptureOtherDatabaseActivities()
+    {
+        using var observedDatabase = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "observed.db"), pooling: false);
+        using var otherDatabase = new DashboardSqliteDatabase(Path.Combine(_workspace.Path, "other.db"), pooling: false);
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(observedDatabase.ActivitySource, onActivityStopped: activities.Enqueue);
+        using var observedConnection = observedDatabase.OpenConnection();
+        using var otherConnection = otherDatabase.OpenConnection();
+
+        observedConnection.QuerySingle<int>("SELECT 1;");
+        otherConnection.QuerySingle<int>("SELECT 2;");
+
+        Assert.Single(activities, activity => Equals(activity.GetTagItem("db.query.text"), "SELECT 1;"));
+        Assert.DoesNotContain(activities, activity => Equals(activity.GetTagItem("db.query.text"), "SELECT 2;"));
+    }
+
+    public void Dispose()
+    {
+        _workspace.Dispose();
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
@@ -23,15 +23,18 @@ public sealed class DefaultInstrumentUnitResolverTests
         // Arrange
         var localizer = new TestStringLocalizer<ControlsStrings>();
         var resolver = new DefaultInstrumentUnitResolver(localizer);
+        var context = TelemetryTestHelpers.CreateContext();
+        var resource = new OtlpResource("resource", instanceId: null, uninstrumentedPeer: false, context);
 
         var otlpInstrumentSummary = new OtlpInstrumentSummary
         {
             Description = "Description!",
             Name = name,
-            Parent = TelemetryTestHelpers.CreateOtlpScope(TelemetryTestHelpers.CreateContext(), name: "meter_name"),
+            Parent = TelemetryTestHelpers.CreateOtlpScope(context, name: "meter_name"),
             Type = OtlpInstrumentType.Gauge,
             Unit = unit,
-            AggregationTemporality = OtlpAggregationTemporality.Cumulative
+            AggregationTemporality = OtlpAggregationTemporality.Cumulative,
+            ResourceView = new OtlpResourceView(resource, Array.Empty<KeyValuePair<string, string>>())
         };
 
         // Act

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -20,13 +20,13 @@ public sealed class GenAIVisualizerDialogViewModelTests
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
     [Fact]
-    public void Create_NoGenAIAttributes_NoMessages()
+    public async Task Create_NoGenAIAttributes_NoMessages()
     {
         // Arrange
         var repository = CreateRepository();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -50,7 +50,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.Items);
@@ -60,7 +60,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_SpanError_HasErrorItem()
+    public async Task Create_SpanError_HasErrorItem()
     {
         // Arrange
         var repository = CreateRepository();
@@ -76,7 +76,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -100,7 +100,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Items,
@@ -118,13 +118,13 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAILogEntries_HasMessages()
+    public async Task Create_GenAILogEntries_HasMessages()
     {
         // Arrange
         var repository = CreateRepository();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -143,7 +143,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
             }
         });
         Assert.Equal(0, addContext.FailureCount);
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -184,7 +184,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Items,
@@ -215,13 +215,13 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAILogEntries_EmptyMessage_NoMessagesCreated()
+    public async Task Create_GenAILogEntries_EmptyMessage_NoMessagesCreated()
     {
         // Arrange
         var repository = CreateRepository();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -240,7 +240,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
             }
         });
         Assert.Equal(0, addContext.FailureCount);
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -275,7 +275,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.Items);
@@ -283,7 +283,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanEvents_HasMessages()
+    public async Task Create_GenAISpanEvents_HasMessages()
     {
         // Arrange
         var repository = CreateRepository();
@@ -320,7 +320,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -344,7 +344,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Items,
@@ -375,7 +375,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanEvents_EmptyContent_NoMessagesCreated()
+    public async Task Create_GenAISpanEvents_EmptyContent_NoMessagesCreated()
     {
         // Arrange
         var repository = CreateRepository();
@@ -398,7 +398,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -422,7 +422,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.Items);
@@ -430,7 +430,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanEvents_MissingContent_NoMessagesCreated()
+    public async Task Create_GenAISpanEvents_MissingContent_NoMessagesCreated()
     {
         // Arrange
         var repository = CreateRepository();
@@ -447,7 +447,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -471,7 +471,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.Items);
@@ -479,7 +479,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanAttributes_HasMessages()
+    public async Task Create_GenAISpanAttributes_HasMessages()
     {
         // Arrange
         var repository = CreateRepository();
@@ -527,7 +527,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -551,7 +551,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Items,
@@ -602,7 +602,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanAttributes_InvalidJson_DisplayErrorMessage()
+    public async Task Create_GenAISpanAttributes_InvalidJson_DisplayErrorMessage()
     {
         // Arrange
         var repository = CreateRepository();
@@ -643,7 +643,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -667,7 +667,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.Items);
@@ -675,7 +675,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanAttributesWithoutContent_HasNoMessageContent()
+    public async Task Create_GenAISpanAttributesWithoutContent_HasNoMessageContent()
     {
         // Arrange
         var repository = CreateRepository();
@@ -723,7 +723,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -747,7 +747,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Items,
@@ -795,7 +795,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_NoMessages_HasNoMessageContent()
+    public async Task Create_NoMessages_HasNoMessageContent()
     {
         // Arrange
         var repository = CreateRepository();
@@ -807,7 +807,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -831,7 +831,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.Items);
@@ -839,7 +839,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_LangSmithFormat_HasMessages()
+    public async Task Create_LangSmithFormat_HasMessages()
     {
         // Arrange
         var repository = CreateRepository();
@@ -860,7 +860,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -884,7 +884,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Items,
@@ -915,7 +915,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_LangSmithFormat_MessageRoleContentFallback_HasMessages()
+    public async Task Create_LangSmithFormat_MessageRoleContentFallback_HasMessages()
     {
         // Arrange
         var repository = CreateRepository();
@@ -936,7 +936,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -960,7 +960,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Items,
@@ -991,7 +991,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_LangSmithFormat_WithGapsInIndices_HasMessages()
+    public async Task Create_LangSmithFormat_WithGapsInIndices_HasMessages()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1019,7 +1019,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1043,7 +1043,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         // Messages should be parsed in order of their indices (0, 2, 5 for prompts; 0, 3 for completions)
@@ -1089,7 +1089,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAIToolDefinitions_ParsesToolDefinitions()
+    public async Task Create_GenAIToolDefinitions_ParsesToolDefinitions()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1127,7 +1127,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1151,7 +1151,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.ToolDefinitions,
@@ -1186,7 +1186,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAIToolDefinitions_InvalidJson_EmptyToolDefinitions()
+    public async Task Create_GenAIToolDefinitions_InvalidJson_EmptyToolDefinitions()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1198,7 +1198,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1222,14 +1222,14 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.ToolDefinitions);
     }
 
     [Fact]
-    public void Create_NoToolDefinitions_EmptyToolDefinitions()
+    public async Task Create_NoToolDefinitions_EmptyToolDefinitions()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1240,7 +1240,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1264,14 +1264,14 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.ToolDefinitions);
     }
 
     [Fact]
-    public void Create_GenAISpanAttributes_JsonWithCommentsAndTrailingCommas_HasMessages()
+    public async Task Create_GenAISpanAttributes_JsonWithCommentsAndTrailingCommas_HasMessages()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1327,7 +1327,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1351,7 +1351,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert - verify JSON with comments and trailing commas is parsed correctly
         Assert.Collection(vm.Items,
@@ -1377,7 +1377,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAIToolDefinitions_JsonWithCommentsAndTrailingCommas_HasToolDefinitions()
+    public async Task Create_GenAIToolDefinitions_JsonWithCommentsAndTrailingCommas_HasToolDefinitions()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1416,7 +1416,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1440,7 +1440,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert - verify tool definitions with comments and trailing commas are parsed correctly
         Assert.Equal(2, vm.ToolDefinitions.Count);
@@ -1449,7 +1449,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAIToolDefinitions_TypeAsArray_ParsesToolDefinitions()
+    public async Task Create_GenAIToolDefinitions_TypeAsArray_ParsesToolDefinitions()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1489,7 +1489,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1513,7 +1513,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.ToolDefinitions,
@@ -1550,7 +1550,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAIToolDefinitions_WithArrayItems_ParsesAndFormatsCorrectly()
+    public async Task Create_GenAIToolDefinitions_WithArrayItems_ParsesAndFormatsCorrectly()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1597,7 +1597,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1621,7 +1621,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.ToolDefinitions,
@@ -1656,26 +1656,27 @@ public sealed class GenAIVisualizerDialogViewModelTests
             });
     }
 
-    private static GenAIVisualizerDialogViewModel Create(
-        TelemetryRepository repository,
+    private static Task<GenAIVisualizerDialogViewModel> CreateAsync(
+        InMemoryTelemetryRepository repository,
         SpanDetailsViewModel spanDetailsViewModel)
     {
-        return GenAIVisualizerDialogViewModel.Create(
+        return GenAIVisualizerDialogViewModel.CreateAsync(
             spanDetailsViewModel,
             selectedLogEntryId: null,
             errorRecorder: new TestTelemetryErrorRecorder(),
             telemetryRepository: repository,
-            () => [spanDetailsViewModel.Span]);
+            () => [spanDetailsViewModel.Span],
+            CancellationToken.None);
     }
 
     [Fact]
-    public void Create_NoEvaluationResults_EmptyEvaluationsList()
+    public async Task Create_NoEvaluationResults_EmptyEvaluationsList()
     {
         // Arrange
         var repository = CreateRepository();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1699,20 +1700,20 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Empty(vm.Evaluations);
     }
 
     [Fact]
-    public void Create_EvaluationResultsInLogEntries_ParsedCorrectly()
+    public async Task Create_EvaluationResultsInLogEntries_ParsedCorrectly()
     {
         // Arrange
         var repository = CreateRepository();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1731,7 +1732,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
             }
         });
 
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1779,7 +1780,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Evaluations,
@@ -1804,7 +1805,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_EvaluationResultsInSpanEvents_ParsedCorrectly()
+    public async Task Create_EvaluationResultsInSpanEvents_ParsedCorrectly()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1833,7 +1834,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1862,7 +1863,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Collection(vm.Evaluations,
@@ -1887,13 +1888,13 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_EvaluationResultsMinimalData_ParsedCorrectly()
+    public async Task Create_EvaluationResultsMinimalData_ParsedCorrectly()
     {
         // Arrange
         var repository = CreateRepository();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1912,7 +1913,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
             }
         });
 
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1944,7 +1945,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Single(vm.Evaluations);
@@ -1957,7 +1958,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_EvaluationResultsFromBothLogEntriesAndSpanEvents_AllParsed()
+    public async Task Create_EvaluationResultsFromBothLogEntriesAndSpanEvents_AllParsed()
     {
         // Arrange
         var repository = CreateRepository();
@@ -1975,7 +1976,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1999,7 +2000,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
             }
         });
 
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -2032,7 +2033,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert
         Assert.Equal(2, vm.Evaluations.Count);
@@ -2041,7 +2042,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAIToolDefinitions_UnexpectedTypeObject_DoesNotThrow()
+    public async Task Create_GenAIToolDefinitions_UnexpectedTypeObject_DoesNotThrow()
     {
         // Arrange
         var repository = CreateRepository();
@@ -2080,7 +2081,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2104,7 +2105,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act - should not throw an exception
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert - tool definition should be parsed, with valid parameter parsed correctly
         // and invalid parameter handled gracefully (type will be null instead of throwing)
@@ -2131,7 +2132,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanAttributes_TruncatedInputMessages_DisplaysAvailableMessages()
+    public async Task Create_GenAISpanAttributes_TruncatedInputMessages_DisplaysAvailableMessages()
     {
         // Arrange
         var repository = CreateRepository();
@@ -2166,7 +2167,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2190,7 +2191,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert - first two messages parsed, third truncated, plus truncation indicator
         Assert.Null(vm.DisplayErrorMessage);
@@ -2216,7 +2217,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanAttributes_TruncatedSystemInstructions_DisplaysPartialContent()
+    public async Task Create_GenAISpanAttributes_TruncatedSystemInstructions_DisplaysPartialContent()
     {
         // Arrange
         var repository = CreateRepository();
@@ -2238,7 +2239,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2262,7 +2263,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert - first instruction parsed, second truncated, plus truncation indicator
         Assert.Null(vm.DisplayErrorMessage);
@@ -2277,7 +2278,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
     }
 
     [Fact]
-    public void Create_GenAISpanAttributes_TruncatedOutputMessages_DisplaysAvailableMessages()
+    public async Task Create_GenAISpanAttributes_TruncatedOutputMessages_DisplaysAvailableMessages()
     {
         // Arrange
         var repository = CreateRepository();
@@ -2307,7 +2308,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         };
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2331,7 +2332,7 @@ public sealed class GenAIVisualizerDialogViewModelTests
         var spanDetailsViewModel = SpanDetailsViewModel.Create(span, repository, repository.GetResources());
 
         // Act
-        var vm = Create(repository, spanDetailsViewModel);
+        var vm = await CreateAsync(repository, spanDetailsViewModel);
 
         // Assert - first output message parsed, second truncated, plus truncation indicator
         Assert.Null(vm.DisplayErrorMessage);

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceMenuBuilderTests.cs
@@ -6,6 +6,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Tests.Shared;
 using Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 using Aspire.Tests.Shared;
 using Aspire.Tests.Shared.DashboardModel;
@@ -19,11 +20,14 @@ using Xunit;
 
 namespace Aspire.Dashboard.Tests.Model;
 
-public sealed class ResourceMenuBuilderTests
+public sealed class ResourceMenuBuilderTests : IDisposable
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private readonly IconResolver _iconResolver = new IconResolver(NullLogger<IconResolver>.Instance);
     private readonly DashboardDialogService _dialogService;
+    private readonly List<DashboardDataSource> _dataSources = [];
+    private readonly List<DashboardDataSourcePool> _databasePools = [];
+    private readonly List<DirectoryInfo> _temporaryDirectories = [];
 
     public ResourceMenuBuilderTests()
     {
@@ -35,15 +39,45 @@ public sealed class ResourceMenuBuilderTests
             dimensionManager);
     }
 
-    private ResourceMenuBuilder CreateResourceMenuBuilder(TelemetryRepository repository)
+    private ResourceMenuBuilder CreateResourceMenuBuilder(
+        InMemoryTelemetryRepository repository,
+        IDashboardClient? dashboardClient = null)
     {
+        dashboardClient ??= new TestDashboardClient();
+        var temporaryDirectory = Directory.CreateTempSubdirectory();
+        _temporaryDirectories.Add(temporaryDirectory);
+        var runStore = new TestDashboardRunStore(databasePath: Path.Combine(temporaryDirectory.FullName, "dashboard.db"));
+        var dataSourcePool = TestDashboardDataSource.CreatePool(repository, dashboardClient, runStore);
+        var dataSource = TestDashboardDataSource.Create(runStore, dataSourcePool);
+        _databasePools.Add(dataSourcePool);
+        _dataSources.Add(dataSource);
+
         return new ResourceMenuBuilder(
             new TestNavigationManager(),
-            repository,
+            dataSource,
             new TestStringLocalizer<ControlsStrings>(),
             new TestStringLocalizer<Resources.Resources>(),
             _iconResolver,
-            _dialogService);
+            _dialogService,
+            dashboardClient);
+    }
+
+    public void Dispose()
+    {
+        foreach (var dataSource in _dataSources)
+        {
+            dataSource.Dispose();
+        }
+
+        foreach (var databasePool in _databasePools)
+        {
+            databasePool.Dispose();
+        }
+
+        foreach (var temporaryDirectory in _temporaryDirectories)
+        {
+            temporaryDirectory.Delete(recursive: true);
+        }
     }
 
     [Fact]
@@ -75,14 +109,14 @@ public sealed class ResourceMenuBuilderTests
     }
 
     [Fact]
-    public void AddMenuItems_UninstrumentedPeer_TraceItem()
+    public async Task AddMenuItems_UninstrumentedPeer_TraceItem()
     {
         // Arrange
         var resource = ModelTestHelpers.CreateResource(resourceName: "test-abc");
         var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: attributes => (resource.Name, resource));
         var repository = TelemetryTestHelpers.CreateRepository(outgoingPeerResolvers: [outgoingPeerResolver]);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -127,13 +161,13 @@ public sealed class ResourceMenuBuilderTests
     }
 
     [Fact]
-    public void AddMenuItems_HasTelemetry_TelemetryItems()
+    public async Task AddMenuItems_HasTelemetry_TelemetryItems()
     {
         // Arrange
         var resource = ModelTestHelpers.CreateResource(resourceName: "test-abc");
         var repository = TelemetryTestHelpers.CreateRepository();
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -287,6 +321,47 @@ public sealed class ResourceMenuBuilderTests
             e => Assert.True(e.IsDivider),
             e => Assert.Equal("Start", e.Text),
             e => Assert.Equal("Stop", e.Text));
+    }
+
+    [Fact]
+    public void AddMenuItems_ReadOnly_DisablesResourceCommands()
+    {
+        var command = new CommandViewModel(
+            CommandViewModel.StartCommand,
+            CommandViewModelState.Enabled,
+            "Start",
+            "Start the resource.",
+            confirmationMessage: "",
+            argumentInputs: [],
+            isHighlighted: true,
+            iconName: string.Empty,
+            iconVariant: IconVariant.Regular);
+        var resource = ModelTestHelpers.CreateResource(commands: [command]);
+        var repository = TelemetryTestHelpers.CreateRepository();
+        var resourceMenuBuilder = CreateResourceMenuBuilder(
+            repository,
+            new TestDashboardClient(isReadOnly: true));
+
+        var menuItems = new List<MenuButtonItem>();
+        resourceMenuBuilder.AddMenuItems(
+            menuItems,
+            resource,
+            new Dictionary<string, ResourceViewModel>(StringComparer.OrdinalIgnoreCase) { [resource.Name] = resource },
+            EventCallback.Empty,
+            EventCallback<CommandViewModel>.Empty,
+            (_, _) => false,
+            showViewDetails: false,
+            showConsoleLogsItem: false,
+            showUrls: false);
+
+        Assert.Collection(menuItems,
+            e => Assert.Equal("Localized:ViewJson", e.Text),
+            e => Assert.True(e.IsDivider),
+            e =>
+            {
+                Assert.Equal("Start", e.Text);
+                Assert.True(e.IsDisabled);
+            });
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -4,11 +4,11 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Tests.Shared.Telemetry;
-using Google.Protobuf.Collections;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using OpenTelemetry.Proto.Common.V1;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Model;
@@ -29,7 +29,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
 
         // Act
-        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], []));
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], []));
 
         // Assert
         Assert.Collection(vm,
@@ -51,16 +51,26 @@ public sealed class SpanWaterfallViewModelTests
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
         var app1 = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
-        var app1View = new OtlpResourceView(app1, new RepeatedField<KeyValue>());
-
         var date = new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "31", parentSpanId: null, startDate: date, endDate: date));
-        var log = new OtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(traceId: trace.TraceId, spanId: "1"), app1View, scope, context);
+        var log = new LogSummary
+        {
+            InternalId = 1,
+            TimeStamp = date,
+            Severity = LogLevel.Information,
+            Message = "Test log",
+            SpanId = "31",
+            TraceId = trace.TraceId,
+            ScopeName = scope.Name,
+            Resource = app1,
+            ExceptionText = null,
+            HasGenAI = false
+        };
 
         // Act
-        var vm = SpanWaterfallViewModel.Create(trace, [log], new SpanWaterfallViewModel.TraceDetailState([], [], []));
+        var vm = SpanWaterfallViewModel.Create(trace, [log], new SpanWaterfallViewModel.TraceDetailState([], []));
 
         // Assert
         Assert.Collection(vm,
@@ -76,7 +86,7 @@ public sealed class SpanWaterfallViewModelTests
     }
 
     [Fact]
-    public void Create_OutgoingPeers_BrowserLink()
+    public void Create_OutgoingPeers_UsesPeerAddressWhenPeerIsNotPersisted()
     {
         // Arrange
         var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
@@ -89,20 +99,44 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "2", parentSpanId: null, startDate: new DateTime(2001, 2, 1, 1, 1, 2, DateTimeKind.Utc), kind: OtlpSpanKind.Client));
 
         // Act
-        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([new BrowserLinkOutgoingPeerResolver()], [], []));
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], []));
 
         // Assert
         Assert.Collection(vm,
             e =>
             {
                 Assert.Equal("1", e.Span.SpanId);
-                Assert.Equal("Browser Link", e.UninstrumentedPeer);
+                Assert.Equal("localhost", e.UninstrumentedPeer);
             },
             e =>
             {
                 Assert.Equal("2", e.Span.SpanId);
                 Assert.Null(e.UninstrumentedPeer);
             });
+    }
+
+    [Fact]
+    public void Create_OutgoingPeers_UsesPersistedNameOnlyPeer()
+    {
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app = new OtlpResource("app", "instance", uninstrumentedPeer: false, context);
+        var browserLink = new OtlpResource("Browser Link", instanceId: null, uninstrumentedPeer: true, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+        trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(
+            app,
+            trace,
+            scope,
+            spanId: "1",
+            parentSpanId: null,
+            startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc),
+            kind: OtlpSpanKind.Client,
+            attributes: [KeyValuePair.Create(OtlpSpan.ServerAddressAttributeKey, "localhost")],
+            uninstrumentedPeer: browserLink));
+
+        var viewModel = Assert.Single(SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [app, browserLink])));
+
+        Assert.Equal("Browser Link", viewModel.UninstrumentedPeer);
     }
 
     [Theory]
@@ -142,7 +176,7 @@ public sealed class SpanWaterfallViewModelTests
         var vm = SpanWaterfallViewModel.Create(
             trace,
             [],
-            new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
+            new SpanWaterfallViewModel.TraceDetailState([], [])).First();
 
         // Act
         var result = vm.MatchesFilter(filter, typeFilter: null, structuredFilters: null, a => a.Resource.ResourceName, out _);
@@ -202,7 +236,7 @@ public sealed class SpanWaterfallViewModelTests
         var vm = SpanWaterfallViewModel.Create(
             trace,
             [],
-            new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
+            new SpanWaterfallViewModel.TraceDetailState([], [])).First();
 
         // Act 1
         var result1 = vm.MatchesFilter(string.Empty, typeFilter: spanType.Id?.Filter, structuredFilters: null, a => a.Resource.ResourceName, out _);
@@ -222,6 +256,14 @@ public sealed class SpanWaterfallViewModelTests
     }
 
     [Fact]
+    public void SpanTypeFilters_EmptyOperandsThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new SpanHasAttributeTelemetryFilter([]));
+        Assert.Throws<ArgumentException>(() => new SpanScopePrefixTelemetryFilter([]));
+        Assert.Throws<ArgumentException>(() => new SpanNoMatchTelemetryFilter([]));
+    }
+
+    [Fact]
     public void MatchesFilter_ParentSpanIncludedWhenChildMatched()
     {
         // Arrange
@@ -234,7 +276,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(parentSpan);
         trace.AddSpan(childSpan);
 
-        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], []));
+        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], []));
         var parent = vms[0];
         var child = vms[1];
 
@@ -256,7 +298,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(parentSpan);
         trace.AddSpan(childSpan);
 
-        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], []));
+        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], []));
         var parent = vms[0];
         var child = vms[1];
 
@@ -297,7 +339,7 @@ public sealed class SpanWaterfallViewModelTests
             statusCode: OtlpSpanStatusCode.Unset, statusMessage: null, kind: OtlpSpanKind.Client);
         trace.AddSpan(span);
 
-        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [])).First();
 
         var filters = new List<FieldTelemetryFilter>
         {
@@ -333,7 +375,7 @@ public sealed class SpanWaterfallViewModelTests
             statusCode: OtlpSpanStatusCode.Unset, statusMessage: null, kind: OtlpSpanKind.Client);
         trace.AddSpan(span);
 
-        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [])).First();
 
         // One filter matches, one doesn't — AND logic means the span shouldn't match.
         var filters = new List<FieldTelemetryFilter>
@@ -370,7 +412,7 @@ public sealed class SpanWaterfallViewModelTests
             statusCode: OtlpSpanStatusCode.Unset, statusMessage: null, kind: OtlpSpanKind.Client);
         trace.AddSpan(span);
 
-        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], [])).First();
+        var vm = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [])).First();
 
         // Filter would exclude the span, but it's disabled.
         var filters = new List<FieldTelemetryFilter>
@@ -409,7 +451,7 @@ public sealed class SpanWaterfallViewModelTests
         trace.AddSpan(parentSpan);
         trace.AddSpan(childSpan);
 
-        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], [], []));
+        var vms = SpanWaterfallViewModel.Create(trace, [], new SpanWaterfallViewModel.TraceDetailState([], []));
         var parent = vms[0];
         var child = vms[1];
 

--- a/tests/Aspire.Dashboard.Tests/Model/SqliteResourceRepositoryTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SqliteResourceRepositoryTests.cs
@@ -1,0 +1,997 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Dashboard.Tests.Shared;
+using Aspire.DashboardService.Proto.V1;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class SqliteResourceRepositoryTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task Resources_PersistAndReplayWithEquivalentValues()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var resource = CreateResource("api-123", "api");
+
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            var writer = (IResourceRepositoryWriter)repositoryContext.Repository;
+            await writer.ReplaceResourcesAsync([resource]);
+
+            AssertResource(Assert.Single(repositoryContext.Repository.GetResources()), resource, replicaIndex: 1);
+
+            var updated = resource.Clone();
+            updated.State = "Running";
+            await writer.ApplyChangesAsync([new WatchResourcesChange { Upsert = updated }]);
+            Assert.Equal("Running", repositoryContext.Repository.GetResource(resource.Name)!.State);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        AssertResource(Assert.Single(historicalContext.Repository.GetResources()), resource, replicaIndex: 1, state: "Running");
+    }
+
+    [Fact]
+    public async Task ResourceSubscription_ReceivesUpsertAndDelete()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = CreateRepository(workspace.Path);
+        var writer = (IResourceRepositoryWriter)repositoryContext.Repository;
+        var subscription = await repositoryContext.Repository.SubscribeResourcesAsync(CancellationToken.None);
+        Assert.Empty(subscription.InitialState);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var enumerator = subscription.Subscription.GetAsyncEnumerator(cts.Token);
+
+        var resource = CreateResource("worker", "worker");
+        await writer.ApplyChangesAsync([new WatchResourcesChange { Upsert = resource }]);
+        Assert.True(await enumerator.MoveNextAsync().AsTask().DefaultTimeout());
+        Assert.Equal(ResourceViewModelChangeType.Upsert, Assert.Single(enumerator.Current).ChangeType);
+
+        await writer.ApplyChangesAsync([new WatchResourcesChange { Delete = new ResourceDeletion { ResourceName = resource.Name } }]);
+        Assert.True(await enumerator.MoveNextAsync().AsTask().DefaultTimeout());
+        Assert.Equal(ResourceViewModelChangeType.Delete, Assert.Single(enumerator.Current).ChangeType);
+        Assert.Empty(repositoryContext.Repository.GetResources());
+    }
+
+    [Fact]
+    public async Task ResourceSubscription_ReplaceResourcesDeletesOmittedResources()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = CreateRepository(workspace.Path);
+        var writer = (IResourceRepositoryWriter)repositoryContext.Repository;
+        await writer.ReplaceResourcesAsync([CreateResource("api", "api"), CreateResource("worker", "worker")]);
+
+        var subscription = await repositoryContext.Repository.SubscribeResourcesAsync(CancellationToken.None);
+        Assert.Equal(2, subscription.InitialState.Length);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var enumerator = subscription.Subscription.GetAsyncEnumerator(cts.Token);
+
+        await writer.ReplaceResourcesAsync([CreateResource("api", "api")]);
+
+        Assert.True(await enumerator.MoveNextAsync().AsTask().DefaultTimeout());
+        Assert.Collection(
+            enumerator.Current,
+            change =>
+            {
+                Assert.Equal(ResourceViewModelChangeType.Delete, change.ChangeType);
+                Assert.Equal("worker", change.Resource.Name);
+            },
+            change =>
+            {
+                Assert.Equal(ResourceViewModelChangeType.Upsert, change.ChangeType);
+                Assert.Equal("api", change.Resource.Name);
+            });
+    }
+
+    [Fact]
+    public async Task ConsoleLogs_SameProcessReplayIsIgnoredAndLineNumbersCanContinueAfterRestart()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var resource = CreateResource("api", "api");
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            var writer = (IResourceRepositoryWriter)repositoryContext.Repository;
+            await writer.ReplaceResourcesAsync([resource]);
+            await writer.AddConsoleLogsAsync("api", [
+                new ConsoleLogLine { LineNumber = 2, Text = "second", IsStdErr = true },
+                new ConsoleLogLine { LineNumber = 1, Text = "first" }
+            ]);
+            await writer.AddConsoleLogsAsync("api", [
+                new ConsoleLogLine { LineNumber = 2, Text = "second-updated", IsStdErr = true },
+                new ConsoleLogLine { LineNumber = 3, Text = "third" }
+            ]);
+        }
+
+        {
+            using var restartedRepositoryContext = CreateRepository(workspace.Path);
+            await ((IResourceRepositoryWriter)restartedRepositoryContext.Repository).AddConsoleLogsAsync(
+                "api",
+                [new ConsoleLogLine { LineNumber = 4, Text = "fourth" }]);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        var batches = new List<IReadOnlyList<global::Aspire.Dashboard.Model.ResourceLogLine>>();
+        await foreach (var batch in historicalContext.Repository.GetConsoleLogs("api", CancellationToken.None))
+        {
+            batches.Add(batch);
+        }
+        var lines = Assert.Single(batches);
+        Assert.Collection(lines,
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(2, "second", true), line),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(1, "first", false), line),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(3, "third", false), line),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(4, "fourth", false), line));
+    }
+
+    [Fact]
+    public async Task ConsoleLogs_ClearSelectedResourcesPersistsAndSuppressesReplay()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            var writer = (IResourceRepositoryWriter)repositoryContext.Repository;
+            await writer.ReplaceResourcesAsync([CreateResource("api", "api"), CreateResource("worker", "worker")]);
+            await writer.AddConsoleLogsAsync("api", [
+                new ConsoleLogLine { LineNumber = 1, Text = "api-first" },
+                new ConsoleLogLine { LineNumber = 2, Text = "api-second" }
+            ]);
+            await writer.AddConsoleLogsAsync("worker", [
+                new ConsoleLogLine { LineNumber = 1, Text = "worker-first" }
+            ]);
+
+            var clearDate = new DateTime(2025, 2, 8, 10, 16, 8, DateTimeKind.Utc);
+            await writer.ClearConsoleLogsAsync(["api"], clearDate);
+            await writer.AddConsoleLogsAsync("api", [
+                new ConsoleLogLine { LineNumber = 1, Text = "api-first-replayed" },
+                new ConsoleLogLine { LineNumber = 3, Text = "2025-02-08T10:16:08Z api-third-before-clear" },
+                new ConsoleLogLine { LineNumber = 4, Text = "2025-02-08T10:16:09Z api-fourth-after-clear" }
+            ]);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        var apiBatches = new List<IReadOnlyList<global::Aspire.Dashboard.Model.ResourceLogLine>>();
+        await foreach (var batch in historicalContext.Repository.GetConsoleLogs("api", CancellationToken.None))
+        {
+            apiBatches.Add(batch);
+        }
+        Assert.Collection(
+            Assert.Single(apiBatches),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(4, "2025-02-08T10:16:09Z api-fourth-after-clear", false), line));
+
+        var workerBatches = new List<IReadOnlyList<global::Aspire.Dashboard.Model.ResourceLogLine>>();
+        await foreach (var batch in historicalContext.Repository.GetConsoleLogs("worker", CancellationToken.None))
+        {
+            workerBatches.Add(batch);
+        }
+        Assert.Collection(
+            Assert.Single(workerBatches),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(1, "worker-first", false), line));
+    }
+
+    [Fact]
+    public async Task ConsoleLogs_ResetLineNumbersAfterRepositoryRestartArePersisted()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var resource = CreateResource("api", "api");
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            var writer = (IResourceRepositoryWriter)repositoryContext.Repository;
+            await writer.ReplaceResourcesAsync([resource]);
+            await writer.AddConsoleLogsAsync("api", [
+                new ConsoleLogLine { LineNumber = 1, Text = "first" },
+                new ConsoleLogLine { LineNumber = 2, Text = "second" }
+            ]);
+        }
+
+        {
+            using var restartedRepositoryContext = CreateRepository(workspace.Path);
+            var writer = (IResourceRepositoryWriter)restartedRepositoryContext.Repository;
+            await writer.ReplaceResourcesAsync([resource]);
+            await writer.AddConsoleLogsAsync("api", [
+                new ConsoleLogLine { LineNumber = 1, Text = "new-first" },
+                new ConsoleLogLine { LineNumber = 2, Text = "new-second" },
+                new ConsoleLogLine { LineNumber = 3, Text = "new-third" }
+            ]);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        var batches = new List<IReadOnlyList<global::Aspire.Dashboard.Model.ResourceLogLine>>();
+        await foreach (var batch in historicalContext.Repository.GetConsoleLogs("api", CancellationToken.None))
+        {
+            batches.Add(batch);
+        }
+
+        Assert.Collection(
+            Assert.Single(batches),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(1, "first", false), line),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(2, "second", false), line),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(1, "new-first", false), line),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(2, "new-second", false), line),
+            line => Assert.Equal(new global::Aspire.Dashboard.Model.ResourceLogLine(3, "new-third", false), line));
+    }
+
+    [Fact]
+    public async Task ConsoleLogs_LargeBatchRoundTrips()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var logLines = Enumerable.Range(1, 201)
+            .Select(lineNumber => new ConsoleLogLine { LineNumber = lineNumber, Text = $"Line {lineNumber}" })
+            .ToArray();
+
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            await ((IResourceRepositoryWriter)repositoryContext.Repository).AddConsoleLogsAsync("api", logLines);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        var batches = new List<IReadOnlyList<global::Aspire.Dashboard.Model.ResourceLogLine>>();
+        await foreach (var batch in historicalContext.Repository.GetConsoleLogs("api", CancellationToken.None))
+        {
+            batches.Add(batch);
+        }
+        var persistedLines = Assert.Single(batches);
+        Assert.Equal(Enumerable.Range(1, 201), persistedLines.Select(line => line.LineNumber));
+        Assert.Equal(logLines.Select(line => line.Text), persistedLines.Select(line => line.Content));
+    }
+
+    [Fact]
+    public async Task Resources_LargeBatchRoundTrips()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var resources = Enumerable.Range(1, 201)
+            .Select(index => CreateResource($"resource-{index}", $"Resource {index}"))
+            .ToArray();
+
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            await ((IResourceRepositoryWriter)repositoryContext.Repository).ReplaceResourcesAsync(resources);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        var expected = resources
+            .OrderBy(resource => resource.Name)
+            .Select(resource => (resource.Name, resource.DisplayName));
+        var actual = historicalContext.Repository.GetResources()
+            .OrderBy(resource => resource.Name)
+            .Select(resource => (resource.Name, resource.DisplayName));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task ConsoleLogsLoaded_PersistsWithoutLogLines()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            var writer = (IResourceRepositoryWriter)repositoryContext.Repository;
+            await writer.ReplaceResourcesAsync([CreateResource("api", "api"), CreateResource("worker", "worker")]);
+            Assert.False(repositoryContext.Repository.GetResource("api")!.ConsoleLogsLoaded);
+
+            await writer.MarkConsoleLogsLoadedAsync("api");
+
+            var readQueries = await CaptureSqlQueriesAsync(() =>
+            {
+                Assert.True(repositoryContext.Repository.GetResource("api")!.ConsoleLogsLoaded);
+                return Task.CompletedTask;
+            });
+            Assert.Empty(readQueries);
+            Assert.False(repositoryContext.Repository.GetResource("worker")!.ConsoleLogsLoaded);
+
+            await writer.ApplyChangesAsync([new WatchResourcesChange { Upsert = CreateResource("api", "api") }]);
+            Assert.True(repositoryContext.Repository.GetResource("api")!.ConsoleLogsLoaded);
+
+            await writer.ReplaceResourcesAsync([CreateResource("api", "api"), CreateResource("worker", "worker")]);
+            Assert.True(repositoryContext.Repository.GetResource("api")!.ConsoleLogsLoaded);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        Assert.True(historicalContext.Repository.GetResource("api")!.ConsoleLogsLoaded);
+        Assert.False(historicalContext.Repository.GetResource("worker")!.ConsoleLogsLoaded);
+    }
+
+    [Fact]
+    public async Task Resources_AllFieldsAndRecursiveValuesRoundTrip()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var nestedValue = new Value
+        {
+            StructValue = new Struct
+            {
+                Fields =
+                {
+                    ["name"] = Value.ForString("database"),
+                    ["values"] = new Value
+                    {
+                        ListValue = new ListValue
+                        {
+                            Values =
+                            {
+                                Value.ForNumber(42.5),
+                                Value.ForBool(true),
+                                new Value { NullValue = NullValue.NullValue }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        var resource = CreateResource("api-complete", "api");
+        resource.State = "Running";
+        resource.StateStyle = "success";
+        resource.StartedAt = Timestamp.FromDateTime(DateTime.UnixEpoch.AddMinutes(1));
+        resource.StoppedAt = Timestamp.FromDateTime(DateTime.UnixEpoch.AddMinutes(2));
+        resource.IsHidden = true;
+        resource.SupportsDetailedTelemetry = true;
+        resource.IconName = "Box";
+        resource.IconVariant = Aspire.DashboardService.Proto.V1.IconVariant.Filled;
+        resource.Environment.Add(new EnvironmentVariable { Name = "OPTIONAL", IsFromSpec = true });
+        resource.Environment.Add(new EnvironmentVariable { Name = "VALUE", Value = "set" });
+        resource.Urls.Add(new Url
+        {
+            EndpointName = "https",
+            FullUrl = "https://api.dev.localhost:5001/path",
+            DisplayProperties = new UrlDisplayProperties { SortOrder = 3, DisplayName = "Secure endpoint" }
+        });
+        resource.Urls.Add(new Url
+        {
+            EndpointName = "https",
+            FullUrl = "https://localhost:5001/path",
+            IsInternal = true,
+            DisplayProperties = new UrlDisplayProperties { SortOrder = 3, DisplayName = "Secure endpoint" }
+        });
+        resource.Volumes.Add(new Volume { Source = "data", Target = "/data", MountType = "volume", IsReadOnly = true });
+        resource.Relationships.Add(new ResourceRelationship { ResourceName = "database", Type = "Reference" });
+        resource.HealthReports.Add(new HealthReport
+        {
+            Status = HealthStatus.Healthy,
+            Key = "ready",
+            Description = "Ready",
+            Exception = string.Empty,
+            LastRunAt = Timestamp.FromDateTime(DateTime.UnixEpoch.AddSeconds(30))
+        });
+        resource.Properties.Add(new ResourceProperty
+        {
+            Name = "nested",
+            DisplayName = "Nested value",
+            Value = nestedValue,
+            IsSensitive = true,
+            IsHighlighted = true,
+            SortOrder = 7
+        });
+#pragma warning disable CS0612 // ResourceCommand.Parameter must be persisted for compatibility with older AppHosts.
+        resource.Commands.Add(new ResourceCommand
+        {
+            Name = "configure",
+            DisplayName = "Configure",
+            Parameter = nestedValue.Clone(),
+            DisplayDescription = "Configure the resource",
+            ConfirmationMessage = "Continue?",
+            IsHighlighted = true,
+            IconName = "Settings",
+            IconVariant = Aspire.DashboardService.Proto.V1.IconVariant.Filled,
+            State = ResourceCommandState.Enabled,
+            ArgumentInputs =
+            {
+                new InteractionInput
+                {
+                    Name = "mode",
+                    Label = "Mode",
+                    Placeholder = "Select a mode",
+                    InputType = InputType.Choice,
+                    Required = true,
+                    Value = "safe",
+                    Description = "Execution mode",
+                    EnableDescriptionMarkdown = true,
+                    MaxLength = 20,
+                    AllowCustomChoice = true,
+                    Loading = true,
+                    UpdateStateOnChange = true,
+                    Disabled = true,
+                    MaxFileSize = 1024,
+                    AllowMultipleFiles = true,
+                    FileFilter = ".json",
+                    Options = { ["safe"] = "Safe", ["fast"] = "Fast" },
+                    ValidationErrors = { "Choose a mode" }
+                }
+            }
+        });
+#pragma warning restore CS0612
+
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            await ((IResourceRepositoryWriter)repositoryContext.Repository).ReplaceResourcesAsync([resource]);
+        }
+
+        using (var connection = new SqliteConnection($"Data Source={GetDatabasePath(workspace.Path)};Mode=ReadOnly;Pooling=False"))
+        {
+            connection.Open();
+            using var sqliteCommand = connection.CreateCommand();
+            sqliteCommand.CommandText = """
+                SELECT COUNT(*)
+                FROM dashboard_resource_commands
+                WHERE json_extract(parameter_value, '$.name') = 'database';
+                """;
+            Assert.Equal(1L, sqliteCommand.ExecuteScalar());
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        var actual = Assert.Single(historicalContext.Repository.GetResources());
+        Assert.Equal("Running", actual.State);
+        Assert.Equal("success", actual.StateStyle);
+        Assert.Equal(DateTime.UnixEpoch.AddMinutes(1), actual.StartTimeStamp);
+        Assert.Equal(DateTime.UnixEpoch.AddMinutes(2), actual.StopTimeStamp);
+        Assert.True(actual.SupportsDetailedTelemetry);
+        Assert.Equal("Box", actual.IconName);
+        Assert.Collection(actual.Environment,
+            item =>
+            {
+                Assert.Equal("OPTIONAL", item.Name);
+                Assert.Equal(string.Empty, item.Value);
+                Assert.True(item.FromSpec);
+            },
+            item => Assert.Equal("set", item.Value));
+        Assert.Equal(nestedValue, actual.Properties["nested"].Value);
+        Assert.True(actual.Properties["nested"].IsValueSensitive);
+        Assert.Equal(14, actual.Properties["nested"].SortOrder);
+        var command = Assert.Single(actual.Commands);
+        Assert.Equal("configure", command.Name);
+        var input = Assert.Single(command.ArgumentInputs);
+        Assert.Equal("Safe", input.Options["safe"]);
+        Assert.Equal("Fast", input.Options["fast"]);
+        Assert.Equal("Choose a mode", Assert.Single(input.ValidationErrors));
+        Assert.Collection(actual.Urls,
+            url =>
+            {
+                Assert.Equal("https", url.EndpointName);
+                Assert.Equal("api.dev.localhost", url.Url.Host);
+                Assert.False(url.IsInternal);
+            },
+            url =>
+            {
+                Assert.Equal("https", url.EndpointName);
+                Assert.Equal("localhost", url.Url.Host);
+                Assert.True(url.IsInternal);
+            });
+        Assert.Equal("/data", Assert.Single(actual.Volumes).Target);
+        Assert.Equal("database", Assert.Single(actual.Relationships).ResourceName);
+        Assert.Equal("ready", Assert.Single(actual.HealthReports).Name);
+    }
+
+    [Fact]
+    public async Task Resources_DuplicateEndpointUrlsRoundTrip()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var resource = CreateResource("frontend-cqgvshvm", "frontend");
+        resource.Urls.AddRange(
+        [
+            CreateUrl("http", "Online store (http)", "http://frontend-testshop.dev.localhost:5266/"),
+            CreateUrl("http", "Online store (http)", "http://localhost:5266/", isInternal: true),
+            CreateUrl("https", "Online store (https)", "https://frontend-testshop.dev.localhost:7269/"),
+            CreateUrl("https", "Online store (https)", "https://localhost:7269/", isInternal: true),
+            CreateUrl("https", "Health", "https://localhost:7269/health", isInternal: true)
+        ]);
+
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            await ((IResourceRepositoryWriter)repositoryContext.Repository).ReplaceResourcesAsync([resource]);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        var actual = Assert.Single(historicalContext.Repository.GetResources());
+        Assert.Collection(actual.Urls,
+            url => AssertUrl(url, "http", "Online store (http)", "http://frontend-testshop.dev.localhost:5266/", isInternal: false),
+            url => AssertUrl(url, "http", "Online store (http)", "http://localhost:5266/", isInternal: true),
+            url => AssertUrl(url, "https", "Online store (https)", "https://frontend-testshop.dev.localhost:7269/", isInternal: false),
+            url => AssertUrl(url, "https", "Online store (https)", "https://localhost:7269/", isInternal: true),
+            url => AssertUrl(url, "https", "Health", "https://localhost:7269/health", isInternal: true));
+
+        static void AssertUrl(global::Aspire.Dashboard.Model.UrlViewModel actual, string endpointName, string displayName, string url, bool isInternal)
+        {
+            Assert.Equal(endpointName, actual.EndpointName);
+            Assert.Equal(displayName, actual.DisplayProperties.DisplayName);
+            Assert.Equal(url, actual.Url.ToString());
+            Assert.Equal(isInternal, actual.IsInternal);
+        }
+    }
+
+    [Fact]
+    public async Task Resources_BulkLoadKeepsChildRecordsIsolated()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var resources = new[]
+        {
+            CreateResourceWithChildren("api", "API", "api-value"),
+            CreateResourceWithChildren("worker", "Worker", "worker-value")
+        };
+
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            await ((IResourceRepositoryWriter)repositoryContext.Repository).ReplaceResourcesAsync(resources);
+        }
+
+        using var historicalContext = CreateRepository(workspace.Path, readOnly: true);
+        var actualResources = historicalContext.Repository.GetResources().OrderBy(resource => resource.Name).ToList();
+        Assert.Collection(actualResources,
+            resource => AssertResourceChildren(resource, "api-value"),
+            resource => AssertResourceChildren(resource, "worker-value"));
+    }
+
+    [Fact]
+    public async Task Resources_MultipleResourcesArePersistedWithBatchedQueries()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = CreateRepository(workspace.Path);
+        var writer = (IResourceRepositoryWriter)repositoryContext.Repository;
+
+        var replaceQueries = await CaptureSqlQueriesAsync(() => writer.ReplaceResourcesAsync([
+            CreateResourceWithChildren("api", "API", "api-value"),
+            CreateResourceWithChildren("worker", "Worker", "worker-value")
+        ]));
+        AssertBatchedResourceQueries(replaceQueries);
+
+        var applyQueries = await CaptureSqlQueriesAsync(() => writer.ApplyChangesAsync([
+            new WatchResourcesChange { Upsert = CreateResourceWithChildren("api", "API", "api-updated") },
+            new WatchResourcesChange { Upsert = CreateResourceWithChildren("worker", "Worker", "worker-updated") }
+        ]));
+        AssertBatchedResourceQueries(applyQueries);
+
+        var resources = repositoryContext.Repository.GetResources().OrderBy(resource => resource.Name).ToArray();
+        Assert.Collection(resources,
+            resource => AssertResourceChildren(resource, "api-updated"),
+            resource => AssertResourceChildren(resource, "worker-updated"));
+    }
+
+    [Fact]
+    public void Schema_HasNoSerializedResourceColumns()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        using (CreateRepository(workspace.Path))
+        {
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM sqlite_schema
+            WHERE type = 'table' AND name = 'resources';
+            """;
+        Assert.Equal(0L, command.ExecuteScalar());
+
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM pragma_table_info('dashboard_resources')
+            WHERE name = 'payload' OR upper(type) = 'BLOB';
+            """;
+        Assert.Equal(0L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task Values_AreStoredOnOwnerRowsAsValidatedJson()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var resource = CreateResource("api", "API");
+        resource.Properties.Add(new ResourceProperty
+        {
+            Name = "nested",
+            Value = new Value
+            {
+                StructValue = new Struct
+                {
+                    Fields =
+                    {
+                        ["name"] = Value.ForString("database"),
+                        ["values"] = new Value
+                        {
+                            ListValue = new ListValue
+                            {
+                                Values =
+                                {
+                                    Value.ForNumber(42.5),
+                                    Value.ForBool(true),
+                                    new Value { NullValue = NullValue.NullValue }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        {
+            using var repositoryContext = CreateRepository(workspace.Path);
+            await ((IResourceRepositoryWriter)repositoryContext.Repository).ReplaceResourcesAsync([resource]);
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM dashboard_resource_properties
+            WHERE typeof(value) = 'text'
+                AND json_valid(value)
+                AND json_extract(value, '$.name') = 'database'
+                AND json_array_length(value, '$.values') = 3;
+            """;
+        Assert.Equal(1L, command.ExecuteScalar());
+
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM sqlite_schema
+            WHERE type = 'table'
+                AND name IN ('dashboard_values', 'dashboard_value_map_entries', 'dashboard_value_list_items');
+            """;
+        Assert.Equal(0L, command.ExecuteScalar());
+
+        command.CommandText = "UPDATE dashboard_resource_properties SET value = 'invalid' WHERE resource_name = 'api';";
+        Assert.Throws<SqliteException>(() => command.ExecuteNonQuery());
+    }
+
+    [Fact]
+    public void Schema_ResourceRepositoryInitializesAllEmbeddedScripts()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        using (CreateRepository(workspace.Path))
+        {
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT name
+            FROM sqlite_schema
+            WHERE type = 'table' AND name IN (
+                'dashboard_schema',
+                'dashboard_resources',
+                'telemetry_logs',
+                'telemetry_trace_resources',
+                'telemetry_traces',
+                'telemetry_metric_instruments')
+            ORDER BY name;
+            """;
+
+        using var reader = command.ExecuteReader();
+        var tableNames = new List<string>();
+        while (reader.Read())
+        {
+            tableNames.Add(reader.GetString(0));
+        }
+
+        Assert.Equal(
+        [
+            "dashboard_resources",
+            "dashboard_schema",
+            "telemetry_logs",
+            "telemetry_metric_instruments",
+            "telemetry_trace_resources",
+            "telemetry_traces"
+        ], tableNames);
+    }
+
+    [Fact]
+    public void Schema_TraceSummaryShapeAndIndexesExist()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        using (CreateRepository(workspace.Path))
+        {
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = "PRAGMA table_info(telemetry_spans);";
+        var spanColumnNames = new List<string>();
+        using (var columnReader = command.ExecuteReader())
+        {
+            while (columnReader.Read())
+            {
+                spanColumnNames.Add(columnReader.GetString(1));
+            }
+        }
+        Assert.DoesNotContain("resource_order_ticks", spanColumnNames);
+
+        command.CommandText = "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'telemetry_trace_resources';";
+        var traceResourcesSql = Assert.IsType<string>(command.ExecuteScalar());
+        Assert.Contains("CHECK (total_spans >= 0)", traceResourcesSql, StringComparison.Ordinal);
+
+        command.CommandText = """
+            SELECT name
+            FROM sqlite_schema
+            WHERE type = 'index' AND name IN (
+                'ix_telemetry_spans_parent',
+                'ix_telemetry_trace_resources_order')
+            ORDER BY name;
+            """;
+
+        var indexNames = new List<string>();
+        using (var reader = command.ExecuteReader())
+        {
+            while (reader.Read())
+            {
+                indexNames.Add(reader.GetString(0));
+            }
+        }
+
+        Assert.Equal(
+        [
+            "ix_telemetry_spans_parent",
+            "ix_telemetry_trace_resources_order"
+        ], indexNames);
+
+        command.CommandText = "INSERT INTO telemetry_resources (resource_name) VALUES ('test'); SELECT last_insert_rowid();";
+        var resourceId = Assert.IsType<long>(command.ExecuteScalar());
+        command.CommandText = """
+            INSERT INTO telemetry_traces (
+                trace_id, first_span_timestamp_ticks, last_span_end_timestamp_ticks, duration_ticks,
+                last_updated_timestamp_ticks, full_name, primary_span_id, has_error, has_gen_ai)
+            VALUES ('trace', 1, 2, 1, 2, 'trace', 'span', 0, 0);
+            """;
+        command.ExecuteNonQuery();
+        command.CommandText = $"INSERT INTO telemetry_trace_resources VALUES ('trace', {resourceId}, 1, 0, 0);";
+        command.ExecuteNonQuery();
+
+        command.CommandText = "UPDATE telemetry_trace_resources SET total_spans = -1;";
+        Assert.Throws<SqliteException>(() => command.ExecuteNonQuery());
+        command.CommandText = "UPDATE telemetry_trace_resources SET errored_spans = -1;";
+        Assert.Throws<SqliteException>(() => command.ExecuteNonQuery());
+        command.CommandText = "UPDATE telemetry_trace_resources SET errored_spans = total_spans + 1;";
+        Assert.Throws<SqliteException>(() => command.ExecuteNonQuery());
+    }
+
+    [Fact]
+    public void Schema_SpanKindAndStatusLookupsExist()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        using (CreateRepository(workspace.Path))
+        {
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT kind || ':' || kind_name
+            FROM telemetry_span_kinds
+            ORDER BY kind;
+            """;
+        using (var reader = command.ExecuteReader())
+        {
+            Assert.Equal(
+            [
+                "0:Unspecified",
+                "1:Internal",
+                "2:Server",
+                "3:Client",
+                "4:Producer",
+                "5:Consumer"
+            ], ReadValues(reader));
+        }
+
+        command.CommandText = """
+            SELECT status || ':' || status_name
+            FROM telemetry_span_statuses
+            ORDER BY status;
+            """;
+        using (var reader = command.ExecuteReader())
+        {
+            Assert.Equal(["0:Unset", "1:Ok", "2:Error"], ReadValues(reader));
+        }
+
+        command.CommandText = """
+            SELECT "table" || ':' || "from" || ':' || "to"
+            FROM pragma_foreign_key_list('telemetry_spans')
+            WHERE "from" IN ('kind', 'status')
+            ORDER BY "from";
+            """;
+        using (var reader = command.ExecuteReader())
+        {
+            Assert.Equal(
+            [
+                "telemetry_span_kinds:kind:kind",
+                "telemetry_span_statuses:status:status"
+            ], ReadValues(reader));
+        }
+
+        static List<string> ReadValues(SqliteDataReader reader)
+        {
+            var values = new List<string>();
+            while (reader.Read())
+            {
+                values.Add(reader.GetString(0));
+            }
+            return values;
+        }
+    }
+
+    [Fact]
+    public void Schema_TelemetryResourceInstanceIdUniquenessPreservesNullAndEmpty()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        using (CreateRepository(workspace.Path))
+        {
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "INSERT INTO telemetry_resources (resource_name, instance_id) VALUES ('api', NULL);";
+        command.ExecuteNonQuery();
+        Assert.Throws<SqliteException>(() => command.ExecuteNonQuery());
+
+        command.CommandText = "INSERT INTO telemetry_resources (resource_name, instance_id) VALUES ('api', '');";
+        command.ExecuteNonQuery();
+        Assert.Throws<SqliteException>(() => command.ExecuteNonQuery());
+
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_resources WHERE resource_name = 'api';";
+        Assert.Equal(2L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public void Schema_AllDashboardTablesAreStrict()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        using (CreateRepository(workspace.Path))
+        {
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT name
+            FROM pragma_table_list
+            WHERE schema = 'main'
+                AND type = 'table'
+                AND name NOT LIKE 'sqlite_%'
+                AND strict = 0
+            ORDER BY name;
+            """;
+
+        using var reader = command.ExecuteReader();
+        var nonStrictTableNames = new List<string>();
+        while (reader.Read())
+        {
+            nonStrictTableNames.Add(reader.GetString(0));
+        }
+
+        Assert.Empty(nonStrictTableNames);
+    }
+
+    private static string GetDatabasePath(string workspacePath) => Path.Combine(workspacePath, "dashboard.db");
+
+    private static SqliteRepositoryTestContext<SqliteResourceRepository> CreateRepository(
+        string workspacePath,
+        bool readOnly = false)
+    {
+        return SqliteRepositoryTestHelpers.CreateResourceRepository(
+            GetDatabasePath(workspacePath),
+            new MockKnownPropertyLookup(),
+            readOnly);
+    }
+
+    private static Resource CreateResource(string name, string displayName)
+    {
+        return new Resource
+        {
+            Name = name,
+            DisplayName = displayName,
+            ResourceType = "Project",
+            Uid = $"uid-{name}",
+            CreatedAt = Timestamp.FromDateTime(DateTime.UnixEpoch)
+        };
+    }
+
+    private static Url CreateUrl(string endpointName, string displayName, string url, bool isInternal = false)
+    {
+        return new Url
+        {
+            EndpointName = endpointName,
+            FullUrl = url,
+            IsInternal = isInternal,
+            DisplayProperties = new UrlDisplayProperties { DisplayName = displayName }
+        };
+    }
+
+    private static Resource CreateResourceWithChildren(string name, string displayName, string value)
+    {
+        var resource = CreateResource(name, displayName);
+        resource.Environment.Add(new EnvironmentVariable { Name = "VALUE", Value = value });
+        resource.Properties.Add(new ResourceProperty { Name = "property", Value = Value.ForString(value) });
+        resource.Commands.Add(new ResourceCommand
+        {
+            Name = "command",
+            DisplayName = "Command",
+            ArgumentInputs =
+            {
+                new InteractionInput
+                {
+                    Name = "input",
+                    Label = "Input",
+                    Options = { [value] = value },
+                    ValidationErrors = { value }
+                }
+            }
+        });
+        return resource;
+    }
+
+    private static async Task<IReadOnlyList<string>> CaptureSqlQueriesAsync(Func<Task> action)
+    {
+        var queries = new List<string>();
+        using var operation = new Activity("Capture resource persistence queries").Start();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == TracingSqliteConnection.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity =>
+            {
+                if (activity.TraceId == operation.TraceId && activity.GetTagItem("db.query.text") is string query)
+                {
+                    queries.Add(query);
+                }
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await action();
+
+        return queries;
+    }
+
+    private static void AssertBatchedResourceQueries(IReadOnlyList<string> queries)
+    {
+        Assert.Equal(9, queries.Count);
+
+        string[] insertedTables =
+        [
+            "dashboard_resources",
+            "dashboard_resource_environment",
+            "dashboard_resource_properties",
+            "dashboard_resource_commands",
+            "dashboard_resource_command_inputs",
+            "dashboard_resource_command_input_options",
+            "dashboard_resource_command_input_validation_errors"
+        ];
+
+        foreach (var table in insertedTables)
+        {
+            Assert.Single(queries, query => query.TrimStart().StartsWith($"INSERT INTO {table} ", StringComparison.Ordinal));
+        }
+    }
+
+    private static void AssertResourceChildren(global::Aspire.Dashboard.Model.ResourceViewModel resource, string expected)
+    {
+        Assert.Equal(expected, Assert.Single(resource.Environment).Value);
+        Assert.Equal(expected, resource.Properties["property"].Value.StringValue);
+        var input = Assert.Single(Assert.Single(resource.Commands).ArgumentInputs);
+        Assert.Equal(expected, input.Options[expected]);
+        Assert.Equal(expected, Assert.Single(input.ValidationErrors));
+    }
+
+    private static void AssertResource(global::Aspire.Dashboard.Model.ResourceViewModel actual, Resource expected, int replicaIndex, string? state = null)
+    {
+        Assert.Equal(expected.Name, actual.Name);
+        Assert.Equal(expected.DisplayName, actual.DisplayName);
+        Assert.Equal(expected.ResourceType, actual.ResourceType);
+        Assert.Equal(expected.Uid, actual.Uid);
+        Assert.Equal(replicaIndex, actual.ReplicaIndex);
+        Assert.Equal(state, actual.State);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/StructuredLogsPageViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/StructuredLogsPageViewModelTests.cs
@@ -226,7 +226,7 @@ public sealed class StructuredLogsPageViewModelTests
         };
 
         var logRecord = TelemetryTestHelpers.CreateLogRecord(message: message, severity: severityNumber);
-        var logEntry = new OtlpLogEntry(logRecord, resourceView, scope, context);
+        var logEntry = TelemetryTestHelpers.CreateOtlpLogEntry(logRecord, resourceView, scope, context);
 
         return new StructureLogsDetailsViewModel { LogEntry = logEntry };
     }

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -5,17 +5,19 @@ using System.Globalization;
 using System.IO.Compression;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Serialization;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Shared;
 using Aspire.Otlp.Serialization;
-using Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 using Aspire.Tests.Shared.DashboardModel;
 using Google.Protobuf.Collections;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
@@ -23,17 +25,21 @@ using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Tests.Model;
 
-public sealed class TelemetryExportServiceTests
+public sealed class TelemetryExportServiceTests(ITestOutputHelper testOutputHelper) : IDisposable
 {
     private static readonly DateTime s_testTime = new(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+    private readonly List<DashboardDataSource> _dataSources = [];
+    private readonly List<DashboardDataSourcePool> _databasePools = [];
+    private readonly List<DirectoryInfo> _temporaryDirectories = [];
 
     [Fact]
-    public void ConvertLogsToOtlpJson_SingleLog_ReturnsCorrectStructure()
+    public async Task ConvertLogsToOtlpJson_SingleLog_ReturnsCorrectStructure()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -49,15 +55,15 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Act
         var result = TelemetryExportService.ConvertLogsToOtlpJson(logs.Items);
@@ -95,12 +101,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertLogsToOtlpJson_AddsAspireLogIdAttribute()
+    public async Task ConvertLogsToOtlpJson_AddsAspireLogIdAttribute()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -116,9 +123,9 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var logs = repository.GetLogs(GetLogsContext.ForResourceKey(resource.ResourceKey));
+        var logs = await repositoryContext.Repository.GetLogsAsync(GetLogsContext.ForResourceKey(resource.ResourceKey), cancellationToken: CancellationToken.None);
 
         // Act
         var result = TelemetryExportService.ConvertLogsToOtlpJson(logs.Items);
@@ -133,12 +140,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertLogsToOtlpJson_MultipleLogs_GroupsByScope()
+    public async Task ConvertLogsToOtlpJson_MultipleLogs_GroupsByScope()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -163,9 +171,9 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var logs = repository.GetLogs(GetLogsContext.ForResourceKey(resource.ResourceKey));
+        var logs = await repositoryContext.Repository.GetLogsAsync(GetLogsContext.ForResourceKey(resource.ResourceKey), cancellationToken: CancellationToken.None);
 
         // Act
         var result = TelemetryExportService.ConvertLogsToOtlpJson(logs.Items);
@@ -214,12 +222,13 @@ public sealed class TelemetryExportServiceTests
     [InlineData(SeverityNumber.Fatal2, "Critical")]
     [InlineData(SeverityNumber.Fatal3, "Critical")]
     [InlineData(SeverityNumber.Fatal4, "Critical")]
-    public void ConvertLogsToOtlpJson_RoundTripsSeverityNumber(SeverityNumber inputSeverity, string expectedSeverityText)
+    public async Task ConvertLogsToOtlpJson_RoundTripsSeverityNumber(SeverityNumber inputSeverity, string expectedSeverityText)
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -235,9 +244,9 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var logs = repository.GetLogs(GetLogsContext.ForResourceKey(resource.ResourceKey));
+        var logs = await repositoryContext.Repository.GetLogsAsync(GetLogsContext.ForResourceKey(resource.ResourceKey), cancellationToken: CancellationToken.None);
 
         // Act
         var result = TelemetryExportService.ConvertLogsToOtlpJson(logs.Items);
@@ -251,12 +260,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertTracesToOtlpJson_SingleTrace_ReturnsCorrectStructure()
+    public async Task ConvertTracesToOtlpJson_SingleTrace_ReturnsCorrectStructure()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -282,18 +292,18 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Act
-        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, []);
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items);
 
         // Assert
         Assert.NotNull(result.ResourceSpans);
@@ -329,12 +339,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertTracesToOtlpJson_SpanWithParent_IncludesParentSpanId()
+    public async Task ConvertTracesToOtlpJson_SpanWithParent_IncludesParentSpanId()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -354,12 +365,12 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var traces = repository.GetTraces(GetTracesRequest.ForResourceKey(resource.ResourceKey));
+        var traces = await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(resource.ResourceKey), cancellationToken: CancellationToken.None);
 
         // Act
-        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, []);
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items);
 
         // Assert
         var spans = result.ResourceSpans![0].ScopeSpans![0].Spans!;
@@ -372,12 +383,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertTracesToOtlpJson_WithPeerResolvers_AddsDestinationNameAttribute()
+    public async Task ConvertTracesToOtlpJson_WithPersistedPeer_AddsDestinationNameAttribute()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -401,18 +413,18 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var traces = repository.GetTraces(GetTracesRequest.ForResourceKey(resource.ResourceKey));
+        var traces = await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(resource.ResourceKey), cancellationToken: CancellationToken.None);
 
-        var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: attributes =>
-        {
-            var peerService = attributes.FirstOrDefault(a => a.Key == "peer.service");
-            return (peerService.Value, null);
-        });
+        traces.PagedResult.Items[0].Spans[0].SetUninstrumentedPeer(new OtlpResource(
+            "target-service",
+            instanceId: null,
+            uninstrumentedPeer: true,
+            new OtlpContext { Logger = NullLogger.Instance, Options = new() }));
 
         // Act
-        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, [outgoingPeerResolver]);
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items);
 
         // Assert
         var span = result.ResourceSpans![0].ScopeSpans![0].Spans![0];
@@ -421,12 +433,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertTracesToOtlpJson_WithoutPeerResolvers_DoesNotAddDestinationNameAttribute()
+    public async Task ConvertTracesToOtlpJson_WithoutPersistedPeer_AddsPeerAddressAttribute()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -450,30 +463,73 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var traces = repository.GetTraces(GetTracesRequest.ForResourceKey(resource.ResourceKey));
+        var traces = await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(resource.ResourceKey), cancellationToken: CancellationToken.None);
 
         // Act
-        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, []);
+        var result = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items);
 
         // Assert
         var span = result.ResourceSpans![0].ScopeSpans![0].Spans![0];
         Assert.NotNull(span.Attributes);
-        Assert.DoesNotContain(span.Attributes, a => a.Key == OtlpHelpers.AspireDestinationNameAttribute);
+        Assert.Contains(span.Attributes, a => a.Key == OtlpHelpers.AspireDestinationNameAttribute && a.Value?.StringValue == "target-service");
     }
 
     [Fact]
-    public void ConvertMetricsToOtlpJson_SingleInstrument_ReturnsCorrectStructure()
+    public void ConvertTracesToOtlpJson_WithInstrumentedChild_AddsDestinationResourceAttribute()
+    {
+        var context = CreateContext();
+        var source = new OtlpResource("source", instanceId: null, uninstrumentedPeer: false, context);
+        var destination = new OtlpResource("destination", instanceId: "replica-1", uninstrumentedPeer: false, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, s_testTime);
+        var scope = CreateOtlpScope(context);
+        var parentSpan = CreateOtlpSpan(
+            source,
+            trace,
+            scope,
+            spanId: "parent",
+            parentSpanId: null,
+            startDate: s_testTime,
+            attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "raw-address")],
+            kind: OtlpSpanKind.Client);
+        var childSpan = CreateOtlpSpan(
+            destination,
+            trace,
+            scope,
+            spanId: "child",
+            parentSpanId: "parent",
+            startDate: s_testTime.AddSeconds(1),
+            kind: OtlpSpanKind.Server);
+        trace.AddSpan(parentSpan);
+        trace.AddSpan(childSpan);
+
+        var result = TelemetryExportService.ConvertTracesToOtlpJson([trace]);
+
+        var exportedParent = result.ResourceSpans!
+            .SelectMany(resourceSpans => resourceSpans.ScopeSpans!)
+            .SelectMany(scopeSpans => scopeSpans.Spans!)
+            .Single(span => span.SpanId == "parent");
+        Assert.Contains(
+            exportedParent.Attributes!,
+            attribute => attribute.Key == OtlpHelpers.AspireDestinationNameAttribute && attribute.Value?.StringValue == "destination-replica-1");
+    }
+
+    [Fact]
+    public async Task ConvertMetricsToOtlpJson_SingleInstrument_ReturnsCorrectStructure()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>()
+        await repositoryContext.Repository.AddMetricsAsync(addContext, new RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>()
         {
             new OpenTelemetry.Proto.Metrics.V1.ResourceMetrics
             {
-                Resource = CreateResource(name: "TestService", instanceId: "instance-1"),
+                Resource = CreateResource(
+                    name: "TestService",
+                    instanceId: "instance-1",
+                    attributes: [KeyValuePair.Create("service.version", "1.2.3")]),
                 ScopeMetrics =
                 {
                     new OpenTelemetry.Proto.Metrics.V1.ScopeMetrics
@@ -485,22 +541,22 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var instrumentSummaries = repository.GetInstrumentsSummaries(resource.ResourceKey);
+        var instrumentSummaries = repositoryContext.Repository.GetInstrumentSummaries(resource.ResourceKey);
 
         // Get full instrument data with values
         var instrumentsData = new List<OtlpInstrumentData>();
         foreach (var summary in instrumentSummaries)
         {
-            var instrumentData = repository.GetInstrument(new GetInstrumentRequest
+            var instrumentData = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
             {
                 ResourceKey = resource.ResourceKey,
                 MeterName = summary.Parent.Name,
                 InstrumentName = summary.Name,
                 StartTime = DateTime.MinValue,
                 EndTime = DateTime.MaxValue
-            });
+            }, cancellationToken: CancellationToken.None);
             if (instrumentData is not null)
             {
                 instrumentsData.Add(instrumentData);
@@ -508,7 +564,7 @@ public sealed class TelemetryExportServiceTests
         }
 
         // Act
-        var result = TelemetryExportService.ConvertMetricsToOtlpJson(resource, instrumentsData);
+        var result = TelemetryExportService.ConvertMetricsToOtlpJson(instrumentsData);
 
         // Assert
         Assert.NotNull(result.ResourceMetrics);
@@ -518,6 +574,7 @@ public sealed class TelemetryExportServiceTests
         Assert.NotNull(resourceMetrics.Resource);
         Assert.NotNull(resourceMetrics.Resource.Attributes);
         Assert.Contains(resourceMetrics.Resource.Attributes, a => a.Key == OtlpResource.SERVICE_NAME && a.Value?.StringValue == "TestService");
+        Assert.Contains(resourceMetrics.Resource.Attributes, a => a.Key == "service.version" && a.Value?.StringValue == "1.2.3");
 
         Assert.NotNull(resourceMetrics.ScopeMetrics);
         Assert.Single(resourceMetrics.ScopeMetrics);
@@ -541,12 +598,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertMetricsToOtlpJson_MultipleInstruments_GroupsByScope()
+    public async Task ConvertMetricsToOtlpJson_MultipleInstruments_GroupsByScope()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>()
+        await repositoryContext.Repository.AddMetricsAsync(addContext, new RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>()
         {
             new OpenTelemetry.Proto.Metrics.V1.ResourceMetrics
             {
@@ -571,22 +629,22 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var resource = resources[0];
-        var instrumentSummaries = repository.GetInstrumentsSummaries(resource.ResourceKey);
+        var instrumentSummaries = repositoryContext.Repository.GetInstrumentSummaries(resource.ResourceKey);
 
         // Get full instrument data with values
         var instrumentsData = new List<OtlpInstrumentData>();
         foreach (var summary in instrumentSummaries)
         {
-            var instrumentData = repository.GetInstrument(new GetInstrumentRequest
+            var instrumentData = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
             {
                 ResourceKey = resource.ResourceKey,
                 MeterName = summary.Parent.Name,
                 InstrumentName = summary.Name,
                 StartTime = DateTime.MinValue,
                 EndTime = DateTime.MaxValue
-            });
+            }, cancellationToken: CancellationToken.None);
             if (instrumentData is not null)
             {
                 instrumentsData.Add(instrumentData);
@@ -594,7 +652,7 @@ public sealed class TelemetryExportServiceTests
         }
 
         // Act
-        var result = TelemetryExportService.ConvertMetricsToOtlpJson(resource, instrumentsData);
+        var result = TelemetryExportService.ConvertMetricsToOtlpJson(instrumentsData);
 
         // Assert
         Assert.NotNull(result.ResourceMetrics);
@@ -625,14 +683,15 @@ public sealed class TelemetryExportServiceTests
     public async Task ExportSelectedAsync_ExportsOnlySelectedDataTypesForSpecificResources()
     {
         // Arrange
-        var repository = CreateRepository();
-        var exportService = await CreateExportServiceAsync(repository);
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+        var exportService = await CreateExportServiceAsync(repositoryContext.Repository);
 
         // Add test data for three resources
-        AddTestData(repository, "resource1", "111");
-        AddTestData(repository, "resource2", "222");
-        AddTestData(repository, "resource3", "333");
-        AddTestData(repository, "resource4", "444");
+        await AddTestData(repositoryContext.Repository, "resource1", "111");
+        await AddTestData(repositoryContext.Repository, "resource2", "222");
+        await AddTestData(repositoryContext.Repository, "resource3", "333");
+        await AddTestData(repositoryContext.Repository, "resource4", "444");
 
         // Act - Export only structured logs for resource1, only traces for resource2, all types for resource3
         var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
@@ -686,11 +745,12 @@ public sealed class TelemetryExportServiceTests
     public async Task ExportAllAsync_WhenDashboardClientDisabled_ExportsOnlyTelemetry()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
 
         // Add logs
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -707,10 +767,10 @@ public sealed class TelemetryExportServiceTests
         });
 
         // Dashboard client is disabled (no console logs)
-        var service = await CreateExportServiceAsync(repository, isDashboardClientEnabled: false);
+        var service = await CreateExportServiceAsync(repositoryContext.Repository, isDashboardClientEnabled: false);
 
         // Build selection for all resources with all data types
-        var selectedResources = BuildAllResourcesSelection(repository);
+        var selectedResources = BuildAllResourcesSelection(repositoryContext.Repository);
 
         // Act
         using var zipStream = await service.ExportSelectedAsync(selectedResources, CancellationToken.None).DefaultTimeout();
@@ -725,14 +785,115 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
+    public async Task ExportSelectedAsync_LargeNumberOfStructuredLogs_ExportsAllLogs()
+    {
+        const int logCount = 40_000;
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+        var logRecords = new RepeatedField<LogRecord>();
+        for (var index = 0; index < logCount; index++)
+        {
+            logRecords.Add(CreateLogRecord(
+                time: s_testTime.AddTicks(index),
+                message: $"Log {index}",
+                attributes: [KeyValuePair.Create("log.index", index.ToString(CultureInfo.InvariantCulture))]));
+        }
+
+        await repositoryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "LargeService", instanceId: "instance-1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("LargeLogger"),
+                        LogRecords = { logRecords }
+                    }
+                }
+            }
+        });
+
+        var service = await CreateExportServiceAsync(repositoryContext.Repository, isDashboardClientEnabled: false);
+        var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
+        {
+            ["LargeService-instance-1"] = [AspireDataType.StructuredLogs]
+        };
+
+        using var zipStream = await service.ExportSelectedAsync(selectedResources, CancellationToken.None).DefaultTimeout();
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        var logEntry = Assert.Single(archive.Entries);
+        Assert.Equal("structuredlogs/LargeService.json", logEntry.FullName);
+
+        using var logStream = logEntry.Open();
+        var logsData = await JsonSerializer.DeserializeAsync(logStream, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
+        var exportedLogs = Assert.Single(logsData!.ResourceLogs!).ScopeLogs!.SelectMany(scope => scope.LogRecords!).ToList();
+        Assert.Equal(logCount, exportedLogs.Count);
+        Assert.All(exportedLogs, log => Assert.Contains(log.Attributes!, attribute => attribute.Key == "log.index"));
+    }
+
+    [Fact]
+    public async Task ExportSelectedAsync_LargeNumberOfTraces_ExportsAllTraces()
+    {
+        const int traceCount = 10_000;
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+        var spans = new RepeatedField<Span>();
+        for (var index = 0; index < traceCount; index++)
+        {
+            spans.Add(CreateSpan(
+                traceId: $"trace-{index}",
+                spanId: $"span-{index}",
+                startTime: s_testTime.AddTicks(index),
+                endTime: s_testTime.AddTicks(index + 1),
+                attributes: [KeyValuePair.Create("trace.index", index.ToString(CultureInfo.InvariantCulture))]));
+        }
+
+        await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "LargeService", instanceId: "instance-1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("LargeTracer"),
+                        Spans = { spans }
+                    }
+                }
+            }
+        });
+
+        var service = await CreateExportServiceAsync(repositoryContext.Repository, isDashboardClientEnabled: false);
+        var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
+        {
+            ["LargeService-instance-1"] = [AspireDataType.Traces]
+        };
+
+        using var zipStream = await service.ExportSelectedAsync(selectedResources, CancellationToken.None).DefaultTimeout();
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        var traceEntry = Assert.Single(archive.Entries);
+        Assert.Equal("traces/LargeService.json", traceEntry.FullName);
+
+        using var traceStream = traceEntry.Open();
+        var tracesData = await JsonSerializer.DeserializeAsync(traceStream, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
+        var exportedSpans = Assert.Single(tracesData!.ResourceSpans!).ScopeSpans!.SelectMany(scope => scope.Spans!).ToList();
+        Assert.Equal(traceCount, exportedSpans.Count);
+        Assert.All(exportedSpans, span => Assert.Contains(span.Attributes!, attribute => attribute.Key == "trace.index"));
+    }
+
+    [Fact]
     public async Task ExportSelectedAsync_SkipsEmptyResources()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
 
         // Add logs for only one resource
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -749,7 +910,7 @@ public sealed class TelemetryExportServiceTests
         });
 
         // Add traces for a different resource
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -765,10 +926,10 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var service = await CreateExportServiceAsync(repository, isDashboardClientEnabled: false);
+        var service = await CreateExportServiceAsync(repositoryContext.Repository, isDashboardClientEnabled: false);
 
         // Build selection for all resources with all data types
-        var selectedResources = BuildAllResourcesSelection(repository);
+        var selectedResources = BuildAllResourcesSelection(repositoryContext.Repository);
 
         // Act
         using var zipStream = await service.ExportSelectedAsync(selectedResources, CancellationToken.None).DefaultTimeout();
@@ -787,14 +948,15 @@ public sealed class TelemetryExportServiceTests
     public async Task ExportSelectedAsync_JapaneseCharactersInLogs_PreservesContent()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
 
         const string japaneseMessage = "これはテストログメッセージです"; // "This is a test log message"
         const string japaneseAttributeValue = "日本語の属性値"; // "Japanese attribute value"
         const string japaneseEventName = "テストイベント"; // "Test event"
 
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -818,10 +980,10 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var service = await CreateExportServiceAsync(repository, isDashboardClientEnabled: false);
+        var service = await CreateExportServiceAsync(repositoryContext.Repository, isDashboardClientEnabled: false);
 
         // Build selection for all resources with all data types
-        var selectedResources = BuildAllResourcesSelection(repository);
+        var selectedResources = BuildAllResourcesSelection(repositoryContext.Repository);
 
         // Act
         using var zipStream = await service.ExportSelectedAsync(selectedResources, CancellationToken.None).DefaultTimeout();
@@ -867,12 +1029,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertSpanToJson_ReturnsValidOtlpTelemetryDataJson()
+    public async Task ConvertSpanToJson_ReturnsValidOtlpTelemetryDataJson()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -888,10 +1051,10 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var span = repository.GetTraces(GetTracesRequest.ForResourceKey(repository.GetResources()[0].ResourceKey)).PagedResult.Items[0].Spans[0];
+        var span = (await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(repositoryContext.Repository.GetResources()[0].ResourceKey), cancellationToken: CancellationToken.None)).PagedResult.Items[0].Spans[0];
 
         // Act
-        var json = TelemetryExportService.ConvertSpanToJson(span, []);
+        var json = TelemetryExportService.ConvertSpanToJson(span);
 
         // Assert - deserialize back to verify OtlpTelemetryDataJson structure
         var data = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
@@ -904,12 +1067,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertSpanToJson_WithLogs_IncludesLogsInOutput()
+    public async Task ConvertSpanToJson_WithLogs_IncludesLogsInOutput()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -924,7 +1088,7 @@ public sealed class TelemetryExportServiceTests
                 }
             }
         });
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -940,11 +1104,11 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var span = repository.GetTraces(GetTracesRequest.ForResourceKey(repository.GetResources()[0].ResourceKey)).PagedResult.Items[0].Spans[0];
-        var logs = repository.GetLogs(GetLogsContext.ForResourceKey(repository.GetResources()[0].ResourceKey)).Items;
+        var span = (await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(repositoryContext.Repository.GetResources()[0].ResourceKey), cancellationToken: CancellationToken.None)).PagedResult.Items[0].Spans[0];
+        var logs = (await repositoryContext.Repository.GetLogsAsync(GetLogsContext.ForResourceKey(repositoryContext.Repository.GetResources()[0].ResourceKey), cancellationToken: CancellationToken.None)).Items;
 
         // Act
-        var json = TelemetryExportService.ConvertSpanToJson(span, [], logs);
+        var json = TelemetryExportService.ConvertSpanToJson(span, logs);
 
         // Assert - verify both spans and logs are in the output
         var data = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
@@ -956,12 +1120,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertTraceToJson_WithLogs_IncludesLogsInOutput()
+    public async Task ConvertTraceToJson_WithLogs_IncludesLogsInOutput()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -980,7 +1145,7 @@ public sealed class TelemetryExportServiceTests
                 }
             }
         });
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1000,11 +1165,11 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var trace = repository.GetTraces(GetTracesRequest.ForResourceKey(repository.GetResources()[0].ResourceKey)).PagedResult.Items[0];
-        var logs = repository.GetLogs(GetLogsContext.ForResourceKey(repository.GetResources()[0].ResourceKey)).Items;
+        var trace = (await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(repositoryContext.Repository.GetResources()[0].ResourceKey), cancellationToken: CancellationToken.None)).PagedResult.Items[0];
+        var logs = (await repositoryContext.Repository.GetLogsAsync(GetLogsContext.ForResourceKey(repositoryContext.Repository.GetResources()[0].ResourceKey), cancellationToken: CancellationToken.None)).Items;
 
         // Act
-        var json = TelemetryExportService.ConvertTraceToJson(trace, [], logs);
+        var json = TelemetryExportService.ConvertTraceToJson(trace, logs);
 
         // Assert - verify both spans and logs are in the output
         var data = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
@@ -1016,12 +1181,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertTraceToJson_ReturnsValidOtlpTelemetryDataJson()
+    public async Task ConvertTraceToJson_ReturnsValidOtlpTelemetryDataJson()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1041,10 +1207,10 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var trace = repository.GetTraces(GetTracesRequest.ForResourceKey(repository.GetResources()[0].ResourceKey)).PagedResult.Items[0];
+        var trace = (await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(repositoryContext.Repository.GetResources()[0].ResourceKey), cancellationToken: CancellationToken.None)).PagedResult.Items[0];
 
         // Act
-        var json = TelemetryExportService.ConvertTraceToJson(trace, []);
+        var json = TelemetryExportService.ConvertTraceToJson(trace);
 
         // Assert - deserialize back to verify OtlpTelemetryDataJson structure
         var data = JsonSerializer.Deserialize(json, OtlpJsonSerializerContext.Default.OtlpTelemetryDataJson);
@@ -1056,12 +1222,13 @@ public sealed class TelemetryExportServiceTests
     }
 
     [Fact]
-    public void ConvertLogEntryToJson_ReturnsValidOtlpTelemetryDataJson()
+    public async Task ConvertLogEntryToJson_ReturnsValidOtlpTelemetryDataJson()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1077,7 +1244,7 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        var logEntry = repository.GetLogs(GetLogsContext.ForResourceKey(repository.GetResources()[0].ResourceKey)).Items[0];
+        var logEntry = (await repositoryContext.Repository.GetLogsAsync(GetLogsContext.ForResourceKey(repositoryContext.Repository.GetResources()[0].ResourceKey), cancellationToken: CancellationToken.None)).Items[0];
 
         // Act
         var json = TelemetryExportService.ConvertLogEntryToJson(logEntry);
@@ -1091,17 +1258,24 @@ public sealed class TelemetryExportServiceTests
         Assert.Single(data.ResourceLogs[0].ScopeLogs![0].LogRecords!);
     }
 
-    private static async Task<TelemetryExportService> CreateExportServiceAsync(TelemetryRepository repository, bool isDashboardClientEnabled = true)
+    private async Task<TelemetryExportService> CreateExportServiceAsync(ITelemetryRepository repository, bool isDashboardClientEnabled = true)
     {
         var dashboardClient = new TestDashboardClient(isEnabled: isDashboardClientEnabled);
         var sessionStorage = new TestSessionStorage();
         var consoleLogsManager = new ConsoleLogsManager(sessionStorage);
         await consoleLogsManager.EnsureInitializedAsync();
-        var consoleLogsFetcher = new ConsoleLogsFetcher(dashboardClient, consoleLogsManager);
-        return new TelemetryExportService(repository, consoleLogsFetcher, dashboardClient, Array.Empty<IOutgoingPeerResolver>());
+        var temporaryDirectory = Directory.CreateTempSubdirectory();
+        _temporaryDirectories.Add(temporaryDirectory);
+        var runStore = new TestDashboardRunStore(databasePath: Path.Combine(temporaryDirectory.FullName, "dashboard.db"));
+        var dataSourcePool = TestDashboardDataSource.CreatePool(repository, dashboardClient, runStore);
+        var dataSource = TestDashboardDataSource.Create(runStore, dataSourcePool);
+        _databasePools.Add(dataSourcePool);
+        _dataSources.Add(dataSource);
+        var consoleLogsFetcher = new ConsoleLogsFetcher(dataSource, dashboardClient, consoleLogsManager);
+        return new TelemetryExportService(dataSource, consoleLogsFetcher, dashboardClient);
     }
 
-    private static Dictionary<string, HashSet<AspireDataType>> BuildAllResourcesSelection(TelemetryRepository repository)
+    private static Dictionary<string, HashSet<AspireDataType>> BuildAllResourcesSelection(ITelemetryRepository repository)
     {
         var allResources = repository.GetResources();
         return allResources.ToDictionary(
@@ -1109,11 +1283,11 @@ public sealed class TelemetryExportServiceTests
             _ => new HashSet<AspireDataType>([AspireDataType.ConsoleLogs, AspireDataType.StructuredLogs, AspireDataType.Traces, AspireDataType.Metrics]));
     }
 
-    private static void AddTestData(TelemetryRepository repository, string resourceName, string instanceId)
+    private static async Task AddTestData(SqliteTelemetryRepository repository, string resourceName, string instanceId)
     {
         var compositeName = $"{resourceName}-{instanceId}";
 
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>()
+        await repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1129,7 +1303,7 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1148,7 +1322,7 @@ public sealed class TelemetryExportServiceTests
             }
         });
 
-        repository.AddMetrics(new AddContext(), new RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>()
+        await repository.AddMetricsAsync(new AddContext(), new RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>()
         {
             new OpenTelemetry.Proto.Metrics.V1.ResourceMetrics
             {
@@ -1166,6 +1340,36 @@ public sealed class TelemetryExportServiceTests
                 }
             }
         });
+    }
+
+    private static async Task<SqliteRepositoryTestContext<SqliteTelemetryRepository>> CreateRepositoryAsync(
+        string workspacePath)
+    {
+        var context = await SqliteRepositoryTestHelpers.CreateTelemetryRepositoryAsync(
+            Path.Combine(workspacePath, "dashboard.db"),
+            dashboardOptions: Options.Create(new DashboardOptions
+            {
+                TelemetryLimits = new TelemetryLimitOptions { MaxLogCount = 40_000 }
+            }));
+        return context;
+    }
+
+    public void Dispose()
+    {
+        foreach (var dataSource in _dataSources)
+        {
+            dataSource.Dispose();
+        }
+
+        foreach (var databasePool in _databasePools)
+        {
+            databasePool.Dispose();
+        }
+
+        foreach (var temporaryDirectory in _temporaryDirectories)
+        {
+            temporaryDirectory.Delete(recursive: true);
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryImportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryImportServiceTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.IO.Compression;
 using System.Text;
@@ -10,6 +11,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Otlp.Serialization;
+using Aspire.Tests;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Logs.V1;
@@ -23,11 +25,29 @@ public sealed class TelemetryImportServiceTests
 {
     private static readonly DateTime s_testTime = new(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
 
-    private static TelemetryImportService CreateImportService(TelemetryRepository repository, bool disableImport = false)
+    private static TelemetryImportService CreateImportService(InMemoryTelemetryRepository repository, bool disableImport = false, DashboardActivitySource? activitySource = null)
     {
         var options = new DashboardOptions { UI = new UIOptions { DisableImport = disableImport } };
         var optionsMonitor = new TestOptionsMonitor<DashboardOptions>(options);
-        return new TelemetryImportService(repository, optionsMonitor, NullLogger<TelemetryImportService>.Instance);
+        return new TelemetryImportService(repository, optionsMonitor, NullLogger<TelemetryImportService>.Instance, activitySource ?? new DashboardActivitySource());
+    }
+
+    [Fact]
+    public async Task ImportAsync_CreatesActivity()
+    {
+        var repository = CreateRepository();
+        using var activitySource = new DashboardActivitySource();
+        var service = CreateImportService(repository, activitySource: activitySource);
+        var activities = new List<Activity>();
+        using var listener = ActivityListenerHelper.Create(activitySource.ActivitySource, onActivityStopped: activities.Add);
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(CreateLogsJson("TestService", "instance-1", "Test log message")));
+
+        await service.ImportAsync("logs.json", stream, CancellationToken.None);
+
+        var activity = Assert.Single(activities);
+        Assert.Equal(DashboardActivitySource.ActivitySourceName, activity.Source.Name);
+        Assert.Equal("Import telemetry data", activity.OperationName);
+        Assert.Equal(ActivityKind.Internal, activity.Kind);
     }
 
     [Fact]
@@ -64,7 +84,7 @@ public sealed class TelemetryImportServiceTests
         Assert.Single(resources);
         Assert.Equal("TestService", resources[0].ResourceName);
 
-        var logs = repository.GetLogs(GetLogsContext.ForResourceKey(resources[0].ResourceKey));
+        var logs = await repository.GetLogsAsync(GetLogsContext.ForResourceKey(resources[0].ResourceKey), cancellationToken: CancellationToken.None);
 
         Assert.Single(logs.Items);
         Assert.Equal("Test log message", logs.Items[0].Message);
@@ -88,7 +108,7 @@ public sealed class TelemetryImportServiceTests
         var resources = repository.GetResources();
         Assert.Single(resources);
 
-        var traces = repository.GetTraces(GetTracesRequest.ForResourceKey(resources[0].ResourceKey));
+        var traces = await repository.GetTracesAsync(GetTracesRequest.ForResourceKey(resources[0].ResourceKey), cancellationToken: CancellationToken.None);
 
         Assert.Single(traces.PagedResult.Items);
     }
@@ -111,7 +131,7 @@ public sealed class TelemetryImportServiceTests
         var resources = repository.GetResources();
         Assert.Single(resources);
 
-        var instruments = resources[0].GetInstrumentsSummary();
+        var instruments = repository.GetInstrumentSummaries(resources[0].ResourceKey);
         Assert.Single(instruments);
         Assert.Equal("test.metric", instruments[0].Name);
     }
@@ -269,7 +289,7 @@ public sealed class TelemetryImportServiceTests
         var sourceRepository = CreateRepository();
         var addContext = new AddContext();
 
-        sourceRepository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await sourceRepository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -286,7 +306,7 @@ public sealed class TelemetryImportServiceTests
         });
 
         var resources = sourceRepository.GetResources();
-        var logs = sourceRepository.GetLogs(GetLogsContext.ForResourceKey(resources[0].ResourceKey));
+        var logs = await sourceRepository.GetLogsAsync(GetLogsContext.ForResourceKey(resources[0].ResourceKey), cancellationToken: CancellationToken.None);
 
         // Export
         var exportedJson = TelemetryExportService.ConvertLogsToOtlpJson(logs.Items);
@@ -306,7 +326,7 @@ public sealed class TelemetryImportServiceTests
         Assert.Equal("RoundTripService", importedResources[0].ResourceName);
         Assert.Equal("round-trip-1", importedResources[0].InstanceId);
 
-        var importedLogs = targetRepository.GetLogs(GetLogsContext.ForResourceKey(importedResources[0].ResourceKey));
+        var importedLogs = await targetRepository.GetLogsAsync(GetLogsContext.ForResourceKey(importedResources[0].ResourceKey), cancellationToken: CancellationToken.None);
 
         Assert.Single(importedLogs.Items);
         Assert.Equal("Round trip test", importedLogs.Items[0].Message);
@@ -320,7 +340,7 @@ public sealed class TelemetryImportServiceTests
         var sourceRepository = CreateRepository();
         var addContext = new AddContext();
 
-        sourceRepository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await sourceRepository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -337,7 +357,7 @@ public sealed class TelemetryImportServiceTests
         });
 
         var resources = sourceRepository.GetResources();
-        var logs = sourceRepository.GetLogs(GetLogsContext.ForResourceKey(resources[0].ResourceKey));
+        var logs = await sourceRepository.GetLogsAsync(GetLogsContext.ForResourceKey(resources[0].ResourceKey), cancellationToken: CancellationToken.None);
         var originalInternalId = logs.Items[0].InternalId;
 
         // Export adds aspire.log_id attribute
@@ -361,7 +381,7 @@ public sealed class TelemetryImportServiceTests
         var importedResources = targetRepository.GetResources();
         Assert.Single(importedResources);
 
-        var importedLogs = targetRepository.GetLogs(GetLogsContext.ForResourceKey(importedResources[0].ResourceKey));
+        var importedLogs = await targetRepository.GetLogsAsync(GetLogsContext.ForResourceKey(importedResources[0].ResourceKey), cancellationToken: CancellationToken.None);
         Assert.Single(importedLogs.Items);
 
         // Verify aspire.log_id is NOT in the imported log's attributes (it should be filtered out)
@@ -381,7 +401,7 @@ public sealed class TelemetryImportServiceTests
         var sourceRepository = CreateRepository();
         var addContext = new AddContext();
 
-        sourceRepository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await sourceRepository.AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -398,10 +418,10 @@ public sealed class TelemetryImportServiceTests
         });
 
         var resources = sourceRepository.GetResources();
-        var traces = sourceRepository.GetTraces(GetTracesRequest.ForResourceKey(resources[0].ResourceKey));
+        var traces = await sourceRepository.GetTracesAsync(GetTracesRequest.ForResourceKey(resources[0].ResourceKey), cancellationToken: CancellationToken.None);
 
         // Export
-        var exportedJson = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items, []);
+        var exportedJson = TelemetryExportService.ConvertTracesToOtlpJson(traces.PagedResult.Items);
         var jsonString = JsonSerializer.Serialize(exportedJson, OtlpJsonSerializerContext.DefaultOptions);
 
         // Import
@@ -417,7 +437,7 @@ public sealed class TelemetryImportServiceTests
         Assert.Single(importedResources);
         Assert.Equal("TraceRoundTrip", importedResources[0].ResourceName);
 
-        var importedTraces = targetRepository.GetTraces(GetTracesRequest.ForResourceKey(importedResources[0].ResourceKey));
+        var importedTraces = await targetRepository.GetTracesAsync(GetTracesRequest.ForResourceKey(importedResources[0].ResourceKey), cancellationToken: CancellationToken.None);
 
         Assert.Single(importedTraces.PagedResult.Items);
     }

--- a/tests/Aspire.Dashboard.Tests/Model/TraceDetailPageViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TraceDetailPageViewModelTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Tests.Shared.Telemetry;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -105,9 +106,23 @@ public sealed class TraceDetailPageViewModelTests
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         var span = TelemetryTestHelpers.CreateOtlpSpan(resource, trace, scope, spanId: "span1", parentSpanId: null, startDate: DateTime.UtcNow);
-        var logEntry = new OtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(message: "test log"), resourceView, scope, context);
+        var logEntry = TelemetryTestHelpers.CreateOtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(message: "test log"), resourceView, scope, context);
+        var logSummary = new LogSummary
+        {
+            InternalId = logEntry.InternalId,
+            TimeStamp = logEntry.TimeStamp,
+            Severity = logEntry.Severity,
+            Message = logEntry.Message,
+            SpanId = logEntry.SpanId,
+            TraceId = logEntry.TraceId,
+            ScopeName = logEntry.Scope.Name,
+            EventName = logEntry.EventName,
+            Resource = resource,
+            ExceptionText = null,
+            HasGenAI = false
+        };
 
-        var spanVm = CreateSpanWaterfallViewModel(span, [new SpanLogEntryViewModel { Index = 0, LogEntry = logEntry, LeftOffset = 0 }]);
+        var spanVm = CreateSpanWaterfallViewModel(span, [new SpanLogEntryViewModel { Index = 0, LogEntry = logSummary, LeftOffset = 0 }]);
 
         var vm = new TraceDetailPageViewModel
         {
@@ -132,7 +147,7 @@ public sealed class TraceDetailPageViewModelTests
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
         var scope = TelemetryTestHelpers.CreateOtlpScope(context);
         var span = TelemetryTestHelpers.CreateOtlpSpan(resource, trace, scope, spanId: "span1", parentSpanId: null, startDate: DateTime.UtcNow);
-        var logEntry = new OtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(message: "test log"), resourceView, scope, context);
+        var logEntry = TelemetryTestHelpers.CreateOtlpLogEntry(TelemetryTestHelpers.CreateLogRecord(message: "test log"), resourceView, scope, context);
 
         // Span with no logs
         var spanVm = CreateSpanWaterfallViewModel(span);

--- a/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
@@ -151,4 +151,42 @@ public sealed class TraceHelpersTests
                 Assert.Equal(app3, g.Resource);
             });
     }
+
+    [Fact]
+    public void GetOrderedResources_SameStartTime_UninstrumentedPeerAfterInstrumentedResources()
+    {
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var app2 = new OtlpResource("app2", "instance", uninstrumentedPeer: false, context);
+        var peer = new OtlpResource("peer", instanceId: null, uninstrumentedPeer: true, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+        var startTime = new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+        trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: startTime, uninstrumentedPeer: peer));
+        trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app2, trace, scope, spanId: "2", parentSpanId: null, startDate: startTime));
+
+        var results = TraceHelpers.GetOrderedResources(trace);
+
+        Assert.Collection(results,
+            resource => Assert.False(resource.Resource.UninstrumentedPeer),
+            resource => Assert.False(resource.Resource.UninstrumentedPeer),
+            resource => Assert.Same(peer, resource.Resource));
+    }
+
+    [Fact]
+    public void GetOrderedResources_DifferentResourceInstancesWithSameKey_GroupedResult()
+    {
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpResource("app1", "instance", uninstrumentedPeer: false, context);
+        var equivalentApp1 = new OtlpResource("app1", "instance", uninstrumentedPeer: true, context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 }, DateTime.MinValue);
+        var scope = TelemetryTestHelpers.CreateOtlpScope(context);
+        trace.AddSpan(TelemetryTestHelpers.CreateOtlpSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc), uninstrumentedPeer: equivalentApp1));
+
+        var results = TraceHelpers.GetOrderedResources(trace);
+
+        var result = Assert.Single(results);
+        Assert.Same(app1, result.Resource);
+        Assert.Equal(2, result.TotalSpans);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -2,12 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 using Aspire.DashboardService.Proto.V1;
+using Aspire.Tests;
 using Aspire.Tests.Shared.DashboardModel;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Struct = Google.Protobuf.WellKnownTypes.Struct;
 using Value = Google.Protobuf.WellKnownTypes.Value;
@@ -274,19 +279,20 @@ public class ResourceOutgoingPeerResolverTests
     public async Task OnPeerChanges_DataUpdates_EventRaised()
     {
         // Arrange
+        Assert.Equal(TimeSpan.FromMilliseconds(500), CallbackThrottler.DefaultMinExecuteInterval);
+
         var tcs = new TaskCompletionSource<ResourceViewModelSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
         var sourceChannel = Channel.CreateUnbounded<ResourceViewModelChange>();
-        var resultChannel = Channel.CreateUnbounded<int>();
+        var resultChannel = Channel.CreateUnbounded<(int ChangeCount, long Timestamp)>();
         var dashboardClient = new MockDashboardClient(tcs.Task);
-        var resolver = new ResourceOutgoingPeerResolver(dashboardClient);
+        var resolver = CreateResolver(dashboardClient);
         var changeCount = 0;
         resolver.OnPeerChanges(async () =>
         {
-            await resultChannel.Writer.WriteAsync(++changeCount);
+            await resultChannel.Writer.WriteAsync((++changeCount, Stopwatch.GetTimestamp()));
         });
 
-        var readValue = 0;
-        Assert.False(resultChannel.Reader.TryRead(out readValue));
+        Assert.False(resultChannel.Reader.TryRead(out _));
 
         // Act 1
         // Initial resource causes change.
@@ -295,8 +301,9 @@ public class ResourceOutgoingPeerResolverTests
             GetChanges()));
 
         // Assert 1
-        readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
-        Assert.Equal(1, readValue);
+        var readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
+        Assert.Equal(1, readValue.ChangeCount);
+        var previousTimestamp = readValue.Timestamp;
 
         // Act 2
         // New resource causes change.
@@ -304,7 +311,9 @@ public class ResourceOutgoingPeerResolverTests
 
         // Assert 2
         readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
-        Assert.Equal(2, readValue);
+        Assert.Equal(2, readValue.ChangeCount);
+        AssertMinimumExecuteInterval(previousTimestamp, readValue.Timestamp);
+        previousTimestamp = readValue.Timestamp;
 
         // Act 3
         // URL change causes change.
@@ -312,7 +321,8 @@ public class ResourceOutgoingPeerResolverTests
 
         // Assert 3
         readValue = await resultChannel.Reader.ReadAsync().DefaultTimeout();
-        Assert.Equal(3, readValue);
+        Assert.Equal(3, readValue.ChangeCount);
+        AssertMinimumExecuteInterval(previousTimestamp, readValue.Timestamp);
 
         // Act 4
         // Resource update doesn't cause change.
@@ -332,6 +342,91 @@ public class ResourceOutgoingPeerResolverTests
             {
                 yield return [item];
             }
+        }
+
+        static void AssertMinimumExecuteInterval(long startTimestamp, long endTimestamp)
+        {
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp, endTimestamp);
+            Assert.True(elapsed >= CallbackThrottler.DefaultMinExecuteInterval - TimeSpan.FromMilliseconds(50), $"Callbacks executed too quickly: {elapsed}.");
+        }
+    }
+
+    [Fact]
+    public async Task Constructor_AmbientActivity_DoesNotFlowToResourceWatch()
+    {
+        var subscribeResult = new TaskCompletionSource<ResourceViewModelSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dashboardClient = new MockDashboardClient(subscribeResult.Task);
+        using var activity = new Activity("request").Start();
+        var resolver = CreateResolver(dashboardClient);
+
+        Assert.Null(await dashboardClient.ActivityOnSubscribe.Task.DefaultTimeout());
+
+        var sourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        sourceChannel.Writer.Complete();
+        subscribeResult.SetResult(new ResourceViewModelSubscription([], sourceChannel.Reader.ReadAllAsync()));
+        await resolver.DisposeAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task OnPeerChanges_AmbientExecutionContext_DoesNotFlowToCallback()
+    {
+        var subscribeResult = new TaskCompletionSource<ResourceViewModelSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var resolver = CreateResolver(new MockDashboardClient(subscribeResult.Task));
+        var ambientValue = new AsyncLocal<string?> { Value = "request" };
+        var callbackValue = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        resolver.OnPeerChanges(() =>
+        {
+            callbackValue.SetResult(ambientValue.Value);
+            return Task.CompletedTask;
+        });
+
+        var sourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        subscribeResult.SetResult(new ResourceViewModelSubscription(
+            [CreateResource("test", serviceAddress: "localhost", servicePort: 8080)],
+            sourceChannel.Reader.ReadAllAsync()));
+
+        Assert.Null(await callbackValue.Task.DefaultTimeout());
+
+        ambientValue.Value = null;
+        sourceChannel.Writer.Complete();
+        await resolver.DisposeAsync().DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ResourceChanges_CreateActivityForEachBatch()
+    {
+        using var activitySource = new DashboardActivitySource();
+        var subscribeResult = new TaskCompletionSource<ResourceViewModelSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var activities = new ConcurrentQueue<Activity>();
+        var activitiesReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var listener = ActivityListenerHelper.Create(activitySource.ActivitySource, onActivityStopped: activity =>
+        {
+            activities.Enqueue(activity);
+            if (activities.Count == 2)
+            {
+                activitiesReceived.TrySetResult();
+            }
+        });
+        var resolver = CreateResolver(new MockDashboardClient(subscribeResult.Task), activitySource);
+        subscribeResult.SetResult(new ResourceViewModelSubscription([], sourceChannel.Reader.ReadAllAsync()));
+
+        await sourceChannel.Writer.WriteAsync([new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test", state: KnownResourceState.Starting))]);
+        await sourceChannel.Writer.WriteAsync([new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test", state: KnownResourceState.Running))]);
+        await activitiesReceived.Task.DefaultTimeout();
+        sourceChannel.Writer.Complete();
+        await resolver.DisposeAsync().DefaultTimeout();
+
+        Assert.Collection(
+            activities,
+            AssertActivity,
+            AssertActivity);
+
+        static void AssertActivity(Activity activity)
+        {
+            Assert.Equal(DashboardActivitySource.ActivitySourceName, activity.Source.Name);
+            Assert.Equal("Process resource subscription changes", activity.OperationName);
+            Assert.Equal(ActivityKind.Consumer, activity.Kind);
         }
     }
 
@@ -370,6 +465,14 @@ public class ResourceOutgoingPeerResolverTests
     private static bool TryResolvePeerName(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, out string? peerName)
     {
         return ResourceOutgoingPeerResolver.TryResolvePeerCore(resources, attributes, out peerName, out _);
+    }
+
+    private static ResourceOutgoingPeerResolver CreateResolver(IResourceRepository resourceRepository, DashboardActivitySource? activitySource = null)
+    {
+        return new ResourceOutgoingPeerResolver(
+            resourceRepository,
+            activitySource ?? new DashboardActivitySource(),
+            NullLogger<ResourceOutgoingPeerResolver>.Instance);
     }
 
     [Fact]
@@ -578,6 +681,7 @@ public class ResourceOutgoingPeerResolverTests
 
     private sealed class MockDashboardClient(Task<ResourceViewModelSubscription> subscribeResult) : IDashboardClient
     {
+        public TaskCompletionSource<Activity?> ActivityOnSubscribe { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public bool IsEnabled => true;
         public Task WhenConnected => Task.CompletedTask;
         public string ApplicationName => "ApplicationName";
@@ -593,9 +697,14 @@ public class ResourceOutgoingPeerResolverTests
         public ResourceViewModel? GetResource(string resourceName) => null;
         public IReadOnlyList<ResourceViewModel> GetResources() => [];
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate) => Task.CompletedTask;
         public Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<WatchInteractionsResponseUpdate> SubscribeInteractionsAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
-        public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => subscribeResult;
+        public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken)
+        {
+            ActivityOnSubscribe.TrySetResult(Activity.Current);
+            return subscribeResult;
+        }
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Shared/SqliteRepositoryTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Shared/SqliteRepositoryTestHelpers.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.Tests.Shared;
+
+internal static class SqliteRepositoryTestHelpers
+{
+    public static async Task<SqliteRepositoryTestContext<SqliteTelemetryRepository>> CreateTelemetryRepositoryAsync(
+        string databasePath,
+        bool readOnly = false,
+        bool pooling = false,
+        ILoggerFactory? loggerFactory = null,
+        IOptions<DashboardOptions>? dashboardOptions = null,
+        PauseManager? pauseManager = null,
+        TimeProvider? timeProvider = null,
+        IEnumerable<IOutgoingPeerResolver>? outgoingPeerResolvers = null)
+    {
+        var database = new DashboardSqliteDatabase(databasePath, readOnly, pooling);
+        try
+        {
+            if (!readOnly)
+            {
+                await database.InitializeSchemaAsync(cancellationToken: CancellationToken.None);
+            }
+
+            var repository = new SqliteTelemetryRepository(
+                database,
+                loggerFactory ?? NullLoggerFactory.Instance,
+                dashboardOptions ?? Options.Create(new DashboardOptions()),
+                pauseManager ?? new PauseManager(),
+                timeProvider ?? TimeProvider.System,
+                outgoingPeerResolvers ?? []);
+            return new SqliteRepositoryTestContext<SqliteTelemetryRepository>(database, repository);
+        }
+        catch
+        {
+            database.ClearPool();
+            database.Dispose();
+            throw;
+        }
+    }
+
+    public static SqliteRepositoryTestContext<SqliteResourceRepository> CreateResourceRepository(
+        string databasePath,
+        IKnownPropertyLookup knownPropertyLookup,
+        bool readOnly = false,
+        bool pooling = false,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var database = new DashboardSqliteDatabase(databasePath, readOnly, pooling);
+        try
+        {
+            if (!readOnly)
+            {
+                database.InitializeSchemaAsync(cancellationToken: CancellationToken.None).GetAwaiter().GetResult();
+            }
+
+            var repository = new SqliteResourceRepository(
+                database,
+                knownPropertyLookup,
+                loggerFactory ?? NullLoggerFactory.Instance);
+            return new SqliteRepositoryTestContext<SqliteResourceRepository>(database, repository);
+        }
+        catch
+        {
+            database.ClearPool();
+            database.Dispose();
+            throw;
+        }
+    }
+}
+
+internal sealed class SqliteRepositoryTestContext<TRepository>(
+    DashboardSqliteDatabase database,
+    TRepository repository) : IDisposable
+    where TRepository : IDisposable
+{
+    public DashboardSqliteDatabase Database { get; } = database;
+
+    public TRepository Repository { get; } = repository;
+
+    public void Dispose()
+    {
+        try
+        {
+            Repository.Dispose();
+        }
+        finally
+        {
+            Database.ClearPool();
+            Database.Dispose();
+        }
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Shared/TestDashboardDataSource.cs
+++ b/tests/Aspire.Dashboard.Tests/Shared/TestDashboardDataSource.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.ServiceClient;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Dashboard.Tests.Shared;
+
+internal static class TestDashboardDataSource
+{
+    public static DashboardDataSource Create(
+        IDashboardRunStore runStore,
+        DashboardDataSourcePool dataSourcePool)
+    {
+        return new DashboardDataSource(
+            runStore,
+            NullLogger<DashboardDataSource>.Instance,
+            dataSourcePool);
+    }
+
+    public static DashboardDataSourcePool CreatePool(
+        ITelemetryRepository telemetryRepository,
+        IResourceRepository resourceRepository,
+        IDashboardRunStore runStore)
+    {
+        return new DashboardDataSourcePool(
+            runStore,
+            new TestRepositoryFactory(telemetryRepository, resourceRepository));
+    }
+
+    private sealed class TestRepositoryFactory(
+        ITelemetryRepository telemetryRepository,
+        IResourceRepository resourceRepository) : IRepositoryFactory
+    {
+        public ITelemetryRepository CreateTelemetryRepository(DashboardSqliteDatabase database) => telemetryRepository;
+        public IResourceRepository CreateResourceRepository(DashboardSqliteDatabase database) => resourceRepository;
+    }
+}
+
+internal sealed class TestDashboardRunStore(
+    IEnumerable<DashboardRunDescriptor>? runs = null,
+    Func<DashboardRunDescriptor, IDisposable?>? tryAcquireRunLease = null,
+    string? databasePath = null) : IDashboardRunStore
+{
+    private readonly IReadOnlyList<DashboardRunDescriptor> _runs = (runs ??
+        [new("current", DashboardRunStore.SchemaVersion, DateTimeOffset.UnixEpoch, null, false, "TestApp", databasePath ?? string.Empty, IsCurrent: true)])
+        .ToArray();
+
+    public bool SupportsRunSelection => _runs.Any(run => !run.IsCurrent);
+
+    public IReadOnlyList<DashboardRunDescriptor> GetRuns() => _runs;
+
+    public DashboardRunDescriptor GetCurrentRun() => _runs.Single(run => run.IsCurrent);
+
+    public DashboardRunDescriptor? GetRunById(string runId) =>
+        _runs.SingleOrDefault(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+
+    public void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
+    {
+        _runs.Single(candidate => string.Equals(candidate.RunId, run.RunId, StringComparison.Ordinal)).IsPinned = isPinned;
+    }
+
+    public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run) => tryAcquireRunLease?.Invoke(run);
+
+    public void PublishRun()
+    {
+    }
+
+    public void PruneExpiredRuns()
+    {
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Shared/TestHostApplicationLifetime.cs
+++ b/tests/Aspire.Dashboard.Tests/Shared/TestHostApplicationLifetime.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+
+namespace Aspire.Dashboard.Tests.Shared;
+
+internal sealed class TestHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+{
+    private readonly CancellationTokenSource _started = new();
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly CancellationTokenSource _stopped = new();
+
+    public CancellationToken ApplicationStarted => _started.Token;
+    public CancellationToken ApplicationStopping => _stopping.Token;
+    public CancellationToken ApplicationStopped => _stopped.Token;
+
+    public void NotifyStarted() => _started.Cancel();
+
+    public void StopApplication() => _stopping.Cancel();
+
+    public void Dispose()
+    {
+        _started.Dispose();
+        _stopping.Dispose();
+        _stopped.Dispose();
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryApiServiceTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Aspire.Dashboard.Api;
-using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Otlp.Serialization;
@@ -23,8 +22,8 @@ public class TelemetryApiServiceTests
     [Fact]
     public async Task FollowSpansAsync_StreamsAllSpans()
     {
-        var repository = CreateRepository();
-        AddSpans(repository, count: 5);
+        var repository = CreateRepository(subscriptionMinExecuteInterval: TimeSpan.Zero);
+        await AddSpans(repository, count: 5);
 
         var service = CreateService(repository);
 
@@ -44,8 +43,8 @@ public class TelemetryApiServiceTests
     [Fact]
     public async Task FollowLogsAsync_StreamsAllLogs()
     {
-        var repository = CreateRepository();
-        AddLogs(repository, ["log1", "log2", "log3", "log4", "log5"]);
+        var repository = CreateRepository(subscriptionMinExecuteInterval: TimeSpan.Zero);
+        await AddLogs(repository, ["log1", "log2", "log3", "log4", "log5"]);
 
         var service = CreateService(repository);
 
@@ -66,14 +65,14 @@ public class TelemetryApiServiceTests
     [InlineData(false, 1)]
     [InlineData(true, 1)]
     [InlineData(null, 2)]
-    public void GetTraces_HasErrorFilter_ReturnsExpectedTraces(bool? hasError, int expectedCount)
+    public async Task GetTraces_HasErrorFilter_ReturnsExpectedTraces(bool? hasError, int expectedCount)
     {
         var repository = CreateRepository();
-        AddTracesWithStatus(repository);
+        await AddTracesWithStatus(repository);
 
         var service = CreateService(repository);
 
-        var result = service.GetTraces(resourceNames: null, hasError: hasError, limit: null);
+        var result = await service.GetTracesAsync(resourceNames: null, hasError: hasError, limit: null, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(expectedCount, result.ReturnedCount);
@@ -83,7 +82,7 @@ public class TelemetryApiServiceTests
     public async Task FollowSpansAsync_WithInvalidResourceName_ReturnsNoSpans()
     {
         var repository = CreateRepository();
-        AddSpans(repository, count: 1);
+        await AddSpans(repository, count: 1);
 
         var service = CreateService(repository);
 
@@ -106,7 +105,7 @@ public class TelemetryApiServiceTests
     public async Task FollowLogsAsync_WithInvalidResourceName_ReturnsNoLogs()
     {
         var repository = CreateRepository();
-        AddLogs(repository, ["log1"]);
+        await AddLogs(repository, ["log1"]);
 
         var service = CreateService(repository);
 
@@ -130,12 +129,12 @@ public class TelemetryApiServiceTests
     [InlineData("7472616", true)] // shortened (7 char) prefix
     [InlineData("747261", false)] // too short
     [InlineData("nonexistent", false)]
-    public void GetTrace_VariousTraceIds_ReturnsExpectedResult(string lookupId, bool expectFound)
+    public async Task GetTrace_VariousTraceIds_ReturnsExpectedResult(string lookupId, bool expectFound)
     {
         var repository = CreateRepository();
         var traceId = Encoding.UTF8.GetString(Convert.FromHexString("747261636531"));
 
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: traceId, spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
         ]);
 
@@ -160,7 +159,7 @@ public class TelemetryApiServiceTests
         var repository = CreateRepository();
         var traceId = Encoding.UTF8.GetString(Convert.FromHexString("747261636531"));
 
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: traceId, spanId: "matching-span", startTime: s_testTime, endTime: s_testTime.AddMinutes(1)),
             CreateSpan(traceId: "other-trace", spanId: "other-span", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3))
         ]);
@@ -180,12 +179,12 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetTrace_ReturnsAllSpansForTrace()
+    public async Task GetTrace_ReturnsAllSpansForTrace()
     {
         var repository = CreateRepository();
         var traceId = Encoding.UTF8.GetString(Convert.FromHexString("747261636531"));
 
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: traceId, spanId: "short-span", startTime: s_testTime, endTime: s_testTime.AddMilliseconds(49)),
             CreateSpan(traceId: traceId, spanId: "long-span", startTime: s_testTime.AddSeconds(1), endTime: s_testTime.AddSeconds(1).AddMilliseconds(50))
         ]);
@@ -200,14 +199,14 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetTraces_WithLimit_ReturnsMostRecentTraces()
+    public async Task GetTraces_WithLimit_ReturnsMostRecentTraces()
     {
         var repository = CreateRepository();
-        AddSpans(repository, count: 3, startMinuteSpacing: 10);
+        await AddSpans(repository, count: 3, startMinuteSpacing: 10);
 
         var service = CreateService(repository);
 
-        var result = service.GetTraces(resourceNames: null, hasError: null, limit: 2);
+        var result = await service.GetTracesAsync(resourceNames: null, hasError: null, limit: 2, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(3, result.TotalCount);
@@ -220,14 +219,14 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetTraces_WithLimitAndDurationSearchFilter_ReturnsMostRecentMatchingTraces()
+    public async Task GetTraces_WithLimitAndDurationSearchFilter_ReturnsMostRecentMatchingTraces()
     {
         var repository = CreateRepository();
-        AddSpans(repository, count: 3, startMinuteSpacing: 10);
+        await AddSpans(repository, count: 3, startMinuteSpacing: 10);
 
         var service = CreateService(repository);
 
-        var result = service.GetTraces(resourceNames: null, hasError: null, limit: 2, search: "duration:>=50");
+        var result = await service.GetTracesAsync(resourceNames: null, hasError: null, limit: 2, cancellationToken: CancellationToken.None, search: "duration:>=50");
 
         Assert.NotNull(result);
         Assert.Equal(3, result.TotalCount);
@@ -241,20 +240,20 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetTraces_WithDurationSearchFilter_FiltersShortSpans()
+    public async Task GetTraces_WithDurationSearchFilter_FiltersShortSpans()
     {
         var repository = CreateRepository();
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "short-trace", spanId: "short-trace-span", startTime: s_testTime, endTime: s_testTime.AddMilliseconds(49))
         ]);
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "mixed-trace", spanId: "mixed-short-span", startTime: s_testTime.AddSeconds(1), endTime: s_testTime.AddSeconds(1).AddMilliseconds(49)),
             CreateSpan(traceId: "mixed-trace", spanId: "mixed-long-span", startTime: s_testTime.AddSeconds(2), endTime: s_testTime.AddSeconds(2).AddMilliseconds(50))
         ]);
 
         var service = CreateService(repository);
 
-        var result = service.GetTraces(resourceNames: null, hasError: null, limit: null, search: "duration:>=50");
+        var result = await service.GetTracesAsync(resourceNames: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: "duration:>=50");
 
         Assert.NotNull(result);
         // The trace with short-trace-span (49ms) is excluded because no span matches the filter.
@@ -269,10 +268,10 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetTraces_WithHasErrorAndDurationSearchFilter_ReturnsAllSpansFromMatchingTraces()
+    public async Task GetTraces_WithHasErrorAndDurationSearchFilter_ReturnsAllSpansFromMatchingTraces()
     {
         var repository = CreateRepository();
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(
                 traceId: "mixed-trace",
                 spanId: "short-error-span",
@@ -289,7 +288,7 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetTraces(resourceNames: null, hasError: true, limit: null, search: "duration:>=50");
+        var result = await service.GetTracesAsync(resourceNames: null, hasError: true, limit: null, cancellationToken: CancellationToken.None, search: "duration:>=50");
 
         Assert.NotNull(result);
         // The trace matches hasError because it has an error span.
@@ -305,14 +304,14 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetLogs_WithLimit_ReturnsMostRecentLogs()
+    public async Task GetLogs_WithLimit_ReturnsMostRecentLogs()
     {
         var repository = CreateRepository();
-        AddLogs(repository, ["old-log", "mid-log", "new-log"]);
+        await AddLogs(repository, ["old-log", "mid-log", "new-log"]);
 
         var service = CreateService(repository);
 
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: 2);
+        var result = await service.GetLogsAsync(resourceNames: null, traceId: null, severity: null, limit: 2, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(3, result.TotalCount);
@@ -325,7 +324,7 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetLogs_LargeLimit_ReturnsAllLogs()
+    public async Task GetLogs_LargeLimit_ReturnsAllLogs()
     {
         const int totalLogs = 20_000;
         var repository = CreateRepository(maxLogCount: totalLogs);
@@ -336,11 +335,11 @@ public class TelemetryApiServiceTests
             logRecords.Add(CreateLogRecord(time: s_testTime.AddMilliseconds(i), message: $"log{i}", severity: SeverityNumber.Info));
         }
 
-        AddLogsToRepository(repository, logRecords);
+        await AddLogsToRepository(repository, logRecords);
 
         var service = CreateService(repository);
 
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: 100_000);
+        var result = await service.GetLogsAsync(resourceNames: null, traceId: null, severity: null, limit: 100_000, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(totalLogs, result.TotalCount);
@@ -350,39 +349,39 @@ public class TelemetryApiServiceTests
     [Theory]
     [InlineData("Connection", 2)]
     [InlineData("nonexistent", 0)]
-    public void GetLogs_WithSearch_FiltersLogsByMessage(string search, int expectedCount)
+    public async Task GetLogs_WithSearch_FiltersLogsByMessage(string search, int expectedCount)
     {
         var repository = CreateRepository();
-        AddLogs(repository, ["Connection established", "Request received", "Connection closed"]);
+        await AddLogs(repository, ["Connection established", "Request received", "Connection closed"]);
 
         var service = CreateService(repository);
 
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: search);
+        var result = await service.GetLogsAsync(resourceNames: null, traceId: null, severity: null, limit: null, cancellationToken: CancellationToken.None, search: search);
 
         Assert.NotNull(result);
         Assert.Equal(expectedCount, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetLogs_WithSearch_IsCaseInsensitive()
+    public async Task GetLogs_WithSearch_IsCaseInsensitive()
     {
         var repository = CreateRepository();
-        AddLogs(repository, ["UPPERCASE warning detected"]);
-        AddLogs(repository, ["Normal log"]);
+        await AddLogs(repository, ["UPPERCASE warning detected"]);
+        await AddLogs(repository, ["Normal log"]);
 
         var service = CreateService(repository);
 
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: "uppercase warning");
+        var result = await service.GetLogsAsync(resourceNames: null, traceId: null, severity: null, limit: null, cancellationToken: CancellationToken.None, search: "uppercase warning");
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetLogs_WithSearch_MatchesAttributes()
+    public async Task GetLogs_WithSearch_MatchesAttributes()
     {
         var repository = CreateRepository();
-        AddLogsToRepository(repository, [
+        await AddLogsToRepository(repository, [
             CreateLogRecord(time: s_testTime, message: "log1", severity: SeverityNumber.Info,
                 attributes: [new KeyValuePair<string, string>("http.url", "/api/products")]),
             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "log2", severity: SeverityNumber.Info,
@@ -391,7 +390,7 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: "products");
+        var result = await service.GetLogsAsync(resourceNames: null, traceId: null, severity: null, limit: null, cancellationToken: CancellationToken.None, search: "products");
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
@@ -400,38 +399,38 @@ public class TelemetryApiServiceTests
     [Theory]
     [InlineData("span1", 1)]
     [InlineData("nonexistent-xyz", 0)]
-    public void GetTraces_WithSearch_FiltersTraces(string search, int expectedCount)
+    public async Task GetTraces_WithSearch_FiltersTraces(string search, int expectedCount)
     {
         var repository = CreateRepository();
 
         // Each trace needs a separate AddTraces call to get distinct trace IDs in the repository
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "trace1", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1))
         ]);
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "trace2", spanId: "span2", startTime: s_testTime.AddMinutes(10), endTime: s_testTime.AddMinutes(11))
         ]);
 
         var service = CreateService(repository);
 
-        var result = service.GetTraces(resourceNames: null, hasError: null, limit: null, search: search);
+        var result = await service.GetTracesAsync(resourceNames: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: search);
 
         Assert.NotNull(result);
         Assert.Equal(expectedCount, result.ReturnedCount);
 
         if (expectedCount > 0)
         {
-            var allResult = service.GetTraces(resourceNames: null, hasError: null, limit: null);
+            var allResult = await service.GetTracesAsync(resourceNames: null, hasError: null, limit: null, cancellationToken: CancellationToken.None);
             Assert.NotNull(allResult);
             Assert.Equal(2, allResult.ReturnedCount);
         }
     }
 
     [Fact]
-    public void GetSpans_WithAttributeFilter_FiltersSpans()
+    public async Task GetSpans_WithAttributeFilter_FiltersSpans()
     {
         var repository = CreateRepository();
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "trace1", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1),
                 attributes: [new KeyValuePair<string, string>("http.method", "GET")]),
             CreateSpan(traceId: "trace1", spanId: "span2", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3),
@@ -440,7 +439,7 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "@http.method:GET");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: "@http.method:GET");
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
@@ -451,21 +450,21 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetTraces_WithAttributeFilter_FiltersTraces()
+    public async Task GetTraces_WithAttributeFilter_FiltersTraces()
     {
         var repository = CreateRepository();
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "trace1", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1),
                 attributes: [new KeyValuePair<string, string>("http.method", "GET")])
         ]);
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "trace2", spanId: "span2", startTime: s_testTime.AddMinutes(10), endTime: s_testTime.AddMinutes(11),
                 attributes: [new KeyValuePair<string, string>("http.method", "POST")])
         ]);
 
         var service = CreateService(repository);
 
-        var result = service.GetTraces(resourceNames: null, hasError: null, limit: null, search: "@http.method:POST");
+        var result = await service.GetTracesAsync(resourceNames: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: "@http.method:POST");
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
@@ -476,10 +475,10 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetLogs_WithAttributeFilter_FiltersLogs()
+    public async Task GetLogs_WithAttributeFilter_FiltersLogs()
     {
         var repository = CreateRepository();
-        AddLogsToRepository(repository, [
+        await AddLogsToRepository(repository, [
             CreateLogRecord(time: s_testTime, message: "log1", severity: SeverityNumber.Info,
                 attributes: [new KeyValuePair<string, string>("http.method", "GET")]),
             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "log2", severity: SeverityNumber.Info,
@@ -488,17 +487,17 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: "@http.method:GET");
+        var result = await service.GetLogsAsync(resourceNames: null, traceId: null, severity: null, limit: null, cancellationToken: CancellationToken.None, search: "@http.method:GET");
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithDurationRangeFilter_ReturnsSpansInRange()
+    public async Task GetSpans_WithDurationRangeFilter_ReturnsSpansInRange()
     {
         var repository = CreateRepository();
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "trace1", spanId: "short-span", startTime: s_testTime, endTime: s_testTime.AddMilliseconds(30)),
             CreateSpan(traceId: "trace1", spanId: "mid-span", startTime: s_testTime.AddSeconds(1), endTime: s_testTime.AddSeconds(1).AddMilliseconds(75)),
             CreateSpan(traceId: "trace1", spanId: "long-span", startTime: s_testTime.AddSeconds(2), endTime: s_testTime.AddSeconds(2).AddMilliseconds(200))
@@ -507,7 +506,7 @@ public class TelemetryApiServiceTests
         var service = CreateService(repository);
 
         // Filter for spans with duration > 50ms AND < 100ms (only mid-span at 75ms matches)
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "duration:>50 duration:<100");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: "duration:>50 duration:<100");
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
@@ -518,10 +517,10 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetLogs_WithUrlSearch_MatchesExactScheme()
+    public async Task GetLogs_WithUrlSearch_MatchesExactScheme()
     {
         var repository = CreateRepository();
-        AddLogs(repository, [
+        await AddLogs(repository, [
             "Request to http://www.contoso.com/api completed",
             "Request to https://www.contoso.com/api completed",
             "No URL in this message"
@@ -530,118 +529,118 @@ public class TelemetryApiServiceTests
         var service = CreateService(repository);
 
         // The entire URL should be treated as a text fragment, not parsed as a qualifier
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: "http://www.contoso.com");
+        var result = await service.GetLogsAsync(resourceNames: null, traceId: null, severity: null, limit: null, cancellationToken: CancellationToken.None, search: "http://www.contoso.com");
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithTimestampGreaterThan_FiltersCorrectly()
+    public async Task GetSpans_WithTimestampGreaterThan_FiltersCorrectly()
     {
         var repository = CreateRepository();
         // Spans at s_testTime+1min, +2min, +3min
-        AddSpans(repository, count: 3);
+        await AddSpans(repository, count: 3);
 
         var service = CreateService(repository);
 
         // Filter for spans after s_testTime+1.5min (should return spans at +2min and +3min)
         var cutoff = s_testTime.AddMinutes(1).AddSeconds(30).ToString("O");
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: $"timestamp:>{cutoff}");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: $"timestamp:>{cutoff}");
 
         Assert.NotNull(result);
         Assert.Equal(2, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithTimestampLessThan_FiltersCorrectly()
+    public async Task GetSpans_WithTimestampLessThan_FiltersCorrectly()
     {
         var repository = CreateRepository();
         // Spans at s_testTime+1min, +2min, +3min
-        AddSpans(repository, count: 3);
+        await AddSpans(repository, count: 3);
 
         var service = CreateService(repository);
 
         // Filter for spans before s_testTime+2.5min (should return spans at +1min and +2min)
         var cutoff = s_testTime.AddMinutes(2).AddSeconds(30).ToString("O");
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: $"timestamp:<{cutoff}");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: $"timestamp:<{cutoff}");
 
         Assert.NotNull(result);
         Assert.Equal(2, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithTimestampGreaterThanOrEqual_FiltersCorrectly()
+    public async Task GetSpans_WithTimestampGreaterThanOrEqual_FiltersCorrectly()
     {
         var repository = CreateRepository();
         // Spans at s_testTime+1min, +2min, +3min
-        AddSpans(repository, count: 3);
+        await AddSpans(repository, count: 3);
 
         var service = CreateService(repository);
 
         // Filter for spans at or after exactly s_testTime+2min (should return spans at +2min and +3min)
         var cutoff = s_testTime.AddMinutes(2).ToString("O");
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: $"timestamp:>={cutoff}");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: $"timestamp:>={cutoff}");
 
         Assert.NotNull(result);
         Assert.Equal(2, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetLogs_WithTimestampGreaterThan_FiltersCorrectly()
+    public async Task GetLogs_WithTimestampGreaterThan_FiltersCorrectly()
     {
         var repository = CreateRepository();
         // Logs at s_testTime, +1min, +2min
-        AddLogs(repository, ["log1", "log2", "log3"]);
+        await AddLogs(repository, ["log1", "log2", "log3"]);
 
         var service = CreateService(repository);
 
         // Filter for logs after s_testTime+0.5min (should return logs at +1min and +2min)
         var cutoff = s_testTime.AddSeconds(30).ToString("O");
-        var result = service.GetLogs(resourceNames: null, traceId: null, severity: null, limit: null, search: $"timestamp:>{cutoff}");
+        var result = await service.GetLogsAsync(resourceNames: null, traceId: null, severity: null, limit: null, cancellationToken: CancellationToken.None, search: $"timestamp:>{cutoff}");
 
         Assert.NotNull(result);
         Assert.Equal(2, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithTimestampInvalidDate_ReturnsNoResults()
+    public async Task GetSpans_WithTimestampInvalidDate_ReturnsNoResults()
     {
         var repository = CreateRepository();
-        AddSpans(repository, count: 3);
+        await AddSpans(repository, count: 3);
 
         var service = CreateService(repository);
 
         // Invalid date string should not match anything
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "timestamp:>not-a-date");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: "timestamp:>not-a-date");
 
         Assert.NotNull(result);
         Assert.Equal(0, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithTimestampUtcSuffix_TreatedAsUtc()
+    public async Task GetSpans_WithTimestampUtcSuffix_TreatedAsUtc()
     {
         var repository = CreateRepository();
         // Spans at s_testTime+1min, +2min, +3min (s_testTime is 1970-01-01T00:00:00Z)
-        AddSpans(repository, count: 3);
+        await AddSpans(repository, count: 3);
 
         var service = CreateService(repository);
 
         // A timestamp ending in Z is UTC and should not be adjusted.
         // s_testTime+1.5min = 1970-01-01T00:01:30Z — should match spans at +2min and +3min
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "timestamp:>1970-01-01T00:01:30Z");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: "timestamp:>1970-01-01T00:01:30Z");
 
         Assert.NotNull(result);
         Assert.Equal(2, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithTimestampNoTimezone_TreatedAsLocalTime()
+    public async Task GetSpans_WithTimestampNoTimezone_TreatedAsLocalTime()
     {
         var repository = CreateRepository();
         // Spans at s_testTime+1min, +2min, +3min (s_testTime is 1970-01-01T00:00:00Z)
-        AddSpans(repository, count: 3);
+        await AddSpans(repository, count: 3);
 
         var service = CreateService(repository);
 
@@ -651,38 +650,38 @@ public class TelemetryApiServiceTests
         var localCutoff = utcCutoff.ToLocalTime();
         var localString = localCutoff.ToString("yyyy-MM-dd'T'HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture);
 
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: $"timestamp:>{localString}");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: $"timestamp:>{localString}");
 
         Assert.NotNull(result);
         Assert.Equal(2, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithTimestampOffset_AdjustedToUtc()
+    public async Task GetSpans_WithTimestampOffset_AdjustedToUtc()
     {
         var repository = CreateRepository();
         // Spans at s_testTime+1min, +2min, +3min (s_testTime is 1970-01-01T00:00:00Z)
-        AddSpans(repository, count: 3);
+        await AddSpans(repository, count: 3);
 
         var service = CreateService(repository);
 
         // A timestamp with an explicit offset is adjusted to UTC.
         // 1970-01-01T01:01:30+01:00 = 1970-01-01T00:01:30Z — should match spans at +2min and +3min
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "timestamp:>1970-01-01T01:01:30+01:00");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: "timestamp:>1970-01-01T01:01:30+01:00");
 
         Assert.NotNull(result);
         Assert.Equal(2, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithTimestampDateOnly_FiltersCorrectly()
+    public async Task GetSpans_WithTimestampDateOnly_FiltersCorrectly()
     {
         var repository = CreateRepository();
         // Create spans on two different days: 1970-01-01 and 1970-01-02
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "trace1", spanId: "span1", startTime: new DateTime(1970, 1, 1, 12, 0, 0, DateTimeKind.Utc), endTime: new DateTime(1970, 1, 1, 12, 1, 0, DateTimeKind.Utc))
         ]);
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "trace2", spanId: "span2", startTime: new DateTime(1970, 1, 2, 12, 0, 0, DateTimeKind.Utc), endTime: new DateTime(1970, 1, 2, 12, 1, 0, DateTimeKind.Utc))
         ]);
 
@@ -690,7 +689,7 @@ public class TelemetryApiServiceTests
 
         // A date-only string (no time component) should be parsed as midnight UTC and filter correctly.
         // "1970-01-02" = midnight 1970-01-02 UTC — only the span on 1970-01-02 has a start time >= that.
-        var result = service.GetSpans(resourceNames: null, traceId: null, hasError: null, limit: null, search: "timestamp:>=1970-01-02");
+        var result = await service.GetSpansAsync(resourceNames: null, traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None, search: "timestamp:>=1970-01-02");
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
@@ -700,11 +699,11 @@ public class TelemetryApiServiceTests
     /// Adds spans with sequential trace/span IDs to the repository. Each span is added in a separate
     /// AddTraces call so that it gets its own trace entry.
     /// </summary>
-    private static void AddSpans(TelemetryRepository repository, int count, int startMinuteSpacing = 1)
+    private static async Task AddSpans(InMemoryTelemetryRepository repository, int count, int startMinuteSpacing = 1)
     {
         for (var i = 1; i <= count; i++)
         {
-            AddSpansToRepository(repository, [
+            await AddSpansToRepository(repository, [
                 CreateSpan(traceId: $"trace{i}", spanId: $"span{i}", startTime: s_testTime.AddMinutes(i * startMinuteSpacing), endTime: s_testTime.AddMinutes(i * startMinuteSpacing + 1))
             ]);
         }
@@ -713,9 +712,9 @@ public class TelemetryApiServiceTests
     /// <summary>
     /// Adds a batch of spans (as raw Span objects) to the repository under a single resource.
     /// </summary>
-    private static void AddSpansToRepository(TelemetryRepository repository, IEnumerable<Span> spans)
+    private static async Task AddSpansToRepository(InMemoryTelemetryRepository repository, IEnumerable<Span> spans)
     {
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -735,12 +734,12 @@ public class TelemetryApiServiceTests
     /// <summary>
     /// Adds two traces (separate trace IDs) with OK and Error status for hasError filter tests.
     /// </summary>
-    private static void AddTracesWithStatus(TelemetryRepository repository)
+    private static async Task AddTracesWithStatus(InMemoryTelemetryRepository repository)
     {
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "ok-trace", spanId: "span1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1), status: new Status { Code = Status.Types.StatusCode.Ok })
         ]);
-        AddSpansToRepository(repository, [
+        await AddSpansToRepository(repository, [
             CreateSpan(traceId: "error-trace", spanId: "span2", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), status: new Status { Code = Status.Types.StatusCode.Error })
         ]);
     }
@@ -748,7 +747,7 @@ public class TelemetryApiServiceTests
     /// <summary>
     /// Adds log entries with the specified messages to the repository.
     /// </summary>
-    private static void AddLogs(TelemetryRepository repository, string[] messages, SeverityNumber severity = SeverityNumber.Info)
+    private static async Task AddLogs(InMemoryTelemetryRepository repository, string[] messages, SeverityNumber severity = SeverityNumber.Info)
     {
         var logRecords = new RepeatedField<LogRecord>();
         for (var i = 0; i < messages.Length; i++)
@@ -756,15 +755,15 @@ public class TelemetryApiServiceTests
             logRecords.Add(CreateLogRecord(time: s_testTime.AddMinutes(i), message: messages[i], severity: severity));
         }
 
-        AddLogsToRepository(repository, logRecords);
+        await AddLogsToRepository(repository, logRecords);
     }
 
     /// <summary>
     /// Adds a batch of raw LogRecord objects to the repository under a single resource.
     /// </summary>
-    private static void AddLogsToRepository(TelemetryRepository repository, RepeatedField<LogRecord> logRecords)
+    private static async Task AddLogsToRepository(InMemoryTelemetryRepository repository, RepeatedField<LogRecord> logRecords)
     {
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -781,13 +780,9 @@ public class TelemetryApiServiceTests
         });
     }
 
-    private static TelemetryApiService CreateService(
-        TelemetryRepository? repository = null,
-        IOutgoingPeerResolver[]? peerResolvers = null)
+    private static TelemetryApiService CreateService(InMemoryTelemetryRepository? repository = null)
     {
-        return new TelemetryApiService(
-            repository ?? CreateRepository(),
-            peerResolvers ?? []);
+        return new TelemetryApiService(repository ?? CreateRepository());
     }
 
     private static List<OtlpSpanJson> GetAllSpans(TelemetryApiResponse result)
@@ -804,7 +799,7 @@ public class TelemetryApiServiceTests
     [Fact]
     public async Task FollowSpansAsync_WaitsForResourceToAppear_ThenStreams()
     {
-        var repository = CreateRepository(subscriptionMinExecuteInterval: TimeSpan.Zero);
+        var repository = CreateRepository();
         var service = CreateService(repository);
 
         // Start enumerating - MoveNextAsync will block until data arrives.
@@ -815,7 +810,7 @@ public class TelemetryApiServiceTests
         Assert.False(moveNextTask.IsCompleted);
 
         // Now add spans for the resource - this should unblock the stream.
-        AddSpans(repository, count: 1);
+        await AddSpans(repository, count: 1);
 
         Assert.True(await moveNextTask.DefaultTimeout());
         Assert.NotNull(enumerator.Current);
@@ -826,7 +821,7 @@ public class TelemetryApiServiceTests
     [Fact]
     public async Task FollowLogsAsync_WaitsForResourceToAppear_ThenStreams()
     {
-        var repository = CreateRepository(subscriptionMinExecuteInterval: TimeSpan.Zero);
+        var repository = CreateRepository();
         var service = CreateService(repository);
 
         // Start enumerating - MoveNextAsync will block until data arrives.
@@ -837,7 +832,7 @@ public class TelemetryApiServiceTests
         Assert.False(moveNextTask.IsCompleted);
 
         // Now add logs for the resource - this should unblock the stream.
-        AddLogs(repository, ["hello"]);
+        await AddLogs(repository, ["hello"]);
 
         Assert.True(await moveNextTask.DefaultTimeout());
         Assert.NotNull(enumerator.Current);
@@ -857,7 +852,7 @@ public class TelemetryApiServiceTests
     }
 
     [Fact]
-    public void GetSpans_WithReplicatedResourceName_DoesNotThrow()
+    public async Task GetSpans_WithReplicatedResourceName_DoesNotThrow()
     {
         // When multiple replicas share the same base ResourceName, the resource resolver
         // must not throw InvalidOperationException from SingleOrDefault. It should treat
@@ -865,7 +860,7 @@ public class TelemetryApiServiceTests
         var repository = CreateRepository();
 
         // Add two replicas of the same service with different instance IDs.
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -873,7 +868,7 @@ public class TelemetryApiServiceTests
                 ScopeSpans = { new ScopeSpans { Scope = CreateScope(), Spans = { CreateSpan(traceId: "t1", spanId: "s1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1)) } } }
             }
         });
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -885,18 +880,18 @@ public class TelemetryApiServiceTests
         var service = CreateService(repository);
 
         // Querying by the base name "myapp" should not throw — it returns null (unresolved).
-        var result = service.GetSpans(resourceNames: ["myapp"], traceId: null, hasError: null, limit: null);
+        var result = await service.GetSpansAsync(resourceNames: ["myapp"], traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None);
         Assert.Null(result);
     }
 
     [Fact]
-    public void GetSpans_WithCompositeResourceKey_ResolvesReplica()
+    public async Task GetSpans_WithCompositeResourceKey_ResolvesReplica()
     {
         // When the caller uses the composite ResourceKey string (e.g. "myapp-replica-1"),
         // the resolver should find the exact replica.
         var repository = CreateRepository();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -904,7 +899,7 @@ public class TelemetryApiServiceTests
                 ScopeSpans = { new ScopeSpans { Scope = CreateScope(), Spans = { CreateSpan(traceId: "t1", spanId: "s1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1)) } } }
             }
         });
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -919,18 +914,18 @@ public class TelemetryApiServiceTests
         var resources = repository.GetResources();
         var replica1Key = resources.First(r => r.ResourceKey.InstanceId == "replica-1").ResourceKey.ToString();
 
-        var result = service.GetSpans(resourceNames: [replica1Key], traceId: null, hasError: null, limit: null);
+        var result = await service.GetSpansAsync(resourceNames: [replica1Key], traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithResourceNameMatchingCompositeResourceKey_ReturnsNull()
+    public async Task GetSpans_WithResourceNameMatchingCompositeResourceKey_ReturnsNull()
     {
         var repository = CreateRepository();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -946,17 +941,17 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetSpans(resourceNames: ["api-1"], traceId: null, hasError: null, limit: null);
+        var result = await service.GetSpansAsync(resourceNames: ["api-1"], traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None);
 
         Assert.Null(result);
     }
 
     [Fact]
-    public void GetSpans_WithAmbiguousCompositeResourceKey_ReturnsNull()
+    public async Task GetSpans_WithAmbiguousCompositeResourceKey_ReturnsNull()
     {
         var repository = CreateRepository();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -972,17 +967,17 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetSpans(resourceNames: ["api-a-1"], traceId: null, hasError: null, limit: null);
+        var result = await service.GetSpansAsync(resourceNames: ["api-a-1"], traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None);
 
         Assert.Null(result);
     }
 
     [Fact]
-    public void GetSpans_WithBaseResourceNameAndMixedInstanceIds_ReturnsNull()
+    public async Task GetSpans_WithBaseResourceNameAndMixedInstanceIds_ReturnsNull()
     {
         var repository = CreateRepository();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -998,18 +993,18 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetSpans(resourceNames: ["api"], traceId: null, hasError: null, limit: null);
+        var result = await service.GetSpansAsync(resourceNames: ["api"], traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None);
 
         Assert.Null(result);
     }
 
     [Fact]
-    public void GetSpans_WithUniqueResourceName_ResolvesDirectly()
+    public async Task GetSpans_WithUniqueResourceName_ResolvesDirectly()
     {
         // When only one resource matches the base name, it should resolve directly.
         var repository = CreateRepository();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -1020,19 +1015,19 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetSpans(resourceNames: ["unique-service"], traceId: null, hasError: null, limit: null);
+        var result = await service.GetSpansAsync(resourceNames: ["unique-service"], traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);
     }
 
     [Fact]
-    public void GetSpans_WithDifferentCaseResourceName_ResolvesCaseInsensitively()
+    public async Task GetSpans_WithDifferentCaseResourceName_ResolvesCaseInsensitively()
     {
         // Resource names are case-insensitive throughout the dashboard.
         var repository = CreateRepository();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -1043,7 +1038,7 @@ public class TelemetryApiServiceTests
 
         var service = CreateService(repository);
 
-        var result = service.GetSpans(resourceNames: ["MYAPP"], traceId: null, hasError: null, limit: null);
+        var result = await service.GetSpansAsync(resourceNames: ["MYAPP"], traceId: null, hasError: null, limit: null, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(1, result.ReturnedCount);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -7,16 +7,18 @@ using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Tests.Integration;
+using Aspire.Dashboard.Utils;
 using Google.Protobuf.Collections;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
 using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 
-public class LogTests
+public abstract class LogTests : TelemetryRepositoryTestBase
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -28,14 +30,14 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs()
+    public async Task AddLogs()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -54,7 +56,7 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -62,13 +64,13 @@ public class LogTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -85,20 +87,272 @@ public class LogTests
                     });
             });
 
-        var propertyKeys = repository.GetLogPropertyKeys(resources[0].ResourceKey)!;
+        var propertyKeys = await repositoryContext.Repository.GetLogPropertyKeysAsync(resources[0].ResourceKey, TestContext.Current.CancellationToken);
         Assert.Collection(propertyKeys,
             s => Assert.Equal("Log", s));
     }
 
     [Fact]
-    public void AddLogs_NoBody_EmptyMessage()
+    public async Task GetLogSummaries_ReturnsPageData()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "frontend", instanceId: "frontend-1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "trace",
+                                spanId: "span",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1),
+                                attributes: [KeyValuePair.Create("gen_ai.provider.name", "test")])
+                        }
+                    }
+                }
+            }
+        });
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "frontend", instanceId: "frontend-1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(
+                                time: s_testTime.AddMinutes(1),
+                                message: "direct",
+                                severity: SeverityNumber.Warn,
+                                traceId: "direct-trace",
+                                spanId: "direct-span",
+                                attributes:
+                                [
+                                    KeyValuePair.Create("custom", "match"),
+                                    KeyValuePair.Create("exception.stacktrace", "stack trace"),
+                                    KeyValuePair.Create("exception.message", "ignored message"),
+                                    KeyValuePair.Create("gen_ai.system", "test")
+                                ]),
+                            CreateLogRecord(
+                                time: s_testTime.AddMinutes(2),
+                                message: "linked",
+                                severity: SeverityNumber.Error,
+                                traceId: "trace",
+                                spanId: "span",
+                                attributes:
+                                [
+                                    KeyValuePair.Create("custom", "other"),
+                                    KeyValuePair.Create("exception.type", "TestException"),
+                                    KeyValuePair.Create("exception.message", "test message")
+                                ]),
+                            CreateLogRecord(
+                                time: s_testTime.AddMinutes(3),
+                                message: "ordinary",
+                                traceId: "ordinary-trace",
+                                spanId: "ordinary-span",
+                                attributes:
+                                [
+                                    KeyValuePair.Create("custom", "other"),
+                                    KeyValuePair.Create("gen_ai.system", string.Empty),
+                                    KeyValuePair.Create("gen_ai.provider.name", "ignored fallback")
+                                ])
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var context = new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        };
+        var summaries = await repositoryContext.Repository.GetLogSummariesAsync(context, cancellationToken: CancellationToken.None);
+        var logs = await repositoryContext.Repository.GetLogsAsync(context, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(logs.TotalItemCount, summaries.TotalItemCount);
+        Assert.Equal(logs.IsFull, summaries.IsFull);
+        Assert.Collection(summaries.Items,
+            summary =>
+            {
+                var log = logs.Items[0];
+                Assert.Equal(log.InternalId, summary.InternalId);
+                Assert.Equal(log.TimeStamp, summary.TimeStamp);
+                Assert.Equal(log.Severity, summary.Severity);
+                Assert.Equal(log.Message, summary.Message);
+                Assert.Equal(log.TraceId, summary.TraceId);
+                Assert.Equal(log.SpanId, summary.SpanId);
+                Assert.Equal(new ResourceKey("frontend", "frontend-1"), summary.Resource.ResourceKey);
+                Assert.Equal("stack trace", summary.ExceptionText);
+                Assert.True(summary.HasGenAI);
+            },
+            summary =>
+            {
+                Assert.Equal("linked", summary.Message);
+                Assert.Equal("TestException: test message", summary.ExceptionText);
+                Assert.True(summary.HasGenAI);
+            },
+            summary =>
+            {
+                Assert.Equal("ordinary", summary.Message);
+                Assert.Null(summary.ExceptionText);
+                Assert.False(summary.HasGenAI);
+            });
+
+        var latestContext = new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = [],
+            LatestItemCount = 2
+        };
+        var latestSummaries = await repositoryContext.Repository.GetLogSummariesAsync(latestContext, cancellationToken: CancellationToken.None);
+        var latestLogs = await repositoryContext.Repository.GetLogsAsync(latestContext, cancellationToken: CancellationToken.None);
+        Assert.Equal(3, latestSummaries.TotalItemCount);
+        Assert.Equal(latestLogs.TotalItemCount, latestSummaries.TotalItemCount);
+        Assert.Collection(latestSummaries.Items,
+            summary =>
+            {
+                Assert.Equal("linked", summary.Message);
+                Assert.Equal(s_testTime.AddMinutes(2), summary.TimeStamp);
+            },
+            summary =>
+            {
+                Assert.Equal("ordinary", summary.Message);
+                Assert.Equal(s_testTime.AddMinutes(3), summary.TimeStamp);
+            });
+        Assert.Collection(latestLogs.Items,
+            log =>
+            {
+                Assert.Equal("linked", log.Message);
+                Assert.Equal(s_testTime.AddMinutes(2), log.TimeStamp);
+            },
+            log =>
+            {
+                Assert.Equal("ordinary", log.Message);
+                Assert.Equal(s_testTime.AddMinutes(3), log.TimeStamp);
+            });
+
+        var filtered = await repositoryContext.Repository.GetLogSummariesAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = "custom",
+                    Condition = FilterCondition.Equals,
+                    Value = "match"
+                }
+            ]
+        }, cancellationToken: CancellationToken.None);
+        Assert.Equal("direct", Assert.Single(filtered.Items).Message);
+        Assert.Equal(1, filtered.TotalItemCount);
+
+        var emptyPage = await repositoryContext.Repository.GetLogSummariesAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 10,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None);
+        Assert.Empty(emptyPage.Items);
+        Assert.Equal(3, emptyPage.TotalItemCount);
+
+        var emptyLogsPage = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 10,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None);
+        Assert.Empty(emptyLogsPage.Items);
+        Assert.Equal(3, emptyLogsPage.TotalItemCount);
+    }
+
+    [Fact]
+    public async Task GetLogsFieldValues_AllFieldsMatchMaterializedLogs()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(time: s_testTime, message: "Message", attributes: [KeyValuePair.Create("custom", "Value")], severity: SeverityNumber.Info, eventName: "Event"),
+                            CreateLogRecord(time: s_testTime, message: "message", attributes: [KeyValuePair.Create("custom", "value")], severity: SeverityNumber.Info2)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var logs = (await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).Items;
+
+        foreach (var field in KnownStructuredLogFields.AllFields
+            .Except([KnownStructuredLogFields.TimestampField])
+            .Append(KnownStructuredLogFields.LevelField)
+            .Append("custom"))
+        {
+            var expected = logs
+                .Select(log => OtlpLogEntry.GetFieldValue(log, field))
+                .Where(value => value is not null)
+                .GroupBy(value => value!, StringComparers.OtlpAttribute)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparers.OtlpAttribute);
+            var actual = await repositoryContext.Repository.GetLogsFieldValuesAsync(field, TestContext.Current.CancellationToken);
+            Assert.True(expected.Count == actual.Count, $"Field '{field}' expected {expected.Count} values but found {actual.Count}.");
+            foreach (var (value, count) in expected)
+            {
+                Assert.True(actual.TryGetValue(value, out var actualCount), $"Field '{field}' is missing value '{value}'.");
+                Assert.True(count == actualCount, $"Field '{field}' value '{value}' expected count {count} but found {actualCount}.");
+            }
+        }
+
+        Assert.Empty(await repositoryContext.Repository.GetLogsFieldValuesAsync(KnownStructuredLogFields.TimestampField, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AddLogs_NoBody_EmptyMessage()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -117,13 +371,13 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -132,14 +386,14 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_MultipleOutOfOrder()
+    public async Task AddLogs_MultipleOutOfOrder()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -169,13 +423,13 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             l =>
             {
@@ -194,14 +448,14 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_Error_UnviewedCount()
+    public async Task AddLogs_Error_UnviewedCount()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -243,7 +497,7 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var unviewedCounts1 = repository.GetResourceUnviewedErrorLogsCount();
+        var unviewedCounts1 = repositoryContext.Repository.GetResourceUnviewedErrorLogsCount();
 
         Assert.True(unviewedCounts1.TryGetValue(new ResourceKey("TestService", "1"), out var unviewedCount1));
         Assert.Equal(2, unviewedCount1);
@@ -251,33 +505,33 @@ public class LogTests
         Assert.True(unviewedCounts1.TryGetValue(new ResourceKey("TestService", "2"), out var unviewedCount2));
         Assert.Equal(1, unviewedCount2);
 
-        repository.MarkViewedErrorLogs(new ResourceKey("TestService", "1"));
+        repositoryContext.Repository.MarkViewedErrorLogs(new ResourceKey("TestService", "1"));
 
-        var unviewedCounts2 = repository.GetResourceUnviewedErrorLogsCount();
+        var unviewedCounts2 = repositoryContext.Repository.GetResourceUnviewedErrorLogsCount();
 
         Assert.False(unviewedCounts2.TryGetValue(new ResourceKey("TestService", "1"), out _));
 
         Assert.True(unviewedCounts2.TryGetValue(new ResourceKey("TestService", "2"), out unviewedCount2));
         Assert.Equal(1, unviewedCount2);
 
-        repository.MarkViewedErrorLogs(null);
+        repositoryContext.Repository.MarkViewedErrorLogs(null);
 
-        var unviewedCounts3 = repository.GetResourceUnviewedErrorLogsCount();
+        var unviewedCounts3 = repositoryContext.Repository.GetResourceUnviewedErrorLogsCount();
 
         Assert.False(unviewedCounts3.TryGetValue(new ResourceKey("TestService", "1"), out _));
         Assert.False(unviewedCounts3.TryGetValue(new ResourceKey("TestService", "2"), out _));
     }
 
     [Fact]
-    public void AddLogs_Error_UnviewedCount_WithReadSubscriptionAll()
+    public async Task AddLogs_Error_UnviewedCount_WithReadSubscriptionAll()
     {
         // Arrange
-        var repository = CreateRepository();
-        using var subscription = repository.OnNewLogs(resourceKey: null, SubscriptionType.Read, () => Task.CompletedTask);
+        using var repositoryContext = await CreateRepositoryAsync();
+        using var subscription = repositoryContext.Repository.OnNewLogs(resourceKey: null, SubscriptionType.Read, () => Task.CompletedTask);
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -314,22 +568,22 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var unviewedCounts = repository.GetResourceUnviewedErrorLogsCount();
+        var unviewedCounts = repositoryContext.Repository.GetResourceUnviewedErrorLogsCount();
 
         Assert.False(unviewedCounts.TryGetValue(new ResourceKey("TestService", "1"), out _));
         Assert.False(unviewedCounts.TryGetValue(new ResourceKey("TestService", "2"), out _));
     }
 
     [Fact]
-    public void AddLogs_Error_UnviewedCount_WithReadSubscriptionOneApp()
+    public async Task AddLogs_Error_UnviewedCount_WithReadSubscriptionOneApp()
     {
         // Arrange
-        var repository = CreateRepository();
-        using var subscription = repository.OnNewLogs(resourceKey: new ResourceKey("TestService", "1"), SubscriptionType.Read, () => Task.CompletedTask);
+        using var repositoryContext = await CreateRepositoryAsync();
+        using var subscription = repositoryContext.Repository.OnNewLogs(resourceKey: new ResourceKey("TestService", "1"), SubscriptionType.Read, () => Task.CompletedTask);
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -366,7 +620,7 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var unviewedCounts = repository.GetResourceUnviewedErrorLogsCount();
+        var unviewedCounts = repositoryContext.Repository.GetResourceUnviewedErrorLogsCount();
 
         Assert.False(unviewedCounts.TryGetValue(new ResourceKey("TestService", "1"), out _));
         Assert.True(unviewedCounts.TryGetValue(new ResourceKey("TestService", "2"), out var unviewedCount));
@@ -374,15 +628,15 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_Error_UnviewedCount_WithNonReadSubscription()
+    public async Task AddLogs_Error_UnviewedCount_WithNonReadSubscription()
     {
         // Arrange
-        var repository = CreateRepository();
-        using var subscription = repository.OnNewLogs(resourceKey: null, SubscriptionType.Other, () => Task.CompletedTask);
+        using var repositoryContext = await CreateRepositoryAsync();
+        using var subscription = repositoryContext.Repository.OnNewLogs(resourceKey: null, SubscriptionType.Other, () => Task.CompletedTask);
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -404,39 +658,39 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var unviewedCounts = repository.GetResourceUnviewedErrorLogsCount();
+        var unviewedCounts = repositoryContext.Repository.GetResourceUnviewedErrorLogsCount();
 
         Assert.True(unviewedCounts.TryGetValue(new ResourceKey("TestService", "1"), out var unviewedCount));
         Assert.Equal(1, unviewedCount);
     }
 
     [Fact]
-    public void GetLogs_UnknownResource()
+    public async Task GetLogs_UnknownResource()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [new ResourceKey("TestService", "UnknownResource")],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Empty(logs.Items);
     }
 
     [Fact]
-    public void GetLogPropertyKeys_UnknownResource()
+    public async Task GetLogPropertyKeys_UnknownResource()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
-        var propertyKeys = repository.GetLogPropertyKeys(new ResourceKey("TestService", "UnknownResource"));
+        var propertyKeys = await repositoryContext.Repository.GetLogPropertyKeysAsync(new ResourceKey("TestService", "UnknownResource"), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(propertyKeys);
@@ -446,10 +700,10 @@ public class LogTests
     public async Task Subscriptions_AddLog()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var newResourcesTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        repository.OnNewResources(() =>
+        repositoryContext.Repository.OnNewResources(() =>
         {
             newResourcesTcs.TrySetResult();
             return Task.CompletedTask;
@@ -457,7 +711,7 @@ public class LogTests
 
         // Act 1
         var addContext1 = new AddContext();
-        repository.AddLogs(addContext1, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext1, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -477,7 +731,7 @@ public class LogTests
         Assert.Equal(0, addContext1.FailureCount);
         await newResourcesTcs.Task.DefaultTimeout();
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -487,14 +741,14 @@ public class LogTests
 
         // Act 2
         var newLogsTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        repository.OnNewLogs(resources[0].ResourceKey, SubscriptionType.Read, () =>
+        repositoryContext.Repository.OnNewLogs(resources[0].ResourceKey, SubscriptionType.Read, () =>
         {
             newLogsTcs.TrySetResult();
             return Task.CompletedTask;
         });
 
         var addContext2 = new AddContext();
-        repository.AddLogs(addContext2, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext2, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -515,25 +769,25 @@ public class LogTests
         // Assert 2
         Assert.Equal(0, addContext2.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = []
-        })!;
+        }, cancellationToken: CancellationToken.None)!;
         Assert.Single(logs.Items);
         Assert.Equal(2, logs.TotalItemCount);
     }
 
     [Fact]
-    public void Unsubscribe()
+    public async Task Unsubscribe()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var onNewResourcesCalled = false;
-        var subscription = repository.OnNewResources(() =>
+        var subscription = repositoryContext.Repository.OnNewResources(() =>
         {
             onNewResourcesCalled = true;
             return Task.CompletedTask;
@@ -542,7 +796,7 @@ public class LogTests
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -570,10 +824,10 @@ public class LogTests
         var asyncLocal = new AsyncLocal<string>();
         asyncLocal.Value = "CustomValue";
 
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var subscription = repository.OnNewResources(() =>
+        var subscription = repositoryContext.Repository.OnNewResources(() =>
         {
             tcs.SetResult(asyncLocal.Value);
             return Task.CompletedTask;
@@ -583,10 +837,10 @@ public class LogTests
         Task task;
         using (ExecutionContext.SuppressFlow())
         {
-            task = Task.Run(() =>
+            task = Task.Run(async () =>
             {
                 var addContext = new AddContext();
-                repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+                await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
                 {
                     new ResourceLogs
                     {
@@ -612,10 +866,10 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_AttributeLimits_LimitsApplied()
+    public async Task AddLogs_AttributeLimits_LimitsApplied()
     {
         // Arrange
-        var repository = CreateRepository(maxAttributeCount: 5, maxAttributeLength: 16);
+        using var repositoryContext = await CreateRepositoryAsync(maxAttributeCount: 5, maxAttributeLength: 16);
 
         // Act
         var attributes = new List<KeyValuePair<string, string>>
@@ -630,7 +884,7 @@ public class LogTests
         }
 
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -649,7 +903,7 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -657,13 +911,13 @@ public class LogTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -702,15 +956,15 @@ public class LogTests
     public async Task Subscription_MultipleUpdates_MinExecuteIntervalApplied()
     {
         // Arrange
-        var minExecuteInterval = TimeSpan.FromMilliseconds(500);
+        var minExecuteInterval = CallbackThrottler.DefaultMinExecuteInterval;
         var loggerFactory = IntegrationTestHelpers.CreateLoggerFactory(_testOutputHelper);
         var logger = loggerFactory.CreateLogger(nameof(LogTests));
-        var repository = CreateRepository(subscriptionMinExecuteInterval: minExecuteInterval, loggerFactory: loggerFactory);
+        using var repositoryContext = await CreateRepositoryAsync(subscriptionMinExecuteInterval: minExecuteInterval, loggerFactory: loggerFactory);
         var stopwatch = new Stopwatch();
 
         var callCount = 0;
         var resultChannel = Channel.CreateUnbounded<int>();
-        var subscription = repository.OnNewLogs(resourceKey: null, SubscriptionType.Read, async () =>
+        var subscription = repositoryContext.Repository.OnNewLogs(resourceKey: null, SubscriptionType.Read, async () =>
         {
             if (!stopwatch.IsRunning)
             {
@@ -728,7 +982,7 @@ public class LogTests
         // Act
         var addContext = new AddContext();
         logger.LogInformation("Writing log 1");
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -750,7 +1004,7 @@ public class LogTests
         logger.LogInformation("Received log 1 callback");
 
         logger.LogInformation("Writing log 2");
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -776,14 +1030,14 @@ public class LogTests
     }
 
     [Fact]
-    public void FilterLogs_With_Message_Returns_CorrectLog()
+    public async Task FilterLogs_With_Message_Returns_CorrectLog()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -802,35 +1056,75 @@ public class LogTests
             }
         });
 
-        var resourceKey = repository.GetResources().First().ResourceKey;
+        var resourceKey = repositoryContext.Repository.GetResources().First().ResourceKey;
 
         // Assert
-        Assert.Empty(repository.GetLogs(new GetLogsContext
+        Assert.Empty((await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = nameof(OtlpLogEntry.Message), Value = "does_not_contain" }]
-        }).Items);
+        }, cancellationToken: CancellationToken.None)).Items);
 
-        Assert.Single(repository.GetLogs(new GetLogsContext
+        Assert.Single((await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 1,
-            Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = nameof(OtlpLogEntry.Message), Value = "message" }]
-        }).Items);
+            Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = nameof(OtlpLogEntry.Message), Value = "MESSAGE" }]
+        }, cancellationToken: CancellationToken.None)).Items);
+    }
+
+    [Theory]
+    [InlineData("%")]
+    [InlineData("_")]
+    [InlineData("!")]
+    public async Task FilterLogs_WithLikeMetacharacter_TreatsValueAsLiteral(string fragment)
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var expectedMessage = $"matches-{fragment}-literal";
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(instanceId: "1"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(time: s_testTime.AddMinutes(1), message: expectedMessage),
+                            CreateLogRecord(time: s_testTime.AddMinutes(2), message: "matches-x-literal")
+                        }
+                    }
+                }
+            }
+        });
+
+        var result = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
+        {
+            ResourceKeys = [repositoryContext.Repository.GetResources().Single().ResourceKey],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = nameof(OtlpLogEntry.Message), Value = fragment }]
+        }, cancellationToken: CancellationToken.None);
+
+        var log = Assert.Single(result.Items);
+        Assert.Equal(expectedMessage, log.Message);
     }
 
     [Fact]
-    public void FilterLogs_With_EventName_Returns_CorrectLog()
+    public async Task FilterLogs_With_EventName_Returns_CorrectLog()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -849,35 +1143,35 @@ public class LogTests
             }
         });
 
-        var resourceKey = repository.GetResources().First().ResourceKey;
+        var resourceKey = repositoryContext.Repository.GetResources().First().ResourceKey;
 
         // Assert
-        Assert.Empty(repository.GetLogs(new GetLogsContext
+        Assert.Empty((await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = KnownStructuredLogFields.EventNameField, Value = "does_not_contain" }]
-        }).Items);
+        }, cancellationToken: CancellationToken.None)).Items);
 
-        Assert.Single(repository.GetLogs(new GetLogsContext
+        Assert.Single((await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 1,
             Filters = [new FieldTelemetryFilter { Condition = FilterCondition.Contains, Field = KnownStructuredLogFields.EventNameField, Value = "MyEvent" }]
-        }).Items);
+        }, cancellationToken: CancellationToken.None)).Items);
     }
 
     [Fact]
-    public void AddLogs_MultipleResources_SameInstanceId_CreateMultipleResources()
+    public async Task AddLogs_MultipleResources_SameInstanceId_CreateMultipleResources()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -908,7 +1202,7 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -921,13 +1215,13 @@ public class LogTests
                 Assert.Equal("computer-name", resource.InstanceId);
             });
 
-        var logs1 = repository.GetLogs(new GetLogsContext
+        var logs1 = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs1.Items,
             resource =>
             {
@@ -944,13 +1238,13 @@ public class LogTests
                     });
             });
 
-        var logs2 = repository.GetLogs(new GetLogsContext
+        var logs2 = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resources[1].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs2.Items,
             resource =>
             {
@@ -969,14 +1263,14 @@ public class LogTests
     }
 
     [Fact]
-    public void GetLogs_MultipleInstances()
+    public async Task GetLogs_MultipleInstances()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1020,13 +1314,13 @@ public class LogTests
         Assert.Equal(0, addContext.FailureCount);
 
         var resourceKey = new ResourceKey("resource1", InstanceId: null);
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -1051,20 +1345,20 @@ public class LogTests
                     });
             });
 
-        var propertyKeys = repository.GetLogPropertyKeys(resourceKey)!;
+        var propertyKeys = await repositoryContext.Repository.GetLogPropertyKeysAsync(resourceKey, TestContext.Current.CancellationToken);
         Assert.Collection(propertyKeys,
             s => Assert.Equal("key-1", s),
             s => Assert.Equal("key-2", s));
     }
 
     [Fact]
-    public void RemoveLogs_All()
+    public async Task RemoveLogs_All()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1105,31 +1399,31 @@ public class LogTests
         });
 
         // Act
-        repository.ClearStructuredLogs();
+        await repositoryContext.Repository.AsWriter().ClearStructuredLogsAsync();
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.NotNull(logs);
         Assert.Empty(logs.Items);
         Assert.Equal(0, logs.TotalItemCount);
     }
 
     [Fact]
-    public void RemoveLogs_SelectedResource()
+    public async Task RemoveLogs_SelectedResource()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1170,18 +1464,18 @@ public class LogTests
         });
 
         // Act
-        repository.ClearStructuredLogs(new ResourceKey("resource1", "123"));
+        await repositoryContext.Repository.AsWriter().ClearStructuredLogsAsync(new ResourceKey("resource1", "123"));
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Equal(2, logs.TotalItemCount);
         Assert.Collection(logs.Items,
                     resource =>
@@ -1197,13 +1491,13 @@ public class LogTests
     }
 
     [Fact]
-    public void RemoveLogs_MultipleSelectedResources()
+    public async Task RemoveLogs_MultipleSelectedResources()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1244,18 +1538,18 @@ public class LogTests
         });
 
         // Act
-        repository.ClearStructuredLogs(new ResourceKey("resource1", null));
+        await repositoryContext.Repository.AsWriter().ClearStructuredLogsAsync(new ResourceKey("resource1", null));
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Equal(1, logs.TotalItemCount);
         var log = Assert.Single(logs.Items);
         Assert.Equal("message-3", log.Message);
@@ -1263,14 +1557,14 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_ObservedUnixTimeNanos()
+    public async Task AddLogs_ObservedUnixTimeNanos()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1289,13 +1583,13 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -1304,14 +1598,14 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_EventName_FromLogRecordField()
+    public async Task AddLogs_EventName_FromLogRecordField()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1330,13 +1624,13 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -1345,14 +1639,14 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_EventName_FromLegacyAttribute()
+    public async Task AddLogs_EventName_FromLegacyAttribute()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1371,13 +1665,13 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -1388,14 +1682,14 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_EventName_FieldTakesPrecedenceOverAttribute()
+    public async Task AddLogs_EventName_FieldTakesPrecedenceOverAttribute()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1414,13 +1708,13 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -1430,14 +1724,14 @@ public class LogTests
     }
 
     [Fact]
-    public void AddLogs_EventName_NullWhenNotSet()
+    public async Task AddLogs_EventName_NullWhenNotSet()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1456,13 +1750,13 @@ public class LogTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(logs.Items,
             resource =>
             {
@@ -1471,11 +1765,11 @@ public class LogTests
     }
 
     [Fact]
-    public void GetLogs_DisabledFiltersAreIgnored()
+    public async Task GetLogs_DisabledFiltersAreIgnored()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -1514,16 +1808,157 @@ public class LogTests
             }
         };
 
-        var logs = repository.GetLogs(new GetLogsContext
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = filters
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // The disabled filter should be ignored — only the enabled "matching" filter applies
         Assert.Single(logs.Items);
         Assert.Equal("matching log", logs.Items[0].Message);
+    }
+}
+
+public sealed class InMemoryLogTests(ITestOutputHelper testOutputHelper) : LogTests(testOutputHelper)
+{
+    protected override bool UseSqlite => false;
+}
+
+public sealed class SqliteLogTests(ITestOutputHelper testOutputHelper) : LogTests(testOutputHelper)
+{
+    protected override bool UseSqlite => true;
+
+    [Fact]
+    public async Task GetLogSummaries_MoreThanSqliteVariableLimit_ReturnsTraceDisplayData()
+    {
+        const int logCount = 1_100;
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        var logRecords = new RepeatedField<LogRecord>();
+        for (var index = 0; index < logCount; index++)
+        {
+            logRecords.Add(CreateLogRecord(
+                time: testTime.AddTicks(index + 1),
+                message: $"Message {index}",
+                severity: index == 0 ? SeverityNumber.Error : SeverityNumber.Info,
+                attributes: [],
+                traceId: "large-trace",
+                spanId: "large-span",
+                eventName: $"Event {index}"));
+        }
+
+        var context = new AddContext();
+        await repository.AsWriter().AddLogsAsync(context, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { logRecords }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, context.FailureCount);
+
+        var logs = (await repository.GetLogSummariesAsync(new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = KnownStructuredLogFields.TraceIdField,
+                    Condition = FilterCondition.Equals,
+                    Value = logRecords[0].TraceId.ToHexString()
+                }
+            ]
+        }, cancellationToken: CancellationToken.None)).Items;
+
+        Assert.Equal(logCount, logs.Count);
+        var first = logs[0];
+        Assert.Equal(testTime.AddTicks(1), first.TimeStamp);
+        Assert.Equal(LogLevel.Error, first.Severity);
+        Assert.Equal("Message 0", first.Message);
+        Assert.Equal(logRecords[0].SpanId.ToHexString(), first.SpanId);
+        Assert.Equal("TestLogger", first.ScopeName);
+        Assert.Equal("Event 0", first.EventName);
+        Assert.True(first.IsError);
+        Assert.Equal("Message 1099", logs[^1].Message);
+    }
+
+    [Fact]
+    public async Task AddLogs_LargeAttributeBatchesRoundTripAcrossResources()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        var context = new AddContext();
+        var attributes = Enumerable.Range(0, 128)
+            .Select(index => KeyValuePair.Create($"key-{index}", $"value-{index}"))
+            .ToArray();
+        await repository.AsWriter().AddLogsAsync(context, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app-one"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "one", attributes: attributes),
+                            CreateLogRecord(message: "two", attributes: attributes)
+                        }
+                    }
+                }
+            },
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app-two"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords =
+                        {
+                            CreateLogRecord(message: "three", attributes: attributes),
+                            CreateLogRecord(message: "four", attributes: attributes)
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(4, context.SuccessCount);
+        Assert.Equal(0, context.FailureCount);
+
+        await AssertResourceLogsAsync("app-one", ["one", "two"]);
+        await AssertResourceLogsAsync("app-two", ["three", "four"]);
+
+        async Task AssertResourceLogsAsync(string resourceName, string[] expectedMessages)
+        {
+            var logs = (await repository.GetLogsAsync(new GetLogsContext
+            {
+                ResourceKeys = [new ResourceKey(resourceName, null)],
+                StartIndex = 0,
+                Count = 10,
+                Filters = []
+            }, cancellationToken: CancellationToken.None)).Items;
+            Assert.Equal(expectedMessages.Order(), logs.Select(log => log.Message).Order());
+            Assert.All(logs, log => Assert.Equal(attributes, log.Attributes));
+        }
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -1,11 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text;
+using Aspire.Dashboard.Components;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Tests;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
@@ -15,19 +18,19 @@ using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 
-public class MetricsTests
+public abstract class MetricsTests : TelemetryRepositoryTestBase
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
     [Fact]
-    public void AddMetrics()
+    public async Task AddMetrics()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -60,15 +63,17 @@ public class MetricsTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
                 Assert.Equal("TestService", resource.ResourceName);
                 Assert.Equal("TestId", resource.InstanceId);
             });
+        var resourceView = Assert.Single(resources[0].GetViews());
+        Assert.Empty(resourceView.Properties);
 
-        var instruments = repository.GetInstrumentsSummaries(resources[0].ResourceKey);
+        var instruments = repositoryContext.Repository.GetInstrumentSummaries(resources[0].ResourceKey);
         Assert.Collection(instruments,
             instrument =>
             {
@@ -98,13 +103,18 @@ public class MetricsTests
                 Assert.Equal("widget", instrument.Unit);
                 Assert.Equal("test-meter2", instrument.Parent.Name);
             });
+
+            var instrumentSummary = repositoryContext.Repository.GetInstrumentSummary(resources[0].ResourceKey, "test-meter2", "test2");
+            Assert.NotNull(instrumentSummary);
+            Assert.Equal(OtlpInstrumentType.Histogram, instrumentSummary.Type);
+            Assert.Null(repositoryContext.Repository.GetInstrumentSummary(resources[0].ResourceKey, "test-meter2", "missing"));
     }
 
     [Fact]
-    public void AddMetrics_MeterAttributeLimits_LimitsApplied()
+    public async Task AddMetrics_MeterAttributeLimits_LimitsApplied()
     {
         // Arrange
-        var repository = CreateRepository(maxAttributeCount: 5, maxAttributeLength: 16);
+        using var repositoryContext = await CreateRepositoryAsync(maxAttributeCount: 5, maxAttributeLength: 16);
 
         var metricAttributes = new List<KeyValuePair<string, string>>();
         var meterAttributes = new List<KeyValuePair<string, string>>();
@@ -118,7 +128,7 @@ public class MetricsTests
 
         // Act
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -140,7 +150,7 @@ public class MetricsTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -148,14 +158,14 @@ public class MetricsTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        var instrument = (await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resources[0].ResourceKey,
             InstrumentName = "test",
             MeterName = "test-meter",
             StartTime = DateTime.MinValue,
             EndTime = DateTime.MaxValue
-        })!;
+        }, cancellationToken: CancellationToken.None))!;
 
         Assert.Collection(instrument.Summary.Parent.Attributes,
             p =>
@@ -185,40 +195,25 @@ public class MetricsTests
             });
 
         var dimensionAttributes = instrument.Dimensions.Single().Attributes;
-
         Assert.Collection(dimensionAttributes,
-            p =>
-            {
-                Assert.Equal("Meter_Key0", p.Key);
-                Assert.Equal("01234", p.Value);
-            },
-            p =>
-            {
-                Assert.Equal("Meter_Key1", p.Key);
-                Assert.Equal("0123456789", p.Value);
-            },
-            p =>
-            {
-                Assert.Equal("Meter_Key2", p.Key);
-                Assert.Equal("012345678901234", p.Value);
-            },
-            p =>
-            {
-                Assert.Equal("Meter_Key3", p.Key);
-                Assert.Equal("0123456789012345", p.Value);
-            },
-            p =>
-            {
-                Assert.Equal("Meter_Key4", p.Key);
-                Assert.Equal("0123456789012345", p.Value);
-            });
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key0", "01234"), p),
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key1", "0123456789"), p),
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key2", "012345678901234"), p),
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key3", "0123456789012345"), p),
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key4", "0123456789012345"), p),
+            p => Assert.Equal(KeyValuePair.Create("Meter_Key0", "01234"), p),
+            p => Assert.Equal(KeyValuePair.Create("Meter_Key1", "0123456789"), p),
+            p => Assert.Equal(KeyValuePair.Create("Meter_Key2", "012345678901234"), p),
+            p => Assert.Equal(KeyValuePair.Create("Meter_Key3", "0123456789012345"), p),
+            p => Assert.Equal(KeyValuePair.Create("Meter_Key4", "0123456789012345"), p));
+        Assert.Equal(10, instrument.KnownAttributeValues.Count);
     }
 
     [Fact]
-    public void AddMetrics_MetricAttributeLimits_LimitsApplied()
+    public async Task AddMetrics_MetricAttributeLimits_LimitsApplied()
     {
         // Arrange
-        var repository = CreateRepository(maxAttributeCount: 5, maxAttributeLength: 16);
+        using var repositoryContext = await CreateRepositoryAsync(maxAttributeCount: 5, maxAttributeLength: 16);
 
         var metricAttributes = new List<KeyValuePair<string, string>>();
         var meterAttributes = new List<KeyValuePair<string, string>>
@@ -234,7 +229,7 @@ public class MetricsTests
 
         // Act
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -256,7 +251,7 @@ public class MetricsTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -264,14 +259,14 @@ public class MetricsTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        var instrument = (await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resources[0].ResourceKey,
             InstrumentName = "test",
             MeterName = "test-meter",
             StartTime = DateTime.MinValue,
             EndTime = DateTime.MaxValue
-        })!;
+        }, cancellationToken: CancellationToken.None))!;
 
         Assert.Collection(instrument.Summary.Parent.Attributes,
             p =>
@@ -281,33 +276,53 @@ public class MetricsTests
             });
 
         var dimensionAttributes = instrument.Dimensions.Single().Attributes;
-
         Assert.Collection(dimensionAttributes,
-            p =>
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key0", "01234"), p),
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key1", "0123456789"), p),
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key2", "012345678901234"), p),
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key3", "0123456789012345"), p),
+            p => Assert.Equal(KeyValuePair.Create("Metric_Key4", "0123456789012345"), p),
+            p => Assert.Equal(KeyValuePair.Create("Meter_Key0", "01234"), p));
+        Assert.Equal(6, instrument.KnownAttributeValues.Count);
+    }
+
+    [Fact]
+    public async Task Metrics_ScopeAttributesAreMergedIntoDimensionsOnRead()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
             {
-                Assert.Equal("Meter_Key0", p.Key);
-                Assert.Equal("01234", p.Value);
-            },
-            p =>
-            {
-                Assert.Equal("Metric_Key0", p.Key);
-                Assert.Equal("01234", p.Value);
-            },
-            p =>
-            {
-                Assert.Equal("Metric_Key1", p.Key);
-                Assert.Equal("0123456789", p.Value);
-            },
-            p =>
-            {
-                Assert.Equal("Metric_Key2", p.Key);
-                Assert.Equal("012345678901234", p.Value);
-            },
-            p =>
-            {
-                Assert.Equal("Metric_Key3", p.Key);
-                Assert.Equal("0123456789012345", p.Value);
-            });
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope("TestMeter", attributes: [KeyValuePair.Create("scope-key", "scope-value")]),
+                        Metrics =
+                        {
+                            CreateSumMetric("requests", s_testTime, attributes: [KeyValuePair.Create("point-key", "point-value")])
+                        }
+                    }
+                }
+            }
+        });
+
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            MeterName = "TestMeter",
+            InstrumentName = "requests",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.NotNull(instrument);
+        Assert.Equal(
+            [KeyValuePair.Create("point-key", "point-value"), KeyValuePair.Create("scope-key", "scope-value")],
+            Assert.Single(instrument.Dimensions).Attributes);
     }
 
     [Fact]
@@ -320,14 +335,14 @@ public class MetricsTests
     }
 
     [Fact]
-    public void GetInstrument()
+    public async Task GetInstrument()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -354,7 +369,7 @@ public class MetricsTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -362,14 +377,14 @@ public class MetricsTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var instrumentData = repository.GetInstrument(new GetInstrumentRequest
+        var instrumentData = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resources[0].ResourceKey,
             InstrumentName = "test",
             MeterName = "test-meter",
             StartTime = s_testTime.AddMinutes(1),
             EndTime = s_testTime.AddMinutes(1.5),
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(instrumentData);
         Assert.Equal("test", instrumentData.Summary.Name);
@@ -390,23 +405,125 @@ public class MetricsTests
             });
 
         Assert.Equal(5, instrumentData.Dimensions.Count);
-
-        var dimension = instrumentData.Dimensions.Single(d => d.Attributes.Length == 0);
-        var exemplar = Assert.Single(dimension.Values[0].Exemplars);
+        Assert.All(instrumentData.Dimensions, dimension => Assert.Equal(1, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value));
+        var dimensionWithoutAttributes = Assert.Single(instrumentData.Dimensions, dimension => dimension.Attributes.Length == 0);
+        var exemplar = Assert.Single(dimensionWithoutAttributes.Values.SelectMany(value => value.Exemplars));
 
         Assert.Equal("key1", exemplar.Attributes[0].Key);
         Assert.Equal("value1", exemplar.Attributes[0].Value);
 
-        var instrument = resources.Single().GetInstrument("test-meter", "test", s_testTime.AddMinutes(1), s_testTime.AddMinutes(1.5));
-        Assert.NotNull(instrument);
+        var filteredInstrumentData = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resources[0].ResourceKey,
+            InstrumentName = "test",
+            MeterName = "test-meter",
+            StartTime = s_testTime.AddMinutes(1),
+            EndTime = s_testTime.AddMinutes(1.5),
+            DimensionFilters = new Dictionary<string, IReadOnlyList<string?>>
+            {
+                ["key1"] = ["value1"]
+            }
+        }, cancellationToken: CancellationToken.None);
 
-        AssertDimensionValues(instrument.Dimensions, Array.Empty<KeyValuePair<string, string>>(), valueCount: 1);
-        AssertDimensionValues(instrument.Dimensions, new KeyValuePair<string, string>[] { KeyValuePair.Create("key1", "value1") }, valueCount: 1);
-        AssertDimensionValues(instrument.Dimensions, new KeyValuePair<string, string>[] { KeyValuePair.Create("key1", "value2") }, valueCount: 1);
-        AssertDimensionValues(instrument.Dimensions, new KeyValuePair<string, string>[] { KeyValuePair.Create("key1", "value1"), KeyValuePair.Create("key2", "value1") }, valueCount: 1);
+        Assert.NotNull(filteredInstrumentData);
+        Assert.Equal(3, filteredInstrumentData.Dimensions.Count);
+        Assert.All(filteredInstrumentData.Dimensions, dimension =>
+        {
+            Assert.Contains(KeyValuePair.Create("key1", "value1"), dimension.Attributes);
+            Assert.Equal(1, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value);
+        });
+        Assert.Equal(instrumentData.KnownAttributeValues, filteredInstrumentData.KnownAttributeValues);
+
     }
 
-    private static Exemplar CreateExemplar(DateTime startTime, double value, IEnumerable<KeyValuePair<string, string>>? attributes = null)
+    [Fact]
+    public async Task GetInstrument_StaggeredDimensionChanges_ReturnsCurrentValues()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), value: 10, attributes: [KeyValuePair.Create("dimension", "stable")]),
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), value: 20, attributes: [KeyValuePair.Create("dimension", "changing")])
+                        }
+                    }
+                }
+            },
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(2), value: 10, attributes: [KeyValuePair.Create("dimension", "stable")]),
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(2), value: 25, attributes: [KeyValuePair.Create("dimension", "changing")])
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = s_testTime,
+            EndTime = s_testTime.AddMinutes(3)
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.NotNull(instrument);
+        var dimensions = instrument.Dimensions.ToDictionary(dimension => Assert.Single(dimension.Attributes).Value);
+        Assert.Equal(10, Assert.IsType<MetricValue<long>>(Assert.Single(dimensions["stable"].Values)).Value);
+        Assert.Equal(25, Assert.IsType<MetricValue<long>>(dimensions["changing"].Values[^1]).Value);
+    }
+
+    [Fact]
+    public async Task GetInstrumentLatestEndTime()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1)),
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(2), attributes: [KeyValuePair.Create("key", "value")])
+                        }
+                    }
+                }
+            }
+        });
+        var resourceKey = Assert.Single(repositoryContext.Repository.GetResources()).ResourceKey;
+
+        Assert.Equal(s_testTime.AddMinutes(2), repositoryContext.Repository.GetInstrumentLatestEndTime(resourceKey, "test-meter", "test"));
+        Assert.Null(repositoryContext.Repository.GetInstrumentLatestEndTime(resourceKey, "test-meter", "missing"));
+    }
+
+    protected static Exemplar CreateExemplar(DateTime startTime, double value, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
         var exemplar = new Exemplar
         {
@@ -428,14 +545,14 @@ public class MetricsTests
     }
 
     [Fact]
-    public void AddMetrics_Capacity_ValuesRemoved()
+    public async Task AddMetrics_Capacity_ValuesRemoved()
     {
         // Arrange
-        var repository = CreateRepository(maxMetricsCount: 3);
+        using var repositoryContext = await CreateRepositoryAsync(maxMetricsCount: 3);
 
         // Act
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -461,7 +578,7 @@ public class MetricsTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -469,14 +586,14 @@ public class MetricsTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        var instrument = (await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resources[0].ResourceKey,
             InstrumentName = "test",
             MeterName = "test-meter",
             StartTime = DateTime.MinValue,
             EndTime = DateTime.MaxValue
-        })!;
+        }, cancellationToken: CancellationToken.None))!;
 
         Assert.Equal("test", instrument.Summary.Name);
         Assert.Equal("Test metric description", instrument.Summary.Description);
@@ -507,14 +624,14 @@ public class MetricsTests
     }
 
     [Fact]
-    public void GetMetrics_MultipleInstances()
+    public async Task GetMetrics_MultipleInstances()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -570,7 +687,7 @@ public class MetricsTests
         Assert.Equal(0, addContext.FailureCount);
 
         var resourceKey = new ResourceKey("resource1", InstanceId: null);
-        var instruments = repository.GetInstrumentsSummaries(resourceKey);
+        var instruments = repositoryContext.Repository.GetInstrumentSummaries(resourceKey);
         Assert.Collection(instruments,
             instrument =>
             {
@@ -587,34 +704,23 @@ public class MetricsTests
                 Assert.Equal("test-meter", instrument.Parent.Name);
             });
 
-        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resourceKey,
             InstrumentName = "test1",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(instrument);
         Assert.Equal("test1", instrument.Summary.Name);
 
-        Assert.Collection(instrument.Dimensions.OrderBy(d => d.Name),
-            d =>
-            {
-                Assert.Equal(KeyValuePair.Create("key-1", "value-1"), d.Attributes.Single());
-                Assert.Equal(1, ((MetricValue<long>)d.Values.Single()).Value);
-            },
-            d =>
-            {
-                Assert.Equal(KeyValuePair.Create("key-1", "value-2"), d.Attributes.Single());
-                Assert.Equal(2, ((MetricValue<long>)d.Values.Single()).Value);
-            },
-            d =>
-            {
-                Assert.Equal(KeyValuePair.Create("key-1", "value-3"), d.Attributes.Single());
-                Assert.Equal(3, ((MetricValue<long>)d.Values.Single()).Value);
-            });
+        Assert.Collection(
+            instrument.Dimensions.OrderBy(dimension => Assert.Single(dimension.Attributes).Value),
+            dimension => Assert.Equal(1, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value),
+            dimension => Assert.Equal(2, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value),
+            dimension => Assert.Equal(3, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value));
 
         var knownValues = Assert.Single(instrument.KnownAttributeValues);
         Assert.Equal("key-1", knownValues.Key);
@@ -626,13 +732,13 @@ public class MetricsTests
     }
 
     [Fact]
-    public void RemoveMetrics_All()
+    public async Task RemoveMetrics_All()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -685,29 +791,29 @@ public class MetricsTests
         });
 
         // Act
-        repository.ClearMetrics();
+        await repositoryContext.Repository.AsWriter().ClearMetricsAsync();
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
         var resource1Key = new ResourceKey("resource1", InstanceId: null);
-        var resource1Instruments = repository.GetInstrumentsSummaries(resource1Key);
+        var resource1Instruments = repositoryContext.Repository.GetInstrumentSummaries(resource1Key);
         Assert.Empty(resource1Instruments);
 
         var resource2Key = new ResourceKey("resource2", InstanceId: null);
-        var resource2Instruments = repository.GetInstrumentsSummaries(resource2Key);
+        var resource2Instruments = repositoryContext.Repository.GetInstrumentSummaries(resource2Key);
 
         Assert.Empty(resource2Instruments);
     }
 
     [Fact]
-    public void RemoveMetrics_SelectedResource()
+    public async Task RemoveMetrics_SelectedResource()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -760,13 +866,13 @@ public class MetricsTests
         });
 
         // Act
-        repository.ClearMetrics(new ResourceKey("resource1", "456"));
+        await repositoryContext.Repository.AsWriter().ClearMetricsAsync(new ResourceKey("resource1", "456"));
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
         var resource1Key = new ResourceKey("resource1", InstanceId: null);
-        var resource1Instruments = repository.GetInstrumentsSummaries(resource1Key);
+        var resource1Instruments = repositoryContext.Repository.GetInstrumentSummaries(resource1Key);
 
         var resource1Instrument = Assert.Single(resource1Instruments);
         Assert.Equal("test1", resource1Instrument.Name);
@@ -774,42 +880,34 @@ public class MetricsTests
         Assert.Equal("widget", resource1Instrument.Unit);
         Assert.Equal("test-meter", resource1Instrument.Parent.Name);
 
-        var resource1Test1Instrument = repository.GetInstrument(new GetInstrumentRequest
+        var resource1Test1Instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource1Key,
             InstrumentName = "test1",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(resource1Test1Instrument);
         Assert.Equal("test1", resource1Test1Instrument.Summary.Name);
 
         var resource1Test1Dimensions = Assert.Single(resource1Test1Instrument.Dimensions);
-        Assert.Collection(resource1Test1Dimensions.Values,
-            v =>
-            {
-                Assert.Equal(1, ((MetricValue<long>)v).Value);
-            },
-            v =>
-            {
-                Assert.Equal(2, ((MetricValue<long>)v).Value);
-            });
+        Assert.Equal(2, Assert.IsType<MetricValue<long>>(resource1Test1Dimensions.Values[^1]).Value);
 
-        var resource1Test2Instrument = repository.GetInstrument(new GetInstrumentRequest
+        var resource1Test2Instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource1Key,
             InstrumentName = "test2",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Null(resource1Test2Instrument);
 
         var resource2Key = new ResourceKey("resource2", InstanceId: null);
-        var resource2Instruments = repository.GetInstrumentsSummaries(resource2Key);
+        var resource2Instruments = repositoryContext.Repository.GetInstrumentSummaries(resource2Key);
 
         Assert.Collection(resource2Instruments,
             instrument =>
@@ -827,14 +925,14 @@ public class MetricsTests
                 Assert.Equal("test-meter", instrument.Parent.Name);
             });
 
-        var resource2Test1Instrument = repository.GetInstrument(new GetInstrumentRequest
+        var resource2Test1Instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource2Key,
             InstrumentName = "test1",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(resource2Test1Instrument);
         Assert.Equal("test1", resource2Test1Instrument.Summary.Name);
@@ -842,14 +940,14 @@ public class MetricsTests
         var resource2Test1Dimensions = Assert.Single(resource2Test1Instrument.Dimensions);
         Assert.Equal(5, ((MetricValue<long>)resource2Test1Dimensions.Values.Single()).Value);
 
-        var resource2Test3Instrument = repository.GetInstrument(new GetInstrumentRequest
+        var resource2Test3Instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource2Key,
             InstrumentName = "test3",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(resource2Test3Instrument);
         Assert.Equal("test3", resource2Test3Instrument.Summary.Name);
@@ -859,13 +957,13 @@ public class MetricsTests
     }
 
     [Fact]
-    public void RemoveMetrics_MultipleSelectedResources()
+    public async Task RemoveMetrics_MultipleSelectedResources()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -918,39 +1016,39 @@ public class MetricsTests
         });
 
         // Act
-        repository.ClearMetrics(new ResourceKey("resource1", null));
+        await repositoryContext.Repository.AsWriter().ClearMetricsAsync(new ResourceKey("resource1", null));
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
         var resource1Key = new ResourceKey("resource1", InstanceId: null);
-        var resource1Instruments = repository.GetInstrumentsSummaries(resource1Key);
+        var resource1Instruments = repositoryContext.Repository.GetInstrumentSummaries(resource1Key);
         Assert.Empty(resource1Instruments);
 
-        var resource1Test1Instrument = repository.GetInstrument(new GetInstrumentRequest
+        var resource1Test1Instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource1Key,
             InstrumentName = "test1",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Null(resource1Test1Instrument);
 
-        var resource1Test2Instrument = repository.GetInstrument(new GetInstrumentRequest
+        var resource1Test2Instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource1Key,
             InstrumentName = "test2",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Null(resource1Test2Instrument);
 
         var resource2Key = new ResourceKey("resource2", InstanceId: null);
-        var resource2Instruments = repository.GetInstrumentsSummaries(resource2Key);
+        var resource2Instruments = repositoryContext.Repository.GetInstrumentSummaries(resource2Key);
         Assert.Collection(resource2Instruments,
             instrument =>
             {
@@ -967,14 +1065,14 @@ public class MetricsTests
                 Assert.Equal("test-meter", instrument.Parent.Name);
             });
 
-        var resource2Test1Instrument = repository.GetInstrument(new GetInstrumentRequest
+        var resource2Test1Instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource2Key,
             InstrumentName = "test1",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(resource2Test1Instrument);
         Assert.Equal("test1", resource2Test1Instrument.Summary.Name);
@@ -982,14 +1080,14 @@ public class MetricsTests
         var resource2Test1Dimensions = Assert.Single(resource2Test1Instrument.Dimensions);
         Assert.Equal(5, ((MetricValue<long>)resource2Test1Dimensions.Values.Single()).Value);
 
-        var resource2Test3Instrument = repository.GetInstrument(new GetInstrumentRequest
+        var resource2Test3Instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resource2Key,
             InstrumentName = "test3",
             MeterName = "test-meter",
             StartTime = s_testTime,
             EndTime = s_testTime.AddMinutes(20)
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(resource2Test3Instrument);
         Assert.Equal("test3", resource2Test3Instrument.Summary.Name);
@@ -999,15 +1097,15 @@ public class MetricsTests
     }
 
     [Fact]
-    public void AddMetrics_InvalidInstrument()
+    public async Task AddMetrics_InvalidInstrument()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
 
         // Act
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -1031,7 +1129,7 @@ public class MetricsTests
         Assert.Equal(1, addContext.FailureCount);
 
         var resource1Key = new ResourceKey("resource1", InstanceId: null);
-        var resource1Instruments = repository.GetInstrumentsSummaries(resource1Key);
+        var resource1Instruments = repositoryContext.Repository.GetInstrumentSummaries(resource1Key);
         Assert.Collection(resource1Instruments,
             instrument =>
             {
@@ -1043,10 +1141,173 @@ public class MetricsTests
     }
 
     [Fact]
-    public void AddMetrics_InvalidHistogramDataPoints()
+    public async Task AddMetrics_NonFiniteDoubleDataPointsRejectedIndividually()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var metric = new Metric
+        {
+            Name = "test",
+            Sum = new Sum
+            {
+                AggregationTemporality = AggregationTemporality.Cumulative,
+                IsMonotonic = true
+            }
+        };
+        metric.Sum.DataPoints.AddRange(
+        [
+            CreateDoublePoint(1, 1, "first"),
+            CreateDoublePoint(double.NaN, 2),
+            CreateDoublePoint(double.PositiveInfinity, 3),
+            CreateDoublePoint(double.NegativeInfinity, 4),
+            CreateDoublePoint(2, 5, "second")
+        ]);
+        var addContext = new AddContext();
+
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { metric }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(2, addContext.SuccessCount);
+        Assert.Equal(3, addContext.FailureCount);
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = new ResourceKey("TestService", "TestId"),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+        Assert.Equal(
+            [1d, 2d],
+            instrument!.Dimensions
+                .OrderBy(dimension => Assert.Single(dimension.Attributes).Value)
+                .Select(dimension => Assert.IsType<MetricValue<double>>(Assert.Single(dimension.Values)).Value));
+
+        static NumberDataPoint CreateDoublePoint(double value, int minute, string? dimension = null)
+        {
+            var timestamp = DateTimeToUnixNanoseconds(s_testTime.AddMinutes(minute));
+            var point = new NumberDataPoint
+            {
+                AsDouble = value,
+                StartTimeUnixNano = timestamp,
+                TimeUnixNano = timestamp
+            };
+            if (dimension is not null)
+            {
+                point.Attributes.Add(new KeyValue
+                {
+                    Key = "dimension",
+                    Value = new AnyValue { StringValue = dimension }
+                });
+            }
+            return point;
+        }
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public async Task AddMetrics_NonFiniteHistogramSumRejected(double sum)
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var metric = CreateHistogramMetric(metricName: "test", startTime: s_testTime.AddMinutes(1));
+        metric.Histogram.DataPoints[0].Sum = sum;
+        var addContext = new AddContext();
+
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { metric }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.SuccessCount);
+        Assert.Equal(1, addContext.FailureCount);
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = new ResourceKey("TestService", "TestId"),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+        Assert.All(instrument!.Dimensions, dimension => Assert.Empty(dimension.Values));
+    }
+
+    [Fact]
+    public async Task AddMetrics_NonFiniteExemplarsIgnoredWithoutRejectingPoint()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(
+                                metricName: "test",
+                                startTime: s_testTime.AddMinutes(1),
+                                exemplars:
+                                [
+                                    CreateExemplar(s_testTime.AddMinutes(1), double.NaN),
+                                    CreateExemplar(s_testTime.AddMinutes(2), double.PositiveInfinity),
+                                    CreateExemplar(s_testTime.AddMinutes(3), double.NegativeInfinity),
+                                    CreateExemplar(s_testTime.AddMinutes(4), 2)
+                                ])
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, addContext.SuccessCount);
+        Assert.Equal(0, addContext.FailureCount);
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = new ResourceKey("TestService", "TestId"),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+        var value = Assert.Single(Assert.Single(instrument!.Dimensions).Values);
+        Assert.Equal(2, Assert.Single(value.Exemplars).Value);
+    }
+
+    [Fact]
+    public async Task AddMetrics_InvalidHistogramDataPoints()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
@@ -1089,7 +1350,7 @@ public class MetricsTests
             }
         };
 
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -1108,16 +1369,16 @@ public class MetricsTests
         // Assert
         Assert.Equal(2, addContext.FailureCount);
 
-        var resources = Assert.Single(repository.GetResources());
+        var resources = Assert.Single(repositoryContext.Repository.GetResources());
 
-        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = resources.ResourceKey,
             MeterName = "test-meter",
             InstrumentName = "test",
             StartTime = DateTime.MinValue,
             EndTime = DateTime.MaxValue
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(instrument);
         Assert.Equal("test", instrument.Summary.Name);
@@ -1130,10 +1391,9 @@ public class MetricsTests
     }
 
     [Fact]
-    public void AddMetrics_HistogramBucketCountLengthChanges_DataPointRejected()
+    public async Task AddMetrics_HistogramBucketCountLengthChanges_DataPointRejected()
     {
-        // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
         var addContext = new AddContext();
         var histogramMetric = new Metric
         {
@@ -1161,8 +1421,7 @@ public class MetricsTests
             }
         };
 
-        // Act
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -1178,18 +1437,17 @@ public class MetricsTests
             }
         });
 
-        // Assert
         Assert.Equal(1, addContext.SuccessCount);
         Assert.Equal(1, addContext.FailureCount);
 
-        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = new ResourceKey("TestService", "TestId"),
             MeterName = "test-meter",
             InstrumentName = "test",
             StartTime = DateTime.MinValue,
             EndTime = DateTime.MaxValue
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(instrument);
         var dimension = Assert.Single(instrument.Dimensions);
@@ -1200,14 +1458,14 @@ public class MetricsTests
     }
 
     [Fact]
-    public void AddMetrics_OverflowDimension()
+    public async Task AddMetrics_OverflowDimension()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -1216,10 +1474,11 @@ public class MetricsTests
                 {
                     new ScopeMetrics
                     {
-                        Scope = CreateScope(name: "test-meter"),
+                        Scope = CreateScope(name: "test-meter", attributes: [KeyValuePair.Create("meter", "value")]),
                         Metrics =
                         {
-                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("otel.metric.overflow", "true")])
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("otel.metric.overflow", "true")]),
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(2), attributes: [KeyValuePair.Create("dimension", "visible")])
                         }
                     },
                     new ScopeMetrics
@@ -1227,7 +1486,14 @@ public class MetricsTests
                         Scope = CreateScope(name: "test-meter2"),
                         Metrics =
                         {
-                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1))
+                            CreateSumMetric(
+                                metricName: "test",
+                                startTime: s_testTime.AddMinutes(1),
+                                attributes:
+                                [
+                                    KeyValuePair.Create("otel.metric.overflow", "true"),
+                                    KeyValuePair.Create("other", "value")
+                                ])
                         }
                     }
                 }
@@ -1237,40 +1503,45 @@ public class MetricsTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var instrument1 = repository.GetInstrument(new GetInstrumentRequest
+        var instrument1 = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = new ResourceKey("TestService", "TestId"),
             InstrumentName = "test",
             MeterName = "test-meter",
             StartTime = DateTime.MinValue,
-            EndTime = DateTime.MaxValue
-        });
+            EndTime = DateTime.MaxValue,
+            DimensionFilters = new Dictionary<string, IReadOnlyList<string?>>
+            {
+                ["dimension"] = ["visible"]
+            }
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(instrument1);
         Assert.True(instrument1.HasOverflow);
+        Assert.Single(instrument1.Dimensions);
 
-        var instrument2 = repository.GetInstrument(new GetInstrumentRequest
+        var instrument2 = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
         {
             ResourceKey = new ResourceKey("TestService", "TestId"),
             InstrumentName = "test",
             MeterName = "test-meter2",
             StartTime = DateTime.MinValue,
             EndTime = DateTime.MaxValue
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(instrument2);
         Assert.False(instrument2.HasOverflow);
     }
 
     [Fact]
-    public void AddMetrics_NoScope()
+    public async Task AddMetrics_NoScope()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -1292,7 +1563,7 @@ public class MetricsTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -1300,7 +1571,7 @@ public class MetricsTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var instruments = repository.GetInstrumentsSummaries(resources[0].ResourceKey);
+        var instruments = repositoryContext.Repository.GetInstrumentSummaries(resources[0].ResourceKey);
         Assert.Collection(instruments,
             instrument =>
             {
@@ -1311,11 +1582,835 @@ public class MetricsTests
             });
     }
 
-    private static void AssertDimensionValues(Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> dimensions, ReadOnlyMemory<KeyValuePair<string, string>> key, int valueCount)
+    [Fact]
+    public async Task GetInstrument_KnownAttributeValuesIgnoreMergedKeyLimit()
     {
-        var scope = dimensions[key];
-        Assert.True(Enumerable.SequenceEqual(MemoryMarshal.ToEnumerable(key), scope.Attributes), "Key and attributes don't match.");
+        const int previousKnownAttributeLimit = 10_000;
+        var pointAttributeCount = (previousKnownAttributeLimit / 2) + 1;
+        var scopeAttributeCount = previousKnownAttributeLimit / 2;
+        using var repositoryContext = await CreateRepositoryAsync(maxAttributeCount: pointAttributeCount);
+        var pointAttributes = Enumerable.Range(0, pointAttributeCount)
+            .Select(index => KeyValuePair.Create($"point-key-{index:D5}", $"point-value-{index:D5}"))
+            .ToArray();
+        var scopeAttributes = Enumerable.Range(0, scopeAttributeCount)
+            .Select(index => KeyValuePair.Create($"scope-key-{index:D5}", $"scope-value-{index:D5}"))
+            .ToArray();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter", attributes: scopeAttributes),
+                        Metrics = { CreateSumMetric(metricName: "test", startTime: s_testTime, attributes: pointAttributes) }
+                    }
+                }
+            }
+        });
 
-        Assert.Equal(valueCount, scope.Values.Count);
+        Assert.Equal(1, addContext.SuccessCount);
+        Assert.Equal(0, addContext.FailureCount);
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = new ResourceKey("TestService", "TestId"),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(pointAttributeCount + scopeAttributeCount, instrument!.KnownAttributeValues.Count);
+        Assert.Equal(pointAttributeCount + scopeAttributeCount, Assert.Single(instrument.Dimensions).Attributes.Length);
     }
+
+    [Fact]
+    public async Task GetInstrument_KnownAttributeValuesIgnoreMergedPerKeyValueLimit()
+    {
+        const int previousKnownAttributeValuesPerKeyLimit = 10_000;
+        var dimensionCountPerView = (previousKnownAttributeValuesPerKeyLimit / 2) + 1;
+        using var repositoryContext = await CreateRepositoryAsync();
+        var resourceMetrics = Enumerable.Range(0, 2)
+            .Select(viewIndex => new ResourceMetrics
+            {
+                Resource = CreateResource(instanceId: $"instance-{viewIndex}"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            Enumerable.Range(0, dimensionCountPerView)
+                                .Select(dimensionIndex => CreateSumMetric(
+                                    metricName: "test",
+                                    startTime: s_testTime,
+                                    attributes: [KeyValuePair.Create("key", $"value-{viewIndex}-{dimensionIndex:D5}")]))
+                        }
+                    }
+                }
+            });
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics> { resourceMetrics });
+
+        Assert.Equal(dimensionCountPerView * 2, addContext.SuccessCount);
+        Assert.Equal(0, addContext.FailureCount);
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = new ResourceKey("TestService", null),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(dimensionCountPerView * 2, Assert.Single(instrument!.KnownAttributeValues).Value.Count);
+        Assert.Equal(dimensionCountPerView * 2, instrument.Dimensions.Count);
+    }
+}
+
+public sealed class InMemoryMetricsTests : MetricsTests
+{
+    protected override bool UseSqlite => false;
+}
+
+public sealed class SqliteMetricsTests : MetricsTests
+{
+    private static readonly DateTime s_queryTestTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    protected override bool UseSqlite => true;
+
+    [Fact]
+    public async Task GetInstrument_PopulateExemplarAttributesFalse_SkipsAttributes()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        await repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            CreateResourceMetrics(CreateSumMetric(
+                metricName: "test",
+                startTime: s_queryTestTime.AddMinutes(1),
+                value: 1,
+                exemplars: [CreateExemplar(s_queryTestTime.AddMinutes(1), 2, [KeyValuePair.Create("key", "value")])]))
+        });
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(repository.SqlActivitySource, onActivityStopped: activities.Enqueue);
+        using var parent = new Activity("metric exemplar attributes test").Start();
+
+        var instrument = await repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = CreateResource().GetResourceKey(),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue,
+            PopulateExemplarAttributes = false
+        }, cancellationToken: CancellationToken.None);
+
+        var exemplar = Assert.Single(Assert.Single(Assert.Single(instrument!.Dimensions).Values).Exemplars);
+        Assert.Empty(exemplar.Attributes);
+        var queries = activities
+            .Where(activity => activity.ParentSpanId == parent.SpanId)
+            .Select(activity => (string)activity.GetTagItem("db.query.text")!);
+        Assert.DoesNotContain(queries, query => query.Contains("telemetry_metric_exemplar_attributes", StringComparison.Ordinal));
+        Assert.Single(queries, query => query.Contains("ranked_metric_points", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetInstrument_WithoutTimeRange_SkipsMetricPointQueries()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        await repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            CreateResourceMetrics(CreateSumMetric("test", s_queryTestTime.AddMinutes(1)))
+        });
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(repository.SqlActivitySource, onActivityStopped: activities.Enqueue);
+        using var parent = new Activity("metric metadata test").Start();
+
+        var instrument = await repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = CreateResource().GetResourceKey(),
+            MeterName = "test-meter",
+            InstrumentName = "test"
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Empty(Assert.Single(instrument!.Dimensions).Values);
+        var queries = activities
+            .Where(activity => activity.ParentSpanId == parent.SpanId)
+            .Select(activity => (string)activity.GetTagItem("db.query.text")!);
+        Assert.DoesNotContain(queries, query => query.Contains("telemetry_metric_points", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetInstrument_StaggeredDimensionChanges_ReturnsDimensionTimelines()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+
+        for (var minute = 1; minute <= 3; minute++)
+        {
+            await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(),
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = CreateScope(name: "test-meter"),
+                            Metrics =
+                            {
+                                CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(minute), value: 10, attributes: [KeyValuePair.Create("dimension", "stable")]),
+                                CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(minute), value: 15 + (minute * 5), attributes: [KeyValuePair.Create("dimension", "changing")])
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        Assert.Equal(0, addContext.FailureCount);
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = s_queryTestTime,
+            EndTime = s_queryTestTime.AddMinutes(4)
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.NotNull(instrument);
+        var dimensions = instrument.Dimensions.ToDictionary(dimension => Assert.Single(dimension.Attributes).Value);
+        var stableValue = Assert.IsType<MetricValue<long>>(Assert.Single(dimensions["stable"].Values));
+        Assert.Equal(10, stableValue.Value);
+        Assert.Collection(
+            dimensions["changing"].Values.Cast<MetricValue<long>>(),
+            value => Assert.Equal(25, value.Value),
+            value => Assert.Equal(30, value.Value));
+    }
+
+    [Fact]
+    public async Task GetHistogram_StaggeredDimensionChanges_ReturnsDimensionTimelines()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+
+        for (var minute = 1; minute <= 3; minute++)
+        {
+            await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(),
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = CreateScope(name: "test-meter"),
+                            Metrics =
+                            {
+                                CreateTestHistogramMetric(startTime: s_queryTestTime.AddMinutes(minute), value: 10, dimension: "stable"),
+                                CreateTestHistogramMetric(startTime: s_queryTestTime.AddMinutes(minute), value: 15 + (minute * 5), dimension: "changing")
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        Assert.Equal(0, addContext.FailureCount);
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = s_queryTestTime,
+            EndTime = s_queryTestTime.AddMinutes(4)
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.NotNull(instrument);
+        var dimensions = instrument.Dimensions.ToDictionary(dimension => Assert.Single(dimension.Attributes).Value);
+        var stableValue = Assert.IsType<HistogramValue>(Assert.Single(dimensions["stable"].Values));
+        Assert.Equal(10ul, stableValue.Count);
+        Assert.Equal(10ul, stableValue.Values[0]);
+        Assert.Collection(
+            dimensions["changing"].Values.Cast<HistogramValue>(),
+            value =>
+            {
+                Assert.Equal(20ul, value.Count);
+                Assert.Equal(20ul, value.Values[0]);
+            },
+            value =>
+            {
+                Assert.Equal(25ul, value.Count);
+                Assert.Equal(25ul, value.Values[0]);
+            },
+            value =>
+            {
+                Assert.Equal(30ul, value.Count);
+                Assert.Equal(30ul, value.Values[0]);
+            });
+
+        static Metric CreateTestHistogramMetric(DateTime startTime, int value, string dimension)
+        {
+            var metric = CreateHistogramMetric("test", startTime);
+            var point = Assert.Single(metric.Histogram.DataPoints);
+            point.Count = checked((ulong)value);
+            point.Sum = value;
+            point.BucketCounts.Clear();
+            point.BucketCounts.AddRange([checked((ulong)value), 0, 0, 0]);
+            point.Attributes.Add(new KeyValue
+            {
+                Key = "dimension",
+                Value = new AnyValue { StringValue = dimension }
+            });
+            return metric;
+        }
+    }
+
+    [Fact]
+    public async Task GetInstrument_DimensionCursor_ReturnsExtendedLatestPoint()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(
+                                metricName: "test",
+                                startTime: s_queryTestTime.AddMinutes(1),
+                                value: 10,
+                                attributes: [KeyValuePair.Create("dimension", "one")],
+                                exemplars: [CreateExemplar(s_queryTestTime.AddMinutes(1), 10)])
+                        }
+                    }
+                }
+            }
+        });
+
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var initialInstrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = s_queryTestTime,
+            EndTime = s_queryTestTime.AddMinutes(1)
+        }, cancellationToken: CancellationToken.None);
+        var initialDimension = Assert.Single(initialInstrument!.Dimensions);
+        var initialValue = Assert.IsType<MetricValue<long>>(Assert.Single(initialDimension.Values));
+
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(
+                                metricName: "test",
+                                startTime: s_queryTestTime.AddMinutes(2),
+                                value: 10,
+                                attributes: [KeyValuePair.Create("dimension", "one")],
+                                exemplars: [CreateExemplar(s_queryTestTime.AddMinutes(2), 20)])
+                        }
+                    }
+                }
+            }
+        });
+
+        var refreshedInstrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = s_queryTestTime,
+            EndTime = s_queryTestTime.AddMinutes(2),
+            DimensionCursors =
+            [
+                new MetricDimensionCursor
+                {
+                    Attributes = initialDimension.Attributes,
+                    StartTime = s_queryTestTime.AddMinutes(1.5)
+                }
+            ]
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(0, addContext.FailureCount);
+        var refreshedValue = Assert.IsType<MetricValue<long>>(Assert.Single(Assert.Single(refreshedInstrument!.Dimensions).Values));
+        Assert.Equal(initialValue.Start, refreshedValue.Start);
+        Assert.Equal(s_queryTestTime.AddMinutes(2), refreshedValue.End);
+        Assert.Equal(2ul, refreshedValue.Count);
+        Assert.Equal(20, Assert.Single(refreshedValue.Exemplars).Value);
+    }
+
+    [Fact]
+    public async Task GetInstrument_DataPointInterval_RollsUpNumericValuesAndExemplars()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(
+                                metricName: "test",
+                                startTime: s_queryTestTime.AddMilliseconds(100),
+                                value: 3,
+                                exemplars: [CreateExemplar(s_queryTestTime.AddMilliseconds(100), 3)]),
+                            CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMilliseconds(200), value: 2),
+                            CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMilliseconds(800), value: 1)
+                        }
+                    }
+                }
+            }
+        });
+
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = s_queryTestTime,
+            EndTime = s_queryTestTime.AddSeconds(1),
+            DataPointInterval = TimeSpan.FromSeconds(1)
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(0, addContext.FailureCount);
+        var value = Assert.IsType<MetricValue<long>>(Assert.Single(Assert.Single(instrument!.Dimensions).Values));
+        Assert.Equal(2, value.Value);
+        Assert.Equal(s_queryTestTime, value.Start);
+        var exemplar = Assert.Single(value.Exemplars);
+        Assert.Equal(3, exemplar.Value);
+    }
+
+    [Fact]
+    public async Task GetInstrument_IncrementalRollup_RecomputesCompleteLatestBucket()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await AddMetric(s_queryTestTime.AddSeconds(1), 5);
+        await AddMetric(s_queryTestTime.AddSeconds(5), 5);
+        await AddMetric(s_queryTestTime.AddSeconds(10), 3);
+        await AddMetric(s_queryTestTime.AddMinutes(2), 3);
+
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var initialInstrument = await GetInstrumentAsync([]);
+        var initialValue = Assert.IsType<MetricValue<long>>(Assert.Single(Assert.Single(initialInstrument.Dimensions).Values));
+        var cursors = MetricInstrumentDataCache.CreateCursors(initialInstrument, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+        var cursor = Assert.Single(cursors);
+
+        Assert.Equal(0, addContext.FailureCount);
+        Assert.Equal(5, initialValue.Value);
+        Assert.Equal(s_queryTestTime, cursor.StartTime);
+
+        var refreshedInstrument = await GetInstrumentAsync(cursors);
+        var refreshedValue = Assert.IsType<MetricValue<long>>(Assert.Single(Assert.Single(refreshedInstrument.Dimensions).Values));
+        Assert.Equal(initialValue.Value, refreshedValue.Value);
+        Assert.Equal(initialValue.Count, refreshedValue.Count);
+        Assert.Equal(initialValue.Start, refreshedValue.Start);
+        Assert.Equal(initialValue.End, refreshedValue.End);
+
+        async Task AddMetric(DateTime startTime, int value)
+        {
+            await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(),
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = CreateScope(name: "test-meter"),
+                            Metrics = { CreateSumMetric(metricName: "test", startTime: startTime, value: value) }
+                        }
+                    }
+                }
+            });
+        }
+
+        async Task<OtlpInstrumentData> GetInstrumentAsync(IReadOnlyList<MetricDimensionCursor> dimensionCursors)
+        {
+            return (await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+            {
+                ResourceKey = resource.ResourceKey,
+                MeterName = "test-meter",
+                InstrumentName = "test",
+                StartTime = s_queryTestTime,
+                EndTime = s_queryTestTime.AddMinutes(2),
+                DataPointInterval = TimeSpan.FromMinutes(1),
+                DimensionCursors = dimensionCursors
+            }, cancellationToken: CancellationToken.None))!;
+        }
+    }
+
+    [Fact]
+    public async Task GetHistogram_DataPointInterval_ReturnsLatestCoherentSnapshot()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        var metrics = new List<Metric>();
+        for (var pointIndex = 1; pointIndex <= 3; pointIndex++)
+        {
+            var metric = CreateHistogramMetric("test", s_queryTestTime.AddMilliseconds(pointIndex * 100));
+            var point = Assert.Single(metric.Histogram.DataPoints);
+            point.Count = checked((ulong)pointIndex);
+            point.Sum = pointIndex * 10;
+            point.BucketCounts.Clear();
+            point.BucketCounts.AddRange(pointIndex switch
+            {
+                1 => [1, 0, 0, 0],
+                2 => [1, 1, 0, 0],
+                _ => [1, 1, 1, 0]
+            });
+            if (pointIndex == 2)
+            {
+                point.Exemplars.Add(CreateExemplar(s_queryTestTime.AddMilliseconds(200), 20));
+            }
+            metrics.Add(metric);
+        }
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { metrics }
+                    }
+                }
+            }
+        });
+
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var instrument = await repositoryContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resource.ResourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = s_queryTestTime,
+            EndTime = s_queryTestTime.AddMinutes(1),
+            DataPointInterval = TimeSpan.FromMinutes(1)
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(0, addContext.FailureCount);
+        var value = Assert.IsType<HistogramValue>(Assert.Single(Assert.Single(instrument!.Dimensions).Values));
+        Assert.Equal(3ul, value.Count);
+        Assert.Equal(30, value.Sum);
+        Assert.Equal([1ul, 1ul, 1ul, 0ul], value.Values);
+        Assert.Equal(20, Assert.Single(value.Exemplars).Value);
+    }
+
+    [Fact]
+    public async Task AddMetrics_ReusesInstrumentAndDimensionLookupsWithinBatch()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(repository.SqlActivitySource, onActivityStopped: activities.Enqueue);
+        using var parent = new Activity("metric ingestion test").Start();
+
+        var context = new AddContext();
+        await repository.AsWriter().AddMetricsAsync(context, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(1), value: 1),
+                            CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(2), value: 2),
+                            CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(3), value: 2)
+                        }
+                    }
+                }
+            }
+        });
+
+        var queries = activities
+            .Where(activity => activity.ParentSpanId == parent.SpanId)
+            .Select(activity => (string)activity.GetTagItem("db.query.text")!)
+            .ToList();
+        Assert.Single(queries, query => query.Contains("SELECT instrument_id", StringComparison.Ordinal));
+        Assert.DoesNotContain(queries, query => query.Contains("FROM telemetry_metric_dimensions d", StringComparison.Ordinal));
+        Assert.Single(queries, query => query.StartsWith("DELETE FROM telemetry_metric_points", StringComparison.Ordinal));
+        var insertQuery = Assert.Single(queries, query => query.StartsWith("INSERT INTO telemetry_metric_points", StringComparison.Ordinal));
+        Assert.Equal(2, insertQuery.Split("@param_dimension_id_", StringSplitOptions.None).Length - 1);
+        Assert.Equal(3, context.SuccessCount);
+    }
+
+    [Fact]
+    public async Task AddMetrics_LargeHistogramAndDimensionAttributeBatchesRoundTrip()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        var histogram = CreateHistogramMetric(metricName: "histogram", startTime: s_queryTestTime.AddMinutes(1));
+        var histogramPoint = histogram.Histogram.DataPoints[0];
+        histogramPoint.ExplicitBounds.Clear();
+        histogramPoint.BucketCounts.Clear();
+        for (var index = 0; index < 200; index++)
+        {
+            histogramPoint.ExplicitBounds.Add(index + 1);
+            histogramPoint.BucketCounts.Add(1);
+        }
+        histogramPoint.BucketCounts.Add(1);
+
+        var firstDimensionAttributes = Enumerable.Range(0, 128)
+            .Select(index => KeyValuePair.Create($"key-{index}", $"first-{index}"))
+            .ToArray();
+        var secondDimensionAttributes = Enumerable.Range(0, 128)
+            .Select(index => KeyValuePair.Create($"key-{index}", $"second-{index}"))
+            .ToArray();
+        var context = new AddContext();
+        await repository.AsWriter().AddMetricsAsync(context, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            histogram,
+                            CreateSumMetric(metricName: "sum", startTime: s_queryTestTime.AddMinutes(1), attributes: firstDimensionAttributes),
+                            CreateSumMetric(metricName: "sum", startTime: s_queryTestTime.AddMinutes(1), attributes: secondDimensionAttributes)
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(3, context.SuccessCount);
+        Assert.Equal(0, context.FailureCount);
+
+        var resourceKey = CreateResource().GetResourceKey();
+        var histogramInstrument = await repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "histogram",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+        var histogramValue = Assert.IsType<HistogramValue>(Assert.Single(Assert.Single(histogramInstrument!.Dimensions).Values));
+        Assert.Equal(Enumerable.Repeat<ulong>(1, 201), histogramValue.Values);
+        Assert.Equal(Enumerable.Range(1, 200).Select(value => (double)value), histogramValue.ExplicitBounds);
+
+        var sumInstrument = await repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = resourceKey,
+            MeterName = "test-meter",
+            InstrumentName = "sum",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+        Assert.Collection(
+            sumInstrument!.Dimensions,
+            dimension =>
+            {
+                Assert.Equal(firstDimensionAttributes.OrderBy(attribute => attribute.Key), dimension.Attributes);
+                Assert.Equal(1, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value);
+            },
+            dimension =>
+            {
+                Assert.Equal(secondDimensionAttributes.OrderBy(attribute => attribute.Key), dimension.Attributes);
+                Assert.Equal(1, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value);
+            });
+    }
+
+    [Fact]
+    public async Task AddMetrics_BatchesAndDeduplicatesExemplars()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        await repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            CreateResourceMetrics(CreateSumMetric(
+                metricName: "test",
+                startTime: s_queryTestTime.AddMinutes(1),
+                value: 1,
+                exemplars: [CreateExemplar(s_queryTestTime.AddMinutes(1), 2, [KeyValuePair.Create("first", "value")])]))
+        });
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(repository.SqlActivitySource, onActivityStopped: activities.Enqueue);
+        using var parent = new Activity("metric exemplar test").Start();
+
+        var context = new AddContext();
+        await repository.AsWriter().AddMetricsAsync(context, new RepeatedField<ResourceMetrics>
+        {
+            CreateResourceMetrics(CreateSumMetric(
+                metricName: "test",
+                startTime: s_queryTestTime.AddMinutes(2),
+                value: 1,
+                exemplars:
+                [
+                    CreateExemplar(s_queryTestTime.AddMinutes(1), 2, [KeyValuePair.Create("first", "value")]),
+                    CreateExemplar(s_queryTestTime.AddMinutes(2), 3, [KeyValuePair.Create("second", "value")])
+                ]))
+        });
+
+        var queries = activities
+            .Where(activity => activity.ParentSpanId == parent.SpanId)
+            .Select(activity => (string)activity.GetTagItem("db.query.text")!)
+            .ToList();
+        Assert.DoesNotContain(queries, query => query.Contains("SELECT EXISTS", StringComparison.Ordinal));
+        var exemplarInsert = Assert.Single(queries, query => query.StartsWith("INSERT OR IGNORE INTO telemetry_metric_exemplars", StringComparison.Ordinal));
+        Assert.Equal(2, exemplarInsert.Split("@PointId", StringSplitOptions.None).Length - 1);
+        Assert.Single(queries, query => query.StartsWith("INSERT INTO telemetry_metric_exemplar_attributes", StringComparison.Ordinal));
+        Assert.Equal(1, context.SuccessCount);
+        Assert.Equal(0, context.FailureCount);
+
+        var instrument = await repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = CreateResource().GetResourceKey(),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+        var value = Assert.IsType<MetricValue<long>>(Assert.Single(Assert.Single(instrument!.Dimensions).Values));
+        Assert.Collection(value.Exemplars,
+            exemplar => Assert.Equal("first", Assert.Single(exemplar.Attributes).Key),
+            exemplar => Assert.Equal("second", Assert.Single(exemplar.Attributes).Key));
+    }
+
+    [Fact]
+    public async Task AddMetrics_UpdateOnlyBatch_DoesNotTrimMetricPoints()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        await repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            CreateResourceMetrics(CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(1), value: 1))
+        });
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(repository.SqlActivitySource, onActivityStopped: activities.Enqueue);
+        using var parent = new Activity("metric update test").Start();
+
+        await repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(2), value: 1),
+                            CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(3), value: 1),
+                            CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(4), value: 1)
+                        }
+                    }
+                }
+            }
+        });
+
+        var queries = activities
+            .Where(activity => activity.ParentSpanId == parent.SpanId)
+            .Select(activity => (string)activity.GetTagItem("db.query.text")!)
+            .ToList();
+        Assert.DoesNotContain(queries, query => query.Contains("SELECT resource_id", StringComparison.Ordinal));
+        Assert.DoesNotContain(queries, query => query.Contains("FROM telemetry_scopes", StringComparison.Ordinal));
+        Assert.DoesNotContain(queries, query => query.Contains("FROM telemetry_scope_attributes", StringComparison.Ordinal));
+        Assert.DoesNotContain(queries, query => query.Contains("SELECT instrument_id", StringComparison.Ordinal));
+        Assert.DoesNotContain(queries, query => query.Contains("FROM telemetry_metric_dimensions d", StringComparison.Ordinal));
+        Assert.DoesNotContain(queries, query => query.StartsWith("UPDATE telemetry_resources SET has_metrics", StringComparison.Ordinal));
+        Assert.DoesNotContain(queries, query => query.StartsWith("DELETE FROM telemetry_metric_points", StringComparison.Ordinal));
+        var updateQuery = Assert.Single(queries, query => query.Contains("UPDATE telemetry_metric_points", StringComparison.Ordinal));
+        Assert.Contains("WITH updates", updateQuery, StringComparison.Ordinal);
+        Assert.Contains("FROM updates", updateQuery, StringComparison.Ordinal);
+        Assert.DoesNotContain("SELECT end_time_ticks FROM updates", updateQuery, StringComparison.Ordinal);
+        var instrument = await repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = CreateResource().GetResourceKey(),
+            MeterName = "test-meter",
+            InstrumentName = "test",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+        var value = Assert.IsType<MetricValue<long>>(Assert.Single(Assert.Single(instrument!.Dimensions).Values));
+        Assert.Equal(4UL, value.Count);
+        Assert.Equal(s_queryTestTime.AddMinutes(4), value.End);
+    }
+
+    [Fact]
+    public async Task ClearMetrics_InvalidatesMetricIngestionCache()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            CreateResourceMetrics(CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(1), value: 1))
+        });
+
+        await repositoryContext.Repository.AsWriter().ClearMetricsAsync();
+
+        var context = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(context, new RepeatedField<ResourceMetrics>
+        {
+            CreateResourceMetrics(CreateSumMetric(metricName: "test", startTime: s_queryTestTime.AddMinutes(2), value: 2))
+        });
+
+        Assert.Equal(1, context.SuccessCount);
+        Assert.Equal(0, context.FailureCount);
+        Assert.Single(repositoryContext.Repository.GetInstrumentSummaries(CreateResource().GetResourceKey()));
+    }
+
+    private static ResourceMetrics CreateResourceMetrics(Metric metric) => new()
+    {
+        Resource = CreateResource(),
+        ScopeMetrics =
+        {
+            new ScopeMetrics
+            {
+                Scope = CreateScope(name: "test-meter"),
+                Metrics = { metric }
+            }
+        }
+    };
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ResourceTests.cs
@@ -10,19 +10,19 @@ using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 
-public class ResourceTests
+public abstract class ResourceTests : TelemetryRepositoryTestBase
 {
     [Fact]
-    public void GetResourceByCompositeName()
+    public async Task GetResourceByCompositeName()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddResource(repository, "app2");
-        AddResource(repository, "app1");
+        await AddResource(repositoryContext.Repository, "app2");
+        await AddResource(repositoryContext.Repository, "app1");
 
         // Act 1
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
 
         // Assert 1
         Assert.Collection(resources,
@@ -38,9 +38,9 @@ public class ResourceTests
             });
 
         // Act 2
-        var app1 = repository.GetResourceByCompositeName("app1-TestId");
-        var app2 = repository.GetResourceByCompositeName("APP2-TESTID");
-        var notFound = repository.GetResourceByCompositeName("APP2_TESTID");
+        var app1 = repositoryContext.Repository.GetResourceByCompositeName("app1-TestId");
+        var app2 = repositoryContext.Repository.GetResourceByCompositeName("APP2-TESTID");
+        var notFound = repositoryContext.Repository.GetResourceByCompositeName("APP2_TESTID");
 
         // Assert 2
         Assert.NotNull(app1);
@@ -55,17 +55,17 @@ public class ResourceTests
     }
 
     [Fact]
-    public void GetResources_WithNameAndNoKey()
+    public async Task GetResources_WithNameAndNoKey()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddResource(repository, "app2");
-        AddResource(repository, "app1", instanceId: "123");
-        AddResource(repository, "app1", instanceId: "456");
+        await AddResource(repositoryContext.Repository, "app2");
+        await AddResource(repositoryContext.Repository, "app1", instanceId: "123");
+        await AddResource(repositoryContext.Repository, "app1", instanceId: "456");
 
         // Act 1
-        var resources1 = repository.GetResources(new ResourceKey("app1", InstanceId: null));
+        var resources1 = repositoryContext.Repository.GetResources(new ResourceKey("app1", InstanceId: null));
 
         // Assert 1
         Assert.Collection(resources1,
@@ -81,7 +81,7 @@ public class ResourceTests
             });
 
         // Act 2
-        var resources2 = repository.GetResources(new ResourceKey("app2", InstanceId: null));
+        var resources2 = repositoryContext.Repository.GetResources(new ResourceKey("app2", InstanceId: null));
 
         // Assert 2
         Assert.Collection(resources2,
@@ -93,17 +93,17 @@ public class ResourceTests
     }
 
     [Fact]
-    public void GetResources_Order()
+    public async Task GetResources_Order()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddResource(repository, "app2");
-        AddResource(repository, "app1", instanceId: "def");
-        AddResource(repository, "app1", instanceId: "abc");
+        await AddResource(repositoryContext.Repository, "app2");
+        await AddResource(repositoryContext.Repository, "app1", instanceId: "def");
+        await AddResource(repositoryContext.Repository, "app1", instanceId: "abc");
 
         // Act
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
 
         // Assert
         Assert.Collection(resources,
@@ -125,18 +125,18 @@ public class ResourceTests
     }
 
     [Fact]
-    public void GetResourceName_GuidInstanceId_Shorten()
+    public async Task GetResourceName_GuidInstanceId_Shorten()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
         var guid1 = "19572b19-d1c0-4a51-98b4-fcc2658f73d3";
         var guid2 = "f66e2b1e-f420-4a22-a067-8dd2f6fcda86";
 
-        AddResource(repository, "app1", guid1);
-        AddResource(repository, "app1", guid2);
+        await AddResource(repositoryContext.Repository, "app1", guid1);
+        await AddResource(repositoryContext.Repository, "app1", guid2);
 
         // Act
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
 
         var instance1Name = OtlpHelpers.GetResourceName(resources[0], resources);
         var instance2Name = OtlpHelpers.GetResourceName(resources[1], resources);
@@ -147,20 +147,20 @@ public class ResourceTests
     }
 
     [Fact]
-    public void GetResourceName_Version7GuidInstanceId_ShortenedNamesDiffer()
+    public async Task GetResourceName_Version7GuidInstanceId_ShortenedNamesDiffer()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Version 7 GUIDs created close in time share the same leading characters.
         var guid1 = "01890a5d-ac96-774b-bcce-b302099a8057";
         var guid2 = "01890a5d-ac96-7768-a3e2-34c4a0e9f6ad";
 
-        AddResource(repository, "app1", guid1);
-        AddResource(repository, "app1", guid2);
+        await AddResource(repositoryContext.Repository, "app1", guid1);
+        await AddResource(repositoryContext.Repository, "app1", guid2);
 
         // Act
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
 
         var instance1 = Assert.Single(resources, r => r.InstanceId == guid1);
         var instance2 = Assert.Single(resources, r => r.InstanceId == guid2);
@@ -173,10 +173,10 @@ public class ResourceTests
         Assert.Equal("app1-a0e9f6ad", instance2Name);
     }
 
-    private static void AddResource(TelemetryRepository repository, string name, string? instanceId = null)
+    private static async Task AddResource(ITelemetryRepository repository, string name, string? instanceId = null)
     {
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -186,4 +186,14 @@ public class ResourceTests
 
         Assert.Equal(0, addContext.FailureCount);
     }
+}
+
+public sealed class InMemoryResourceTests : ResourceTests
+{
+    protected override bool UseSqlite => false;
+}
+
+public sealed class SqliteResourceTests : ResourceTests
+{
+    protected override bool UseSqlite => true;
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/SqliteTelemetryPersistenceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/SqliteTelemetryPersistenceTests.cs
@@ -1,0 +1,975 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Tests.Shared;
+using Aspire.Tests;
+using Aspire.Tests.Shared.DashboardModel;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Metrics.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
+
+namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
+
+public sealed class SqliteTelemetryPersistenceTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task RunReadAsync_CancellationInterruptsLongRunningQuery()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+        using var cancellationSource = new CancellationTokenSource();
+        var queryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var queryTask = SqliteTelemetryRepository.RunReadAsync(token =>
+        {
+            using var connection = repositoryContext.Database.OpenConnection();
+            using var interrupt = connection.RegisterInterrupt(token);
+            // Signal from inside the statement so cancellation can't happen before SQLite starts executing it.
+            // Return immediately so the cancellation interrupts SQLite's recursive query, not managed code.
+            connection.CreateFunction("query_started", () =>
+            {
+                queryStarted.TrySetResult();
+                return 1;
+            });
+
+            using var command = connection.CreateCommand();
+            // This query is deliberately too large to complete within the test timeout without interruption.
+            command.CommandText = """
+                WITH RECURSIVE numbers(value) AS (
+                    SELECT query_started()
+                    UNION ALL
+                    SELECT value + 1 FROM numbers WHERE value < 1000000000
+                )
+                SELECT SUM(value) FROM numbers;
+                """;
+            return command.ExecuteScalar();
+        }, cancellationSource.Token);
+
+        await queryStarted.Task.DefaultTimeout();
+        cancellationSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queryTask).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task Cache_UsesCanonicalResourceViewAndScopeAcrossSignals()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var startTime = new DateTime(2025, 4, 5, 6, 7, 8, DateTimeKind.Utc);
+        var resource = CreateResource(attributes: [KeyValuePair.Create("resource-key", "resource-value")]);
+        var scope = CreateScope(name: "SharedScope", attributes: [KeyValuePair.Create("scope-key", "scope-value")]);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+
+        await repositoryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = resource,
+                ScopeLogs = { new ScopeLogs { Scope = scope, LogRecords = { CreateLogRecord() } } }
+            }
+        });
+        await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = resource,
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = scope,
+                        Spans = { CreateSpan("cache-trace", "cache-span", startTime, startTime.AddSeconds(1)) }
+                    }
+                }
+            }
+        });
+        await repositoryContext.Repository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = resource,
+                ScopeMetrics = { new ScopeMetrics { Scope = scope, Metrics = { CreateSumMetric("requests", startTime) } } }
+            }
+        });
+
+        var cachedResource = Assert.Single(repositoryContext.Repository.GetResources());
+        var log = Assert.Single((await repositoryContext.Repository.GetLogsAsync(CreateLogsContext(), cancellationToken: CancellationToken.None)).Items);
+        var span = Assert.Single(Assert.Single((await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(cachedResource.ResourceKey), cancellationToken: CancellationToken.None)).PagedResult.Items).Spans);
+        var instrument = Assert.Single(repositoryContext.Repository.GetInstrumentSummaries(cachedResource.ResourceKey));
+
+        Assert.Same(cachedResource, log.ResourceView.Resource);
+        Assert.Same(cachedResource, span.Source.Resource);
+        Assert.Same(log.ResourceView, span.Source);
+        Assert.Same(log.Scope, span.Scope);
+        Assert.Same(log.Scope, instrument.Parent);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task InstrumentedPeer_RemainsInstrumented(bool resolvePeerDuringIngestion)
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var resolvePeer = resolvePeerDuringIngestion;
+        var backend = ModelTestHelpers.CreateResource(resourceName: "backend-TestId", displayName: "backend");
+        using var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: _ => resolvePeer ? (backend.Name, backend) : (null, null));
+        using (var repositoryContext = await CreateRepositoryAsync(workspace.Path, outgoingPeerResolvers: [outgoingPeerResolver]))
+        {
+            await repositoryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(name: "backend", instanceId: "TestId"),
+                    ScopeLogs = { new ScopeLogs { Scope = CreateScope(), LogRecords = { CreateLogRecord() } } }
+                }
+            });
+            await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+            {
+                new ResourceSpans
+                {
+                    Resource = CreateResource(name: "frontend", instanceId: "TestId"),
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Scope = CreateScope(),
+                            Spans =
+                            {
+                                CreateSpan(
+                                    traceId: "peer-trace",
+                                    spanId: "peer-span",
+                                    startTime: DateTime.UnixEpoch,
+                                    endTime: DateTime.UnixEpoch.AddSeconds(1),
+                                    attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "backend")],
+                                    kind: Span.Types.SpanKind.Client)
+                            }
+                        }
+                    }
+                }
+            });
+
+            if (!resolvePeerDuringIngestion)
+            {
+                resolvePeer = true;
+                await outgoingPeerResolver.InvokePeerChanges();
+            }
+        }
+
+        using var reopenedContext = await CreateRepositoryAsync(workspace.Path, readOnly: true);
+        var backendResource = Assert.IsType<OtlpResource>(
+            reopenedContext.Repository.GetResource(new ResourceKey("backend", "TestId")));
+        Assert.False(backendResource.UninstrumentedPeer);
+
+        var span = Assert.Single(reopenedContext.Repository.GetTrace(GetHexId("peer-trace"))!.Spans);
+        Assert.Same(backendResource, span.UninstrumentedPeer);
+    }
+
+    [Fact]
+    public async Task Cache_HydratesPersistedMetadataOnce()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var startTime = new DateTime(2025, 4, 5, 6, 7, 8, DateTimeKind.Utc);
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            await repositoryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(attributes: [KeyValuePair.Create("resource-key", "resource-value")]),
+                    ScopeLogs = { new ScopeLogs { Scope = CreateScope("TestScope"), LogRecords = { CreateLogRecord() } } }
+                }
+            });
+            await repositoryContext.Repository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(),
+                    ScopeMetrics = { new ScopeMetrics { Scope = CreateScope("TestScope"), Metrics = { CreateSumMetric("requests", startTime) } } }
+                }
+            });
+        }
+
+        using var historicalContext = await CreateRepositoryAsync(workspace.Path, readOnly: true);
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = ActivityListenerHelper.Create(historicalContext.Repository.SqlActivitySource, onActivityStopped: activities.Enqueue);
+        using var parent = new Activity("cache hydration test").Start();
+        var firstResource = Assert.Single(historicalContext.Repository.GetResources());
+        Assert.NotEmpty(activities);
+        activities.Clear();
+
+        var secondResource = Assert.Single(historicalContext.Repository.GetResources());
+        var summary = Assert.Single(historicalContext.Repository.GetInstrumentSummaries(firstResource.ResourceKey));
+        var views = firstResource.GetViews().OrderBy(view => view.Properties.Length).ToList();
+
+        Assert.Same(firstResource, secondResource);
+        Assert.Collection(views,
+            view =>
+            {
+                Assert.Same(firstResource, view.Resource);
+                Assert.Empty(view.Properties);
+            },
+            view =>
+            {
+                Assert.Same(firstResource, view.Resource);
+                var property = Assert.Single(view.Properties);
+                Assert.Equal(KeyValuePair.Create("resource-key", "resource-value"), property);
+            });
+        Assert.Equal("requests", summary.Name);
+        Assert.Empty(activities);
+    }
+
+    [Fact]
+    public async Task Metrics_ReopenWithResourceView()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            await repositoryContext.Repository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(attributes: [KeyValuePair.Create("resource-key", "resource-value")]),
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = CreateScope("TestScope"),
+                            Metrics = { CreateSumMetric("requests", new DateTime(2025, 4, 5, 6, 7, 8, DateTimeKind.Utc)) }
+                        }
+                    }
+                }
+            });
+        }
+
+        using var reopenedContext = await CreateRepositoryAsync(workspace.Path, readOnly: true);
+        var resource = Assert.Single(reopenedContext.Repository.GetResources());
+        var views = resource.GetViews().OrderBy(view => view.Properties.Length).ToArray();
+        var instrument = Assert.Single(reopenedContext.Repository.GetInstrumentSummaries(resource.ResourceKey));
+
+        Assert.Collection(views,
+            view => Assert.Empty(view.Properties),
+            view => Assert.Equal(KeyValuePair.Create("resource-key", "resource-value"), Assert.Single(view.Properties)));
+        Assert.Same(views[1], instrument.ResourceView);
+    }
+
+    [Fact]
+    public async Task Logs_ReopenFromNormalizedRowsWithStableIds()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        long logId;
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            await repositoryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(),
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            Scope = CreateScope("TestLogger"),
+                            LogRecords = { CreateLogRecord() }
+                        }
+                    }
+                }
+            });
+
+            var log = Assert.Single((await repositoryContext.Repository.GetLogsAsync(CreateLogsContext(), cancellationToken: CancellationToken.None)).Items);
+            logId = log.InternalId;
+        }
+
+        {
+            using var historicalContext = await CreateRepositoryAsync(workspace.Path, readOnly: true);
+            var log = Assert.Single((await historicalContext.Repository.GetLogsAsync(CreateLogsContext(), cancellationToken: CancellationToken.None)).Items);
+            Assert.Equal(logId, log.InternalId);
+            Assert.Equal("Test Value!", log.Message);
+            Assert.Equal("TestLogger", log.Scope.Name);
+            Assert.Equal(logId, historicalContext.Repository.GetLog(logId)!.InternalId);
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'telemetry_records';";
+        Assert.Equal(0L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_logs;";
+        Assert.Equal(1L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task Traces_ReopenFromNormalizedRowsWithStableEventIds()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var startTime = new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var link = new Span.Types.Link
+        {
+            TraceId = ByteString.CopyFromUtf8("2"),
+            SpanId = ByteString.CopyFromUtf8("2-1"),
+            TraceState = "state"
+        };
+        Guid eventId;
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+            {
+                new ResourceSpans
+                {
+                    Resource = CreateResource(),
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Scope = CreateScope("TestSource"),
+                            Spans =
+                            {
+                                CreateSpan(
+                                    traceId: "1",
+                                    spanId: "1-1",
+                                    startTime,
+                                    startTime.AddSeconds(2),
+                                    events: [CreateSpanEvent("event", 1, [KeyValuePair.Create("event-key", "event-value")])],
+                                    links: [link],
+                                    attributes: [KeyValuePair.Create("span-key", "span-value")]),
+                                CreateSpan("1", "1-2", startTime.AddSeconds(1), startTime.AddSeconds(2), parentSpanId: "1-1")
+                            }
+                        }
+                    }
+                }
+            });
+
+            var trace = Assert.Single((await repositoryContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(new ResourceKey("TestService", "TestId")), cancellationToken: CancellationToken.None)).PagedResult.Items);
+            eventId = Assert.Single(trace.FirstSpan.Events).InternalId;
+        }
+
+        {
+            using var historicalContext = await CreateRepositoryAsync(workspace.Path, readOnly: true);
+            var trace = Assert.Single((await historicalContext.Repository.GetTracesAsync(GetTracesRequest.ForResourceKey(new ResourceKey("TestService", "TestId")), cancellationToken: CancellationToken.None)).PagedResult.Items);
+            Assert.Equal("TestSource", trace.FirstSpan.Scope.Name);
+            Assert.Equal(KeyValuePair.Create("span-key", "span-value"), Assert.Single(trace.FirstSpan.Attributes));
+            var spanEvent = Assert.Single(trace.FirstSpan.Events);
+            Assert.Equal(eventId, spanEvent.InternalId);
+            Assert.Equal(KeyValuePair.Create("event-key", "event-value"), Assert.Single(spanEvent.Attributes));
+            var persistedLink = Assert.Single(trace.FirstSpan.Links);
+            Assert.Equal(link.TraceId.ToHexString(), persistedLink.TraceId);
+            Assert.Equal(link.SpanId.ToHexString(), persistedLink.SpanId);
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'telemetry_records';";
+        Assert.Equal(0L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_spans;";
+        Assert.Equal(2L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task Metrics_ReopenFromNormalizedRows()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var startTime = new DateTime(2025, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            await repositoryContext.Repository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(),
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = CreateScope("TestMeter"),
+                            Metrics = { CreateSumMetric("requests", startTime, attributes: [KeyValuePair.Create("route", "/api")], value: 42) }
+                        }
+                    }
+                }
+            });
+        }
+
+        {
+            using var historicalContext = await CreateRepositoryAsync(workspace.Path, readOnly: true);
+            var resourceKey = new ResourceKey("TestService", "TestId");
+            var summary = Assert.Single(historicalContext.Repository.GetInstrumentSummaries(resourceKey));
+            Assert.Equal("requests", summary.Name);
+            Assert.Equal("TestMeter", summary.Parent.Name);
+
+            var instrument = await historicalContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+            {
+                ResourceKey = resourceKey,
+                MeterName = "TestMeter",
+                InstrumentName = "requests",
+                StartTime = startTime.AddMinutes(-1),
+                EndTime = startTime.AddMinutes(1)
+            }, cancellationToken: CancellationToken.None);
+            var dimension = Assert.Single(instrument!.Dimensions);
+            Assert.Equal(KeyValuePair.Create("route", "/api"), Assert.Single(dimension.Attributes));
+            var routeValues = Assert.Single(instrument.KnownAttributeValues);
+            Assert.Equal("route", routeValues.Key);
+            Assert.Equal("/api", Assert.Single(routeValues.Value));
+            Assert.Equal(42, Assert.IsType<MetricValue<long>>(Assert.Single(dimension.Values)).Value);
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_metric_points;";
+        Assert.Equal(1L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task Metrics_HistogramPackedStorage_ReopensAndRejectsChangedBucketCountLength()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var startTime = new DateTime(2025, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            var histogram = CreateHistogramMetric("histogram", startTime);
+            histogram.Histogram.DataPoints[0].ExplicitBounds.Clear();
+            histogram.Histogram.DataPoints[0].ExplicitBounds.Add([1, 2]);
+            var addContext = new AddContext();
+            await repositoryContext.Repository.AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(),
+                    ScopeMetrics = { new ScopeMetrics { Scope = CreateScope("TestMeter"), Metrics = { histogram } } }
+                }
+            });
+            Assert.Equal(1, addContext.SuccessCount);
+            Assert.Equal(0, addContext.FailureCount);
+        }
+
+        using (var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False"))
+        {
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT length(bucket_counts) FROM telemetry_metric_points;";
+            Assert.Equal(24L, command.ExecuteScalar());
+            command.CommandText = "SELECT length(explicit_bounds) FROM telemetry_metric_points;";
+            Assert.Equal(16L, command.ExecuteScalar());
+            command.CommandText = """
+                SELECT COUNT(*)
+                FROM sqlite_schema
+                WHERE type = 'table'
+                  AND name IN ('telemetry_metric_histograms', 'telemetry_metric_histogram_bucket_counts', 'telemetry_metric_histogram_explicit_bounds');
+                """;
+            Assert.Equal(0L, command.ExecuteScalar());
+        }
+
+        using var reopenedContext = await CreateRepositoryAsync(workspace.Path);
+        var changedHistogram = CreateHistogramMetric("histogram", startTime.AddMinutes(1));
+        changedHistogram.Histogram.DataPoints[0].BucketCounts.Add(4);
+        var changedContext = new AddContext();
+        await reopenedContext.Repository.AddMetricsAsync(changedContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics = { new ScopeMetrics { Scope = CreateScope("TestMeter"), Metrics = { changedHistogram } } }
+            }
+        });
+
+        Assert.Equal(0, changedContext.SuccessCount);
+        Assert.Equal(1, changedContext.FailureCount);
+        var instrument = await reopenedContext.Repository.GetInstrumentAsync(new GetInstrumentRequest
+        {
+            ResourceKey = new ResourceKey("TestService", "TestId"),
+            MeterName = "TestMeter",
+            InstrumentName = "histogram",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        }, cancellationToken: CancellationToken.None);
+        var value = Assert.IsType<HistogramValue>(Assert.Single(Assert.Single(instrument!.Dimensions).Values));
+        Assert.Equal([1UL, 2UL, 3UL], value.Values);
+        Assert.Equal([1d, 2d], value.ExplicitBounds);
+    }
+
+    [Fact]
+    public async Task Metrics_EquivalentAttributesShareIndexedDimension()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var startTime = new DateTime(2025, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            var addContext = new AddContext();
+            foreach (var attributes in new[]
+            {
+                new[] { KeyValuePair.Create("second", "2"), KeyValuePair.Create("first", "1") },
+                new[] { KeyValuePair.Create("first", "1"), KeyValuePair.Create("second", "2") },
+                new[] { KeyValuePair.Create("first", "different") }
+            })
+            {
+                await repositoryContext.Repository.AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+                {
+                    new ResourceMetrics
+                    {
+                        Resource = CreateResource(),
+                        ScopeMetrics =
+                        {
+                            new ScopeMetrics
+                            {
+                                Scope = CreateScope("TestMeter"),
+                                Metrics = { CreateSumMetric("requests", startTime, attributes: attributes) }
+                            }
+                        }
+                    }
+                });
+            }
+            Assert.Equal(0, addContext.FailureCount);
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_metric_dimensions;";
+        Assert.Equal(2L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = 'ix_telemetry_metric_dimensions_hash';";
+        Assert.Equal(1L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task Scopes_AreSharedAcrossLogsTracesAndMetrics()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var startTime = new DateTime(2025, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+        var scope = CreateScope(name: "SharedScope", attributes: [KeyValuePair.Create("scope-key", "scope-value")]);
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            await repositoryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(),
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            Scope = scope,
+                            LogRecords = { CreateLogRecord() }
+                        }
+                    }
+                }
+            });
+            await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+            {
+                new ResourceSpans
+                {
+                    Resource = CreateResource(),
+                    ScopeSpans =
+                    {
+                        new ScopeSpans
+                        {
+                            Scope = scope,
+                            Spans = { CreateSpan("shared-trace", "shared-span", startTime, startTime.AddSeconds(1)) }
+                        }
+                    }
+                }
+            });
+            await repositoryContext.Repository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+            {
+                new ResourceMetrics
+                {
+                    Resource = CreateResource(),
+                    ScopeMetrics =
+                    {
+                        new ScopeMetrics
+                        {
+                            Scope = scope,
+                            Metrics = { CreateSumMetric("requests", startTime) }
+                        }
+                    }
+                }
+            });
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_scopes WHERE scope_name = 'SharedScope';";
+        Assert.Equal(1L, command.ExecuteScalar());
+        command.CommandText = """
+            SELECT COUNT(DISTINCT scope_id)
+            FROM (
+                SELECT scope_id FROM telemetry_logs
+                UNION ALL
+                SELECT scope_id FROM telemetry_spans
+                UNION ALL
+                SELECT scope_id FROM telemetry_metric_instruments
+            );
+            """;
+        Assert.Equal(1L, command.ExecuteScalar());
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM telemetry_scope_attributes
+            WHERE attribute_key = 'scope-key' AND attribute_value = 'scope-value';
+            """;
+        Assert.Equal(1L, command.ExecuteScalar());
+        command.CommandText = """
+            SELECT COUNT(*)
+            FROM sqlite_schema
+            WHERE type = 'table' AND name IN (
+                'telemetry_log_scopes',
+                'telemetry_log_scope_attributes',
+                'telemetry_trace_scopes',
+                'telemetry_trace_scope_attributes',
+                'telemetry_metric_scopes',
+                'telemetry_metric_scope_attributes');
+            """;
+        Assert.Equal(0L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task Scopes_ReopenAndReusePersistedScopesWithAndWithoutAttributes()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var attributedScope = CreateScope(name: "AttributedScope", attributes: [KeyValuePair.Create("scope-key", "scope-value")]);
+        var emptyScope = CreateScope(name: "EmptyScope");
+
+        for (var iteration = 0; iteration < 2; iteration++)
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            var addContext = new AddContext();
+            await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(),
+                    ScopeLogs =
+                    {
+                        new ScopeLogs { Scope = attributedScope, LogRecords = { CreateLogRecord() } },
+                        new ScopeLogs { Scope = emptyScope, LogRecords = { CreateLogRecord() } }
+                    }
+                }
+            });
+            Assert.Equal(0, addContext.FailureCount);
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_scopes;";
+        Assert.Equal(2L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_scope_attributes;";
+        Assert.Equal(1L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_logs;";
+        Assert.Equal(4L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task ResourceViews_EquivalentAttributesShareNormalizedRows()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        {
+            using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+            var addContext = new AddContext();
+            await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>
+            {
+                new ResourceLogs
+                {
+                    Resource = CreateResource(attributes: [KeyValuePair.Create("second", "2"), KeyValuePair.Create("first", "1")]),
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            Scope = CreateScope(),
+                            LogRecords = { CreateLogRecord() }
+                        }
+                    }
+                },
+                new ResourceLogs
+                {
+                    Resource = CreateResource(attributes: [KeyValuePair.Create("first", "1"), KeyValuePair.Create("second", "2")]),
+                    ScopeLogs =
+                    {
+                        new ScopeLogs
+                        {
+                            Scope = CreateScope(),
+                            LogRecords = { CreateLogRecord() }
+                        }
+                    }
+                }
+            });
+            Assert.Equal(0, addContext.FailureCount);
+        }
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_resource_views;";
+        Assert.Equal(2L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_resource_view_attributes;";
+        Assert.Equal(2L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task ResourceViews_LimitRejectsNewNormalizedRow()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+        var addContext = new AddContext();
+            await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(),
+                        LogRecords = { CreateLogRecord() }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        using (var connection = new SqliteConnection($"Data Source={databasePath};Pooling=False"))
+        {
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = $"""
+                WITH RECURSIVE numbers(value) AS (
+                    SELECT 1
+                    UNION ALL
+                    SELECT value + 1 FROM numbers WHERE value < {TelemetryRepositoryLimits.MaxResourceViewCount - 1}
+                )
+                INSERT INTO telemetry_resource_views (resource_id)
+                SELECT resource_id
+                FROM telemetry_resources
+                CROSS JOIN numbers;
+                """;
+            command.ExecuteNonQuery();
+            command.CommandText = "SELECT COUNT(*) FROM telemetry_resource_views;";
+            Assert.Equal((long)TelemetryRepositoryLimits.MaxResourceViewCount, command.ExecuteScalar());
+        }
+
+            await repositoryContext.Repository.AddLogsAsync(addContext, new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(attributes: [KeyValuePair.Create("new", "value")]),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope(),
+                        LogRecords = { CreateLogRecord() }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, addContext.FailureCount);
+    }
+
+    [Fact]
+    public async Task Scopes_AreDeletedAfterTheirFinalOwnerIsCleared()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var startTime = new DateTime(2025, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+        var scope = CreateScope("SharedScope");
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+        await repositoryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs = { new ScopeLogs { Scope = scope, LogRecords = { CreateLogRecord() } } }
+            }
+        });
+        await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = scope,
+                        Spans = { CreateSpan("shared-trace", "shared-span", startTime, startTime.AddSeconds(1)) }
+                    }
+                }
+            }
+        });
+        await repositoryContext.Repository.AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = scope,
+                        Metrics = { CreateSumMetric("requests", startTime) }
+                    }
+                }
+            }
+        });
+
+        await repositoryContext.Repository.ClearStructuredLogsAsync();
+        Assert.Equal(1L, GetScopeCount(databasePath));
+        await repositoryContext.Repository.ClearTracesAsync();
+        Assert.Equal(1L, GetScopeCount(databasePath));
+        await repositoryContext.Repository.ClearMetricsAsync();
+        Assert.Equal(0L, GetScopeCount(databasePath));
+    }
+
+    [Fact]
+    public async Task ResourcesAndResourceViews_AreRetainedAfterSignalsCleared()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var startTime = new DateTime(2025, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path);
+        await repositoryContext.Repository.AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(attributes: [KeyValuePair.Create("signal", "logs")]),
+                ScopeLogs = { new ScopeLogs { Scope = CreateScope("Logger"), LogRecords = { CreateLogRecord() } } }
+            }
+        });
+        await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(attributes: [KeyValuePair.Create("signal", "traces")]),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("Tracer"),
+                        Spans = { CreateSpan("trace", "span", startTime, startTime.AddSeconds(1)) }
+                    }
+                }
+            }
+        });
+
+        await repositoryContext.Repository.ClearStructuredLogsAsync();
+        await repositoryContext.Repository.ClearTracesAsync();
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_resources;";
+        Assert.Equal(1L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_resource_views;";
+        Assert.Equal(3L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_resource_view_attributes;";
+        Assert.Equal(2L, command.ExecuteScalar());
+    }
+
+    [Fact]
+    public async Task TraceTrimming_DoesNotRecalculateResourceFlags()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var databasePath = GetDatabasePath(workspace.Path);
+        var startTime = new DateTime(2025, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync(workspace.Path, maxTraceCount: 1);
+        await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "FirstService", instanceId: "first"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan("first-trace", "first-span", startTime, startTime.AddSeconds(1)) }
+                    }
+                }
+            }
+        });
+        await repositoryContext.Repository.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "SecondService", instanceId: "second"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan("second-trace", "second-span", startTime.AddMinutes(1), startTime.AddMinutes(1).AddSeconds(1)) }
+                    }
+                }
+            }
+        });
+
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_traces;";
+        Assert.Equal(1L, command.ExecuteScalar());
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_resources WHERE has_traces = 1;";
+        Assert.Equal(2L, command.ExecuteScalar());
+    }
+
+    private static long GetScopeCount(string databasePath)
+    {
+        using var connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM telemetry_scopes;";
+        return (long)command.ExecuteScalar()!;
+    }
+
+    private static string GetDatabasePath(string workspacePath) => Path.Combine(workspacePath, "dashboard.db");
+
+    private static async Task<SqliteRepositoryTestContext<SqliteTelemetryRepository>> CreateRepositoryAsync(
+        string workspacePath,
+        bool readOnly = false,
+        int? maxTraceCount = null,
+        IEnumerable<IOutgoingPeerResolver>? outgoingPeerResolvers = null)
+    {
+        var options = new DashboardOptions();
+        options.TelemetryLimits.MaxTraceCount = maxTraceCount ?? options.TelemetryLimits.MaxTraceCount;
+        var context = await SqliteRepositoryTestHelpers.CreateTelemetryRepositoryAsync(
+            GetDatabasePath(workspacePath),
+            readOnly,
+            dashboardOptions: Options.Create(options),
+            outgoingPeerResolvers: outgoingPeerResolvers);
+        return context;
+    }
+
+    private static GetLogsContext CreateLogsContext()
+    {
+        return new GetLogsContext
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        };
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryLimitTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryLimitTests.cs
@@ -4,6 +4,8 @@
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Trace.V1;
@@ -12,19 +14,19 @@ using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 
-public class TelemetryLimitTests
+public abstract class TelemetryLimitTests : TelemetryRepositoryTestBase
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
     [Fact]
-    public void AddTraces_ExceedsResourceLimit_ReportsFailure()
+    public async Task AddTraces_ExceedsResourceLimit_ReportsFailure()
     {
-        var repository = CreateRepository(maxResourceCount: 3);
+        using var repositoryContext = await CreateRepositoryAsync(maxResourceCount: 3);
 
         for (var i = 0; i < 3; i++)
         {
             var addContext = new AddContext();
-            repository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+            await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
             {
                 new ResourceSpans
                 {
@@ -42,11 +44,11 @@ public class TelemetryLimitTests
             Assert.Equal(0, addContext.FailureCount);
         }
 
-        Assert.Equal(3, repository.GetResources().Count);
+        Assert.Equal(3, repositoryContext.Repository.GetResources().Count);
 
         // Adding a 4th resource should fail.
         var failContext = new AddContext();
-        repository.AddTraces(failContext, new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(failContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -64,19 +66,19 @@ public class TelemetryLimitTests
 
         Assert.Equal(1, failContext.FailureCount);
         Assert.Equal(0, failContext.SuccessCount);
-        Assert.Equal(3, repository.GetResources().Count);
+        Assert.Equal(3, repositoryContext.Repository.GetResources().Count);
     }
 
     [Fact]
-    public void AddTraces_ExistingResourceAfterLimitReached_Succeeds()
+    public async Task AddTraces_ExistingResourceAfterLimitReached_Succeeds()
     {
-        var repository = CreateRepository(maxResourceCount: 2);
+        using var repositoryContext = await CreateRepositoryAsync(maxResourceCount: 2);
 
         // Add 2 resources to fill up the limit.
         for (var i = 0; i < 2; i++)
         {
             var addContext = new AddContext();
-            repository.AddTraces(addContext, new RepeatedField<ResourceSpans>
+            await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
             {
                 new ResourceSpans
                 {
@@ -96,7 +98,7 @@ public class TelemetryLimitTests
 
         // Adding data for an existing resource should still succeed.
         var successContext = new AddContext();
-        repository.AddTraces(successContext, new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(successContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -117,19 +119,23 @@ public class TelemetryLimitTests
     }
 
     [Fact]
-    public void AddMetrics_ExceedsInstrumentLimit_ReportsFailure()
+    public async Task AddMetrics_ExceedsInstrumentLimit_ReportsFailure()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Fill instruments up to the limit.
         var metrics = new RepeatedField<Metric>();
-        for (var i = 0; i < TelemetryRepository.MaxInstrumentCount; i++)
+        for (var i = 0; i < TelemetryRepositoryLimits.MaxInstrumentCount; i++)
         {
-            metrics.Add(CreateSumMetric(metricName: $"metric{i}", startTime: s_testTime.AddMinutes(1)));
+            var metric = CreateSumMetric(metricName: $"metric{i}", startTime: s_testTime.AddMinutes(1));
+            // This test only needs distinct instrument definitions to reach the instrument limit.
+            // Remove the helper-created data point to avoid storing 10,000 unrelated metric values.
+            metric.Sum.DataPoints.Clear();
+            metrics.Add(metric);
         }
 
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -147,13 +153,13 @@ public class TelemetryLimitTests
 
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
-        var instruments = repository.GetInstrumentsSummaries(resources[0].ResourceKey);
-        Assert.Equal(TelemetryRepository.MaxInstrumentCount, instruments.Count);
+        var resources = repositoryContext.Repository.GetResources();
+        var instruments = repositoryContext.Repository.GetInstrumentSummaries(resources[0].ResourceKey);
+        Assert.Equal(TelemetryRepositoryLimits.MaxInstrumentCount, instruments.Count);
 
         // Adding one more instrument should fail.
         var failContext = new AddContext();
-        repository.AddMetrics(failContext, new RepeatedField<ResourceMetrics>
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(failContext, new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -172,18 +178,85 @@ public class TelemetryLimitTests
         Assert.Equal(1, failContext.FailureCount);
         Assert.Equal(0, failContext.SuccessCount);
 
-        instruments = repository.GetInstrumentsSummaries(resources[0].ResourceKey);
-        Assert.Equal(TelemetryRepository.MaxInstrumentCount, instruments.Count);
+        instruments = repositoryContext.Repository.GetInstrumentSummaries(resources[0].ResourceKey);
+        Assert.Equal(TelemetryRepositoryLimits.MaxInstrumentCount, instruments.Count);
     }
 
     [Fact]
-    public void AddLogs_ExceedsResourceLimit_FailureCountIsLogRecordCount()
+    public async Task AddMetrics_ExceedsKnownAttributeKeyLimit_ReportsFailure()
     {
-        var repository = CreateRepository(maxResourceCount: 1);
+        var attributeCount = TelemetryRepositoryLimits.MaxKnownAttributeValueCount + 1;
+        using var repositoryContext = await CreateRepositoryAsync(maxAttributeCount: attributeCount);
+        var attributes = Enumerable.Range(0, attributeCount)
+            .Select(index => KeyValuePair.Create($"key-{index:D5}", $"value-{index:D5}"))
+            .ToArray();
+        var addContext = new AddContext();
+
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { CreateSumMetric(metricName: "test", startTime: s_testTime, attributes: attributes) }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, addContext.FailureCount);
+        Assert.Equal(0, addContext.SuccessCount);
+    }
+
+    [Fact]
+    public async Task AddMetrics_ExceedsKnownAttributeValuesPerKeyLimit_ReportsFailure()
+    {
+        var testSink = new TestSink();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new TestLoggerProvider(testSink)));
+        using var repositoryContext = await CreateRepositoryAsync(loggerFactory: loggerFactory);
+        var metrics = Enumerable.Range(0, TelemetryRepositoryLimits.MaxKnownAttributeValuesPerKey + 1)
+            .Select(index => CreateSumMetric(
+                metricName: "test",
+                startTime: s_testTime,
+                attributes: [KeyValuePair.Create("key", $"value-{index:D5}")]));
+        var addContext = new AddContext();
+
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics = { metrics }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, addContext.FailureCount);
+        Assert.Equal(TelemetryRepositoryLimits.MaxKnownAttributeValuesPerKey, addContext.SuccessCount);
+        var write = Assert.Single(testSink.Writes, write => write.Message == "Error adding metric.");
+        Assert.Equal(
+            $"Known attribute value limit of {TelemetryRepositoryLimits.MaxKnownAttributeValuesPerKey} reached for key 'key'.",
+            write.Exception!.Message);
+    }
+
+    [Fact]
+    public async Task AddLogs_ExceedsResourceLimit_FailureCountIsLogRecordCount()
+    {
+        using var repositoryContext = await CreateRepositoryAsync(maxResourceCount: 1);
 
         // Fill the single resource slot.
         var setupContext = new AddContext();
-        repository.AddLogs(setupContext, new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(setupContext, new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -203,7 +276,7 @@ public class TelemetryLimitTests
         // Attempt to add logs for a new resource with multiple scopes and records.
         // FailureCount must equal total log records, not number of scopes.
         var failContext = new AddContext();
-        repository.AddLogs(failContext, new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(failContext, new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -238,13 +311,13 @@ public class TelemetryLimitTests
     }
 
     [Fact]
-    public void AddMetrics_ExceedsResourceLimit_FailureCountIsDataPointCount()
+    public async Task AddMetrics_ExceedsResourceLimit_FailureCountIsDataPointCount()
     {
-        var repository = CreateRepository(maxResourceCount: 1);
+        using var repositoryContext = await CreateRepositoryAsync(maxResourceCount: 1);
 
         // Fill the single resource slot.
         var setupContext = new AddContext();
-        repository.AddMetrics(setupContext, new RepeatedField<ResourceMetrics>
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(setupContext, new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -264,7 +337,7 @@ public class TelemetryLimitTests
         // Attempt to add metrics for a new resource with multiple scopes and metrics.
         // FailureCount must equal total data points, not number of metrics.
         var failContext = new AddContext();
-        repository.AddMetrics(failContext, new RepeatedField<ResourceMetrics>
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(failContext, new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -300,13 +373,13 @@ public class TelemetryLimitTests
     }
 
     [Fact]
-    public void AddTraces_ExceedsResourceLimit_FailureCountIsSpanCount()
+    public async Task AddTraces_ExceedsResourceLimit_FailureCountIsSpanCount()
     {
-        var repository = CreateRepository(maxResourceCount: 1);
+        using var repositoryContext = await CreateRepositoryAsync(maxResourceCount: 1);
 
         // Fill the single resource slot.
         var setupContext = new AddContext();
-        repository.AddTraces(setupContext, new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(setupContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -326,7 +399,7 @@ public class TelemetryLimitTests
         // Attempt to add traces for a new resource with multiple scopes and spans.
         // FailureCount must equal total spans, not number of scopes.
         var failContext = new AddContext();
-        repository.AddTraces(failContext, new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(failContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -359,30 +432,29 @@ public class TelemetryLimitTests
     }
 
     [Fact]
-    public void AddLogs_ExceedsScopeLimit_ReportsFailure()
+    public async Task AddLogs_ExceedsScopeLimit_ReportsFailure()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Fill scopes up to the limit.
         var scopeLogs = new RepeatedField<ResourceLogs>();
         var rl = new ResourceLogs { Resource = CreateResource() };
-        for (var i = 0; i < TelemetryRepository.MaxScopeCount; i++)
+        for (var i = 0; i < TelemetryRepositoryLimits.MaxScopeCount; i++)
         {
             rl.ScopeLogs.Add(new ScopeLogs
             {
-                Scope = CreateScope(name: $"logger{i}"),
-                LogRecords = { CreateLogRecord() }
+                Scope = CreateScope(name: $"logger{i}")
             });
         }
         scopeLogs.Add(rl);
 
         var addContext = new AddContext();
-        repository.AddLogs(addContext, scopeLogs);
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, scopeLogs);
         Assert.Equal(0, addContext.FailureCount);
 
         // Adding one more scope should fail.
         var failContext = new AddContext();
-        repository.AddLogs(failContext, new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(failContext, new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -408,28 +480,27 @@ public class TelemetryLimitTests
     }
 
     [Fact]
-    public void AddTraces_ExceedsScopeLimit_ReportsFailure()
+    public async Task AddTraces_ExceedsScopeLimit_ReportsFailure()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Fill scopes up to the limit.
         var rs = new ResourceSpans { Resource = CreateResource() };
-        for (var i = 0; i < TelemetryRepository.MaxScopeCount; i++)
+        for (var i = 0; i < TelemetryRepositoryLimits.MaxScopeCount; i++)
         {
             rs.ScopeSpans.Add(new ScopeSpans
             {
-                Scope = CreateScope(name: $"tracer{i}"),
-                Spans = { CreateSpan($"trace{i}", $"span{i}", s_testTime, s_testTime.AddMinutes(1)) }
+                Scope = CreateScope(name: $"tracer{i}")
             });
         }
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans> { rs });
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans> { rs });
         Assert.Equal(0, addContext.FailureCount);
 
         // Adding one more scope should fail.
         var failContext = new AddContext();
-        repository.AddTraces(failContext, new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(failContext, new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -454,28 +525,27 @@ public class TelemetryLimitTests
     }
 
     [Fact]
-    public void AddMetrics_ExceedsScopeLimit_ReportsFailure()
+    public async Task AddMetrics_ExceedsScopeLimit_ReportsFailure()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Fill scopes up to the limit.
         var rm = new ResourceMetrics { Resource = CreateResource() };
-        for (var i = 0; i < TelemetryRepository.MaxScopeCount; i++)
+        for (var i = 0; i < TelemetryRepositoryLimits.MaxScopeCount; i++)
         {
             rm.ScopeMetrics.Add(new ScopeMetrics
             {
-                Scope = CreateScope(name: $"meter{i}"),
-                Metrics = { CreateSumMetric(metricName: $"metric{i}", startTime: s_testTime.AddMinutes(1)) }
+                Scope = CreateScope(name: $"meter{i}")
             });
         }
 
         var addContext = new AddContext();
-        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics> { rm });
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics> { rm });
         Assert.Equal(0, addContext.FailureCount);
 
         // Adding one more scope should fail. Each metric has 1 data point.
         var failContext = new AddContext();
-        repository.AddMetrics(failContext, new RepeatedField<ResourceMetrics>
+        await repositoryContext.Repository.AsWriter().AddMetricsAsync(failContext, new RepeatedField<ResourceMetrics>
         {
             new ResourceMetrics
             {
@@ -499,4 +569,14 @@ public class TelemetryLimitTests
         Assert.Equal(2, failContext.FailureCount);
         Assert.Equal(0, failContext.SuccessCount);
     }
+}
+
+public sealed class InMemoryTelemetryLimitTests : TelemetryLimitTests
+{
+    protected override bool UseSqlite => false;
+}
+
+public sealed class SqliteTelemetryLimitTests : TelemetryLimitTests
+{
+    protected override bool UseSqlite => true;
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTestBase.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTestBase.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Tests.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
+
+public abstract class TelemetryRepositoryTestBase
+{
+    protected abstract bool UseSqlite { get; }
+
+    protected async Task<RepositoryTestContext> CreateRepositoryAsync(
+        int? maxMetricsCount = null,
+        int? maxAttributeCount = null,
+        int? maxAttributeLength = null,
+        int? maxSpanEventCount = null,
+        int? maxTraceCount = null,
+        int? maxLogCount = null,
+        int? maxResourceCount = null,
+        TimeSpan? subscriptionMinExecuteInterval = null,
+        ILoggerFactory? loggerFactory = null,
+        global::Aspire.Dashboard.Model.PauseManager? pauseManager = null,
+        TimeProvider? timeProvider = null,
+        global::Aspire.Dashboard.Model.IOutgoingPeerResolver[]? outgoingPeerResolvers = null)
+    {
+        var telemetryLimits = new global::Aspire.Dashboard.Configuration.TelemetryLimitOptions();
+        telemetryLimits.MaxMetricsCount = maxMetricsCount ?? telemetryLimits.MaxMetricsCount;
+        telemetryLimits.MaxAttributeCount = maxAttributeCount ?? telemetryLimits.MaxAttributeCount;
+        telemetryLimits.MaxAttributeLength = maxAttributeLength ?? telemetryLimits.MaxAttributeLength;
+        telemetryLimits.MaxSpanEventCount = maxSpanEventCount ?? telemetryLimits.MaxSpanEventCount;
+        telemetryLimits.MaxTraceCount = maxTraceCount ?? telemetryLimits.MaxTraceCount;
+        telemetryLimits.MaxLogCount = maxLogCount ?? telemetryLimits.MaxLogCount;
+        telemetryLimits.MaxResourceCount = maxResourceCount ?? telemetryLimits.MaxResourceCount;
+
+        loggerFactory ??= NullLoggerFactory.Instance;
+        pauseManager ??= new global::Aspire.Dashboard.Model.PauseManager();
+        outgoingPeerResolvers ??= [];
+        var options = Options.Create(new global::Aspire.Dashboard.Configuration.DashboardOptions { TelemetryLimits = telemetryLimits });
+
+        if (UseSqlite)
+        {
+            var temporaryDirectory = Directory.CreateTempSubdirectory("aspire-tests-dashboard-telemetry-").FullName;
+            SqliteRepositoryTestContext<SqliteTelemetryRepository> context;
+            try
+            {
+                context = await SqliteRepositoryTestHelpers.CreateTelemetryRepositoryAsync(
+                    Path.Combine(temporaryDirectory, "dashboard.db"),
+                    pooling: true,
+                    loggerFactory: loggerFactory,
+                    dashboardOptions: options,
+                    pauseManager: pauseManager,
+                    timeProvider: timeProvider,
+                    outgoingPeerResolvers: outgoingPeerResolvers);
+            }
+            catch
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+                throw;
+            }
+
+            var sqliteRepository = context.Repository;
+            if (subscriptionMinExecuteInterval is not null)
+            {
+                sqliteRepository.SubscriptionMinExecuteInterval = subscriptionMinExecuteInterval.Value;
+            }
+            return new RepositoryTestContext(
+                sqliteRepository,
+                new TemporaryDirectoryRepositoryContext(context, temporaryDirectory));
+        }
+        else
+        {
+            var inMemoryRepository = new InMemoryTelemetryRepository(loggerFactory, options, pauseManager, outgoingPeerResolvers);
+            if (subscriptionMinExecuteInterval is not null)
+            {
+                inMemoryRepository._subscriptionMinExecuteInterval = subscriptionMinExecuteInterval.Value;
+            }
+            return new RepositoryTestContext(inMemoryRepository, inMemoryRepository);
+        }
+    }
+
+    protected sealed class RepositoryTestContext(
+        ITelemetryRepository repository,
+        IDisposable owner) : IDisposable
+    {
+        public ITelemetryRepository Repository { get; } = repository;
+
+        public void Dispose() => owner.Dispose();
+    }
+
+    private sealed class TemporaryDirectoryRepositoryContext(IDisposable repositoryContext, string temporaryDirectory) : IDisposable
+    {
+        public void Dispose()
+        {
+            try
+            {
+                repositoryContext.Dispose();
+            }
+            finally
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+        }
+    }
+}
+
+internal static class TelemetryRepositoryTestExtensions
+{
+    public static ITelemetryRepositoryWriter AsWriter(this ITelemetryRepository repository) => (ITelemetryRepositoryWriter)repository;
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TelemetryRepositoryTests.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
@@ -17,48 +18,48 @@ using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 
-public class TelemetryRepositoryTests
+public abstract class TelemetryRepositoryTests : TelemetryRepositoryTestBase
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
     [Fact]
-    public void AddData_WhilePaused_IsDiscarded()
+    public async Task AddData_WhilePaused_IsDiscarded()
     {
         // Arrange
         var pauseManager = new PauseManager();
-        var repository = CreateRepository(pauseManager: pauseManager);
-        using var subscription = repository.OnNewLogs(resourceKey: null, SubscriptionType.Other, () => Task.CompletedTask);
+        using var repositoryContext = await CreateRepositoryAsync(pauseManager: pauseManager);
+        using var subscription = repositoryContext.Repository.OnNewLogs(resourceKey: null, SubscriptionType.Other, () => Task.CompletedTask);
 
         // Act and assert
         pauseManager.SetStructuredLogsPaused(true);
         pauseManager.SetMetricsPaused(true);
         pauseManager.SetTracesPaused(true);
-        AddLog();
-        AddMetric();
-        AddTrace();
+        await AddLog();
+        await AddMetric();
+        await AddTrace();
 
         var resourceKey = new ResourceKey("resource", "resource");
-        Assert.Empty(repository.GetLogs(new GetLogsContext { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).Items);
-        Assert.Null(repository.GetResource(resourceKey));
-        Assert.Empty(repository.GetTraces(new GetTracesRequest { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).PagedResult.Items);
+        Assert.Empty((await repositoryContext.Repository.GetLogsAsync(new GetLogsContext { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }, cancellationToken: CancellationToken.None)).Items);
+        Assert.Null(repositoryContext.Repository.GetResource(resourceKey));
+        Assert.Empty((await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }, cancellationToken: CancellationToken.None)).PagedResult.Items);
 
         pauseManager.SetStructuredLogsPaused(false);
         pauseManager.SetMetricsPaused(false);
         pauseManager.SetTracesPaused(false);
 
-        AddLog();
-        AddMetric();
-        AddTrace();
-        Assert.Single(repository.GetLogs(new GetLogsContext { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).Items);
-        var resource = repository.GetResource(resourceKey);
+        await AddLog();
+        await AddMetric();
+        await AddTrace();
+        Assert.Single((await repositoryContext.Repository.GetLogsAsync(new GetLogsContext { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }, cancellationToken: CancellationToken.None)).Items);
+        var resource = repositoryContext.Repository.GetResource(resourceKey);
         Assert.NotNull(resource);
-        Assert.NotEmpty(resource.GetInstrumentsSummary());
-        Assert.Single(repository.GetTraces(new GetTracesRequest { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }).PagedResult.Items);
+        Assert.NotEmpty(repositoryContext.Repository.GetInstrumentSummaries(resource.ResourceKey));
+        Assert.Single((await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest { ResourceKeys = [resourceKey], Count = 100, Filters = [], StartIndex = 0 }, cancellationToken: CancellationToken.None)).PagedResult.Items);
 
-        void AddLog()
+        async Task AddLog()
         {
             var addContext = new AddContext();
-            repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+            await repositoryContext.Repository.AsWriter().AddLogsAsync(addContext, new RepeatedField<ResourceLogs>()
             {
                 new ResourceLogs
                 {
@@ -78,10 +79,10 @@ public class TelemetryRepositoryTests
             });
         }
 
-        void AddMetric()
+        async Task AddMetric()
         {
             var addContext = new AddContext();
-            repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+            await repositoryContext.Repository.AsWriter().AddMetricsAsync(addContext, new RepeatedField<ResourceMetrics>()
             {
                 new ResourceMetrics
                 {
@@ -112,10 +113,10 @@ public class TelemetryRepositoryTests
             });
         }
 
-        void AddTrace()
+        async Task AddTrace()
         {
             var addContext = new AddContext();
-            repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+            await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
             {
                 new ResourceSpans
                 {
@@ -141,7 +142,6 @@ public class TelemetryRepositoryTests
     public void Subscription_MultipleDisposes_UnsubscribeOnce()
     {
         // Arrange
-        var telemetryRepository = CreateRepository();
         var unsubscribeCallCount = 0;
 
         var subscription = new Subscription(
@@ -151,7 +151,8 @@ public class TelemetryRepositoryTests
             callback: () => Task.CompletedTask,
             unsubscribe: () => unsubscribeCallCount++,
             executionContext: null,
-            telemetryRepository: telemetryRepository);
+            logger: NullLogger.Instance,
+            minExecuteInterval: TimeSpan.FromMilliseconds(100));
 
         // Act
         subscription.Dispose();
@@ -180,8 +181,6 @@ public class TelemetryRepositoryTests
             b.SetMinimumLevel(LogLevel.Trace);
         });
 
-        var telemetryRepository = CreateRepository(loggerFactory: factory);
-
         var subscription = new Subscription(
             name: "Test",
             resourceKey: null,
@@ -189,7 +188,8 @@ public class TelemetryRepositoryTests
             callback: () => Task.CompletedTask,
             unsubscribe: () => { },
             executionContext: null,
-            telemetryRepository: telemetryRepository);
+            logger: factory.CreateLogger("Test"),
+            minExecuteInterval: TimeSpan.FromMilliseconds(100));
 
         subscription.Dispose();
 
@@ -201,16 +201,16 @@ public class TelemetryRepositoryTests
     }
 
     [Fact]
-    public void ClearSelectedSignals_ClearsSelectedDataTypes_ForSpecificResources()
+    public async Task ClearSelectedSignals_ClearsSelectedDataTypes_ForSpecificResources()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddTestData(repository, "resource1", "123");
-        AddTestData(repository, "resource2", "456");
+        await AddTestData(repositoryContext.Repository, "resource1", "123");
+        await AddTestData(repositoryContext.Repository, "resource2", "456");
 
         // Verify unviewed error logs exist before clearing
-        var unviewedBefore = repository.GetResourceUnviewedErrorLogsCount();
+        var unviewedBefore = repositoryContext.Repository.GetResourceUnviewedErrorLogsCount();
         Assert.True(unviewedBefore.TryGetValue(new ResourceKey("resource1", "123"), out var errorCount1));
         Assert.Equal(1, errorCount1);
         Assert.True(unviewedBefore.TryGetValue(new ResourceKey("resource2", "456"), out var errorCount2));
@@ -221,86 +221,86 @@ public class TelemetryRepositoryTests
         {
             ["resource1-123"] = [AspireDataType.StructuredLogs]
         };
-        repository.ClearSelectedSignals(selectedResources);
+        await repositoryContext.Repository.AsWriter().ClearSelectedSignalsAsync(selectedResources);
 
         // Assert - resource1 unviewed error logs cleared
-        var unviewedAfter = repository.GetResourceUnviewedErrorLogsCount();
+        var unviewedAfter = repositoryContext.Repository.GetResourceUnviewedErrorLogsCount();
         Assert.False(unviewedAfter.TryGetValue(new ResourceKey("resource1", "123"), out _));
         Assert.True(unviewedAfter.TryGetValue(new ResourceKey("resource2", "456"), out errorCount2));
         Assert.Equal(1, errorCount2);
 
         // Assert - resource1 logs cleared, but traces and metrics remain
-        var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Single(logs.Items);
         Assert.Equal("log-resource2-456", logs.Items[0].Message);
 
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Equal(2, traces.PagedResult.TotalItemCount);
 
-        var resource1Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "123"));
+        var resource1Metrics = repositoryContext.Repository.GetInstrumentSummaries(new ResourceKey("resource1", "123"));
         Assert.Single(resource1Metrics);
 
         // Assert - resource2 data is unaffected
         var resource2Key = new ResourceKey("resource2", "456");
-        var resource2Logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [resource2Key], StartIndex = 0, Count = 10, Filters = [] });
+        var resource2Logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext { ResourceKeys = [resource2Key], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Single(resource2Logs.Items);
         Assert.Equal("log-resource2-456", resource2Logs.Items[0].Message);
 
-        var resource2Traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [resource2Key], StartIndex = 0, Count = 10, Filters = [] });
+        var resource2Traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest { ResourceKeys = [resource2Key], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Single(resource2Traces.PagedResult.Items);
 
-        var resource2Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource2", "456"));
+        var resource2Metrics = repositoryContext.Repository.GetInstrumentSummaries(new ResourceKey("resource2", "456"));
         Assert.Single(resource2Metrics);
     }
 
     [Fact]
-    public void ClearSelectedSignals_OtherResourcesRemainUnaffected()
+    public async Task ClearSelectedSignals_OtherResourcesRemainUnaffected()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddTestData(repository, "resource1", "111");
-        AddTestData(repository, "resource2", "222");
-        AddTestData(repository, "resource3", "333");
+        await AddTestData(repositoryContext.Repository, "resource1", "111");
+        await AddTestData(repositoryContext.Repository, "resource2", "222");
+        await AddTestData(repositoryContext.Repository, "resource3", "333");
 
         // Act - Clear all data types for resource2 only
         var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
         {
             ["resource2-222"] = [AspireDataType.StructuredLogs, AspireDataType.Traces, AspireDataType.Metrics, AspireDataType.Resource]
         };
-        repository.ClearSelectedSignals(selectedResources);
+        await repositoryContext.Repository.AsWriter().ClearSelectedSignalsAsync(selectedResources);
 
         // Assert - resource1 and resource3 data is unaffected
-        var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Equal(2, logs.TotalItemCount);
         Assert.Contains(logs.Items, l => l.Message == "log-resource1-111");
         Assert.Contains(logs.Items, l => l.Message == "log-resource3-333");
         Assert.DoesNotContain(logs.Items, l => l.Message == "log-resource2-222");
 
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Equal(2, traces.PagedResult.TotalItemCount);
 
-        var resource1Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "111"));
+        var resource1Metrics = repositoryContext.Repository.GetInstrumentSummaries(new ResourceKey("resource1", "111"));
         Assert.Single(resource1Metrics);
 
-        var resource3Metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource3", "333"));
+        var resource3Metrics = repositoryContext.Repository.GetInstrumentSummaries(new ResourceKey("resource3", "333"));
         Assert.Single(resource3Metrics);
 
         // Assert - resource2 is removed from the repository since all data types were cleared
-        var resource2 = repository.GetResource(new ResourceKey("resource2", "222"));
+        var resource2 = repositoryContext.Repository.GetResource(new ResourceKey("resource2", "222"));
         Assert.Null(resource2);
     }
 
     [Fact]
-    public void ClearSelectedSignals_ResourceRemovedWhenAllDataTypesCleared()
+    public async Task ClearSelectedSignals_ResourceRemovedWhenAllDataTypesCleared()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddTestData(repository, "resource1", "123");
+        await AddTestData(repositoryContext.Repository, "resource1", "123");
 
         // Verify resource exists before clearing
-        var resourceBefore = repository.GetResource(new ResourceKey("resource1", "123"));
+        var resourceBefore = repositoryContext.Repository.GetResource(new ResourceKey("resource1", "123"));
         Assert.NotNull(resourceBefore);
 
         // Act - Clear all data types for resource1
@@ -308,51 +308,51 @@ public class TelemetryRepositoryTests
         {
             ["resource1-123"] = [AspireDataType.StructuredLogs, AspireDataType.Traces, AspireDataType.Metrics, AspireDataType.Resource]
         };
-        repository.ClearSelectedSignals(selectedResources);
+        await repositoryContext.Repository.AsWriter().ClearSelectedSignalsAsync(selectedResources);
 
         // Assert - Resource is removed from the repository
-        var resourceAfter = repository.GetResource(new ResourceKey("resource1", "123"));
+        var resourceAfter = repositoryContext.Repository.GetResource(new ResourceKey("resource1", "123"));
         Assert.Null(resourceAfter);
 
         // Assert - All telemetry data is cleared
-        var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Empty(logs.Items);
 
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Empty(traces.PagedResult.Items);
 
         // Assert - Resources list is empty
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Empty(resources);
     }
 
     [Fact]
-    public void ClearSelectedSignals_PartialClear_ResourceNotRemoved()
+    public async Task ClearSelectedSignals_PartialClear_ResourceNotRemoved()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddTestData(repository, "resource1", "123");
+        await AddTestData(repositoryContext.Repository, "resource1", "123");
 
         // Act - Clear only logs and traces for resource1 (not metrics)
         var selectedResources = new Dictionary<string, HashSet<AspireDataType>>
         {
             ["resource1-123"] = [AspireDataType.StructuredLogs, AspireDataType.Traces]
         };
-        repository.ClearSelectedSignals(selectedResources);
+        await repositoryContext.Repository.AsWriter().ClearSelectedSignalsAsync(selectedResources);
 
         // Assert - Resource still exists because not all data types were cleared
-        var resourceAfter = repository.GetResource(new ResourceKey("resource1", "123"));
+        var resourceAfter = repositoryContext.Repository.GetResource(new ResourceKey("resource1", "123"));
         Assert.NotNull(resourceAfter);
 
         // Assert - Logs and traces are cleared, but metrics remain
-        var logs = repository.GetLogs(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
+        var logs = await repositoryContext.Repository.GetLogsAsync(new GetLogsContext { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Empty(logs.Items);
 
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] });
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest { ResourceKeys = [], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
         Assert.Empty(traces.PagedResult.Items);
 
-        var metrics = repository.GetInstrumentsSummaries(new ResourceKey("resource1", "123"));
+        var metrics = repositoryContext.Repository.GetInstrumentSummaries(new ResourceKey("resource1", "123"));
         Assert.Single(metrics);
     }
 
@@ -362,10 +362,10 @@ public class TelemetryRepositoryTests
     public async Task WatchSpansAsync_ReturnsExistingSpans_ThenNewSpans()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Add initial span
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -391,7 +391,7 @@ public class TelemetryRepositoryTests
         // Act
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, cts.Token))
+            await foreach (var span in repositoryContext.Repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, cts.Token))
             {
                 receivedSpans.Add(span);
                 if (receivedSpans.Count == 1)
@@ -406,10 +406,10 @@ public class TelemetryRepositoryTests
         });
 
         // Wait for initial span to be received
-        await firstSpanReceived.Task;
+        await firstSpanReceived.Task.DefaultTimeout();
 
         // Add another span while watching
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -442,7 +442,7 @@ public class TelemetryRepositoryTests
     public async Task WatchSpansAsync_CanBeCancelled()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
         using var cts = new CancellationTokenSource();
         var watchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -453,7 +453,7 @@ public class TelemetryRepositoryTests
             watchStarted.TrySetResult();
             try
             {
-                await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, cts.Token))
+                await foreach (var span in repositoryContext.Repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, cts.Token))
                 {
                     count++;
                 }
@@ -466,7 +466,7 @@ public class TelemetryRepositoryTests
         });
 
         // Wait for watcher to start
-        await watchStarted.Task;
+        await watchStarted.Task.DefaultTimeout();
 
         // Cancel the watch
         cts.Cancel();
@@ -480,10 +480,10 @@ public class TelemetryRepositoryTests
     public async Task WatchLogsAsync_ReturnsExistingLogs_ThenNewLogs()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Add initial log
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -509,7 +509,7 @@ public class TelemetryRepositoryTests
         // Act
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = [] }, cts.Token))
+            await foreach (var log in repositoryContext.Repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = [] }, cts.Token))
             {
                 receivedLogs.Add(log);
                 if (receivedLogs.Count == 1)
@@ -524,10 +524,10 @@ public class TelemetryRepositoryTests
         });
 
         // Wait for initial log to be received
-        await firstLogReceived.Task;
+        await firstLogReceived.Task.DefaultTimeout();
 
         // Add another log while watching
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -559,7 +559,7 @@ public class TelemetryRepositoryTests
     public async Task WatchLogsAsync_CanBeCancelled()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
         using var cts = new CancellationTokenSource();
         var watchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -570,7 +570,7 @@ public class TelemetryRepositoryTests
             watchStarted.TrySetResult();
             try
             {
-                await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = [] }, cts.Token))
+                await foreach (var log in repositoryContext.Repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = [] }, cts.Token))
                 {
                     count++;
                 }
@@ -583,7 +583,7 @@ public class TelemetryRepositoryTests
         });
 
         // Wait for watcher to start
-        await watchStarted.Task;
+        await watchStarted.Task.DefaultTimeout();
 
         // Cancel the watch
         cts.Cancel();
@@ -597,10 +597,10 @@ public class TelemetryRepositoryTests
     public async Task WatchSpansAsync_ReturnsExistingSpans_OrderedByStartTime()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Add spans with non-chronological start times across different traces
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -662,7 +662,7 @@ public class TelemetryRepositoryTests
         // Act
         try
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, linkedCts.Token))
+            await foreach (var span in repositoryContext.Repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, linkedCts.Token))
             {
                 receivedSpans.Add(span);
                 if (receivedSpans.Count == expectedSpans)
@@ -687,14 +687,14 @@ public class TelemetryRepositoryTests
     public async Task WatchSpansAsync_ReturnsExistingSpans_OrderedByStartTime_AcrossTracesWithOverlappingTimes()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Add two traces with multiple spans that overlap in time.
         // Trace1 starts earlier but has a span that is later than Trace2's spans.
         // Without explicit sorting, iterating trace-by-trace would yield:
         //   T=1 (trace1), T=8 (trace1), then T=3 (trace2), T=5 (trace2)
         // Correct chronological order is: T=1, T=3, T=5, T=8
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -740,7 +740,7 @@ public class TelemetryRepositoryTests
         // Act
         try
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, linkedCts.Token))
+            await foreach (var span in repositoryContext.Repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = [] }, linkedCts.Token))
             {
                 receivedSpans.Add(span);
                 if (receivedSpans.Count == expectedSpans)
@@ -766,10 +766,10 @@ public class TelemetryRepositoryTests
     public async Task WatchSpansAsync_FiltersById_WhenResourceKeyProvided()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Add spans for two different resources
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -809,7 +809,7 @@ public class TelemetryRepositoryTests
         // Act - Watch only service1
         try
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [new ResourceKey("service1", "inst1")], Filters = [] }, cts.Token))
+            await foreach (var span in repositoryContext.Repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [new ResourceKey("service1", "inst1")], Filters = [] }, cts.Token))
             {
                 receivedSpans.Add(span);
             }
@@ -825,58 +825,58 @@ public class TelemetryRepositoryTests
     }
 
     [Fact]
-    public void GetTraces_MultipleResourceKeys_ReturnsMatchingTracesOnly()
+    public async Task GetTraces_MultipleResourceKeys_ReturnsMatchingTracesOnly()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddTestData(repository, "resource1", "inst1");
-        AddTestData(repository, "resource2", "inst2");
-        AddTestData(repository, "resource3", "inst3");
+        await AddTestData(repositoryContext.Repository, "resource1", "inst1");
+        await AddTestData(repositoryContext.Repository, "resource2", "inst2");
+        await AddTestData(repositoryContext.Repository, "resource3", "inst3");
 
         var key1 = new ResourceKey("resource1", "inst1");
         var key2 = new ResourceKey("resource2", "inst2");
 
         // Act - query with two resource keys
-        var traces = repository.GetTraces(new GetTracesRequest { ResourceKeys = [key1, key2], StartIndex = 0, Count = 10, Filters = [] });
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest { ResourceKeys = [key1, key2], StartIndex = 0, Count = 10, Filters = [] }, cancellationToken: CancellationToken.None);
 
         // Assert - should return traces from both resource1 and resource2, but not resource3
         Assert.Collection(traces.PagedResult.Items,
-            t => AssertId("resource2-inst2", t.TraceId),
-            t => AssertId("resource1-inst1", t.TraceId));
+            t => AssertId("resource1-inst1", t.TraceId),
+            t => AssertId("resource2-inst2", t.TraceId));
     }
 
     [Fact]
-    public void GetSpans_MultipleResourceKeys_ReturnsMatchingSpansOnly()
+    public async Task GetSpans_MultipleResourceKeys_ReturnsMatchingSpansOnly()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddTestData(repository, "service1", "inst1");
-        AddTestData(repository, "service2", "inst2");
-        AddTestData(repository, "service3", "inst3");
+        await AddTestData(repositoryContext.Repository, "service1", "inst1");
+        await AddTestData(repositoryContext.Repository, "service2", "inst2");
+        await AddTestData(repositoryContext.Repository, "service3", "inst3");
 
         // Act - query spans for service1 and service2 only
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [new ResourceKey("service1", "inst1"), new ResourceKey("service2", "inst2")],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert - should return spans from service1 and service2, not service3
         Assert.Collection(result.PagedResult.Items,
-            s => Assert.Equal("Test span. Id: service2-inst2-1", s.Name),
-            s => Assert.Equal("Test span. Id: service1-inst1-1", s.Name));
+            s => Assert.Equal("Test span. Id: service1-inst1-1", s.Name),
+            s => Assert.Equal("Test span. Id: service2-inst2-1", s.Name));
     }
 
     [Fact]
     public async Task WatchSpansAsync_MultipleResourceKeys_FiltersCorrectly()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddTestData(repository, "service1", "inst1");
-        AddTestData(repository, "service2", "inst2");
-        AddTestData(repository, "service3", "inst3");
+        await AddTestData(repositoryContext.Repository, "service1", "inst1");
+        await AddTestData(repositoryContext.Repository, "service2", "inst2");
+        await AddTestData(repositoryContext.Repository, "service3", "inst3");
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         var receivedSpans = new List<OtlpSpan>();
@@ -884,7 +884,7 @@ public class TelemetryRepositoryTests
         // Act - Watch service1 and service2 (not service3)
         try
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [new ResourceKey("service1", "inst1"), new ResourceKey("service2", "inst2")], Filters = [] }, cts.Token))
+            await foreach (var span in repositoryContext.Repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [new ResourceKey("service1", "inst1"), new ResourceKey("service2", "inst2")], Filters = [] }, cts.Token))
             {
                 receivedSpans.Add(span);
             }
@@ -896,18 +896,18 @@ public class TelemetryRepositoryTests
 
         // Assert - should receive spans from service1 and service2, not service3
         Assert.Collection(receivedSpans,
-            s => Assert.Equal("Test span. Id: service2-inst2-1", s.Name),
-            s => Assert.Equal("Test span. Id: service1-inst1-1", s.Name));
+            s => Assert.Equal("Test span. Id: service1-inst1-1", s.Name),
+            s => Assert.Equal("Test span. Id: service2-inst2-1", s.Name));
     }
 
     [Fact]
     public async Task WatchLogsAsync_MultipleResourceKeys_FiltersCorrectly()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        AddTestData(repository, "service1", "inst1");
-        AddTestData(repository, "service2", "inst2");
-        AddTestData(repository, "service3", "inst3");
+        await AddTestData(repositoryContext.Repository, "service1", "inst1");
+        await AddTestData(repositoryContext.Repository, "service2", "inst2");
+        await AddTestData(repositoryContext.Repository, "service3", "inst3");
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         var receivedLogs = new List<OtlpLogEntry>();
@@ -915,7 +915,7 @@ public class TelemetryRepositoryTests
         // Act - Watch service1 and service2 (not service3)
         try
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [new ResourceKey("service1", "inst1"), new ResourceKey("service2", "inst2")], Filters = [] }, cts.Token))
+            await foreach (var log in repositoryContext.Repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [new ResourceKey("service1", "inst1"), new ResourceKey("service2", "inst2")], Filters = [] }, cts.Token))
             {
                 receivedLogs.Add(log);
             }
@@ -935,7 +935,7 @@ public class TelemetryRepositoryTests
     public async Task WatchLogsAsync_FiltersAppliedWhenPushing()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Create a filter that matches only logs containing "match"
         var filters = new List<TelemetryFilter>
@@ -949,7 +949,7 @@ public class TelemetryRepositoryTests
         };
 
         // Add an initial matching log so we know when watcher is ready
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -975,7 +975,7 @@ public class TelemetryRepositoryTests
         // Start watching with filter
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
+            await foreach (var log in repositoryContext.Repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
             {
                 receivedLogs.Add(log);
                 if (receivedLogs.Count == 1)
@@ -991,10 +991,10 @@ public class TelemetryRepositoryTests
         });
 
         // Wait for initial log to be received (proves watcher is registered)
-        await firstLogReceived.Task;
+        await firstLogReceived.Task.DefaultTimeout();
 
         // Add more logs - one matches filter, one doesn't
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -1026,7 +1026,7 @@ public class TelemetryRepositoryTests
     public async Task WatchLogsAsync_SeverityFilterApplied()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Create a filter for Error and above
         var filters = new List<TelemetryFilter>
@@ -1040,7 +1040,7 @@ public class TelemetryRepositoryTests
         };
 
         // Add an initial error log so we know when watcher is ready
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -1066,7 +1066,7 @@ public class TelemetryRepositoryTests
         // Start watching with severity filter
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
+            await foreach (var log in repositoryContext.Repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
             {
                 receivedLogs.Add(log);
                 if (receivedLogs.Count == 1)
@@ -1082,10 +1082,10 @@ public class TelemetryRepositoryTests
         });
 
         // Wait for initial log to be received (proves watcher is registered)
-        await firstLogReceived.Task;
+        await firstLogReceived.Task.DefaultTimeout();
 
         // Add logs with different severity levels
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -1119,10 +1119,10 @@ public class TelemetryRepositoryTests
     [Fact]
     public async Task WatchLogsAsync_TextFragmentsFilterApplied()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Add initial logs — one matches text fragments, one doesn't
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -1149,7 +1149,7 @@ public class TelemetryRepositoryTests
         // Watch with text fragments that should match "timeout" AND "error"
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest
+            await foreach (var log in repositoryContext.Repository.WatchLogsAsync(new WatchLogsRequest
             {
                 ResourceKeys = [],
                 Filters = [],
@@ -1169,10 +1169,10 @@ public class TelemetryRepositoryTests
         });
 
         // Wait for initial matching log to be received
-        await firstLogReceived.Task;
+        await firstLogReceived.Task.DefaultTimeout();
 
         // Add more logs — one matches both fragments, one matches only one
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -1203,7 +1203,7 @@ public class TelemetryRepositoryTests
     [Fact]
     public async Task WatchLogsAsync_DisabledFiltersAreIgnored()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Create two filters: one enabled (matches "match"), one disabled (excludes everything)
         var filters = new List<TelemetryFilter>
@@ -1225,7 +1225,7 @@ public class TelemetryRepositoryTests
         };
 
         // Add a matching log
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -1251,7 +1251,7 @@ public class TelemetryRepositoryTests
 
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var log in repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
+            await foreach (var log in repositoryContext.Repository.WatchLogsAsync(new WatchLogsRequest { ResourceKeys = [], Filters = filters }, cts.Token))
             {
                 receivedLogs.Add(log);
                 if (receivedLogs.Count == 1)
@@ -1265,10 +1265,10 @@ public class TelemetryRepositoryTests
             }
         });
 
-        await firstLogReceived.Task;
+        await firstLogReceived.Task.DefaultTimeout();
 
         // Push a new matching log
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>
+        await repositoryContext.Repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>
         {
             new ResourceLogs
             {
@@ -1300,7 +1300,7 @@ public class TelemetryRepositoryTests
     [Fact]
     public async Task WatchSpansAsync_DisabledFiltersAreIgnored()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Create two filters: one enabled (matches span name containing "span1"), one disabled
         var filters = new List<TelemetryFilter>
@@ -1322,7 +1322,7 @@ public class TelemetryRepositoryTests
         };
 
         // Add spans — one whose name contains "span1", one that doesn't
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -1348,7 +1348,7 @@ public class TelemetryRepositoryTests
 
         var watchTask = Task.Run(async () =>
         {
-            await foreach (var span in repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = filters }, cts.Token))
+            await foreach (var span in repositoryContext.Repository.WatchSpansAsync(new WatchSpansRequest { ResourceKeys = [], Filters = filters }, cts.Token))
             {
                 receivedSpans.Add(span);
                 if (receivedSpans.Count == 1)
@@ -1362,10 +1362,10 @@ public class TelemetryRepositoryTests
             }
         });
 
-        await firstSpanReceived.Task;
+        await firstSpanReceived.Task.DefaultTimeout();
 
         // Push a new span that matches the enabled filter
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -1395,11 +1395,11 @@ public class TelemetryRepositoryTests
 
     #endregion
 
-    private static void AddTestData(TelemetryRepository repository, string resourceName, string instanceId)
+    private static async Task AddTestData(ITelemetryRepository repository, string resourceName, string instanceId)
     {
         var compositeName = $"{resourceName}-{instanceId}";
 
-        repository.AddLogs(new AddContext(), new RepeatedField<ResourceLogs>()
+        await repository.AsWriter().AddLogsAsync(new AddContext(), new RepeatedField<ResourceLogs>()
         {
             new ResourceLogs
             {
@@ -1415,7 +1415,7 @@ public class TelemetryRepositoryTests
             }
         });
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1434,7 +1434,7 @@ public class TelemetryRepositoryTests
             }
         });
 
-        repository.AddMetrics(new AddContext(), new RepeatedField<ResourceMetrics>()
+        await repository.AsWriter().AddMetricsAsync(new AddContext(), new RepeatedField<ResourceMetrics>()
         {
             new ResourceMetrics
             {
@@ -1453,4 +1453,14 @@ public class TelemetryRepositoryTests
             }
         });
     }
+}
+
+public sealed class InMemoryTelemetryRepositoryTests : TelemetryRepositoryTests
+{
+    protected override bool UseSqlite => false;
+}
+
+public sealed class SqliteTelemetryRepositoryTests : TelemetryRepositoryTests
+{
+    protected override bool UseSqlite => true;
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Text;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
@@ -18,7 +19,7 @@ using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 
 namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
 
-public class TraceTests
+public abstract class TraceTests : TelemetryRepositoryTestBase
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -32,19 +33,19 @@ public class TraceTests
     [InlineData(OtlpSpanKind.Unspecified, (Span.Types.SpanKind)1000)]
     public void ConvertSpanKind(OtlpSpanKind expected, Span.Types.SpanKind value)
     {
-        var result = TelemetryRepository.ConvertSpanKind(value);
+        var result = InMemoryTelemetryRepository.ConvertSpanKind(value);
         Assert.Equal(expected, result);
     }
 
     [Fact]
-    public void AddTraces()
+    public async Task AddTraces()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -67,7 +68,7 @@ public class TraceTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -76,13 +77,13 @@ public class TraceTests
                 Assert.False(resource.UninstrumentedPeer);
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -94,17 +95,430 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_SelfParent_Reject()
+    public async Task GetTraceSummaries_ReturnsPageData()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "frontend", instanceId: "frontend-1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(3),
+                                attributes:
+                                [
+                                    KeyValuePair.Create("custom", "match"),
+                                    KeyValuePair.Create("gen_ai.system", "test")
+                                ],
+                                status: new Status { Code = Status.Types.StatusCode.Error }),
+                            CreateSpan(
+                                traceId: "2",
+                                spanId: "2-1",
+                                startTime: s_testTime.AddMinutes(2),
+                                endTime: s_testTime.AddMinutes(4),
+                                attributes: [KeyValuePair.Create("custom", "other")])
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "backend", instanceId: "backend-1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                parentSpanId: "1-1",
+                                startTime: s_testTime.AddMinutes(2),
+                                endTime: s_testTime.AddMinutes(6),
+                                status: new Status { Code = Status.Types.StatusCode.Ok })
+                        }
+                    }
+                }
+            }
+        });
+
+        var request = new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            TraceNameFilterText = "frontend",
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = "custom",
+                    Condition = FilterCondition.Equals,
+                    Value = "match"
+                }
+            ]
+        };
+
+        var summaries = await repositoryContext.Repository.GetTraceSummariesAsync(request, cancellationToken: CancellationToken.None);
+        var traces = await repositoryContext.Repository.GetTracesAsync(request, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(traces.PagedResult.TotalItemCount, summaries.PagedResult.TotalItemCount);
+        Assert.Equal(traces.MaxDuration, summaries.MaxDuration);
+        var summary = Assert.Single(summaries.PagedResult.Items);
+        AssertId("1", summary.TraceId);
+        Assert.Equal("frontend: Test span. Id: 1-1", summary.FullName);
+        Assert.Equal(s_testTime.AddMinutes(1), summary.StartTime);
+        Assert.Equal(TimeSpan.FromMinutes(5), summary.Duration);
+        Assert.Equal(new ResourceKey("frontend", "frontend-1"), summary.RootResource.ResourceKey);
+        Assert.True(summary.HasError);
+        Assert.True(summary.HasGenAI);
+        Assert.Collection(summary.Resources,
+            resource =>
+            {
+                Assert.Equal(new ResourceKey("frontend", "frontend-1"), resource.Resource.ResourceKey);
+                Assert.Equal(1, resource.TotalSpans);
+                Assert.Equal(1, resource.ErroredSpans);
+            },
+            resource =>
+            {
+                Assert.Equal(new ResourceKey("backend", "backend-1"), resource.Resource.ResourceKey);
+                Assert.Equal(1, resource.TotalSpans);
+                Assert.Equal(0, resource.ErroredSpans);
+            });
+
+        var latestRequest = new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = [],
+            LatestItemCount = 1
+        };
+        var latestSummaries = await repositoryContext.Repository.GetTraceSummariesAsync(latestRequest, cancellationToken: CancellationToken.None);
+        var latestTraces = await repositoryContext.Repository.GetTracesAsync(latestRequest, cancellationToken: CancellationToken.None);
+        Assert.Equal(2, latestSummaries.PagedResult.TotalItemCount);
+        var latestSummary = Assert.Single(latestSummaries.PagedResult.Items);
+        AssertId("2", latestSummary.TraceId);
+        Assert.Equal(s_testTime.AddMinutes(2), latestSummary.StartTime);
+        Assert.Equal(latestTraces.PagedResult.TotalItemCount, latestSummaries.PagedResult.TotalItemCount);
+        var latestTrace = Assert.Single(latestTraces.PagedResult.Items);
+        AssertId("2", latestTrace.TraceId);
+        Assert.Equal(s_testTime.AddMinutes(2), latestTrace.FirstSpan.StartTime);
+
+        var emptyPage = await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = request.ResourceKeys,
+            StartIndex = 10,
+            Count = request.Count,
+            TraceNameFilterText = request.TraceNameFilterText,
+            Filters = request.Filters
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Empty(emptyPage.PagedResult.Items);
+        Assert.Equal(1, emptyPage.PagedResult.TotalItemCount);
+        Assert.Equal(TimeSpan.FromMinutes(5), emptyPage.MaxDuration);
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_SpanTypeFiltersMatchGetTraces()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("TestScope"),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "http", spanId: "1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("http.request.method", "GET")]),
+                            CreateSpan(traceId: "database", spanId: "2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2), attributes: [KeyValuePair.Create("db.system", "sqlite")]),
+                            CreateSpan(traceId: "messaging", spanId: "3", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), attributes: [KeyValuePair.Create("messaging.system", "kafka")]),
+                            CreateSpan(traceId: "rpc", spanId: "4", startTime: s_testTime.AddMinutes(3), endTime: s_testTime.AddMinutes(4), attributes: [KeyValuePair.Create("rpc.system", "grpc")]),
+                            CreateSpan(traceId: "genai", spanId: "5", startTime: s_testTime.AddMinutes(4), endTime: s_testTime.AddMinutes(5), attributes: [KeyValuePair.Create("gen_ai.provider.name", "test")])
+                        }
+                    },
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("azure.messaging"),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "cloud-azure", spanId: "6", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(6))
+                        }
+                    },
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("AWSSDK"),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "cloud-aws", spanId: "7", startTime: s_testTime.AddMinutes(6), endTime: s_testTime.AddMinutes(7))
+                        }
+                    },
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope("Azureish"),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "other", spanId: "8", startTime: s_testTime.AddMinutes(7), endTime: s_testTime.AddMinutes(8), attributes: [KeyValuePair.Create("http.request.method", string.Empty)])
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var cases = new (SpanType SpanType, string[] ExpectedTraceIds)[]
+        {
+            (SpanType.Http, ["http"]),
+            (SpanType.Database, ["database"]),
+            (SpanType.Messaging, ["messaging"]),
+            (SpanType.Rpc, ["rpc"]),
+            (SpanType.GenAI, ["genai"]),
+            (SpanType.Cloud, ["cloud-azure", "cloud-aws"]),
+            (SpanType.Other, ["other"])
+        };
+        foreach (var (spanType, expectedTraceIds) in cases)
+        {
+            var request = new GetTracesRequest
+            {
+                ResourceKeys = [],
+                StartIndex = 0,
+                Count = 10,
+                Filters = [spanType.Filter]
+            };
+
+            var traces = (await repositoryContext.Repository.GetTracesAsync(request, cancellationToken: CancellationToken.None)).PagedResult.Items;
+            var summaries = (await repositoryContext.Repository.GetTraceSummariesAsync(request, cancellationToken: CancellationToken.None)).PagedResult.Items;
+
+            Assert.Equal(expectedTraceIds.Select(GetHexId), traces.Select(trace => trace.TraceId));
+            Assert.Equal(expectedTraceIds.Select(GetHexId), summaries.Select(summary => summary.TraceId));
+        }
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_LateParent_PreservesResourceOrder()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "z-child"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                parentSpanId: "1-1",
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(10))
+                        }
+                    }
+                }
+            }
+        ]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "a-parent"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime.AddMinutes(5),
+                                endTime: s_testTime.AddMinutes(10))
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        var trace = Assert.IsType<OtlpTrace>(repositoryContext.Repository.GetTrace(summary.TraceId));
+
+        Assert.Equal(
+            TraceHelpers.GetOrderedResources(trace).Select(resource => resource.Resource.ResourceKey),
+            summary.Resources.Select(resource => resource.Resource.ResourceKey));
+        Assert.Collection(summary.Resources,
+            resource => Assert.Equal("a-parent", resource.Resource.ResourceName),
+            resource => Assert.Equal("z-child", resource.Resource.ResourceName));
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_SameOrderTime_UninstrumentedPeerAfterInstrumentedResource()
+    {
+        var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: _ => ("dashboard.db", null));
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "unknown_service:Aspire.Dashboard"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1),
+                                attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "dashboard.db")],
+                                kind: Span.Types.SpanKind.Client)
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+
+        Assert.Collection(summary.Resources,
+            resource =>
+            {
+                Assert.Equal("unknown_service:Aspire.Dashboard", resource.Resource.ResourceName);
+                Assert.False(resource.Resource.UninstrumentedPeer);
+            },
+            resource =>
+            {
+                Assert.Equal("dashboard.db", resource.Resource.ResourceName);
+                Assert.True(resource.Resource.UninstrumentedPeer);
+            });
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_IncrementalAppend_UpdatesSummaryValues()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "frontend"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        ]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "backend"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                parentSpanId: "1-1",
+                                startTime: s_testTime.AddSeconds(1),
+                                endTime: s_testTime.AddMinutes(2),
+                                attributes: [KeyValuePair.Create("gen_ai.provider.name", "test")],
+                                status: new Status { Code = Status.Types.StatusCode.Error })
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+
+        Assert.True(summary.HasError);
+        Assert.True(summary.HasGenAI);
+        Assert.Collection(summary.Resources,
+            resource =>
+            {
+                Assert.Equal("frontend", resource.Resource.ResourceName);
+                Assert.Equal(1, resource.TotalSpans);
+                Assert.Equal(0, resource.ErroredSpans);
+            },
+            resource =>
+            {
+                Assert.Equal("backend", resource.Resource.ResourceName);
+                Assert.Equal(1, resource.TotalSpans);
+                Assert.Equal(1, resource.ErroredSpans);
+            });
+    }
+
+    [Fact]
+    public async Task AddTraces_SelfParent_Reject()
     {
         // Arrange
         var testSink = new TestSink();
         var factory = LoggerFactory.Create(b => b.AddProvider(new TestLoggerProvider(testSink)));
 
-        var repository = CreateRepository(loggerFactory: factory);
+        using var repositoryContext = await CreateRepositoryAsync(loggerFactory: factory);
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -126,7 +540,7 @@ public class TraceTests
         // Assert
         Assert.Equal(1, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -134,13 +548,13 @@ public class TraceTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Empty(traces.PagedResult.Items);
 
         var write = Assert.Single(testSink.Writes);
@@ -149,14 +563,14 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_MultipleSpansLoop_Reject()
+    public async Task AddTraces_MultipleSpansLoop_Reject()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -180,7 +594,7 @@ public class TraceTests
         // Assert
         Assert.Equal(1, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -188,13 +602,13 @@ public class TraceTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -203,14 +617,71 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_DuplicateTraceIds_Reject()
+    public async Task AddTraces_CircularReferenceAcrossIngestionCalls_Reject()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), parentSpanId: "1-1"),
+                            CreateSpan(traceId: "1", spanId: "1-3", startTime: s_testTime.AddMinutes(3), endTime: s_testTime.AddMinutes(4), parentSpanId: "1-2")
+                        }
+                    }
+                }
+            }
+        });
+
+        var context = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(context, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(5), parentSpanId: "1-3")
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(1, context.FailureCount);
+        var trace = Assert.Single((await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(trace.Spans,
+            span => AssertId("1-2", span.SpanId),
+            span => AssertId("1-3", span.SpanId));
+    }
+
+    [Fact]
+    public async Task AddTraces_DuplicateTraceIds_Reject()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -234,7 +705,7 @@ public class TraceTests
         // Assert
         Assert.Equal(1, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -242,13 +713,13 @@ public class TraceTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -257,14 +728,14 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_Scope_Multiple()
+    public async Task AddTraces_Scope_Multiple()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -282,7 +753,7 @@ public class TraceTests
                 }
             }
         });
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -304,7 +775,7 @@ public class TraceTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -312,13 +783,13 @@ public class TraceTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -334,14 +805,14 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_Traces_MultipleOutOrOrder()
+    public async Task AddTraces_Traces_MultipleOutOrOrder()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext1 = new AddContext();
-        repository.AddTraces(addContext1, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext1, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -361,7 +832,7 @@ public class TraceTests
         Assert.Equal(0, addContext1.FailureCount);
 
         var addContext2 = new AddContext();
-        repository.AddTraces(addContext2, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext2, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -380,7 +851,7 @@ public class TraceTests
         });
         Assert.Equal(0, addContext2.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -388,13 +859,13 @@ public class TraceTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var traces1 = repository.GetTraces(new GetTracesRequest
+        var traces1 = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces1.PagedResult.Items,
             trace =>
             {
@@ -410,7 +881,7 @@ public class TraceTests
             });
 
         var addContext3 = new AddContext();
-        repository.AddTraces(addContext3, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext3, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -429,13 +900,13 @@ public class TraceTests
         });
         Assert.Equal(0, addContext3.FailureCount);
 
-        var traces2 = repository.GetTraces(new GetTracesRequest
+        var traces2 = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces2.PagedResult.Items,
             trace =>
             {
@@ -454,13 +925,13 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_Spans_MultipleOutOrOrder()
+    public async Task AddTraces_Spans_MultipleOutOrOrder()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -483,13 +954,13 @@ public class TraceTests
             }
         });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -506,13 +977,13 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_SpanEvents_ReturnData()
+    public async Task AddTraces_SpanEvents_ReturnData()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -551,13 +1022,13 @@ public class TraceTests
             }
         });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -582,13 +1053,13 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_SpanLinks_ReturnData()
+    public async Task AddTraces_SpanLinks_ReturnData()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -627,13 +1098,13 @@ public class TraceTests
             }
         });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -664,40 +1135,17 @@ public class TraceTests
                     });
             });
 
-        Assert.Collection(repository.SpanLinks,
-            l =>
-            {
-                AssertId("1", l.TraceId);
-                AssertId("1-1", l.SpanId);
-                Assert.Collection(l.Attributes,
-                    a =>
-                    {
-                        Assert.Equal("key2", a.Key);
-                        Assert.Equal("Value!", a.Value);
-                    });
-            },
-            l =>
-            {
-                AssertId("2", l.TraceId);
-                AssertId("2-1", l.SpanId);
-                Assert.Collection(l.Attributes,
-                    a =>
-                    {
-                        Assert.Equal("key1", a.Key);
-                        Assert.Equal("Value!", a.Value);
-                    });
-            });
     }
 
     [Fact]
-    public void GetTraces_ReturnCopies()
+    public async Task GetTraces_ReturnCopies()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext1 = new AddContext();
-        repository.AddTraces(addContext1, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext1, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -716,13 +1164,13 @@ public class TraceTests
             }
         });
 
-        var traces1 = repository.GetTraces(new GetTracesRequest
+        var traces1 = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces1.PagedResult.Items,
             trace =>
             {
@@ -731,27 +1179,27 @@ public class TraceTests
                 AssertId("1-1", trace.RootSpan!.SpanId);
             });
 
-        var traces2 = repository.GetTraces(new GetTracesRequest
+        var traces2 = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.NotSame(traces1.PagedResult.Items[0], traces2.PagedResult.Items[0]);
         Assert.NotSame(traces1.PagedResult.Items[0].Spans[0].Trace, traces2.PagedResult.Items[0].Spans[0].Trace);
 
-        var trace1 = repository.GetTrace(GetHexId("1"))!;
-        var trace2 = repository.GetTrace(GetHexId("1"))!;
+        var trace1 = repositoryContext.Repository.GetTrace(GetHexId("1"))!;
+        var trace2 = repositoryContext.Repository.GetTrace(GetHexId("1"))!;
         Assert.NotSame(trace1, trace2);
         Assert.NotSame(trace1.Spans[0].Trace, trace2.Spans[0].Trace);
     }
 
     [Fact]
-    public void AddTraces_AttributeAndEventLimits_LimitsApplied()
+    public async Task AddTraces_AttributeAndEventLimits_LimitsApplied()
     {
         // Arrange
-        var repository = CreateRepository(maxAttributeCount: 5, maxAttributeLength: 16, maxSpanEventCount: 5);
+        using var repositoryContext = await CreateRepositoryAsync(maxAttributeCount: 5, maxAttributeLength: 16, maxSpanEventCount: 5);
 
         var attributes = new List<KeyValuePair<string, string>>();
         for (var i = 0; i < 10; i++)
@@ -768,7 +1216,7 @@ public class TraceTests
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -790,7 +1238,7 @@ public class TraceTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -798,13 +1246,13 @@ public class TraceTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         var trace = Assert.Single(traces.PagedResult.Items);
 
@@ -842,20 +1290,20 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_Links_BacklinksPopulated()
+    public async Task AddTraces_Links_BacklinksPopulated()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
-        AddTrace(repository, "1", s_testTime);
-        var traces = repository.GetTraces(new GetTracesRequest
+        await AddTrace(repositoryContext.Repository, "1", s_testTime);
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         var trace = Assert.Single(traces.PagedResult.Items);
@@ -884,26 +1332,28 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_ExceedLimit_FirstInFirstOut()
+    public async Task AddTraces_ExceedLimit_OrderedByTimestampAndTraceId()
     {
         // Arrange
         const int MaxTraceCount = 10;
-        var repository = CreateRepository(maxTraceCount: MaxTraceCount);
+        using var repositoryContext = await CreateRepositoryAsync(maxTraceCount: MaxTraceCount);
 
         var testTime = s_testTime.AddDays(1);
+        var expectedTraces = new List<(string TraceId, DateTime StartTime)>();
 
         // Act
-        for (var i = 0; i < 2000; i++)
+        for (var i = 0; i < MaxTraceCount * 3; i++)
         {
             var traceNumber = i + 1;
             var traceId = traceNumber.ToString(CultureInfo.InvariantCulture);
 
             // Insert traces out of order to stress the circular buffer type.
             var startTime = testTime.AddMinutes(i + (i % 2 == 0 ? -5 : 0));
+            expectedTraces.Add((GetHexId(traceId), startTime));
 
             try
             {
-                AddTrace(repository, traceId, startTime);
+                await AddTrace(repositoryContext.Repository, traceId, startTime);
             }
             catch (Exception ex)
             {
@@ -912,7 +1362,7 @@ public class TraceTests
         }
 
         // Assert
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         Assert.Collection(resources,
             resource =>
             {
@@ -920,29 +1370,27 @@ public class TraceTests
                 Assert.Equal("TestId", resource.InstanceId);
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
-        // Most recent traces are returned.
-        var first = GetStringId(traces.PagedResult.Items.First().TraceId);
-        var last = GetStringId(traces.PagedResult.Items.Last().TraceId);
-        Assert.Equal("1988", first);
-        Assert.Equal("2000", last);
-
-        // Traces returned are ordered by start time.
         var actualOrder = traces.PagedResult.Items.Select(t => t.TraceId).ToList();
-        var expectedOrder = traces.PagedResult.Items.OrderBy(t => t.FirstSpan.StartTime).Select(t => t.TraceId).ToList();
+        var expectedOrder = expectedTraces
+            .OrderBy(trace => trace.StartTime)
+            .ThenBy(trace => trace.TraceId, StringComparer.Ordinal)
+            .TakeLast(MaxTraceCount)
+            .Select(trace => trace.TraceId)
+            .ToList();
         Assert.Equal(expectedOrder, actualOrder);
 
-        Assert.Equal(MaxTraceCount * 2, repository.SpanLinks.Count);
+        Assert.Equal(MaxTraceCount * 2, traces.PagedResult.Items.SelectMany(t => t.Spans).SelectMany(s => s.Links).Count());
     }
 
-    private static void AddTrace(TelemetryRepository repository, string traceId, DateTime startTime)
+    private static async Task AddTrace(ITelemetryRepository repository, string traceId, DateTime startTime)
     {
         var addContext = new AddContext();
 
@@ -965,7 +1413,7 @@ public class TraceTests
             }
         };
 
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -995,14 +1443,14 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_MultipleRootSpans_RootSpanIsEarliestWithoutParent()
+    public async Task AddTraces_MultipleRootSpans_RootSpanIsEarliestWithoutParent()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1026,13 +1474,13 @@ public class TraceTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -1044,14 +1492,14 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetTraces_MultipleInstances()
+    public async Task GetTraces_MultipleInstances()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1095,13 +1543,13 @@ public class TraceTests
         Assert.Equal(0, addContext.FailureCount);
 
         var resourceKey = new ResourceKey("resource1", InstanceId: null);
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         Assert.Collection(traces.PagedResult.Items,
             trace =>
             {
@@ -1112,20 +1560,113 @@ public class TraceTests
                 AssertId("2", trace.TraceId);
             });
 
-        var propertyKeys = repository.GetTracePropertyKeys(resourceKey)!;
+        var propertyKeys = await repositoryContext.Repository.GetTracePropertyKeysAsync(resourceKey, TestContext.Current.CancellationToken);
         Assert.Collection(propertyKeys,
             s => Assert.Equal("key-1", s),
             s => Assert.Equal("key-2", s));
     }
 
     [Fact]
-    public void GetTraces_AttributeFilters()
+    public async Task AddTraces_MissingAndEmptyInstanceIdsAreDistinct()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var missingInstanceIdResource = CreateResource(name: "resource", instanceId: "placeholder");
+        missingInstanceIdResource.Attributes.Remove(missingInstanceIdResource.Attributes.Single(attribute => attribute.Key == OtlpResource.SERVICE_INSTANCE_ID));
+        var addContext = new AddContext();
+
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = missingInstanceIdResource,
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1)) }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "resource", instanceId: string.Empty),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans = { CreateSpan(traceId: "2", spanId: "2-1", startTime: s_testTime, endTime: s_testTime.AddMinutes(1)) }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        var resources = repositoryContext.Repository.GetResources();
+        Assert.Equal(2, resources.Count);
+        Assert.Contains(resources, resource => resource.ResourceKey == new ResourceKey("resource", InstanceId: null));
+        Assert.Contains(resources, resource => resource.ResourceKey == new ResourceKey("resource", InstanceId: string.Empty));
+    }
+
+    [Fact]
+    public async Task GetTraceFieldValues_AllFieldsMatchMaterializedTraces()
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(3), attributes: [KeyValuePair.Create("custom", "one")], kind: Span.Types.SpanKind.Client),
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(5), parentSpanId: "1-1", attributes: [KeyValuePair.Create("custom", "two")], kind: Span.Types.SpanKind.Server)
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
+        var traces = (await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [resource.ResourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items;
+
+        foreach (var field in KnownTraceFields.AllFields.Append("custom"))
+        {
+            var expected = OtlpSpan.GetFieldValuesFromTraces(traces, field);
+            var actual = await repositoryContext.Repository.GetTraceFieldValuesAsync(field, TestContext.Current.CancellationToken);
+            Assert.Equal(expected.Count, actual.Count);
+            foreach (var (value, count) in expected)
+            {
+                Assert.Equal(count, actual[value]);
+            }
+        }
+
+        Assert.Empty(await repositoryContext.Repository.GetTraceFieldValuesAsync(KnownTraceFields.DurationField, TestContext.Current.CancellationToken));
+        Assert.Empty(await repositoryContext.Repository.GetTraceFieldValuesAsync(KnownTraceFields.TimestampField, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetTraces_AttributeFilters()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1158,7 +1699,7 @@ public class TraceTests
         var resourceKey = new ResourceKey("resource1", InstanceId: null);
 
         // Act 1
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -1166,7 +1707,7 @@ public class TraceTests
             Filters = [
                 new FieldTelemetryFilter { Field = "key1", Condition = FilterCondition.Equals, Value = "value1" }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
         // Assert 1
         // Match first span.
         Assert.Collection(traces.PagedResult.Items,
@@ -1176,7 +1717,7 @@ public class TraceTests
             });
 
         // Act 2
-        traces = repository.GetTraces(new GetTracesRequest
+        traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -1184,7 +1725,7 @@ public class TraceTests
             Filters = [
                 new FieldTelemetryFilter { Field = "key2", Condition = FilterCondition.Equals, Value = "value2" }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
         // Assert 2
         // Match second span.
         Assert.Collection(traces.PagedResult.Items,
@@ -1194,7 +1735,7 @@ public class TraceTests
             });
 
         // Act 3
-        traces = repository.GetTraces(new GetTracesRequest
+        traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -1203,7 +1744,7 @@ public class TraceTests
                 new FieldTelemetryFilter { Field = "key1", Condition = FilterCondition.Equals, Value = "value1" },
                 new FieldTelemetryFilter { Field = "key2", Condition = FilterCondition.Equals, Value = "value2" }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
         // Assert 3
         // Match neither span.
         Assert.Empty(traces.PagedResult.Items);
@@ -1218,14 +1759,15 @@ public class TraceTests
     [InlineData(KnownResourceFields.ServiceNameField, "TestPeer")]
     [InlineData(KnownSourceFields.NameField, "TestScope")]
     [InlineData(KnownTraceFields.DurationField, "540000")]
-    public void GetTraces_KnownFilters(string name, string value)
+    public async Task GetTraces_KnownFilters(string name, string value)
     {
         // Arrange
         var outgoingPeerResolver = new TestOutgoingPeerResolver();
-        var repository = CreateRepository(outgoingPeerResolvers: [outgoingPeerResolver]);
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1246,7 +1788,7 @@ public class TraceTests
         var resourceKey = new ResourceKey("resource1", InstanceId: null);
 
         // Act 1
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -1254,14 +1796,14 @@ public class TraceTests
             Filters = [
                 new FieldTelemetryFilter { Field = name, Condition = FilterCondition.NotEqual, Value = value }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert 1
         // Doesn't match filter.
         Assert.Empty(traces.PagedResult.Items);
 
         // Act 2
-        traces = repository.GetTraces(new GetTracesRequest
+        traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -1269,7 +1811,7 @@ public class TraceTests
             Filters = [
                 new FieldTelemetryFilter { Field = name, Condition = FilterCondition.Equals, Value = value }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert 2
         // Matches filter.
@@ -1281,12 +1823,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetTraces_FiltersPagingAndMaxDuration_ComputedFromAllMatchingTraces()
+    public async Task GetTraces_FiltersPagingAndMaxDuration_ComputedFromAllMatchingTraces()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1315,7 +1857,7 @@ public class TraceTests
         // dynamic field filters, known duration filters, paging, total count, and max
         // duration must all be computed from the same filtered trace set. MaxDuration
         // intentionally comes from all matching traces, not just the returned page.
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [new ResourceKey("resource1", InstanceId: null)],
             StartIndex = 1,
@@ -1325,7 +1867,7 @@ public class TraceTests
                 new FieldTelemetryFilter { Field = "dynamic.filter", Condition = FilterCondition.Equals, Value = "match" },
                 new FieldTelemetryFilter { Field = KnownTraceFields.DurationField, Condition = FilterCondition.GreaterThanOrEqual, Value = "20" }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Equal(3, traces.PagedResult.TotalItemCount);
         Assert.Equal(TimeSpan.FromMilliseconds(50), traces.MaxDuration);
@@ -1338,16 +1880,16 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetTraces_DurationFilter_AppliesTraceLevelDuration()
+    public async Task GetTraces_DurationFilter_AppliesTraceLevelDuration()
     {
         // Verifies that the duration filter uses the trace's overall duration (first span
         // start to latest span end), not individual span durations. A trace with a 100ms
         // root span containing a 5ms child span should match "> 50ms" (trace is 100ms)
         // but NOT "< 10ms" (even though the child span is only 5ms).
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1374,37 +1916,37 @@ public class TraceTests
         var resourceKey = new ResourceKey("resource1", InstanceId: null);
 
         // Duration filter "> 50ms" should match because trace duration is 100ms.
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [new FieldTelemetryFilter { Field = KnownTraceFields.DurationField, Condition = FilterCondition.GreaterThan, Value = "50" }]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Single(traces.PagedResult.Items);
 
         // Duration filter "< 10ms" should NOT match because trace duration is 100ms,
         // even though the child span is only 5ms.
-        traces = repository.GetTraces(new GetTracesRequest
+        traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = [new FieldTelemetryFilter { Field = KnownTraceFields.DurationField, Condition = FilterCondition.LessThan, Value = "10" }]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Empty(traces.PagedResult.Items);
     }
 
     [Fact]
-    public void GetTraces_NotEqualFilter_NonMatchingValue_ReturnsTrace()
+    public async Task GetTraces_NotEqualFilter_NonMatchingValue_ReturnsTrace()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1423,7 +1965,7 @@ public class TraceTests
         Assert.Equal(0, addContext.FailureCount);
 
         // Act - filter for key1 != "other_value" should return the trace since key1 is "value1"
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [new ResourceKey("resource1", InstanceId: null)],
             StartIndex = 0,
@@ -1431,7 +1973,7 @@ public class TraceTests
             Filters = [
                 new FieldTelemetryFilter { Field = "key1", Condition = FilterCondition.NotEqual, Value = "other_value" }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Collection(traces.PagedResult.Items,
@@ -1442,10 +1984,10 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_OutOfOrder_FullName()
+    public async Task AddTraces_OutOfOrder_FullName()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
         var request = new GetTracesRequest
         {
             ResourceKeys = [new ResourceKey("TestService", "TestId")],
@@ -1456,7 +1998,7 @@ public class TraceTests
 
         // Act 1
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1477,11 +2019,11 @@ public class TraceTests
         Assert.Equal(0, addContext.FailureCount);
 
         // Assert 1
-        var trace = Assert.Single(repository.GetTraces(request).PagedResult.Items);
+        var trace = Assert.Single((await repositoryContext.Repository.GetTracesAsync(request, cancellationToken: CancellationToken.None)).PagedResult.Items);
         Assert.Equal("TestService: Test span. Id: 1-3", trace.FullName);
 
         // Act 2
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1502,11 +2044,11 @@ public class TraceTests
         Assert.Equal(0, addContext.FailureCount);
 
         // Assert 2
-        trace = Assert.Single(repository.GetTraces(request).PagedResult.Items);
+        trace = Assert.Single((await repositoryContext.Repository.GetTracesAsync(request, cancellationToken: CancellationToken.None)).PagedResult.Items);
         Assert.Equal("TestService: Test span. Id: 1-2", trace.FullName);
 
         // Act 3
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1527,11 +2069,11 @@ public class TraceTests
         Assert.Equal(0, addContext.FailureCount);
 
         // Assert 3
-        trace = Assert.Single(repository.GetTraces(request).PagedResult.Items);
+        trace = Assert.Single((await repositoryContext.Repository.GetTracesAsync(request, cancellationToken: CancellationToken.None)).PagedResult.Items);
         Assert.Equal("TestService: Test span. Id: 1-1", trace.FullName);
 
         // Act 4
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1552,19 +2094,19 @@ public class TraceTests
         Assert.Equal(0, addContext.FailureCount);
 
         // Assert 4
-        trace = Assert.Single(repository.GetTraces(request).PagedResult.Items);
+        trace = Assert.Single((await repositoryContext.Repository.GetTracesAsync(request, cancellationToken: CancellationToken.None)).PagedResult.Items);
         Assert.Equal("TestService: Test span. Id: 1-1", trace.FullName);
     }
 
     [Fact]
-    public void AddTraces_SameResourceDifferentProperties_MultipleResourceViews()
+    public async Task AddTraces_SameResourceDifferentProperties_MultipleResourceViews()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1617,13 +2159,18 @@ public class TraceTests
         Assert.Equal(0, addContext.FailureCount);
 
         // Spans belong to the same resource
-        var resource = Assert.Single(repository.GetResources());
+        var resource = Assert.Single(repositoryContext.Repository.GetResources());
         Assert.Equal("TestService", resource.ResourceName);
         Assert.Equal("TestId", resource.InstanceId);
 
         // Spans have different views
         var views = resource.GetViews().OrderBy(v => v.Properties.Length).ToList();
-        Assert.Collection(views,
+        Assert.Equal(UseSqlite ? 3 : 2, views.Count);
+        if (UseSqlite)
+        {
+            Assert.Empty(views[0].Properties);
+        }
+        Assert.Collection(views.Where(v => v.Properties.Length > 0),
             v =>
             {
                 Assert.Collection(v.Properties,
@@ -1648,13 +2195,13 @@ public class TraceTests
                     });
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resource.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
         var trace = Assert.Single(traces.PagedResult.Items);
 
         Assert.Collection(trace.Spans,
@@ -1701,13 +2248,13 @@ public class TraceTests
     }
 
     [Fact]
-    public void RemoveTraces_All()
+    public async Task RemoveTraces_All()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1760,18 +2307,18 @@ public class TraceTests
         });
 
         // Act
-        repository.ClearTraces();
+        await repositoryContext.Repository.AsWriter().ClearTracesAsync();
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(traces?.PagedResult?.Items);
         Assert.Empty(traces.PagedResult.Items);
@@ -1779,13 +2326,13 @@ public class TraceTests
     }
 
     [Fact]
-    public void RemoveTraces_SelectedResource()
+    public async Task RemoveTraces_SelectedResource()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1838,18 +2385,18 @@ public class TraceTests
         });
 
         // Act
-        repository.ClearTraces(new ResourceKey("resource1", "123"));
+        await repositoryContext.Repository.AsWriter().ClearTracesAsync(new ResourceKey("resource1", "123"));
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(traces?.PagedResult?.Items);
         Assert.Equal(2, traces.PagedResult.TotalItemCount);
@@ -1884,13 +2431,13 @@ public class TraceTests
     }
 
     [Fact]
-    public void RemoveTraces_MultipleSelectedResources()
+    public async Task RemoveTraces_MultipleSelectedResources()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -1943,18 +2490,18 @@ public class TraceTests
         });
 
         // Act
-        repository.ClearTraces(new ResourceKey("resource1", null));
+        await repositoryContext.Repository.AsWriter().ClearTracesAsync(new ResourceKey("resource1", null));
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(traces?.PagedResult?.Items);
         var trace = Assert.Single(traces.PagedResult.Items);
@@ -1972,13 +2519,13 @@ public class TraceTests
     }
 
     [Fact]
-    public void RemoveTraces_SelectedResource_SpansFromDifferentTrace()
+    public async Task RemoveTraces_SelectedResource_SpansFromDifferentTrace()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2034,18 +2581,18 @@ public class TraceTests
         });
 
         // Act
-        repository.ClearTraces(new ResourceKey("resource1", null));
+        await repositoryContext.Repository.AsWriter().ClearTracesAsync(new ResourceKey("resource1", null));
 
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.NotNull(traces?.PagedResult?.Items);
         var trace = Assert.Single(traces.PagedResult.Items);
@@ -2063,15 +2610,16 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_HaveUninstrumentedPeers()
+    public async Task AddTraces_HaveUninstrumentedPeers()
     {
         // Arrange
         var outgoingPeerResolver = new TestOutgoingPeerResolver();
-        var repository = CreateRepository(outgoingPeerResolvers: [outgoingPeerResolver]);
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2094,7 +2642,7 @@ public class TraceTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources(includeUninstrumentedPeers: true);
+        var resources = repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true);
         Assert.Collection(resources,
             resource =>
             {
@@ -2111,13 +2659,13 @@ public class TraceTests
 
         var uninstrumentedPeerApp = resources.Single(a => a.UninstrumentedPeer);
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [uninstrumentedPeerApp.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         var trace = Assert.Single(traces.PagedResult.Items);
         Assert.Collection(trace.Spans,
@@ -2132,6 +2680,138 @@ public class TraceTests
                 Assert.NotNull(s.UninstrumentedPeer);
                 Assert.Equal("TestPeer", s.UninstrumentedPeer.ResourceName);
             });
+
+        var serviceNames = await repositoryContext.Repository.GetTraceFieldValuesAsync(KnownResourceFields.ServiceNameField, TestContext.Current.CancellationToken);
+        Assert.Equal(2, serviceNames["TestService"]);
+        Assert.Equal(1, serviceNames["TestPeer"]);
+    }
+
+    [Fact]
+    public async Task AddTraces_ChildAddedLater_UpdatesUninstrumentedPeers()
+    {
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [new TestOutgoingPeerResolver()]);
+        var writer = repositoryContext.Repository.AsWriter();
+
+        await writer.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(10),
+                                attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "value-1")],
+                                kind: Span.Types.SpanKind.Client,
+                                status: new Status { Code = Status.Types.StatusCode.Error })
+                        }
+                    }
+                }
+            }
+        });
+
+        var trace = Assert.IsType<OtlpTrace>(repositoryContext.Repository.GetTrace(GetHexId("1")));
+        Assert.NotNull(Assert.Single(trace.Spans).UninstrumentedPeer);
+
+        await writer.AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                parentSpanId: "1-1",
+                                startTime: s_testTime.AddMinutes(5),
+                                endTime: s_testTime.AddMinutes(10),
+                                attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "value-2")],
+                                kind: Span.Types.SpanKind.Client)
+                        }
+                    }
+                }
+            }
+        });
+
+        trace = Assert.IsType<OtlpTrace>(repositoryContext.Repository.GetTrace(GetHexId("1")));
+        Assert.Collection(
+            trace.Spans,
+            span => Assert.Null(span.UninstrumentedPeer),
+            span => Assert.Equal("TestPeer", span.UninstrumentedPeer?.ResourceName));
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(
+            summary.Resources,
+            resource =>
+            {
+                Assert.Equal("TestService", resource.Resource.ResourceName);
+                Assert.Equal(2, resource.TotalSpans);
+                Assert.Equal(1, resource.ErroredSpans);
+            },
+            resource =>
+            {
+                Assert.Equal("TestPeer", resource.Resource.ResourceName);
+                Assert.Equal(1, resource.TotalSpans);
+                Assert.Equal(0, resource.ErroredSpans);
+            });
+    }
+
+    [Fact]
+    public async Task ClearTraces_UninstrumentedPeer_RemovesOrphanedPeerResource()
+    {
+        var outgoingPeerResolver = new TestOutgoingPeerResolver();
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
+
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "value-1")], kind: Span.Types.SpanKind.Client)
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        Assert.Contains(repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true), resource => resource.UninstrumentedPeer);
+
+        await repositoryContext.Repository.AsWriter().ClearTracesAsync();
+
+        // The peer resource only ever existed because a span named it. Once the spans are gone nothing else
+        // deletes it, so without cleanup it lingers in the resource list for the life of the database.
+        Assert.DoesNotContain(repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true), resource => resource.UninstrumentedPeer);
     }
 
     [Fact]
@@ -2153,11 +2833,12 @@ public class TraceTests
                 return (null, null);
             }
         });
-        var repository = CreateRepository(outgoingPeerResolvers: [outgoingPeerResolver]);
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
 
         // Act
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2180,7 +2861,7 @@ public class TraceTests
         // Assert
         Assert.Equal(0, addContext.FailureCount);
 
-        var resources = repository.GetResources(includeUninstrumentedPeers: true);
+        var resources = repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true);
         Assert.Collection(resources,
             resource =>
             {
@@ -2189,13 +2870,13 @@ public class TraceTests
                 Assert.False(resource.UninstrumentedPeer);
             });
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resources[0].ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         var trace = Assert.Single(traces.PagedResult.Items);
         Assert.Collection(trace.Spans,
@@ -2213,7 +2894,7 @@ public class TraceTests
         matchPeer = true;
         await outgoingPeerResolver.InvokePeerChanges();
 
-        resources = repository.GetResources(includeUninstrumentedPeers: true);
+        resources = repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true);
         Assert.Collection(resources,
             resource =>
             {
@@ -2230,13 +2911,13 @@ public class TraceTests
 
         var uninstrumentedPeerApp = resources.Single(a => a.UninstrumentedPeer);
 
-        traces = repository.GetTraces(new GetTracesRequest
+        traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [uninstrumentedPeerApp.ResourceKey],
             StartIndex = 0,
             Count = 10,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         trace = Assert.Single(traces.PagedResult.Items);
         Assert.Collection(trace.Spans,
@@ -2254,14 +2935,124 @@ public class TraceTests
     }
 
     [Fact]
-    public void AddTraces_UninstrumentedPeer_InstanceIdDashes_AppKeyResolvedCorrectly()
+    public async Task AddTraces_NameOnlyPeerResolver_PersistsUninstrumentedPeer()
+    {
+        var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: _ => ("Browser Link", null));
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
+
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1),
+                                attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "localhost")],
+                                kind: Span.Types.SpanKind.Client)
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        var peerResource = Assert.Single(repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true), resource => resource.UninstrumentedPeer);
+        Assert.Equal("Browser Link", peerResource.ResourceName);
+        Assert.Null(peerResource.InstanceId);
+
+        var trace = Assert.IsType<OtlpTrace>(repositoryContext.Repository.GetTrace(GetHexId("1")));
+        var span = Assert.Single(trace.Spans);
+        Assert.Equal(peerResource.ResourceKey, span.UninstrumentedPeer?.ResourceKey);
+    }
+
+    [Fact]
+    public async Task AddTraces_NameOnlyPeerResolverChange_PersistsUninstrumentedPeer()
+    {
+        var matchPeer = false;
+        var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: _ => matchPeer ? ("Browser Link", null) : (null, null));
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
+
+        var addContext = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime,
+                                endTime: s_testTime.AddMinutes(1),
+                                attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "localhost")],
+                                kind: Span.Types.SpanKind.Client)
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+        Assert.Null(Assert.Single(repositoryContext.Repository.GetTrace(GetHexId("1"))!.Spans).UninstrumentedPeer);
+
+        matchPeer = true;
+        await outgoingPeerResolver.InvokePeerChanges();
+
+        var peerResource = Assert.Single(repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true), resource => resource.UninstrumentedPeer);
+        Assert.Equal("Browser Link", peerResource.ResourceName);
+        var span = Assert.Single(repositoryContext.Repository.GetTrace(GetHexId("1"))!.Spans);
+        Assert.Equal(peerResource.ResourceKey, span.UninstrumentedPeer?.ResourceKey);
+
+        matchPeer = false;
+        await outgoingPeerResolver.InvokePeerChanges();
+
+        Assert.Null(Assert.Single(repositoryContext.Repository.GetTrace(GetHexId("1"))!.Spans).UninstrumentedPeer);
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(summary.Resources, resource => Assert.Equal("TestService", resource.Resource.ResourceName));
+        Assert.Empty((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [peerResource.ResourceKey],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+    }
+
+    [Fact]
+    public async Task AddTraces_UninstrumentedPeer_InstanceIdDashes_AppKeyResolvedCorrectly()
     {
         // Arrange
         var resource = ModelTestHelpers.CreateResource(resourceName: "test-abc-def", displayName: "test");
         var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: attributes => (resource.Name, resource));
-        var repository = CreateRepository(outgoingPeerResolvers: [outgoingPeerResolver]);
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
         var addContext = new AddContext();
-        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(addContext, new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2281,7 +3072,7 @@ public class TraceTests
             }
         });
 
-        var resources = repository.GetResources(includeUninstrumentedPeers: true);
+        var resources = repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true);
         Assert.Collection(resources,
             resource =>
             {
@@ -2298,12 +3089,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_ReturnsAllSpans()
+    public async Task GetSpans_ReturnsAllSpans()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2325,13 +3116,13 @@ public class TraceTests
         });
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(3, result.PagedResult.TotalItemCount);
@@ -2339,12 +3130,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_FilterByTraceId_ReturnsMatchingSpans()
+    public async Task GetSpans_FilterByTraceId_ReturnsMatchingSpans()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2366,14 +3157,14 @@ public class TraceTests
         });
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
             TraceId = "31" // hex prefix of "1"
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(2, result.PagedResult.TotalItemCount);
@@ -2381,12 +3172,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_FilterByHasError_ReturnsErrorSpansOnly()
+    public async Task GetSpans_FilterByHasError_ReturnsErrorSpansOnly()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2407,14 +3198,14 @@ public class TraceTests
         });
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
             HasError = true
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(1, result.PagedResult.TotalItemCount);
@@ -2422,12 +3213,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_FilterByHasErrorFalse_ReturnsNonErrorSpansOnly()
+    public async Task GetSpans_FilterByHasErrorFalse_ReturnsNonErrorSpansOnly()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2448,27 +3239,80 @@ public class TraceTests
         });
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
             HasError = false
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(1, result.PagedResult.TotalItemCount);
         AssertId("1-2", result.PagedResult.Items[0].SpanId);
     }
 
+    [Theory]
+    [InlineData(FilterCondition.Equals, "1", "3")]
+    [InlineData(FilterCondition.NotEqual, "2")]
+    public async Task GetTraces_StatusFilter_ReturnsMatchingTraces(FilterCondition condition, params string[] expectedTraceIds)
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(2), status: new Status { Code = Status.Types.StatusCode.Error }),
+                            CreateSpan(traceId: "2", spanId: "2-1", startTime: s_testTime.AddMinutes(2), endTime: s_testTime.AddMinutes(3), status: new Status { Code = Status.Types.StatusCode.Ok }),
+                            CreateSpan(traceId: "3", spanId: "3-1", startTime: s_testTime.AddMinutes(3), endTime: s_testTime.AddMinutes(4), status: new Status { Code = Status.Types.StatusCode.Error }),
+                            CreateSpan(traceId: "3", spanId: "3-2", startTime: s_testTime.AddMinutes(4), endTime: s_testTime.AddMinutes(5), status: new Status { Code = Status.Types.StatusCode.Ok })
+                        }
+                    }
+                }
+            }
+        });
+
+        var result = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = KnownTraceFields.StatusField,
+                    Value = nameof(OtlpSpanStatusCode.Error),
+                    Condition = condition
+                }
+            ]
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(expectedTraceIds.Length, result.PagedResult.TotalItemCount);
+        Assert.Equal(expectedTraceIds.Length, result.PagedResult.Items.Count);
+        for (var index = 0; index < expectedTraceIds.Length; index++)
+        {
+            AssertId(expectedTraceIds[index], result.PagedResult.Items[index].TraceId);
+        }
+    }
+
     [Fact]
-    public void GetSpans_FilterByResource_ReturnsMatchingSpans()
+    public async Task GetSpans_FilterByResource_ReturnsMatchingSpans()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2502,17 +3346,17 @@ public class TraceTests
             }
         });
 
-        var resources = repository.GetResources();
+        var resources = repositoryContext.Repository.GetResources();
         var serviceA = resources.Single(r => r.ResourceName == "service-a");
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [serviceA.ResourceKey],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(1, result.PagedResult.TotalItemCount);
@@ -2520,12 +3364,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_FilterByDuration_ReturnsMatchingSpans()
+    public async Task GetSpans_FilterByDuration_ReturnsMatchingSpans()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2548,7 +3392,7 @@ public class TraceTests
         });
 
         // Act - filter for spans with duration >= 100000ms (100s)
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
@@ -2562,7 +3406,7 @@ public class TraceTests
                     Value = "100000"
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert - only the long span matches
         Assert.Equal(1, result.PagedResult.TotalItemCount);
@@ -2570,12 +3414,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_FilterByTextFragments_ReturnsMatchingSpans()
+    public async Task GetSpans_FilterByTextFragments_ReturnsMatchingSpans()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2596,27 +3440,96 @@ public class TraceTests
         });
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
             TextFragments = ["example.com"]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(1, result.PagedResult.TotalItemCount);
         AssertId("1-1", result.PagedResult.Items[0].SpanId);
     }
 
+    [Theory]
+    [InlineData(KnownTraceFields.KindField, "Client")]
+    [InlineData(KnownTraceFields.StatusField, "Error")]
+    public async Task GetSpans_FilterByKindOrStatusText_ReturnsMatchingSpans(string field, string value)
+    {
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(2),
+                                kind: Span.Types.SpanKind.Client,
+                                status: new Status { Code = Status.Types.StatusCode.Error }),
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                parentSpanId: "1-1",
+                                startTime: s_testTime.AddMinutes(2),
+                                endTime: s_testTime.AddMinutes(3),
+                                kind: Span.Types.SpanKind.Server,
+                                status: new Status { Code = Status.Types.StatusCode.Ok })
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var fieldResult = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters =
+            [
+                new FieldTelemetryFilter
+                {
+                    Field = field,
+                    Condition = FilterCondition.Equals,
+                    Value = value
+                }
+            ]
+        }, cancellationToken: CancellationToken.None);
+        var textResult = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = int.MaxValue,
+            Filters = [],
+            TextFragments = [value]
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(1, fieldResult.PagedResult.TotalItemCount);
+        AssertId("1-1", Assert.Single(fieldResult.PagedResult.Items).SpanId);
+        Assert.Equal(1, textResult.PagedResult.TotalItemCount);
+        AssertId("1-1", Assert.Single(textResult.PagedResult.Items).SpanId);
+    }
+
     [Fact]
-    public void GetSpans_Pagination_ReturnsCorrectPage()
+    public async Task GetSpans_Pagination_ReturnsCorrectPage()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2638,13 +3551,13 @@ public class TraceTests
         });
 
         // Act - get second page (skip 1, take 1)
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 1,
             Count = 1,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(3, result.PagedResult.TotalItemCount);
@@ -2653,12 +3566,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_CombinedFilters_ReturnsMatchingSpans()
+    public async Task GetSpans_CombinedFilters_ReturnsMatchingSpans()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2680,7 +3593,7 @@ public class TraceTests
         });
 
         // Act - filter for error spans with "example.com" text
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
@@ -2688,7 +3601,7 @@ public class TraceTests
             Filters = [],
             HasError = true,
             TextFragments = ["example.com"]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(1, result.PagedResult.TotalItemCount);
@@ -2696,19 +3609,19 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_EmptyRepository_ReturnsEmpty()
+    public async Task GetSpans_EmptyRepository_ReturnsEmpty()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(0, result.PagedResult.TotalItemCount);
@@ -2716,12 +3629,12 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetSpans_UnknownResource_ReturnsEmpty()
+    public async Task GetSpans_UnknownResource_ReturnsEmpty()
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2741,13 +3654,13 @@ public class TraceTests
         });
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [ResourceKey.Create("nonexistent", "unknown")],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = []
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(0, result.PagedResult.TotalItemCount);
@@ -2758,15 +3671,15 @@ public class TraceTests
     [InlineData("747261636531", 1)] // full hex trace ID — prefix match
     [InlineData("7472616", 1)] // 7 chars — meets ShortenedIdLength, prefix match
     [InlineData("747261", 0)] // 6 chars — below ShortenedIdLength, requires exact match
-    public void GetSpans_TraceIdPrefixLength_MatchesShortenedIds(string traceIdFilter, int expectedCount)
+    public async Task GetSpans_TraceIdPrefixLength_MatchesShortenedIds(string traceIdFilter, int expectedCount)
     {
         // Arrange
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
         // Use a trace ID whose hex representation is "747261636531" (UTF-8 bytes of "trace1")
         var traceId = Encoding.UTF8.GetString(Convert.FromHexString("747261636531"));
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>()
         {
             new ResourceSpans
             {
@@ -2787,25 +3700,25 @@ public class TraceTests
         });
 
         // Act
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
             Count = int.MaxValue,
             Filters = [],
             TraceId = traceIdFilter
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(expectedCount, result.PagedResult.TotalItemCount);
     }
 
     [Fact]
-    public void GetSpans_DisabledFiltersAreIgnored()
+    public async Task GetSpans_DisabledFiltersAreIgnored()
     {
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -2826,7 +3739,7 @@ public class TraceTests
         });
 
         // Enabled filter matches span name containing "span1", disabled filter would exclude everything
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
@@ -2848,7 +3761,7 @@ public class TraceTests
                     Enabled = false
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // The disabled filter should be ignored — only the enabled "span1" filter applies
         Assert.Equal(1, result.PagedResult.TotalItemCount);
@@ -2856,14 +3769,14 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetTraces_NotContainsFilter_ExcludesTraceWhenAnySpanMatches()
+    public async Task GetTraces_NotContainsFilter_ExcludesTraceWhenAnySpanMatches()
     {
         // Verifies that a "not contains" filter on the trace Name field excludes the trace
         // when ANY span's name contains the filtered text, even if other spans in the same
         // trace do not contain it. This is the fix for https://github.com/microsoft/aspire/issues/18684.
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -2889,7 +3802,7 @@ public class TraceTests
 
         // Filter: Name not contains "1-1" — the root span's name is "Test span. Id: 1-1" which
         // contains "1-1", so the trace should be excluded even though the child span doesn't match.
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -2903,19 +3816,19 @@ public class TraceTests
                     Value = "1-1"
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Empty(traces.PagedResult.Items);
     }
 
     [Fact]
-    public void GetTraces_NotContainsFilter_IncludesTraceWhenNoSpanMatches()
+    public async Task GetTraces_NotContainsFilter_IncludesTraceWhenNoSpanMatches()
     {
         // Verifies that a "not contains" filter includes the trace when none of its spans'
         // names contain the filtered text.
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -2939,7 +3852,7 @@ public class TraceTests
 
         // Filter: Name not contains "NONEXISTENT" — no span name contains this text,
         // so the trace should be included.
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -2953,20 +3866,20 @@ public class TraceTests
                     Value = "NONEXISTENT"
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Collection(traces.PagedResult.Items,
             trace => AssertId("1", trace.TraceId));
     }
 
     [Fact]
-    public void GetTraces_NotEqualFilter_ExcludesTraceWhenAnySpanMatches()
+    public async Task GetTraces_NotEqualFilter_ExcludesTraceWhenAnySpanMatches()
     {
         // Verifies that a "not equal" filter excludes the trace when ANY span's field value
         // equals the filtered text.
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -2990,7 +3903,7 @@ public class TraceTests
 
         // Filter: Name != "Test span. Id: 1-1" — the root span matches exactly, so the trace
         // should be excluded even though the child span doesn't match.
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -3004,20 +3917,20 @@ public class TraceTests
                     Value = "Test span. Id: 1-1"
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Empty(traces.PagedResult.Items);
     }
 
     [Fact]
-    public void GetTraces_NotContainsWithPositiveFilter_CombinesCorrectly()
+    public async Task GetTraces_NotContainsWithPositiveFilter_CombinesCorrectly()
     {
         // Verifies that combining a positive filter with a negative filter works correctly:
         // the trace must have at least one span matching the positive filter AND all spans
         // must satisfy the negative filter.
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -3076,7 +3989,7 @@ public class TraceTests
 
         // Positive: attribute env contains "prod"
         // Negative: name not contains "1-1" (excludes trace 1 because root span name matches)
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -3086,7 +3999,7 @@ public class TraceTests
                 new FieldTelemetryFilter { Field = "env", Condition = FilterCondition.Contains, Value = "prod" },
                 new FieldTelemetryFilter { Field = KnownTraceFields.NameField, Condition = FilterCondition.NotContains, Value = "1-1" }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         // Trace 1 is excluded (root span name contains "1-1" even though env=prod matches).
         // Trace 2 doesn't match the positive filter (env=staging, not prod).
@@ -3096,14 +4009,14 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetTraces_NotContainsFilter_AbsentAttributeDoesNotExcludeTrace()
+    public async Task GetTraces_NotContainsFilter_AbsentAttributeDoesNotExcludeTrace()
     {
         // Verifies that a negative filter on an attribute field does NOT exclude a trace
         // just because some spans lack the attribute. A span without the field trivially
         // satisfies "not contains X" — it cannot contain the value.
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -3131,7 +4044,7 @@ public class TraceTests
 
         // Filter: http.method not contains "GET" — span 1-1 has POST (passes), span 1-2
         // has no http.method (trivially passes). The trace should be included.
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -3145,20 +4058,20 @@ public class TraceTests
                     Value = "GET"
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Collection(traces.PagedResult.Items,
             trace => AssertId("1", trace.TraceId));
     }
 
     [Fact]
-    public void GetTraces_NotContainsFilter_AbsentAttributeWithViolatingSpanExcludes()
+    public async Task GetTraces_NotContainsFilter_AbsentAttributeWithViolatingSpanExcludes()
     {
         // Verifies that a trace is excluded when one span has the attribute and violates
         // the negative condition, even though another span lacks the attribute entirely.
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -3184,7 +4097,7 @@ public class TraceTests
 
         var resourceKey = new ResourceKey("service1", InstanceId: null);
 
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -3198,19 +4111,19 @@ public class TraceTests
                     Value = "GET"
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Empty(traces.PagedResult.Items);
     }
 
     [Fact]
-    public void GetSpans_NotContainsFilter_AbsentAttributeIncludesSpan()
+    public async Task GetSpans_NotContainsFilter_AbsentAttributeIncludesSpan()
     {
         // Verifies that span-level negative filtering correctly includes spans that lack the
         // filtered attribute. A span without the field trivially satisfies "not contains X".
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -3239,7 +4152,7 @@ public class TraceTests
         // Span 1-1 has GET → excluded
         // Span 1-2 has POST → included (POST doesn't contain GET)
         // Span 1-3 has no http.method → included (absent field trivially satisfies "not contains")
-        var result = repository.GetSpans(new GetSpansRequest
+        var result = await repositoryContext.Repository.GetSpansAsync(new GetSpansRequest
         {
             ResourceKeys = [],
             StartIndex = 0,
@@ -3253,7 +4166,7 @@ public class TraceTests
                     Value = "GET"
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Equal(2, result.PagedResult.TotalItemCount);
         Assert.Contains(result.PagedResult.Items, s => GetStringId(s.SpanId) == "1-2");
@@ -3261,14 +4174,14 @@ public class TraceTests
     }
 
     [Fact]
-    public void GetTraces_NotEqualTimestampFilter_ExcludesTraceViaUnoptimizedPath()
+    public async Task GetTraces_NotEqualTimestampFilter_ExcludesTraceViaUnoptimizedPath()
     {
         // Verifies that the non-optimized MatchesFilters path (used for date/numeric fields)
         // correctly applies ALL-span semantics for negative filters. A timestamp NotEqual
         // filter excludes a trace when any span's timestamp matches the filter value.
-        var repository = CreateRepository();
+        using var repositoryContext = await CreateRepositoryAsync();
 
-        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
         {
             new ResourceSpans
             {
@@ -3313,7 +4226,7 @@ public class TraceTests
         // CreateOptimizedTraceFilters falls through to the non-optimized path.
         // Filter: Timestamp != "1970-01-01T00:00:00Z" — span 1-1 violates this (its timestamp
         // equals the filter value), so trace 1 is excluded. Trace 2 passes.
-        var traces = repository.GetTraces(new GetTracesRequest
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
         {
             ResourceKeys = [resourceKey],
             StartIndex = 0,
@@ -3327,9 +4240,516 @@ public class TraceTests
                     Value = "1970-01-01T00:00:00Z"
                 }
             ]
-        });
+        }, cancellationToken: CancellationToken.None);
 
         Assert.Collection(traces.PagedResult.Items,
             trace => AssertId("2", trace.TraceId));
     }
+}
+
+public sealed class InMemoryTraceTests : TraceTests
+{
+    protected override bool UseSqlite => false;
+}
+
+public sealed class SqliteTraceTests : TraceTests
+{
+    protected override bool UseSqlite => true;
+
+    [Fact]
+    public async Task GetTraceSummaries_MultipleRootResourcesInPayload_OrdersByReceipt()
+    {
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            CreateRootResourceSpans("z-first", "1-1", testTime.AddMinutes(2)),
+            CreateRootResourceSpans("a-second", "1-2", testTime)
+        ]);
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(
+            summary.Resources,
+            resource => Assert.Equal("z-first", resource.Resource.ResourceName),
+            resource => Assert.Equal("a-second", resource.Resource.ResourceName));
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_MultipleRootResourcesAcrossCalls_OrdersByReceipt()
+    {
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(
+            new AddContext(),
+            [CreateRootResourceSpans("z-first", "1-1", testTime.AddMinutes(2))]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(
+            new AddContext(),
+            [CreateRootResourceSpans("a-second", "1-2", testTime)]);
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(
+            summary.Resources,
+            resource => Assert.Equal("z-first", resource.Resource.ResourceName),
+            resource => Assert.Equal("a-second", resource.Resource.ResourceName));
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_PeerRecalculationPreservesRootReceiptOrder()
+    {
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var outgoingPeerResolver = new TestOutgoingPeerResolver(onResolve: _ => (null, null));
+        using var repositoryContext = await CreateRepositoryAsync(
+            timeProvider: new FixedTimeProvider(DateTimeOffset.MaxValue.AddTicks(-100)),
+            outgoingPeerResolvers: [outgoingPeerResolver]);
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        await repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            CreateRootResourceSpans("first", "1-1", testTime),
+            CreateRootResourceSpans("z-second", "1-2", testTime)
+        ]);
+
+        await outgoingPeerResolver.InvokePeerChanges();
+        await repository.AsWriter().AddTracesAsync(
+            new AddContext(),
+            [CreateRootResourceSpans("a-third", "1-3", testTime)]);
+
+        var summary = Assert.Single((await repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(
+            summary.Resources,
+            resource => Assert.Equal("first", resource.Resource.ResourceName),
+            resource => Assert.Equal("z-second", resource.Resource.ResourceName),
+            resource => Assert.Equal("a-third", resource.Resource.ResourceName));
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_NonRootResourceEarlierSpanAddedLater_UpdatesOrder()
+    {
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            CreateResourceSpans("root", "1-1", testTime, parentSpanId: null),
+            CreateResourceSpans("z-updated", "1-2", testTime.AddMinutes(5), parentSpanId: "1-1"),
+            CreateResourceSpans("middle", "1-3", testTime.AddMinutes(4), parentSpanId: "1-1")
+        ]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(
+            new AddContext(),
+            [CreateResourceSpans("z-updated", "1-4", testTime.AddMinutes(3), parentSpanId: "1-1")]);
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(
+            summary.Resources,
+            resource => Assert.Equal("root", resource.Resource.ResourceName),
+            resource =>
+            {
+                Assert.Equal("z-updated", resource.Resource.ResourceName);
+                Assert.Equal(2, resource.TotalSpans);
+            },
+            resource => Assert.Equal("middle", resource.Resource.ResourceName));
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_ResourceSeenAsRootLater_PromotesOrderByReceipt()
+    {
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            CreateResourceSpans("first-root", "1-1", testTime, parentSpanId: null),
+            CreateResourceSpans("promoted", "1-2", testTime.AddMinutes(2), parentSpanId: "1-1"),
+            CreateResourceSpans("non-root", "1-3", testTime.AddMinutes(1), parentSpanId: "1-1")
+        ]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(
+            new AddContext(),
+            [CreateResourceSpans("promoted", "1-4", testTime.AddMinutes(4), parentSpanId: null)]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(
+            new AddContext(),
+            [CreateResourceSpans("later-root", "1-5", testTime.AddMinutes(3), parentSpanId: null)]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(
+            new AddContext(),
+            [CreateResourceSpans("promoted", "1-6", testTime.AddMinutes(5), parentSpanId: null)]);
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(
+            summary.Resources,
+            resource => Assert.Equal("first-root", resource.Resource.ResourceName),
+            resource =>
+            {
+                Assert.Equal("promoted", resource.Resource.ResourceName);
+                Assert.Equal(3, resource.TotalSpans);
+            },
+            resource => Assert.Equal("later-root", resource.Resource.ResourceName),
+            resource => Assert.Equal("non-root", resource.Resource.ResourceName));
+    }
+
+    private static ResourceSpans CreateRootResourceSpans(string resourceName, string spanId, DateTime startTime)
+        => CreateResourceSpans(resourceName, spanId, startTime, parentSpanId: null);
+
+    private static ResourceSpans CreateResourceSpans(string resourceName, string spanId, DateTime startTime, string? parentSpanId)
+    {
+        return new ResourceSpans
+        {
+            Resource = CreateResource(name: resourceName),
+            ScopeSpans =
+            {
+                new ScopeSpans
+                {
+                    Scope = CreateScope(),
+                    Spans =
+                    {
+                        CreateSpan(
+                            traceId: "1",
+                            spanId: spanId,
+                            startTime: startTime,
+                            endTime: startTime.AddMinutes(1),
+                            parentSpanId: parentSpanId)
+                    }
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task AddTraces_CircularReferenceAcrossPersistedAndIncomingSpans_Reject()
+    {
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                parentSpanId: "1-2",
+                                startTime: testTime.AddMinutes(1),
+                                endTime: testTime.AddMinutes(2))
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var context = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(context,
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                parentSpanId: "1-3",
+                                startTime: testTime.AddMinutes(2),
+                                endTime: testTime.AddMinutes(3)),
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-3",
+                                parentSpanId: "1-1",
+                                startTime: testTime.AddMinutes(3),
+                                endTime: testTime.AddMinutes(4))
+                        }
+                    }
+                }
+            }
+        ]);
+
+        Assert.Equal(1, context.SuccessCount);
+        Assert.Equal(1, context.FailureCount);
+        var trace = Assert.IsType<OtlpTrace>(repositoryContext.Repository.GetTrace(GetHexId("1")));
+        Assert.Collection(trace.Spans,
+            span => AssertId("1-1", span.SpanId),
+            span => AssertId("1-2", span.SpanId));
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_EqualStartTime_MatchesMaterializedTrace()
+    {
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "first"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: testTime, endTime: testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        ]);
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "second"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: testTime, endTime: testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        ]);
+
+        var trace = Assert.IsType<OtlpTrace>(repositoryContext.Repository.GetTrace(GetHexId("1")));
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+
+        Assert.Equal(trace.FullName, summary.FullName);
+        Assert.Equal(trace.RootOrFirstSpan.Source.Resource.ResourceKey, summary.RootResource.ResourceKey);
+    }
+
+    [Fact]
+    public async Task AddTraces_LargeAppend_DoesNotExceedSqliteParameterLimit()
+    {
+        const int appendedSpanCount = 8_192;
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "root", startTime: testTime, endTime: testTime.AddMinutes(1))
+                        }
+                    }
+                }
+            }
+        ]);
+        var resourceSpans = new ResourceSpans
+        {
+            Resource = CreateResource(),
+            ScopeSpans =
+            {
+                new ScopeSpans
+                {
+                    Scope = CreateScope()
+                }
+            }
+        };
+        for (var index = 0; index < appendedSpanCount; index++)
+        {
+            resourceSpans.ScopeSpans[0].Spans.Add(CreateSpan(
+                traceId: "1",
+                spanId: $"child-{index}",
+                parentSpanId: $"missing-parent-{index}",
+                startTime: testTime.AddSeconds(1),
+                endTime: testTime.AddMinutes(1)));
+        }
+
+        var context = new AddContext();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(context, [resourceSpans]);
+
+        Assert.Equal(appendedSpanCount, context.SuccessCount);
+        Assert.Equal(0, context.FailureCount);
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        Assert.Collection(summary.Resources, resource => Assert.Equal(appendedSpanCount + 1, resource.TotalSpans));
+    }
+
+    [Fact]
+    public async Task GetTraceSummaries_AfterResourceDeletion_DeletesAffectedTraces()
+    {
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        using var repositoryContext = await CreateRepositoryAsync();
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(),
+        [
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "frontend"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: testTime,
+                                endTime: testTime.AddMinutes(5),
+                                attributes: [KeyValuePair.Create("gen_ai.system", "test")],
+                                status: new Status { Code = Status.Types.StatusCode.Error })
+                        }
+                    }
+                }
+            },
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "backend"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-2",
+                                parentSpanId: "1-1",
+                                startTime: testTime.AddMinutes(1),
+                                endTime: testTime.AddMinutes(2)),
+                            CreateSpan(
+                                traceId: "2",
+                                spanId: "2-1",
+                                startTime: testTime.AddMinutes(3),
+                                endTime: testTime.AddMinutes(4))
+                        }
+                    }
+                }
+            }
+        ]);
+
+        await repositoryContext.Repository.AsWriter().ClearSelectedSignalsAsync(new Dictionary<string, HashSet<AspireDataType>>
+        {
+            [new ResourceKey("frontend", "TestId").GetCompositeName()] = [AspireDataType.Resource]
+        });
+
+        Assert.Null(repositoryContext.Repository.GetTrace(GetHexId("1")));
+        Assert.NotNull(repositoryContext.Repository.GetTrace(GetHexId("2")));
+
+        var summary = Assert.Single((await repositoryContext.Repository.GetTraceSummariesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None)).PagedResult.Items);
+        AssertId("2", summary.TraceId);
+        Assert.Equal("backend: Test span. Id: 2-1", summary.FullName);
+        Assert.Equal(testTime.AddMinutes(3), summary.StartTime);
+        Assert.Equal(TimeSpan.FromMinutes(1), summary.Duration);
+        Assert.False(summary.HasError);
+        Assert.False(summary.HasGenAI);
+        Assert.Collection(summary.Resources, resource =>
+        {
+            Assert.Equal("backend", resource.Resource.ResourceName);
+            Assert.Equal(1, resource.TotalSpans);
+            Assert.Equal(0, resource.ErroredSpans);
+        });
+    }
+
+    [Fact]
+    public async Task AddTraces_LargeSpanAndAttributeBatchesRoundTrip()
+    {
+        const int spanCount = 101;
+        using var repositoryContext = await CreateRepositoryAsync();
+        var repository = Assert.IsType<SqliteTelemetryRepository>(repositoryContext.Repository);
+        var resourceSpans = new ResourceSpans
+        {
+            Resource = CreateResource(),
+            ScopeSpans =
+            {
+                new ScopeSpans { Scope = CreateScope() }
+            }
+        };
+        var testTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (var index = 0; index < spanCount; index++)
+        {
+            resourceSpans.ScopeSpans[0].Spans.Add(CreateSpan(
+                traceId: "trace",
+                spanId: $"span-{index}",
+                startTime: testTime.AddTicks(index),
+                endTime: testTime.AddTicks(index + 1),
+                attributes: [KeyValuePair.Create("index", index.ToString(CultureInfo.InvariantCulture))]));
+        }
+
+        var context = new AddContext();
+        await repository.AsWriter().AddTracesAsync(context, [resourceSpans]);
+
+        Assert.Equal(spanCount, context.SuccessCount);
+        Assert.Equal(0, context.FailureCount);
+
+        var trace = Assert.IsType<OtlpTrace>(repository.GetTrace(GetHexId("trace")));
+        Assert.Equal(spanCount, trace.Spans.Count);
+        for (var index = 0; index < spanCount; index++)
+        {
+            var span = trace.Spans[index];
+            AssertId($"span-{index}", span.SpanId);
+            Assert.Equal(KeyValuePair.Create("index", index.ToString(CultureInfo.InvariantCulture)), Assert.Single(span.Attributes));
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -2815,6 +2815,56 @@ public abstract class TraceTests : TelemetryRepositoryTestBase
     }
 
     [Fact]
+    public async Task ClearTraces_UninstrumentedPeer_RemovesAssociatedTrace()
+    {
+        var outgoingPeerResolver = new TestOutgoingPeerResolver();
+        using var repositoryContext = await CreateRepositoryAsync(
+            outgoingPeerResolvers: [outgoingPeerResolver]);
+
+        await repositoryContext.Repository.AsWriter().AddTracesAsync(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(
+                                traceId: "1",
+                                spanId: "1-1",
+                                startTime: s_testTime.AddMinutes(1),
+                                endTime: s_testTime.AddMinutes(10),
+                                attributes: [KeyValuePair.Create(OtlpSpan.PeerServiceAttributeKey, "value-1")],
+                                kind: Span.Types.SpanKind.Client)
+                        }
+                    }
+                }
+            }
+        });
+
+        var peerResource = Assert.Single(
+            repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true),
+            resource => resource.UninstrumentedPeer);
+
+        await repositoryContext.Repository.AsWriter().ClearTracesAsync(peerResource.ResourceKey);
+
+        var traces = await repositoryContext.Repository.GetTracesAsync(new GetTracesRequest
+        {
+            ResourceKeys = [],
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        }, cancellationToken: CancellationToken.None);
+
+        Assert.Empty(traces.PagedResult.Items);
+        Assert.DoesNotContain(repositoryContext.Repository.GetResources(includeUninstrumentedPeers: true), resource => resource.UninstrumentedPeer);
+    }
+
+    [Fact]
     public async Task AddTraces_OnPeerUpdated_HaveUninstrumentedPeers()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Terminal/DefaultTerminalConnectionResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Terminal/DefaultTerminalConnectionResolverTests.cs
@@ -153,6 +153,7 @@ public class DefaultTerminalConnectionResolverTests
         public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate) => Task.CompletedTask;
         public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<WatchInteractionsResponseUpdate> SubscribeInteractionsAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
         public Task SendInteractionRequestAsync(WatchInteractionsRequestUpdate request, CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardEventHandlersTests.cs
@@ -309,6 +309,102 @@ public class DashboardEventHandlersTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
+    [InlineData(null, null, "Run", false)]
+    [InlineData("", null, "Run", false)]
+    [InlineData("   ", null, "Run", false)]
+    [InlineData(null, "   ", "Run", false)]
+    [InlineData(null, "None", "None", false)]
+    [InlineData("Run", "None", "None", false)]
+    [InlineData("Run", "None", "None", true)]
+    public async Task ConfigureEnvironmentVariables_ConfiguresDashboardApplicationNameAndPersistenceMode(
+        string? configuredPersistenceMode,
+        string? configuredPersistenceModeEnvironmentAlias,
+        string expectedPersistenceMode,
+        bool configureExplicitAliases)
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var explicitApplicationName = "Explicit Dashboard";
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Aspire:Store:Path"] = workspace.Path,
+                ["AppHost:DashboardApplicationName"] = "My App.AppHost",
+                ["Aspire:Dashboard:PersistenceMode"] = configuredPersistenceMode,
+                [DashboardConfigNames.DashboardPersistenceModeName.EnvVarName] = configuredPersistenceModeEnvironmentAlias,
+                [DashboardConfigNames.DashboardApplicationName.EnvVarName] = configureExplicitAliases ? explicitApplicationName : null
+            })
+            .Build();
+        var dashboardOptions = Options.Create(new DashboardOptions
+        {
+            DashboardPath = "test.dll",
+            DashboardUrl = "http://localhost:8080",
+            OtlpGrpcEndpointUrl = "http://localhost:4317",
+        });
+        var hook = CreateHook(resourceLoggerService, resourceNotificationService, configuration, dashboardOptions: dashboardOptions);
+        var environmentVariables = new Dictionary<string, object>();
+        var dashboardResource = new ExecutableResource("aspire-dashboard", "dashboard.exe", ".");
+        var model = new DistributedApplicationModel([dashboardResource]);
+        var context = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
+        {
+            Services = new TestServiceProvider().AddService(model)
+        });
+
+        await hook.ConfigureEnvironmentVariables(new EnvironmentCallbackContext(context, environmentVariables: environmentVariables, resource: dashboardResource));
+
+        Assert.Equal(
+            configureExplicitAliases ? explicitApplicationName : "My App",
+            environmentVariables[DashboardConfigNames.DashboardApplicationName.EnvVarName]);
+        Assert.Equal(expectedPersistenceMode, environmentVariables[DashboardConfigNames.DashboardPersistenceModeName.EnvVarName]);
+    }
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("configured-dashboard", null, "configured-dashboard")]
+    [InlineData("configured-dashboard", "environment-dashboard", "environment-dashboard")]
+    public async Task ConfigureEnvironmentVariables_ConfiguresExplicitDashboardDataDirectoryWithoutDefault(
+        string? configuredDataDirectory,
+        string? configuredDataDirectoryEnvironmentAlias,
+        string? expectedDataDirectory)
+    {
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [DashboardConfigNames.DashboardDataDirectoryName.ConfigKey] = configuredDataDirectory,
+                [DashboardConfigNames.DashboardDataDirectoryName.EnvVarName] = configuredDataDirectoryEnvironmentAlias
+            })
+            .Build();
+        var dashboardOptions = Options.Create(new DashboardOptions
+        {
+            DashboardPath = "test.dll",
+            DashboardUrl = "http://localhost:8080",
+            OtlpGrpcEndpointUrl = "http://localhost:4317",
+        });
+        var hook = CreateHook(resourceLoggerService, resourceNotificationService, configuration, dashboardOptions: dashboardOptions);
+        var environmentVariables = new Dictionary<string, object>();
+        var dashboardResource = new ExecutableResource("aspire-dashboard", "dashboard.exe", ".");
+        var model = new DistributedApplicationModel([dashboardResource]);
+        var context = new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
+        {
+            Services = new TestServiceProvider().AddService(model)
+        });
+
+        await hook.ConfigureEnvironmentVariables(new EnvironmentCallbackContext(context, environmentVariables: environmentVariables, resource: dashboardResource));
+
+        if (expectedDataDirectory is null)
+        {
+            Assert.False(environmentVariables.ContainsKey(DashboardConfigNames.DashboardDataDirectoryName.EnvVarName));
+        }
+        else
+        {
+            Assert.Equal(expectedDataDirectory, environmentVariables[DashboardConfigNames.DashboardDataDirectoryName.EnvVarName]);
+        }
+    }
+
+    [Theory]
     [InlineData("https://localhost:17131", "localhost", 9999, "https", "localhost")]
     [InlineData("https://aspire-dashboard.dev.localhost:17131", "aspire-dashboard.dev.localhost", 9999, "https", "aspire-dashboard.dev.localhost")]
     [InlineData("http://myapp.localhost:8080", "myapp.localhost", 5555, "http", "localhost")]

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -133,6 +133,11 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
             },
             e =>
             {
+                Assert.Equal(DashboardConfigNames.DashboardPersistenceModeName.EnvVarName, e.Key);
+                Assert.Equal("Run", e.Value);
+            },
+            e =>
+            {
                 Assert.Equal(KnownConfigNames.ResourceServiceEndpointUrl, e.Key);
                 Assert.Equal("http://localhost:5000", e.Value);
             },

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -222,6 +222,27 @@ public class ProjectResourceTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
+    [InlineData("aspire-dashboard", false)]
+    [InlineData("projectName", true)]
+    public async Task AddProjectAddsOtlpExporterEnvironmentVariablesBasedOnResourceName(string resourceName, bool expectedOtlpExporter)
+    {
+        var appBuilder = CreateBuilder(args: ["--environment", "Development", $"{KnownConfigNames.DashboardOtlpGrpcEndpointUrl}=http://localhost:18889"],
+            DistributedApplicationOperation.Run);
+
+        appBuilder.AddProject<TestProject>(resourceName, launchProfileName: null);
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resource = Assert.Single(appModel.GetProjectResources());
+
+        Assert.Equal(expectedOtlpExporter, resource.Annotations.OfType<OtlpExporterAnnotation>().Any());
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance).DefaultTimeout();
+
+        Assert.Equal(expectedOtlpExporter, config.ContainsKey(KnownOtelConfigNames.ExporterOtlpEndpoint));
+    }
+
+    [Theory]
     [InlineData("true", false)]
     [InlineData("1", false)]
     [InlineData("false", true)]

--- a/tests/Aspire.Hosting.Tests/Publishing/DeploymentStateManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/DeploymentStateManagerTests.cs
@@ -371,8 +371,7 @@ public class DeploymentStateManagerTests : IDisposable
         Assert.True(Directory.Exists(stateDirectory));
 
         // Verify permissions on the directory (should be 0700 - user only)
-        // This check only applies to non-Windows and non-macOS systems (e.g., Linux)
-        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
+        if (!OperatingSystem.IsWindows())
         {
             var mode = File.GetUnixFileMode(stateDirectory);
             var expectedMode = UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead;

--- a/tests/Shared/Telemetry/InMemoryTelemetryRepository.Watchers.cs
+++ b/tests/Shared/Telemetry/InMemoryTelemetryRepository.Watchers.cs
@@ -5,13 +5,14 @@ using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
 /// <summary>
 /// Partial class containing push-based streaming (watcher) functionality.
 /// </summary>
-public sealed partial class TelemetryRepository
+public sealed partial class InMemoryTelemetryRepository
 {
     // Watcher fields are defined in the main file:
     // private readonly object _watchersLock;
@@ -55,7 +56,7 @@ public sealed partial class TelemetryRepository
         {
             // Get existing spans directly using GetSpans, which applies all filters
             // (resource, traceId, hasError, telemetry filters, text fragments) at the query level.
-            var existingSpans = GetSpans(new GetSpansRequest
+            var existingSpans = await GetSpansAsync(new GetSpansRequest
             {
                 ResourceKeys = request.ResourceKeys,
                 StartIndex = 0,
@@ -64,7 +65,7 @@ public sealed partial class TelemetryRepository
                 TraceId = request.TraceId,
                 HasError = request.HasError,
                 TextFragments = request.TextFragments
-            });
+            }, cancellationToken).ConfigureAwait(false);
 
             // Track seen span IDs to deduplicate spans that arrive during the snapshot read.
             // Race condition: watcher is registered BEFORE GetSpans, so spans arriving during
@@ -146,14 +147,14 @@ public sealed partial class TelemetryRepository
         try
         {
             // Get existing logs snapshot (capped to prevent OOM)
-            var existingLogs = GetLogs(new GetLogsContext
+            var existingLogs = await GetLogsAsync(new GetLogsContext
             {
                 ResourceKeys = request.ResourceKeys,
                 StartIndex = 0,
                 Count = MaxWatcherSnapshotCount,
                 Filters = request.Filters,
                 TextFragments = request.TextFragments
-            });
+            }, cancellationToken).ConfigureAwait(false);
 
             // Track the highest log ID we've yielded to deduplicate
             long maxYieldedLogId = 0;

--- a/tests/Shared/Telemetry/InMemoryTelemetryRepository.cs
+++ b/tests/Shared/Telemetry/InMemoryTelemetryRepository.cs
@@ -14,31 +14,41 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Utils;
 using Google.Protobuf.Collections;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
+using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Resource.V1;
 using OpenTelemetry.Proto.Trace.V1;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
 using static OpenTelemetry.Proto.Trace.V1.Span.Types;
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
-public sealed partial class TelemetryRepository : IDisposable
+public sealed partial class InMemoryTelemetryRepository : ITelemetryRepository, ITelemetryRepositoryWriter
 {
-    internal const int MaxResourceViewCount = 10_000;
-    internal const int MaxInstrumentCount = 10_000;
-    internal const int MaxScopeCount = 10_000;
-    internal const int MaxDimensionCount = 10_000;
-    internal const int MaxKnownAttributeValueCount = 10_000;
-    internal const int MaxKnownAttributeValuesPerKey = 10_000;
-
     private readonly PauseManager _pauseManager;
     private readonly IOutgoingPeerResolver[] _outgoingPeerResolvers;
     private readonly ILogger _logger;
+    private bool _isReadOnly;
 
     private readonly object _lock = new();
-    internal TimeSpan _subscriptionMinExecuteInterval = TimeSpan.FromMilliseconds(100);
+    internal TimeSpan _subscriptionMinExecuteInterval = CallbackThrottler.DefaultMinExecuteInterval;
+
+    /// <summary>
+    /// Gets or sets a hook invoked at the start of each async read, identified by member name.
+    /// </summary>
+    /// <remarks>
+    /// Every async member of this fake otherwise completes synchronously, so callers never observe the
+    /// interleaving or faults that <c>SqliteTelemetryRepository</c> produces by running reads on the thread
+    /// pool. Version guards and loading-flag resets therefore go untested. Set this to return an incomplete
+    /// or faulted task to exercise those paths. When null, reads complete synchronously as before.
+    /// </remarks>
+    public Func<string, Task>? OnReadAsync { get; set; }
+
+    private Task ReadGateAsync(string readName) => OnReadAsync?.Invoke(readName) ?? Task.CompletedTask;
 
     private readonly List<Subscription> _resourceSubscriptions = new();
     private readonly List<Subscription> _logSubscriptions = new();
@@ -50,10 +60,10 @@ public sealed partial class TelemetryRepository : IDisposable
     private List<SpanWatcher>? _spanWatchers;
     private List<LogWatcher>? _logWatchers;
 
-    private readonly ConcurrentDictionary<ResourceKey, OtlpResource> _resources = new();
+    private readonly ConcurrentDictionary<ResourceKey, ResourceEntry> _resources = new();
 
     private readonly ReaderWriterLockSlim _logsLock = new();
-    // Bounded by MaxScopeCount. Cleared when all logs are cleared.
+    // Bounded by TelemetryRepositoryLimits.MaxScopeCount. Cleared when all logs are cleared.
     private readonly Dictionary<string, OtlpScope> _logScopes = new();
     private readonly CircularBuffer<OtlpLogEntry> _logs;
     // Bounded by _resources count * MaxAttributeCount. Cleared per-resource or when all logs are cleared.
@@ -63,7 +73,7 @@ public sealed partial class TelemetryRepository : IDisposable
     private readonly Dictionary<ResourceKey, int> _resourceUnviewedErrorLogs = new();
 
     private readonly ReaderWriterLockSlim _tracesLock = new();
-    // Bounded by MaxScopeCount. Cleared when all traces are cleared.
+    // Bounded by TelemetryRepositoryLimits.MaxScopeCount. Cleared when all traces are cleared.
     private readonly Dictionary<string, OtlpScope> _traceScopes = new();
     private readonly CircularBuffer<OtlpTrace> _traces;
     // Not explicitly capped per add — bounded only by the sum of span links across in-buffer traces.
@@ -71,6 +81,8 @@ public sealed partial class TelemetryRepository : IDisposable
     private readonly List<OtlpSpanLink> _spanLinks = new();
     private readonly List<IDisposable> _peerResolverSubscriptions = new();
     internal readonly OtlpContext _otlpContext;
+
+    public bool IsReadOnly => _isReadOnly;
 
     public bool HasDisplayedMaxLogLimitMessage { get; set; }
     public Message? MaxLogLimitMessage { get; set; }
@@ -82,9 +94,19 @@ public sealed partial class TelemetryRepository : IDisposable
     internal List<OtlpSpanLink> SpanLinks => _spanLinks;
     internal List<Subscription> TracesSubscriptions => _tracesSubscriptions;
 
-    public TelemetryRepository(ILoggerFactory loggerFactory, IOptions<DashboardOptions> dashboardOptions, PauseManager pauseManager, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    internal void MakeReadOnly() => _isReadOnly = true;
+
+    private void ThrowIfReadOnly()
     {
-        _logger = loggerFactory.CreateLogger(typeof(TelemetryRepository));
+        if (_isReadOnly)
+        {
+            throw new InvalidOperationException("Historical telemetry is read-only.");
+        }
+    }
+
+    public InMemoryTelemetryRepository(ILoggerFactory loggerFactory, IOptions<DashboardOptions> dashboardOptions, PauseManager pauseManager, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    {
+        _logger = loggerFactory.CreateLogger(typeof(InMemoryTelemetryRepository));
         _otlpContext = new OtlpContext
         {
             Logger = _logger,
@@ -126,7 +148,7 @@ public sealed partial class TelemetryRepository : IDisposable
 
     private List<OtlpResource> GetResourcesCore(bool includeUninstrumentedPeers, string? name)
     {
-        IEnumerable<OtlpResource> results = _resources.Values;
+        IEnumerable<OtlpResource> results = _resources.Values.Select(entry => entry.Resource);
         if (!includeUninstrumentedPeers)
         {
             results = results.Where(a => !a.UninstrumentedPeer);
@@ -146,7 +168,7 @@ public sealed partial class TelemetryRepository : IDisposable
         {
             if (kvp.Key.EqualsCompositeName(compositeName))
             {
-                return kvp.Value;
+                return kvp.Value.Resource;
             }
         }
 
@@ -160,8 +182,7 @@ public sealed partial class TelemetryRepository : IDisposable
             throw new InvalidOperationException($"{nameof(ResourceKey)} must have an instance ID.");
         }
 
-        _resources.TryGetValue(key, out var resource);
-        return resource;
+        return _resources.TryGetValue(key, out var entry) ? entry.Resource : null;
     }
 
     public List<OtlpResource> GetResources(ResourceKey key, bool includeUninstrumentedPeers = false)
@@ -180,6 +201,20 @@ public sealed partial class TelemetryRepository : IDisposable
         return [resource];
     }
 
+    private List<ResourceEntry> GetResourceEntries(ResourceKey key, bool includeUninstrumentedPeers = false)
+    {
+        IEnumerable<ResourceEntry> entries = key.InstanceId is null
+            ? _resources.Values.Where(entry => string.Equals(entry.Resource.ResourceName, key.Name, StringComparisons.ResourceName))
+            : _resources.TryGetValue(key, out var entry) ? [entry] : [];
+
+        if (!includeUninstrumentedPeers)
+        {
+            entries = entries.Where(entry => !entry.Resource.UninstrumentedPeer);
+        }
+
+        return entries.ToList();
+    }
+
     public Dictionary<ResourceKey, int> GetResourceUnviewedErrorLogsCount()
     {
         _logsLock.EnterReadLock();
@@ -194,7 +229,7 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    internal void MarkViewedErrorLogs(ResourceKey? key)
+    public void MarkViewedErrorLogs(ResourceKey? key)
     {
         _logsLock.EnterWriteLock();
 
@@ -226,28 +261,30 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    private OtlpResourceView GetOrAddResourceView(Resource resource)
+    private OtlpResourceView GetOrAddResourceView(Resource resource) => GetOrAddResourceView(resource, out _);
+
+    private OtlpResourceView GetOrAddResourceView(Resource resource, out ResourceEntry resourceEntry)
     {
         ArgumentNullException.ThrowIfNull(resource);
 
         var key = resource.GetResourceKey();
 
-        var (otlpResource, isNew) = GetOrAddResource(key, uninstrumentedPeer: false);
+        (resourceEntry, var isNew) = GetOrAddResourceEntry(key, uninstrumentedPeer: false);
         if (isNew)
         {
             RaiseSubscriptionChanged(_resourceSubscriptions);
         }
 
-        return otlpResource.GetView(resource.Attributes);
+        return resourceEntry.Resource.GetView(resource.Attributes);
     }
 
-    private (OtlpResource Resource, bool IsNew) GetOrAddResource(ResourceKey key, bool uninstrumentedPeer)
+    private (ResourceEntry Entry, bool IsNew) GetOrAddResourceEntry(ResourceKey key, bool uninstrumentedPeer)
     {
         // Fast path.
-        if (_resources.TryGetValue(key, out var resource))
+        if (_resources.TryGetValue(key, out var entry))
         {
-            resource.SetUninstrumentedPeer(uninstrumentedPeer);
-            return (Resource: resource, IsNew: false);
+            entry.Resource.SetUninstrumentedPeer(uninstrumentedPeer);
+            return (Entry: entry, IsNew: false);
         }
 
         // Check resource limit before adding a new resource.
@@ -261,20 +298,20 @@ public sealed partial class TelemetryRepository : IDisposable
         // Slower get or add path.
         // This GetOrAdd allocates a closure, so we avoid it if possible.
         var newResource = false;
-        resource = _resources.GetOrAdd(key, _ =>
+        entry = _resources.GetOrAdd(key, _ =>
         {
             newResource = true;
-            return new OtlpResource(key.Name, key.InstanceId, uninstrumentedPeer, _otlpContext);
+            return new ResourceEntry(new OtlpResource(key.Name, key.InstanceId, uninstrumentedPeer, _otlpContext));
         });
         if (!newResource)
         {
-            resource.SetUninstrumentedPeer(uninstrumentedPeer);
+            entry.Resource.SetUninstrumentedPeer(uninstrumentedPeer);
         }
         else
         {
             _logger.LogTrace("New resource added: {ResourceKey}", key);
         }
-        return (Resource: resource, IsNew: newResource);
+        return (Entry: entry, IsNew: newResource);
     }
 
     public Subscription OnNewResources(Func<Task> callback)
@@ -306,7 +343,7 @@ public sealed partial class TelemetryRepository : IDisposable
             {
                 subscriptions.Remove(subscription!);
             }
-        }, ExecutionContext.Capture(), this);
+        }, ExecutionContext.Capture(), _logger, _subscriptionMinExecuteInterval);
 
         lock (_lock)
         {
@@ -327,12 +364,14 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    public void AddLogs(AddContext context, RepeatedField<ResourceLogs> resourceLogs)
+    public Task AddLogsAsync(AddContext context, RepeatedField<ResourceLogs> resourceLogs)
     {
+        ThrowIfReadOnly();
+
         if (_pauseManager.AreStructuredLogsPaused(out _))
         {
             _logger.LogTrace("{Count} incoming structured log(s) ignored because of an active pause.", resourceLogs.Count);
-            return;
+            return Task.CompletedTask;
         }
 
         foreach (var rl in resourceLogs)
@@ -354,6 +393,7 @@ public sealed partial class TelemetryRepository : IDisposable
         }
 
         RaiseSubscriptionChanged(_logSubscriptions);
+        return Task.CompletedTask;
     }
 
     public void AddLogsCore(AddContext context, OtlpResourceView resourceView, RepeatedField<ScopeLogs> scopeLogs)
@@ -376,7 +416,7 @@ public sealed partial class TelemetryRepository : IDisposable
                 {
                     try
                     {
-                        var logEntry = new OtlpLogEntry(record, resourceView, scope, _otlpContext);
+                        var logEntry = CreateOtlpLogEntry(record, resourceView, scope, _otlpContext);
 
                         // Insert log entry in the correct position based on timestamp.
                         // Logs can be added out of order by different services.
@@ -439,7 +479,9 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    public PagedResult<OtlpLogEntry> GetLogs(GetLogsContext context)
+    public Task<PagedResult<OtlpLogEntry>> GetLogsAsync(GetLogsContext context, CancellationToken cancellationToken = default) => Task.FromResult(GetLogs(context));
+
+    private PagedResult<OtlpLogEntry> GetLogs(GetLogsContext context)
     {
         List<OtlpResource>? resources = null;
         if (context.ResourceKeys is { Count: > 0 } keys)
@@ -476,12 +518,49 @@ public sealed partial class TelemetryRepository : IDisposable
                 results = results.Where(l => MatchesLogTextFragments(l, textFragments));
             }
 
-            return OtlpHelpers.GetItems(results, context.StartIndex, context.Count, _logs.IsFull);
+            var startIndex = context.StartIndex;
+            if (context.LatestItemCount is { } latestItemCount)
+            {
+                startIndex += Math.Max(results.Count() - Math.Max(latestItemCount, 0), 0);
+            }
+
+            return OtlpHelpers.GetItems(results, startIndex, context.Count, _logs.IsFull);
         }
         finally
         {
             _logsLock.ExitReadLock();
         }
+    }
+
+    public Task<PagedResult<LogSummary>> GetLogSummariesAsync(GetLogsContext context, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(GetLogSummaries(context));
+    }
+
+    private PagedResult<LogSummary> GetLogSummaries(GetLogsContext context)
+    {
+        var result = GetLogs(context);
+        return new PagedResult<LogSummary>
+        {
+            Items = result.Items.Select(log => new LogSummary
+            {
+                InternalId = log.InternalId,
+                TimeStamp = log.TimeStamp,
+                Severity = log.Severity,
+                Message = log.Message,
+                SpanId = log.SpanId,
+                TraceId = log.TraceId,
+                ScopeName = log.Scope.Name,
+                EventName = OtlpHelpers.GetEventName(log),
+                Resource = log.ResourceView.Resource,
+                ExceptionText = OtlpLogEntry.GetExceptionText(log),
+                HasGenAI = global::Aspire.Dashboard.Model.GenAI.GenAIHelpers.HasGenAIAttribute(log.Attributes) ||
+                    GetSpan(log.TraceId, log.SpanId) is { } span && global::Aspire.Dashboard.Model.GenAI.GenAIHelpers.HasGenAIAttribute(span.Attributes)
+            }).ToList(),
+            TotalItemCount = result.TotalItemCount,
+            IsFull = result.IsFull
+        };
     }
 
     public OtlpLogEntry? GetLog(long logId)
@@ -512,9 +591,15 @@ public sealed partial class TelemetryRepository : IDisposable
     /// <param name="traceId">The trace ID.</param>
     /// <param name="spanId">The span ID.</param>
     /// <returns>A list of log entries associated with the span.</returns>
-    public List<OtlpLogEntry> GetLogsForSpan(string traceId, string spanId)
+    public async Task<List<OtlpLogEntry>> GetLogsForSpanAsync(string traceId, string spanId, CancellationToken cancellationToken)
     {
-        var logsContext = new GetLogsContext
+        var result = await GetLogsAsync(CreateLogsForSpanContext(traceId, spanId), cancellationToken).ConfigureAwait(false);
+        return result.Items;
+    }
+
+    private static GetLogsContext CreateLogsForSpanContext(string traceId, string spanId)
+    {
+        return new GetLogsContext
         {
             ResourceKeys = [],
             Count = int.MaxValue,
@@ -535,7 +620,6 @@ public sealed partial class TelemetryRepository : IDisposable
                 }
             ]
         };
-        return GetLogs(logsContext).Items;
     }
 
     /// <summary>
@@ -543,9 +627,15 @@ public sealed partial class TelemetryRepository : IDisposable
     /// </summary>
     /// <param name="traceId">The trace ID.</param>
     /// <returns>A list of log entries associated with the trace.</returns>
-    public List<OtlpLogEntry> GetLogsForTrace(string traceId)
+    public async Task<List<OtlpLogEntry>> GetLogsForTraceAsync(string traceId, CancellationToken cancellationToken)
     {
-        var logsContext = new GetLogsContext
+        var result = await GetLogsAsync(CreateLogsForTraceContext(traceId), cancellationToken).ConfigureAwait(false);
+        return result.Items;
+    }
+
+    private static GetLogsContext CreateLogsForTraceContext(string traceId)
+    {
+        return new GetLogsContext
         {
             ResourceKeys = [],
             Count = int.MaxValue,
@@ -560,11 +650,13 @@ public sealed partial class TelemetryRepository : IDisposable
                 }
             ]
         };
-        return GetLogs(logsContext).Items;
     }
 
-    public List<string> GetLogPropertyKeys(ResourceKey? resourceKey)
+    public async Task<List<string>> GetLogPropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken)
     {
+        await ReadGateAsync(nameof(GetLogPropertyKeysAsync)).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
         List<OtlpResource>? resources = null;
         if (resourceKey != null)
         {
@@ -590,8 +682,11 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    public List<string> GetTracePropertyKeys(ResourceKey? resourceKey)
+    public async Task<List<string>> GetTracePropertyKeysAsync(ResourceKey? resourceKey, CancellationToken cancellationToken)
     {
+        await ReadGateAsync(nameof(GetTracePropertyKeysAsync)).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
         List<OtlpResource>? resources = null;
         if (resourceKey != null)
         {
@@ -617,7 +712,9 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    public GetTracesResponse GetTraces(GetTracesRequest context)
+    public Task<GetTracesResponse> GetTracesAsync(GetTracesRequest context, CancellationToken cancellationToken = default) => Task.FromResult(GetTraces(context));
+
+    private GetTracesResponse GetTraces(GetTracesRequest context)
     {
         List<OtlpResource>? resources = null;
         if (context.ResourceKeys is { Count: > 0 } keys)
@@ -651,6 +748,10 @@ public sealed partial class TelemetryRepository : IDisposable
             var startIndex = Math.Max(context.StartIndex, 0);
             var count = Math.Max(context.Count, 0);
             List<OtlpTrace>? items = null;
+            var latestItemCount = Math.Max(context.LatestItemCount ?? 0, 0);
+            Queue<OtlpTrace>? latestItems = context.LatestItemCount is not null
+                ? new Queue<OtlpTrace>(latestItemCount)
+                : null;
             var totalItemCount = 0;
             var maxDuration = default(TimeSpan);
 
@@ -684,6 +785,17 @@ public sealed partial class TelemetryRepository : IDisposable
                     maxDuration = duration;
                 }
 
+                if (latestItems is not null)
+                {
+                    latestItems.Enqueue(trace);
+                    if (latestItems.Count > latestItemCount)
+                    {
+                        latestItems.Dequeue();
+                    }
+
+                    continue;
+                }
+
                 // Keep paging, total count, and MaxDuration in the same scan. The dashboard
                 // needs MaxDuration for the full filtered set, while only the requested page
                 // should pay the clone cost needed to isolate callers from live span updates.
@@ -692,6 +804,11 @@ public sealed partial class TelemetryRepository : IDisposable
                     items ??= new List<OtlpTrace>(Math.Min(count, _traces.Count));
                     items.Add(OtlpTrace.Clone(trace));
                 }
+            }
+
+            if (latestItems is not null)
+            {
+                items = latestItems.Skip(startIndex).Take(count).Select(OtlpTrace.Clone).ToList();
             }
 
             var pagedResults = new PagedResult<OtlpTrace>
@@ -713,7 +830,45 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    public GetSpansResponse GetSpans(GetSpansRequest context)
+    public Task<GetTraceSummariesResponse> GetTraceSummariesAsync(GetTracesRequest context, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(GetTraceSummaries(context));
+    }
+
+    private GetTraceSummariesResponse GetTraceSummaries(GetTracesRequest context)
+    {
+        var result = GetTraces(context);
+        return new GetTraceSummariesResponse
+        {
+            PagedResult = new PagedResult<TraceSummary>
+            {
+                Items = result.PagedResult.Items.Select(trace => new TraceSummary
+                {
+                    TraceId = trace.TraceId,
+                    FullName = trace.FullName,
+                    StartTime = trace.FirstSpan.StartTime,
+                    Duration = trace.Duration,
+                    RootResource = trace.RootOrFirstSpan.Source.Resource,
+                    Resources = TraceHelpers.GetOrderedResources(trace).Select(resource => new TraceResourceSummary
+                    {
+                        Resource = resource.Resource,
+                        TotalSpans = resource.TotalSpans,
+                        ErroredSpans = resource.ErroredSpans
+                    }).ToList(),
+                    HasError = trace.Spans.Any(span => span.Status == OtlpSpanStatusCode.Error),
+                    HasGenAI = trace.Spans.Any(span => global::Aspire.Dashboard.Model.GenAI.GenAIHelpers.HasGenAIAttribute(span.Attributes))
+                }).ToList(),
+                TotalItemCount = result.PagedResult.TotalItemCount,
+                IsFull = result.PagedResult.IsFull
+            },
+            MaxDuration = result.MaxDuration
+        };
+    }
+
+    public Task<GetSpansResponse> GetSpansAsync(GetSpansRequest context, CancellationToken cancellationToken = default) => Task.FromResult(GetSpans(context));
+
+    private GetSpansResponse GetSpans(GetSpansRequest context)
     {
         List<OtlpResource>? resources = null;
         if (context.ResourceKeys is { Count: > 0 } keys)
@@ -1309,8 +1464,10 @@ public sealed partial class TelemetryRepository : IDisposable
     /// Clears selected telemetry signals for specified resources.
     /// </summary>
     /// <param name="selectedResources">Dictionary mapping resource names to the data types to clear.</param>
-    public void ClearSelectedSignals(Dictionary<string, HashSet<AspireDataType>> selectedResources)
+    public Task ClearSelectedSignalsAsync(Dictionary<string, HashSet<AspireDataType>> selectedResources)
     {
+        ThrowIfReadOnly();
+
         var allOtlpResources = GetResources();
 
         foreach (var otlpResource in allOtlpResources)
@@ -1353,10 +1510,20 @@ public sealed partial class TelemetryRepository : IDisposable
             // Always remove everything if the resource is being removed.
             return dataTypes.Contains(dataType) || dataTypes.Contains(AspireDataType.Resource);
         }
+
+        return Task.CompletedTask;
     }
 
-    public void ClearTraces(ResourceKey? resourceKey = null)
+    public Task ClearTracesAsync(ResourceKey? resourceKey = null)
     {
+        ClearTraces(resourceKey);
+        return Task.CompletedTask;
+    }
+
+    private void ClearTraces(ResourceKey? resourceKey)
+    {
+        ThrowIfReadOnly();
+
         List<OtlpResource>? resources = null;
         if (resourceKey.HasValue)
         {
@@ -1376,7 +1543,7 @@ public sealed partial class TelemetryRepository : IDisposable
 
                 foreach (var resource in _resources.Values)
                 {
-                    SetResourceHasTraces(resource, false);
+                    SetResourceHasTraces(resource.Resource, false);
                 }
             }
             else
@@ -1414,11 +1581,68 @@ public sealed partial class TelemetryRepository : IDisposable
             _tracesLock.ExitWriteLock();
         }
 
+        RemoveOrphanedUninstrumentedPeers();
         RaiseSubscriptionChanged(_tracesSubscriptions);
     }
 
-    public void ClearStructuredLogs(ResourceKey? resourceKey = null)
+    /// <summary>
+    /// Removes peer resources that no remaining span references.
+    /// </summary>
+    /// <remarks>
+    /// Uninstrumented peers are synthesised from span attributes rather than reported by a real resource, so
+    /// clearing traces is the only thing that can retire them. This mirrors the SQLite repository, which deletes
+    /// the same rows so peers do not accumulate across clears.
+    /// </remarks>
+    private void RemoveOrphanedUninstrumentedPeers()
     {
+        List<ResourceKey>? orphanedKeys = null;
+
+        _tracesLock.EnterReadLock();
+        try
+        {
+            foreach (var (key, entry) in _resources)
+            {
+                if (!entry.Resource.UninstrumentedPeer)
+                {
+                    continue;
+                }
+
+                var referenced = _traces.Any(trace => trace.Spans.Any(span =>
+                    span.UninstrumentedPeer == entry.Resource || span.Source.Resource == entry.Resource));
+                if (!referenced)
+                {
+                    (orphanedKeys ??= []).Add(key);
+                }
+            }
+        }
+        finally
+        {
+            _tracesLock.ExitReadLock();
+        }
+
+        if (orphanedKeys is null)
+        {
+            return;
+        }
+
+        foreach (var key in orphanedKeys)
+        {
+            _resources.TryRemove(key, out _);
+        }
+
+        RaiseSubscriptionChanged(_resourceSubscriptions);
+    }
+
+    public Task ClearStructuredLogsAsync(ResourceKey? resourceKey = null)
+    {
+        ClearStructuredLogs(resourceKey);
+        return Task.CompletedTask;
+    }
+
+    private void ClearStructuredLogs(ResourceKey? resourceKey)
+    {
+        ThrowIfReadOnly();
+
         List<OtlpResource>? resources = null;
         if (resourceKey.HasValue)
         {
@@ -1438,7 +1662,7 @@ public sealed partial class TelemetryRepository : IDisposable
 
                 foreach (var resource in _resources.Values)
                 {
-                    SetResourceHasLogs(resource, false);
+                    SetResourceHasLogs(resource.Resource, false);
                 }
 
                 _resourceUnviewedErrorLogs.Clear();
@@ -1479,34 +1703,55 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    public void ClearMetrics(ResourceKey? resourceKey = null)
+    public Task ClearMetricsAsync(ResourceKey? resourceKey = null)
     {
-        List<OtlpResource> resources;
+        ClearMetrics(resourceKey);
+        return Task.CompletedTask;
+    }
+
+    private void ClearMetrics(ResourceKey? resourceKey)
+    {
+        ThrowIfReadOnly();
+
+        List<ResourceEntry> resources;
         if (resourceKey.HasValue)
         {
-            resources = GetResources(resourceKey.Value);
+            resources = GetResourceEntries(resourceKey.Value);
         }
         else
         {
             resources = _resources.Values.ToList();
         }
 
-        foreach (var resource in resources)
+        foreach (var entry in resources)
         {
-            resource.ClearMetrics();
-            SetResourceHasMetrics(resource, false);
+            entry.MetricsLock.EnterWriteLock();
+            try
+            {
+                entry.Instruments.Clear();
+                entry.Meters.Clear();
+            }
+            finally
+            {
+                entry.MetricsLock.ExitWriteLock();
+            }
+            SetResourceHasMetrics(entry.Resource, false);
         }
 
         RaiseSubscriptionChanged(_metricsSubscriptions);
     }
 
-    public Dictionary<string, int> GetTraceFieldValues(string attributeName)
+    public async Task<Dictionary<string, int>> GetTraceFieldValuesAsync(string attributeName, CancellationToken cancellationToken)
     {
+        await ReadGateAsync(nameof(GetTraceFieldValuesAsync)).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
         _tracesLock.EnterReadLock();
 
         try
         {
-            return OtlpSpan.GetFieldValuesFromTraces(_traces, attributeName);
+            var fieldValues = OtlpSpan.GetFieldValuesFromTraces(_traces, attributeName);
+            return fieldValues;
         }
         finally
         {
@@ -1514,11 +1759,18 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    public Dictionary<string, int> GetLogsFieldValues(string attributeName)
+    public async Task<Dictionary<string, int>> GetLogsFieldValuesAsync(string attributeName, CancellationToken cancellationToken)
     {
-        _logsLock.EnterReadLock();
+        await ReadGateAsync(nameof(GetLogsFieldValuesAsync)).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
 
         var attributesValues = new Dictionary<string, int>(StringComparers.OtlpAttribute);
+        if (attributeName == KnownStructuredLogFields.TimestampField)
+        {
+            return attributesValues;
+        }
+
+        _logsLock.EnterReadLock();
 
         try
         {
@@ -1634,41 +1886,204 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    public void AddMetrics(AddContext context, RepeatedField<ResourceMetrics> resourceMetrics)
+    public Task AddMetricsAsync(AddContext context, RepeatedField<ResourceMetrics> resourceMetrics)
     {
+        ThrowIfReadOnly();
+
         if (_pauseManager.AreMetricsPaused(out _))
         {
             _logger.LogTrace("{Count} incoming metric(s) ignored because of an active pause.", resourceMetrics.Count);
-            return;
+            return Task.CompletedTask;
         }
 
         foreach (var rm in resourceMetrics)
         {
             OtlpResourceView resourceView;
+            ResourceEntry resourceEntry;
             try
             {
-                resourceView = GetOrAddResourceView(rm.Resource);
+                resourceView = GetOrAddResourceView(rm.Resource, out resourceEntry);
             }
             catch (Exception ex)
             {
-                context.FailureCount += rm.ScopeMetrics.Sum(sm => sm.Metrics.Sum(OtlpResource.GetMetricDataPointCount));
+                context.FailureCount += rm.ScopeMetrics.Sum(sm => sm.Metrics.Sum(OtlpHelpers.GetMetricDataPointCount));
                 _otlpContext.Logger.LogInformation(ex, "Error adding resource.");
                 continue;
             }
 
-            resourceView.Resource.AddMetrics(context, rm.ScopeMetrics);
+            AddMetrics(resourceEntry, resourceView, context, rm.ScopeMetrics);
             SetResourceHasMetrics(resourceView.Resource, true);
         }
 
         RaiseSubscriptionChanged(_metricsSubscriptions);
+        return Task.CompletedTask;
     }
 
-    public void AddTraces(AddContext context, RepeatedField<ResourceSpans> resourceSpans)
+    private void AddMetrics(ResourceEntry resourceEntry, OtlpResourceView resourceView, AddContext context, RepeatedField<ScopeMetrics> scopeMetrics)
     {
+        resourceEntry.MetricsLock.EnterWriteLock();
+
+        try
+        {
+            foreach (var scopeMetric in scopeMetrics)
+            {
+                if (!OtlpHelpers.TryGetOrAddScope(resourceEntry.Meters, scopeMetric.Scope, _otlpContext, TelemetryType.Metrics, out var scope))
+                {
+                    context.FailureCount += scopeMetric.Metrics.Sum(OtlpHelpers.GetMetricDataPointCount);
+                    continue;
+                }
+
+                foreach (var metric in scopeMetric.Metrics)
+                {
+                    InMemoryInstrument instrument;
+
+                    try
+                    {
+                        if (string.IsNullOrEmpty(metric.Name))
+                        {
+                            throw new InvalidOperationException("Instrument name is required.");
+                        }
+
+                        var instrumentKey = new OtlpInstrumentKey(scope.Name, metric.Name);
+                        if (resourceEntry.Instruments.TryGetValue(instrumentKey, out var existingInstrument))
+                        {
+                            instrument = existingInstrument;
+                        }
+                        else if (resourceEntry.Instruments.Count < TelemetryRepositoryLimits.MaxInstrumentCount)
+                        {
+                            instrument = new InMemoryInstrument
+                            {
+                                Summary = new OtlpInstrumentSummary
+                                {
+                                    Name = metric.Name,
+                                    Description = metric.Description,
+                                    Unit = metric.Unit,
+                                    Type = MapMetricType(metric.DataCase),
+                                    AggregationTemporality = MapAggregationTemporality(metric),
+                                    Parent = scope,
+                                    ResourceView = resourceView
+                                },
+                                Context = _otlpContext
+                            };
+
+                            resourceEntry.Instruments.Add(instrumentKey, instrument);
+                            _otlpContext.Logger.LogTrace("Added metric instrument '{InstrumentName}' for scope '{ScopeName}'.", instrument.Summary.Name, scope.Name);
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"Instrument limit of {TelemetryRepositoryLimits.MaxInstrumentCount} reached. Instrument '{metric.Name}' will not be added.");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // If we can't create the instrument then all data points for it are failures.
+                        context.FailureCount += OtlpHelpers.GetMetricDataPointCount(metric);
+                        _otlpContext.Logger.LogInformation(ex, "Error adding metric instrument {MetricName}.", metric.Name);
+                        continue;
+                    }
+
+                    AddMetrics(instrument, metric, context);
+                }
+            }
+        }
+        finally
+        {
+            resourceEntry.MetricsLock.ExitWriteLock();
+        }
+    }
+
+    private void AddMetrics(InMemoryInstrument instrument, Metric metric, AddContext context)
+    {
+        switch (metric.DataCase)
+        {
+            case Metric.DataOneofCase.Gauge:
+                foreach (var dataPoint in metric.Gauge.DataPoints)
+                {
+                    try
+                    {
+                        OtlpHelpers.ValidateNumberDataPoint(dataPoint);
+                        instrument.FindScope(dataPoint.Attributes).AddPointValue(dataPoint, _otlpContext);
+                        context.SuccessCount++;
+                    }
+                    catch (Exception ex)
+                    {
+                        context.FailureCount++;
+                        _otlpContext.Logger.LogInformation(ex, "Error adding metric.");
+                    }
+                }
+                break;
+            case Metric.DataOneofCase.Sum:
+                foreach (var dataPoint in metric.Sum.DataPoints)
+                {
+                    try
+                    {
+                        OtlpHelpers.ValidateNumberDataPoint(dataPoint);
+                        instrument.FindScope(dataPoint.Attributes).AddPointValue(dataPoint, _otlpContext);
+                        context.SuccessCount++;
+                    }
+                    catch (Exception ex)
+                    {
+                        context.FailureCount++;
+                        _otlpContext.Logger.LogInformation(ex, "Error adding metric.");
+                    }
+                }
+                break;
+            case Metric.DataOneofCase.Histogram:
+                foreach (var dataPoint in metric.Histogram.DataPoints)
+                {
+                    try
+                    {
+                        instrument.FindScope(dataPoint.Attributes).AddHistogramValue(dataPoint, _otlpContext);
+                        context.SuccessCount++;
+                    }
+                    catch (Exception ex)
+                    {
+                        context.FailureCount++;
+                        _otlpContext.Logger.LogInformation(ex, "Error adding metric.");
+                    }
+                }
+                break;
+            case Metric.DataOneofCase.Summary:
+                context.FailureCount += metric.Summary.DataPoints.Count;
+                _otlpContext.Logger.LogInformation("Error adding summary metrics. Summary is not supported.");
+                break;
+            case Metric.DataOneofCase.ExponentialHistogram:
+                context.FailureCount += metric.ExponentialHistogram.DataPoints.Count;
+                _otlpContext.Logger.LogInformation("Error adding exponential histogram metrics. Exponential histogram is not supported.");
+                break;
+        }
+    }
+
+    private static OtlpInstrumentType MapMetricType(Metric.DataOneofCase data)
+    {
+        return data switch
+        {
+            Metric.DataOneofCase.Gauge => OtlpInstrumentType.Gauge,
+            Metric.DataOneofCase.Sum => OtlpInstrumentType.Sum,
+            Metric.DataOneofCase.Histogram => OtlpInstrumentType.Histogram,
+            _ => OtlpInstrumentType.Unsupported
+        };
+    }
+
+    private static OtlpAggregationTemporality MapAggregationTemporality(Metric metric)
+    {
+        return metric.DataCase switch
+        {
+            Metric.DataOneofCase.Sum => (OtlpAggregationTemporality)metric.Sum.AggregationTemporality,
+            Metric.DataOneofCase.Histogram => (OtlpAggregationTemporality)metric.Histogram.AggregationTemporality,
+            Metric.DataOneofCase.ExponentialHistogram => (OtlpAggregationTemporality)metric.ExponentialHistogram.AggregationTemporality,
+            _ => OtlpAggregationTemporality.Unspecified
+        };
+    }
+
+    public Task AddTracesAsync(AddContext context, RepeatedField<ResourceSpans> resourceSpans)
+    {
+        ThrowIfReadOnly();
+
         if (_pauseManager.AreTracesPaused(out _))
         {
             _logger.LogTrace("{Count} incoming trace(s) ignored because of an active pause.", resourceSpans.Count);
-            return;
+            return Task.CompletedTask;
         }
 
         foreach (var rs in resourceSpans)
@@ -1690,6 +2105,7 @@ public sealed partial class TelemetryRepository : IDisposable
         }
 
         RaiseSubscriptionChanged(_tracesSubscriptions);
+        return Task.CompletedTask;
     }
 
     private static OtlpSpanStatusCode ConvertStatus(Status? status)
@@ -1705,18 +2121,7 @@ public sealed partial class TelemetryRepository : IDisposable
 
     internal static OtlpSpanKind ConvertSpanKind(SpanKind? kind)
     {
-        return kind switch
-        {
-            // Unspecified to Internal is intentional.
-            // "Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED."
-            SpanKind.Unspecified => OtlpSpanKind.Internal,
-            SpanKind.Internal => OtlpSpanKind.Internal,
-            SpanKind.Client => OtlpSpanKind.Client,
-            SpanKind.Server => OtlpSpanKind.Server,
-            SpanKind.Producer => OtlpSpanKind.Producer,
-            SpanKind.Consumer => OtlpSpanKind.Consumer,
-            _ => OtlpSpanKind.Unspecified
-        };
+        return OtlpHelpers.ConvertSpanKind(kind);
     }
 
     internal void AddTracesCore(AddContext context, OtlpResourceView resourceView, RepeatedField<ScopeSpans> scopeSpans)
@@ -1776,7 +2181,7 @@ public sealed partial class TelemetryRepository : IDisposable
                             linkedSpan?.BackLinks.Add(link);
                         }
 
-                        // Traces are sorted by the start time of the first span.
+                        // Traces are sorted by the start time of the first span, then by trace ID.
                         // We need to ensure traces are in the correct order if we're:
                         // 1. Adding a new trace.
                         // 2. The first span of the trace has changed.
@@ -1786,7 +2191,7 @@ public sealed partial class TelemetryRepository : IDisposable
                             for (var i = _traces.Count - 1; i >= 0; i--)
                             {
                                 var currentTrace = _traces[i];
-                                if (trace.FirstSpan.StartTime > currentTrace.FirstSpan.StartTime)
+                                if (CompareTraceOrder(trace, currentTrace) > 0)
                                 {
                                     _traces.Insert(i + 1, trace);
                                     added = true;
@@ -1808,7 +2213,7 @@ public sealed partial class TelemetryRepository : IDisposable
                                 for (var i = index - 1; i >= 0; i--)
                                 {
                                     var currentTrace = _traces[i];
-                                    if (trace.FirstSpan.StartTime > currentTrace.FirstSpan.StartTime)
+                                    if (CompareTraceOrder(trace, currentTrace) > 0)
                                     {
                                         var insertPosition = i + 1;
                                         if (index != insertPosition)
@@ -1893,25 +2298,15 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
+    private static int CompareTraceOrder(OtlpTrace left, OtlpTrace right)
+    {
+        var timestampComparison = left.FirstSpan.StartTime.CompareTo(right.FirstSpan.StartTime);
+        return timestampComparison != 0 ? timestampComparison : string.CompareOrdinal(left.TraceId, right.TraceId);
+    }
+
     public OtlpResource? GetPeerResource(OtlpSpan span)
     {
-        var peer = ResolveUninstrumentedPeerResource(span, _outgoingPeerResolvers);
-        if (peer == null)
-        {
-            return null;
-        }
-
-        try
-        {
-            var resourceKey = ResourceKey.Create(name: peer.DisplayName, instanceId: peer.Name);
-            var (resource, _) = GetOrAddResource(resourceKey, uninstrumentedPeer: true);
-            return resource;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogInformation(ex, "Error adding peer resource.");
-            return null;
-        }
+        return span.UninstrumentedPeer;
     }
 
     private void CalculateTraceUninstrumentedPeers(OtlpTrace trace)
@@ -1921,11 +2316,11 @@ public sealed partial class TelemetryRepository : IDisposable
             // A span may indicate a call to another service but the service isn't instrumented.
             var hasPeerService = OtlpHelpers.GetPeerAddress(span.Attributes) != null;
             var hasUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
-            var uninstrumentedPeer = hasUninstrumentedPeer ? ResolveUninstrumentedPeerResource(span, _outgoingPeerResolvers) : null;
+            var uninstrumentedPeerKey = hasUninstrumentedPeer ? ResolveUninstrumentedPeerResourceKey(span, _outgoingPeerResolvers) : null;
 
-            if (uninstrumentedPeer != null)
+            if (uninstrumentedPeerKey is { } peerKey)
             {
-                if (span.UninstrumentedPeer?.ResourceKey.EqualsCompositeName(uninstrumentedPeer.Name) ?? false)
+                if (span.UninstrumentedPeer?.ResourceKey == peerKey)
                 {
                     // Already the correct value. No changes needed.
                     continue;
@@ -1933,9 +2328,8 @@ public sealed partial class TelemetryRepository : IDisposable
 
                 try
                 {
-                    var resourceKey = ResourceKey.Create(name: uninstrumentedPeer.DisplayName, instanceId: uninstrumentedPeer.Name);
-                    var (resource, _) = GetOrAddResource(resourceKey, uninstrumentedPeer: true);
-                    trace.SetSpanUninstrumentedPeer(span, resource);
+                    var (resource, _) = GetOrAddResourceEntry(peerKey, uninstrumentedPeer: true);
+                    trace.SetSpanUninstrumentedPeer(span, resource.Resource);
                 }
                 catch (Exception ex)
                 {
@@ -1949,14 +2343,23 @@ public sealed partial class TelemetryRepository : IDisposable
         }
     }
 
-    private static ResourceViewModel? ResolveUninstrumentedPeerResource(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    private static ResourceKey? ResolveUninstrumentedPeerResourceKey(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
     {
-        // Attempt to resolve uninstrumented peer to a friendly name from the span.
         foreach (var resolver in outgoingPeerResolvers)
         {
-            if (resolver.TryResolvePeer(span.Attributes, out _, out var matchedResourced))
+            if (!resolver.TryResolvePeer(span.Attributes, out var name, out var matchedResource))
             {
-                return matchedResourced;
+                continue;
+            }
+
+            if (matchedResource is not null)
+            {
+                return ResourceKey.Create(matchedResource.DisplayName, matchedResource.Name);
+            }
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                return new ResourceKey(name, InstanceId: null);
             }
         }
 
@@ -2074,87 +2477,139 @@ public sealed partial class TelemetryRepository : IDisposable
         return newSpan;
     }
 
-    public List<OtlpInstrumentSummary> GetInstrumentsSummaries(ResourceKey key)
+    public List<OtlpInstrumentSummary> GetInstrumentSummaries(ResourceKey key)
     {
-        var resources = GetResources(key);
-        if (resources.Count == 0)
+        var resources = GetResourceEntries(key);
+        var summaries = new List<OtlpInstrumentSummary>();
+        foreach (var resource in resources)
         {
-            return new List<OtlpInstrumentSummary>();
-        }
-        else if (resources.Count == 1)
-        {
-            return resources[0].GetInstrumentsSummary();
-        }
-        else
-        {
-            var allResourceSummaries = resources
-                .SelectMany(a => a.GetInstrumentsSummary())
-                .DistinctBy(s => s.GetKey())
-                .ToList();
-
-            return allResourceSummaries;
+            resource.MetricsLock.EnterReadLock();
+            try
+            {
+                summaries.AddRange(resource.Instruments.Values.Select(instrument => instrument.Summary));
+            }
+            finally
+            {
+                resource.MetricsLock.ExitReadLock();
+            }
         }
 
+        return resources.Count > 1 ? summaries.DistinctBy(summary => summary.GetKey()).ToList() : summaries;
     }
 
-    public OtlpInstrumentData? GetInstrument(GetInstrumentRequest request)
+    public OtlpInstrumentSummary? GetInstrumentSummary(ResourceKey resourceKey, string meterName, string instrumentName)
     {
-        var resources = GetResources(request.ResourceKey);
+        var instrumentKey = new OtlpInstrumentKey(meterName, instrumentName);
+        foreach (var resource in GetResourceEntries(resourceKey))
+        {
+            resource.MetricsLock.EnterReadLock();
+            try
+            {
+                if (resource.Instruments.TryGetValue(instrumentKey, out var instrument))
+                {
+                    return instrument.Summary;
+                }
+            }
+            finally
+            {
+                resource.MetricsLock.ExitReadLock();
+            }
+        }
+
+        return null;
+    }
+
+    public async Task<OtlpInstrumentData?> GetInstrumentAsync(GetInstrumentRequest request, CancellationToken cancellationToken)
+    {
+        await ReadGateAsync(nameof(GetInstrumentAsync)).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        return GetInstrument(request);
+    }
+
+    private OtlpInstrumentData? GetInstrument(GetInstrumentRequest request)
+    {
+        var resources = GetResourceEntries(request.ResourceKey);
+        var instrumentKey = new OtlpInstrumentKey(request.MeterName, request.InstrumentName);
         var instruments = resources
-            .Select(a => a.GetInstrument(request.MeterName, request.InstrumentName, request.StartTime, request.EndTime))
-            .OfType<OtlpInstrument>()
+            .Select(resource => CloneInstrument(resource, instrumentKey, request.StartTime, request.EndTime))
+            .OfType<InMemoryInstrument>()
             .ToList();
 
         if (instruments.Count == 0)
         {
             return null;
         }
-        else if (instruments.Count == 1)
+
+        var allKnownAttributes = new Dictionary<string, List<string?>>();
+        var matchingDimensions = new List<DimensionScope>();
+        var hasOverflow = false;
+        foreach (var instrument in instruments)
         {
-            var instrument = instruments[0];
-            return new OtlpInstrumentData
+            foreach (var knownAttributeValues in instrument.KnownAttributeValues)
             {
-                Summary = instrument.Summary,
-                KnownAttributeValues = instrument.KnownAttributeValues,
-                Dimensions = instrument.Dimensions.Values.ToList(),
-                HasOverflow = instrument.HasOverflow
-            };
-        }
-        else
-        {
-            var allDimensions = new List<DimensionScope>();
-            var allKnownAttributes = new Dictionary<string, List<string?>>();
-            var hasOverflow = false;
-
-            foreach (var instrument in instruments)
-            {
-                allDimensions.AddRange(instrument.Dimensions.Values);
-
-                foreach (var knownAttributeValues in instrument.KnownAttributeValues)
-                {
-                    ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(allKnownAttributes, knownAttributeValues.Key, out _);
-                    // Adds to dictionary if not present.
-                    if (values != null)
-                    {
-                        values = values.Union(knownAttributeValues.Value).ToList();
-                    }
-                    else
-                    {
-                        values = knownAttributeValues.Value.ToList();
-                    }
-                }
-
-                hasOverflow = hasOverflow || instrument.HasOverflow;
+                ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(allKnownAttributes, knownAttributeValues.Key, out _);
+                values = values is not null
+                    ? values.Union(knownAttributeValues.Value).ToList()
+                    : knownAttributeValues.Value.ToList();
             }
 
-            return new OtlpInstrumentData
-            {
-                Summary = instruments[0].Summary,
-                Dimensions = allDimensions,
-                KnownAttributeValues = allKnownAttributes,
-                HasOverflow = hasOverflow
-            };
+            matchingDimensions.AddRange(instrument.Dimensions.Values.Where(dimension => MatchesDimensionFilters(dimension.Attributes, request.DimensionFilters)));
+            hasOverflow = hasOverflow || instrument.HasOverflow;
         }
+
+        return new OtlpInstrumentData
+        {
+            Summary = instruments[0].Summary,
+            Dimensions = matchingDimensions,
+            KnownAttributeValues = allKnownAttributes,
+            HasOverflow = hasOverflow
+        };
+    }
+
+    private static InMemoryInstrument? CloneInstrument(ResourceEntry resource, OtlpInstrumentKey key, DateTime? valuesStart, DateTime? valuesEnd)
+    {
+        resource.MetricsLock.EnterReadLock();
+        try
+        {
+            return resource.Instruments.TryGetValue(key, out var instrument)
+                ? InMemoryInstrument.Clone(instrument, valuesStart, valuesEnd)
+                : null;
+        }
+        finally
+        {
+            resource.MetricsLock.ExitReadLock();
+        }
+    }
+
+    private static bool MatchesDimensionFilters(
+        KeyValuePair<string, string>[] attributes,
+        IReadOnlyDictionary<string, IReadOnlyList<string?>> dimensionFilters)
+    {
+        foreach (var (key, values) in dimensionFilters)
+        {
+            if (!values.Contains(OtlpHelpers.GetValue(attributes, key)))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public DateTime? GetInstrumentLatestEndTime(ResourceKey resourceKey, string meterName, string instrumentName)
+    {
+        var instrument = GetInstrument(new GetInstrumentRequest
+        {
+            ResourceKey = resourceKey,
+            MeterName = meterName,
+            InstrumentName = instrumentName,
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        });
+
+        return instrument?.Dimensions
+            .SelectMany(dimension => dimension.Values)
+            .Select(value => (DateTime?)value.End)
+            .Max();
     }
 
     private Task OnPeerChanged()
@@ -2192,5 +2647,143 @@ public sealed partial class TelemetryRepository : IDisposable
         }
 
         DisposeWatchers();
+    }
+
+    [DebuggerDisplay("Name = {Summary.Name}, Unit = {Summary.Unit}, Type = {Summary.Type}")]
+    private sealed class InMemoryInstrument
+    {
+        public required OtlpInstrumentSummary Summary { get; init; }
+        public required OtlpContext Context { get; init; }
+
+        public Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> Dimensions { get; } = new(ScopeAttributesComparer.Instance);
+        private KnownAttributeValuesState IncomingKnownAttributeValues { get; } = new();
+        public Dictionary<string, List<string?>> KnownAttributeValues { get; } = [];
+        public bool HasOverflow { get; set; }
+
+        public DimensionScope FindScope(RepeatedField<KeyValue> attributes)
+        {
+            // See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute
+            // Inspect attributes before they're merged with parent attributes. "otel.metric.overflow" should be the only attribute.
+            if (!HasOverflow && attributes.Count == 1 && attributes[0].Key == "otel.metric.overflow" && attributes[0].Value.GetString() == "true")
+            {
+                HasOverflow = true;
+            }
+
+            var pointAttributes = attributes.ToKeyValuePairs(Context);
+            Array.Sort(pointAttributes, KeyValuePairComparer.Instance);
+            KeyValuePair<string, string>[] mergedAttributes = [.. pointAttributes, .. Summary.Parent.Attributes];
+            var comparableAttributes = mergedAttributes.AsMemory();
+
+            // Can't use CollectionsMarshal.GetValueRefOrAddDefault here because comparableAttributes is a view over mutable data.
+            // Need to add dimensions using durable attributes instance after scope is created.
+            if (!Dimensions.TryGetValue(comparableAttributes, out var dimension))
+            {
+                IncomingKnownAttributeValues.ValidateDimension(pointAttributes);
+                if (Dimensions.Count >= TelemetryRepositoryLimits.MaxDimensionCount)
+                {
+                    throw new InvalidOperationException($"Dimension limit of {TelemetryRepositoryLimits.MaxDimensionCount} reached for instrument '{Summary.Name}'.");
+                }
+
+                IncomingKnownAttributeValues.AddDimension(pointAttributes);
+                dimension = CreateDimensionScope(comparableAttributes);
+                Dimensions.Add(dimension.Attributes, dimension);
+            }
+            return dimension;
+        }
+
+        private DimensionScope CreateDimensionScope(Memory<KeyValuePair<string, string>> comparableAttributes)
+        {
+            var isFirst = Dimensions.Count == 0;
+            var durableAttributes = comparableAttributes.ToArray();
+            var dimension = new DimensionScope(Context.Options.MaxMetricsCount, durableAttributes);
+
+            // Point and scope attributes were already accepted during ingestion, so intentionally do not limit their
+            // merged key or per-key value counts while building display metadata.
+            var keys = KnownAttributeValues.Keys.Union(durableAttributes.Select(attribute => attribute.Key)).Distinct();
+            foreach (var key in keys)
+            {
+                if (!KnownAttributeValues.TryGetValue(key, out var values))
+                {
+                    values = [];
+                    KnownAttributeValues.Add(key, values);
+
+                    // If the key is new and there are already dimensions, add an empty value because there are dimensions without this key.
+                    if (!isFirst)
+                    {
+                        TryAddValue(values, null);
+                    }
+                }
+
+                var currentDimensionValue = OtlpHelpers.GetValue(durableAttributes, key);
+                TryAddValue(values, currentDimensionValue);
+            }
+
+            return dimension;
+
+            static void TryAddValue(List<string?> values, string? value)
+            {
+                if (!values.Contains(value))
+                {
+                    values.Add(value);
+                }
+            }
+        }
+
+        public static InMemoryInstrument Clone(InMemoryInstrument instrument, DateTime? valuesStart, DateTime? valuesEnd)
+        {
+            var newInstrument = new InMemoryInstrument
+            {
+                Summary = instrument.Summary,
+                Context = instrument.Context,
+                HasOverflow = instrument.HasOverflow
+            };
+
+            foreach (var item in instrument.KnownAttributeValues)
+            {
+                newInstrument.KnownAttributeValues.Add(item.Key, item.Value.ToList());
+            }
+            foreach (var item in instrument.Dimensions)
+            {
+                newInstrument.Dimensions.Add(item.Key, DimensionScope.Clone(item.Value, valuesStart, valuesEnd));
+            }
+
+            return newInstrument;
+        }
+
+        private sealed class ScopeAttributesComparer : IEqualityComparer<ReadOnlyMemory<KeyValuePair<string, string>>>
+        {
+            public static readonly ScopeAttributesComparer Instance = new();
+
+            public bool Equals(ReadOnlyMemory<KeyValuePair<string, string>> x, ReadOnlyMemory<KeyValuePair<string, string>> y) =>
+                x.Span.SequenceEqual(y.Span);
+
+            public int GetHashCode([DisallowNull] ReadOnlyMemory<KeyValuePair<string, string>> obj)
+            {
+                var hashcode = new HashCode();
+                foreach (var pair in obj.Span)
+                {
+                    hashcode.Add(pair.Key);
+                    hashcode.Add(pair.Value);
+                }
+                return hashcode.ToHashCode();
+            }
+        }
+
+        private sealed class KeyValuePairComparer : IComparer<KeyValuePair<string, string>>
+        {
+            public static readonly KeyValuePairComparer Instance = new();
+
+            public int Compare(KeyValuePair<string, string> x, KeyValuePair<string, string> y) =>
+                string.Compare(x.Key, y.Key, StringComparison.Ordinal);
+        }
+    }
+
+    private sealed record ResourceEntry(OtlpResource Resource)
+    {
+        public ReaderWriterLockSlim MetricsLock { get; } = new();
+        // Bounded by TelemetryRepositoryLimits.MaxScopeCount. Cleared when metrics are cleared.
+        public Dictionary<string, OtlpScope> Meters { get; } = [];
+        // Bounded by TelemetryRepositoryLimits.MaxInstrumentCount. Cleared when metrics are cleared.
+        public Dictionary<OtlpInstrumentKey, InMemoryInstrument> Instruments { get; } = [];
     }
 }

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -6,13 +6,20 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Aspire.Dashboard.Configuration;
+#if !ASPIRE_DASHBOARD_COMPONENT_TESTS
 using Aspire.Dashboard.Model;
+#endif
+using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
+#if !ASPIRE_DASHBOARD_COMPONENT_TESTS
 using Aspire.Dashboard.Otlp.Storage;
+#endif
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+#if !ASPIRE_DASHBOARD_COMPONENT_TESTS
 using Microsoft.Extensions.Options;
+#endif
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
@@ -24,6 +31,8 @@ namespace Aspire.Tests.Shared.Telemetry;
 
 internal static class TelemetryTestHelpers
 {
+    private static long s_nextLogEntryId;
+
     public static void AssertId(string expected, string actual)
     {
         var resolvedActual = GetStringId(actual);
@@ -209,6 +218,11 @@ internal static class TelemetryTestHelpers
         return logRecord;
     }
 
+    public static OtlpLogEntry CreateOtlpLogEntry(LogRecord record, OtlpResourceView resourceView, OtlpScope scope, OtlpContext context)
+    {
+        return new OtlpLogEntryData(record, resourceView, scope, context).CreateLogEntry(Interlocked.Increment(ref s_nextLogEntryId));
+    }
+
     public static Resource CreateResource(string? name = null, string? instanceId = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
         var resource = new Resource()
@@ -231,7 +245,8 @@ internal static class TelemetryTestHelpers
         return resource;
     }
 
-    public static TelemetryRepository CreateRepository(
+#if !ASPIRE_DASHBOARD_COMPONENT_TESTS
+    public static InMemoryTelemetryRepository CreateRepository(
         int? maxMetricsCount = null,
         int? maxAttributeCount = null,
         int? maxAttributeLength = null,
@@ -274,7 +289,7 @@ internal static class TelemetryTestHelpers
             options.MaxResourceCount = maxResourceCount.Value;
         }
 
-        var repository = new TelemetryRepository(
+        var repository = new InMemoryTelemetryRepository(
             loggerFactory ?? NullLoggerFactory.Instance,
             Options.Create(new DashboardOptions { TelemetryLimits = options }),
             pauseManager ?? new PauseManager(),
@@ -285,6 +300,7 @@ internal static class TelemetryTestHelpers
         }
         return repository;
     }
+#endif
 
     public static ulong DateTimeToUnixNanoseconds(DateTime dateTime)
     {

--- a/tests/Shared/TestDashboardClient.cs
+++ b/tests/Shared/TestDashboardClient.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
@@ -22,10 +23,12 @@ public class TestDashboardClient : IDashboardClient
     private readonly IList<ResourceViewModel>? _initialResources;
 
     public bool IsEnabled { get; }
+    public bool IsReadOnly { get; }
     public Task WhenConnected { get; }
     public string ApplicationName { get; } = "TestApp";
     public string? MinRequiredVersion => null;
     public DashboardConnectionState ConnectionState => DashboardConnectionState.Connected;
+    public ConcurrentQueue<(IReadOnlyList<string> ResourceNames, DateTime ClearDate)> ClearedConsoleLogs { get; } = new();
 #pragma warning disable CS0067 // Event is never used - required by interface
     public event Action<DashboardConnectionState>? ConnectionStateChanged;
 #pragma warning restore CS0067
@@ -41,9 +44,11 @@ public class TestDashboardClient : IDashboardClient
         Func<string, string, CommandViewModel, ExecuteResourceCommandOptions, CancellationToken, Task<ResourceCommandResponseViewModel>>? executeResourceCommand = null,
         Channel<WatchInteractionsRequestUpdate>? sendInteractionUpdateChannel = null,
         IList<ResourceViewModel>? initialResources = null,
-        Task? whenConnected = null)
+        Task? whenConnected = null,
+        bool isReadOnly = false)
     {
         IsEnabled = isEnabled ?? false;
+        IsReadOnly = isReadOnly;
         ApplicationName = applicationName ?? "TestApp";
         WhenConnected = whenConnected ?? Task.CompletedTask;
         _consoleLogsChannelProvider = consoleLogsChannelProvider;
@@ -108,6 +113,12 @@ public class TestDashboardClient : IDashboardClient
         {
             yield return item;
         }
+    }
+
+    public Task ClearConsoleLogsAsync(IReadOnlyList<string> resourceNames, DateTime clearDate)
+    {
+        ClearedConsoleLogs.Enqueue((resourceNames, clearDate));
+        return Task.CompletedTask;
     }
 
     public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken)

--- a/tests/Shared/TestSessionStorage.cs
+++ b/tests/Shared/TestSessionStorage.cs
@@ -8,17 +8,24 @@ namespace Aspire.Dashboard.Tests.Shared;
 public sealed class TestSessionStorage : ISessionStorage
 {
     public Func<string, (bool Success, object? Value)>? OnGetAsync { get; set; }
+    public Func<string, Task<(bool Success, object? Value)>>? OnGetTaskAsync { get; set; }
     public Action<string, object?>? OnSetAsync { get; set; }
 
-    public Task<StorageResult<T>> GetAsync<T>(string key)
+    public async Task<StorageResult<T>> GetAsync<T>(string key)
     {
+        if (OnGetTaskAsync is { } asyncCallback)
+        {
+            var (success, value) = await asyncCallback(key).ConfigureAwait(false);
+            return new StorageResult<T>(success: success, value: (T)(value ?? default(T))!);
+        }
+
         if (OnGetAsync is { } callback)
         {
             var (success, value) = callback(key);
-            return Task.FromResult(new StorageResult<T>(success: success, value: (T)(value ?? default(T))!));
+            return new StorageResult<T>(success: success, value: (T)(value ?? default(T))!);
         }
 
-        return Task.FromResult<StorageResult<T>>(new StorageResult<T>(success: false, value: default));
+        return new StorageResult<T>(success: false, value: default);
     }
 
     public Task SetAsync<T>(string key, T value)


### PR DESCRIPTION
**Specification:** [Dashboard persistence](https://github.com/microsoft/aspire/blob/7ba4d2e87c27d3b07564810b6e18d87d3af1a9c3/docs/specs/dashboard-persistence.md)

Fixes https://github.com/microsoft/aspire/issues/4256

## Description

Dashboard resources and telemetry previously existed only for the lifetime of the Dashboard process. This change adds SQLite-backed persistence so users can inspect completed application runs, compare telemetry before and after code changes, or keep a standalone Dashboard's data across restarts.

### Highlights

- Adds versioned, normalized SQLite storage for resource snapshots, console logs, structured logs, traces, spans, events, links, metrics, dimensions, histogram data, and exemplars. Telemetry is stored relationally rather than as opaque OTLP payloads.
- Adds three persistence modes:
  - `None` creates a temporary database for one Dashboard process and remains the standalone Dashboard default.
  - `Run` creates a persistent database for each Dashboard process, retains up to ten runs per application, and is the AppHost Dashboard default.
  - `Resume` reuses one persistent database across Dashboard restarts without exposing run selection.
- Adds a run selector to the Dashboard header. Users can switch between `Live run` and completed runs without reloading the browser. Historical runs are opened read-only, mutation controls are disabled, and metric views use the latest stored timestamp as their fixed end time.
- Adds run metadata, exclusive ownership locks, schema compatibility checks, abandoned-run handling, and lock-aware pruning. Historical databases are pooled and shared across Dashboard circuits while selected.
- Moves filtering, searching, paging, aggregation, field-value lookup, and retention into SQLite. Batched writes, transactions, connection pooling, normalized identities, targeted caches, trace summaries, and metric rollups support high-volume ingestion and bounded UI queries.
- Passes the normalized application name, data directory, and persistence mode from AppHost, and adds `--application-name` and `--persistence` to `aspire dashboard run`.
- Uses `Microsoft.Data.Sqlite` with the transitive `SQLitePCLRaw.bundle_e_sqlite3` and `SQLitePCLRaw.lib.e_sqlite3` native packages, including the required native assets in the managed Dashboard bundle.
- Exercises the SQLite repositories through shared resource and telemetry repository tests, with additional coverage for run lifecycle, retention, schema compatibility, read-only history, run selection, and persistence configuration.

### Persistence scenarios

#### Temporary standalone Dashboard

Run the standalone Dashboard without persistence configuration:

```bash
aspire dashboard run
```

The default `None` mode is useful for a single development or diagnostic session. Its temporary database is deleted when the Dashboard stops.

#### Compare AppHost runs

Start an AppHost normally. Its Dashboard defaults to `Run`, so each AppHost start creates a separate run database. After changing application code and restarting the AppHost, use the header selector to compare resources and telemetry from `Live run` with completed runs.

#### Resume a standalone Dashboard

Give a standalone Dashboard a stable application name and select `Resume`:

```bash
aspire dashboard run --application-name my-app --persistence Resume
```

The Dashboard reopens the same database after restart. Container deployments must mount `ASPIRE_DASHBOARD_DATA_DIRECTORY` from persistent storage and reuse the same application name, directory, and persistence mode.

### Screenshots / Recordings

<img width="932" height="1114" alt="persistence-run-ui" src="https://github.com/user-attachments/assets/6a3772bf-741c-4e71-87ce-3255aea06bf0"/>

### Security considerations

Persisted Dashboard data can contain sensitive application-supplied values. Resource properties marked sensitive are stored without redaction or encryption, although their sensitivity marker is retained and current and historical values remain masked in the UI.

The database has no independent authorization or encryption layer. For `Run` and `Resume` persistence, the Dashboard creates the application-specific directory with owner-only permissions on Unix (0700). If that directory already exists, the Dashboard changes its mode to 0700, which may modify permissions on a configured directory. On Windows, the Dashboard does not set or validate specific ACLs. Operators must still ensure that the configured data root (`ASPIRE_HOME` or `Dashboard:Data:Directory`), backups, and copies have restrictive filesystem access controls that prevent unauthorized users from reading or modifying persisted data.

This change does not add a network endpoint. Network ingestion, endpoint authentication and authorization, transport security, and data-read APIs are existing Dashboard concerns and are documented separately.

### Validation

- `dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --configuration Release --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build src/Aspire.Dashboard/Aspire.Dashboard.csproj --no-restore`

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<summary>` and `<remarks>` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No