### PR TITLE
Fix waiting for custom resources

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/BeforeResourceStartedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/BeforeResourceStartedEvent.cs
@@ -21,4 +21,15 @@ public class BeforeResourceStartedEvent(IResource resource, IServiceProvider ser
 
     /// <inheritdoc />
     public IServiceProvider Services { get; } = services;
+
+    /// <summary>
+    /// The id of the specific resource instance that is being started, which is the same value as
+    /// <see cref="ResourceEvent.ResourceId"/> for that instance.
+    /// </summary>
+    /// <remarks>
+    /// <see langword="null" /> when the event covers the resource as a whole rather than one instance of it: either
+    /// because the resource has no DCP instances (it drives its own startup), or because a replicated resource is
+    /// being started as a group, in which case every replica shares this one event.
+    /// </remarks>
+    internal string? ResourceInstanceId { get; init; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -607,17 +607,17 @@ public class ResourceNotificationService : IDisposable
     /// This is an allow-list of the states that mean "has not started yet". It ensures that resources/replicas that are
     /// in running, stopping, or in one of terminal states cannot be transitioned to waiting.
     ///
-    /// <see cref="KnownResourceStates.NotStarted"/> is conditional. It must be allowed for custom resources that drive
+    /// Transition from <see cref="KnownResourceStates.NotStarted"/> is conditional. It must be allowed for custom resources that drive
     /// their own startup: they can publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so
     /// they are still in the initial state supplied by <c>WithInitialState</c> when the wait is published, rather than
     /// having been moved to "Starting" by the orchestrator first. Omitting it silently skipped the transition and, in
     /// turn, the wait itself. See https://github.com/microsoft/aspire/issues/17453.
     ///
-    /// It must not be allowed when the resource has more than one instance, because the wait is published as a
+    /// Transition from <see cref="KnownResourceStates.NotStarted"/> must not be allowed 
+    /// when the resource has more than one instance, because the wait is published as a
     /// model-level update that reaches every replica. Replicas are started individually (a start request moves only that
     /// replica to "Starting"), so a replica that is still "NotStarted" is one that was deliberately not started - for
-    /// example with <c>WithExplicitStart</c> - and relabeling it "Waiting" would misreport it and disable its start
-    /// command. Self-driven resources are never DCP-backed, so they always resolve to a single instance and keep the fix.
+    /// example with <c>WithExplicitStart</c> - and relabeling it "Waiting" would misreport it and disable its start command.
     /// </remarks>
     private static bool CanTransitionToWaiting(string? state, bool allowNotStarted) =>
         state is null

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -600,19 +600,12 @@ public class ResourceNotificationService : IDisposable
     /// while its dependencies are being awaited.
     /// </summary>
     /// <remarks>
-    /// This is an allow-list of the states that mean "has not started yet". A guard is needed because
-    /// <see cref="PublishUpdateAsync(IResource, Func{CustomResourceSnapshot, CustomResourceSnapshot})"/> broadcasts to
-    /// ALL replicas of the resource (it is a model-level update), not just the specific replica being started. Replicas
-    /// that are already running, stopping, rebuilding, or in a terminal state must not be clobbered back to "Waiting" -
-    /// for example, <c>ExecuteRebuildAsync</c> puts replicas into <see cref="KnownResourceStates.Building"/> and relies
-    /// on that state surviving while a sibling replica is still waiting on dependencies.
-    /// <para>
+    /// This is an allow-list of the states that mean "has not started yet". 
     /// <see cref="KnownResourceStates.NotStarted"/> must be allowed: custom resources that drive their own startup
-    /// publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so they are still in the
+    /// can publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so they are still in the
     /// initial state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to
     /// "Starting" by the orchestrator first. Omitting it silently skipped the transition and, in turn, the wait itself.
     /// See https://github.com/microsoft/aspire/issues/17453.
-    /// </para>
     /// </remarks>
     private static bool CanTransitionToWaiting(string? state) =>
         state is null

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -600,7 +600,9 @@ public class ResourceNotificationService : IDisposable
     /// while its dependencies are being awaited.
     /// </summary>
     /// <remarks>
-    /// This is an allow-list of the states that mean "has not started yet".
+    /// This is an allow-list of the states that mean "has not started yet". It ensures that resources/replicas that are 
+    /// in running, stopping, or in one of terminal states cannot be transitioned to waiting.
+    /// 
     /// <see cref="KnownResourceStates.NotStarted"/> must be allowed: custom resources that drive their own startup
     /// can publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so they are still in the
     /// initial state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -585,14 +585,8 @@ public class ResourceNotificationService : IDisposable
             .Distinct(StringComparers.ResourceName)
             .ToArray();
 
-        // Only transition replicas that are actually starting up to "Waiting".
-        // Replicas already in a Running or terminal state should not be clobbered,
-        // as this broadcast targets ALL replicas of the resource (model-level update),
-        // not just the specific replica being started.
         return PublishUpdateAsync(resource, s =>
-            s.State?.Text is null
-            || s.State?.Text == KnownResourceStates.Starting
-            || s.State?.Text == KnownResourceStates.Waiting
+            CanTransitionToWaiting(s.State?.Text)
                 ? s with
                 {
                     State = KnownResourceStates.Waiting,
@@ -600,6 +594,31 @@ public class ResourceNotificationService : IDisposable
                 }
                 : s);
     }
+
+    /// <summary>
+    /// Determines whether a resource in the specified state may be transitioned to <see cref="KnownResourceStates.Waiting"/>
+    /// while its dependencies are being awaited.
+    /// </summary>
+    /// <remarks>
+    /// This is an allow-list of the states that mean "has not started yet". A guard is needed because
+    /// <see cref="PublishUpdateAsync(IResource, Func{CustomResourceSnapshot, CustomResourceSnapshot})"/> broadcasts to
+    /// ALL replicas of the resource (it is a model-level update), not just the specific replica being started. Replicas
+    /// that are already running, stopping, rebuilding, or in a terminal state must not be clobbered back to "Waiting" -
+    /// for example, <c>ExecuteRebuildAsync</c> puts replicas into <see cref="KnownResourceStates.Building"/> and relies
+    /// on that state surviving while a sibling replica is still waiting on dependencies.
+    /// <para>
+    /// <see cref="KnownResourceStates.NotStarted"/> must be allowed: custom resources that drive their own startup
+    /// publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so they are still in the
+    /// initial state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to
+    /// "Starting" by the orchestrator first. Omitting it silently skipped the transition and, in turn, the wait itself.
+    /// See https://github.com/microsoft/aspire/issues/17453.
+    /// </para>
+    /// </remarks>
+    private static bool CanTransitionToWaiting(string? state) =>
+        state is null
+        || state == KnownResourceStates.NotStarted
+        || state == KnownResourceStates.Starting
+        || state == KnownResourceStates.Waiting;
 
     private Task ClearWaitingForDependenciesAsync(IResource resource)
     {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -600,7 +600,7 @@ public class ResourceNotificationService : IDisposable
     /// while its dependencies are being awaited.
     /// </summary>
     /// <remarks>
-    /// This is an allow-list of the states that mean "has not started yet". 
+    /// This is an allow-list of the states that mean "has not started yet".
     /// <see cref="KnownResourceStates.NotStarted"/> must be allowed: custom resources that drive their own startup
     /// can publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so they are still in the
     /// initial state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -585,9 +585,11 @@ public class ResourceNotificationService : IDisposable
             .Distinct(StringComparers.ResourceName)
             .ToArray();
 
-        // "NotStarted" is only OK to transition to Waiting if the resource is not of "explicit startup" kind. 
-        // See the remarks in CanTransitionToWaiting for details.
-        var allowNotStarted = !resource.HasAnnotationOfType<ExplicitStartupAnnotation>();
+        // Explicit-start resources should not auto-transition to Waiting even if they have dependencies
+        // (they should be considered Waiting only after an attempt is made to start them).
+        // Resources with no instances managed by Aspire do not "start" from Aspire's perspective, 
+        // so they are always allowed to transition to Waiting if they are waiting on dependencies.
+        var allowNotStarted = !resource.HasAnnotationOfType<ExplicitStartupAnnotation>() || !resource.TryGetInstances(out _);
 
         return PublishUpdateAsync(resource, s =>
             CanTransitionToWaiting(s.State?.Text, allowNotStarted)
@@ -599,42 +601,6 @@ public class ResourceNotificationService : IDisposable
                 : s);
     }
 
-    /// <summary>
-    /// Determines whether a resource in the specified state may be transitioned to <see cref="KnownResourceStates.Waiting"/>
-    /// while its dependencies are being awaited.
-    /// </summary>
-    /// <remarks>
-    /// This is an allow-list of the states that mean "has not started yet". It ensures that resources/instances that are
-    /// in running, stopping, or in one of terminal states cannot be transitioned to waiting.
-    ///
-    /// Transition from <see cref="KnownResourceStates.NotStarted"/> is conditional, because that state carries two
-    /// different meanings:
-    /// <list type="bullet">
-    /// <item>
-    /// For resources that are started automatically it means "just created--about to start". Such resources can publish
-    /// <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so there they are still in the initial
-    /// state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to
-    /// "Starting" by the orchestrator first. Refusing the transition here silently skipped the wait itself.
-    /// See https://github.com/microsoft/aspire/issues/17453.
-    /// </item>
-    /// <item>
-    /// For a resource with explicit startup it means "not started--on purpose". Relabeling such a resource
-    /// "Waiting" would misreport it and make its start command a no-op, because
-    /// <c>ApplicationOrchestrator.StartResourceAsync</c> reads "Waiting" as proof that startup is already in flight and
-    /// therefore never forwards the start to DCP. This matters even for a resource with a single instance, since the
-    /// public <see cref="WaitForDependenciesAsync"/> can be called on it by any integration.
-    /// </item>
-    /// </list>
-    ///
-    /// <see cref="ExplicitStartupAnnotation"/> distinguishes the two, and it is an exact signal rather than a heuristic:
-    /// DCP only ever reports an instance as "NotStarted" from its two explicit-start paths (a resource that is not ready
-    /// to be created yet, and one created with <c>Spec.Start = false</c>). Stopping a resource does not produce
-    /// "NotStarted" - containers report "Exited" and executables "Finished"/"Terminated". So for a DCP-managed resource,
-    /// sitting in "NotStarted" and being an explicit-start resource are the same thing.
-    ///
-    /// The annotation lives on the model resource, so every replica is covered by this single check. That is what makes
-    /// it safe for the wait to be published as a model-level update even though replicas are started individually.
-    /// </remarks>
     private static bool CanTransitionToWaiting(string? state, bool allowNotStarted) =>
         state is null
         || (allowNotStarted && state == KnownResourceStates.NotStarted)

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -585,8 +585,12 @@ public class ResourceNotificationService : IDisposable
             .Distinct(StringComparers.ResourceName)
             .ToArray();
 
+        // This is a model-level update, so it reaches every instance (replica) of the resource. "NotStarted" is
+        // only safe to transition when there is a single instance to update - see CanTransitionToWaiting.
+        var allowNotStarted = !resource.TryGetInstances(out var instances) || instances.Length == 1;
+
         return PublishUpdateAsync(resource, s =>
-            CanTransitionToWaiting(s.State?.Text)
+            CanTransitionToWaiting(s.State?.Text, allowNotStarted)
                 ? s with
                 {
                     State = KnownResourceStates.Waiting,
@@ -600,18 +604,24 @@ public class ResourceNotificationService : IDisposable
     /// while its dependencies are being awaited.
     /// </summary>
     /// <remarks>
-    /// This is an allow-list of the states that mean "has not started yet". It ensures that resources/replicas that are 
+    /// This is an allow-list of the states that mean "has not started yet". It ensures that resources/replicas that are
     /// in running, stopping, or in one of terminal states cannot be transitioned to waiting.
-    /// 
-    /// <see cref="KnownResourceStates.NotStarted"/> must be allowed: custom resources that drive their own startup
-    /// can publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so they are still in the
-    /// initial state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to
-    /// "Starting" by the orchestrator first. Omitting it silently skipped the transition and, in turn, the wait itself.
-    /// See https://github.com/microsoft/aspire/issues/17453.
+    ///
+    /// <see cref="KnownResourceStates.NotStarted"/> is conditional. It must be allowed for custom resources that drive
+    /// their own startup: they can publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so
+    /// they are still in the initial state supplied by <c>WithInitialState</c> when the wait is published, rather than
+    /// having been moved to "Starting" by the orchestrator first. Omitting it silently skipped the transition and, in
+    /// turn, the wait itself. See https://github.com/microsoft/aspire/issues/17453.
+    ///
+    /// It must not be allowed when the resource has more than one instance, because the wait is published as a
+    /// model-level update that reaches every replica. Replicas are started individually (a start request moves only that
+    /// replica to "Starting"), so a replica that is still "NotStarted" is one that was deliberately not started - for
+    /// example with <c>WithExplicitStart</c> - and relabeling it "Waiting" would misreport it and disable its start
+    /// command. Self-driven resources are never DCP-backed, so they always resolve to a single instance and keep the fix.
     /// </remarks>
-    private static bool CanTransitionToWaiting(string? state) =>
+    private static bool CanTransitionToWaiting(string? state, bool allowNotStarted) =>
         state is null
-        || state == KnownResourceStates.NotStarted
+        || (allowNotStarted && state == KnownResourceStates.NotStarted)
         || state == KnownResourceStates.Starting
         || state == KnownResourceStates.Waiting;
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -585,9 +585,9 @@ public class ResourceNotificationService : IDisposable
             .Distinct(StringComparers.ResourceName)
             .ToArray();
 
-        // This is a model-level update, so it reaches every instance (replica) of the resource. "NotStarted" is
-        // only safe to transition when there is a single instance to update - see CanTransitionToWaiting.
-        var allowNotStarted = !resource.TryGetInstances(out var instances) || instances.Length == 1;
+        // This is a model-level update, so it reaches every instance of the resource. "NotStarted" is only safe
+        // to transition for resources that have no DCP instances at all - see CanTransitionToWaiting.
+        var allowNotStarted = !resource.TryGetInstances(out _);
 
         return PublishUpdateAsync(resource, s =>
             CanTransitionToWaiting(s.State?.Text, allowNotStarted)
@@ -604,20 +604,23 @@ public class ResourceNotificationService : IDisposable
     /// while its dependencies are being awaited.
     /// </summary>
     /// <remarks>
-    /// This is an allow-list of the states that mean "has not started yet". It ensures that resources/replicas that are
+    /// This is an allow-list of the states that mean "has not started yet". It ensures that resources/instances that are
     /// in running, stopping, or in one of terminal states cannot be transitioned to waiting.
     ///
-    /// Transition from <see cref="KnownResourceStates.NotStarted"/> is conditional. It must be allowed for custom resources that drive
-    /// their own startup: they can publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so
-    /// they are still in the initial state supplied by <c>WithInitialState</c> when the wait is published, rather than
-    /// having been moved to "Starting" by the orchestrator first. Omitting it silently skipped the transition and, in
-    /// turn, the wait itself. See https://github.com/microsoft/aspire/issues/17453.
+    /// Transition from <see cref="KnownResourceStates.NotStarted"/> is conditional, and only allowed for resources that
+    /// have no DCP instances, which is exactly the set of resources that drive their own startup. Those resources can
+    /// publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so they are still in the
+    /// initial state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to
+    /// "Starting" by the orchestrator first. Omitting it silently skipped the transition and, in turn, the wait itself.
+    /// See https://github.com/microsoft/aspire/issues/17453.
     ///
-    /// Transition from <see cref="KnownResourceStates.NotStarted"/> must not be allowed 
-    /// when the resource has more than one instance, because the wait is published as a
-    /// model-level update that reaches every replica. Replicas are started individually (a start request moves only that
-    /// replica to "Starting"), so a replica that is still "NotStarted" is one that was deliberately not started - for
-    /// example with <c>WithExplicitStart</c> - and relabeling it "Waiting" would misreport it and disable its start command.
+    /// DCP-managed resources never need it: the orchestrator publishes "Starting" for the instance that is being started
+    /// before <see cref="BeforeResourceStartedEvent"/> is raised. Allowing it for them would be actively harmful, because
+    /// the wait is published as a model-level update that reaches every instance, while instances are started
+    /// individually. An instance that is still "NotStarted" is one that was deliberately not started - for example with
+    /// <c>WithExplicitStart</c> - and relabeling it "Waiting" would misreport it and make its start command a no-op
+    /// (<c>ApplicationOrchestrator.StartResourceAsync</c> reads "Waiting" as proof that startup is already in flight).
+    /// The public <see cref="WaitForDependenciesAsync"/> can be called on such a resource by any integration.
     /// </remarks>
     private static bool CanTransitionToWaiting(string? state, bool allowNotStarted) =>
         state is null

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -585,9 +585,9 @@ public class ResourceNotificationService : IDisposable
             .Distinct(StringComparers.ResourceName)
             .ToArray();
 
-        // This is a model-level update, so it reaches every instance of the resource. "NotStarted" is only safe
-        // to transition for resources that have no DCP instances at all - see CanTransitionToWaiting.
-        var allowNotStarted = !resource.TryGetInstances(out _);
+        // "NotStarted" is only OK to transition to Waiting if the resource is not of "explicit startup" kind. 
+        // See the remarks in CanTransitionToWaiting for details.
+        var allowNotStarted = !resource.HasAnnotationOfType<ExplicitStartupAnnotation>();
 
         return PublishUpdateAsync(resource, s =>
             CanTransitionToWaiting(s.State?.Text, allowNotStarted)
@@ -607,20 +607,33 @@ public class ResourceNotificationService : IDisposable
     /// This is an allow-list of the states that mean "has not started yet". It ensures that resources/instances that are
     /// in running, stopping, or in one of terminal states cannot be transitioned to waiting.
     ///
-    /// Transition from <see cref="KnownResourceStates.NotStarted"/> is conditional, and only allowed for resources that
-    /// have no DCP instances, which is exactly the set of resources that drive their own startup. Those resources can
-    /// publish <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so they are still in the
-    /// initial state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to
-    /// "Starting" by the orchestrator first. Omitting it silently skipped the transition and, in turn, the wait itself.
+    /// Transition from <see cref="KnownResourceStates.NotStarted"/> is conditional, because that state carries two
+    /// different meanings:
+    /// <list type="bullet">
+    /// <item>
+    /// For resources that are started automatically it means "just created--about to start". Such resources can publish
+    /// <see cref="BeforeResourceStartedEvent"/> from <c>OnInitializeResource</c>, so there they are still in the initial
+    /// state supplied by <c>WithInitialState</c> when the wait is published, rather than having been moved to
+    /// "Starting" by the orchestrator first. Refusing the transition here silently skipped the wait itself.
     /// See https://github.com/microsoft/aspire/issues/17453.
+    /// </item>
+    /// <item>
+    /// For a resource with explicit startup it means "not started--on purpose". Relabeling such a resource
+    /// "Waiting" would misreport it and make its start command a no-op, because
+    /// <c>ApplicationOrchestrator.StartResourceAsync</c> reads "Waiting" as proof that startup is already in flight and
+    /// therefore never forwards the start to DCP. This matters even for a resource with a single instance, since the
+    /// public <see cref="WaitForDependenciesAsync"/> can be called on it by any integration.
+    /// </item>
+    /// </list>
     ///
-    /// DCP-managed resources never need it: the orchestrator publishes "Starting" for the instance that is being started
-    /// before <see cref="BeforeResourceStartedEvent"/> is raised. Allowing it for them would be actively harmful, because
-    /// the wait is published as a model-level update that reaches every instance, while instances are started
-    /// individually. An instance that is still "NotStarted" is one that was deliberately not started - for example with
-    /// <c>WithExplicitStart</c> - and relabeling it "Waiting" would misreport it and make its start command a no-op
-    /// (<c>ApplicationOrchestrator.StartResourceAsync</c> reads "Waiting" as proof that startup is already in flight).
-    /// The public <see cref="WaitForDependenciesAsync"/> can be called on such a resource by any integration.
+    /// <see cref="ExplicitStartupAnnotation"/> distinguishes the two, and it is an exact signal rather than a heuristic:
+    /// DCP only ever reports an instance as "NotStarted" from its two explicit-start paths (a resource that is not ready
+    /// to be created yet, and one created with <c>Spec.Start = false</c>). Stopping a resource does not produce
+    /// "NotStarted" - containers report "Exited" and executables "Finished"/"Terminated". So for a DCP-managed resource,
+    /// sitting in "NotStarted" and being an explicit-start resource are the same thing.
+    ///
+    /// The annotation lives on the model resource, so every replica is covered by this single check. That is what makes
+    /// it safe for the wait to be published as a model-level update even though replicas are started individually.
     /// </remarks>
     private static bool CanTransitionToWaiting(string? state, bool allowNotStarted) =>
         state is null

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -108,25 +108,35 @@ internal sealed class ApplicationOrchestrator
         // Wait for either dependencies to be ready or for someone to move the resource out of a waiting state.
         // This happens when resource start command is run, which forces the status to "Starting".
         //
-        // The resource has to be observed in "Waiting" before a non-"Waiting" state
-        // counts as the release signal. Otherwise, a simple check for "state is not Waiting" could be satisfied
-        // by the very first replayed event whenever the resource never entered "Waiting", which would result in
-        // the wait being silently abandoned and resource being started with unmet dependencies.
-        var seenWaiting = false;
+        // A resource instance has to be observed in "Waiting" first, and then leave it, for a non-"Waiting" state
+        // to count as the release signal. The tracking is per resource id because WaitForResourceAsync only
+        // filters on the model resource name, so this predicate is fed events for every replica. Both halves
+        // of the condition matter:
+        //   - Without "was seen waiting", the very first replayed event of a resource that never entered
+        //     "Waiting" satisfies the predicate, and the resource starts with unmet dependencies.
+        //   - Without the per-id scoping, a sibling replica reporting a non-"Waiting" state releases a wait that
+        //     nobody asked to be released. The rebuild command relies on this: it moves non-waiting replicas to
+        //     "Building" while intentionally leaving waiting replicas alone, precisely so that waiting replicas
+        //     don't get unblocked and launch the old binary mid-build (see CommandsConfigurationExtensions).
+        //
+        // The wait itself is still per BeforeResourceStartedEvent rather than per replica, because the event
+        // does not carry the DCP resource id. Force-starting any replica that was waiting therefore releases
+        // the wait for the whole resource.
+        //
+        // No synchronization is needed for the set: WaitForResourceAsync evaluates the predicate from a single
+        // sequential consumer loop.
+        var waitingResourceIds = new HashSet<string>(StringComparers.ResourceName);
         var waitForNonWaitingStateTask = _notificationService.WaitForResourceAsync(
             @event.Resource.Name,
             e =>
             {
-                var isWaiting = e.Snapshot.State?.Text == KnownResourceStates.Waiting;
-                if (isWaiting)
+                if (e.Snapshot.State?.Text == KnownResourceStates.Waiting)
                 {
-                    seenWaiting = true;
+                    waitingResourceIds.Add(e.ResourceId);
                     return false;
                 }
-                else
-                {
-                    return seenWaiting;
-                }
+
+                return waitingResourceIds.Contains(e.ResourceId);
             },
             cts.Token);
 
@@ -202,27 +212,27 @@ internal sealed class ApplicationOrchestrator
 
                 break;
             case KnownResourceTypes.Container:
+            {
+                var (displayName, isHighlighted, sortOrder) = ResourcePropertySnapshotMetadata.Get(KnownResourceTypes.Container, KnownProperties.Container.Image);
+                var imageName = context.Resource.TryGetContainerImageName(out var resolvedImageName) ? resolvedImageName : "";
+
+                await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
                 {
-                    var (displayName, isHighlighted, sortOrder) = ResourcePropertySnapshotMetadata.Get(KnownResourceTypes.Container, KnownProperties.Container.Image);
-                    var imageName = context.Resource.TryGetContainerImageName(out var resolvedImageName) ? resolvedImageName : "";
+                    State = KnownResourceStates.Starting,
+                    Properties = s.Properties.SetResourceProperty(
+                        KnownProperties.Container.Image,
+                        imageName,
+                        displayName: displayName,
+                        isHighlighted: isHighlighted,
+                        sortOrder: sortOrder),
+                    HealthReports = GetInitialHealthReports(context.Resource)
+                })
+                .ConfigureAwait(false);
 
-                    await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
-                    {
-                        State = KnownResourceStates.Starting,
-                        Properties = s.Properties.SetResourceProperty(
-                            KnownProperties.Container.Image,
-                            imageName,
-                            displayName: displayName,
-                            isHighlighted: isHighlighted,
-                            sortOrder: sortOrder),
-                        HealthReports = GetInitialHealthReports(context.Resource)
-                    })
-                    .ConfigureAwait(false);
-
-                    Debug.Assert(context.DcpResourceName is not null, "Container that is starting should always include the DCP name.");
-                    await SetChildResourceAsync(context.Resource, state: KnownResourceStates.Starting, startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
-                    break;
-                }
+                Debug.Assert(context.DcpResourceName is not null, "Container that is starting should always include the DCP name.");
+                await SetChildResourceAsync(context.Resource, state: KnownResourceStates.Starting, startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
+                break;
+            }
             default:
                 break;
         }

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -109,9 +109,9 @@ internal sealed class ApplicationOrchestrator
         // This happens when resource start command is run, which forces the status to "Starting".
         //
         // The resource has to be observed in "Waiting" before a non-"Waiting" state
-        // counts as the release signal. Otherwise, a simple check for "state is not Waiting" could be satisfied 
-        // by the very first replayed event whenever the resource never entered "Waiting", which would result in 
-        // the wait being silently abandoned and resource being started with unmet dependencies. 
+        // counts as the release signal. Otherwise, a simple check for "state is not Waiting" could be satisfied
+        // by the very first replayed event whenever the resource never entered "Waiting", which would result in
+        // the wait being silently abandoned and resource being started with unmet dependencies.
         var seenWaiting = false;
         var waitForNonWaitingStateTask = _notificationService.WaitForResourceAsync(
             @event.Resource.Name,

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -107,9 +107,25 @@ internal sealed class ApplicationOrchestrator
 
         // Wait for either dependencies to be ready or for someone to move the resource out of a waiting state.
         // This happens when resource start command is run, which forces the status to "Starting".
+        //
+        // This must be edge-triggered: the resource has to be observed in "Waiting" before a non-"Waiting" state
+        // counts as the release signal. WatchAsync replays the current snapshot to new subscribers, so a level
+        // check ("state is not Waiting") is satisfied by that very first replayed event whenever the resource
+        // never entered "Waiting" - which silently abandoned the wait and started the resource with unmet
+        // dependencies. See https://github.com/microsoft/aspire/issues/17453.
+        var seenWaiting = false;
         var waitForNonWaitingStateTask = _notificationService.WaitForResourceAsync(
             @event.Resource.Name,
-            e => e.Snapshot.State?.Text != KnownResourceStates.Waiting,
+            e =>
+            {
+                if (e.Snapshot.State?.Text == KnownResourceStates.Waiting)
+                {
+                    seenWaiting = true;
+                    return false;
+                }
+
+                return seenWaiting;
+            },
             cts.Token);
 
         try

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -97,30 +97,35 @@ internal sealed class ApplicationOrchestrator
     private async Task WaitForInBeforeResourceStartedEvent(BeforeResourceStartedEvent @event, CancellationToken cancellationToken)
     {
         using var activity = ProfilingTelemetry.StartResourceBeforeStartWait(Configuration, @event.Resource);
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-        var waitForDependenciesTask = _notificationService.WaitForDependenciesAsync(@event.Resource, cts.Token);
-        if (waitForDependenciesTask.IsCompletedSuccessfully)
+        // A resource without wait annotations can never be put into "Waiting", so there is nothing to do.
+        // WaitForDependenciesAsync makes the same check, but it has to be repeated here because the watcher
+        // below has to be subscribed before that call is made (see below).
+        if (!@event.Resource.HasAnnotationOfType<WaitAnnotation>())
         {
-            // Nothing to wait for. Return immediately.
             return;
         }
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         // Wait for either dependencies to be ready or for someone to move the resource out of a waiting state.
         // This happens when resource start command is run, which forces the status to "Starting".
         //
         // A resource instance has to be observed in "Waiting" first, and then leave it, for a non-"Waiting" state
         // to count as the release signal. The tracking is per resource id because WaitForResourceAsync only
-        // filters on the model resource name, so this predicate is fed events for every replica. 
+        // filters on the model resource name, so this predicate is fed events for every replica.
         // Both halves of the condition matter:
         //   - Without "was seen waiting", the very first replayed event of a resource that never entered
         //     "Waiting" satisfies the predicate, and the resource starts with unmet dependencies.
         //   - Without the per-id scoping, a sibling replica reporting a non-"Waiting" state releases a wait that
-        //     nobody asked to be released. 
+        //     nobody asked to be released.
         //
         // The wait itself is still per BeforeResourceStartedEvent rather than per replica, because the event
-        // does not carry the resource id. 
+        // does not carry the resource id.
         // Force-starting any replica that was waiting therefore releases the wait for the whole resource.
+        //
+        // Important: call WaitForResourceAsync before WaitForDependenciesAsync, because the latter can complete synchronously 
+        // if there are no dependencies to wait for, and the transition from Waiting to Starting will be lost.
         var waitingResourceIds = new ConcurrentDictionary<string, bool>(StringComparers.ResourceName);
         var waitForNonWaitingStateTask = _notificationService.WaitForResourceAsync(
             @event.Resource.Name,
@@ -138,6 +143,14 @@ internal sealed class ApplicationOrchestrator
 
         try
         {
+            var waitForDependenciesTask = _notificationService.WaitForDependenciesAsync(@event.Resource, cts.Token);
+            if (waitForDependenciesTask.IsCompletedSuccessfully)
+            {
+                // Nothing to wait for after all, e.g. every dependency is a resource without a lifetime.
+                // The finally block below cancels the watcher started above.
+                return;
+            }
+
             var completedTask = await Task.WhenAny(waitForDependenciesTask, waitForNonWaitingStateTask).ConfigureAwait(false);
             if (completedTask.IsFaulted)
             {

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -123,8 +123,10 @@ internal sealed class ApplicationOrchestrator
                     seenWaiting = true;
                     return false;
                 }
-
-                return seenWaiting && !isWaiting;
+                else
+                {
+                    return seenWaiting;
+                }
             },
             cts.Token);
 
@@ -200,27 +202,27 @@ internal sealed class ApplicationOrchestrator
 
                 break;
             case KnownResourceTypes.Container:
-            {
-                var (displayName, isHighlighted, sortOrder) = ResourcePropertySnapshotMetadata.Get(KnownResourceTypes.Container, KnownProperties.Container.Image);
-                var imageName = context.Resource.TryGetContainerImageName(out var resolvedImageName) ? resolvedImageName : "";
-
-                await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
                 {
-                    State = KnownResourceStates.Starting,
-                    Properties = s.Properties.SetResourceProperty(
-                        KnownProperties.Container.Image,
-                        imageName,
-                        displayName: displayName,
-                        isHighlighted: isHighlighted,
-                        sortOrder: sortOrder),
-                    HealthReports = GetInitialHealthReports(context.Resource)
-                })
-                .ConfigureAwait(false);
+                    var (displayName, isHighlighted, sortOrder) = ResourcePropertySnapshotMetadata.Get(KnownResourceTypes.Container, KnownProperties.Container.Image);
+                    var imageName = context.Resource.TryGetContainerImageName(out var resolvedImageName) ? resolvedImageName : "";
 
-                Debug.Assert(context.DcpResourceName is not null, "Container that is starting should always include the DCP name.");
-                await SetChildResourceAsync(context.Resource, state: KnownResourceStates.Starting, startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
-                break;
-            }
+                    await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
+                    {
+                        State = KnownResourceStates.Starting,
+                        Properties = s.Properties.SetResourceProperty(
+                            KnownProperties.Container.Image,
+                            imageName,
+                            displayName: displayName,
+                            isHighlighted: isHighlighted,
+                            sortOrder: sortOrder),
+                        HealthReports = GetInitialHealthReports(context.Resource)
+                    })
+                    .ConfigureAwait(false);
+
+                    Debug.Assert(context.DcpResourceName is not null, "Container that is starting should always include the DCP name.");
+                    await SetChildResourceAsync(context.Resource, state: KnownResourceStates.Starting, startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
+                    break;
+                }
             default:
                 break;
         }

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -112,25 +112,34 @@ internal sealed class ApplicationOrchestrator
         // This happens when resource start command is run, which forces the status to "Starting".
         //
         // A resource instance has to be observed in "Waiting" first, and then leave it, for a non-"Waiting" state
-        // to count as the release signal. The tracking is per resource id because WaitForResourceAsync only
-        // filters on the model resource name, so this predicate is fed events for every replica.
-        // Both halves of the condition matter:
+        // to count as the release signal. WaitForResourceAsync only filters on the model resource name, so this
+        // predicate is fed events for every instance, and both halves of the condition matter:
         //   - Without "was seen waiting", the very first replayed event of a resource that never entered
         //     "Waiting" satisfies the predicate, and the resource starts with unmet dependencies.
-        //   - Without the per-id scoping, a sibling replica reporting a non-"Waiting" state releases a wait that
-        //     nobody asked to be released.
+        //   - Without the per-id scoping, a sibling instance reporting a non-"Waiting" state releases a wait that
+        //     nobody asked to be released. The rebuild command relies on this: it moves non-waiting replicas to
+        //     "Building" while intentionally leaving waiting replicas alone, precisely so that waiting replicas
+        //     don't get unblocked and launch the old binary mid-build (see CommandsConfigurationExtensions).
         //
-        // The wait itself is still per BeforeResourceStartedEvent rather than per replica, because the event
-        // does not carry the resource id.
-        // Force-starting any replica that was waiting therefore releases the wait for the whole resource.
+        // When the event identifies the instance being started, events from all other instances are ignored
+        // outright. Otherwise a force-start of one replica would release the wait of a sibling replica that the
+        // user never asked to start. ResourceInstanceId is null when the event covers the resource as a whole:
+        // either the resource has no instances, or a replicated resource is being started as a group and all of
+        // its replicas legitimately share this single wait.
         //
         // Important: call WaitForResourceAsync before WaitForDependenciesAsync, because the latter can complete synchronously 
         // if there are no dependencies to wait for, and the transition from Waiting to Starting will be lost.
+        var startingInstanceId = @event.ResourceInstanceId;
         var waitingResourceIds = new ConcurrentDictionary<string, bool>(StringComparers.ResourceName);
         var waitForNonWaitingStateTask = _notificationService.WaitForResourceAsync(
             @event.Resource.Name,
             e =>
             {
+                if (startingInstanceId is not null && !StringComparers.ResourceName.Equals(e.ResourceId, startingInstanceId))
+                {
+                    return false;
+                }
+
                 if (e.Snapshot.State?.Text == KnownResourceStates.Waiting)
                 {
                     _ = waitingResourceIds.TryAdd(e.ResourceId, true);
@@ -246,7 +255,10 @@ internal sealed class ApplicationOrchestrator
                 break;
         }
 
-        var beforeResourceStartedEvent = new BeforeResourceStartedEvent(context.Resource, _serviceProvider);
+        var beforeResourceStartedEvent = new BeforeResourceStartedEvent(context.Resource, _serviceProvider)
+        {
+            ResourceInstanceId = context.DcpResourceName
+        };
         await _eventing.PublishAsync(beforeResourceStartedEvent, context.CancellationToken).ConfigureAwait(false);
 
         static Task PublishUpdateAsync(ResourceNotificationService notificationService, IResource resource, string? resourceId, Func<CustomResourceSnapshot, CustomResourceSnapshot> stateFactory)

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Collections.Concurrent;
 
 namespace Aspire.Hosting.Orchestrator;
 
@@ -127,10 +126,10 @@ internal sealed class ApplicationOrchestrator
         // either the resource has no instances, or a replicated resource is being started as a group and all of
         // its replicas legitimately share this single wait.
         //
-        // Important: call WaitForResourceAsync before WaitForDependenciesAsync, because the latter can complete synchronously 
+        // Important: call WaitForResourceAsync before WaitForDependenciesAsync, because the latter can complete synchronously
         // if there are no dependencies to wait for, and the transition from Waiting to Starting will be lost.
         var startingInstanceId = @event.ResourceInstanceId;
-        var waitingResourceIds = new ConcurrentDictionary<string, bool>(StringComparers.ResourceName);
+        var waitingResourceIds = new HashSet<string>(StringComparers.ResourceName);
         var waitForNonWaitingStateTask = _notificationService.WaitForResourceAsync(
             @event.Resource.Name,
             e =>
@@ -142,11 +141,11 @@ internal sealed class ApplicationOrchestrator
 
                 if (e.Snapshot.State?.Text == KnownResourceStates.Waiting)
                 {
-                    _ = waitingResourceIds.TryAdd(e.ResourceId, true);
+                    _ = waitingResourceIds.Add(e.ResourceId);
                     return false;
                 }
 
-                return waitingResourceIds.ContainsKey(e.ResourceId);
+                return waitingResourceIds.Contains(e.ResourceId);
             },
             cts.Token);
 

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -108,23 +108,23 @@ internal sealed class ApplicationOrchestrator
         // Wait for either dependencies to be ready or for someone to move the resource out of a waiting state.
         // This happens when resource start command is run, which forces the status to "Starting".
         //
-        // This must be edge-triggered: the resource has to be observed in "Waiting" before a non-"Waiting" state
-        // counts as the release signal. WatchAsync replays the current snapshot to new subscribers, so a level
-        // check ("state is not Waiting") is satisfied by that very first replayed event whenever the resource
-        // never entered "Waiting" - which silently abandoned the wait and started the resource with unmet
-        // dependencies. See https://github.com/microsoft/aspire/issues/17453.
+        // The resource has to be observed in "Waiting" before a non-"Waiting" state
+        // counts as the release signal. Otherwise, a simple check for "state is not Waiting" could be satisfied 
+        // by the very first replayed event whenever the resource never entered "Waiting", which would result in 
+        // the wait being silently abandoned and resource being started with unmet dependencies. 
         var seenWaiting = false;
         var waitForNonWaitingStateTask = _notificationService.WaitForResourceAsync(
             @event.Resource.Name,
             e =>
             {
-                if (e.Snapshot.State?.Text == KnownResourceStates.Waiting)
+                var isWaiting = e.Snapshot.State?.Text == KnownResourceStates.Waiting;
+                if (isWaiting)
                 {
                     seenWaiting = true;
                     return false;
                 }
 
-                return seenWaiting;
+                return seenWaiting && !isWaiting;
             },
             cts.Token);
 

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
 
 namespace Aspire.Hosting.Orchestrator;
 
@@ -110,33 +111,28 @@ internal sealed class ApplicationOrchestrator
         //
         // A resource instance has to be observed in "Waiting" first, and then leave it, for a non-"Waiting" state
         // to count as the release signal. The tracking is per resource id because WaitForResourceAsync only
-        // filters on the model resource name, so this predicate is fed events for every replica. Both halves
-        // of the condition matter:
+        // filters on the model resource name, so this predicate is fed events for every replica. 
+        // Both halves of the condition matter:
         //   - Without "was seen waiting", the very first replayed event of a resource that never entered
         //     "Waiting" satisfies the predicate, and the resource starts with unmet dependencies.
         //   - Without the per-id scoping, a sibling replica reporting a non-"Waiting" state releases a wait that
-        //     nobody asked to be released. The rebuild command relies on this: it moves non-waiting replicas to
-        //     "Building" while intentionally leaving waiting replicas alone, precisely so that waiting replicas
-        //     don't get unblocked and launch the old binary mid-build (see CommandsConfigurationExtensions).
+        //     nobody asked to be released. 
         //
         // The wait itself is still per BeforeResourceStartedEvent rather than per replica, because the event
-        // does not carry the DCP resource id. Force-starting any replica that was waiting therefore releases
-        // the wait for the whole resource.
-        //
-        // No synchronization is needed for the set: WaitForResourceAsync evaluates the predicate from a single
-        // sequential consumer loop.
-        var waitingResourceIds = new HashSet<string>(StringComparers.ResourceName);
+        // does not carry the resource id. 
+        // Force-starting any replica that was waiting therefore releases the wait for the whole resource.
+        var waitingResourceIds = new ConcurrentDictionary<string, bool>(StringComparers.ResourceName);
         var waitForNonWaitingStateTask = _notificationService.WaitForResourceAsync(
             @event.Resource.Name,
             e =>
             {
                 if (e.Snapshot.State?.Text == KnownResourceStates.Waiting)
                 {
-                    waitingResourceIds.Add(e.ResourceId);
+                    _ = waitingResourceIds.TryAdd(e.ResourceId, true);
                     return false;
                 }
 
-                return waitingResourceIds.Contains(e.ResourceId);
+                return waitingResourceIds.ContainsKey(e.ResourceId);
             },
             cts.Token);
 
@@ -212,27 +208,27 @@ internal sealed class ApplicationOrchestrator
 
                 break;
             case KnownResourceTypes.Container:
-            {
-                var (displayName, isHighlighted, sortOrder) = ResourcePropertySnapshotMetadata.Get(KnownResourceTypes.Container, KnownProperties.Container.Image);
-                var imageName = context.Resource.TryGetContainerImageName(out var resolvedImageName) ? resolvedImageName : "";
-
-                await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
                 {
-                    State = KnownResourceStates.Starting,
-                    Properties = s.Properties.SetResourceProperty(
-                        KnownProperties.Container.Image,
-                        imageName,
-                        displayName: displayName,
-                        isHighlighted: isHighlighted,
-                        sortOrder: sortOrder),
-                    HealthReports = GetInitialHealthReports(context.Resource)
-                })
-                .ConfigureAwait(false);
+                    var (displayName, isHighlighted, sortOrder) = ResourcePropertySnapshotMetadata.Get(KnownResourceTypes.Container, KnownProperties.Container.Image);
+                    var imageName = context.Resource.TryGetContainerImageName(out var resolvedImageName) ? resolvedImageName : "";
 
-                Debug.Assert(context.DcpResourceName is not null, "Container that is starting should always include the DCP name.");
-                await SetChildResourceAsync(context.Resource, state: KnownResourceStates.Starting, startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
-                break;
-            }
+                    await PublishUpdateAsync(_notificationService, context.Resource, context.DcpResourceName, s => s with
+                    {
+                        State = KnownResourceStates.Starting,
+                        Properties = s.Properties.SetResourceProperty(
+                            KnownProperties.Container.Image,
+                            imageName,
+                            displayName: displayName,
+                            isHighlighted: isHighlighted,
+                            sortOrder: sortOrder),
+                        HealthReports = GetInitialHealthReports(context.Resource)
+                    })
+                    .ConfigureAwait(false);
+
+                    Debug.Assert(context.DcpResourceName is not null, "Container that is starting should always include the DCP name.");
+                    await SetChildResourceAsync(context.Resource, state: KnownResourceStates.Starting, startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
+                    break;
+                }
             default:
                 break;
         }

--- a/tests/Aspire.Hosting.TestUtilities/Utils/TestDcpExecutor.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/TestDcpExecutor.cs
@@ -1,19 +1,58 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using Aspire.Hosting.Dcp;
 
 namespace Aspire.Hosting.Tests.Utils;
 
 internal sealed class TestDcpExecutor : IDcpExecutor
 {
-    public IResourceReference GetResource(string resourceName) => throw new NotImplementedException();
+    private readonly Dictionary<string, IResourceReference> _resources = new(StringComparers.ResourceName);
+    private readonly ConcurrentQueue<string> _startedResources = new();
+
+    /// <summary>
+    /// DCP resource names passed to <see cref="StartResourceAsync"/>, in the order they were requested.
+    /// </summary>
+    /// <remarks>
+    /// <c>ApplicationOrchestrator.StartResourceAsync</c> only forwards to the executor when it decides the resource
+    /// is not already starting, so this is how a test tells "the start reached DCP" apart from "the start was
+    /// swallowed because the snapshot claimed the resource was already on its way up".
+    /// </remarks>
+    public IReadOnlyCollection<string> StartedResources => _startedResources;
+
+    /// <summary>
+    /// Registers a resource so that <see cref="GetResource"/> can resolve it, mimicking a DCP resource that was
+    /// created for <paramref name="modelResource"/> under the DCP name <paramref name="dcpResourceName"/>.
+    /// </summary>
+    public void AddResource(IResource modelResource, string dcpResourceName)
+    {
+        _resources[dcpResourceName] = new TestResourceReference(modelResource, dcpResourceName);
+    }
+
+    public IResourceReference GetResource(string resourceName)
+    {
+        return _resources.TryGetValue(resourceName, out var resource)
+            ? resource
+            : throw new InvalidOperationException($"Resource '{resourceName}' not found.");
+    }
 
     public Task RunApplicationAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-    public Task StartResourceAsync(IResourceReference resourceReference, CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task StartResourceAsync(IResourceReference resourceReference, CancellationToken cancellationToken)
+    {
+        _startedResources.Enqueue(resourceReference.DcpResourceName);
+        return Task.CompletedTask;
+    }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     public Task StopResourceAsync(IResourceReference resource, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private sealed class TestResourceReference(IResource modelResource, string dcpResourceName) : IResourceReference
+    {
+        public IResource ModelResource { get; } = modelResource;
+
+        public string DcpResourceName { get; } = dcpResourceName;
+    }
 }

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -582,7 +582,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var blockerReleased = new TaskCompletionSource();
+        var blockerReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var blocker = AddSelfDrivenResource(builder, "blocker", blockerReleased.Task);
         var waiter = AddSelfDrivenResource(builder, "waiter").WaitFor(blocker);
 
@@ -618,7 +618,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var dependencyReleased = new TaskCompletionSource();
+        var dependencyReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
         var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
 
@@ -660,7 +660,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var dependencyReleased = new TaskCompletionSource();
+        var dependencyReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
         var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
         waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
@@ -720,7 +720,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var dependencyReleased = new TaskCompletionSource();
+        var dependencyReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
         var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
         waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
@@ -769,7 +769,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var dependencyReleased = new TaskCompletionSource();
+        var dependencyReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
         var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
         waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
@@ -813,6 +813,77 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task ForceStartingOneReplicaDoesNotReleaseAnotherReplicasWait()
+    {
+        // Each individually started replica gets its own BeforeResourceStartedEvent, but WaitForResourceAsync
+        // filters only on the model resource name, so every one of those waits is fed events for every replica.
+        // Forcing replica B out of "Waiting" with the start command must not release replica A's wait - the user
+        // only asked for B, and A would otherwise start with unmet dependencies.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var dependencyReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
+        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
+        waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
+            new DcpInstance("waiter-abc123", "abc123", 0),
+            new DcpInstance("waiter-def456", "def456", 1)
+        ]));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var dcpExecutor = new TestDcpExecutor();
+        dcpExecutor.AddResource(waiter.Resource, "waiter-abc123");
+        dcpExecutor.AddResource(waiter.Resource, "waiter-def456");
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing, dcpExecutor: dcpExecutor);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        await PublishReplicaStatesAsync(resourceNotificationService, waiter.Resource, KnownResourceStates.NotStarted);
+
+        // Both replicas are started, so both end up waiting on the same dependency.
+        var startingFirstReplicaTask = events.PublishAsync(new OnResourceStartingContext(
+            CancellationToken.None, KnownResourceTypes.Executable, waiter.Resource, "waiter-abc123"));
+
+        await resourceNotificationService.WaitForResourceAsync(
+            waiter.Resource.Name,
+            e => e.ResourceId == "waiter-abc123" && e.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            TestContext.Current.CancellationToken).DefaultTimeout();
+
+        var startingSecondReplicaTask = events.PublishAsync(new OnResourceStartingContext(
+            CancellationToken.None, KnownResourceTypes.Executable, waiter.Resource, "waiter-def456"));
+
+        await resourceNotificationService.WaitForResourceAsync(
+            waiter.Resource.Name,
+            e => e.ResourceId == "waiter-def456" && e.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            TestContext.Current.CancellationToken).DefaultTimeout();
+
+        // Stand in for the user invoking the start command on the second replica to force it past the wait.
+        await appOrchestrator.StartResourceAsync("waiter-def456", TestContext.Current.CancellationToken).DefaultTimeout();
+
+        // The replica was already waiting, so the start was served by moving it to "Starting" rather than by DCP.
+        Assert.Empty(dcpExecutor.StartedResources);
+
+        await startingSecondReplicaTask.DefaultTimeout();
+
+        // Negative assertion: give the first replica's wait a chance to be released incorrectly. This can only
+        // ever produce a false pass, never a false failure - with a model-wide release flag the wait is abandoned
+        // as soon as the second replica leaves "Waiting".
+        await Task.Delay(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
+        Assert.False(startingFirstReplicaTask.IsCompleted, "Force-starting one replica must not release another replica's dependency wait.");
+
+        dependencyReleased.SetResult();
+
+        await startingFirstReplicaTask.DefaultTimeout();
+    }
+
+    [Fact]
     public async Task ResourceForcedOutOfWaitingStopsWaitingForItsDependency()
     {
         // The Start command forces a waiting resource to start by moving it from "Waiting" to "Starting"
@@ -821,7 +892,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var blockerReleased = new TaskCompletionSource();
+        var blockerReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var blocker = AddSelfDrivenResource(builder, "blocker", blockerReleased.Task);
         var waiter = AddSelfDrivenResource(builder, "waiter").WaitFor(blocker);
 
@@ -862,7 +933,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var blockerReleased = new TaskCompletionSource();
+        var blockerReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var blocker = AddSelfDrivenResource(builder, "blocker", blockerReleased.Task);
         var waiter = AddSelfDrivenResource(builder, "waiter").WaitFor(blocker);
 
@@ -877,11 +948,21 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
 
         // Stand in for the Start command, firing as soon as the waiting state is stored. PublishUpdateAsync
         // stores the snapshot synchronously, so a tight poll observes "Waiting" well before any watcher started
-        // afterwards could - which is exactly the window the fix has to cover. Losing the poll only ever
-        // produces a false pass, never a false failure.
+        // afterwards could - which is exactly the window the fix has to cover. A delay-based poll or a watcher
+        // subscription would only see "Waiting" after the orchestrator had already subscribed, so the regression
+        // would go unnoticed. Losing the poll only ever produces a false pass, never a false failure.
         var cancellationToken = TestContext.Current.CancellationToken;
         var forceStartTask = Task.Run(async () =>
         {
+            // Wait for the waiter's initial snapshot first so the tight poll below only spins across the short
+            // window in which the dependency wait is set up, rather than for the whole of application startup.
+            // "Waiting" is tolerated as well: if the poll is late the snapshot has already moved on, and the
+            // loop below exits immediately.
+            await resourceNotificationService.WaitForResourceAsync(
+                waiter.Resource.Name,
+                [KnownResourceStates.NotStarted, KnownResourceStates.Waiting],
+                cancellationToken);
+
             while (!resourceNotificationService.TryGetCurrentState(waiter.Resource.Name, out var waiterEvent)
                 || waiterEvent.Snapshot.State?.Text != KnownResourceStates.Waiting)
             {
@@ -915,7 +996,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var referencedReleased = new TaskCompletionSource();
+        var referencedReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var referenced = AddSelfDrivenResource(builder, "referenced", referencedReleased.Task);
         var connectionString = builder.AddConnectionString("cs", ReferenceExpression.Create($"Endpoint={referenced.Resource}"));
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -711,6 +711,108 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task WaitingUpdateDoesNotDisturbNotStartedReplicas()
+    {
+        // A replicated resource that uses WithExplicitStart is started one replica at a time, so only the replica
+        // named in the start request is moved to "Starting". The waiting update, however, is published as a
+        // model-level update that reaches every replica, so a sibling that is still "NotStarted" - deliberately not
+        // started - must be left alone.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var dependencyReleased = new TaskCompletionSource();
+        var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
+        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
+        waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
+            new DcpInstance("waiter-abc123", "abc123", 0),
+            new DcpInstance("waiter-def456", "def456", 1)
+        ]));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        // Both replicas of an explicit start resource report "NotStarted" until someone starts them.
+        await PublishReplicaStatesAsync(resourceNotificationService, waiter.Resource, KnownResourceStates.NotStarted);
+
+        // Only the first replica is being started.
+        var startingTask = events.PublishAsync(new OnResourceStartingContext(
+            CancellationToken.None, KnownResourceTypes.Executable, waiter.Resource, "waiter-abc123"));
+
+        await resourceNotificationService.WaitForResourceAsync(
+            waiter.Resource.Name,
+            e => e.ResourceId == "waiter-abc123" && e.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.True(resourceNotificationService.TryGetCurrentState("waiter-def456", out var siblingEvent));
+        Assert.Equal(KnownResourceStates.NotStarted, siblingEvent.Snapshot.State?.Text);
+
+        dependencyReleased.SetResult();
+
+        await startingTask.DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task StartingNotStartedReplicaIsForwardedToDcpWhileSiblingWaits()
+    {
+        // The consequence of WaitingUpdateDoesNotDisturbNotStartedReplicas: StartResourceAsync reads "Waiting" as
+        // proof that startup is already in flight and only updates the snapshot, skipping DCP. If the waiting update
+        // relabelled the untouched replica, its start command would silently do nothing - the dashboard would show
+        // "Starting" while no process was ever launched.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var dependencyReleased = new TaskCompletionSource();
+        var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
+        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
+        waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
+            new DcpInstance("waiter-abc123", "abc123", 0),
+            new DcpInstance("waiter-def456", "def456", 1)
+        ]));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var dcpExecutor = new TestDcpExecutor();
+        dcpExecutor.AddResource(waiter.Resource, "waiter-abc123");
+        dcpExecutor.AddResource(waiter.Resource, "waiter-def456");
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing, dcpExecutor: dcpExecutor);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        await PublishReplicaStatesAsync(resourceNotificationService, waiter.Resource, KnownResourceStates.NotStarted);
+
+        var startingTask = events.PublishAsync(new OnResourceStartingContext(
+            CancellationToken.None, KnownResourceTypes.Executable, waiter.Resource, "waiter-abc123"));
+
+        await resourceNotificationService.WaitForResourceAsync(
+            waiter.Resource.Name,
+            e => e.ResourceId == "waiter-abc123" && e.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            TestContext.Current.CancellationToken).DefaultTimeout();
+
+        // Stand in for the user invoking the start command on the replica that was never started.
+        await appOrchestrator.StartResourceAsync("waiter-def456", TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.Equal(["waiter-def456"], dcpExecutor.StartedResources);
+
+        dependencyReleased.SetResult();
+
+        await startingTask.DefaultTimeout();
+    }
+
+    [Fact]
     public async Task ResourceForcedOutOfWaitingStopsWaitingForItsDependency()
     {
         // The Start command forces a waiting resource to start by moving it from "Waiting" to "Starting"
@@ -837,6 +939,20 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     }
 
     /// <summary>
+    /// Publishes <paramref name="state"/> for every DCP instance (replica) of <paramref name="resource"/>, as an
+    /// individual per-instance update rather than a model-level one.
+    /// </summary>
+    private static async Task PublishReplicaStatesAsync(ResourceNotificationService notificationService, IResource resource, string state)
+    {
+        Assert.True(resource.TryGetInstances(out var instances));
+
+        foreach (var instance in instances)
+        {
+            await notificationService.PublishUpdateAsync(resource, instance.Name, s => s with { State = state }).DefaultTimeout();
+        }
+    }
+
+    /// <summary>
     /// Adds a resource shaped like a custom hosting integration that drives its own startup: it starts in
     /// <see cref="KnownResourceStates.NotStarted"/> and publishes <see cref="BeforeResourceStartedEvent"/> itself
     /// instead of being started by DCP.
@@ -877,7 +993,8 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         DcpExecutorEvents? dcpEvents = null,
         IDistributedApplicationEventing? applicationEventing = null,
         ResourceLoggerService? resourceLoggerService = null,
-        DashboardOptions? dashboardOptions = null)
+        DashboardOptions? dashboardOptions = null,
+        TestDcpExecutor? dcpExecutor = null)
     {
         var services = new ServiceCollection();
         var configuration = new ConfigurationManager();
@@ -890,7 +1007,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
 
         return new ApplicationOrchestrator(
             distributedAppModel,
-            new TestDcpExecutor(),
+            dcpExecutor ?? new TestDcpExecutor(),
             dcpEvents ?? new DcpExecutorEvents(),
             [],
             notificationService,

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -748,6 +748,62 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task ResourceForcedOutOfWaitingImmediatelyStopsWaitingForItsDependency()
+    {
+        // Regression test for a race between publishing "Waiting" and subscribing to state changes.
+        // WaitForInBeforeResourceStartedEvent detects a force-start by observing the resource leave "Waiting",
+        // and ResourceNotificationService.WatchAsync only replays the latest snapshot of each resource rather
+        // than the full history. If the Start command lands in the window between the wait publishing "Waiting"
+        // and the orchestrator subscribing, a replay-only view shows "Starting" without ever showing "Waiting",
+        // and the force-start signal is lost - the resource stays blocked on a dependency that never becomes
+        // ready. https://github.com/microsoft/aspire/pull/18930#discussion_r3677777200
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var blockerReleased = new TaskCompletionSource();
+        var blocker = AddSelfDrivenResource(builder, "blocker", blockerReleased.Task);
+        var waiter = AddSelfDrivenResource(builder, "waiter").WaitFor(blocker);
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        // Stand in for the Start command, firing as soon as the waiting state is stored. PublishUpdateAsync
+        // stores the snapshot synchronously, so a tight poll observes "Waiting" well before any watcher started
+        // afterwards could - which is exactly the window the fix has to cover. Losing the poll only ever
+        // produces a false pass, never a false failure.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var forceStartTask = Task.Run(async () =>
+        {
+            while (!resourceNotificationService.TryGetCurrentState(waiter.Resource.Name, out var waiterEvent)
+                || waiterEvent.Snapshot.State?.Text != KnownResourceStates.Waiting)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+
+            await resourceNotificationService.PublishUpdateAsync(waiter.Resource, s => s with { State = KnownResourceStates.Starting });
+        }, cancellationToken);
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        await forceStartTask.DefaultTimeout();
+
+        // The waiter has to start even though the blocker is still inside its initialize callback.
+        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Running, cancellationToken).DefaultTimeout();
+
+        Assert.True(resourceNotificationService.TryGetCurrentState(blocker.Resource.Name, out var blockerEvent));
+        Assert.NotEqual(KnownResourceStates.Running, blockerEvent.Snapshot.State?.Text);
+
+        blockerReleased.SetResult();
+    }
+
+    [Fact]
     public async Task ConnectionStringResourceWaitsForReferencedResourceBeforeBecomingAvailable()
     {
         // AddConnectionString has the same shape as a third-party custom resource: it starts in "NotStarted"

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -572,6 +572,182 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(KnownResourceStates.Starting, snapshotEvent.Snapshot.State?.Text);
     }
 
+    [Fact]
+    public async Task SelfDrivenResourceWaitsForDependencyBeforeStarting()
+    {
+        // Custom resources that drive their own startup publish BeforeResourceStartedEvent from
+        // OnInitializeResource, so they are still in the initial "NotStarted" state when the wait is
+        // published rather than having been moved to "Starting" by the orchestrator first.
+        // https://github.com/microsoft/aspire/issues/17453
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var blockerReleased = new TaskCompletionSource();
+        var blocker = AddSelfDrivenResource(builder, "blocker", blockerReleased.Task);
+        var waiter = AddSelfDrivenResource(builder, "waiter").WaitFor(blocker);
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Waiting, TestContext.Current.CancellationToken).DefaultTimeout();
+
+        // The blocker is still inside its initialize callback, so the waiter must not have started.
+        Assert.True(resourceNotificationService.TryGetCurrentState(waiter.Resource.Name, out var waitingEvent));
+        Assert.Equal(KnownResourceStates.Waiting, waitingEvent.Snapshot.State?.Text);
+
+        blockerReleased.SetResult();
+
+        await resourceNotificationService.WaitForResourceAsync(blocker.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ResourceWaitingOnSelfDrivenResourceWaitsForItToStart()
+    {
+        // The reciprocal of SelfDrivenResourceWaitsForDependencyBeforeStarting: the dependency is the
+        // resource that drives its own startup. https://github.com/microsoft/aspire/issues/17453
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var dependencyReleased = new TaskCompletionSource();
+        var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
+        var waiter = AddSelfDrivenResource(builder, "waiter").WaitFor(dependency);
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Waiting, TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.True(resourceNotificationService.TryGetCurrentState(dependency.Resource.Name, out var dependencyEvent));
+        Assert.NotEqual(KnownResourceStates.Running, dependencyEvent.Snapshot.State?.Text);
+
+        dependencyReleased.SetResult();
+
+        await resourceNotificationService.WaitForResourceAsync(dependency.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ResourceForcedOutOfWaitingStopsWaitingForItsDependency()
+    {
+        // The Start command forces a waiting resource to start by moving it from "Waiting" to "Starting"
+        // (see ApplicationOrchestrator.StartResourceAsync). BeforeResourceStartedEvent has to stop waiting
+        // when that happens, even though the dependency is still not ready.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var blockerReleased = new TaskCompletionSource();
+        var blocker = AddSelfDrivenResource(builder, "blocker", blockerReleased.Task);
+        var waiter = AddSelfDrivenResource(builder, "waiter").WaitFor(blocker);
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Waiting, TestContext.Current.CancellationToken).DefaultTimeout();
+
+        // Stand in for the Start command.
+        await resourceNotificationService.PublishUpdateAsync(waiter.Resource, s => s with { State = KnownResourceStates.Starting }).DefaultTimeout();
+
+        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+
+        Assert.True(resourceNotificationService.TryGetCurrentState(blocker.Resource.Name, out var blockerEvent));
+        Assert.NotEqual(KnownResourceStates.Running, blockerEvent.Snapshot.State?.Text);
+
+        blockerReleased.SetResult();
+    }
+
+    [Fact]
+    public async Task ConnectionStringResourceWaitsForReferencedResourceBeforeBecomingAvailable()
+    {
+        // AddConnectionString has the same shape as a third-party custom resource: it starts in "NotStarted"
+        // and publishes BeforeResourceStartedEvent from OnInitializeResource, and it implicitly adds a
+        // WaitForStart on every resource its expression references. It must not report a connection string
+        // before those resources have started. https://github.com/microsoft/aspire/issues/17453
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var referencedReleased = new TaskCompletionSource();
+        var referenced = AddSelfDrivenResource(builder, "referenced", referencedReleased.Task);
+        var connectionString = builder.AddConnectionString("cs", ReferenceExpression.Create($"Endpoint={referenced.Resource}"));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        await resourceNotificationService.WaitForResourceAsync(connectionString.Resource.Name, KnownResourceStates.Waiting, TestContext.Current.CancellationToken).DefaultTimeout();
+
+        referencedReleased.SetResult();
+
+        await resourceNotificationService.WaitForResourceAsync(referenced.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+        await resourceNotificationService.WaitForResourceAsync(connectionString.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+    }
+
+    /// <summary>
+    /// Adds a resource shaped like a custom hosting integration that drives its own startup: it starts in
+    /// <see cref="KnownResourceStates.NotStarted"/> and publishes <see cref="BeforeResourceStartedEvent"/> itself
+    /// instead of being started by DCP.
+    /// </summary>
+    private static IResourceBuilder<CustomResourceWithWaitSupport> AddSelfDrivenResource(IDistributedApplicationBuilder builder, string name, Task? gate = null)
+    {
+        return builder.AddResource(new CustomResourceWithWaitSupport(name))
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = "CustomResource",
+                State = KnownResourceStates.NotStarted,
+                Properties = []
+            })
+            .OnInitializeResource(async (resource, @event, ct) =>
+            {
+                // This is where waiting happens.
+                await @event.Eventing.PublishAsync(new BeforeResourceStartedEvent(resource, @event.Services), ct);
+
+                if (gate is not null)
+                {
+                    await gate;
+                }
+
+                // ResourceHealthCheckService isn't running in this harness, so stand in for it and publish the
+                // ready event a resource with no health checks would otherwise get. Without it, WaitFor - which
+                // waits until healthy - could never observe the dependency as ready.
+                await @event.Notifications.PublishUpdateAsync(resource, s => s with
+                {
+                    State = KnownResourceStates.Running,
+                    ResourceReadyEvent = new EventSnapshot(Task.CompletedTask)
+                });
+            });
+    }
+
     private ApplicationOrchestrator CreateOrchestrator(
         DistributedApplicationModel distributedAppModel,
         ResourceNotificationService notificationService,
@@ -644,6 +820,11 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     }
 
     private sealed class CustomResource(string name) : Resource(name);
+
+    private sealed class CustomResourceWithWaitSupport(string name) : Resource(name), IResourceWithWaitSupport, IResourceWithConnectionString
+    {
+        public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{Name}-connection-string");
+    }
 
     private sealed class CustomChildResource(string name, IResource parent) : Resource(name), IResourceWithParent
     {

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -722,7 +722,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
 
         var dependencyReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
-        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
+        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency).WithExplicitStart();
         waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
             new DcpInstance("waiter-abc123", "abc123", 0),
             new DcpInstance("waiter-def456", "def456", 1)
@@ -771,7 +771,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
 
         var dependencyReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
-        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
+        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency).WithExplicitStart();
         waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
             new DcpInstance("waiter-abc123", "abc123", 0),
             new DcpInstance("waiter-def456", "def456", 1)

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -612,14 +612,15 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task ResourceWaitingOnSelfDrivenResourceWaitsForItToStart()
     {
-        // The reciprocal of SelfDrivenResourceWaitsForDependencyBeforeStarting: the dependency is the
-        // resource that drives its own startup. https://github.com/microsoft/aspire/issues/17453
+        // The reciprocal of SelfDrivenResourceWaitsForDependencyBeforeStarting: the dependency is the resource
+        // that drives its own startup, while the waiter is a regular DCP-managed resource that the orchestrator
+        // starts through OnResourceStarting. https://github.com/microsoft/aspire/issues/17453
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
         var dependencyReleased = new TaskCompletionSource();
         var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
-        var waiter = AddSelfDrivenResource(builder, "waiter").WaitFor(dependency);
+        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
 
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -632,6 +633,12 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
 
         await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
 
+        // Stand in for DCP starting the resource. This does not complete until the wait for dependencies is over,
+        // so it cannot be awaited here. The resource name is used as the DCP name so that the per-instance update
+        // published by OnResourceStarting and the model-level waiting update address the same snapshot.
+        var startingTask = events.PublishAsync(new OnResourceStartingContext(
+            CancellationToken.None, KnownResourceTypes.Executable, waiter.Resource, waiter.Resource.Name));
+
         await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Waiting, TestContext.Current.CancellationToken).DefaultTimeout();
 
         Assert.True(resourceNotificationService.TryGetCurrentState(dependency.Resource.Name, out var dependencyEvent));
@@ -640,7 +647,67 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         dependencyReleased.SetResult();
 
         await resourceNotificationService.WaitForResourceAsync(dependency.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
-        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+        await startingTask.DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task WaitIsNotReleasedByAnotherReplicaLeavingWaitingState()
+    {
+        // The wait is released when the resource is forced out of "Waiting" by the start command, but
+        // WaitForResourceAsync only filters on the model resource name, so the release signal has to be scoped
+        // to the replica that was forced out. Here the model-level waiting update also re-publishes the running
+        // sibling replica, and that must not be mistaken for a force-start of the waiting replica.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var dependencyReleased = new TaskCompletionSource();
+        var dependency = AddSelfDrivenResource(builder, "dependency", dependencyReleased.Task);
+        var waiter = builder.AddResource(new CustomResourceWithWaitSupport("waiter")).WaitFor(dependency);
+        waiter.Resource.Annotations.Add(new DcpInstancesAnnotation([
+            new DcpInstance("waiter-abc123", "abc123", 0),
+            new DcpInstance("waiter-def456", "def456", 1)
+        ]));
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        // The second replica is already running and is not part of this start attempt.
+        await resourceNotificationService.PublishUpdateAsync(waiter.Resource, "waiter-def456", s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+
+        var startingTask = events.PublishAsync(new OnResourceStartingContext(
+            CancellationToken.None, KnownResourceTypes.Executable, waiter.Resource, "waiter-abc123"));
+
+        await resourceNotificationService.WaitForResourceAsync(
+            waiter.Resource.Name,
+            e => e.ResourceId == "waiter-abc123" && e.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            TestContext.Current.CancellationToken).DefaultTimeout();
+
+        // The rebuild command moves non-waiting replicas to "Building" while deliberately leaving waiting
+        // replicas alone, so this is a state change a waiting replica really does observe from a sibling.
+        await resourceNotificationService.PublishUpdateAsync(waiter.Resource, "waiter-def456", s => s with
+        {
+            State = KnownResourceStates.Building
+        }).DefaultTimeout();
+
+        // Negative assertion: give the wait a chance to be released incorrectly. This can only ever produce a
+        // false pass, never a false failure - with a model-wide release flag the wait is abandoned immediately.
+        await Task.Delay(TimeSpan.FromMilliseconds(250), TestContext.Current.CancellationToken);
+        Assert.False(startingTask.IsCompleted, "The dependency wait must not be released by a sibling replica leaving the waiting state.");
+
+        dependencyReleased.SetResult();
+
+        await startingTask.DefaultTimeout();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -1019,6 +1019,49 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         await resourceNotificationService.WaitForResourceAsync(connectionString.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
     }
 
+    [Fact]
+    public async Task ExplicitStartResourceWithoutDcpInstancesReportsWaitingForItsDependency()
+    {
+        // Resources not managed by Aspire (no instances) should transition to "Waiting" directly from NotStarted,
+        // regardless whether they have ExplicitStartAnnotation or not. The annotation does not really makes a difference here
+        // because it is only used to control the behavior of the orchestrator when starting a resource
+        // and since the resource has no instances, it is not subject to the orchestrator's start logic.
+        var builder = DistributedApplication.CreateBuilder();
+        builder.WithTestAndResourceLogging(testOutputHelper);
+
+        var blockerReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blocker = AddSelfDrivenResource(builder, "blocker", blockerReleased.Task);
+        var waiter = builder.AddConnectionString("waiter", ReferenceExpression.Create($"Host=localhost;Port=5678"))
+            .WaitFor(blocker)
+            .WithExplicitStart();
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var events = new DcpExecutorEvents();
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appOrchestrator = CreateOrchestrator(distributedAppModel, notificationService: resourceNotificationService, dcpEvents: events, applicationEventing: builder.Eventing);
+        await appOrchestrator.RunApplicationAsync();
+
+        await events.PublishAsync(new OnResourcesPreparedContext(CancellationToken.None));
+
+        var waitingEvent = await resourceNotificationService.WaitForResourceAsync(
+            waiter.Resource.Name,
+            re => re.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            TestContext.Current.CancellationToken).DefaultTimeout();
+
+        var waitingFor = waitingEvent.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.WaitingFor)?.Value;
+        Assert.Equal(new[] { blocker.Resource.Name }, Assert.IsAssignableFrom<IEnumerable<string>>(waitingFor));
+
+        blockerReleased.SetResult();
+
+        // The resource starts without anyone issuing a start command, which is what makes "Waiting" - rather than
+        // "NotStarted" - the honest label for the period above.
+        await resourceNotificationService.WaitForResourceAsync(blocker.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+        await resourceNotificationService.WaitForResourceAsync(waiter.Resource.Name, KnownResourceStates.Running, TestContext.Current.CancellationToken).DefaultTimeout();
+    }
+
     /// <summary>
     /// Publishes <paramref name="state"/> for every DCP instance (replica) of <paramref name="resource"/>, as an
     /// individual per-instance update rather than a model-level one.

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -502,6 +502,77 @@ public class ResourceNotificationTests
     }
 
     [Fact]
+    public async Task WaitForDependenciesTransitionsNotStartedResourceToWaiting()
+    {
+        // Custom resources that drive their own startup publish BeforeResourceStartedEvent from
+        // OnInitializeResource, so they are still in the "NotStarted" state supplied by WithInitialState
+        // when the dependency wait is published. https://github.com/microsoft/aspire/issues/17453
+        var dependency = new CustomResource("dependency");
+        var resource = new CustomResource("resource");
+        resource.Annotations.Add(new WaitAnnotation(dependency, WaitType.WaitUntilStarted));
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, s => s with
+        {
+            State = KnownResourceStates.NotStarted
+        }).DefaultTimeout();
+
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
+        var waitTask = notificationService.WaitForDependenciesAsync(resource, cts.Token);
+
+        var waitingEvent = await notificationService.WaitForResourceAsync(
+            resource.Name,
+            re => re.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            cts.Token).DefaultTimeout();
+
+        Assert.Equal(KnownResourceStates.Waiting, waitingEvent.Snapshot.State?.Text);
+        Assert.Equal(new[] { dependency.Name }, GetWaitingForDependencies(waitingEvent));
+
+        await notificationService.PublishUpdateAsync(dependency, s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+
+        await waitTask.DefaultTimeout();
+    }
+
+    [Theory]
+    [InlineData(nameof(KnownResourceStates.Running))]
+    [InlineData(nameof(KnownResourceStates.Stopping))]
+    [InlineData(nameof(KnownResourceStates.Building))]
+    [InlineData(nameof(KnownResourceStates.Finished))]
+    [InlineData(nameof(KnownResourceStates.Exited))]
+    [InlineData(nameof(KnownResourceStates.FailedToStart))]
+    public async Task WaitForDependenciesDoesNotTransitionActiveOrTerminalResourceToWaiting(string state)
+    {
+        // The dependency wait is a model-level update, so it reaches every replica of the resource.
+        // Replicas that already started, are stopping, are being rebuilt, or have terminated must keep
+        // their state. In particular the rebuild command puts replicas into "Building" and relies on
+        // that surviving while a sibling replica is still waiting on dependencies.
+        var dependency = new CustomResource("dependency");
+        var resource = new CustomResource("resource");
+        resource.Annotations.Add(new WaitAnnotation(dependency, WaitType.WaitUntilStarted));
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, s => s with { State = state }).DefaultTimeout();
+
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
+        var waitTask = notificationService.WaitForDependenciesAsync(resource, cts.Token);
+
+        await notificationService.PublishUpdateAsync(dependency, s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+
+        await waitTask.DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState(resource.Name, out var resourceEvent));
+        Assert.Equal(state, resourceEvent.Snapshot.State?.Text);
+    }
+
+    [Fact]
     public async Task WaitForDependenciesPublishesResolvedWaitingForDependenciesForReplicas()
     {
         var dependency = new CustomResource("dependency");

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -573,6 +573,54 @@ public class ResourceNotificationTests
     }
 
     [Fact]
+    public async Task WaitForDependenciesDoesNotTransitionNotStartedReplicaToWaiting()
+    {
+        // "NotStarted" is only a valid pre-wait state for a resource that drives its own startup, and those
+        // resources always resolve to a single instance. Replicas are started individually, so a replica that
+        // is still "NotStarted" while a sibling is starting - for example with WithExplicitStart - was
+        // deliberately not started and must keep its state even though the wait is a model-level update.
+        var dependency = new CustomResource("dependency");
+        var resource = new CustomResource("resource");
+        resource.Annotations.Add(new DcpInstancesAnnotation([
+            new DcpInstance("resource-abc123", "abc123", 0),
+            new DcpInstance("resource-def456", "def456", 1)
+        ]));
+        resource.Annotations.Add(new WaitAnnotation(dependency, WaitType.WaitUntilStarted));
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, "resource-abc123", s => s with
+        {
+            State = KnownResourceStates.Starting
+        }).DefaultTimeout();
+        await notificationService.PublishUpdateAsync(resource, "resource-def456", s => s with
+        {
+            State = KnownResourceStates.NotStarted
+        }).DefaultTimeout();
+
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
+        var waitTask = notificationService.WaitForDependenciesAsync(resource, cts.Token);
+
+        await notificationService.WaitForResourceAsync(
+            resource.Name,
+            re => re.ResourceId == "resource-abc123" && re.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            cts.Token).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("resource-def456", out var notStartedEvent));
+        Assert.Equal(KnownResourceStates.NotStarted, notStartedEvent.Snapshot.State?.Text);
+
+        await notificationService.PublishUpdateAsync(dependency, s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+
+        await waitTask.DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("resource-def456", out notStartedEvent));
+        Assert.Equal(KnownResourceStates.NotStarted, notStartedEvent.Snapshot.State?.Text);
+    }
+
+    [Fact]
     public async Task WaitForDependenciesPublishesResolvedWaitingForDependenciesForReplicas()
     {
         var dependency = new CustomResource("dependency");

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -623,10 +623,6 @@ public class ResourceNotificationTests
     [Fact]
     public async Task WaitForDependenciesDoesNotTransitionNotStartedExplicitStartResourceToWaiting()
     {
-        // The same protection has to apply to a single-instance explicit start resource, not just to replicas.
-        // The public WaitForDependenciesAsync can be called on a stopped resource by any integration, and
-        // ApplicationOrchestrator.StartResourceAsync reads "Waiting" as proof that startup is already in flight -
-        // so relabelling here would make the start command silently never reach DCP.
         var dependency = new CustomResource("dependency");
         var resource = new CustomResource("resource");
         resource.Annotations.Add(new ExplicitStartupAnnotation());
@@ -652,6 +648,43 @@ public class ResourceNotificationTests
 
         Assert.True(notificationService.TryGetCurrentState("resource-abc123", out var notStartedEvent));
         Assert.Equal(KnownResourceStates.NotStarted, notStartedEvent.Snapshot.State?.Text);
+    }
+
+    [Fact]
+    public async Task WaitForDependenciesTransitionsNotStartedExplicitStartResourceWithoutDcpInstancesToWaiting()
+    {
+        // Resources not managed by Aspire (no instances) should transition to "Waiting" directly from NotStarted,
+        // regardless whether they have ExplicitStartAnnotation or not. The annotation does not really makes a difference here
+        // because it is only used to control the behavior of the orchestrator when starting a resource
+        // and since the resource has no instances, it is not subject to the orchestrator's start logic.
+        var dependency = new CustomResource("dependency");
+        var resource = new CustomResource("resource");
+        resource.Annotations.Add(new ExplicitStartupAnnotation());
+        resource.Annotations.Add(new WaitAnnotation(dependency, WaitType.WaitUntilStarted));
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, s => s with
+        {
+            State = KnownResourceStates.NotStarted
+        }).DefaultTimeout();
+
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
+        var waitTask = notificationService.WaitForDependenciesAsync(resource, cts.Token);
+
+        var waitingEvent = await notificationService.WaitForResourceAsync(
+            resource.Name,
+            re => re.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            cts.Token).DefaultTimeout();
+
+        Assert.Equal(new[] { dependency.Name }, GetWaitingForDependencies(waitingEvent));
+
+        await notificationService.PublishUpdateAsync(dependency, s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+
+        await waitTask.DefaultTimeout();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -575,12 +575,12 @@ public class ResourceNotificationTests
     [Fact]
     public async Task WaitForDependenciesDoesNotTransitionNotStartedReplicaToWaiting()
     {
-        // "NotStarted" is only a valid pre-wait state for a resource that drives its own startup, and those
-        // resources have no DCP instances at all. DCP instances are started individually, so an instance that
-        // is still "NotStarted" while a sibling is starting - for example with WithExplicitStart - was
-        // deliberately not started and must keep its state even though the wait is a model-level update.
+        // Replicas of an explicit start resource are started individually, so a replica that is still "NotStarted"
+        // while a sibling is starting was deliberately not started and must keep its state, even though the wait is
+        // published as a model-level update that reaches every replica.
         var dependency = new CustomResource("dependency");
         var resource = new CustomResource("resource");
+        resource.Annotations.Add(new ExplicitStartupAnnotation());
         resource.Annotations.Add(new DcpInstancesAnnotation([
             new DcpInstance("resource-abc123", "abc123", 0),
             new DcpInstance("resource-def456", "def456", 1)
@@ -621,16 +621,15 @@ public class ResourceNotificationTests
     }
 
     [Fact]
-    public async Task WaitForDependenciesDoesNotTransitionNotStartedSingleInstanceResourceToWaiting()
+    public async Task WaitForDependenciesDoesNotTransitionNotStartedExplicitStartResourceToWaiting()
     {
-        // Single-instance DCP resources (containers, executables, single-replica projects) never need the
-        // "NotStarted" exception either: the orchestrator publishes "Starting" for them before raising
-        // BeforeResourceStartedEvent. Allowing it would break WithExplicitStart, because the public
-        // WaitForDependenciesAsync can be called on a stopped resource by any integration, and
-        // ApplicationOrchestrator.StartResourceAsync reads "Waiting" as proof that startup is already in
-        // flight - so the start command would silently never reach DCP.
+        // The same protection has to apply to a single-instance explicit start resource, not just to replicas.
+        // The public WaitForDependenciesAsync can be called on a stopped resource by any integration, and
+        // ApplicationOrchestrator.StartResourceAsync reads "Waiting" as proof that startup is already in flight -
+        // so relabelling here would make the start command silently never reach DCP.
         var dependency = new CustomResource("dependency");
         var resource = new CustomResource("resource");
+        resource.Annotations.Add(new ExplicitStartupAnnotation());
         resource.Annotations.Add(new DcpInstancesAnnotation([new DcpInstance("resource-abc123", "abc123", 0)]));
         resource.Annotations.Add(new WaitAnnotation(dependency, WaitType.WaitUntilStarted));
 
@@ -653,6 +652,45 @@ public class ResourceNotificationTests
 
         Assert.True(notificationService.TryGetCurrentState("resource-abc123", out var notStartedEvent));
         Assert.Equal(KnownResourceStates.NotStarted, notStartedEvent.Snapshot.State?.Text);
+    }
+
+    [Fact]
+    public async Task WaitForDependenciesTransitionsNotStartedInstanceWithoutExplicitStartToWaiting()
+    {
+        // The guard is scoped to explicit start rather than to whether the resource has DCP instances. An instance
+        // that is "NotStarted" without the user having asked for that is simply about to start, so it must still get
+        // the "Waiting" label - otherwise the dashboard would under-report a resource that really is blocked.
+        var dependency = new CustomResource("dependency");
+        var resource = new CustomResource("resource");
+        resource.Annotations.Add(new DcpInstancesAnnotation([
+            new DcpInstance("resource-abc123", "abc123", 0),
+            new DcpInstance("resource-def456", "def456", 1)
+        ]));
+        resource.Annotations.Add(new WaitAnnotation(dependency, WaitType.WaitUntilStarted));
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, "resource-abc123", s => s with
+        {
+            State = KnownResourceStates.NotStarted
+        }).DefaultTimeout();
+
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
+        var waitTask = notificationService.WaitForDependenciesAsync(resource, cts.Token);
+
+        var waitingEvent = await notificationService.WaitForResourceAsync(
+            resource.Name,
+            re => re.ResourceId == "resource-abc123" && re.Snapshot.State?.Text == KnownResourceStates.Waiting,
+            cts.Token).DefaultTimeout();
+
+        Assert.Equal(new[] { dependency.Name }, GetWaitingForDependencies(waitingEvent));
+
+        await notificationService.PublishUpdateAsync(dependency, s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+
+        await waitTask.DefaultTimeout();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -576,7 +576,7 @@ public class ResourceNotificationTests
     public async Task WaitForDependenciesDoesNotTransitionNotStartedReplicaToWaiting()
     {
         // "NotStarted" is only a valid pre-wait state for a resource that drives its own startup, and those
-        // resources always resolve to a single instance. Replicas are started individually, so a replica that
+        // resources have no DCP instances at all. DCP instances are started individually, so an instance that
         // is still "NotStarted" while a sibling is starting - for example with WithExplicitStart - was
         // deliberately not started and must keep its state even though the wait is a model-level update.
         var dependency = new CustomResource("dependency");
@@ -617,6 +617,41 @@ public class ResourceNotificationTests
         await waitTask.DefaultTimeout();
 
         Assert.True(notificationService.TryGetCurrentState("resource-def456", out notStartedEvent));
+        Assert.Equal(KnownResourceStates.NotStarted, notStartedEvent.Snapshot.State?.Text);
+    }
+
+    [Fact]
+    public async Task WaitForDependenciesDoesNotTransitionNotStartedSingleInstanceResourceToWaiting()
+    {
+        // Single-instance DCP resources (containers, executables, single-replica projects) never need the
+        // "NotStarted" exception either: the orchestrator publishes "Starting" for them before raising
+        // BeforeResourceStartedEvent. Allowing it would break WithExplicitStart, because the public
+        // WaitForDependenciesAsync can be called on a stopped resource by any integration, and
+        // ApplicationOrchestrator.StartResourceAsync reads "Waiting" as proof that startup is already in
+        // flight - so the start command would silently never reach DCP.
+        var dependency = new CustomResource("dependency");
+        var resource = new CustomResource("resource");
+        resource.Annotations.Add(new DcpInstancesAnnotation([new DcpInstance("resource-abc123", "abc123", 0)]));
+        resource.Annotations.Add(new WaitAnnotation(dependency, WaitType.WaitUntilStarted));
+
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, "resource-abc123", s => s with
+        {
+            State = KnownResourceStates.NotStarted
+        }).DefaultTimeout();
+
+        using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource();
+        var waitTask = notificationService.WaitForDependenciesAsync(resource, cts.Token);
+
+        await notificationService.PublishUpdateAsync(dependency, s => s with
+        {
+            State = KnownResourceStates.Running
+        }).DefaultTimeout();
+
+        await waitTask.DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("resource-abc123", out var notStartedEvent));
         Assert.Equal(KnownResourceStates.NotStarted, notStartedEvent.Snapshot.State?.Text);
     }
 


### PR DESCRIPTION
## Description

Fix waiting behavior for custom resources (in some cases the wait is entirely skipped and resource is started with unmet dependencies).

Fixes https://github.com/microsoft/aspire/issues/17453

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
