### PR TITLE
Add pinning to Dashboard run history

### DIFF
--- a/docs/specs/dashboard-persistence.md
+++ b/docs/specs/dashboard-persistence.md
@@ -160,9 +160,9 @@ Historical discovery only includes directories that:
 - have readable, valid `run.json` metadata; and
 - have the current metadata schema version.
 
-The current run is listed first. Historical runs are ordered by descending start time.
+Run discovery orders pinned runs before unpinned runs, then orders each group by descending start time. The run selector applies its presentation order separately: the current run is first, followed by pinned historical runs and then unpinned historical runs, with each historical group ordered by descending start time. Pin state is stored in `run.json`; both current and historical runs can be pinned or unpinned.
 
-`Run` mode retains at most ten runs per application: the current run and the nine newest historical run directories. Pruning happens after a new run writes its metadata. A run is deleted only after the pruner acquires its lock, so a historical run selected by another Dashboard circuit or a run owned by another Dashboard process is skipped. I/O and access failures are logged and do not prevent Dashboard startup.
+`Run` mode retains the five newest unpinned historical run directories. The current run and pinned historical runs do not count toward this limit, so the total number of retained runs is not fixed. Pruning happens after a new run writes its metadata. Before deleting a candidate, the pruner acquires its lock and rechecks its pin state. A historical run selected by another Dashboard circuit or a run owned by another Dashboard process is skipped, which can temporarily leave more than five unpinned historical runs. I/O and access failures are logged and do not prevent Dashboard startup.
 
 ## Database lifecycle
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -37,6 +37,19 @@
                 {
                     <FluentIcon Value="@item.Icon" Style="vertical-align: text-bottom;" Width="16px" Slot="@GetIconSlot(item.Role)" />
                 }
+                @if (item.SecondaryActionIcon is not null)
+                {
+                    <span slot="end" @onclick:stopPropagation="true" @onkeydown:stopPropagation="true">
+                        <FluentButton Class="@($"aspire-menu-secondary-action{(item.IsSecondaryActionSelected ? " selected" : null)}")"
+                                      Appearance="Appearance.Stealth"
+                                      Title="@item.SecondaryActionAriaLabel"
+                                      AriaLabel="@item.SecondaryActionAriaLabel"
+                                      aria-pressed="@(item.IsSecondaryActionSelected ? "true" : "false")"
+                                      @onclick="() => HandleSecondaryActionClicked(item)">
+                            <FluentIcon Value="@item.SecondaryActionIcon" Width="16px" />
+                        </FluentButton>
+                    </span>
+                }
             </FluentMenuItem>;
         }
     }

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -36,6 +36,12 @@ public partial class AspireMenu : FluentComponentBase
     [Parameter]
     public EventCallback OnRenderComplete { get; set; }
 
+    /// <summary>
+    /// Raised after a menu item's secondary action completes so the owner can regenerate the menu items.
+    /// </summary>
+    [Parameter]
+    public EventCallback OnSecondaryActionComplete { get; set; }
+
     [Parameter]
     public required IReadOnlyList<MenuButtonItem> Items { get; set; }
 
@@ -154,6 +160,28 @@ public partial class AspireMenu : FluentComponentBase
         if (item.OnClick is { } onClick)
         {
             await onClick();
+        }
+    }
+
+    private async Task HandleSecondaryActionClicked(MenuButtonItem item)
+    {
+        if (item.OnSecondaryActionClick is { } onSecondaryActionClick)
+        {
+            await onSecondaryActionClick();
+        }
+
+        if (OnSecondaryActionComplete.HasDelegate)
+        {
+            await OnSecondaryActionComplete.InvokeAsync();
+        }
+        else
+        {
+            StateHasChanged();
+
+            if (_menu is { Id: not null } menu)
+            {
+                await MenuService.RefreshMenuAsync(menu.Id, isOpen: true);
+            }
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.css
@@ -1,0 +1,27 @@
+::deep .aspire-menu-secondary-action {
+    opacity: 0;
+    visibility: hidden;
+    padding-left: 8px;
+}
+
+::deep .aspire-menu-secondary-action::part(control) {
+    background-color: transparent;
+}
+
+::deep .aspire-menu-secondary-action:hover::part(control) {
+    background-color: var(--neutral-fill-secondary-hover);
+}
+
+fluent-menu-item:hover > span[slot="end"] ::deep .aspire-menu-secondary-action,
+fluent-menu-item:focus-within > span[slot="end"] ::deep .aspire-menu-secondary-action,
+::deep .aspire-menu-secondary-action.selected {
+    opacity: 1;
+    visibility: visible;
+}
+
+@media (hover: none) {
+    fluent-menu-item > span[slot="end"] ::deep .aspire-menu-secondary-action {
+        opacity: 1;
+        visibility: visible;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -36,5 +36,5 @@
 @* Render lazily because FluentMenu is expensive: building menu items and initializing its JavaScript interop add significant overhead when many menu buttons are displayed. *@
 @if (_renderMenu)
 {
-    <AspireMenu Anchor="@MenuButtonId" Open="@_visible" OpenChanged="OnMenuOpenChanged" OnRenderComplete="OnMenuRenderComplete" Items="_items" RestoreFocusOnItemClick="@RestoreFocusOnItemClick" />
+    <AspireMenu Anchor="@MenuButtonId" Open="@_visible" OpenChanged="OnMenuOpenChanged" OnRenderComplete="OnMenuRenderComplete" OnSecondaryActionComplete="RefreshItems" Items="_items" RestoreFocusOnItemClick="@RestoreFocusOnItemClick" />
 }

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -60,6 +60,9 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
     [Parameter]
     public required Func<IList<MenuButtonItem>> ItemsProvider { get; set; }
 
+    // Exposed only for tests to inspect the rendered menu items.
+    internal IReadOnlyList<MenuButtonItem> Items => _items;
+
     [Parameter]
     public Appearance? ButtonAppearance { get; set; }
 

--- a/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/DashboardRunSelect.razor.cs
@@ -14,6 +14,8 @@ namespace Aspire.Dashboard.Components.Controls;
 public partial class DashboardRunSelect : ComponentBase
 {
     private static readonly Icon s_checkmarkIcon = new Icons.Regular.Size16.Checkmark();
+    private static readonly Icon s_pinIcon = new Icons.Regular.Size16.Pin();
+    private static readonly Icon s_pinnedIcon = new Icons.Filled.Size16.Pin();
 
     private string RunSelectTitle => Loc[nameof(LayoutResources.DashboardRunSelectTitle)];
     private string RunSelectAccessibleLabel => Loc[nameof(LayoutResources.DashboardRunSelectAccessibleLabel), SelectedRunText];
@@ -42,20 +44,39 @@ public partial class DashboardRunSelect : ComponentBase
     [Inject]
     public required IDashboardRunStore RunStore { get; init; }
 
+    [Inject]
+    public required ILogger<DashboardRunSelect> Logger { get; init; }
+
     private IList<MenuButtonItem> LoadRuns()
     {
-        var runs = RunStore.GetRuns().Where(run => !run.IsPruned).ToArray();
+        var runs = RunStore.GetRuns()
+            .Where(run => !run.IsPruned)
+            .OrderByDescending(run => run.IsCurrent)
+            .ThenByDescending(run => run.IsPinned)
+            .ThenByDescending(run => run.StartedAtUtc)
+            .ToArray();
         var menuItems = new List<MenuButtonItem>();
         foreach (var run in runs)
         {
-            menuItems.Add(new MenuButtonItem
+            var menuItem = new MenuButtonItem
             {
                 Text = FormatRunOption(run),
                 Role = MenuItemRole.MenuItemRadio,
                 Checked = string.Equals(run.RunId, SelectedRunId, StringComparison.Ordinal),
                 Icon = s_checkmarkIcon,
+                SecondaryActionIcon = run.IsPinned ? s_pinnedIcon : s_pinIcon,
+                SecondaryActionAriaLabel = Loc[run.IsPinned
+                    ? nameof(LayoutResources.DashboardRunSelectUnpin)
+                    : nameof(LayoutResources.DashboardRunSelectPin)],
+                IsSecondaryActionSelected = run.IsPinned,
+                OnSecondaryActionClick = () =>
+                {
+                    SetRunPinned(run, !run.IsPinned);
+                    return Task.CompletedTask;
+                },
                 OnClick = () => SelectedRunIdChanged.InvokeAsync(run.IsCurrent ? null : run.RunId)
-            });
+            };
+            menuItems.Add(menuItem);
 
             if (run.IsCurrent && runs.Any(candidate => !candidate.IsCurrent))
             {
@@ -64,6 +85,18 @@ public partial class DashboardRunSelect : ComponentBase
         }
 
         return menuItems;
+    }
+
+    private void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
+    {
+        try
+        {
+            RunStore.SetRunPinned(run, isPinned);
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError(exception, "Failed to update the pinned state of dashboard run '{RunId}'.", run.RunId);
+        }
     }
 
     private string FormatRunOption(DashboardRunDescriptor run)

--- a/src/Aspire.Dashboard/Model/MenuButtonItem.cs
+++ b/src/Aspire.Dashboard/Model/MenuButtonItem.cs
@@ -12,6 +12,10 @@ public class MenuButtonItem
     public string? Text { get; set; }
     public string? Tooltip { get; set; }
     public Icon? Icon { get; set; }
+    public Icon? SecondaryActionIcon { get; set; }
+    public string? SecondaryActionAriaLabel { get; set; }
+    public Func<Task>? OnSecondaryActionClick { get; set; }
+    public bool IsSecondaryActionSelected { get; set; }
     /// <summary>
     /// Optional ARIA role for the item. Set to <see cref="MenuItemRole.MenuItemCheckbox"/> or
     /// <see cref="MenuItemRole.MenuItemRadio"/> to expose an accessible checked state (via

--- a/src/Aspire.Dashboard/Resources/Layout.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Layout.Designer.cs
@@ -88,6 +88,24 @@ namespace Aspire.Dashboard.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Pin run.
+        /// </summary>
+        public static string DashboardRunSelectPin {
+            get {
+                return ResourceManager.GetString("DashboardRunSelectPin", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Unpin run.
+        /// </summary>
+        public static string DashboardRunSelectUnpin {
+            get {
+                return ResourceManager.GetString("DashboardRunSelectUnpin", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Aspire.
         /// </summary>
         public static string MainLayoutAspire {

--- a/src/Aspire.Dashboard/Resources/Layout.resx
+++ b/src/Aspire.Dashboard/Resources/Layout.resx
@@ -195,4 +195,10 @@
   <data name="DashboardRunSelectCurrent" xml:space="preserve">
     <value>Live run</value>
   </data>
+  <data name="DashboardRunSelectPin" xml:space="preserve">
+    <value>Pin run</value>
+  </data>
+  <data name="DashboardRunSelectUnpin" xml:space="preserve">
+    <value>Unpin run</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
@@ -12,9 +12,19 @@
         <target state="new">Live run</target>
         <note />
       </trans-unit>
+      <trans-unit id="DashboardRunSelectPin">
+        <source>Pin run</source>
+        <target state="new">Pin run</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DashboardRunSelectTitle">
         <source>Select dashboard run</source>
         <target state="new">Select dashboard run</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DashboardRunSelectUnpin">
+        <source>Unpin run</source>
+        <target state="new">Unpin run</target>
         <note />
       </trans-unit>
       <trans-unit id="MainLayoutAspire">

--- a/src/Aspire.Dashboard/ServiceClient/DashboardDataSource.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardDataSource.cs
@@ -79,9 +79,8 @@ public sealed class DashboardDataSource : IDashboardRunSelection, IDisposable
 
     internal void SelectRun(string? runId)
     {
-        var runs = _runStore.GetRuns();
-        var currentRun = runs.Single(run => run.IsCurrent);
-        var selectedRun = runs.FirstOrDefault(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+        var currentRun = _runStore.GetCurrentRun();
+        var selectedRun = runId is not null ? _runStore.GetRunById(runId) : null;
         if (selectedRun is null)
         {
             if (!string.IsNullOrEmpty(runId))

--- a/src/Aspire.Dashboard/ServiceClient/DashboardDataSourcePool.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardDataSourcePool.cs
@@ -46,7 +46,7 @@ public sealed class DashboardDataSourcePool : IDisposable
             {
                 ObjectDisposedException.ThrowIf(_disposed, this);
 
-                var currentRun = _runStore.GetRuns().Single(run => run.IsCurrent);
+                var currentRun = _runStore.GetCurrentRun();
                 if (_current is null)
                 {
                     var database = new DashboardSqliteDatabase(currentRun.DatabasePath);

--- a/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardRunStore.cs
@@ -28,6 +28,26 @@ public interface IDashboardRunStore
     IReadOnlyList<DashboardRunDescriptor> GetRuns();
 
     /// <summary>
+    /// Gets the current dashboard run.
+    /// </summary>
+    /// <returns>The current dashboard run.</returns>
+    DashboardRunDescriptor GetCurrentRun();
+
+    /// <summary>
+    /// Gets the dashboard run with the specified ID.
+    /// </summary>
+    /// <param name="runId">The ID of the dashboard run.</param>
+    /// <returns>The dashboard run, or <see langword="null"/> when the run is not available.</returns>
+    DashboardRunDescriptor? GetRunById(string runId);
+
+    /// <summary>
+    /// Pins or unpins the specified dashboard run.
+    /// </summary>
+    /// <param name="run">The dashboard run to update.</param>
+    /// <param name="isPinned"><see langword="true"/> to pin the dashboard run; <see langword="false"/> to unpin it.</param>
+    void SetRunPinned(DashboardRunDescriptor run, bool isPinned);
+
+    /// <summary>
     /// Attempts to acquire a lease that keeps the specified dashboard run available while it is selected.
     /// </summary>
     /// <param name="run">The dashboard run to lease.</param>
@@ -50,11 +70,12 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
     private readonly string? _metadataPath;
     private readonly string? _temporaryDirectory;
     private readonly FileStream? _runLock;
-    private readonly DashboardRunMetadata _metadata;
+    private DashboardRunMetadata _metadata;
     private readonly ILogger<DashboardRunStore> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly Action<string> _deleteRunDirectory;
     private readonly Lazy<IReadOnlyList<DashboardRunDescriptor>> _runs;
+    private readonly object _runStateLock = new();
     private bool _metadataPublished;
 
     public DashboardRunStore(IOptions<DashboardOptions> options, ILogger<DashboardRunStore> logger, TimeProvider timeProvider)
@@ -205,6 +226,52 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
             : runs;
     }
 
+    public DashboardRunDescriptor GetCurrentRun() => GetRuns().Single(run => run.IsCurrent);
+
+    public DashboardRunDescriptor? GetRunById(string runId) =>
+        GetRuns().SingleOrDefault(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+
+    public void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
+    {
+        var storedRun = GetRunById(run.RunId);
+        if (storedRun is null)
+        {
+            throw new InvalidOperationException($"Dashboard run '{run.RunId}' is no longer available.");
+        }
+
+        var runDirectory = Path.GetDirectoryName(storedRun.DatabasePath)!;
+        lock (_runStateLock)
+        {
+            // The current run has the store's lifetime lock, and a selected historical run has a lease.
+            // Only an unselected historical run needs a temporary lock while its metadata is updated.
+            using var runLock = storedRun.IsCurrent || storedRun.IsLeased
+                ? null
+                : TryOpenRunLock(runDirectory)
+                    ?? throw new InvalidOperationException($"Dashboard run '{storedRun.RunId}' is no longer available.");
+            UpdatePinnedState(storedRun, runDirectory, isPinned);
+        }
+    }
+
+    private void UpdatePinnedState(DashboardRunDescriptor run, string runDirectory, bool isPinned)
+    {
+        var metadataPath = Path.Combine(runDirectory, "run.json");
+        var metadata = JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath));
+        if (metadata is not { SchemaVersion: SchemaVersion } ||
+            !string.Equals(metadata.RunId, run.RunId, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Dashboard run metadata for '{run.RunId}' is invalid.");
+        }
+
+        var updatedMetadata = metadata with { IsPinned = isPinned };
+        File.WriteAllText(metadataPath, JsonSerializer.Serialize(updatedMetadata, s_jsonOptions));
+        if (string.Equals(run.RunId, RunId, StringComparison.Ordinal))
+        {
+            _metadata = updatedMetadata;
+        }
+
+        run.IsPinned = isPinned;
+    }
+
     internal void PublishRun()
     {
         if (_metadataPath is null || _metadataPublished)
@@ -237,8 +304,24 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run)
     {
-        var runDirectory = Path.GetDirectoryName(run.DatabasePath)!;
-        return TryOpenRunLock(runDirectory);
+        var storedRun = GetRunById(run.RunId);
+        if (storedRun is null)
+        {
+            return null;
+        }
+
+        var runDirectory = Path.GetDirectoryName(storedRun.DatabasePath)!;
+        lock (_runStateLock)
+        {
+            var runLock = TryOpenRunLock(runDirectory);
+            if (runLock is null)
+            {
+                return null;
+            }
+
+            storedRun.IsLeased = true;
+            return new RunLease(this, storedRun, runLock);
+        }
     }
 
     private IReadOnlyList<DashboardRunDescriptor> LoadRuns()
@@ -265,7 +348,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
                     {
                         var run = CreateDescriptor(metadata, directory, isCurrent: false);
                         // Filter out in-progress runs that are owned by other Dashboard instances.
-                        using var runLock = TryAcquireRunLease(run);
+                        using var runLock = TryOpenRunLock(directory);
                         run.IsSelectable = runLock is not null;
                         runs.Add(run);
                     }
@@ -279,6 +362,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
         var orderedRuns = runs
             .OrderByDescending(run => run.IsCurrent)
+            .ThenByDescending(run => run.IsPinned)
             .ThenByDescending(run => run.StartedAtUtc)
             .ToArray();
         _logger.LogDebug(
@@ -339,11 +423,13 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
 
     private void PruneRuns(Action<string> deleteRunDirectory)
     {
-        foreach (var run in _runs.Value.Skip(MaxRuns))
+        foreach (var run in _runs.Value.Where(run => !run.IsPinned).Skip(MaxRuns))
         {
             var directory = Path.GetDirectoryName(run.DatabasePath)!;
             using var runLock = TryOpenRunLock(directory);
-            if (runLock is null)
+            // Pinning can happen after the candidate list is created. Recheck while holding the same lock used by
+            // SetRunPinned so a successful pin always completes before pruning decides whether to delete the run.
+            if (runLock is null || IsPinnedRunDirectory(directory))
             {
                 continue;
             }
@@ -360,6 +446,21 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
                     "Failed to delete expired dashboard run directory '{RunDirectory}'. The directory may still be in use by another dashboard process.",
                     directory);
             }
+        }
+    }
+
+    private static bool IsPinnedRunDirectory(string runDirectory)
+    {
+        try
+        {
+            var metadataPath = Path.Combine(runDirectory, "run.json");
+            return JsonSerializer.Deserialize<DashboardRunMetadata>(File.ReadAllText(metadataPath))?.IsPinned == true;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            // Run metadata is written locally by DashboardRunStore and is assumed to be reliable during normal usage.
+            // Treat unreadable metadata as unpinned so incomplete or abandoned run directories can still be pruned.
+            return false;
         }
     }
 
@@ -422,7 +523,10 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
             metadata.CleanShutdown,
             metadata.ApplicationName,
             Path.Combine(runDirectory, metadata.DatabaseFileName),
-            isCurrent);
+            isCurrent)
+        {
+            IsPinned = metadata.IsPinned
+        };
     }
 
     internal static string GetApplicationDirectory(string? dataRoot, string applicationName)
@@ -474,6 +578,32 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
         return $"{prefix}-{hash}";
     }
 
+    private sealed class RunLease(DashboardRunStore owner, DashboardRunDescriptor run, FileStream runLock) : IDisposable
+    {
+        private FileStream? _runLock = runLock;
+
+        public void Dispose()
+        {
+            lock (owner._runStateLock)
+            {
+                var runLock = Interlocked.Exchange(ref _runLock, null);
+                if (runLock is not null)
+                {
+                    try
+                    {
+                        runLock.Dispose();
+                    }
+                    finally
+                    {
+                        run.IsLeased = false;
+                    }
+                }
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+
     private sealed record DashboardRunMetadata
     {
         public required int SchemaVersion { get; init; }
@@ -483,6 +613,7 @@ internal sealed class DashboardRunStore : IDashboardRunStore, IDisposable
         public bool CleanShutdown { get; init; }
         public string? ApplicationName { get; init; }
         public required string DatabaseFileName { get; init; }
+        public bool IsPinned { get; init; }
     }
 }
 
@@ -513,4 +644,11 @@ public sealed record DashboardRunDescriptor(
     public bool IsPruned { get; set; }
 
     internal bool IsSelectable { get; set; } = true;
+
+    /// <summary>
+    /// Gets a value indicating whether the dashboard run is pinned.
+    /// </summary>
+    public bool IsPinned { get; internal set; }
+
+    internal bool IsLeased { get; set; }
 }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -2022,6 +2022,10 @@ fluent-tooltip[anchor="dialog_close"] > div {
     text-overflow: ellipsis;
 }
 
+.aspire-menu-container fluent-menu-item.indent-1[role="menuitemradio"]:has(> span[slot="end"]) {
+    grid-template-columns: minmax(32px, auto) auto 1fr minmax(32px, auto);
+}
+
 .aspire-menu-container.mobile-nav-menu fluent-menu-item {
     scroll-margin-block: var(--mobile-nav-menu-focus-padding);
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
@@ -5,13 +5,65 @@ using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
+using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components.Tests.Controls;
 
 public class AspireMenuTests : DashboardTestContext
 {
+    [Fact]
+    public async Task ClickSecondaryAction_RefreshesOpenMenu()
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+
+        var item = new MenuButtonItem
+        {
+            Text = "Historical run",
+            SecondaryActionIcon = new Icons.Regular.Size16.Pin(),
+            SecondaryActionAriaLabel = "Pin run"
+        };
+        item.OnSecondaryActionClick = () =>
+        {
+            item.SecondaryActionIcon = new Icons.Filled.Size16.Pin();
+            item.SecondaryActionAriaLabel = "Unpin run";
+            item.IsSecondaryActionSelected = true;
+            return Task.CompletedTask;
+        };
+
+        var menuService = Services.GetRequiredService<IMenuService>();
+        var provider = RenderComponent<FluentMenuProvider>();
+        var menuHost = RenderComponent<CascadingValue<bool>>(builder =>
+        {
+            builder.Add(p => p.Value, false);
+            builder.AddChildContent<AspireMenu>(menuBuilder =>
+            {
+                menuBuilder.Add(p => p.Anchor, "menu-anchor");
+                menuBuilder.Add(p => p.Open, true);
+                menuBuilder.Add(p => p.Items, new[] { item });
+            });
+        });
+        var menu = menuHost.FindComponent<FluentMenu>().Instance;
+        await menuHost.InvokeAsync(() => menuService.RefreshMenuAsync(menu.Id!, isOpen: true));
+
+        var pinButton = provider.WaitForElement("fluent-button[aria-label='Pin run']");
+        Assert.Equal("false", pinButton.GetAttribute("aria-pressed"));
+        pinButton.Click();
+
+        provider.WaitForAssertion(() =>
+        {
+            Assert.Single(provider.FindComponents<FluentMenu>());
+            var unpinButton = provider.Find("fluent-button[aria-label='Unpin run']");
+            Assert.Equal("true", unpinButton.GetAttribute("aria-pressed"));
+        });
+    }
+
     [Fact]
     public void UnanchoredAspireMenu_RendersFluentMenu()
     {

--- a/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Layout/MainLayoutTests.cs
@@ -459,6 +459,9 @@ public partial class MainLayoutTests : DashboardTestContext
                 Assert.Equal(MenuItemRole.MenuItemRadio, item.Role);
                 Assert.True(item.Checked);
                 Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
+                Assert.IsType<Icons.Regular.Size16.Pin>(item.SecondaryActionIcon);
+                Assert.Equal("Pin run", item.SecondaryActionAriaLabel);
+                Assert.False(item.IsSecondaryActionSelected);
             },
             item => Assert.True(item.IsDivider),
             item =>
@@ -467,6 +470,9 @@ public partial class MainLayoutTests : DashboardTestContext
                 Assert.Equal(MenuItemRole.MenuItemRadio, item.Role);
                 Assert.False(item.Checked);
                 Assert.IsType<Icons.Regular.Size16.Checkmark>(item.Icon);
+                Assert.IsType<Icons.Regular.Size16.Pin>(item.SecondaryActionIcon);
+                Assert.Equal("Pin run", item.SecondaryActionAriaLabel);
+                Assert.False(item.IsSecondaryActionSelected);
             });
 
         var menuItems = cut.WaitForElements("fluent-menu-item");
@@ -479,10 +485,35 @@ public partial class MainLayoutTests : DashboardTestContext
         Assert.True(menuItems[0].HasAttribute("checked"));
         Assert.Equal("menuitemradio", menuItems[1].GetAttribute("role"));
         Assert.False(menuItems[1].HasAttribute("checked"));
+        var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
+        var currentRun = runStore.GetRuns().Single(run => run.IsCurrent);
+        Assert.Single(menuItems[0].QuerySelectorAll("fluent-button")).Click();
+
+        Assert.True(currentRun.IsPinned);
+        Assert.Null(runSelection.SelectedRunId);
+        Assert.True(runSelect.FindComponent<AspireMenu>().Instance.Open);
+        menuButton = runSelect.FindComponent<AspireMenuButton>();
+        Assert.IsType<Icons.Filled.Size16.Pin>(menuButton.Instance.Items[0].SecondaryActionIcon);
+        Assert.True(menuButton.Instance.Items[0].IsSecondaryActionSelected);
+
+        menuItems = cut.WaitForElements("fluent-menu-item");
+        var pinButton = Assert.Single(menuItems[1].QuerySelectorAll("fluent-button"));
+        pinButton.Click();
+
+        Assert.True(historicalRun.IsPinned);
+        Assert.Null(storedRunId);
+        Assert.Null(runSelection.SelectedRunId);
+        Assert.True(runSelect.FindComponent<AspireMenu>().Instance.Open);
+        menuButton = runSelect.FindComponent<AspireMenuButton>();
+        var historicalItem = menuButton.Instance.Items[2];
+        Assert.IsType<Icons.Filled.Size16.Pin>(historicalItem.SecondaryActionIcon);
+        Assert.Equal("Unpin run", historicalItem.SecondaryActionAriaLabel);
+        Assert.True(historicalItem.IsSecondaryActionSelected);
+
+        menuItems = cut.WaitForElements("fluent-menu-item");
         menuItems[1].Click();
 
         Assert.Equal("historical", storedRunId);
-        var runSelection = Assert.IsType<FluentUISetupHelpers.TestDashboardRunSelection>(Services.GetRequiredService<IDashboardRunSelection>());
         Assert.Equal("historical", runSelection.SelectedRunId);
         Assert.False(navigationOccurred);
         Assert.Equal(2, initializedCount);
@@ -593,6 +624,122 @@ public partial class MainLayoutTests : DashboardTestContext
         Assert.Equal(LogLevel.Error, errorLog.LogLevel);
         Assert.Equal("Failed to switch to dashboard run 'historical'. Keeping dashboard run 'current' selected.", errorLog.Message);
         Assert.Same(exception, errorLog.Exception);
+    }
+
+    [Fact]
+    public void DashboardRunSelect_PinningFailure_KeepsMenuAndCircuitActive()
+    {
+        var currentRun = new DashboardRunDescriptor(
+            RunId: "current",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: DateTimeOffset.UnixEpoch,
+            EndedAtUtc: null,
+            CleanShutdown: false,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: true);
+        var historicalRun = new DashboardRunDescriptor(
+            RunId: "historical",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: DateTimeOffset.UnixEpoch,
+            EndedAtUtc: DateTimeOffset.UnixEpoch,
+            CleanShutdown: true,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: false);
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore([currentRun, historicalRun]);
+        var exception = new IOException("The run metadata could not be written.");
+        runStore.OnSetRunPinned = (run, _) =>
+        {
+            if (run.RunId == historicalRun.RunId)
+            {
+                throw exception;
+            }
+        };
+        SetupMainLayoutServices(dashboardRunStore: runStore);
+        var testSink = new TestSink();
+        Services.AddSingleton<ILogger<DashboardRunSelect>>(new TestLogger<DashboardRunSelect>(new TestLoggerFactory(testSink, enabled: true)));
+        var provider = RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<DashboardRunSelect>(builder =>
+        {
+            builder.Add(component => component.SelectedRunId, currentRun.RunId);
+            builder.Add(component => component.SelectedRunIsCurrent, true);
+            builder.Add(component => component.SelectedRunStartedAtUtc, currentRun.StartedAtUtc);
+        });
+        cut.Find("fluent-button").Click();
+
+        var historicalMenuItem = provider.WaitForElements("fluent-menu-item")[1];
+        Assert.Single(historicalMenuItem.QuerySelectorAll("fluent-button")).Click();
+
+        Assert.False(historicalRun.IsPinned);
+        Assert.True(cut.FindComponent<AspireMenu>().Instance.Open);
+        Assert.NotNull(cut.Find("fluent-button"));
+        var errorLog = Assert.Single(testSink.Writes);
+        Assert.Equal(LogLevel.Error, errorLog.LogLevel);
+        Assert.Equal("Failed to update the pinned state of dashboard run 'historical'.", errorLog.Message);
+        Assert.Same(exception, errorLog.Exception);
+    }
+
+    [Fact]
+    public void DashboardRunSelect_SortsHistoricalRunsByPinnedThenDateDescendingAndUpdatesOrderWhenPinned()
+    {
+        var currentRun = new DashboardRunDescriptor(
+            RunId: "current",
+            SchemaVersion: DashboardRunStore.SchemaVersion,
+            StartedAtUtc: DateTimeOffset.UnixEpoch,
+            EndedAtUtc: null,
+            CleanShutdown: false,
+            ApplicationName: "TestApp",
+            DatabasePath: string.Empty,
+            IsCurrent: true);
+        var historicalRuns = new[]
+        {
+            new DashboardRunDescriptor("unpinned-b", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 12, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false),
+            new DashboardRunDescriptor("pinned-b", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 11, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false),
+            new DashboardRunDescriptor("unpinned-a", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 9, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false),
+            new DashboardRunDescriptor("pinned-a", DashboardRunStore.SchemaVersion, new(2025, 1, 2, 10, 0, 0, TimeSpan.Zero), null, true, "TestApp", string.Empty, IsCurrent: false)
+        };
+        var runStore = new FluentUISetupHelpers.TestDashboardRunStore([currentRun, .. historicalRuns]);
+        runStore.SetRunPinned(historicalRuns[1], isPinned: true);
+        runStore.SetRunPinned(historicalRuns[3], isPinned: true);
+        SetupMainLayoutServices(dashboardRunStore: runStore);
+        var browserTimeProvider = Services.GetRequiredService<BrowserTimeProvider>();
+        var expectedHistoricalTexts = historicalRuns
+            .OrderByDescending(run => run.IsPinned)
+            .ThenByDescending(run => run.StartedAtUtc)
+            .Select(run => FormatHelpers.FormatTimeWithOptionalDate(browserTimeProvider, run.StartedAtUtc.UtcDateTime))
+            .ToArray();
+        var provider = RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<DashboardRunSelect>(builder =>
+        {
+            builder.Add(component => component.SelectedRunId, currentRun.RunId);
+            builder.Add(component => component.SelectedRunIsCurrent, true);
+            builder.Add(component => component.SelectedRunStartedAtUtc, currentRun.StartedAtUtc);
+        });
+
+        cut.Find("fluent-button").Click();
+
+        var items = cut.FindComponent<AspireMenuButton>().Instance.Items;
+        Assert.Equal("Live run", items[0].Text);
+        Assert.IsType<Icons.Regular.Size16.Pin>(items[0].SecondaryActionIcon);
+        Assert.False(items[0].IsSecondaryActionSelected);
+        Assert.True(items[1].IsDivider);
+        Assert.Equal(expectedHistoricalTexts, items.Skip(2).Select(item => item.Text));
+        Assert.All(items.Skip(2).Take(2), item => Assert.True(item.IsSecondaryActionSelected));
+        Assert.All(items.Skip(4), item => Assert.False(item.IsSecondaryActionSelected));
+
+        var menuItems = provider.WaitForElements("fluent-menu-item");
+        Assert.Single(menuItems[3].QuerySelectorAll("fluent-button")).Click();
+
+        expectedHistoricalTexts = historicalRuns
+            .OrderByDescending(run => run.IsPinned)
+            .ThenByDescending(run => run.StartedAtUtc)
+            .Select(run => FormatHelpers.FormatTimeWithOptionalDate(browserTimeProvider, run.StartedAtUtc.UtcDateTime))
+            .ToArray();
+        items = cut.FindComponent<AspireMenuButton>().Instance.Items;
+        Assert.Equal(expectedHistoricalTexts, items.Skip(2).Select(item => item.Text));
+        Assert.All(items.Skip(2).Take(3), item => Assert.True(item.IsSecondaryActionSelected));
+        Assert.False(items[5].IsSecondaryActionSelected);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
@@ -248,11 +248,11 @@ internal static class FluentUISetupHelpers
     }
 
     internal sealed class TestDashboardRunStore(
-        IReadOnlyList<DashboardRunDescriptor>? runs = null,
+        IEnumerable<DashboardRunDescriptor>? runs = null,
         bool supportsRunSelection = true,
         string? databasePath = null) : IDashboardRunStore
     {
-        private readonly IReadOnlyList<DashboardRunDescriptor> _runs = runs ??
+        private readonly IReadOnlyList<DashboardRunDescriptor> _runs = (runs ??
             [
                 new(
                 RunId: "current",
@@ -263,9 +263,11 @@ internal static class FluentUISetupHelpers
                 ApplicationName: "TestApp",
                 DatabasePath: databasePath ?? string.Empty,
                 IsCurrent: true)
-            ];
+            ]).ToArray();
 
         public int GetRunsCallCount { get; private set; }
+
+        public Action<DashboardRunDescriptor, bool>? OnSetRunPinned { get; set; }
 
         public IReadOnlyList<DashboardRunDescriptor> GetRuns()
         {
@@ -273,14 +275,24 @@ internal static class FluentUISetupHelpers
             return _runs;
         }
 
-        public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run) => null;
+        public DashboardRunDescriptor GetCurrentRun() => _runs.Single(run => run.IsCurrent);
 
+        public DashboardRunDescriptor? GetRunById(string runId) =>
+            _runs.SingleOrDefault(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+
+        public void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
+        {
+            OnSetRunPinned?.Invoke(run, isPinned);
+            _runs.Single(candidate => string.Equals(candidate.RunId, run.RunId, StringComparison.Ordinal)).IsPinned = isPinned;
+        }
+
+        public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run) => null;
         public bool SupportsRunSelection => supportsRunSelection;
     }
 
     internal sealed class TestDashboardRunSelection(IDashboardRunStore runStore) : IDashboardRunSelection
     {
-        public DashboardRunDescriptor SelectedRun { get; private set; } = runStore.GetRuns().Single(run => run.IsCurrent);
+        public DashboardRunDescriptor SelectedRun { get; private set; } = runStore.GetCurrentRun();
 
         public string? SelectedRunId { get; private set; }
 
@@ -289,9 +301,7 @@ internal static class FluentUISetupHelpers
         public void SelectRun(string? runId)
         {
             OnSelectRun?.Invoke(runId);
-            var runs = runStore.GetRuns();
-            SelectedRun = runs.FirstOrDefault(run => string.Equals(run.RunId, runId, StringComparison.Ordinal))
-                ?? runs.Single(run => run.IsCurrent);
+            SelectedRun = runId is not null ? runStore.GetRunById(runId) ?? runStore.GetCurrentRun() : runStore.GetCurrentRun();
             SelectedRunId = SelectedRun.IsCurrent ? null : SelectedRun.RunId;
         }
     }

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardDataSourceTests.cs
@@ -122,6 +122,34 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task CurrentRun_PinPersistsWhenRunBecomesHistorical()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2026, 7, 29, 12, 0, 0, TimeSpan.Zero);
+        string pinnedRunId;
+
+        using (var currentRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt)))
+        {
+            await InitializeAndPublishRunAsync(currentRunStore);
+            var currentRun = Assert.Single(currentRunStore.GetRuns());
+            Assert.False(currentRun.IsPinned);
+
+            currentRunStore.SetRunPinned(currentRun, isPinned: true);
+
+            Assert.True(currentRun.IsPinned);
+            using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(currentRunStore.RunDirectory, "run.json")));
+            Assert.True(metadata.RootElement.GetProperty("IsPinned").GetBoolean());
+            pinnedRunId = currentRun.RunId;
+        }
+
+        using var nextRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddMinutes(1)));
+        var historicalRun = nextRunStore.GetRuns().Single(run => string.Equals(run.RunId, pinnedRunId, StringComparison.Ordinal));
+        Assert.False(historicalRun.IsCurrent);
+        Assert.True(historicalRun.IsPinned);
+    }
+
+    [Fact]
     public async Task RunMetadata_SchemaInitializationFailure_DoesNotPublishRun()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
@@ -510,6 +538,19 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void GetCurrentRunAndGetRunById_ReturnSnapshotDescriptors()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        using var runStore = CreateRunStore(CreateOptions(workspace));
+
+        var currentRun = runStore.GetCurrentRun();
+
+        Assert.True(currentRun.IsCurrent);
+        Assert.Same(currentRun, runStore.GetRunById(currentRun.RunId));
+        Assert.Null(runStore.GetRunById("missing"));
+    }
+
+    [Fact]
     public async Task GetRuns_ExcludesRunOwnedByAnotherDashboard()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
@@ -614,6 +655,55 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task RunMode_PinnedRunsDoNotCountTowardHistoricalLimitAndReloadFromMetadata()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        var startedAt = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var pinnedRunIds = new List<string>();
+        var pinnedRunDirectories = new List<string>();
+        var runIndex = 0;
+
+        for (var index = 0; index < 3; index++)
+        {
+            string runId;
+            using (var runStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(runIndex++))))
+            {
+                runId = runStore.RunId;
+                await InitializeAndPublishRunAsync(runStore);
+            }
+
+            using var pinningRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(runIndex++)));
+            await InitializeAndPublishRunAsync(pinningRunStore);
+            var run = pinningRunStore.GetRuns().Single(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+            pinningRunStore.SetRunPinned(run, isPinned: true);
+            pinnedRunIds.Add(runId);
+            pinnedRunDirectories.Add(Path.GetDirectoryName(run.DatabasePath)!);
+
+            using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(pinnedRunDirectories[^1], "run.json")));
+            Assert.True(metadata.RootElement.GetProperty("IsPinned").GetBoolean());
+        }
+
+        for (var index = 0; index < DashboardRunStore.MaxRuns - 1; index++)
+        {
+            using var runStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(runIndex++)));
+            await InitializeAndPublishRunAsync(runStore);
+        }
+
+        using var finalRunStore = CreateRunStore(options, new FixedTimeProvider(startedAt.AddDays(runIndex)));
+        await InitializeAndPublishRunAsync(finalRunStore);
+        var runs = finalRunStore.GetRuns();
+        Assert.Equal(
+            runs.OrderByDescending(run => run.IsCurrent).ThenByDescending(run => run.IsPinned).ThenByDescending(run => run.StartedAtUtc),
+            runs);
+        Assert.Single(runs, run => run.IsCurrent);
+        Assert.Equal(3, runs.Count(run => !run.IsCurrent && run.IsPinned));
+        Assert.Equal(DashboardRunStore.MaxRuns - 1, runs.Count(run => !run.IsCurrent && !run.IsPinned));
+        Assert.All(pinnedRunIds, runId => Assert.True(finalRunStore.GetRuns().Single(run => string.Equals(run.RunId, runId, StringComparison.Ordinal)).IsPinned));
+        Assert.All(pinnedRunDirectories, directory => Assert.True(Directory.Exists(directory)));
+    }
+
+    [Fact]
     public async Task RunMode_DoesNotDeleteActiveExpiredRun()
     {
         using var workspace = TemporaryWorkspace.Create(testOutputHelper);
@@ -705,7 +795,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         }
 
         using var currentRunStore = CreateRunStore(options);
-        var historicalRun = currentRunStore.GetRuns().Single(run => run.RunId == historicalRunId);
+        var historicalRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));
         var innerRepositoryFactory = CreateRepositoryFactory(options);
         var repositoryFactory = new RecordingRepositoryFactory(innerRepositoryFactory);
         using var dataSourcePool = new DashboardDataSourcePool(currentRunStore, repositoryFactory);
@@ -715,6 +805,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         firstDataSource.SelectRun(historicalRunId);
         secondDataSource.SelectRun(historicalRunId);
 
+        Assert.True(historicalRun.IsLeased);
         var historicalDatabases = repositoryFactory.Databases.Where(database => database.IsReadOnly).ToList();
         var sharedDatabase = Assert.IsType<DashboardSqliteDatabase>(historicalDatabases[0]);
         Assert.Equal(4, historicalDatabases.Count);
@@ -724,13 +815,48 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
 
         firstDataSource.SelectRun(runId: null);
 
+        Assert.True(historicalRun.IsLeased);
         Assert.Empty(secondDataSource.TelemetryRepository.GetResources());
         Assert.Null(currentRunStore.TryAcquireRunLease(historicalRun));
 
         secondDataSource.SelectRun(runId: null);
 
-        using var releasedRunLease = currentRunStore.TryAcquireRunLease(historicalRun);
-        Assert.NotNull(releasedRunLease);
+        Assert.False(historicalRun.IsLeased);
+        using (var releasedRunLease = currentRunStore.TryAcquireRunLease(historicalRun))
+        {
+            Assert.NotNull(releasedRunLease);
+            Assert.True(historicalRun.IsLeased);
+        }
+        Assert.False(historicalRun.IsLeased);
+    }
+
+    [Fact]
+    public async Task SelectedHistoricalRun_CanBePinned()
+    {
+        using var workspace = TemporaryWorkspace.Create(testOutputHelper);
+        var options = CreateOptions(workspace);
+        string historicalRunId;
+
+        using (var historicalRunStore = CreateRunStore(options))
+        {
+            historicalRunId = historicalRunStore.RunId;
+            using var historicalTelemetryContext = await CreateTelemetryRepositoryAsync(historicalRunStore.DatabasePath, options);
+            historicalRunStore.PublishRun();
+        }
+
+        using var currentRunStore = CreateRunStore(options);
+        var historicalRun = currentRunStore.GetRuns().Single(run => string.Equals(run.RunId, historicalRunId, StringComparison.Ordinal));
+        using var dataSourcePool = new DashboardDataSourcePool(currentRunStore, CreateRepositoryFactory(options));
+        using var dataSource = CreateDataSource(currentRunStore, dataSourcePool);
+        dataSource.SelectRun(historicalRunId);
+
+        Assert.True(historicalRun.IsLeased);
+        currentRunStore.SetRunPinned(historicalRun, isPinned: true);
+
+        Assert.True(historicalRun.IsPinned);
+        Assert.True(historicalRun.IsLeased);
+        using var metadata = JsonDocument.Parse(File.ReadAllText(Path.Combine(Path.GetDirectoryName(historicalRun.DatabasePath)!, "run.json")));
+        Assert.True(metadata.RootElement.GetProperty("IsPinned").GetBoolean());
     }
 
     [Fact]
@@ -798,7 +924,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         };
         var runStore = new TestDashboardRunStore(
             [currentRun, malformedRun],
-            currentRunStore.TryAcquireRunLease);
+            TryOpenTestRunLease);
         var repositoryFactory = CreateRepositoryFactory(options);
         using var dataSourcePool = new DashboardDataSourcePool(runStore, repositoryFactory);
         using var dataSource = CreateDataSource(runStore, dataSourcePool);
@@ -808,10 +934,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         var exception = Assert.Throws<InvalidOperationException>(() => dataSource.SelectRun(malformedRunId));
         Assert.Contains("does not match run metadata schema version", exception.Message, StringComparison.Ordinal);
 
-        using (var runLease = currentRunStore.TryAcquireRunLease(malformedRun))
-        {
-            Assert.NotNull(runLease);
-        }
+        using var runLease = Assert.IsType<FileStream>(TryOpenTestRunLease(malformedRun));
 
         var malformedRunDirectory = Path.GetDirectoryName(malformedDatabasePath)!;
         Directory.Delete(malformedRunDirectory, recursive: true);
@@ -863,7 +986,7 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         };
         var runStore = new TestDashboardRunStore(
             [currentRun, historicalRun, malformedRun, unavailableRun],
-            currentRunStore.TryAcquireRunLease);
+            TryOpenTestRunLease);
         var repositoryFactory = CreateRepositoryFactory(options);
         using var dataSourcePool = new DashboardDataSourcePool(runStore, repositoryFactory);
         using var dataSource = CreateDataSource(runStore, dataSourcePool);
@@ -877,14 +1000,14 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(historicalRun, dataSource.SelectedRun);
         Assert.Same(historicalTelemetryRepository, dataSource.TelemetryRepository);
         Assert.Same(historicalResourceRepository, dataSource.ResourceRepository);
-        Assert.Null(currentRunStore.TryAcquireRunLease(historicalRun));
+        Assert.Null(TryOpenTestRunLease(historicalRun));
 
         dataSource.SelectRun(unavailableRun.RunId);
 
         Assert.Equal(historicalRun, dataSource.SelectedRun);
         Assert.Same(historicalTelemetryRepository, dataSource.TelemetryRepository);
         Assert.Same(historicalResourceRepository, dataSource.ResourceRepository);
-        Assert.Null(currentRunStore.TryAcquireRunLease(historicalRun));
+        Assert.Null(TryOpenTestRunLease(historicalRun));
     }
 
     [Fact]
@@ -1149,6 +1272,32 @@ public sealed class DashboardDataSourceTests(ITestOutputHelper testOutputHelper)
             runStore,
             logger ?? NullLogger<DashboardDataSource>.Instance,
             dataSourcePool);
+    }
+
+    private static FileStream? TryOpenTestRunLease(DashboardRunDescriptor run)
+    {
+        var runDirectory = Path.GetDirectoryName(run.DatabasePath)!;
+        try
+        {
+            var runLock = new FileStream(
+                DashboardRunStore.GetRunLockPath(runDirectory),
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                bufferSize: 1,
+                FileOptions.DeleteOnClose);
+            if (!Directory.Exists(runDirectory))
+            {
+                runLock.Dispose();
+                return null;
+            }
+
+            return runLock;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
     }
 
     private static RepositoryFactory CreateRepositoryFactory(IOptions<DashboardOptions> options)

--- a/tests/Aspire.Dashboard.Tests/Shared/TestDashboardDataSource.cs
+++ b/tests/Aspire.Dashboard.Tests/Shared/TestDashboardDataSource.cs
@@ -39,16 +39,27 @@ internal static class TestDashboardDataSource
 }
 
 internal sealed class TestDashboardRunStore(
-    IReadOnlyList<DashboardRunDescriptor>? runs = null,
+    IEnumerable<DashboardRunDescriptor>? runs = null,
     Func<DashboardRunDescriptor, IDisposable?>? tryAcquireRunLease = null,
     string? databasePath = null) : IDashboardRunStore
 {
-    private readonly IReadOnlyList<DashboardRunDescriptor> _runs = runs ??
-        [new("current", DashboardRunStore.SchemaVersion, DateTimeOffset.UnixEpoch, null, false, "TestApp", databasePath ?? string.Empty, IsCurrent: true)];
+    private readonly IReadOnlyList<DashboardRunDescriptor> _runs = (runs ??
+        [new("current", DashboardRunStore.SchemaVersion, DateTimeOffset.UnixEpoch, null, false, "TestApp", databasePath ?? string.Empty, IsCurrent: true)])
+        .ToArray();
 
     public bool SupportsRunSelection => _runs.Any(run => !run.IsCurrent);
 
     public IReadOnlyList<DashboardRunDescriptor> GetRuns() => _runs;
+
+    public DashboardRunDescriptor GetCurrentRun() => _runs.Single(run => run.IsCurrent);
+
+    public DashboardRunDescriptor? GetRunById(string runId) =>
+        _runs.SingleOrDefault(run => string.Equals(run.RunId, runId, StringComparison.Ordinal));
+
+    public void SetRunPinned(DashboardRunDescriptor run, bool isPinned)
+    {
+        _runs.Single(candidate => string.Equals(candidate.RunId, run.RunId, StringComparison.Ordinal)).IsPinned = isPinned;
+    }
 
     public IDisposable? TryAcquireRunLease(DashboardRunDescriptor run) => tryAcquireRunLease?.Invoke(run);
 }


### PR DESCRIPTION
## Description

Stacked on #18924.

Dashboard run history can grow difficult to manage when an important run would otherwise age out. This change adds pin controls to the run selector so current and historical runs can be preserved directly from the menu.

The pin action stays hidden until hover unless selected, updates without closing the menu, and persists in `run.json`. Pinned runs sort ahead of unpinned history and do not count toward the five retained historical runs.

### User-facing usage

Open the Dashboard run selector and use the pin action beside a run. Pinned runs remain available across Dashboard restarts and can be unpinned from the same menu.

### Screenshots / Recordings

<img width="728" height="473" alt="image" src="https://github.com/user-attachments/assets/b87bf444-341b-465e-bc11-c175f243cd54" />

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No