### PR TITLE
Add configuration schemas for named integration resources

### DIFF
--- a/src/Components/Aspire.Azure.AI.Inference/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.AI.Inference/AssemblyInfo.cs
@@ -7,6 +7,8 @@ using Azure.AI.Inference;
 
 [assembly: ConfigurationSchema("Aspire:Azure:AI:Inference", typeof(ChatCompletionsClientSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:AI:Inference:ClientOptions", typeof(AzureAIInferenceClientOptions))]
+[assembly: ConfigurationSchema("Aspire:Azure:AI:Inference:*", typeof(ChatCompletionsClientSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:AI:Inference:*:ClientOptions", typeof(AzureAIInferenceClientOptions))]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.AI.Inference/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.AI.Inference/ConfigurationSchema.json
@@ -146,7 +146,130 @@
                       "description": "Gets or sets the API key used for authentication with the Azure AI service."
                     }
                   },
-                  "description": "Represents configuration settings for Azure AI Chat Completions client."
+                  "description": "Represents configuration settings for Azure AI Chat Completions client.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "Diagnostics": {
+                            "type": "object",
+                            "properties": {
+                              "ApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                              },
+                              "DefaultApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                              },
+                              "IsDistributedTracingEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                              },
+                              "IsLoggingContentEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request or response content should be logged."
+                              },
+                              "IsLoggingEnabled": {
+                                "type": "boolean",
+                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                              },
+                              "IsTelemetryEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                              },
+                              "LoggedContentSizeLimit": {
+                                "type": "integer",
+                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                              },
+                              "LoggedHeaderNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of header names that are not redacted during logging."
+                              },
+                              "LoggedQueryParameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                              }
+                            },
+                            "description": "Gets the client diagnostic options."
+                          },
+                          "Retry": {
+                            "type": "object",
+                            "properties": {
+                              "Delay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxDelay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxRetries": {
+                                "type": "integer",
+                                "description": "The maximum number of retry attempts before giving up."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Fixed",
+                                  "Exponential"
+                                ],
+                                "description": "The approach to use for calculating retry delays."
+                              },
+                              "NetworkTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The timeout applied to individual network operations."
+                              }
+                            },
+                            "description": "Gets the client retry options."
+                          }
+                        },
+                        "description": "Client options for Azure.AI.Inference library clients."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string used to connect to the AI Foundry account."
+                      },
+                      "DeploymentName": {
+                        "type": "string",
+                        "description": "Gets or sets the name of the AI model deployment to use for chat completions."
+                      },
+                      "DisableMetrics": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "EnableSensitiveTelemetryData": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                      },
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Gets or sets the endpoint URI for the Azure AI service."
+                      },
+                      "Key": {
+                        "type": "string",
+                        "description": "Gets or sets the API key used for authentication with the Azure AI service."
+                      }
+                    },
+                    "description": "Represents configuration settings for Azure AI Chat Completions client."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.AI.Inference/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.AI.Inference/ConfigurationSchema.json
@@ -117,7 +117,27 @@
                           "description": "Client options for Azure.AI.Inference library clients."
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "Diagnostics"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Retry"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/Components/Aspire.Azure.AI.Inference/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.AI.Inference/ConfigurationSchema.json
@@ -29,246 +29,311 @@
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "Diagnostics": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "ApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                            },
-                            "DefaultApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                            },
-                            "IsDistributedTracingEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                            },
-                            "IsLoggingContentEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request or response content should be logged."
-                            },
-                            "IsLoggingEnabled": {
-                              "type": "boolean",
-                              "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                            },
-                            "IsTelemetryEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                            },
-                            "LoggedContentSizeLimit": {
-                              "type": "integer",
-                              "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                            },
-                            "LoggedHeaderNames": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Diagnostics": {
+                              "type": "object",
+                              "properties": {
+                                "ApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                },
+                                "DefaultApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                },
+                                "IsDistributedTracingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                },
+                                "IsLoggingContentEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request or response content should be logged."
+                                },
+                                "IsLoggingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                },
+                                "IsTelemetryEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                },
+                                "LoggedContentSizeLimit": {
+                                  "type": "integer",
+                                  "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                },
+                                "LoggedHeaderNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of header names that are not redacted during logging."
+                                },
+                                "LoggedQueryParameters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of query parameter names that are not redacted during logging."
+                                }
                               },
-                              "description": "Gets a list of header names that are not redacted during logging."
+                              "description": "Gets the client diagnostic options."
                             },
-                            "LoggedQueryParameters": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Retry": {
+                              "type": "object",
+                              "properties": {
+                                "Delay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxDelay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxRetries": {
+                                  "type": "integer",
+                                  "description": "The maximum number of retry attempts before giving up."
+                                },
+                                "Mode": {
+                                  "enum": [
+                                    "Fixed",
+                                    "Exponential"
+                                  ],
+                                  "description": "The approach to use for calculating retry delays."
+                                },
+                                "NetworkTimeout": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The timeout applied to individual network operations."
+                                }
                               },
-                              "description": "Gets a list of query parameter names that are not redacted during logging."
+                              "description": "Gets the client retry options."
                             }
                           },
-                          "description": "Gets the client diagnostic options."
+                          "description": "Client options for Azure.AI.Inference library clients."
                         },
-                        "Retry": {
-                          "type": "object",
-                          "properties": {
-                            "Delay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxDelay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxRetries": {
-                              "type": "integer",
-                              "description": "The maximum number of retry attempts before giving up."
-                            },
-                            "Mode": {
-                              "enum": [
-                                "Fixed",
-                                "Exponential"
-                              ],
-                              "description": "The approach to use for calculating retry delays."
-                            },
-                            "NetworkTimeout": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The timeout applied to individual network operations."
-                            }
-                          },
-                          "description": "Gets the client retry options."
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "Client options for Azure.AI.Inference library clients."
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string used to connect to the AI Foundry account."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string used to connect to the AI Foundry account."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DeploymentName": {
-                      "type": "string",
-                      "description": "Gets or sets the name of the AI model deployment to use for chat completions."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the name of the AI model deployment to use for chat completions."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableMetrics": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "EnableSensitiveTelemetryData": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "Endpoint": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "Gets or sets the endpoint URI for the Azure AI service."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "Gets or sets the endpoint URI for the Azure AI service."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "Key": {
-                      "type": "string",
-                      "description": "Gets or sets the API key used for authentication with the Azure AI service."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the API key used for authentication with the Azure AI service."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/Inference/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Represents configuration settings for Azure AI Chat Completions client.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
                         "type": "object",
                         "properties": {
-                          "Diagnostics": {
+                          "ClientOptions": {
                             "type": "object",
                             "properties": {
-                              "ApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                              },
-                              "DefaultApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                              },
-                              "IsDistributedTracingEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                              },
-                              "IsLoggingContentEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request or response content should be logged."
-                              },
-                              "IsLoggingEnabled": {
-                                "type": "boolean",
-                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                              },
-                              "IsTelemetryEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                              },
-                              "LoggedContentSizeLimit": {
-                                "type": "integer",
-                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                              },
-                              "LoggedHeaderNames": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "Diagnostics": {
+                                "type": "object",
+                                "properties": {
+                                  "ApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                  },
+                                  "DefaultApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                  },
+                                  "IsDistributedTracingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                  },
+                                  "IsLoggingContentEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request or response content should be logged."
+                                  },
+                                  "IsLoggingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                  },
+                                  "IsTelemetryEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                  },
+                                  "LoggedContentSizeLimit": {
+                                    "type": "integer",
+                                    "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                  },
+                                  "LoggedHeaderNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of header names that are not redacted during logging."
+                                  },
+                                  "LoggedQueryParameters": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of query parameter names that are not redacted during logging."
+                                  }
                                 },
-                                "description": "Gets a list of header names that are not redacted during logging."
+                                "description": "Gets the client diagnostic options."
                               },
-                              "LoggedQueryParameters": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "Retry": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before giving up."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "NetworkTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The timeout applied to individual network operations."
+                                  }
                                 },
-                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                                "description": "Gets the client retry options."
                               }
                             },
-                            "description": "Gets the client diagnostic options."
+                            "description": "Client options for Azure.AI.Inference library clients."
                           },
-                          "Retry": {
-                            "type": "object",
-                            "properties": {
-                              "Delay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxDelay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxRetries": {
-                                "type": "integer",
-                                "description": "The maximum number of retry attempts before giving up."
-                              },
-                              "Mode": {
-                                "enum": [
-                                  "Fixed",
-                                  "Exponential"
-                                ],
-                                "description": "The approach to use for calculating retry delays."
-                              },
-                              "NetworkTimeout": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The timeout applied to individual network operations."
-                              }
-                            },
-                            "description": "Gets the client retry options."
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the AI Foundry account."
+                          },
+                          "DeploymentName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the AI model deployment to use for chat completions."
+                          },
+                          "DisableMetrics": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "EnableSensitiveTelemetryData": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                          },
+                          "Endpoint": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Gets or sets the endpoint URI for the Azure AI service."
+                          },
+                          "Key": {
+                            "type": "string",
+                            "description": "Gets or sets the API key used for authentication with the Azure AI service."
                           }
                         },
-                        "description": "Client options for Azure.AI.Inference library clients."
-                      },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string used to connect to the AI Foundry account."
-                      },
-                      "DeploymentName": {
-                        "type": "string",
-                        "description": "Gets or sets the name of the AI model deployment to use for chat completions."
-                      },
-                      "DisableMetrics": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "EnableSensitiveTelemetryData": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
-                      },
-                      "Endpoint": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "Gets or sets the endpoint URI for the Azure AI service."
-                      },
-                      "Key": {
-                        "type": "string",
-                        "description": "Gets or sets the API key used for authentication with the Azure AI service."
+                        "description": "Represents configuration settings for Azure AI Chat Completions client."
                       }
-                    },
-                    "description": "Represents configuration settings for Azure AI Chat Completions client."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Azure.AI.OpenAI/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.AI.OpenAI/AssemblyInfo.cs
@@ -7,6 +7,8 @@ using Azure.AI.OpenAI;
 
 [assembly: ConfigurationSchema("Aspire:Azure:AI:OpenAI", typeof(AzureOpenAISettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:AI:OpenAI:ClientOptions", typeof(AzureOpenAIClientOptions))]
+[assembly: ConfigurationSchema("Aspire:Azure:AI:OpenAI:*", typeof(AzureOpenAISettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:AI:OpenAI:*:ClientOptions", typeof(AzureOpenAIClientOptions))]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
@@ -119,7 +119,103 @@
                       "description": "Gets or sets the key to use to authenticate to the Azure OpenAI endpoint."
                     }
                   },
-                  "description": "The settings relevant to accessing Azure OpenAI or OpenAI."
+                  "description": "The settings relevant to accessing Azure OpenAI or OpenAI.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "ClientLoggingOptions": {
+                            "type": "object",
+                            "properties": {
+                              "AllowedHeaderNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets or sets a list of header names that are not redacted during logging."
+                              },
+                              "AllowedQueryParameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets or sets a list of query parameter names that are not redacted during logging."
+                              },
+                              "EnableLogging": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                              },
+                              "EnableMessageContentLogging": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request and response content should be logged."
+                              },
+                              "EnableMessageLogging": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request and response uri and header information should be logged."
+                              },
+                              "MessageContentSizeLimit": {
+                                "type": "integer",
+                                "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                              }
+                            },
+                            "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
+                          },
+                          "DefaultHeaders": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "DefaultQueryParameters": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "EnableDistributedTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
+                          },
+                          "NetworkTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "The timeout applied to an individual network operation."
+                          },
+                          "UserAgentApplicationId": {
+                            "type": "string",
+                            "description": "An optional application ID to use as part of the request User-Agent header."
+                          }
+                        },
+                        "description": "Defines the scenario-independent, client-level options for the Azure-specific OpenAI client."
+                      },
+                      "DisableMetrics": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "EnableSensitiveTelemetryData": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                      },
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Gets or sets a 'System.Uri' referencing the Azure OpenAI endpoint. This is likely to be similar to \"https://{account_name}.openai.azure.com\"."
+                      },
+                      "Key": {
+                        "type": "string",
+                        "description": "Gets or sets the key to use to authenticate to the Azure OpenAI endpoint."
+                      }
+                    },
+                    "description": "The settings relevant to accessing Azure OpenAI or OpenAI."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
@@ -29,192 +29,243 @@
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "ClientLoggingOptions": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "AllowedHeaderNames": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "ClientLoggingOptions": {
+                              "type": "object",
+                              "properties": {
+                                "AllowedHeaderNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets or sets a list of header names that are not redacted during logging."
+                                },
+                                "AllowedQueryParameters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets or sets a list of query parameter names that are not redacted during logging."
+                                },
+                                "EnableLogging": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                                },
+                                "EnableMessageContentLogging": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request and response content should be logged."
+                                },
+                                "EnableMessageLogging": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request and response uri and header information should be logged."
+                                },
+                                "MessageContentSizeLimit": {
+                                  "type": "integer",
+                                  "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                                }
                               },
-                              "description": "Gets or sets a list of header names that are not redacted during logging."
+                              "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
                             },
-                            "AllowedQueryParameters": {
-                              "type": "array",
-                              "items": {
+                            "DefaultHeaders": {
+                              "type": "object",
+                              "additionalProperties": {
                                 "type": "string"
-                              },
-                              "description": "Gets or sets a list of query parameter names that are not redacted during logging."
+                              }
                             },
-                            "EnableLogging": {
+                            "DefaultQueryParameters": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "EnableDistributedTracing": {
                               "type": "boolean",
-                              "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                              "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
                             },
-                            "EnableMessageContentLogging": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request and response content should be logged."
+                            "NetworkTimeout": {
+                              "type": "string",
+                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                              "description": "The timeout applied to an individual network operation."
                             },
-                            "EnableMessageLogging": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request and response uri and header information should be logged."
-                            },
-                            "MessageContentSizeLimit": {
-                              "type": "integer",
-                              "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                            "UserAgentApplicationId": {
+                              "type": "string",
+                              "description": "An optional application ID to use as part of the request User-Agent header."
                             }
                           },
-                          "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
+                          "description": "Defines the scenario-independent, client-level options for the Azure-specific OpenAI client."
                         },
-                        "DefaultHeaders": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "string"
-                          }
-                        },
-                        "DefaultQueryParameters": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "string"
-                          }
-                        },
-                        "EnableDistributedTracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
-                        },
-                        "NetworkTimeout": {
-                          "type": "string",
-                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                          "description": "The timeout applied to an individual network operation."
-                        },
-                        "UserAgentApplicationId": {
-                          "type": "string",
-                          "description": "An optional application ID to use as part of the request User-Agent header."
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/OpenAI/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "Defines the scenario-independent, client-level options for the Azure-specific OpenAI client."
+                      ]
                     },
                     "DisableMetrics": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/OpenAI/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/OpenAI/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "EnableSensitiveTelemetryData": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/OpenAI/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "Endpoint": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "Gets or sets a 'System.Uri' referencing the Azure OpenAI endpoint. This is likely to be similar to \"https://{account_name}.openai.azure.com\"."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "Gets or sets a 'System.Uri' referencing the Azure OpenAI endpoint. This is likely to be similar to \"https://{account_name}.openai.azure.com\"."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/OpenAI/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "Key": {
-                      "type": "string",
-                      "description": "Gets or sets the key to use to authenticate to the Azure OpenAI endpoint."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the key to use to authenticate to the Azure OpenAI endpoint."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/OpenAI/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "The settings relevant to accessing Azure OpenAI or OpenAI.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
                         "type": "object",
                         "properties": {
-                          "ClientLoggingOptions": {
+                          "ClientOptions": {
                             "type": "object",
                             "properties": {
-                              "AllowedHeaderNames": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "ClientLoggingOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "AllowedHeaderNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets or sets a list of header names that are not redacted during logging."
+                                  },
+                                  "AllowedQueryParameters": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets or sets a list of query parameter names that are not redacted during logging."
+                                  },
+                                  "EnableLogging": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                                  },
+                                  "EnableMessageContentLogging": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request and response content should be logged."
+                                  },
+                                  "EnableMessageLogging": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request and response uri and header information should be logged."
+                                  },
+                                  "MessageContentSizeLimit": {
+                                    "type": "integer",
+                                    "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                                  }
                                 },
-                                "description": "Gets or sets a list of header names that are not redacted during logging."
+                                "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
                               },
-                              "AllowedQueryParameters": {
-                                "type": "array",
-                                "items": {
+                              "DefaultHeaders": {
+                                "type": "object",
+                                "additionalProperties": {
                                   "type": "string"
-                                },
-                                "description": "Gets or sets a list of query parameter names that are not redacted during logging."
+                                }
                               },
-                              "EnableLogging": {
+                              "DefaultQueryParameters": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "EnableDistributedTracing": {
                                 "type": "boolean",
-                                "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                                "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
                               },
-                              "EnableMessageContentLogging": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request and response content should be logged."
+                              "NetworkTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The timeout applied to an individual network operation."
                               },
-                              "EnableMessageLogging": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request and response uri and header information should be logged."
-                              },
-                              "MessageContentSizeLimit": {
-                                "type": "integer",
-                                "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                              "UserAgentApplicationId": {
+                                "type": "string",
+                                "description": "An optional application ID to use as part of the request User-Agent header."
                               }
                             },
-                            "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
+                            "description": "Defines the scenario-independent, client-level options for the Azure-specific OpenAI client."
                           },
-                          "DefaultHeaders": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "string"
-                            }
-                          },
-                          "DefaultQueryParameters": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "string"
-                            }
-                          },
-                          "EnableDistributedTracing": {
+                          "DisableMetrics": {
                             "type": "boolean",
-                            "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
+                            "default": false
                           },
-                          "NetworkTimeout": {
-                            "type": "string",
-                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                            "description": "The timeout applied to an individual network operation."
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
                           },
-                          "UserAgentApplicationId": {
+                          "EnableSensitiveTelemetryData": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                          },
+                          "Endpoint": {
                             "type": "string",
-                            "description": "An optional application ID to use as part of the request User-Agent header."
+                            "format": "uri",
+                            "description": "Gets or sets a 'System.Uri' referencing the Azure OpenAI endpoint. This is likely to be similar to \"https://{account_name}.openai.azure.com\"."
+                          },
+                          "Key": {
+                            "type": "string",
+                            "description": "Gets or sets the key to use to authenticate to the Azure OpenAI endpoint."
                           }
                         },
-                        "description": "Defines the scenario-independent, client-level options for the Azure-specific OpenAI client."
-                      },
-                      "DisableMetrics": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "EnableSensitiveTelemetryData": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
-                      },
-                      "Endpoint": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "Gets or sets a 'System.Uri' referencing the Azure OpenAI endpoint. This is likely to be similar to \"https://{account_name}.openai.azure.com\"."
-                      },
-                      "Key": {
-                        "type": "string",
-                        "description": "Gets or sets the key to use to authenticate to the Azure OpenAI endpoint."
+                        "description": "The settings relevant to accessing Azure OpenAI or OpenAI."
                       }
-                    },
-                    "description": "The settings relevant to accessing Azure OpenAI or OpenAI."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
@@ -98,7 +98,47 @@
                           "description": "Defines the scenario-independent, client-level options for the Azure-specific OpenAI client."
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/OpenAI/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/AI/properties/OpenAI/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "UserAgentApplicationId"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "DefaultHeaders"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "DefaultQueryParameters"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "NetworkTimeout"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "ClientLoggingOptions"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "EnableDistributedTracing"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/Components/Aspire.Azure.Data.Tables/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AssemblyInfo.cs
@@ -7,6 +7,8 @@ using Azure.Data.Tables;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Data:Tables", typeof(AzureDataTablesSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Data:Tables:ClientOptions", typeof(TableClientOptions), exclusionPaths: ["Default"])]
+[assembly: ConfigurationSchema("Aspire:Azure:Data:Tables:*", typeof(AzureDataTablesSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Data:Tables:*:ClientOptions", typeof(TableClientOptions), exclusionPaths: ["Default"])]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.Data.Tables/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Data.Tables/ConfigurationSchema.json
@@ -121,7 +121,32 @@
                           "description": "Options to configure the requests to the Table service."
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/Data/properties/Tables/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Data/properties/Tables/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "EnableTenantDiscovery"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Diagnostics"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Retry"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/Components/Aspire.Azure.Data.Tables/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Data.Tables/ConfigurationSchema.json
@@ -29,230 +29,274 @@
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "Diagnostics": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "ApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                            },
-                            "DefaultApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                            },
-                            "IsDistributedTracingEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                            },
-                            "IsLoggingContentEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request or response content should be logged."
-                            },
-                            "IsLoggingEnabled": {
-                              "type": "boolean",
-                              "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                            },
-                            "IsTelemetryEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                            },
-                            "LoggedContentSizeLimit": {
-                              "type": "integer",
-                              "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                            },
-                            "LoggedHeaderNames": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Diagnostics": {
+                              "type": "object",
+                              "properties": {
+                                "ApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                },
+                                "DefaultApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                },
+                                "IsDistributedTracingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                },
+                                "IsLoggingContentEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request or response content should be logged."
+                                },
+                                "IsLoggingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                },
+                                "IsTelemetryEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                },
+                                "LoggedContentSizeLimit": {
+                                  "type": "integer",
+                                  "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                },
+                                "LoggedHeaderNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of header names that are not redacted during logging."
+                                },
+                                "LoggedQueryParameters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of query parameter names that are not redacted during logging."
+                                }
                               },
-                              "description": "Gets a list of header names that are not redacted during logging."
+                              "description": "Gets the client diagnostic options."
                             },
-                            "LoggedQueryParameters": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "EnableTenantDiscovery": {
+                              "type": "boolean",
+                              "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When true, the client will attempt an initial un-authorized request to prompt an OAuth challenge in order to discover the correct tenant for the resource."
+                            },
+                            "Retry": {
+                              "type": "object",
+                              "properties": {
+                                "Delay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxDelay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxRetries": {
+                                  "type": "integer",
+                                  "description": "The maximum number of retry attempts before giving up."
+                                },
+                                "Mode": {
+                                  "enum": [
+                                    "Fixed",
+                                    "Exponential"
+                                  ],
+                                  "description": "The approach to use for calculating retry delays."
+                                },
+                                "NetworkTimeout": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The timeout applied to individual network operations."
+                                }
                               },
-                              "description": "Gets a list of query parameter names that are not redacted during logging."
+                              "description": "Gets the client retry options."
                             }
                           },
-                          "description": "Gets the client diagnostic options."
+                          "description": "Options to configure the requests to the Table service."
                         },
-                        "EnableTenantDiscovery": {
-                          "type": "boolean",
-                          "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When true, the client will attempt an initial un-authorized request to prompt an OAuth challenge in order to discover the correct tenant for the resource."
-                        },
-                        "Retry": {
-                          "type": "object",
-                          "properties": {
-                            "Delay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxDelay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxRetries": {
-                              "type": "integer",
-                              "description": "The maximum number of retry attempts before giving up."
-                            },
-                            "Mode": {
-                              "enum": [
-                                "Fixed",
-                                "Exponential"
-                              ],
-                              "description": "The approach to use for calculating retry delays."
-                            },
-                            "NetworkTimeout": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The timeout applied to individual network operations."
-                            }
-                          },
-                          "description": "Gets the client retry options."
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Data/properties/Tables/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "Options to configure the requests to the Table service."
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string used to connect to the table service account."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string used to connect to the table service account."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Data/properties/Tables/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Data/properties/Tables/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Data/properties/Tables/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ServiceUri": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "A 'System.Uri' referencing the table service account. This is likely to be similar to \"https://{account_name}.table.core.windows.net/\" or \"https://{account_name}.table.cosmos.azure.com/\"."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A 'System.Uri' referencing the table service account. This is likely to be similar to \"https://{account_name}.table.core.windows.net/\" or \"https://{account_name}.table.cosmos.azure.com/\"."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Data/properties/Tables/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Tables.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
                         "type": "object",
                         "properties": {
-                          "Diagnostics": {
+                          "ClientOptions": {
                             "type": "object",
                             "properties": {
-                              "ApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                              },
-                              "DefaultApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                              },
-                              "IsDistributedTracingEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                              },
-                              "IsLoggingContentEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request or response content should be logged."
-                              },
-                              "IsLoggingEnabled": {
-                                "type": "boolean",
-                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                              },
-                              "IsTelemetryEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                              },
-                              "LoggedContentSizeLimit": {
-                                "type": "integer",
-                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                              },
-                              "LoggedHeaderNames": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "Diagnostics": {
+                                "type": "object",
+                                "properties": {
+                                  "ApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                  },
+                                  "DefaultApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                  },
+                                  "IsDistributedTracingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                  },
+                                  "IsLoggingContentEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request or response content should be logged."
+                                  },
+                                  "IsLoggingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                  },
+                                  "IsTelemetryEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                  },
+                                  "LoggedContentSizeLimit": {
+                                    "type": "integer",
+                                    "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                  },
+                                  "LoggedHeaderNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of header names that are not redacted during logging."
+                                  },
+                                  "LoggedQueryParameters": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of query parameter names that are not redacted during logging."
+                                  }
                                 },
-                                "description": "Gets a list of header names that are not redacted during logging."
+                                "description": "Gets the client diagnostic options."
                               },
-                              "LoggedQueryParameters": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "EnableTenantDiscovery": {
+                                "type": "boolean",
+                                "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When true, the client will attempt an initial un-authorized request to prompt an OAuth challenge in order to discover the correct tenant for the resource."
+                              },
+                              "Retry": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before giving up."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "NetworkTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The timeout applied to individual network operations."
+                                  }
                                 },
-                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                                "description": "Gets the client retry options."
                               }
                             },
-                            "description": "Gets the client diagnostic options."
+                            "description": "Options to configure the requests to the Table service."
                           },
-                          "EnableTenantDiscovery": {
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the table service account."
+                          },
+                          "DisableHealthChecks": {
                             "type": "boolean",
-                            "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When true, the client will attempt an initial un-authorized request to prompt an OAuth challenge in order to discover the correct tenant for the resource."
+                            "description": "Gets or sets a boolean value that indicates whether the health check is disabled or not.",
+                            "default": false
                           },
-                          "Retry": {
-                            "type": "object",
-                            "properties": {
-                              "Delay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxDelay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxRetries": {
-                                "type": "integer",
-                                "description": "The maximum number of retry attempts before giving up."
-                              },
-                              "Mode": {
-                                "enum": [
-                                  "Fixed",
-                                  "Exponential"
-                                ],
-                                "description": "The approach to use for calculating retry delays."
-                              },
-                              "NetworkTimeout": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The timeout applied to individual network operations."
-                              }
-                            },
-                            "description": "Gets the client retry options."
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "ServiceUri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "A 'System.Uri' referencing the table service account. This is likely to be similar to \"https://{account_name}.table.core.windows.net/\" or \"https://{account_name}.table.cosmos.azure.com/\"."
                           }
                         },
-                        "description": "Options to configure the requests to the Table service."
-                      },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string used to connect to the table service account."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "ServiceUri": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "A 'System.Uri' referencing the table service account. This is likely to be similar to \"https://{account_name}.table.core.windows.net/\" or \"https://{account_name}.table.cosmos.azure.com/\"."
+                        "description": "Provides the client configuration settings for connecting to Azure Tables."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to Azure Tables."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Azure.Data.Tables/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Data.Tables/ConfigurationSchema.json
@@ -138,7 +138,122 @@
                       "description": "A 'System.Uri' referencing the table service account. This is likely to be similar to \"https://{account_name}.table.core.windows.net/\" or \"https://{account_name}.table.cosmos.azure.com/\"."
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to Azure Tables."
+                  "description": "Provides the client configuration settings for connecting to Azure Tables.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "Diagnostics": {
+                            "type": "object",
+                            "properties": {
+                              "ApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                              },
+                              "DefaultApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                              },
+                              "IsDistributedTracingEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                              },
+                              "IsLoggingContentEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request or response content should be logged."
+                              },
+                              "IsLoggingEnabled": {
+                                "type": "boolean",
+                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                              },
+                              "IsTelemetryEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                              },
+                              "LoggedContentSizeLimit": {
+                                "type": "integer",
+                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                              },
+                              "LoggedHeaderNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of header names that are not redacted during logging."
+                              },
+                              "LoggedQueryParameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                              }
+                            },
+                            "description": "Gets the client diagnostic options."
+                          },
+                          "EnableTenantDiscovery": {
+                            "type": "boolean",
+                            "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When true, the client will attempt an initial un-authorized request to prompt an OAuth challenge in order to discover the correct tenant for the resource."
+                          },
+                          "Retry": {
+                            "type": "object",
+                            "properties": {
+                              "Delay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxDelay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxRetries": {
+                                "type": "integer",
+                                "description": "The maximum number of retry attempts before giving up."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Fixed",
+                                  "Exponential"
+                                ],
+                                "description": "The approach to use for calculating retry delays."
+                              },
+                              "NetworkTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The timeout applied to individual network operations."
+                              }
+                            },
+                            "description": "Gets the client retry options."
+                          }
+                        },
+                        "description": "Options to configure the requests to the Table service."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string used to connect to the table service account."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "ServiceUri": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A 'System.Uri' referencing the table service account. This is likely to be similar to \"https://{account_name}.table.core.windows.net/\" or \"https://{account_name}.table.cosmos.azure.com/\"."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to Azure Tables."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/AssemblyInfo.cs
@@ -10,18 +10,28 @@ using Azure.Messaging.EventHubs.Producer;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubConsumerClient", typeof(AzureMessagingEventHubsConsumerSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubConsumerClient:ClientOptions", typeof(EventHubConsumerClientOptions))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubConsumerClient:*", typeof(AzureMessagingEventHubsConsumerSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubConsumerClient:*:ClientOptions", typeof(EventHubConsumerClientOptions))]
 
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubProducerClient", typeof(AzureMessagingEventHubsProducerSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubProducerClient:ClientOptions", typeof(EventHubProducerClientOptions))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubProducerClient:*", typeof(AzureMessagingEventHubsProducerSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubProducerClient:*:ClientOptions", typeof(EventHubProducerClientOptions))]
 
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventProcessorClient", typeof(AzureMessagingEventHubsProcessorSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventProcessorClient:ClientOptions", typeof(EventProcessorClientOptions))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventProcessorClient:*", typeof(AzureMessagingEventHubsProcessorSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventProcessorClient:*:ClientOptions", typeof(EventProcessorClientOptions))]
 
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:PartitionReceiver", typeof(AzureMessagingEventHubsPartitionReceiverSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:PartitionReceiver:ClientOptions", typeof(PartitionReceiverOptions))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:PartitionReceiver:*", typeof(AzureMessagingEventHubsPartitionReceiverSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:PartitionReceiver:*:ClientOptions", typeof(PartitionReceiverOptions))]
 
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubBufferedProducerClient", typeof(AzureMessagingEventHubsBufferedProducerSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubBufferedProducerClient:ClientOptions", typeof(EventHubBufferedProducerClientOptions))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubBufferedProducerClient:*", typeof(AzureMessagingEventHubsBufferedProducerSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:EventHubs:EventHubBufferedProducerClient:*:ClientOptions", typeof(EventHubBufferedProducerClientOptions))]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
@@ -35,1218 +35,1515 @@
                       "type": "object",
                       "properties": {
                         "ClientOptions": {
-                          "type": "object",
-                          "properties": {
-                            "ConnectionOptions": {
+                          "anyOf": [
+                            {
                               "type": "object",
                               "properties": {
-                                "ConnectionIdleTimeout": {
+                                "ConnectionOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "ConnectionIdleTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    },
+                                    "CustomEndpointAddress": {
+                                      "type": "string",
+                                      "format": "uri",
+                                      "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                    },
+                                    "ReceiveBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for receiving information via the active transport."
+                                    },
+                                    "SendBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for sending information via the active transport."
+                                    },
+                                    "TransportType": {
+                                      "enum": [
+                                        "AmqpTcp",
+                                        "AmqpWebSockets"
+                                      ],
+                                      "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                    }
+                                  },
+                                  "description": "The options used for configuring the connection to the Event Hubs service."
+                                },
+                                "EnableIdempotentRetries": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing will attempt to avoid duplication with a minor cost to throughput.  Duplicates are still possible but the chance of them occurring is much lower when idempotent retries are enabled."
+                                },
+                                "Identifier": {
+                                  "type": "string",
+                                  "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
+                                },
+                                "MaximumConcurrentSends": {
+                                  "type": "integer",
+                                  "description": "The total number of batches that may be sent concurrently, across all partitions.  This limit takes precedence over the value specified in 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition', ensuring this maximum is respected."
+                                },
+                                "MaximumConcurrentSendsPerPartition": {
+                                  "type": "integer",
+                                  "description": "The number of batches that may be sent concurrently for a given partition.  This option is superseded by the value specified for 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSends', ensuring that limit is respected."
+                                },
+                                "MaximumEventBufferLengthPerPartition": {
+                                  "type": "integer",
+                                  "description": "The total number of events that can be buffered for publishing at a given time for a given partition.  Once this capacity is reached, more events can enqueued by calling 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventAsync(Azure.Messaging.EventHubs.EventData,Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)' or 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventsAsync(System.Collections.Generic.IEnumerable{Azure.Messaging.EventHubs.EventData},Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)', which will automatically wait for room to be available."
+                                },
+                                "MaximumWaitTime": {
                                   "type": "string",
                                   "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  "description": "The amount of time to wait for a batch to be built with events in the buffer before publishing a partially full batch."
                                 },
-                                "CustomEndpointAddress": {
-                                  "type": "string",
-                                  "format": "uri",
-                                  "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
-                                },
-                                "ReceiveBufferSizeInBytes": {
-                                  "type": "integer",
-                                  "description": "The size of the buffer used for receiving information via the active transport."
-                                },
-                                "SendBufferSizeInBytes": {
-                                  "type": "integer",
-                                  "description": "The size of the buffer used for sending information via the active transport."
-                                },
-                                "TransportType": {
-                                  "enum": [
-                                    "AmqpTcp",
-                                    "AmqpWebSockets"
-                                  ],
-                                  "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                "RetryOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Delay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                    },
+                                    "MaximumDelay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum permissible delay between retry attempts."
+                                    },
+                                    "MaximumRetries": {
+                                      "type": "integer",
+                                      "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                    },
+                                    "Mode": {
+                                      "enum": [
+                                        "Fixed",
+                                        "Exponential"
+                                      ],
+                                      "description": "The approach to use for calculating retry delays."
+                                    },
+                                    "TryTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                    }
+                                  },
+                                  "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
                                 }
                               },
-                              "description": "The options used for configuring the connection to the Event Hubs service."
+                              "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient' to configure its behavior."
                             },
-                            "EnableIdempotentRetries": {
-                              "type": "boolean",
-                              "description": "Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing will attempt to avoid duplication with a minor cost to throughput.  Duplicates are still possible but the chance of them occurring is much lower when idempotent retries are enabled."
-                            },
-                            "Identifier": {
-                              "type": "string",
-                              "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
-                            },
-                            "MaximumConcurrentSends": {
-                              "type": "integer",
-                              "description": "The total number of batches that may be sent concurrently, across all partitions.  This limit takes precedence over the value specified in 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition', ensuring this maximum is respected."
-                            },
-                            "MaximumConcurrentSendsPerPartition": {
-                              "type": "integer",
-                              "description": "The number of batches that may be sent concurrently for a given partition.  This option is superseded by the value specified for 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSends', ensuring that limit is respected."
-                            },
-                            "MaximumEventBufferLengthPerPartition": {
-                              "type": "integer",
-                              "description": "The total number of events that can be buffered for publishing at a given time for a given partition.  Once this capacity is reached, more events can enqueued by calling 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventAsync(Azure.Messaging.EventHubs.EventData,Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)' or 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventsAsync(System.Collections.Generic.IEnumerable{Azure.Messaging.EventHubs.EventData},Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)', which will automatically wait for room to be available."
-                            },
-                            "MaximumWaitTime": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The amount of time to wait for a batch to be built with events in the buffer before publishing a partially full batch."
-                            },
-                            "RetryOptions": {
-                              "type": "object",
-                              "properties": {
-                                "Delay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                },
-                                "MaximumDelay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum permissible delay between retry attempts."
-                                },
-                                "MaximumRetries": {
-                                  "type": "integer",
-                                  "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                },
-                                "Mode": {
-                                  "enum": [
-                                    "Fixed",
-                                    "Exponential"
-                                  ],
-                                  "description": "The approach to use for calculating retry delays."
-                                },
-                                "TryTimeout": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                }
-                              },
-                              "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubBufferedProducerClient/additionalProperties/anyOf/1"
                             }
-                          },
-                          "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient' to configure its behavior."
+                          ]
                         },
                         "ConnectionString": {
-                          "type": "string",
-                          "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubBufferedProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableHealthChecks": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubBufferedProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableTracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubBufferedProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "EventHubName": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the Event Hub."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the Event Hub."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubBufferedProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "FullyQualifiedNamespace": {
-                          "type": "string",
-                          "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubBufferedProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient'.",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "ClientOptions": {
+                        "anyOf": [
+                          {
+                            "not": {
+                              "type": "object"
+                            }
+                          },
+                          {
                             "type": "object",
                             "properties": {
-                              "ConnectionOptions": {
+                              "ClientOptions": {
                                 "type": "object",
                                 "properties": {
-                                  "ConnectionIdleTimeout": {
+                                  "ConnectionOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ConnectionIdleTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                      },
+                                      "CustomEndpointAddress": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                      },
+                                      "ReceiveBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for receiving information via the active transport."
+                                      },
+                                      "SendBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for sending information via the active transport."
+                                      },
+                                      "TransportType": {
+                                        "enum": [
+                                          "AmqpTcp",
+                                          "AmqpWebSockets"
+                                        ],
+                                        "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                      }
+                                    },
+                                    "description": "The options used for configuring the connection to the Event Hubs service."
+                                  },
+                                  "EnableIdempotentRetries": {
+                                    "type": "boolean",
+                                    "description": "Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing will attempt to avoid duplication with a minor cost to throughput.  Duplicates are still possible but the chance of them occurring is much lower when idempotent retries are enabled."
+                                  },
+                                  "Identifier": {
+                                    "type": "string",
+                                    "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
+                                  },
+                                  "MaximumConcurrentSends": {
+                                    "type": "integer",
+                                    "description": "The total number of batches that may be sent concurrently, across all partitions.  This limit takes precedence over the value specified in 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition', ensuring this maximum is respected."
+                                  },
+                                  "MaximumConcurrentSendsPerPartition": {
+                                    "type": "integer",
+                                    "description": "The number of batches that may be sent concurrently for a given partition.  This option is superseded by the value specified for 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSends', ensuring that limit is respected."
+                                  },
+                                  "MaximumEventBufferLengthPerPartition": {
+                                    "type": "integer",
+                                    "description": "The total number of events that can be buffered for publishing at a given time for a given partition.  Once this capacity is reached, more events can enqueued by calling 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventAsync(Azure.Messaging.EventHubs.EventData,Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)' or 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventsAsync(System.Collections.Generic.IEnumerable{Azure.Messaging.EventHubs.EventData},Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)', which will automatically wait for room to be available."
+                                  },
+                                  "MaximumWaitTime": {
                                     "type": "string",
                                     "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    "description": "The amount of time to wait for a batch to be built with events in the buffer before publishing a partially full batch."
                                   },
-                                  "CustomEndpointAddress": {
-                                    "type": "string",
-                                    "format": "uri",
-                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
-                                  },
-                                  "ReceiveBufferSizeInBytes": {
-                                    "type": "integer",
-                                    "description": "The size of the buffer used for receiving information via the active transport."
-                                  },
-                                  "SendBufferSizeInBytes": {
-                                    "type": "integer",
-                                    "description": "The size of the buffer used for sending information via the active transport."
-                                  },
-                                  "TransportType": {
-                                    "enum": [
-                                      "AmqpTcp",
-                                      "AmqpWebSockets"
-                                    ],
-                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  "RetryOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "Delay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                      },
+                                      "MaximumDelay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum permissible delay between retry attempts."
+                                      },
+                                      "MaximumRetries": {
+                                        "type": "integer",
+                                        "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                      },
+                                      "Mode": {
+                                        "enum": [
+                                          "Fixed",
+                                          "Exponential"
+                                        ],
+                                        "description": "The approach to use for calculating retry delays."
+                                      },
+                                      "TryTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                      }
+                                    },
+                                    "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
                                   }
                                 },
-                                "description": "The options used for configuring the connection to the Event Hubs service."
+                                "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient' to configure its behavior."
                               },
-                              "EnableIdempotentRetries": {
+                              "ConnectionString": {
+                                "type": "string",
+                                "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                              },
+                              "DisableHealthChecks": {
                                 "type": "boolean",
-                                "description": "Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing will attempt to avoid duplication with a minor cost to throughput.  Duplicates are still possible but the chance of them occurring is much lower when idempotent retries are enabled."
+                                "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                                "default": false
                               },
-                              "Identifier": {
+                              "DisableTracing": {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                                "default": false
+                              },
+                              "EventHubName": {
                                 "type": "string",
-                                "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
+                                "description": "Gets or sets the name of the Event Hub."
                               },
-                              "MaximumConcurrentSends": {
-                                "type": "integer",
-                                "description": "The total number of batches that may be sent concurrently, across all partitions.  This limit takes precedence over the value specified in 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition', ensuring this maximum is respected."
-                              },
-                              "MaximumConcurrentSendsPerPartition": {
-                                "type": "integer",
-                                "description": "The number of batches that may be sent concurrently for a given partition.  This option is superseded by the value specified for 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSends', ensuring that limit is respected."
-                              },
-                              "MaximumEventBufferLengthPerPartition": {
-                                "type": "integer",
-                                "description": "The total number of events that can be buffered for publishing at a given time for a given partition.  Once this capacity is reached, more events can enqueued by calling 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventAsync(Azure.Messaging.EventHubs.EventData,Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)' or 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventsAsync(System.Collections.Generic.IEnumerable{Azure.Messaging.EventHubs.EventData},Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)', which will automatically wait for room to be available."
-                              },
-                              "MaximumWaitTime": {
+                              "FullyQualifiedNamespace": {
                                 "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The amount of time to wait for a batch to be built with events in the buffer before publishing a partially full batch."
-                              },
-                              "RetryOptions": {
-                                "type": "object",
-                                "properties": {
-                                  "Delay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                  },
-                                  "MaximumDelay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum permissible delay between retry attempts."
-                                  },
-                                  "MaximumRetries": {
-                                    "type": "integer",
-                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                  },
-                                  "Mode": {
-                                    "enum": [
-                                      "Fixed",
-                                      "Exponential"
-                                    ],
-                                    "description": "The approach to use for calculating retry delays."
-                                  },
-                                  "TryTimeout": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                  }
-                                },
-                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                                "description": "Gets or sets the fully qualified Event Hubs namespace."
                               }
                             },
-                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient' to configure its behavior."
-                          },
-                          "ConnectionString": {
-                            "type": "string",
-                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
-                          },
-                          "DisableHealthChecks": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                            "default": false
-                          },
-                          "DisableTracing": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                            "default": false
-                          },
-                          "EventHubName": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the Event Hub."
-                          },
-                          "FullyQualifiedNamespace": {
-                            "type": "string",
-                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient'."
                           }
-                        },
-                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient'."
+                        ]
                       }
                     },
                     "EventHubConsumerClient": {
                       "type": "object",
                       "properties": {
                         "ClientOptions": {
-                          "type": "object",
-                          "properties": {
-                            "ConnectionOptions": {
+                          "anyOf": [
+                            {
                               "type": "object",
                               "properties": {
-                                "ConnectionIdleTimeout": {
+                                "ConnectionOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "ConnectionIdleTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    },
+                                    "CustomEndpointAddress": {
+                                      "type": "string",
+                                      "format": "uri",
+                                      "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                    },
+                                    "ReceiveBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for receiving information via the active transport."
+                                    },
+                                    "SendBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for sending information via the active transport."
+                                    },
+                                    "TransportType": {
+                                      "enum": [
+                                        "AmqpTcp",
+                                        "AmqpWebSockets"
+                                      ],
+                                      "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                    }
+                                  },
+                                  "description": "The options used for configuring the connection to the Event Hubs service."
+                                },
+                                "Identifier": {
                                   "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
                                 },
-                                "CustomEndpointAddress": {
-                                  "type": "string",
-                                  "format": "uri",
-                                  "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
-                                },
-                                "ReceiveBufferSizeInBytes": {
-                                  "type": "integer",
-                                  "description": "The size of the buffer used for receiving information via the active transport."
-                                },
-                                "SendBufferSizeInBytes": {
-                                  "type": "integer",
-                                  "description": "The size of the buffer used for sending information via the active transport."
-                                },
-                                "TransportType": {
-                                  "enum": [
-                                    "AmqpTcp",
-                                    "AmqpWebSockets"
-                                  ],
-                                  "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                "RetryOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Delay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                    },
+                                    "MaximumDelay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum permissible delay between retry attempts."
+                                    },
+                                    "MaximumRetries": {
+                                      "type": "integer",
+                                      "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                    },
+                                    "Mode": {
+                                      "enum": [
+                                        "Fixed",
+                                        "Exponential"
+                                      ],
+                                      "description": "The approach to use for calculating retry delays."
+                                    },
+                                    "TryTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                    }
+                                  },
+                                  "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
                                 }
                               },
-                              "description": "The options used for configuring the connection to the Event Hubs service."
+                              "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient' to configure its behavior."
                             },
-                            "Identifier": {
-                              "type": "string",
-                              "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
-                            },
-                            "RetryOptions": {
-                              "type": "object",
-                              "properties": {
-                                "Delay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                },
-                                "MaximumDelay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum permissible delay between retry attempts."
-                                },
-                                "MaximumRetries": {
-                                  "type": "integer",
-                                  "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                },
-                                "Mode": {
-                                  "enum": [
-                                    "Fixed",
-                                    "Exponential"
-                                  ],
-                                  "description": "The approach to use for calculating retry delays."
-                                },
-                                "TryTimeout": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                }
-                              },
-                              "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
                             }
-                          },
-                          "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient' to configure its behavior."
+                          ]
                         },
                         "ConnectionString": {
-                          "type": "string",
-                          "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "ConsumerGroup": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the consumer group."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the consumer group."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableHealthChecks": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableTracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "EventHubName": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the Event Hub."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the Event Hub."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "FullyQualifiedNamespace": {
-                          "type": "string",
-                          "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient'.",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "ClientOptions": {
+                        "anyOf": [
+                          {
+                            "not": {
+                              "type": "object"
+                            }
+                          },
+                          {
                             "type": "object",
                             "properties": {
-                              "ConnectionOptions": {
+                              "ClientOptions": {
                                 "type": "object",
                                 "properties": {
-                                  "ConnectionIdleTimeout": {
+                                  "ConnectionOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ConnectionIdleTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                      },
+                                      "CustomEndpointAddress": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                      },
+                                      "ReceiveBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for receiving information via the active transport."
+                                      },
+                                      "SendBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for sending information via the active transport."
+                                      },
+                                      "TransportType": {
+                                        "enum": [
+                                          "AmqpTcp",
+                                          "AmqpWebSockets"
+                                        ],
+                                        "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                      }
+                                    },
+                                    "description": "The options used for configuring the connection to the Event Hubs service."
+                                  },
+                                  "Identifier": {
                                     "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
                                   },
-                                  "CustomEndpointAddress": {
-                                    "type": "string",
-                                    "format": "uri",
-                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
-                                  },
-                                  "ReceiveBufferSizeInBytes": {
-                                    "type": "integer",
-                                    "description": "The size of the buffer used for receiving information via the active transport."
-                                  },
-                                  "SendBufferSizeInBytes": {
-                                    "type": "integer",
-                                    "description": "The size of the buffer used for sending information via the active transport."
-                                  },
-                                  "TransportType": {
-                                    "enum": [
-                                      "AmqpTcp",
-                                      "AmqpWebSockets"
-                                    ],
-                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  "RetryOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "Delay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                      },
+                                      "MaximumDelay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum permissible delay between retry attempts."
+                                      },
+                                      "MaximumRetries": {
+                                        "type": "integer",
+                                        "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                      },
+                                      "Mode": {
+                                        "enum": [
+                                          "Fixed",
+                                          "Exponential"
+                                        ],
+                                        "description": "The approach to use for calculating retry delays."
+                                      },
+                                      "TryTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                      }
+                                    },
+                                    "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
                                   }
                                 },
-                                "description": "The options used for configuring the connection to the Event Hubs service."
+                                "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient' to configure its behavior."
                               },
-                              "Identifier": {
+                              "ConnectionString": {
                                 "type": "string",
-                                "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
+                                "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
                               },
-                              "RetryOptions": {
-                                "type": "object",
-                                "properties": {
-                                  "Delay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                  },
-                                  "MaximumDelay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum permissible delay between retry attempts."
-                                  },
-                                  "MaximumRetries": {
-                                    "type": "integer",
-                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                  },
-                                  "Mode": {
-                                    "enum": [
-                                      "Fixed",
-                                      "Exponential"
-                                    ],
-                                    "description": "The approach to use for calculating retry delays."
-                                  },
-                                  "TryTimeout": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                  }
-                                },
-                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
+                              "ConsumerGroup": {
+                                "type": "string",
+                                "description": "Gets or sets the name of the consumer group."
+                              },
+                              "DisableHealthChecks": {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                                "default": false
+                              },
+                              "DisableTracing": {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                                "default": false
+                              },
+                              "EventHubName": {
+                                "type": "string",
+                                "description": "Gets or sets the name of the Event Hub."
+                              },
+                              "FullyQualifiedNamespace": {
+                                "type": "string",
+                                "description": "Gets or sets the fully qualified Event Hubs namespace."
                               }
                             },
-                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient' to configure its behavior."
-                          },
-                          "ConnectionString": {
-                            "type": "string",
-                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
-                          },
-                          "ConsumerGroup": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the consumer group."
-                          },
-                          "DisableHealthChecks": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                            "default": false
-                          },
-                          "DisableTracing": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                            "default": false
-                          },
-                          "EventHubName": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the Event Hub."
-                          },
-                          "FullyQualifiedNamespace": {
-                            "type": "string",
-                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient'."
                           }
-                        },
-                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient'."
+                        ]
                       }
                     },
                     "EventHubProducerClient": {
                       "type": "object",
                       "properties": {
                         "ClientOptions": {
-                          "type": "object",
-                          "properties": {
-                            "ConnectionOptions": {
+                          "anyOf": [
+                            {
                               "type": "object",
                               "properties": {
-                                "ConnectionIdleTimeout": {
+                                "ConnectionOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "ConnectionIdleTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    },
+                                    "CustomEndpointAddress": {
+                                      "type": "string",
+                                      "format": "uri",
+                                      "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                    },
+                                    "ReceiveBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for receiving information via the active transport."
+                                    },
+                                    "SendBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for sending information via the active transport."
+                                    },
+                                    "TransportType": {
+                                      "enum": [
+                                        "AmqpTcp",
+                                        "AmqpWebSockets"
+                                      ],
+                                      "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                    }
+                                  },
+                                  "description": "The options used for configuring the connection to the Event Hubs service."
+                                },
+                                "Identifier": {
                                   "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
                                 },
-                                "CustomEndpointAddress": {
-                                  "type": "string",
-                                  "format": "uri",
-                                  "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
-                                },
-                                "ReceiveBufferSizeInBytes": {
-                                  "type": "integer",
-                                  "description": "The size of the buffer used for receiving information via the active transport."
-                                },
-                                "SendBufferSizeInBytes": {
-                                  "type": "integer",
-                                  "description": "The size of the buffer used for sending information via the active transport."
-                                },
-                                "TransportType": {
-                                  "enum": [
-                                    "AmqpTcp",
-                                    "AmqpWebSockets"
-                                  ],
-                                  "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                "RetryOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Delay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                    },
+                                    "MaximumDelay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum permissible delay between retry attempts."
+                                    },
+                                    "MaximumRetries": {
+                                      "type": "integer",
+                                      "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                    },
+                                    "Mode": {
+                                      "enum": [
+                                        "Fixed",
+                                        "Exponential"
+                                      ],
+                                      "description": "The approach to use for calculating retry delays."
+                                    },
+                                    "TryTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                    }
+                                  },
+                                  "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
                                 }
                               },
-                              "description": "The options used for configuring the connection to the Event Hubs service."
+                              "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient' to configure its behavior."
                             },
-                            "Identifier": {
-                              "type": "string",
-                              "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
-                            },
-                            "RetryOptions": {
-                              "type": "object",
-                              "properties": {
-                                "Delay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                },
-                                "MaximumDelay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum permissible delay between retry attempts."
-                                },
-                                "MaximumRetries": {
-                                  "type": "integer",
-                                  "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                },
-                                "Mode": {
-                                  "enum": [
-                                    "Fixed",
-                                    "Exponential"
-                                  ],
-                                  "description": "The approach to use for calculating retry delays."
-                                },
-                                "TryTimeout": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                }
-                              },
-                              "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubProducerClient/additionalProperties/anyOf/1"
                             }
-                          },
-                          "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient' to configure its behavior."
+                          ]
                         },
                         "ConnectionString": {
-                          "type": "string",
-                          "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableHealthChecks": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableTracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "EventHubName": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the Event Hub."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the Event Hub."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "FullyQualifiedNamespace": {
-                          "type": "string",
-                          "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubProducerClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient'.",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "ClientOptions": {
+                        "anyOf": [
+                          {
+                            "not": {
+                              "type": "object"
+                            }
+                          },
+                          {
                             "type": "object",
                             "properties": {
-                              "ConnectionOptions": {
+                              "ClientOptions": {
                                 "type": "object",
                                 "properties": {
-                                  "ConnectionIdleTimeout": {
+                                  "ConnectionOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ConnectionIdleTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                      },
+                                      "CustomEndpointAddress": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                      },
+                                      "ReceiveBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for receiving information via the active transport."
+                                      },
+                                      "SendBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for sending information via the active transport."
+                                      },
+                                      "TransportType": {
+                                        "enum": [
+                                          "AmqpTcp",
+                                          "AmqpWebSockets"
+                                        ],
+                                        "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                      }
+                                    },
+                                    "description": "The options used for configuring the connection to the Event Hubs service."
+                                  },
+                                  "Identifier": {
                                     "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
                                   },
-                                  "CustomEndpointAddress": {
-                                    "type": "string",
-                                    "format": "uri",
-                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
-                                  },
-                                  "ReceiveBufferSizeInBytes": {
-                                    "type": "integer",
-                                    "description": "The size of the buffer used for receiving information via the active transport."
-                                  },
-                                  "SendBufferSizeInBytes": {
-                                    "type": "integer",
-                                    "description": "The size of the buffer used for sending information via the active transport."
-                                  },
-                                  "TransportType": {
-                                    "enum": [
-                                      "AmqpTcp",
-                                      "AmqpWebSockets"
-                                    ],
-                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  "RetryOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "Delay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                      },
+                                      "MaximumDelay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum permissible delay between retry attempts."
+                                      },
+                                      "MaximumRetries": {
+                                        "type": "integer",
+                                        "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                      },
+                                      "Mode": {
+                                        "enum": [
+                                          "Fixed",
+                                          "Exponential"
+                                        ],
+                                        "description": "The approach to use for calculating retry delays."
+                                      },
+                                      "TryTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                      }
+                                    },
+                                    "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
                                   }
                                 },
-                                "description": "The options used for configuring the connection to the Event Hubs service."
+                                "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient' to configure its behavior."
                               },
-                              "Identifier": {
+                              "ConnectionString": {
                                 "type": "string",
-                                "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
+                                "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
                               },
-                              "RetryOptions": {
-                                "type": "object",
-                                "properties": {
-                                  "Delay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                  },
-                                  "MaximumDelay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum permissible delay between retry attempts."
-                                  },
-                                  "MaximumRetries": {
-                                    "type": "integer",
-                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                  },
-                                  "Mode": {
-                                    "enum": [
-                                      "Fixed",
-                                      "Exponential"
-                                    ],
-                                    "description": "The approach to use for calculating retry delays."
-                                  },
-                                  "TryTimeout": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                  }
-                                },
-                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                              "DisableHealthChecks": {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                                "default": false
+                              },
+                              "DisableTracing": {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                                "default": false
+                              },
+                              "EventHubName": {
+                                "type": "string",
+                                "description": "Gets or sets the name of the Event Hub."
+                              },
+                              "FullyQualifiedNamespace": {
+                                "type": "string",
+                                "description": "Gets or sets the fully qualified Event Hubs namespace."
                               }
                             },
-                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient' to configure its behavior."
-                          },
-                          "ConnectionString": {
-                            "type": "string",
-                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
-                          },
-                          "DisableHealthChecks": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                            "default": false
-                          },
-                          "DisableTracing": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                            "default": false
-                          },
-                          "EventHubName": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the Event Hub."
-                          },
-                          "FullyQualifiedNamespace": {
-                            "type": "string",
-                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient'."
                           }
-                        },
-                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient'."
+                        ]
                       }
                     },
                     "EventProcessorClient": {
                       "type": "object",
                       "properties": {
                         "BlobClientServiceKey": {
-                          "type": "string",
-                          "description": "Gets or sets the IServiceProvider service key used to obtain an Azure BlobServiceClient."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the IServiceProvider service key used to obtain an Azure BlobServiceClient."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "BlobContainerName": {
-                          "type": "string",
-                          "description": "Get or sets the name of the blob container used to store the checkpoint data. If this container does not exist, Aspire will attempt to create it. If this is not provided, Aspire will attempt to automatically create a container with a name based on the Namespace, Event Hub name and Consumer Group. If a container is provided in the connection string, it will override this value and the container will be assumed to exist."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Get or sets the name of the blob container used to store the checkpoint data. If this container does not exist, Aspire will attempt to create it. If this is not provided, Aspire will attempt to automatically create a container with a name based on the Namespace, Event Hub name and Consumer Group. If a container is provided in the connection string, it will override this value and the container will be assumed to exist."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "ClientOptions": {
-                          "type": "object",
-                          "properties": {
-                            "CacheEventCount": {
-                              "type": "integer",
-                              "description": "The maximum number of events that will be read from the Event Hubs service and held in a local memory cache when reading is active and events are being emitted to an enumerator for processing."
-                            },
-                            "ConnectionOptions": {
+                          "anyOf": [
+                            {
                               "type": "object",
                               "properties": {
-                                "ConnectionIdleTimeout": {
+                                "CacheEventCount": {
+                                  "type": "integer",
+                                  "description": "The maximum number of events that will be read from the Event Hubs service and held in a local memory cache when reading is active and events are being emitted to an enumerator for processing."
+                                },
+                                "ConnectionOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "ConnectionIdleTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    },
+                                    "CustomEndpointAddress": {
+                                      "type": "string",
+                                      "format": "uri",
+                                      "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                    },
+                                    "ReceiveBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for receiving information via the active transport."
+                                    },
+                                    "SendBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for sending information via the active transport."
+                                    },
+                                    "TransportType": {
+                                      "enum": [
+                                        "AmqpTcp",
+                                        "AmqpWebSockets"
+                                      ],
+                                      "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                    }
+                                  },
+                                  "description": "Gets or sets the options used for configuring the connection to the Event Hubs service."
+                                },
+                                "Identifier": {
+                                  "type": "string",
+                                  "description": "A unique name used to identify the event processor.  If null or empty, a GUID will be used as the identifier."
+                                },
+                                "LoadBalancingStrategy": {
+                                  "enum": [
+                                    "Balanced",
+                                    "Greedy"
+                                  ],
+                                  "description": "The strategy that an event processor will use to make decisions about partition ownership when performing load balancing to share work with other event processors."
+                                },
+                                "LoadBalancingUpdateInterval": {
                                   "type": "string",
                                   "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  "description": "The desired amount of time to allow between load balancing verification attempts."
                                 },
-                                "CustomEndpointAddress": {
+                                "MaximumWaitTime": {
                                   "type": "string",
-                                  "format": "uri",
-                                  "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum amount of time to wait for an event to become available for a given partition before emitting an empty event."
                                 },
-                                "ReceiveBufferSizeInBytes": {
+                                "PartitionOwnershipExpirationInterval": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The desired amount of time to consider a partition owned by a specific event processor instance before the ownership is considered stale and the partition becomes eligible to be requested by another event processor that wishes to assume responsibility for processing it."
+                                },
+                                "PrefetchCount": {
                                   "type": "integer",
-                                  "description": "The size of the buffer used for receiving information via the active transport."
+                                  "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
                                 },
-                                "SendBufferSizeInBytes": {
+                                "PrefetchSizeInBytes": {
                                   "type": "integer",
-                                  "description": "The size of the buffer used for sending information via the active transport."
+                                  "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
                                 },
-                                "TransportType": {
-                                  "enum": [
-                                    "AmqpTcp",
-                                    "AmqpWebSockets"
-                                  ],
-                                  "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                "RetryOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Delay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                    },
+                                    "MaximumDelay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum permissible delay between retry attempts."
+                                    },
+                                    "MaximumRetries": {
+                                      "type": "integer",
+                                      "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                    },
+                                    "Mode": {
+                                      "enum": [
+                                        "Fixed",
+                                        "Exponential"
+                                      ],
+                                      "description": "The approach to use for calculating retry delays."
+                                    },
+                                    "TryTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                    }
+                                  },
+                                  "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                                },
+                                "TrackLastEnqueuedEventProperties": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether or not the consumer should request information on the last enqueued event on the partition associated with a given event, and track that information as events are received."
                                 }
                               },
-                              "description": "Gets or sets the options used for configuring the connection to the Event Hubs service."
+                              "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.EventProcessorClient' to configure its behavior."
                             },
-                            "Identifier": {
-                              "type": "string",
-                              "description": "A unique name used to identify the event processor.  If null or empty, a GUID will be used as the identifier."
-                            },
-                            "LoadBalancingStrategy": {
-                              "enum": [
-                                "Balanced",
-                                "Greedy"
-                              ],
-                              "description": "The strategy that an event processor will use to make decisions about partition ownership when performing load balancing to share work with other event processors."
-                            },
-                            "LoadBalancingUpdateInterval": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The desired amount of time to allow between load balancing verification attempts."
-                            },
-                            "MaximumWaitTime": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum amount of time to wait for an event to become available for a given partition before emitting an empty event."
-                            },
-                            "PartitionOwnershipExpirationInterval": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The desired amount of time to consider a partition owned by a specific event processor instance before the ownership is considered stale and the partition becomes eligible to be requested by another event processor that wishes to assume responsibility for processing it."
-                            },
-                            "PrefetchCount": {
-                              "type": "integer",
-                              "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
-                            },
-                            "PrefetchSizeInBytes": {
-                              "type": "integer",
-                              "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
-                            },
-                            "RetryOptions": {
-                              "type": "object",
-                              "properties": {
-                                "Delay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                },
-                                "MaximumDelay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum permissible delay between retry attempts."
-                                },
-                                "MaximumRetries": {
-                                  "type": "integer",
-                                  "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                },
-                                "Mode": {
-                                  "enum": [
-                                    "Fixed",
-                                    "Exponential"
-                                  ],
-                                  "description": "The approach to use for calculating retry delays."
-                                },
-                                "TryTimeout": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                }
-                              },
-                              "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
-                            },
-                            "TrackLastEnqueuedEventProperties": {
-                              "type": "boolean",
-                              "description": "Indicates whether or not the consumer should request information on the last enqueued event on the partition associated with a given event, and track that information as events are received."
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
                             }
-                          },
-                          "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.EventProcessorClient' to configure its behavior."
+                          ]
                         },
                         "ConnectionString": {
-                          "type": "string",
-                          "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "ConsumerGroup": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the consumer group."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the consumer group."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableHealthChecks": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableTracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "EventHubName": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the Event Hub."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the Event Hub."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "FullyQualifiedNamespace": {
-                          "type": "string",
-                          "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                            }
+                          ]
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.EventProcessorClient'.",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "BlobClientServiceKey": {
-                            "type": "string",
-                            "description": "Gets or sets the IServiceProvider service key used to obtain an Azure BlobServiceClient."
+                        "anyOf": [
+                          {
+                            "not": {
+                              "type": "object"
+                            }
                           },
-                          "BlobContainerName": {
-                            "type": "string",
-                            "description": "Get or sets the name of the blob container used to store the checkpoint data. If this container does not exist, Aspire will attempt to create it. If this is not provided, Aspire will attempt to automatically create a container with a name based on the Namespace, Event Hub name and Consumer Group. If a container is provided in the connection string, it will override this value and the container will be assumed to exist."
-                          },
-                          "ClientOptions": {
+                          {
                             "type": "object",
                             "properties": {
-                              "CacheEventCount": {
-                                "type": "integer",
-                                "description": "The maximum number of events that will be read from the Event Hubs service and held in a local memory cache when reading is active and events are being emitted to an enumerator for processing."
+                              "BlobClientServiceKey": {
+                                "type": "string",
+                                "description": "Gets or sets the IServiceProvider service key used to obtain an Azure BlobServiceClient."
                               },
-                              "ConnectionOptions": {
+                              "BlobContainerName": {
+                                "type": "string",
+                                "description": "Get or sets the name of the blob container used to store the checkpoint data. If this container does not exist, Aspire will attempt to create it. If this is not provided, Aspire will attempt to automatically create a container with a name based on the Namespace, Event Hub name and Consumer Group. If a container is provided in the connection string, it will override this value and the container will be assumed to exist."
+                              },
+                              "ClientOptions": {
                                 "type": "object",
                                 "properties": {
-                                  "ConnectionIdleTimeout": {
+                                  "CacheEventCount": {
+                                    "type": "integer",
+                                    "description": "The maximum number of events that will be read from the Event Hubs service and held in a local memory cache when reading is active and events are being emitted to an enumerator for processing."
+                                  },
+                                  "ConnectionOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ConnectionIdleTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                      },
+                                      "CustomEndpointAddress": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                      },
+                                      "ReceiveBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for receiving information via the active transport."
+                                      },
+                                      "SendBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for sending information via the active transport."
+                                      },
+                                      "TransportType": {
+                                        "enum": [
+                                          "AmqpTcp",
+                                          "AmqpWebSockets"
+                                        ],
+                                        "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                      }
+                                    },
+                                    "description": "Gets or sets the options used for configuring the connection to the Event Hubs service."
+                                  },
+                                  "Identifier": {
+                                    "type": "string",
+                                    "description": "A unique name used to identify the event processor.  If null or empty, a GUID will be used as the identifier."
+                                  },
+                                  "LoadBalancingStrategy": {
+                                    "enum": [
+                                      "Balanced",
+                                      "Greedy"
+                                    ],
+                                    "description": "The strategy that an event processor will use to make decisions about partition ownership when performing load balancing to share work with other event processors."
+                                  },
+                                  "LoadBalancingUpdateInterval": {
                                     "type": "string",
                                     "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    "description": "The desired amount of time to allow between load balancing verification attempts."
                                   },
-                                  "CustomEndpointAddress": {
+                                  "MaximumWaitTime": {
                                     "type": "string",
-                                    "format": "uri",
-                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum amount of time to wait for an event to become available for a given partition before emitting an empty event."
                                   },
-                                  "ReceiveBufferSizeInBytes": {
+                                  "PartitionOwnershipExpirationInterval": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The desired amount of time to consider a partition owned by a specific event processor instance before the ownership is considered stale and the partition becomes eligible to be requested by another event processor that wishes to assume responsibility for processing it."
+                                  },
+                                  "PrefetchCount": {
                                     "type": "integer",
-                                    "description": "The size of the buffer used for receiving information via the active transport."
+                                    "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
                                   },
-                                  "SendBufferSizeInBytes": {
+                                  "PrefetchSizeInBytes": {
                                     "type": "integer",
-                                    "description": "The size of the buffer used for sending information via the active transport."
+                                    "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
                                   },
-                                  "TransportType": {
-                                    "enum": [
-                                      "AmqpTcp",
-                                      "AmqpWebSockets"
-                                    ],
-                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  "RetryOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "Delay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                      },
+                                      "MaximumDelay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum permissible delay between retry attempts."
+                                      },
+                                      "MaximumRetries": {
+                                        "type": "integer",
+                                        "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                      },
+                                      "Mode": {
+                                        "enum": [
+                                          "Fixed",
+                                          "Exponential"
+                                        ],
+                                        "description": "The approach to use for calculating retry delays."
+                                      },
+                                      "TryTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                      }
+                                    },
+                                    "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                                  },
+                                  "TrackLastEnqueuedEventProperties": {
+                                    "type": "boolean",
+                                    "description": "Indicates whether or not the consumer should request information on the last enqueued event on the partition associated with a given event, and track that information as events are received."
                                   }
                                 },
-                                "description": "Gets or sets the options used for configuring the connection to the Event Hubs service."
+                                "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.EventProcessorClient' to configure its behavior."
                               },
-                              "Identifier": {
+                              "ConnectionString": {
                                 "type": "string",
-                                "description": "A unique name used to identify the event processor.  If null or empty, a GUID will be used as the identifier."
+                                "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
                               },
-                              "LoadBalancingStrategy": {
-                                "enum": [
-                                  "Balanced",
-                                  "Greedy"
-                                ],
-                                "description": "The strategy that an event processor will use to make decisions about partition ownership when performing load balancing to share work with other event processors."
-                              },
-                              "LoadBalancingUpdateInterval": {
+                              "ConsumerGroup": {
                                 "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The desired amount of time to allow between load balancing verification attempts."
+                                "description": "Gets or sets the name of the consumer group."
                               },
-                              "MaximumWaitTime": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum amount of time to wait for an event to become available for a given partition before emitting an empty event."
-                              },
-                              "PartitionOwnershipExpirationInterval": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The desired amount of time to consider a partition owned by a specific event processor instance before the ownership is considered stale and the partition becomes eligible to be requested by another event processor that wishes to assume responsibility for processing it."
-                              },
-                              "PrefetchCount": {
-                                "type": "integer",
-                                "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
-                              },
-                              "PrefetchSizeInBytes": {
-                                "type": "integer",
-                                "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
-                              },
-                              "RetryOptions": {
-                                "type": "object",
-                                "properties": {
-                                  "Delay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                  },
-                                  "MaximumDelay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum permissible delay between retry attempts."
-                                  },
-                                  "MaximumRetries": {
-                                    "type": "integer",
-                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                  },
-                                  "Mode": {
-                                    "enum": [
-                                      "Fixed",
-                                      "Exponential"
-                                    ],
-                                    "description": "The approach to use for calculating retry delays."
-                                  },
-                                  "TryTimeout": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                  }
-                                },
-                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
-                              },
-                              "TrackLastEnqueuedEventProperties": {
+                              "DisableHealthChecks": {
                                 "type": "boolean",
-                                "description": "Indicates whether or not the consumer should request information on the last enqueued event on the partition associated with a given event, and track that information as events are received."
+                                "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                                "default": false
+                              },
+                              "DisableTracing": {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                                "default": false
+                              },
+                              "EventHubName": {
+                                "type": "string",
+                                "description": "Gets or sets the name of the Event Hub."
+                              },
+                              "FullyQualifiedNamespace": {
+                                "type": "string",
+                                "description": "Gets or sets the fully qualified Event Hubs namespace."
                               }
                             },
-                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.EventProcessorClient' to configure its behavior."
-                          },
-                          "ConnectionString": {
-                            "type": "string",
-                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
-                          },
-                          "ConsumerGroup": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the consumer group."
-                          },
-                          "DisableHealthChecks": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                            "default": false
-                          },
-                          "DisableTracing": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                            "default": false
-                          },
-                          "EventHubName": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the Event Hub."
-                          },
-                          "FullyQualifiedNamespace": {
-                            "type": "string",
-                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.EventProcessorClient'."
                           }
-                        },
-                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.EventProcessorClient'."
+                        ]
                       }
                     },
                     "PartitionReceiver": {
                       "type": "object",
                       "properties": {
                         "ClientOptions": {
-                          "type": "object",
-                          "properties": {
-                            "ConnectionOptions": {
+                          "anyOf": [
+                            {
                               "type": "object",
                               "properties": {
-                                "ConnectionIdleTimeout": {
+                                "ConnectionOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "ConnectionIdleTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    },
+                                    "CustomEndpointAddress": {
+                                      "type": "string",
+                                      "format": "uri",
+                                      "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                    },
+                                    "ReceiveBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for receiving information via the active transport."
+                                    },
+                                    "SendBufferSizeInBytes": {
+                                      "type": "integer",
+                                      "description": "The size of the buffer used for sending information via the active transport."
+                                    },
+                                    "TransportType": {
+                                      "enum": [
+                                        "AmqpTcp",
+                                        "AmqpWebSockets"
+                                      ],
+                                      "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                    }
+                                  },
+                                  "description": "The options used for configuring the connection to the Event Hubs service."
+                                },
+                                "DefaultMaximumReceiveWaitTime": {
                                   "type": "string",
                                   "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  "description": "The default amount of time to wait for the requested amount of messages when reading; if this period elapses before the requested amount of messages were available or read, then the set of messages that were read will be returned."
                                 },
-                                "CustomEndpointAddress": {
+                                "Identifier": {
                                   "type": "string",
-                                  "format": "uri",
-                                  "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                  "description": "A unique name used to identify the receiver.  If null or empty, a GUID will be used as the identifier."
                                 },
-                                "ReceiveBufferSizeInBytes": {
+                                "OwnerLevel": {
                                   "type": "integer",
-                                  "description": "The size of the buffer used for receiving information via the active transport."
+                                  "description": "When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same partition/consumer group pair, the one having a larger 'Azure.Messaging.EventHubs.Primitives.PartitionReceiverOptions.OwnerLevel' value will \"win.\"\n\nWhen an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation."
                                 },
-                                "SendBufferSizeInBytes": {
+                                "PrefetchCount": {
                                   "type": "integer",
-                                  "description": "The size of the buffer used for sending information via the active transport."
+                                  "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
                                 },
-                                "TransportType": {
-                                  "enum": [
-                                    "AmqpTcp",
-                                    "AmqpWebSockets"
-                                  ],
-                                  "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                "PrefetchSizeInBytes": {
+                                  "type": "integer",
+                                  "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
+                                },
+                                "RetryOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Delay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                    },
+                                    "MaximumDelay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum permissible delay between retry attempts."
+                                    },
+                                    "MaximumRetries": {
+                                      "type": "integer",
+                                      "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                    },
+                                    "Mode": {
+                                      "enum": [
+                                        "Fixed",
+                                        "Exponential"
+                                      ],
+                                      "description": "The approach to use for calculating retry delays."
+                                    },
+                                    "TryTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                    }
+                                  },
+                                  "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
+                                },
+                                "TrackLastEnqueuedEventProperties": {
+                                  "type": "boolean",
+                                  "description": "Indicates whether or not the reader should request information on the last enqueued event on the partition associated with a given event, and track that information as events are read."
                                 }
                               },
-                              "description": "The options used for configuring the connection to the Event Hubs service."
+                              "description": "The set of options that can be specified when creating a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver' to configure its behavior."
                             },
-                            "DefaultMaximumReceiveWaitTime": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The default amount of time to wait for the requested amount of messages when reading; if this period elapses before the requested amount of messages were available or read, then the set of messages that were read will be returned."
-                            },
-                            "Identifier": {
-                              "type": "string",
-                              "description": "A unique name used to identify the receiver.  If null or empty, a GUID will be used as the identifier."
-                            },
-                            "OwnerLevel": {
-                              "type": "integer",
-                              "description": "When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same partition/consumer group pair, the one having a larger 'Azure.Messaging.EventHubs.Primitives.PartitionReceiverOptions.OwnerLevel' value will \"win.\"\n\nWhen an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation."
-                            },
-                            "PrefetchCount": {
-                              "type": "integer",
-                              "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
-                            },
-                            "PrefetchSizeInBytes": {
-                              "type": "integer",
-                              "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
-                            },
-                            "RetryOptions": {
-                              "type": "object",
-                              "properties": {
-                                "Delay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                },
-                                "MaximumDelay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum permissible delay between retry attempts."
-                                },
-                                "MaximumRetries": {
-                                  "type": "integer",
-                                  "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                },
-                                "Mode": {
-                                  "enum": [
-                                    "Fixed",
-                                    "Exponential"
-                                  ],
-                                  "description": "The approach to use for calculating retry delays."
-                                },
-                                "TryTimeout": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                }
-                              },
-                              "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
-                            },
-                            "TrackLastEnqueuedEventProperties": {
-                              "type": "boolean",
-                              "description": "Indicates whether or not the reader should request information on the last enqueued event on the partition associated with a given event, and track that information as events are read."
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
                             }
-                          },
-                          "description": "The set of options that can be specified when creating a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver' to configure its behavior."
+                          ]
                         },
                         "ConnectionString": {
-                          "type": "string",
-                          "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "ConsumerGroup": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the consumer group."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the consumer group."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableHealthChecks": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableTracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "EventHubName": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the Event Hub."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the Event Hub."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "FullyQualifiedNamespace": {
-                          "type": "string",
-                          "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the fully qualified Event Hubs namespace."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "PartitionId": {
-                          "type": "string",
-                          "description": "Gets or sets the partition identifier."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the partition identifier."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                            }
+                          ]
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver'.",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "ClientOptions": {
+                        "anyOf": [
+                          {
+                            "not": {
+                              "type": "object"
+                            }
+                          },
+                          {
                             "type": "object",
                             "properties": {
-                              "ConnectionOptions": {
+                              "ClientOptions": {
                                 "type": "object",
                                 "properties": {
-                                  "ConnectionIdleTimeout": {
+                                  "ConnectionOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ConnectionIdleTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                      },
+                                      "CustomEndpointAddress": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                      },
+                                      "ReceiveBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for receiving information via the active transport."
+                                      },
+                                      "SendBufferSizeInBytes": {
+                                        "type": "integer",
+                                        "description": "The size of the buffer used for sending information via the active transport."
+                                      },
+                                      "TransportType": {
+                                        "enum": [
+                                          "AmqpTcp",
+                                          "AmqpWebSockets"
+                                        ],
+                                        "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                      }
+                                    },
+                                    "description": "The options used for configuring the connection to the Event Hubs service."
+                                  },
+                                  "DefaultMaximumReceiveWaitTime": {
                                     "type": "string",
                                     "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                    "description": "The default amount of time to wait for the requested amount of messages when reading; if this period elapses before the requested amount of messages were available or read, then the set of messages that were read will be returned."
                                   },
-                                  "CustomEndpointAddress": {
+                                  "Identifier": {
                                     "type": "string",
-                                    "format": "uri",
-                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                    "description": "A unique name used to identify the receiver.  If null or empty, a GUID will be used as the identifier."
                                   },
-                                  "ReceiveBufferSizeInBytes": {
+                                  "OwnerLevel": {
                                     "type": "integer",
-                                    "description": "The size of the buffer used for receiving information via the active transport."
+                                    "description": "When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same partition/consumer group pair, the one having a larger 'Azure.Messaging.EventHubs.Primitives.PartitionReceiverOptions.OwnerLevel' value will \"win.\"\n\nWhen an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation."
                                   },
-                                  "SendBufferSizeInBytes": {
+                                  "PrefetchCount": {
                                     "type": "integer",
-                                    "description": "The size of the buffer used for sending information via the active transport."
+                                    "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
                                   },
-                                  "TransportType": {
-                                    "enum": [
-                                      "AmqpTcp",
-                                      "AmqpWebSockets"
-                                    ],
-                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  "PrefetchSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
+                                  },
+                                  "RetryOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "Delay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                      },
+                                      "MaximumDelay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum permissible delay between retry attempts."
+                                      },
+                                      "MaximumRetries": {
+                                        "type": "integer",
+                                        "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                      },
+                                      "Mode": {
+                                        "enum": [
+                                          "Fixed",
+                                          "Exponential"
+                                        ],
+                                        "description": "The approach to use for calculating retry delays."
+                                      },
+                                      "TryTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                      }
+                                    },
+                                    "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
+                                  },
+                                  "TrackLastEnqueuedEventProperties": {
+                                    "type": "boolean",
+                                    "description": "Indicates whether or not the reader should request information on the last enqueued event on the partition associated with a given event, and track that information as events are read."
                                   }
                                 },
-                                "description": "The options used for configuring the connection to the Event Hubs service."
+                                "description": "The set of options that can be specified when creating a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver' to configure its behavior."
                               },
-                              "DefaultMaximumReceiveWaitTime": {
+                              "ConnectionString": {
                                 "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The default amount of time to wait for the requested amount of messages when reading; if this period elapses before the requested amount of messages were available or read, then the set of messages that were read will be returned."
+                                "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
                               },
-                              "Identifier": {
+                              "ConsumerGroup": {
                                 "type": "string",
-                                "description": "A unique name used to identify the receiver.  If null or empty, a GUID will be used as the identifier."
+                                "description": "Gets or sets the name of the consumer group."
                               },
-                              "OwnerLevel": {
-                                "type": "integer",
-                                "description": "When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same partition/consumer group pair, the one having a larger 'Azure.Messaging.EventHubs.Primitives.PartitionReceiverOptions.OwnerLevel' value will \"win.\"\n\nWhen an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation."
-                              },
-                              "PrefetchCount": {
-                                "type": "integer",
-                                "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
-                              },
-                              "PrefetchSizeInBytes": {
-                                "type": "integer",
-                                "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
-                              },
-                              "RetryOptions": {
-                                "type": "object",
-                                "properties": {
-                                  "Delay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
-                                  },
-                                  "MaximumDelay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum permissible delay between retry attempts."
-                                  },
-                                  "MaximumRetries": {
-                                    "type": "integer",
-                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
-                                  },
-                                  "Mode": {
-                                    "enum": [
-                                      "Fixed",
-                                      "Exponential"
-                                    ],
-                                    "description": "The approach to use for calculating retry delays."
-                                  },
-                                  "TryTimeout": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
-                                  }
-                                },
-                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
-                              },
-                              "TrackLastEnqueuedEventProperties": {
+                              "DisableHealthChecks": {
                                 "type": "boolean",
-                                "description": "Indicates whether or not the reader should request information on the last enqueued event on the partition associated with a given event, and track that information as events are read."
+                                "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                                "default": false
+                              },
+                              "DisableTracing": {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                                "default": false
+                              },
+                              "EventHubName": {
+                                "type": "string",
+                                "description": "Gets or sets the name of the Event Hub."
+                              },
+                              "FullyQualifiedNamespace": {
+                                "type": "string",
+                                "description": "Gets or sets the fully qualified Event Hubs namespace."
+                              },
+                              "PartitionId": {
+                                "type": "string",
+                                "description": "Gets or sets the partition identifier."
                               }
                             },
-                            "description": "The set of options that can be specified when creating a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver' to configure its behavior."
-                          },
-                          "ConnectionString": {
-                            "type": "string",
-                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
-                          },
-                          "ConsumerGroup": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the consumer group."
-                          },
-                          "DisableHealthChecks": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
-                            "default": false
-                          },
-                          "DisableTracing": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                            "default": false
-                          },
-                          "EventHubName": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the Event Hub."
-                          },
-                          "FullyQualifiedNamespace": {
-                            "type": "string",
-                            "description": "Gets or sets the fully qualified Event Hubs namespace."
-                          },
-                          "PartitionId": {
-                            "type": "string",
-                            "description": "Gets or sets the partition identifier."
+                            "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver'."
                           }
-                        },
-                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver'."
+                        ]
                       }
                     }
                   }

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
@@ -131,7 +131,57 @@
                               "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient' to configure its behavior."
                             },
                             {
-                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubBufferedProducerClient/additionalProperties/anyOf/1"
+                              "allOf": [
+                                {
+                                  "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubBufferedProducerClient/additionalProperties/anyOf/1"
+                                },
+                                {
+                                  "not": {
+                                    "anyOf": [
+                                      {
+                                        "required": [
+                                          "EnableIdempotentRetries"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "MaximumWaitTime"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "MaximumEventBufferLengthPerPartition"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "MaximumConcurrentSends"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "MaximumConcurrentSendsPerPartition"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "Identifier"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "ConnectionOptions"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "RetryOptions"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
                             }
                           ]
                         },
@@ -405,7 +455,32 @@
                               "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient' to configure its behavior."
                             },
                             {
-                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
+                              "allOf": [
+                                {
+                                  "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubConsumerClient/additionalProperties/anyOf/1"
+                                },
+                                {
+                                  "not": {
+                                    "anyOf": [
+                                      {
+                                        "required": [
+                                          "Identifier"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "ConnectionOptions"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "RetryOptions"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
                             }
                           ]
                         },
@@ -673,7 +748,32 @@
                               "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient' to configure its behavior."
                             },
                             {
-                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubProducerClient/additionalProperties/anyOf/1"
+                              "allOf": [
+                                {
+                                  "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventHubProducerClient/additionalProperties/anyOf/1"
+                                },
+                                {
+                                  "not": {
+                                    "anyOf": [
+                                      {
+                                        "required": [
+                                          "Identifier"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "ConnectionOptions"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "RetryOptions"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
                             }
                           ]
                         },
@@ -986,7 +1086,72 @@
                               "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.EventProcessorClient' to configure its behavior."
                             },
                             {
-                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                              "allOf": [
+                                {
+                                  "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/EventProcessorClient/additionalProperties/anyOf/1"
+                                },
+                                {
+                                  "not": {
+                                    "anyOf": [
+                                      {
+                                        "required": [
+                                          "Identifier"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "TrackLastEnqueuedEventProperties"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "LoadBalancingStrategy"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "MaximumWaitTime"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "CacheEventCount"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "PrefetchCount"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "PrefetchSizeInBytes"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "LoadBalancingUpdateInterval"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "PartitionOwnershipExpirationInterval"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "ConnectionOptions"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "RetryOptions"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
                             }
                           ]
                         },
@@ -1321,7 +1486,57 @@
                               "description": "The set of options that can be specified when creating a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver' to configure its behavior."
                             },
                             {
-                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                              "allOf": [
+                                {
+                                  "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/EventHubs/properties/PartitionReceiver/additionalProperties/anyOf/1"
+                                },
+                                {
+                                  "not": {
+                                    "anyOf": [
+                                      {
+                                        "required": [
+                                          "ConnectionOptions"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "RetryOptions"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "DefaultMaximumReceiveWaitTime"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "Identifier"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "OwnerLevel"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "PrefetchCount"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "PrefetchSizeInBytes"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "TrackLastEnqueuedEventProperties"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
                             }
                           ]
                         },

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
@@ -151,7 +151,129 @@
                           "description": "Gets or sets the fully qualified Event Hubs namespace."
                         }
                       },
-                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient'."
+                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient'.",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "ClientOptions": {
+                            "type": "object",
+                            "properties": {
+                              "ConnectionOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "ConnectionIdleTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  },
+                                  "CustomEndpointAddress": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                  },
+                                  "ReceiveBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for receiving information via the active transport."
+                                  },
+                                  "SendBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for sending information via the active transport."
+                                  },
+                                  "TransportType": {
+                                    "enum": [
+                                      "AmqpTcp",
+                                      "AmqpWebSockets"
+                                    ],
+                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  }
+                                },
+                                "description": "The options used for configuring the connection to the Event Hubs service."
+                              },
+                              "EnableIdempotentRetries": {
+                                "type": "boolean",
+                                "description": "Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing will attempt to avoid duplication with a minor cost to throughput.  Duplicates are still possible but the chance of them occurring is much lower when idempotent retries are enabled."
+                              },
+                              "Identifier": {
+                                "type": "string",
+                                "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
+                              },
+                              "MaximumConcurrentSends": {
+                                "type": "integer",
+                                "description": "The total number of batches that may be sent concurrently, across all partitions.  This limit takes precedence over the value specified in 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition', ensuring this maximum is respected."
+                              },
+                              "MaximumConcurrentSendsPerPartition": {
+                                "type": "integer",
+                                "description": "The number of batches that may be sent concurrently for a given partition.  This option is superseded by the value specified for 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions.MaximumConcurrentSends', ensuring that limit is respected."
+                              },
+                              "MaximumEventBufferLengthPerPartition": {
+                                "type": "integer",
+                                "description": "The total number of events that can be buffered for publishing at a given time for a given partition.  Once this capacity is reached, more events can enqueued by calling 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventAsync(Azure.Messaging.EventHubs.EventData,Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)' or 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient.EnqueueEventsAsync(System.Collections.Generic.IEnumerable{Azure.Messaging.EventHubs.EventData},Azure.Messaging.EventHubs.Producer.EnqueueEventOptions,System.Threading.CancellationToken)', which will automatically wait for room to be available."
+                              },
+                              "MaximumWaitTime": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The amount of time to wait for a batch to be built with events in the buffer before publishing a partially full batch."
+                              },
+                              "RetryOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                  },
+                                  "MaximumDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts."
+                                  },
+                                  "MaximumRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "TryTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                  }
+                                },
+                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                              }
+                            },
+                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient' to configure its behavior."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "EventHubName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the Event Hub."
+                          },
+                          "FullyQualifiedNamespace": {
+                            "type": "string",
+                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          }
+                        },
+                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClient'."
+                      }
                     },
                     "EventHubConsumerClient": {
                       "type": "object",
@@ -256,7 +378,112 @@
                           "description": "Gets or sets the fully qualified Event Hubs namespace."
                         }
                       },
-                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient'."
+                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient'.",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "ClientOptions": {
+                            "type": "object",
+                            "properties": {
+                              "ConnectionOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "ConnectionIdleTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  },
+                                  "CustomEndpointAddress": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                  },
+                                  "ReceiveBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for receiving information via the active transport."
+                                  },
+                                  "SendBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for sending information via the active transport."
+                                  },
+                                  "TransportType": {
+                                    "enum": [
+                                      "AmqpTcp",
+                                      "AmqpWebSockets"
+                                    ],
+                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  }
+                                },
+                                "description": "The options used for configuring the connection to the Event Hubs service."
+                              },
+                              "Identifier": {
+                                "type": "string",
+                                "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
+                              },
+                              "RetryOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                  },
+                                  "MaximumDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts."
+                                  },
+                                  "MaximumRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "TryTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                  }
+                                },
+                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
+                              }
+                            },
+                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient' to configure its behavior."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          },
+                          "ConsumerGroup": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the consumer group."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "EventHubName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the Event Hub."
+                          },
+                          "FullyQualifiedNamespace": {
+                            "type": "string",
+                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          }
+                        },
+                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient'."
+                      }
                     },
                     "EventHubProducerClient": {
                       "type": "object",
@@ -357,7 +584,108 @@
                           "description": "Gets or sets the fully qualified Event Hubs namespace."
                         }
                       },
-                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient'."
+                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient'.",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "ClientOptions": {
+                            "type": "object",
+                            "properties": {
+                              "ConnectionOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "ConnectionIdleTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  },
+                                  "CustomEndpointAddress": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                  },
+                                  "ReceiveBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for receiving information via the active transport."
+                                  },
+                                  "SendBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for sending information via the active transport."
+                                  },
+                                  "TransportType": {
+                                    "enum": [
+                                      "AmqpTcp",
+                                      "AmqpWebSockets"
+                                    ],
+                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  }
+                                },
+                                "description": "The options used for configuring the connection to the Event Hubs service."
+                              },
+                              "Identifier": {
+                                "type": "string",
+                                "description": "A unique name used to identify the consumer.  If null or empty, a GUID will be used as the identifier."
+                              },
+                              "RetryOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                  },
+                                  "MaximumDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts."
+                                  },
+                                  "MaximumRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "TryTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                  }
+                                },
+                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                              }
+                            },
+                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient' to configure its behavior."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "EventHubName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the Event Hub."
+                          },
+                          "FullyQualifiedNamespace": {
+                            "type": "string",
+                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          }
+                        },
+                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient'."
+                      }
                     },
                     "EventProcessorClient": {
                       "type": "object",
@@ -508,7 +836,158 @@
                           "description": "Gets or sets the fully qualified Event Hubs namespace."
                         }
                       },
-                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.EventProcessorClient'."
+                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.EventProcessorClient'.",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "BlobClientServiceKey": {
+                            "type": "string",
+                            "description": "Gets or sets the IServiceProvider service key used to obtain an Azure BlobServiceClient."
+                          },
+                          "BlobContainerName": {
+                            "type": "string",
+                            "description": "Get or sets the name of the blob container used to store the checkpoint data. If this container does not exist, Aspire will attempt to create it. If this is not provided, Aspire will attempt to automatically create a container with a name based on the Namespace, Event Hub name and Consumer Group. If a container is provided in the connection string, it will override this value and the container will be assumed to exist."
+                          },
+                          "ClientOptions": {
+                            "type": "object",
+                            "properties": {
+                              "CacheEventCount": {
+                                "type": "integer",
+                                "description": "The maximum number of events that will be read from the Event Hubs service and held in a local memory cache when reading is active and events are being emitted to an enumerator for processing."
+                              },
+                              "ConnectionOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "ConnectionIdleTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  },
+                                  "CustomEndpointAddress": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                  },
+                                  "ReceiveBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for receiving information via the active transport."
+                                  },
+                                  "SendBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for sending information via the active transport."
+                                  },
+                                  "TransportType": {
+                                    "enum": [
+                                      "AmqpTcp",
+                                      "AmqpWebSockets"
+                                    ],
+                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  }
+                                },
+                                "description": "Gets or sets the options used for configuring the connection to the Event Hubs service."
+                              },
+                              "Identifier": {
+                                "type": "string",
+                                "description": "A unique name used to identify the event processor.  If null or empty, a GUID will be used as the identifier."
+                              },
+                              "LoadBalancingStrategy": {
+                                "enum": [
+                                  "Balanced",
+                                  "Greedy"
+                                ],
+                                "description": "The strategy that an event processor will use to make decisions about partition ownership when performing load balancing to share work with other event processors."
+                              },
+                              "LoadBalancingUpdateInterval": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The desired amount of time to allow between load balancing verification attempts."
+                              },
+                              "MaximumWaitTime": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum amount of time to wait for an event to become available for a given partition before emitting an empty event."
+                              },
+                              "PartitionOwnershipExpirationInterval": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The desired amount of time to consider a partition owned by a specific event processor instance before the ownership is considered stale and the partition becomes eligible to be requested by another event processor that wishes to assume responsibility for processing it."
+                              },
+                              "PrefetchCount": {
+                                "type": "integer",
+                                "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
+                              },
+                              "PrefetchSizeInBytes": {
+                                "type": "integer",
+                                "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
+                              },
+                              "RetryOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                  },
+                                  "MaximumDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts."
+                                  },
+                                  "MaximumRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "TryTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                  }
+                                },
+                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for publishing events and other interactions with the Event Hubs service."
+                              },
+                              "TrackLastEnqueuedEventProperties": {
+                                "type": "boolean",
+                                "description": "Indicates whether or not the consumer should request information on the last enqueued event on the partition associated with a given event, and track that information as events are received."
+                              }
+                            },
+                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.EventHubs.EventProcessorClient' to configure its behavior."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          },
+                          "ConsumerGroup": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the consumer group."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "EventHubName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the Event Hub."
+                          },
+                          "FullyQualifiedNamespace": {
+                            "type": "string",
+                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          }
+                        },
+                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.EventProcessorClient'."
+                      }
                     },
                     "PartitionReceiver": {
                       "type": "object",
@@ -638,7 +1117,137 @@
                           "description": "Gets or sets the partition identifier."
                         }
                       },
-                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver'."
+                      "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver'.",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "ClientOptions": {
+                            "type": "object",
+                            "properties": {
+                              "ConnectionOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "ConnectionIdleTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                                  },
+                                  "CustomEndpointAddress": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "The address to use for establishing a connection to the Event Hubs service, allowing network requests to be routed through any application gateways or other paths needed for the host environment."
+                                  },
+                                  "ReceiveBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for receiving information via the active transport."
+                                  },
+                                  "SendBufferSizeInBytes": {
+                                    "type": "integer",
+                                    "description": "The size of the buffer used for sending information via the active transport."
+                                  },
+                                  "TransportType": {
+                                    "enum": [
+                                      "AmqpTcp",
+                                      "AmqpWebSockets"
+                                    ],
+                                    "description": "The type of protocol and transport that will be used for communicating with the Event Hubs service."
+                                  }
+                                },
+                                "description": "The options used for configuring the connection to the Event Hubs service."
+                              },
+                              "DefaultMaximumReceiveWaitTime": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The default amount of time to wait for the requested amount of messages when reading; if this period elapses before the requested amount of messages were available or read, then the set of messages that were read will be returned."
+                              },
+                              "Identifier": {
+                                "type": "string",
+                                "description": "A unique name used to identify the receiver.  If null or empty, a GUID will be used as the identifier."
+                              },
+                              "OwnerLevel": {
+                                "type": "integer",
+                                "description": "When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same partition/consumer group pair, the one having a larger 'Azure.Messaging.EventHubs.Primitives.PartitionReceiverOptions.OwnerLevel' value will \"win.\"\n\nWhen an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation."
+                              },
+                              "PrefetchCount": {
+                                "type": "integer",
+                                "description": "The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
+                              },
+                              "PrefetchSizeInBytes": {
+                                "type": "integer",
+                                "description": "The desired number of bytes to attempt to eagerly request from the Event Hubs service and queued locally without regard to whether a read operation is currently active, intended to help maximize throughput by allowing events to be read from from a local cache rather than waiting on a service request."
+                              },
+                              "RetryOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                  },
+                                  "MaximumDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts."
+                                  },
+                                  "MaximumRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "TryTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                  }
+                                },
+                                "description": "The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for reading events and other interactions with the Event Hubs service."
+                              },
+                              "TrackLastEnqueuedEventProperties": {
+                                "type": "boolean",
+                                "description": "Indicates whether or not the reader should request information on the last enqueued event on the partition associated with a given event, and track that information as events are read."
+                              }
+                            },
+                            "description": "The set of options that can be specified when creating a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver' to configure its behavior."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
+                          },
+                          "ConsumerGroup": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the consumer group."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the Azure Event Hubs health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "EventHubName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the Event Hub."
+                          },
+                          "FullyQualifiedNamespace": {
+                            "type": "string",
+                            "description": "Gets or sets the fully qualified Event Hubs namespace."
+                          },
+                          "PartitionId": {
+                            "type": "string",
+                            "description": "Gets or sets the partition identifier."
+                          }
+                        },
+                        "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver'."
+                      }
                     }
                   }
                 }

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AssemblyInfo.cs
@@ -7,6 +7,8 @@ using Azure.Messaging.ServiceBus;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:ServiceBus", typeof(AzureMessagingServiceBusSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:ServiceBus:ClientOptions", typeof(ServiceBusClientOptions))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:ServiceBus:*", typeof(AzureMessagingServiceBusSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:ServiceBus:*:ClientOptions", typeof(ServiceBusClientOptions))]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/ConfigurationSchema.json
@@ -124,7 +124,105 @@
                       "description": "Name of the subscription associated with the connection string."
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to Azure Service Bus."
+                  "description": "Provides the client configuration settings for connecting to Azure Service Bus.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "ConnectionIdleTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
+                          },
+                          "CustomEndpointAddress": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "A custom endpoint address that can be used when establishing the connection to the Service Bus service."
+                          },
+                          "EnableCrossEntityTransactions": {
+                            "type": "boolean",
+                            "description": "Gets or sets a flag that indicates whether or not transactions may span multiple Service Bus entities."
+                          },
+                          "Identifier": {
+                            "type": "string",
+                            "description": "A property used to set the 'Azure.Messaging.ServiceBus.ServiceBusClient' ID to identify the client. This can be used to correlate logs and exceptions. If null or empty, a random unique value will be used."
+                          },
+                          "RetryOptions": {
+                            "type": "object",
+                            "properties": {
+                              "Delay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                              },
+                              "MaxDelay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum permissible delay between retry attempts."
+                              },
+                              "MaxRetries": {
+                                "type": "integer",
+                                "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Fixed",
+                                  "Exponential"
+                                ],
+                                "description": "The approach to use for calculating retry delays."
+                              },
+                              "TryTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                              }
+                            },
+                            "description": "The set of options to use for determining whether a failed service operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for the individual network operations used for interactions with the Service Bus service."
+                          },
+                          "TransportType": {
+                            "enum": [
+                              "AmqpTcp",
+                              "AmqpWebSockets"
+                            ],
+                            "description": "The type of protocol and transport that will be used for communicating with the Service Bus service."
+                          }
+                        },
+                        "description": "The set of options that can be specified when creating an 'Azure.Messaging.ServiceBus.ServiceBusConnection' to configure its behavior."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string used to connect to the Service Bus namespace."
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "FullyQualifiedNamespace": {
+                        "type": "string",
+                        "description": "Gets or sets the fully qualified Service Bus namespace."
+                      },
+                      "HealthCheckQueueName": {
+                        "type": "string",
+                        "description": "Name of the queue used by the health check. Mandatory to get health checks enabled."
+                      },
+                      "HealthCheckTopicName": {
+                        "type": "string",
+                        "description": "Name of the topic used by the health check. Mandatory to get health checks enabled."
+                      },
+                      "QueueOrTopicName": {
+                        "type": "string",
+                        "description": "Name of the queue or topic associated with the connection string."
+                      },
+                      "SubscriptionName": {
+                        "type": "string",
+                        "description": "Name of the subscription associated with the connection string."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to Azure Service Bus."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/ConfigurationSchema.json
@@ -97,7 +97,47 @@
                           "description": "The set of options that can be specified when creating an 'Azure.Messaging.ServiceBus.ServiceBusConnection' to configure its behavior."
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "TransportType"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Identifier"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "CustomEndpointAddress"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "ConnectionIdleTimeout"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "RetryOptions"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "EnableCrossEntityTransactions"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/ConfigurationSchema.json
@@ -32,196 +32,261 @@
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "ConnectionIdleTimeout": {
-                          "type": "string",
-                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                          "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
-                        },
-                        "CustomEndpointAddress": {
-                          "type": "string",
-                          "format": "uri",
-                          "description": "A custom endpoint address that can be used when establishing the connection to the Service Bus service."
-                        },
-                        "EnableCrossEntityTransactions": {
-                          "type": "boolean",
-                          "description": "Gets or sets a flag that indicates whether or not transactions may span multiple Service Bus entities."
-                        },
-                        "Identifier": {
-                          "type": "string",
-                          "description": "A property used to set the 'Azure.Messaging.ServiceBus.ServiceBusClient' ID to identify the client. This can be used to correlate logs and exceptions. If null or empty, a random unique value will be used."
-                        },
-                        "RetryOptions": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "Delay": {
+                            "ConnectionIdleTimeout": {
                               "type": "string",
                               "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                              "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
                             },
-                            "MaxDelay": {
+                            "CustomEndpointAddress": {
                               "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum permissible delay between retry attempts."
+                              "format": "uri",
+                              "description": "A custom endpoint address that can be used when establishing the connection to the Service Bus service."
                             },
-                            "MaxRetries": {
-                              "type": "integer",
-                              "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                            "EnableCrossEntityTransactions": {
+                              "type": "boolean",
+                              "description": "Gets or sets a flag that indicates whether or not transactions may span multiple Service Bus entities."
                             },
-                            "Mode": {
+                            "Identifier": {
+                              "type": "string",
+                              "description": "A property used to set the 'Azure.Messaging.ServiceBus.ServiceBusClient' ID to identify the client. This can be used to correlate logs and exceptions. If null or empty, a random unique value will be used."
+                            },
+                            "RetryOptions": {
+                              "type": "object",
+                              "properties": {
+                                "Delay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                },
+                                "MaxDelay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum permissible delay between retry attempts."
+                                },
+                                "MaxRetries": {
+                                  "type": "integer",
+                                  "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                },
+                                "Mode": {
+                                  "enum": [
+                                    "Fixed",
+                                    "Exponential"
+                                  ],
+                                  "description": "The approach to use for calculating retry delays."
+                                },
+                                "TryTimeout": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                }
+                              },
+                              "description": "The set of options to use for determining whether a failed service operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for the individual network operations used for interactions with the Service Bus service."
+                            },
+                            "TransportType": {
                               "enum": [
-                                "Fixed",
-                                "Exponential"
+                                "AmqpTcp",
+                                "AmqpWebSockets"
                               ],
-                              "description": "The approach to use for calculating retry delays."
-                            },
-                            "TryTimeout": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                              "description": "The type of protocol and transport that will be used for communicating with the Service Bus service."
                             }
                           },
-                          "description": "The set of options to use for determining whether a failed service operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for the individual network operations used for interactions with the Service Bus service."
+                          "description": "The set of options that can be specified when creating an 'Azure.Messaging.ServiceBus.ServiceBusConnection' to configure its behavior."
                         },
-                        "TransportType": {
-                          "enum": [
-                            "AmqpTcp",
-                            "AmqpWebSockets"
-                          ],
-                          "description": "The type of protocol and transport that will be used for communicating with the Service Bus service."
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "The set of options that can be specified when creating an 'Azure.Messaging.ServiceBus.ServiceBusConnection' to configure its behavior."
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string used to connect to the Service Bus namespace."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string used to connect to the Service Bus namespace."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "FullyQualifiedNamespace": {
-                      "type": "string",
-                      "description": "Gets or sets the fully qualified Service Bus namespace."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the fully qualified Service Bus namespace."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "HealthCheckQueueName": {
-                      "type": "string",
-                      "description": "Name of the queue used by the health check. Mandatory to get health checks enabled."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Name of the queue used by the health check. Mandatory to get health checks enabled."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "HealthCheckTopicName": {
-                      "type": "string",
-                      "description": "Name of the topic used by the health check. Mandatory to get health checks enabled."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Name of the topic used by the health check. Mandatory to get health checks enabled."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "QueueOrTopicName": {
-                      "type": "string",
-                      "description": "Name of the queue or topic associated with the connection string."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Name of the queue or topic associated with the connection string."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "SubscriptionName": {
-                      "type": "string",
-                      "description": "Name of the subscription associated with the connection string."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Name of the subscription associated with the connection string."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/ServiceBus/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Service Bus.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
                         "type": "object",
                         "properties": {
-                          "ConnectionIdleTimeout": {
-                            "type": "string",
-                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                            "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
-                          },
-                          "CustomEndpointAddress": {
-                            "type": "string",
-                            "format": "uri",
-                            "description": "A custom endpoint address that can be used when establishing the connection to the Service Bus service."
-                          },
-                          "EnableCrossEntityTransactions": {
-                            "type": "boolean",
-                            "description": "Gets or sets a flag that indicates whether or not transactions may span multiple Service Bus entities."
-                          },
-                          "Identifier": {
-                            "type": "string",
-                            "description": "A property used to set the 'Azure.Messaging.ServiceBus.ServiceBusClient' ID to identify the client. This can be used to correlate logs and exceptions. If null or empty, a random unique value will be used."
-                          },
-                          "RetryOptions": {
+                          "ClientOptions": {
                             "type": "object",
                             "properties": {
-                              "Delay": {
+                              "ConnectionIdleTimeout": {
                                 "type": "string",
                                 "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                "description": "The amount of time to allow a connection to have no observed traffic before considering it idle and eligible to close."
                               },
-                              "MaxDelay": {
+                              "CustomEndpointAddress": {
                                 "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum permissible delay between retry attempts."
+                                "format": "uri",
+                                "description": "A custom endpoint address that can be used when establishing the connection to the Service Bus service."
                               },
-                              "MaxRetries": {
-                                "type": "integer",
-                                "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                              "EnableCrossEntityTransactions": {
+                                "type": "boolean",
+                                "description": "Gets or sets a flag that indicates whether or not transactions may span multiple Service Bus entities."
                               },
-                              "Mode": {
+                              "Identifier": {
+                                "type": "string",
+                                "description": "A property used to set the 'Azure.Messaging.ServiceBus.ServiceBusClient' ID to identify the client. This can be used to correlate logs and exceptions. If null or empty, a random unique value will be used."
+                              },
+                              "RetryOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach."
+                                  },
+                                  "MaxDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts."
+                                  },
+                                  "MaxRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before considering the associated operation to have failed."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "TryTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                  }
+                                },
+                                "description": "The set of options to use for determining whether a failed service operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for the individual network operations used for interactions with the Service Bus service."
+                              },
+                              "TransportType": {
                                 "enum": [
-                                  "Fixed",
-                                  "Exponential"
+                                  "AmqpTcp",
+                                  "AmqpWebSockets"
                                 ],
-                                "description": "The approach to use for calculating retry delays."
-                              },
-                              "TryTimeout": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum duration to wait for completion of a single attempt, whether the initial attempt or a retry."
+                                "description": "The type of protocol and transport that will be used for communicating with the Service Bus service."
                               }
                             },
-                            "description": "The set of options to use for determining whether a failed service operation should be retried and, if so, the amount of time to wait between retry attempts.  These options also control the amount of time allowed for the individual network operations used for interactions with the Service Bus service."
+                            "description": "The set of options that can be specified when creating an 'Azure.Messaging.ServiceBus.ServiceBusConnection' to configure its behavior."
                           },
-                          "TransportType": {
-                            "enum": [
-                              "AmqpTcp",
-                              "AmqpWebSockets"
-                            ],
-                            "description": "The type of protocol and transport that will be used for communicating with the Service Bus service."
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the Service Bus namespace."
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "FullyQualifiedNamespace": {
+                            "type": "string",
+                            "description": "Gets or sets the fully qualified Service Bus namespace."
+                          },
+                          "HealthCheckQueueName": {
+                            "type": "string",
+                            "description": "Name of the queue used by the health check. Mandatory to get health checks enabled."
+                          },
+                          "HealthCheckTopicName": {
+                            "type": "string",
+                            "description": "Name of the topic used by the health check. Mandatory to get health checks enabled."
+                          },
+                          "QueueOrTopicName": {
+                            "type": "string",
+                            "description": "Name of the queue or topic associated with the connection string."
+                          },
+                          "SubscriptionName": {
+                            "type": "string",
+                            "description": "Name of the subscription associated with the connection string."
                           }
                         },
-                        "description": "The set of options that can be specified when creating an 'Azure.Messaging.ServiceBus.ServiceBusConnection' to configure its behavior."
-                      },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string used to connect to the Service Bus namespace."
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "FullyQualifiedNamespace": {
-                        "type": "string",
-                        "description": "Gets or sets the fully qualified Service Bus namespace."
-                      },
-                      "HealthCheckQueueName": {
-                        "type": "string",
-                        "description": "Name of the queue used by the health check. Mandatory to get health checks enabled."
-                      },
-                      "HealthCheckTopicName": {
-                        "type": "string",
-                        "description": "Name of the topic used by the health check. Mandatory to get health checks enabled."
-                      },
-                      "QueueOrTopicName": {
-                        "type": "string",
-                        "description": "Name of the queue or topic associated with the connection string."
-                      },
-                      "SubscriptionName": {
-                        "type": "string",
-                        "description": "Name of the subscription associated with the connection string."
+                        "description": "Provides the client configuration settings for connecting to Azure Service Bus."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to Azure Service Bus."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Azure.Messaging.WebPubSub/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Messaging.WebPubSub/AssemblyInfo.cs
@@ -7,6 +7,9 @@ using Azure.Messaging.WebPubSub;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:WebPubSub", typeof(AzureMessagingWebPubSubSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Messaging:WebPubSub:ClientOptions", typeof(WebPubSubServiceClientOptions), exclusionPaths: ["Default"])]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:WebPubSub:*", typeof(AzureMessagingWebPubSubSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:WebPubSub:*:ClientOptions", typeof(WebPubSubServiceClientOptions), exclusionPaths: ["Default"])]
+[assembly: ConfigurationSchema("Aspire:Azure:Messaging:WebPubSub:*:*", typeof(AzureMessagingWebPubSubSettings))]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.Messaging.WebPubSub/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.WebPubSub/ConfigurationSchema.json
@@ -125,7 +125,32 @@
                           "description": "Provides the client configuration options for connecting to Azure WebPubSub service."
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "ReverseProxyEndpoint"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Diagnostics"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Retry"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },
@@ -293,7 +318,32 @@
                                 "description": "Provides the client configuration options for connecting to Azure WebPubSub service."
                               },
                               {
-                                "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1/additionalProperties/anyOf/1"
+                                "allOf": [
+                                  {
+                                    "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1/additionalProperties/anyOf/1"
+                                  },
+                                  {
+                                    "not": {
+                                      "anyOf": [
+                                        {
+                                          "required": [
+                                            "ReverseProxyEndpoint"
+                                          ]
+                                        },
+                                        {
+                                          "required": [
+                                            "Diagnostics"
+                                          ]
+                                        },
+                                        {
+                                          "required": [
+                                            "Retry"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
                               }
                             ]
                           },

--- a/src/Components/Aspire.Azure.Messaging.WebPubSub/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.WebPubSub/ConfigurationSchema.json
@@ -146,7 +146,156 @@
                       "description": "Gets or sets the name of the hub used."
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to Azure Web PubSub."
+                  "description": "Provides the client configuration settings for connecting to Azure Web PubSub.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "Diagnostics": {
+                            "type": "object",
+                            "properties": {
+                              "ApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                              },
+                              "DefaultApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                              },
+                              "IsDistributedTracingEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                              },
+                              "IsLoggingContentEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request or response content should be logged."
+                              },
+                              "IsLoggingEnabled": {
+                                "type": "boolean",
+                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                              },
+                              "IsTelemetryEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                              },
+                              "LoggedContentSizeLimit": {
+                                "type": "integer",
+                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                              },
+                              "LoggedHeaderNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of header names that are not redacted during logging."
+                              },
+                              "LoggedQueryParameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                              }
+                            },
+                            "description": "Gets the client diagnostic options."
+                          },
+                          "Retry": {
+                            "type": "object",
+                            "properties": {
+                              "Delay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxDelay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxRetries": {
+                                "type": "integer",
+                                "description": "The maximum number of retry attempts before giving up."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Fixed",
+                                  "Exponential"
+                                ],
+                                "description": "The approach to use for calculating retry delays."
+                              },
+                              "NetworkTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The timeout applied to individual network operations."
+                              }
+                            },
+                            "description": "Gets the client retry options."
+                          },
+                          "ReverseProxyEndpoint": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Reverse proxy."
+                          }
+                        },
+                        "description": "Provides the client configuration options for connecting to Azure WebPubSub service."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string used to connect to the Web PubSub service."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the Web PubSub health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Gets or sets the endpoint of the Web PubSub service. This is likely to be similar to \"https://{name}.webpubsub.azure.com/\"."
+                      },
+                      "HubName": {
+                        "type": "string",
+                        "description": "Gets or sets the name of the hub used."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to Azure Web PubSub.",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "ConnectionString": {
+                          "type": "string",
+                          "description": "Gets or sets the connection string used to connect to the Web PubSub service."
+                        },
+                        "DisableHealthChecks": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the Web PubSub health check is disabled or not.",
+                          "default": false
+                        },
+                        "DisableTracing": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        "Endpoint": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "Gets or sets the endpoint of the Web PubSub service. This is likely to be similar to \"https://{name}.webpubsub.azure.com/\"."
+                        },
+                        "HubName": {
+                          "type": "string",
+                          "description": "Gets or sets the name of the hub used."
+                        }
+                      },
+                      "description": "Provides the client configuration settings for connecting to Azure Web PubSub."
+                    }
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.Messaging.WebPubSub/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.WebPubSub/ConfigurationSchema.json
@@ -32,269 +32,371 @@
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "Diagnostics": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "ApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                            },
-                            "DefaultApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                            },
-                            "IsDistributedTracingEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                            },
-                            "IsLoggingContentEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request or response content should be logged."
-                            },
-                            "IsLoggingEnabled": {
-                              "type": "boolean",
-                              "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                            },
-                            "IsTelemetryEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                            },
-                            "LoggedContentSizeLimit": {
-                              "type": "integer",
-                              "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                            },
-                            "LoggedHeaderNames": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Diagnostics": {
+                              "type": "object",
+                              "properties": {
+                                "ApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                },
+                                "DefaultApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                },
+                                "IsDistributedTracingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                },
+                                "IsLoggingContentEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request or response content should be logged."
+                                },
+                                "IsLoggingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                },
+                                "IsTelemetryEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                },
+                                "LoggedContentSizeLimit": {
+                                  "type": "integer",
+                                  "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                },
+                                "LoggedHeaderNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of header names that are not redacted during logging."
+                                },
+                                "LoggedQueryParameters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of query parameter names that are not redacted during logging."
+                                }
                               },
-                              "description": "Gets a list of header names that are not redacted during logging."
+                              "description": "Gets the client diagnostic options."
                             },
-                            "LoggedQueryParameters": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Retry": {
+                              "type": "object",
+                              "properties": {
+                                "Delay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxDelay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxRetries": {
+                                  "type": "integer",
+                                  "description": "The maximum number of retry attempts before giving up."
+                                },
+                                "Mode": {
+                                  "enum": [
+                                    "Fixed",
+                                    "Exponential"
+                                  ],
+                                  "description": "The approach to use for calculating retry delays."
+                                },
+                                "NetworkTimeout": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The timeout applied to individual network operations."
+                                }
                               },
-                              "description": "Gets a list of query parameter names that are not redacted during logging."
+                              "description": "Gets the client retry options."
+                            },
+                            "ReverseProxyEndpoint": {
+                              "type": "string",
+                              "format": "uri",
+                              "description": "Reverse proxy."
                             }
                           },
-                          "description": "Gets the client diagnostic options."
+                          "description": "Provides the client configuration options for connecting to Azure WebPubSub service."
                         },
-                        "Retry": {
-                          "type": "object",
-                          "properties": {
-                            "Delay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxDelay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxRetries": {
-                              "type": "integer",
-                              "description": "The maximum number of retry attempts before giving up."
-                            },
-                            "Mode": {
-                              "enum": [
-                                "Fixed",
-                                "Exponential"
-                              ],
-                              "description": "The approach to use for calculating retry delays."
-                            },
-                            "NetworkTimeout": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The timeout applied to individual network operations."
-                            }
-                          },
-                          "description": "Gets the client retry options."
-                        },
-                        "ReverseProxyEndpoint": {
-                          "type": "string",
-                          "format": "uri",
-                          "description": "Reverse proxy."
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "Provides the client configuration options for connecting to Azure WebPubSub service."
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string used to connect to the Web PubSub service."
-                    },
-                    "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Web PubSub health check is disabled or not.",
-                      "default": false
-                    },
-                    "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
-                    },
-                    "Endpoint": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "Gets or sets the endpoint of the Web PubSub service. This is likely to be similar to \"https://{name}.webpubsub.azure.com/\"."
-                    },
-                    "HubName": {
-                      "type": "string",
-                      "description": "Gets or sets the name of the hub used."
-                    }
-                  },
-                  "description": "Provides the client configuration settings for connecting to Azure Web PubSub.",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
-                        "type": "object",
-                        "properties": {
-                          "Diagnostics": {
-                            "type": "object",
-                            "properties": {
-                              "ApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                              },
-                              "DefaultApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                              },
-                              "IsDistributedTracingEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                              },
-                              "IsLoggingContentEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request or response content should be logged."
-                              },
-                              "IsLoggingEnabled": {
-                                "type": "boolean",
-                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                              },
-                              "IsTelemetryEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                              },
-                              "LoggedContentSizeLimit": {
-                                "type": "integer",
-                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                              },
-                              "LoggedHeaderNames": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "Gets a list of header names that are not redacted during logging."
-                              },
-                              "LoggedQueryParameters": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "Gets a list of query parameter names that are not redacted during logging."
-                              }
-                            },
-                            "description": "Gets the client diagnostic options."
-                          },
-                          "Retry": {
-                            "type": "object",
-                            "properties": {
-                              "Delay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxDelay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxRetries": {
-                                "type": "integer",
-                                "description": "The maximum number of retry attempts before giving up."
-                              },
-                              "Mode": {
-                                "enum": [
-                                  "Fixed",
-                                  "Exponential"
-                                ],
-                                "description": "The approach to use for calculating retry delays."
-                              },
-                              "NetworkTimeout": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The timeout applied to individual network operations."
-                              }
-                            },
-                            "description": "Gets the client retry options."
-                          },
-                          "ReverseProxyEndpoint": {
-                            "type": "string",
-                            "format": "uri",
-                            "description": "Reverse proxy."
-                          }
-                        },
-                        "description": "Provides the client configuration options for connecting to Azure WebPubSub service."
-                      },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string used to connect to the Web PubSub service."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the Web PubSub health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "Endpoint": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "Gets or sets the endpoint of the Web PubSub service. This is likely to be similar to \"https://{name}.webpubsub.azure.com/\"."
-                      },
-                      "HubName": {
-                        "type": "string",
-                        "description": "Gets or sets the name of the hub used."
-                      }
-                    },
-                    "description": "Provides the client configuration settings for connecting to Azure Web PubSub.",
-                    "additionalProperties": {
-                      "type": "object",
-                      "properties": {
-                        "ConnectionString": {
+                      "anyOf": [
+                        {
                           "type": "string",
                           "description": "Gets or sets the connection string used to connect to the Web PubSub service."
                         },
-                        "DisableHealthChecks": {
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1"
+                        }
+                      ]
+                    },
+                    "DisableHealthChecks": {
+                      "anyOf": [
+                        {
                           "type": "boolean",
                           "description": "Gets or sets a boolean value that indicates whether the Web PubSub health check is disabled or not.",
                           "default": false
                         },
-                        "DisableTracing": {
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1"
+                        }
+                      ]
+                    },
+                    "DisableTracing": {
+                      "anyOf": [
+                        {
                           "type": "boolean",
                           "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
                           "default": false
                         },
-                        "Endpoint": {
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1"
+                        }
+                      ]
+                    },
+                    "Endpoint": {
+                      "anyOf": [
+                        {
                           "type": "string",
                           "format": "uri",
                           "description": "Gets or sets the endpoint of the Web PubSub service. This is likely to be similar to \"https://{name}.webpubsub.azure.com/\"."
                         },
-                        "HubName": {
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1"
+                        }
+                      ]
+                    },
+                    "HubName": {
+                      "anyOf": [
+                        {
                           "type": "string",
                           "description": "Gets or sets the name of the hub used."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1"
+                        }
+                      ]
+                    }
+                  },
+                  "description": "Provides the client configuration settings for connecting to Azure Web PubSub.",
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
                         }
                       },
-                      "description": "Provides the client configuration settings for connecting to Azure Web PubSub."
-                    }
+                      {
+                        "type": "object",
+                        "properties": {
+                          "ClientOptions": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "Diagnostics": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ApplicationId": {
+                                        "type": "string",
+                                        "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                      },
+                                      "DefaultApplicationId": {
+                                        "type": "string",
+                                        "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                      },
+                                      "IsDistributedTracingEnabled": {
+                                        "type": "boolean",
+                                        "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                      },
+                                      "IsLoggingContentEnabled": {
+                                        "type": "boolean",
+                                        "description": "Gets or sets value indicating if request or response content should be logged."
+                                      },
+                                      "IsLoggingEnabled": {
+                                        "type": "boolean",
+                                        "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                      },
+                                      "IsTelemetryEnabled": {
+                                        "type": "boolean",
+                                        "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                      },
+                                      "LoggedContentSizeLimit": {
+                                        "type": "integer",
+                                        "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                      },
+                                      "LoggedHeaderNames": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "description": "Gets a list of header names that are not redacted during logging."
+                                      },
+                                      "LoggedQueryParameters": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "description": "Gets a list of query parameter names that are not redacted during logging."
+                                      }
+                                    },
+                                    "description": "Gets the client diagnostic options."
+                                  },
+                                  "Retry": {
+                                    "type": "object",
+                                    "properties": {
+                                      "Delay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                      },
+                                      "MaxDelay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                      },
+                                      "MaxRetries": {
+                                        "type": "integer",
+                                        "description": "The maximum number of retry attempts before giving up."
+                                      },
+                                      "Mode": {
+                                        "enum": [
+                                          "Fixed",
+                                          "Exponential"
+                                        ],
+                                        "description": "The approach to use for calculating retry delays."
+                                      },
+                                      "NetworkTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The timeout applied to individual network operations."
+                                      }
+                                    },
+                                    "description": "Gets the client retry options."
+                                  },
+                                  "ReverseProxyEndpoint": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "Reverse proxy."
+                                  }
+                                },
+                                "description": "Provides the client configuration options for connecting to Azure WebPubSub service."
+                              },
+                              {
+                                "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1/additionalProperties/anyOf/1"
+                              }
+                            ]
+                          },
+                          "ConnectionString": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "description": "Gets or sets the connection string used to connect to the Web PubSub service."
+                              },
+                              {
+                                "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1/additionalProperties/anyOf/1"
+                              }
+                            ]
+                          },
+                          "DisableHealthChecks": {
+                            "anyOf": [
+                              {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the Web PubSub health check is disabled or not.",
+                                "default": false
+                              },
+                              {
+                                "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1/additionalProperties/anyOf/1"
+                              }
+                            ]
+                          },
+                          "DisableTracing": {
+                            "anyOf": [
+                              {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                                "default": false
+                              },
+                              {
+                                "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1/additionalProperties/anyOf/1"
+                              }
+                            ]
+                          },
+                          "Endpoint": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uri",
+                                "description": "Gets or sets the endpoint of the Web PubSub service. This is likely to be similar to \"https://{name}.webpubsub.azure.com/\"."
+                              },
+                              {
+                                "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1/additionalProperties/anyOf/1"
+                              }
+                            ]
+                          },
+                          "HubName": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "description": "Gets or sets the name of the hub used."
+                              },
+                              {
+                                "$ref": "#/properties/Aspire/properties/Azure/properties/Messaging/properties/WebPubSub/additionalProperties/anyOf/1/additionalProperties/anyOf/1"
+                              }
+                            ]
+                          }
+                        },
+                        "description": "Provides the client configuration settings for connecting to Azure Web PubSub.",
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "not": {
+                                "type": "object"
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "ConnectionString": {
+                                  "type": "string",
+                                  "description": "Gets or sets the connection string used to connect to the Web PubSub service."
+                                },
+                                "DisableHealthChecks": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets a boolean value that indicates whether the Web PubSub health check is disabled or not.",
+                                  "default": false
+                                },
+                                "DisableTracing": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                                  "default": false
+                                },
+                                "Endpoint": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "description": "Gets or sets the endpoint of the Web PubSub service. This is likely to be similar to \"https://{name}.webpubsub.azure.com/\"."
+                                },
+                                "HubName": {
+                                  "type": "string",
+                                  "description": "Gets or sets the name of the hub used."
+                                }
+                              },
+                              "description": "Provides the client configuration settings for connecting to Azure Web PubSub."
+                            }
+                          ]
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Azure.Search.Documents/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Search.Documents/AssemblyInfo.cs
@@ -7,6 +7,8 @@ using Azure.Search.Documents;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Search:Documents", typeof(AzureSearchSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Search:Documents:ClientOptions", typeof(SearchClientOptions), exclusionPaths: ["Default"])]
+[assembly: ConfigurationSchema("Aspire:Azure:Search:Documents:*", typeof(AzureSearchSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Search:Documents:*:ClientOptions", typeof(SearchClientOptions), exclusionPaths: ["Default"])]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
@@ -32,222 +32,266 @@
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "Diagnostics": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "ApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                            },
-                            "DefaultApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                            },
-                            "IsDistributedTracingEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                            },
-                            "IsLoggingContentEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request or response content should be logged."
-                            },
-                            "IsLoggingEnabled": {
-                              "type": "boolean",
-                              "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                            },
-                            "IsTelemetryEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                            },
-                            "LoggedContentSizeLimit": {
-                              "type": "integer",
-                              "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                            },
-                            "LoggedHeaderNames": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Diagnostics": {
+                              "type": "object",
+                              "properties": {
+                                "ApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                },
+                                "DefaultApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                },
+                                "IsDistributedTracingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                },
+                                "IsLoggingContentEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request or response content should be logged."
+                                },
+                                "IsLoggingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                },
+                                "IsTelemetryEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                },
+                                "LoggedContentSizeLimit": {
+                                  "type": "integer",
+                                  "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                },
+                                "LoggedHeaderNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of header names that are not redacted during logging."
+                                },
+                                "LoggedQueryParameters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of query parameter names that are not redacted during logging."
+                                }
                               },
-                              "description": "Gets a list of header names that are not redacted during logging."
+                              "description": "Gets the client diagnostic options."
                             },
-                            "LoggedQueryParameters": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Retry": {
+                              "type": "object",
+                              "properties": {
+                                "Delay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxDelay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxRetries": {
+                                  "type": "integer",
+                                  "description": "The maximum number of retry attempts before giving up."
+                                },
+                                "Mode": {
+                                  "enum": [
+                                    "Fixed",
+                                    "Exponential"
+                                  ],
+                                  "description": "The approach to use for calculating retry delays."
+                                },
+                                "NetworkTimeout": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The timeout applied to individual network operations."
+                                }
                               },
-                              "description": "Gets a list of query parameter names that are not redacted during logging."
+                              "description": "Gets the client retry options."
                             }
                           },
-                          "description": "Gets the client diagnostic options."
+                          "description": "Client options for clients in this library."
                         },
-                        "Retry": {
-                          "type": "object",
-                          "properties": {
-                            "Delay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxDelay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxRetries": {
-                              "type": "integer",
-                              "description": "The maximum number of retry attempts before giving up."
-                            },
-                            "Mode": {
-                              "enum": [
-                                "Fixed",
-                                "Exponential"
-                              ],
-                              "description": "The approach to use for calculating retry delays."
-                            },
-                            "NetworkTimeout": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The timeout applied to individual network operations."
-                            }
-                          },
-                          "description": "Gets the client retry options."
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Search/properties/Documents/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "Client options for clients in this library."
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Azure AI Search health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the Azure AI Search health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Search/properties/Documents/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Search/properties/Documents/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "Endpoint": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "Gets or sets a 'System.Uri' referencing the Azure AI Search endpoint. This is likely to be similar to \"https://{search_service}.search.windows.net\"."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "Gets or sets a 'System.Uri' referencing the Azure AI Search endpoint. This is likely to be similar to \"https://{search_service}.search.windows.net\"."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Search/properties/Documents/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "Key": {
-                      "type": "string",
-                      "description": "Gets or sets the key to use to authenticate to the Azure AI Search endpoint."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the key to use to authenticate to the Azure AI Search endpoint."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Search/properties/Documents/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure AI Search.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
                         "type": "object",
                         "properties": {
-                          "Diagnostics": {
+                          "ClientOptions": {
                             "type": "object",
                             "properties": {
-                              "ApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                              },
-                              "DefaultApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                              },
-                              "IsDistributedTracingEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                              },
-                              "IsLoggingContentEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request or response content should be logged."
-                              },
-                              "IsLoggingEnabled": {
-                                "type": "boolean",
-                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                              },
-                              "IsTelemetryEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                              },
-                              "LoggedContentSizeLimit": {
-                                "type": "integer",
-                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                              },
-                              "LoggedHeaderNames": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "Diagnostics": {
+                                "type": "object",
+                                "properties": {
+                                  "ApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                  },
+                                  "DefaultApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                  },
+                                  "IsDistributedTracingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                  },
+                                  "IsLoggingContentEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request or response content should be logged."
+                                  },
+                                  "IsLoggingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                  },
+                                  "IsTelemetryEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                  },
+                                  "LoggedContentSizeLimit": {
+                                    "type": "integer",
+                                    "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                  },
+                                  "LoggedHeaderNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of header names that are not redacted during logging."
+                                  },
+                                  "LoggedQueryParameters": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of query parameter names that are not redacted during logging."
+                                  }
                                 },
-                                "description": "Gets a list of header names that are not redacted during logging."
+                                "description": "Gets the client diagnostic options."
                               },
-                              "LoggedQueryParameters": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "Retry": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before giving up."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "NetworkTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The timeout applied to individual network operations."
+                                  }
                                 },
-                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                                "description": "Gets the client retry options."
                               }
                             },
-                            "description": "Gets the client diagnostic options."
+                            "description": "Client options for clients in this library."
                           },
-                          "Retry": {
-                            "type": "object",
-                            "properties": {
-                              "Delay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxDelay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxRetries": {
-                                "type": "integer",
-                                "description": "The maximum number of retry attempts before giving up."
-                              },
-                              "Mode": {
-                                "enum": [
-                                  "Fixed",
-                                  "Exponential"
-                                ],
-                                "description": "The approach to use for calculating retry delays."
-                              },
-                              "NetworkTimeout": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The timeout applied to individual network operations."
-                              }
-                            },
-                            "description": "Gets the client retry options."
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the Azure AI Search health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "Endpoint": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Gets or sets a 'System.Uri' referencing the Azure AI Search endpoint. This is likely to be similar to \"https://{search_service}.search.windows.net\"."
+                          },
+                          "Key": {
+                            "type": "string",
+                            "description": "Gets or sets the key to use to authenticate to the Azure AI Search endpoint."
                           }
                         },
-                        "description": "Client options for clients in this library."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the Azure AI Search health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "Endpoint": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "Gets or sets a 'System.Uri' referencing the Azure AI Search endpoint. This is likely to be similar to \"https://{search_service}.search.windows.net\"."
-                      },
-                      "Key": {
-                        "type": "string",
-                        "description": "Gets or sets the key to use to authenticate to the Azure AI Search endpoint."
+                        "description": "Provides the client configuration settings for connecting to Azure AI Search."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to Azure AI Search."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
@@ -137,7 +137,118 @@
                       "description": "Gets or sets the key to use to authenticate to the Azure AI Search endpoint."
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to Azure AI Search."
+                  "description": "Provides the client configuration settings for connecting to Azure AI Search.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "Diagnostics": {
+                            "type": "object",
+                            "properties": {
+                              "ApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                              },
+                              "DefaultApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                              },
+                              "IsDistributedTracingEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                              },
+                              "IsLoggingContentEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request or response content should be logged."
+                              },
+                              "IsLoggingEnabled": {
+                                "type": "boolean",
+                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                              },
+                              "IsTelemetryEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                              },
+                              "LoggedContentSizeLimit": {
+                                "type": "integer",
+                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                              },
+                              "LoggedHeaderNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of header names that are not redacted during logging."
+                              },
+                              "LoggedQueryParameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                              }
+                            },
+                            "description": "Gets the client diagnostic options."
+                          },
+                          "Retry": {
+                            "type": "object",
+                            "properties": {
+                              "Delay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxDelay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxRetries": {
+                                "type": "integer",
+                                "description": "The maximum number of retry attempts before giving up."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Fixed",
+                                  "Exponential"
+                                ],
+                                "description": "The approach to use for calculating retry delays."
+                              },
+                              "NetworkTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The timeout applied to individual network operations."
+                              }
+                            },
+                            "description": "Gets the client retry options."
+                          }
+                        },
+                        "description": "Client options for clients in this library."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the Azure AI Search health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Gets or sets a 'System.Uri' referencing the Azure AI Search endpoint. This is likely to be similar to \"https://{search_service}.search.windows.net\"."
+                      },
+                      "Key": {
+                        "type": "string",
+                        "description": "Gets or sets the key to use to authenticate to the Azure AI Search endpoint."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to Azure AI Search."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
@@ -120,7 +120,27 @@
                           "description": "Client options for clients in this library."
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/Search/properties/Documents/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Search/properties/Documents/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "Diagnostics"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Retry"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/Components/Aspire.Azure.Security.KeyVault/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AssemblyInfo.cs
@@ -7,6 +7,8 @@ using Azure.Security.KeyVault.Secrets;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Security:KeyVault", typeof(AzureSecurityKeyVaultSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Security:KeyVault:ClientOptions", typeof(SecretClientOptions), exclusionPaths: ["Default"])]
+[assembly: ConfigurationSchema("Aspire:Azure:Security:KeyVault:*", typeof(AzureSecurityKeyVaultSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Security:KeyVault:*:ClientOptions", typeof(SecretClientOptions), exclusionPaths: ["Default"])]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
@@ -134,7 +134,118 @@
                       "description": "A 'System.Uri' to the vault on which the client operates. Appears as \"DNS Name\" in the Azure portal. If you have a secret 'System.Uri', use 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier' to parse the 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier.VaultUri' and other information. You should validate that this URI references a valid Key Vault resource. See https://aka.ms/azsdk/blog/vault-uri for details."
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to Azure Key Vault."
+                  "description": "Provides the client configuration settings for connecting to Azure Key Vault.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "Diagnostics": {
+                            "type": "object",
+                            "properties": {
+                              "ApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                              },
+                              "DefaultApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                              },
+                              "IsDistributedTracingEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                              },
+                              "IsLoggingContentEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request or response content should be logged."
+                              },
+                              "IsLoggingEnabled": {
+                                "type": "boolean",
+                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                              },
+                              "IsTelemetryEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                              },
+                              "LoggedContentSizeLimit": {
+                                "type": "integer",
+                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                              },
+                              "LoggedHeaderNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of header names that are not redacted during logging."
+                              },
+                              "LoggedQueryParameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                              }
+                            },
+                            "description": "Gets the client diagnostic options."
+                          },
+                          "DisableChallengeResourceVerification": {
+                            "type": "boolean",
+                            "description": "Gets or sets whether to disable verification that the authentication challenge resource matches the Key Vault domain."
+                          },
+                          "Retry": {
+                            "type": "object",
+                            "properties": {
+                              "Delay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxDelay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxRetries": {
+                                "type": "integer",
+                                "description": "The maximum number of retry attempts before giving up."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Fixed",
+                                  "Exponential"
+                                ],
+                                "description": "The approach to use for calculating retry delays."
+                              },
+                              "NetworkTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The timeout applied to individual network operations."
+                              }
+                            },
+                            "description": "Gets the client retry options."
+                          }
+                        },
+                        "description": "Options that allow you to configure the requests sent to Key Vault."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the Key Vault health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "VaultUri": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A 'System.Uri' to the vault on which the client operates. Appears as \"DNS Name\" in the Azure portal. If you have a secret 'System.Uri', use 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier' to parse the 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier.VaultUri' and other information. You should validate that this URI references a valid Key Vault resource. See https://aka.ms/azsdk/blog/vault-uri for details."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to Azure Key Vault."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
@@ -29,222 +29,259 @@
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "Diagnostics": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "ApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                            },
-                            "DefaultApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                            },
-                            "IsDistributedTracingEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                            },
-                            "IsLoggingContentEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request or response content should be logged."
-                            },
-                            "IsLoggingEnabled": {
-                              "type": "boolean",
-                              "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                            },
-                            "IsTelemetryEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                            },
-                            "LoggedContentSizeLimit": {
-                              "type": "integer",
-                              "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                            },
-                            "LoggedHeaderNames": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Diagnostics": {
+                              "type": "object",
+                              "properties": {
+                                "ApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                },
+                                "DefaultApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                },
+                                "IsDistributedTracingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                },
+                                "IsLoggingContentEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request or response content should be logged."
+                                },
+                                "IsLoggingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                },
+                                "IsTelemetryEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                },
+                                "LoggedContentSizeLimit": {
+                                  "type": "integer",
+                                  "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                },
+                                "LoggedHeaderNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of header names that are not redacted during logging."
+                                },
+                                "LoggedQueryParameters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of query parameter names that are not redacted during logging."
+                                }
                               },
-                              "description": "Gets a list of header names that are not redacted during logging."
+                              "description": "Gets the client diagnostic options."
                             },
-                            "LoggedQueryParameters": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "DisableChallengeResourceVerification": {
+                              "type": "boolean",
+                              "description": "Gets or sets whether to disable verification that the authentication challenge resource matches the Key Vault domain."
+                            },
+                            "Retry": {
+                              "type": "object",
+                              "properties": {
+                                "Delay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxDelay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxRetries": {
+                                  "type": "integer",
+                                  "description": "The maximum number of retry attempts before giving up."
+                                },
+                                "Mode": {
+                                  "enum": [
+                                    "Fixed",
+                                    "Exponential"
+                                  ],
+                                  "description": "The approach to use for calculating retry delays."
+                                },
+                                "NetworkTimeout": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The timeout applied to individual network operations."
+                                }
                               },
-                              "description": "Gets a list of query parameter names that are not redacted during logging."
+                              "description": "Gets the client retry options."
                             }
                           },
-                          "description": "Gets the client diagnostic options."
+                          "description": "Options that allow you to configure the requests sent to Key Vault."
                         },
-                        "DisableChallengeResourceVerification": {
-                          "type": "boolean",
-                          "description": "Gets or sets whether to disable verification that the authentication challenge resource matches the Key Vault domain."
-                        },
-                        "Retry": {
-                          "type": "object",
-                          "properties": {
-                            "Delay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxDelay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxRetries": {
-                              "type": "integer",
-                              "description": "The maximum number of retry attempts before giving up."
-                            },
-                            "Mode": {
-                              "enum": [
-                                "Fixed",
-                                "Exponential"
-                              ],
-                              "description": "The approach to use for calculating retry delays."
-                            },
-                            "NetworkTimeout": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The timeout applied to individual network operations."
-                            }
-                          },
-                          "description": "Gets the client retry options."
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Security/properties/KeyVault/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "Options that allow you to configure the requests sent to Key Vault."
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Key Vault health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the Key Vault health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Security/properties/KeyVault/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Security/properties/KeyVault/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "VaultUri": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "A 'System.Uri' to the vault on which the client operates. Appears as \"DNS Name\" in the Azure portal. If you have a secret 'System.Uri', use 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier' to parse the 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier.VaultUri' and other information. You should validate that this URI references a valid Key Vault resource. See https://aka.ms/azsdk/blog/vault-uri for details."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A 'System.Uri' to the vault on which the client operates. Appears as \"DNS Name\" in the Azure portal. If you have a secret 'System.Uri', use 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier' to parse the 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier.VaultUri' and other information. You should validate that this URI references a valid Key Vault resource. See https://aka.ms/azsdk/blog/vault-uri for details."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Security/properties/KeyVault/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Key Vault.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
                         "type": "object",
                         "properties": {
-                          "Diagnostics": {
+                          "ClientOptions": {
                             "type": "object",
                             "properties": {
-                              "ApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                              },
-                              "DefaultApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                              },
-                              "IsDistributedTracingEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                              },
-                              "IsLoggingContentEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request or response content should be logged."
-                              },
-                              "IsLoggingEnabled": {
-                                "type": "boolean",
-                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                              },
-                              "IsTelemetryEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                              },
-                              "LoggedContentSizeLimit": {
-                                "type": "integer",
-                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                              },
-                              "LoggedHeaderNames": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "Diagnostics": {
+                                "type": "object",
+                                "properties": {
+                                  "ApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                  },
+                                  "DefaultApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                  },
+                                  "IsDistributedTracingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                  },
+                                  "IsLoggingContentEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request or response content should be logged."
+                                  },
+                                  "IsLoggingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                  },
+                                  "IsTelemetryEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                  },
+                                  "LoggedContentSizeLimit": {
+                                    "type": "integer",
+                                    "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                  },
+                                  "LoggedHeaderNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of header names that are not redacted during logging."
+                                  },
+                                  "LoggedQueryParameters": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of query parameter names that are not redacted during logging."
+                                  }
                                 },
-                                "description": "Gets a list of header names that are not redacted during logging."
+                                "description": "Gets the client diagnostic options."
                               },
-                              "LoggedQueryParameters": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "DisableChallengeResourceVerification": {
+                                "type": "boolean",
+                                "description": "Gets or sets whether to disable verification that the authentication challenge resource matches the Key Vault domain."
+                              },
+                              "Retry": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before giving up."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "NetworkTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The timeout applied to individual network operations."
+                                  }
                                 },
-                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                                "description": "Gets the client retry options."
                               }
                             },
-                            "description": "Gets the client diagnostic options."
+                            "description": "Options that allow you to configure the requests sent to Key Vault."
                           },
-                          "DisableChallengeResourceVerification": {
+                          "DisableHealthChecks": {
                             "type": "boolean",
-                            "description": "Gets or sets whether to disable verification that the authentication challenge resource matches the Key Vault domain."
+                            "description": "Gets or sets a boolean value that indicates whether the Key Vault health check is disabled or not.",
+                            "default": false
                           },
-                          "Retry": {
-                            "type": "object",
-                            "properties": {
-                              "Delay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxDelay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxRetries": {
-                                "type": "integer",
-                                "description": "The maximum number of retry attempts before giving up."
-                              },
-                              "Mode": {
-                                "enum": [
-                                  "Fixed",
-                                  "Exponential"
-                                ],
-                                "description": "The approach to use for calculating retry delays."
-                              },
-                              "NetworkTimeout": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The timeout applied to individual network operations."
-                              }
-                            },
-                            "description": "Gets the client retry options."
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "VaultUri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "A 'System.Uri' to the vault on which the client operates. Appears as \"DNS Name\" in the Azure portal. If you have a secret 'System.Uri', use 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier' to parse the 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier.VaultUri' and other information. You should validate that this URI references a valid Key Vault resource. See https://aka.ms/azsdk/blog/vault-uri for details."
                           }
                         },
-                        "description": "Options that allow you to configure the requests sent to Key Vault."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the Key Vault health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "VaultUri": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "A 'System.Uri' to the vault on which the client operates. Appears as \"DNS Name\" in the Azure portal. If you have a secret 'System.Uri', use 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier' to parse the 'Azure.Security.KeyVault.Secrets.KeyVaultSecretIdentifier.VaultUri' and other information. You should validate that this URI references a valid Key Vault resource. See https://aka.ms/azsdk/blog/vault-uri for details."
+                        "description": "Provides the client configuration settings for connecting to Azure Key Vault."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to Azure Key Vault."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
@@ -121,7 +121,32 @@
                           "description": "Options that allow you to configure the requests sent to Key Vault."
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/Security/properties/KeyVault/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Security/properties/KeyVault/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "DisableChallengeResourceVerification"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Diagnostics"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Retry"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/Components/Aspire.Azure.Storage.Blobs/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AssemblyInfo.cs
@@ -7,7 +7,11 @@ using Azure.Storage.Blobs;
 using System.Runtime.CompilerServices;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Storage:Blobs", typeof(AzureStorageBlobsSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Blobs", typeof(AzureBlobStorageContainerSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Storage:Blobs:ClientOptions", typeof(BlobClientOptions), exclusionPaths: ["Default"])]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Blobs:*", typeof(AzureStorageBlobsSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Blobs:*", typeof(AzureBlobStorageContainerSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Blobs:*:ClientOptions", typeof(BlobClientOptions), exclusionPaths: ["Default"])]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.Storage.Blobs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Blobs/ConfigurationSchema.json
@@ -29,390 +29,441 @@
                   "type": "object",
                   "properties": {
                     "BlobContainerName": {
-                      "type": "string",
-                      "description": "Gets or sets the name of the blob container."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the name of the blob container."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Blobs/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "Diagnostics": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "ApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                            },
-                            "DefaultApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                            },
-                            "IsDistributedTracingEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                            },
-                            "IsLoggingContentEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request or response content should be logged."
-                            },
-                            "IsLoggingEnabled": {
-                              "type": "boolean",
-                              "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                            },
-                            "IsTelemetryEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                            },
-                            "LoggedContentSizeLimit": {
-                              "type": "integer",
-                              "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                            },
-                            "LoggedHeaderNames": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "Gets a list of header names that are not redacted during logging."
-                            },
-                            "LoggedQueryParameters": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "Gets a list of query parameter names that are not redacted during logging."
-                            }
-                          },
-                          "description": "Gets the client diagnostic options."
-                        },
-                        "EnableTenantDiscovery": {
-                          "type": "boolean",
-                          "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
-                        },
-                        "EncryptionScope": {
-                          "type": "string",
-                          "description": "Gets the 'Azure.Storage.Blobs.BlobClientOptions.EncryptionScope' to be used when making requests."
-                        },
-                        "GeoRedundantSecondaryUri": {
-                          "type": "string",
-                          "format": "uri",
-                          "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
-                        },
-                        "Request100ContinueOptions": {
-                          "type": "object",
-                          "properties": {
-                            "AutoInterval": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "In mode 'Azure.Storage.Request100ContinueMode.Auto', the time interval to apply the header after recieving a triggering error. The default time is one minute."
-                            },
-                            "ContentLengthThreshold": {
-                              "type": "integer",
-                              "description": "The minimum value of HTTP request Content-Length for applying expect-continue."
-                            },
-                            "Mode": {
-                              "enum": [
-                                "Auto",
-                                "Always",
-                                "Never"
-                              ],
-                              "description": "Mode for these options."
-                            }
-                          },
-                          "description": "Behavior options for setting HTTP header Expect: 100-continue on requests."
-                        },
-                        "Retry": {
-                          "type": "object",
-                          "properties": {
-                            "Delay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxDelay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxRetries": {
-                              "type": "integer",
-                              "description": "The maximum number of retry attempts before giving up."
-                            },
-                            "Mode": {
-                              "enum": [
-                                "Fixed",
-                                "Exponential"
-                              ],
-                              "description": "The approach to use for calculating retry delays."
-                            },
-                            "NetworkTimeout": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The timeout applied to individual network operations."
-                            }
-                          },
-                          "description": "Gets the client retry options."
-                        },
-                        "TransferValidation": {
-                          "type": "object",
-                          "properties": {
-                            "Download": {
+                            "Diagnostics": {
                               "type": "object",
                               "properties": {
-                                "AutoValidateChecksum": {
-                                  "type": "boolean",
-                                  "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
+                                "ApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
                                 },
-                                "ChecksumAlgorithm": {
-                                  "enum": [
-                                    "Auto",
-                                    "None",
-                                    "MD5",
-                                    "StorageCrc64"
-                                  ],
-                                  "description": "Checksum algorithm to use."
+                                "DefaultApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                },
+                                "IsDistributedTracingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                },
+                                "IsLoggingContentEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request or response content should be logged."
+                                },
+                                "IsLoggingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                },
+                                "IsTelemetryEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                },
+                                "LoggedContentSizeLimit": {
+                                  "type": "integer",
+                                  "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                },
+                                "LoggedHeaderNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of header names that are not redacted during logging."
+                                },
+                                "LoggedQueryParameters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of query parameter names that are not redacted during logging."
                                 }
                               },
-                              "description": "Options on download."
+                              "description": "Gets the client diagnostic options."
                             },
-                            "Upload": {
+                            "EnableTenantDiscovery": {
+                              "type": "boolean",
+                              "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                            },
+                            "EncryptionScope": {
+                              "type": "string",
+                              "description": "Gets the 'Azure.Storage.Blobs.BlobClientOptions.EncryptionScope' to be used when making requests."
+                            },
+                            "GeoRedundantSecondaryUri": {
+                              "type": "string",
+                              "format": "uri",
+                              "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
+                            },
+                            "Request100ContinueOptions": {
                               "type": "object",
                               "properties": {
-                                "ChecksumAlgorithm": {
+                                "AutoInterval": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "In mode 'Azure.Storage.Request100ContinueMode.Auto', the time interval to apply the header after recieving a triggering error. The default time is one minute."
+                                },
+                                "ContentLengthThreshold": {
+                                  "type": "integer",
+                                  "description": "The minimum value of HTTP request Content-Length for applying expect-continue."
+                                },
+                                "Mode": {
                                   "enum": [
                                     "Auto",
-                                    "None",
-                                    "MD5",
-                                    "StorageCrc64"
+                                    "Always",
+                                    "Never"
                                   ],
-                                  "description": "Checksum algorithm to use."
+                                  "description": "Mode for these options."
                                 }
                               },
-                              "description": "Options on upload."
+                              "description": "Behavior options for setting HTTP header Expect: 100-continue on requests."
+                            },
+                            "Retry": {
+                              "type": "object",
+                              "properties": {
+                                "Delay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxDelay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxRetries": {
+                                  "type": "integer",
+                                  "description": "The maximum number of retry attempts before giving up."
+                                },
+                                "Mode": {
+                                  "enum": [
+                                    "Fixed",
+                                    "Exponential"
+                                  ],
+                                  "description": "The approach to use for calculating retry delays."
+                                },
+                                "NetworkTimeout": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The timeout applied to individual network operations."
+                                }
+                              },
+                              "description": "Gets the client retry options."
+                            },
+                            "TransferValidation": {
+                              "type": "object",
+                              "properties": {
+                                "Download": {
+                                  "type": "object",
+                                  "properties": {
+                                    "AutoValidateChecksum": {
+                                      "type": "boolean",
+                                      "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
+                                    },
+                                    "ChecksumAlgorithm": {
+                                      "enum": [
+                                        "Auto",
+                                        "None",
+                                        "MD5",
+                                        "StorageCrc64"
+                                      ],
+                                      "description": "Checksum algorithm to use."
+                                    }
+                                  },
+                                  "description": "Options on download."
+                                },
+                                "Upload": {
+                                  "type": "object",
+                                  "properties": {
+                                    "ChecksumAlgorithm": {
+                                      "enum": [
+                                        "Auto",
+                                        "None",
+                                        "MD5",
+                                        "StorageCrc64"
+                                      ],
+                                      "description": "Checksum algorithm to use."
+                                    }
+                                  },
+                                  "description": "Options on upload."
+                                }
+                              },
+                              "description": "Configures whether to send or receive checksum headers for blob uploads and downloads. Downloads can optionally validate that the content matches the checksum."
+                            },
+                            "TrimBlobNameSlashes": {
+                              "type": "boolean",
+                              "description": "Whether to trim leading and trailing slashes on a blob name when using 'Azure.Storage.Blobs.BlobContainerClient.GetBlobClient(System.String)' and similar methods. Defaults to true for backwards compatibility."
                             }
                           },
-                          "description": "Configures whether to send or receive checksum headers for blob uploads and downloads. Downloads can optionally validate that the content matches the checksum."
+                          "description": "Provides the client configuration options for connecting to Azure Blob Storage."
                         },
-                        "TrimBlobNameSlashes": {
-                          "type": "boolean",
-                          "description": "Whether to trim leading and trailing slashes on a blob name when using 'Azure.Storage.Blobs.BlobContainerClient.GetBlobClient(System.String)' and similar methods. Defaults to true for backwards compatibility."
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Blobs/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "Provides the client configuration options for connecting to Azure Blob Storage."
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string used to connect to the blob service."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string used to connect to the blob service."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Blobs/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Blob Storage health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the Blob Storage health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Blobs/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Blobs/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ServiceUri": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "A 'System.Uri' referencing the blob service. This is likely to be similar to \"https://{account_name}.blob.core.windows.net\"."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A 'System.Uri' referencing the blob service. This is likely to be similar to \"https://{account_name}.blob.core.windows.net\"."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Blobs/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Blob Storage container.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "BlobContainerName": {
-                        "type": "string",
-                        "description": "Gets or sets the name of the blob container."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
                       },
-                      "ClientOptions": {
+                      {
                         "type": "object",
                         "properties": {
-                          "Diagnostics": {
+                          "BlobContainerName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the blob container."
+                          },
+                          "ClientOptions": {
                             "type": "object",
                             "properties": {
-                              "ApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                              },
-                              "DefaultApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                              },
-                              "IsDistributedTracingEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                              },
-                              "IsLoggingContentEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request or response content should be logged."
-                              },
-                              "IsLoggingEnabled": {
-                                "type": "boolean",
-                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                              },
-                              "IsTelemetryEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                              },
-                              "LoggedContentSizeLimit": {
-                                "type": "integer",
-                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                              },
-                              "LoggedHeaderNames": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "Diagnostics": {
+                                "type": "object",
+                                "properties": {
+                                  "ApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                  },
+                                  "DefaultApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                  },
+                                  "IsDistributedTracingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                  },
+                                  "IsLoggingContentEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request or response content should be logged."
+                                  },
+                                  "IsLoggingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                  },
+                                  "IsTelemetryEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                  },
+                                  "LoggedContentSizeLimit": {
+                                    "type": "integer",
+                                    "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                  },
+                                  "LoggedHeaderNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of header names that are not redacted during logging."
+                                  },
+                                  "LoggedQueryParameters": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of query parameter names that are not redacted during logging."
+                                  }
                                 },
-                                "description": "Gets a list of header names that are not redacted during logging."
+                                "description": "Gets the client diagnostic options."
                               },
-                              "LoggedQueryParameters": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "EnableTenantDiscovery": {
+                                "type": "boolean",
+                                "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                              },
+                              "EncryptionScope": {
+                                "type": "string",
+                                "description": "Gets the 'Azure.Storage.Blobs.BlobClientOptions.EncryptionScope' to be used when making requests."
+                              },
+                              "GeoRedundantSecondaryUri": {
+                                "type": "string",
+                                "format": "uri",
+                                "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
+                              },
+                              "Request100ContinueOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "AutoInterval": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "In mode 'Azure.Storage.Request100ContinueMode.Auto', the time interval to apply the header after recieving a triggering error. The default time is one minute."
+                                  },
+                                  "ContentLengthThreshold": {
+                                    "type": "integer",
+                                    "description": "The minimum value of HTTP request Content-Length for applying expect-continue."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Auto",
+                                      "Always",
+                                      "Never"
+                                    ],
+                                    "description": "Mode for these options."
+                                  }
                                 },
-                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                                "description": "Behavior options for setting HTTP header Expect: 100-continue on requests."
+                              },
+                              "Retry": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before giving up."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "NetworkTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The timeout applied to individual network operations."
+                                  }
+                                },
+                                "description": "Gets the client retry options."
+                              },
+                              "TransferValidation": {
+                                "type": "object",
+                                "properties": {
+                                  "Download": {
+                                    "type": "object",
+                                    "properties": {
+                                      "AutoValidateChecksum": {
+                                        "type": "boolean",
+                                        "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
+                                      },
+                                      "ChecksumAlgorithm": {
+                                        "enum": [
+                                          "Auto",
+                                          "None",
+                                          "MD5",
+                                          "StorageCrc64"
+                                        ],
+                                        "description": "Checksum algorithm to use."
+                                      }
+                                    },
+                                    "description": "Options on download."
+                                  },
+                                  "Upload": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ChecksumAlgorithm": {
+                                        "enum": [
+                                          "Auto",
+                                          "None",
+                                          "MD5",
+                                          "StorageCrc64"
+                                        ],
+                                        "description": "Checksum algorithm to use."
+                                      }
+                                    },
+                                    "description": "Options on upload."
+                                  }
+                                },
+                                "description": "Configures whether to send or receive checksum headers for blob uploads and downloads. Downloads can optionally validate that the content matches the checksum."
+                              },
+                              "TrimBlobNameSlashes": {
+                                "type": "boolean",
+                                "description": "Whether to trim leading and trailing slashes on a blob name when using 'Azure.Storage.Blobs.BlobContainerClient.GetBlobClient(System.String)' and similar methods. Defaults to true for backwards compatibility."
                               }
                             },
-                            "description": "Gets the client diagnostic options."
+                            "description": "Provides the client configuration options for connecting to Azure Blob Storage."
                           },
-                          "EnableTenantDiscovery": {
-                            "type": "boolean",
-                            "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
-                          },
-                          "EncryptionScope": {
+                          "ConnectionString": {
                             "type": "string",
-                            "description": "Gets the 'Azure.Storage.Blobs.BlobClientOptions.EncryptionScope' to be used when making requests."
+                            "description": "Gets or sets the connection string used to connect to the blob service."
                           },
-                          "GeoRedundantSecondaryUri": {
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the Blob Storage health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "ServiceUri": {
                             "type": "string",
                             "format": "uri",
-                            "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
-                          },
-                          "Request100ContinueOptions": {
-                            "type": "object",
-                            "properties": {
-                              "AutoInterval": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "In mode 'Azure.Storage.Request100ContinueMode.Auto', the time interval to apply the header after recieving a triggering error. The default time is one minute."
-                              },
-                              "ContentLengthThreshold": {
-                                "type": "integer",
-                                "description": "The minimum value of HTTP request Content-Length for applying expect-continue."
-                              },
-                              "Mode": {
-                                "enum": [
-                                  "Auto",
-                                  "Always",
-                                  "Never"
-                                ],
-                                "description": "Mode for these options."
-                              }
-                            },
-                            "description": "Behavior options for setting HTTP header Expect: 100-continue on requests."
-                          },
-                          "Retry": {
-                            "type": "object",
-                            "properties": {
-                              "Delay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxDelay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxRetries": {
-                                "type": "integer",
-                                "description": "The maximum number of retry attempts before giving up."
-                              },
-                              "Mode": {
-                                "enum": [
-                                  "Fixed",
-                                  "Exponential"
-                                ],
-                                "description": "The approach to use for calculating retry delays."
-                              },
-                              "NetworkTimeout": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The timeout applied to individual network operations."
-                              }
-                            },
-                            "description": "Gets the client retry options."
-                          },
-                          "TransferValidation": {
-                            "type": "object",
-                            "properties": {
-                              "Download": {
-                                "type": "object",
-                                "properties": {
-                                  "AutoValidateChecksum": {
-                                    "type": "boolean",
-                                    "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
-                                  },
-                                  "ChecksumAlgorithm": {
-                                    "enum": [
-                                      "Auto",
-                                      "None",
-                                      "MD5",
-                                      "StorageCrc64"
-                                    ],
-                                    "description": "Checksum algorithm to use."
-                                  }
-                                },
-                                "description": "Options on download."
-                              },
-                              "Upload": {
-                                "type": "object",
-                                "properties": {
-                                  "ChecksumAlgorithm": {
-                                    "enum": [
-                                      "Auto",
-                                      "None",
-                                      "MD5",
-                                      "StorageCrc64"
-                                    ],
-                                    "description": "Checksum algorithm to use."
-                                  }
-                                },
-                                "description": "Options on upload."
-                              }
-                            },
-                            "description": "Configures whether to send or receive checksum headers for blob uploads and downloads. Downloads can optionally validate that the content matches the checksum."
-                          },
-                          "TrimBlobNameSlashes": {
-                            "type": "boolean",
-                            "description": "Whether to trim leading and trailing slashes on a blob name when using 'Azure.Storage.Blobs.BlobContainerClient.GetBlobClient(System.String)' and similar methods. Defaults to true for backwards compatibility."
+                            "description": "A 'System.Uri' referencing the blob service. This is likely to be similar to \"https://{account_name}.blob.core.windows.net\"."
                           }
                         },
-                        "description": "Provides the client configuration options for connecting to Azure Blob Storage."
-                      },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string used to connect to the blob service."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the Blob Storage health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "ServiceUri": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "A 'System.Uri' referencing the blob service. This is likely to be similar to \"https://{account_name}.blob.core.windows.net\"."
+                        "description": "Provides the client configuration settings for connecting to Azure Blob Storage container."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to Azure Blob Storage container."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Azure.Storage.Blobs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Blobs/ConfigurationSchema.json
@@ -208,7 +208,57 @@
                           "description": "Provides the client configuration options for connecting to Azure Blob Storage."
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Blobs/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Blobs/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "EncryptionScope"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "GeoRedundantSecondaryUri"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "TransferValidation"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "TrimBlobNameSlashes"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Request100ContinueOptions"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "EnableTenantDiscovery"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Diagnostics"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Retry"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/Components/Aspire.Azure.Storage.Blobs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Blobs/ConfigurationSchema.json
@@ -28,6 +28,10 @@
                 "Blobs": {
                   "type": "object",
                   "properties": {
+                    "BlobContainerName": {
+                      "type": "string",
+                      "description": "Gets or sets the name of the blob container."
+                    },
                     "ClientOptions": {
                       "type": "object",
                       "properties": {
@@ -214,7 +218,202 @@
                       "description": "A 'System.Uri' referencing the blob service. This is likely to be similar to \"https://{account_name}.blob.core.windows.net\"."
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to Azure Blob Storage."
+                  "description": "Provides the client configuration settings for connecting to Azure Blob Storage container.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "BlobContainerName": {
+                        "type": "string",
+                        "description": "Gets or sets the name of the blob container."
+                      },
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "Diagnostics": {
+                            "type": "object",
+                            "properties": {
+                              "ApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                              },
+                              "DefaultApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                              },
+                              "IsDistributedTracingEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                              },
+                              "IsLoggingContentEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request or response content should be logged."
+                              },
+                              "IsLoggingEnabled": {
+                                "type": "boolean",
+                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                              },
+                              "IsTelemetryEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                              },
+                              "LoggedContentSizeLimit": {
+                                "type": "integer",
+                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                              },
+                              "LoggedHeaderNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of header names that are not redacted during logging."
+                              },
+                              "LoggedQueryParameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                              }
+                            },
+                            "description": "Gets the client diagnostic options."
+                          },
+                          "EnableTenantDiscovery": {
+                            "type": "boolean",
+                            "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                          },
+                          "EncryptionScope": {
+                            "type": "string",
+                            "description": "Gets the 'Azure.Storage.Blobs.BlobClientOptions.EncryptionScope' to be used when making requests."
+                          },
+                          "GeoRedundantSecondaryUri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
+                          },
+                          "Request100ContinueOptions": {
+                            "type": "object",
+                            "properties": {
+                              "AutoInterval": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "In mode 'Azure.Storage.Request100ContinueMode.Auto', the time interval to apply the header after recieving a triggering error. The default time is one minute."
+                              },
+                              "ContentLengthThreshold": {
+                                "type": "integer",
+                                "description": "The minimum value of HTTP request Content-Length for applying expect-continue."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Auto",
+                                  "Always",
+                                  "Never"
+                                ],
+                                "description": "Mode for these options."
+                              }
+                            },
+                            "description": "Behavior options for setting HTTP header Expect: 100-continue on requests."
+                          },
+                          "Retry": {
+                            "type": "object",
+                            "properties": {
+                              "Delay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxDelay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxRetries": {
+                                "type": "integer",
+                                "description": "The maximum number of retry attempts before giving up."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Fixed",
+                                  "Exponential"
+                                ],
+                                "description": "The approach to use for calculating retry delays."
+                              },
+                              "NetworkTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The timeout applied to individual network operations."
+                              }
+                            },
+                            "description": "Gets the client retry options."
+                          },
+                          "TransferValidation": {
+                            "type": "object",
+                            "properties": {
+                              "Download": {
+                                "type": "object",
+                                "properties": {
+                                  "AutoValidateChecksum": {
+                                    "type": "boolean",
+                                    "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
+                                  },
+                                  "ChecksumAlgorithm": {
+                                    "enum": [
+                                      "Auto",
+                                      "None",
+                                      "MD5",
+                                      "StorageCrc64"
+                                    ],
+                                    "description": "Checksum algorithm to use."
+                                  }
+                                },
+                                "description": "Options on download."
+                              },
+                              "Upload": {
+                                "type": "object",
+                                "properties": {
+                                  "ChecksumAlgorithm": {
+                                    "enum": [
+                                      "Auto",
+                                      "None",
+                                      "MD5",
+                                      "StorageCrc64"
+                                    ],
+                                    "description": "Checksum algorithm to use."
+                                  }
+                                },
+                                "description": "Options on upload."
+                              }
+                            },
+                            "description": "Configures whether to send or receive checksum headers for blob uploads and downloads. Downloads can optionally validate that the content matches the checksum."
+                          },
+                          "TrimBlobNameSlashes": {
+                            "type": "boolean",
+                            "description": "Whether to trim leading and trailing slashes on a blob name when using 'Azure.Storage.Blobs.BlobContainerClient.GetBlobClient(System.String)' and similar methods. Defaults to true for backwards compatibility."
+                          }
+                        },
+                        "description": "Provides the client configuration options for connecting to Azure Blob Storage."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string used to connect to the blob service."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the Blob Storage health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "ServiceUri": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A 'System.Uri' referencing the blob service. This is likely to be similar to \"https://{account_name}.blob.core.windows.net\"."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to Azure Blob Storage container."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.Storage.Files.DataLake/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Storage.Files.DataLake/AssemblyInfo.cs
@@ -6,9 +6,17 @@ using Aspire.Azure.Storage.Files.DataLake;
 using Azure.Storage.Files.DataLake;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Storage:Files:DataLake", typeof(AzureDataLakeSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Files:DataLake", typeof(AzureDataLakeFileSystemSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Files:DataLake:*", typeof(AzureDataLakeSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Files:DataLake:*", typeof(AzureDataLakeFileSystemSettings))]
 [assembly:
     ConfigurationSchema(
         "Aspire:Azure:Storage:Files:DataLake:ClientOptions",
+        typeof(DataLakeClientOptions),
+        exclusionPaths: ["Default"])]
+[assembly:
+    ConfigurationSchema(
+        "Aspire:Azure:Storage:Files:DataLake:*:ClientOptions",
         typeof(DataLakeClientOptions),
         exclusionPaths: ["Default"])]
 

--- a/src/Components/Aspire.Azure.Storage.Files.DataLake/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Files.DataLake/ConfigurationSchema.json
@@ -32,328 +32,379 @@
                       "type": "object",
                       "properties": {
                         "ClientOptions": {
-                          "type": "object",
-                          "properties": {
-                            "Diagnostics": {
+                          "anyOf": [
+                            {
                               "type": "object",
                               "properties": {
-                                "ApplicationId": {
-                                  "type": "string",
-                                  "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                                },
-                                "DefaultApplicationId": {
-                                  "type": "string",
-                                  "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                                },
-                                "IsDistributedTracingEnabled": {
-                                  "type": "boolean",
-                                  "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                                },
-                                "IsLoggingContentEnabled": {
-                                  "type": "boolean",
-                                  "description": "Gets or sets value indicating if request or response content should be logged."
-                                },
-                                "IsLoggingEnabled": {
-                                  "type": "boolean",
-                                  "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                                },
-                                "IsTelemetryEnabled": {
-                                  "type": "boolean",
-                                  "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                                },
-                                "LoggedContentSizeLimit": {
-                                  "type": "integer",
-                                  "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                                },
-                                "LoggedHeaderNames": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "description": "Gets a list of header names that are not redacted during logging."
-                                },
-                                "LoggedQueryParameters": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "description": "Gets a list of query parameter names that are not redacted during logging."
-                                }
-                              },
-                              "description": "Gets the client diagnostic options."
-                            },
-                            "EnableTenantDiscovery": {
-                              "type": "boolean",
-                              "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
-                            },
-                            "GeoRedundantSecondaryUri": {
-                              "type": "string",
-                              "format": "uri",
-                              "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
-                            },
-                            "Retry": {
-                              "type": "object",
-                              "properties": {
-                                "Delay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                                },
-                                "MaxDelay": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                                },
-                                "MaxRetries": {
-                                  "type": "integer",
-                                  "description": "The maximum number of retry attempts before giving up."
-                                },
-                                "Mode": {
-                                  "enum": [
-                                    "Fixed",
-                                    "Exponential"
-                                  ],
-                                  "description": "The approach to use for calculating retry delays."
-                                },
-                                "NetworkTimeout": {
-                                  "type": "string",
-                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                  "description": "The timeout applied to individual network operations."
-                                }
-                              },
-                              "description": "Gets the client retry options."
-                            },
-                            "TransferValidation": {
-                              "type": "object",
-                              "properties": {
-                                "Download": {
+                                "Diagnostics": {
                                   "type": "object",
                                   "properties": {
-                                    "AutoValidateChecksum": {
-                                      "type": "boolean",
-                                      "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
+                                    "ApplicationId": {
+                                      "type": "string",
+                                      "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
                                     },
-                                    "ChecksumAlgorithm": {
-                                      "enum": [
-                                        "Auto",
-                                        "None",
-                                        "MD5",
-                                        "StorageCrc64"
-                                      ],
-                                      "description": "Checksum algorithm to use."
+                                    "DefaultApplicationId": {
+                                      "type": "string",
+                                      "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                    },
+                                    "IsDistributedTracingEnabled": {
+                                      "type": "boolean",
+                                      "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                    },
+                                    "IsLoggingContentEnabled": {
+                                      "type": "boolean",
+                                      "description": "Gets or sets value indicating if request or response content should be logged."
+                                    },
+                                    "IsLoggingEnabled": {
+                                      "type": "boolean",
+                                      "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                    },
+                                    "IsTelemetryEnabled": {
+                                      "type": "boolean",
+                                      "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                    },
+                                    "LoggedContentSizeLimit": {
+                                      "type": "integer",
+                                      "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                    },
+                                    "LoggedHeaderNames": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "description": "Gets a list of header names that are not redacted during logging."
+                                    },
+                                    "LoggedQueryParameters": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "description": "Gets a list of query parameter names that are not redacted during logging."
                                     }
                                   },
-                                  "description": "Options on download."
+                                  "description": "Gets the client diagnostic options."
                                 },
-                                "Upload": {
+                                "EnableTenantDiscovery": {
+                                  "type": "boolean",
+                                  "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                                },
+                                "GeoRedundantSecondaryUri": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
+                                },
+                                "Retry": {
                                   "type": "object",
                                   "properties": {
-                                    "ChecksumAlgorithm": {
+                                    "Delay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                    },
+                                    "MaxDelay": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                    },
+                                    "MaxRetries": {
+                                      "type": "integer",
+                                      "description": "The maximum number of retry attempts before giving up."
+                                    },
+                                    "Mode": {
                                       "enum": [
-                                        "Auto",
-                                        "None",
-                                        "MD5",
-                                        "StorageCrc64"
+                                        "Fixed",
+                                        "Exponential"
                                       ],
-                                      "description": "Checksum algorithm to use."
+                                      "description": "The approach to use for calculating retry delays."
+                                    },
+                                    "NetworkTimeout": {
+                                      "type": "string",
+                                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                      "description": "The timeout applied to individual network operations."
                                     }
                                   },
-                                  "description": "Options on upload."
+                                  "description": "Gets the client retry options."
+                                },
+                                "TransferValidation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Download": {
+                                      "type": "object",
+                                      "properties": {
+                                        "AutoValidateChecksum": {
+                                          "type": "boolean",
+                                          "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
+                                        },
+                                        "ChecksumAlgorithm": {
+                                          "enum": [
+                                            "Auto",
+                                            "None",
+                                            "MD5",
+                                            "StorageCrc64"
+                                          ],
+                                          "description": "Checksum algorithm to use."
+                                        }
+                                      },
+                                      "description": "Options on download."
+                                    },
+                                    "Upload": {
+                                      "type": "object",
+                                      "properties": {
+                                        "ChecksumAlgorithm": {
+                                          "enum": [
+                                            "Auto",
+                                            "None",
+                                            "MD5",
+                                            "StorageCrc64"
+                                          ],
+                                          "description": "Checksum algorithm to use."
+                                        }
+                                      },
+                                      "description": "Options on upload."
+                                    }
+                                  },
+                                  "description": "Transfer validation options to be applied to blob transfers from this client."
                                 }
                               },
-                              "description": "Transfer validation options to be applied to blob transfers from this client."
+                              "description": "Provides the client configuration options for connecting to Azure Data Lake service."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Files/properties/DataLake/additionalProperties/anyOf/1"
                             }
-                          },
-                          "description": "Provides the client configuration options for connecting to Azure Data Lake service."
+                          ]
                         },
                         "ConnectionString": {
-                          "type": "string",
-                          "description": "Gets or sets the connection string used to connect to the Azure Data Lake Storage service."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the connection string used to connect to the Azure Data Lake Storage service."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Files/properties/DataLake/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableHealthChecks": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the Azure Data Lake Storage health check is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the Azure Data Lake Storage health check is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Files/properties/DataLake/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "DisableTracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                          "default": false
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                              "default": false
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Files/properties/DataLake/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "FileSystemName": {
-                          "type": "string",
-                          "description": "Gets or sets the name of the DataLake FileSystem."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "description": "Gets or sets the name of the DataLake FileSystem."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Files/properties/DataLake/additionalProperties/anyOf/1"
+                            }
+                          ]
                         },
                         "ServiceUri": {
-                          "type": "string",
-                          "format": "uri",
-                          "description": "A 'System.Uri' referencing the data lake service. This is likely to be similar to \"https://{account_name}.dfs.core.windows.net\"."
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uri",
+                              "description": "A 'System.Uri' referencing the data lake service. This is likely to be similar to \"https://{account_name}.dfs.core.windows.net\"."
+                            },
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Files/properties/DataLake/additionalProperties/anyOf/1"
+                            }
+                          ]
                         }
                       },
                       "description": "Provides the client configuration settings for connecting to an Azure DataLake FileSystem.",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "ClientOptions": {
+                        "anyOf": [
+                          {
+                            "not": {
+                              "type": "object"
+                            }
+                          },
+                          {
                             "type": "object",
                             "properties": {
-                              "Diagnostics": {
+                              "ClientOptions": {
                                 "type": "object",
                                 "properties": {
-                                  "ApplicationId": {
-                                    "type": "string",
-                                    "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                                  },
-                                  "DefaultApplicationId": {
-                                    "type": "string",
-                                    "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                                  },
-                                  "IsDistributedTracingEnabled": {
-                                    "type": "boolean",
-                                    "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                                  },
-                                  "IsLoggingContentEnabled": {
-                                    "type": "boolean",
-                                    "description": "Gets or sets value indicating if request or response content should be logged."
-                                  },
-                                  "IsLoggingEnabled": {
-                                    "type": "boolean",
-                                    "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                                  },
-                                  "IsTelemetryEnabled": {
-                                    "type": "boolean",
-                                    "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                                  },
-                                  "LoggedContentSizeLimit": {
-                                    "type": "integer",
-                                    "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                                  },
-                                  "LoggedHeaderNames": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
+                                  "Diagnostics": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ApplicationId": {
+                                        "type": "string",
+                                        "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                      },
+                                      "DefaultApplicationId": {
+                                        "type": "string",
+                                        "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                      },
+                                      "IsDistributedTracingEnabled": {
+                                        "type": "boolean",
+                                        "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                      },
+                                      "IsLoggingContentEnabled": {
+                                        "type": "boolean",
+                                        "description": "Gets or sets value indicating if request or response content should be logged."
+                                      },
+                                      "IsLoggingEnabled": {
+                                        "type": "boolean",
+                                        "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                      },
+                                      "IsTelemetryEnabled": {
+                                        "type": "boolean",
+                                        "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                      },
+                                      "LoggedContentSizeLimit": {
+                                        "type": "integer",
+                                        "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                      },
+                                      "LoggedHeaderNames": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "description": "Gets a list of header names that are not redacted during logging."
+                                      },
+                                      "LoggedQueryParameters": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "description": "Gets a list of query parameter names that are not redacted during logging."
+                                      }
                                     },
-                                    "description": "Gets a list of header names that are not redacted during logging."
+                                    "description": "Gets the client diagnostic options."
                                   },
-                                  "LoggedQueryParameters": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
+                                  "EnableTenantDiscovery": {
+                                    "type": "boolean",
+                                    "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                                  },
+                                  "GeoRedundantSecondaryUri": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
+                                  },
+                                  "Retry": {
+                                    "type": "object",
+                                    "properties": {
+                                      "Delay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                      },
+                                      "MaxDelay": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                      },
+                                      "MaxRetries": {
+                                        "type": "integer",
+                                        "description": "The maximum number of retry attempts before giving up."
+                                      },
+                                      "Mode": {
+                                        "enum": [
+                                          "Fixed",
+                                          "Exponential"
+                                        ],
+                                        "description": "The approach to use for calculating retry delays."
+                                      },
+                                      "NetworkTimeout": {
+                                        "type": "string",
+                                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                        "description": "The timeout applied to individual network operations."
+                                      }
                                     },
-                                    "description": "Gets a list of query parameter names that are not redacted during logging."
+                                    "description": "Gets the client retry options."
+                                  },
+                                  "TransferValidation": {
+                                    "type": "object",
+                                    "properties": {
+                                      "Download": {
+                                        "type": "object",
+                                        "properties": {
+                                          "AutoValidateChecksum": {
+                                            "type": "boolean",
+                                            "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
+                                          },
+                                          "ChecksumAlgorithm": {
+                                            "enum": [
+                                              "Auto",
+                                              "None",
+                                              "MD5",
+                                              "StorageCrc64"
+                                            ],
+                                            "description": "Checksum algorithm to use."
+                                          }
+                                        },
+                                        "description": "Options on download."
+                                      },
+                                      "Upload": {
+                                        "type": "object",
+                                        "properties": {
+                                          "ChecksumAlgorithm": {
+                                            "enum": [
+                                              "Auto",
+                                              "None",
+                                              "MD5",
+                                              "StorageCrc64"
+                                            ],
+                                            "description": "Checksum algorithm to use."
+                                          }
+                                        },
+                                        "description": "Options on upload."
+                                      }
+                                    },
+                                    "description": "Transfer validation options to be applied to blob transfers from this client."
                                   }
                                 },
-                                "description": "Gets the client diagnostic options."
+                                "description": "Provides the client configuration options for connecting to Azure Data Lake service."
                               },
-                              "EnableTenantDiscovery": {
+                              "ConnectionString": {
+                                "type": "string",
+                                "description": "Gets or sets the connection string used to connect to the Azure Data Lake Storage service."
+                              },
+                              "DisableHealthChecks": {
                                 "type": "boolean",
-                                "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                                "description": "Gets or sets a boolean value that indicates whether the Azure Data Lake Storage health check is disabled or not.",
+                                "default": false
                               },
-                              "GeoRedundantSecondaryUri": {
+                              "DisableTracing": {
+                                "type": "boolean",
+                                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                                "default": false
+                              },
+                              "FileSystemName": {
+                                "type": "string",
+                                "description": "Gets or sets the name of the DataLake FileSystem."
+                              },
+                              "ServiceUri": {
                                 "type": "string",
                                 "format": "uri",
-                                "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
-                              },
-                              "Retry": {
-                                "type": "object",
-                                "properties": {
-                                  "Delay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                                  },
-                                  "MaxDelay": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                                  },
-                                  "MaxRetries": {
-                                    "type": "integer",
-                                    "description": "The maximum number of retry attempts before giving up."
-                                  },
-                                  "Mode": {
-                                    "enum": [
-                                      "Fixed",
-                                      "Exponential"
-                                    ],
-                                    "description": "The approach to use for calculating retry delays."
-                                  },
-                                  "NetworkTimeout": {
-                                    "type": "string",
-                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                    "description": "The timeout applied to individual network operations."
-                                  }
-                                },
-                                "description": "Gets the client retry options."
-                              },
-                              "TransferValidation": {
-                                "type": "object",
-                                "properties": {
-                                  "Download": {
-                                    "type": "object",
-                                    "properties": {
-                                      "AutoValidateChecksum": {
-                                        "type": "boolean",
-                                        "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
-                                      },
-                                      "ChecksumAlgorithm": {
-                                        "enum": [
-                                          "Auto",
-                                          "None",
-                                          "MD5",
-                                          "StorageCrc64"
-                                        ],
-                                        "description": "Checksum algorithm to use."
-                                      }
-                                    },
-                                    "description": "Options on download."
-                                  },
-                                  "Upload": {
-                                    "type": "object",
-                                    "properties": {
-                                      "ChecksumAlgorithm": {
-                                        "enum": [
-                                          "Auto",
-                                          "None",
-                                          "MD5",
-                                          "StorageCrc64"
-                                        ],
-                                        "description": "Checksum algorithm to use."
-                                      }
-                                    },
-                                    "description": "Options on upload."
-                                  }
-                                },
-                                "description": "Transfer validation options to be applied to blob transfers from this client."
+                                "description": "A 'System.Uri' referencing the data lake service. This is likely to be similar to \"https://{account_name}.dfs.core.windows.net\"."
                               }
                             },
-                            "description": "Provides the client configuration options for connecting to Azure Data Lake service."
-                          },
-                          "ConnectionString": {
-                            "type": "string",
-                            "description": "Gets or sets the connection string used to connect to the Azure Data Lake Storage service."
-                          },
-                          "DisableHealthChecks": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the Azure Data Lake Storage health check is disabled or not.",
-                            "default": false
-                          },
-                          "DisableTracing": {
-                            "type": "boolean",
-                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                            "default": false
-                          },
-                          "FileSystemName": {
-                            "type": "string",
-                            "description": "Gets or sets the name of the DataLake FileSystem."
-                          },
-                          "ServiceUri": {
-                            "type": "string",
-                            "format": "uri",
-                            "description": "A 'System.Uri' referencing the data lake service. This is likely to be similar to \"https://{account_name}.dfs.core.windows.net\"."
+                            "description": "Provides the client configuration settings for connecting to an Azure DataLake FileSystem."
                           }
-                        },
-                        "description": "Provides the client configuration settings for connecting to an Azure DataLake FileSystem."
+                        ]
                       }
                     }
                   }

--- a/src/Components/Aspire.Azure.Storage.Files.DataLake/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Files.DataLake/ConfigurationSchema.json
@@ -169,7 +169,42 @@
                               "description": "Provides the client configuration options for connecting to Azure Data Lake service."
                             },
                             {
-                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Files/properties/DataLake/additionalProperties/anyOf/1"
+                              "allOf": [
+                                {
+                                  "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Files/properties/DataLake/additionalProperties/anyOf/1"
+                                },
+                                {
+                                  "not": {
+                                    "anyOf": [
+                                      {
+                                        "required": [
+                                          "GeoRedundantSecondaryUri"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "EnableTenantDiscovery"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "TransferValidation"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "Diagnostics"
+                                        ]
+                                      },
+                                      {
+                                        "required": [
+                                          "Retry"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
                             }
                           ]
                         },

--- a/src/Components/Aspire.Azure.Storage.Files.DataLake/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Files.DataLake/ConfigurationSchema.json
@@ -180,13 +180,181 @@
                           "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
                           "default": false
                         },
+                        "FileSystemName": {
+                          "type": "string",
+                          "description": "Gets or sets the name of the DataLake FileSystem."
+                        },
                         "ServiceUri": {
                           "type": "string",
                           "format": "uri",
                           "description": "A 'System.Uri' referencing the data lake service. This is likely to be similar to \"https://{account_name}.dfs.core.windows.net\"."
                         }
                       },
-                      "description": "Provides the client configuration settings for connecting to Azure Data Lake Storage."
+                      "description": "Provides the client configuration settings for connecting to an Azure DataLake FileSystem.",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "ClientOptions": {
+                            "type": "object",
+                            "properties": {
+                              "Diagnostics": {
+                                "type": "object",
+                                "properties": {
+                                  "ApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                  },
+                                  "DefaultApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                  },
+                                  "IsDistributedTracingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                  },
+                                  "IsLoggingContentEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request or response content should be logged."
+                                  },
+                                  "IsLoggingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                  },
+                                  "IsTelemetryEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                  },
+                                  "LoggedContentSizeLimit": {
+                                    "type": "integer",
+                                    "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                  },
+                                  "LoggedHeaderNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of header names that are not redacted during logging."
+                                  },
+                                  "LoggedQueryParameters": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of query parameter names that are not redacted during logging."
+                                  }
+                                },
+                                "description": "Gets the client diagnostic options."
+                              },
+                              "EnableTenantDiscovery": {
+                                "type": "boolean",
+                                "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                              },
+                              "GeoRedundantSecondaryUri": {
+                                "type": "string",
+                                "format": "uri",
+                                "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
+                              },
+                              "Retry": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before giving up."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "NetworkTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The timeout applied to individual network operations."
+                                  }
+                                },
+                                "description": "Gets the client retry options."
+                              },
+                              "TransferValidation": {
+                                "type": "object",
+                                "properties": {
+                                  "Download": {
+                                    "type": "object",
+                                    "properties": {
+                                      "AutoValidateChecksum": {
+                                        "type": "boolean",
+                                        "description": "Defaults to true. False can only be specified on specific operations and not at the client level. Indicates whether the SDK should validate the content body against the content hash before returning contents to the caller. If set to false, caller is responsible for extracting the hash out of the 'Azure.Response`1' and validating the hash themselves."
+                                      },
+                                      "ChecksumAlgorithm": {
+                                        "enum": [
+                                          "Auto",
+                                          "None",
+                                          "MD5",
+                                          "StorageCrc64"
+                                        ],
+                                        "description": "Checksum algorithm to use."
+                                      }
+                                    },
+                                    "description": "Options on download."
+                                  },
+                                  "Upload": {
+                                    "type": "object",
+                                    "properties": {
+                                      "ChecksumAlgorithm": {
+                                        "enum": [
+                                          "Auto",
+                                          "None",
+                                          "MD5",
+                                          "StorageCrc64"
+                                        ],
+                                        "description": "Checksum algorithm to use."
+                                      }
+                                    },
+                                    "description": "Options on upload."
+                                  }
+                                },
+                                "description": "Transfer validation options to be applied to blob transfers from this client."
+                              }
+                            },
+                            "description": "Provides the client configuration options for connecting to Azure Data Lake service."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the Azure Data Lake Storage service."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the Azure Data Lake Storage health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "FileSystemName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the DataLake FileSystem."
+                          },
+                          "ServiceUri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "A 'System.Uri' referencing the data lake service. This is likely to be similar to \"https://{account_name}.dfs.core.windows.net\"."
+                          }
+                        },
+                        "description": "Provides the client configuration settings for connecting to an Azure DataLake FileSystem."
+                      }
                     }
                   }
                 }

--- a/src/Components/Aspire.Azure.Storage.Queues/AssemblyInfo.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AssemblyInfo.cs
@@ -7,7 +7,11 @@ using Aspire.Azure.Storage.Queues;
 using Azure.Storage.Queues;
 
 [assembly: ConfigurationSchema("Aspire:Azure:Storage:Queues", typeof(AzureStorageQueuesSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Queues", typeof(AzureStorageQueueSettings))]
 [assembly: ConfigurationSchema("Aspire:Azure:Storage:Queues:ClientOptions", typeof(QueueClientOptions), exclusionPaths: ["Default"])]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Queues:*", typeof(AzureStorageQueuesSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Queues:*", typeof(AzureStorageQueueSettings))]
+[assembly: ConfigurationSchema("Aspire:Azure:Storage:Queues:*:ClientOptions", typeof(QueueClientOptions), exclusionPaths: ["Default"])]
 
 [assembly: LoggingCategories(
     "Azure",

--- a/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
@@ -144,13 +144,148 @@
                       "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
                       "default": false
                     },
+                    "QueueName": {
+                      "type": "string",
+                      "description": "Gets or sets the name of the Queue."
+                    },
                     "ServiceUri": {
                       "type": "string",
                       "format": "uri",
                       "description": "A 'System.Uri' referencing the queue service. This is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to Azure Storage Queues."
+                  "description": "Provides the client configuration settings for connecting to an Azure Storage queue.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "Diagnostics": {
+                            "type": "object",
+                            "properties": {
+                              "ApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                              },
+                              "DefaultApplicationId": {
+                                "type": "string",
+                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                              },
+                              "IsDistributedTracingEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                              },
+                              "IsLoggingContentEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating if request or response content should be logged."
+                              },
+                              "IsLoggingEnabled": {
+                                "type": "boolean",
+                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                              },
+                              "IsTelemetryEnabled": {
+                                "type": "boolean",
+                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                              },
+                              "LoggedContentSizeLimit": {
+                                "type": "integer",
+                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                              },
+                              "LoggedHeaderNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of header names that are not redacted during logging."
+                              },
+                              "LoggedQueryParameters": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                              }
+                            },
+                            "description": "Gets the client diagnostic options."
+                          },
+                          "EnableTenantDiscovery": {
+                            "type": "boolean",
+                            "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                          },
+                          "GeoRedundantSecondaryUri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
+                          },
+                          "MessageEncoding": {
+                            "enum": [
+                              "None",
+                              "Base64"
+                            ],
+                            "description": "Gets or sets a message encoding that determines how 'Azure.Storage.Queues.Models.QueueMessage.Body' is represented in HTTP requests and responses. The default is 'Azure.Storage.Queues.QueueMessageEncoding.None'."
+                          },
+                          "Retry": {
+                            "type": "object",
+                            "properties": {
+                              "Delay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxDelay": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              },
+                              "MaxRetries": {
+                                "type": "integer",
+                                "description": "The maximum number of retry attempts before giving up."
+                              },
+                              "Mode": {
+                                "enum": [
+                                  "Fixed",
+                                  "Exponential"
+                                ],
+                                "description": "The approach to use for calculating retry delays."
+                              },
+                              "NetworkTimeout": {
+                                "type": "string",
+                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                "description": "The timeout applied to individual network operations."
+                              }
+                            },
+                            "description": "Gets the client retry options."
+                          }
+                        },
+                        "description": "Provides the client configuration options for connecting to Azure Queue Storage"
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string used to connect to the queue service."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the Queues Storage health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "QueueName": {
+                        "type": "string",
+                        "description": "Gets or sets the name of the Queue."
+                      },
+                      "ServiceUri": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A 'System.Uri' referencing the queue service. This is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to an Azure Storage queue."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
@@ -133,7 +133,42 @@
                           "description": "Provides the client configuration options for connecting to Azure Queue Storage"
                         },
                         {
-                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Queues/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Queues/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "GeoRedundantSecondaryUri"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "MessageEncoding"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "EnableTenantDiscovery"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Diagnostics"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "Retry"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
@@ -29,262 +29,313 @@
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "Diagnostics": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "ApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                            },
-                            "DefaultApplicationId": {
-                              "type": "string",
-                              "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                            },
-                            "IsDistributedTracingEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                            },
-                            "IsLoggingContentEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating if request or response content should be logged."
-                            },
-                            "IsLoggingEnabled": {
-                              "type": "boolean",
-                              "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                            },
-                            "IsTelemetryEnabled": {
-                              "type": "boolean",
-                              "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                            },
-                            "LoggedContentSizeLimit": {
-                              "type": "integer",
-                              "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                            },
-                            "LoggedHeaderNames": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
+                            "Diagnostics": {
+                              "type": "object",
+                              "properties": {
+                                "ApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                },
+                                "DefaultApplicationId": {
+                                  "type": "string",
+                                  "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                },
+                                "IsDistributedTracingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                },
+                                "IsLoggingContentEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating if request or response content should be logged."
+                                },
+                                "IsLoggingEnabled": {
+                                  "type": "boolean",
+                                  "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                },
+                                "IsTelemetryEnabled": {
+                                  "type": "boolean",
+                                  "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                },
+                                "LoggedContentSizeLimit": {
+                                  "type": "integer",
+                                  "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                },
+                                "LoggedHeaderNames": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of header names that are not redacted during logging."
+                                },
+                                "LoggedQueryParameters": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Gets a list of query parameter names that are not redacted during logging."
+                                }
                               },
-                              "description": "Gets a list of header names that are not redacted during logging."
+                              "description": "Gets the client diagnostic options."
                             },
-                            "LoggedQueryParameters": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "Gets a list of query parameter names that are not redacted during logging."
-                            }
-                          },
-                          "description": "Gets the client diagnostic options."
-                        },
-                        "EnableTenantDiscovery": {
-                          "type": "boolean",
-                          "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
-                        },
-                        "GeoRedundantSecondaryUri": {
-                          "type": "string",
-                          "format": "uri",
-                          "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
-                        },
-                        "MessageEncoding": {
-                          "enum": [
-                            "None",
-                            "Base64"
-                          ],
-                          "description": "Gets or sets a message encoding that determines how 'Azure.Storage.Queues.Models.QueueMessage.Body' is represented in HTTP requests and responses. The default is 'Azure.Storage.Queues.QueueMessageEncoding.None'."
-                        },
-                        "Retry": {
-                          "type": "object",
-                          "properties": {
-                            "Delay": {
+                            "EnableTenantDiscovery": {
+                              "type": "boolean",
+                              "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                            },
+                            "GeoRedundantSecondaryUri": {
                               "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                              "format": "uri",
+                              "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
                             },
-                            "MaxDelay": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                            },
-                            "MaxRetries": {
-                              "type": "integer",
-                              "description": "The maximum number of retry attempts before giving up."
-                            },
-                            "Mode": {
+                            "MessageEncoding": {
                               "enum": [
-                                "Fixed",
-                                "Exponential"
+                                "None",
+                                "Base64"
                               ],
-                              "description": "The approach to use for calculating retry delays."
+                              "description": "Gets or sets a message encoding that determines how 'Azure.Storage.Queues.Models.QueueMessage.Body' is represented in HTTP requests and responses. The default is 'Azure.Storage.Queues.QueueMessageEncoding.None'."
                             },
-                            "NetworkTimeout": {
-                              "type": "string",
-                              "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                              "description": "The timeout applied to individual network operations."
+                            "Retry": {
+                              "type": "object",
+                              "properties": {
+                                "Delay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxDelay": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                },
+                                "MaxRetries": {
+                                  "type": "integer",
+                                  "description": "The maximum number of retry attempts before giving up."
+                                },
+                                "Mode": {
+                                  "enum": [
+                                    "Fixed",
+                                    "Exponential"
+                                  ],
+                                  "description": "The approach to use for calculating retry delays."
+                                },
+                                "NetworkTimeout": {
+                                  "type": "string",
+                                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                  "description": "The timeout applied to individual network operations."
+                                }
+                              },
+                              "description": "Gets the client retry options."
                             }
                           },
-                          "description": "Gets the client retry options."
+                          "description": "Provides the client configuration options for connecting to Azure Queue Storage"
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Queues/additionalProperties/anyOf/1"
                         }
-                      },
-                      "description": "Provides the client configuration options for connecting to Azure Queue Storage"
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string used to connect to the queue service."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string used to connect to the queue service."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Queues/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Queues Storage health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the Queues Storage health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Queues/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Queues/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "QueueName": {
-                      "type": "string",
-                      "description": "Gets or sets the name of the Queue."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the name of the Queue."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Queues/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ServiceUri": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "A 'System.Uri' referencing the queue service. This is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A 'System.Uri' referencing the queue service. This is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Azure/properties/Storage/properties/Queues/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to an Azure Storage queue.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
                         "type": "object",
                         "properties": {
-                          "Diagnostics": {
+                          "ClientOptions": {
                             "type": "object",
                             "properties": {
-                              "ApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
-                              },
-                              "DefaultApplicationId": {
-                                "type": "string",
-                                "description": "Gets or sets the default application id. Default application id would be set on all instances."
-                              },
-                              "IsDistributedTracingEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
-                              },
-                              "IsLoggingContentEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating if request or response content should be logged."
-                              },
-                              "IsLoggingEnabled": {
-                                "type": "boolean",
-                                "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
-                              },
-                              "IsTelemetryEnabled": {
-                                "type": "boolean",
-                                "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
-                              },
-                              "LoggedContentSizeLimit": {
-                                "type": "integer",
-                                "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
-                              },
-                              "LoggedHeaderNames": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "Diagnostics": {
+                                "type": "object",
+                                "properties": {
+                                  "ApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the value sent as the first part of \"User-Agent\" headers for all requests issues by this client. Defaults to 'Azure.Core.DiagnosticsOptions.DefaultApplicationId'."
+                                  },
+                                  "DefaultApplicationId": {
+                                    "type": "string",
+                                    "description": "Gets or sets the default application id. Default application id would be set on all instances."
+                                  },
+                                  "IsDistributedTracingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether distributed tracing activities ('System.Diagnostics.Activity') are going to be created for the clients methods calls and HTTP calls."
+                                  },
+                                  "IsLoggingContentEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating if request or response content should be logged."
+                                  },
+                                  "IsLoggingEnabled": {
+                                    "type": "boolean",
+                                    "description": "Get or sets value indicating whether HTTP pipeline logging is enabled."
+                                  },
+                                  "IsTelemetryEnabled": {
+                                    "type": "boolean",
+                                    "description": "Gets or sets value indicating whether the \"User-Agent\" header containing 'Azure.Core.DiagnosticsOptions.ApplicationId', client library package name and version, 'System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription' and 'System.Runtime.InteropServices.RuntimeInformation.OSDescription' should be sent. The default value can be controlled process wide by setting AZURE_TELEMETRY_DISABLED to true, false, 1 or 0."
+                                  },
+                                  "LoggedContentSizeLimit": {
+                                    "type": "integer",
+                                    "description": "Gets or sets value indicating maximum size of content to log in bytes. Defaults to 4096."
+                                  },
+                                  "LoggedHeaderNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of header names that are not redacted during logging."
+                                  },
+                                  "LoggedQueryParameters": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Gets a list of query parameter names that are not redacted during logging."
+                                  }
                                 },
-                                "description": "Gets a list of header names that are not redacted during logging."
+                                "description": "Gets the client diagnostic options."
                               },
-                              "LoggedQueryParameters": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                              "EnableTenantDiscovery": {
+                                "type": "boolean",
+                                "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                              },
+                              "GeoRedundantSecondaryUri": {
+                                "type": "string",
+                                "format": "uri",
+                                "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
+                              },
+                              "MessageEncoding": {
+                                "enum": [
+                                  "None",
+                                  "Base64"
+                                ],
+                                "description": "Gets or sets a message encoding that determines how 'Azure.Storage.Queues.Models.QueueMessage.Body' is represented in HTTP requests and responses. The default is 'Azure.Storage.Queues.QueueMessageEncoding.None'."
+                              },
+                              "Retry": {
+                                "type": "object",
+                                "properties": {
+                                  "Delay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxDelay": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
+                                  },
+                                  "MaxRetries": {
+                                    "type": "integer",
+                                    "description": "The maximum number of retry attempts before giving up."
+                                  },
+                                  "Mode": {
+                                    "enum": [
+                                      "Fixed",
+                                      "Exponential"
+                                    ],
+                                    "description": "The approach to use for calculating retry delays."
+                                  },
+                                  "NetworkTimeout": {
+                                    "type": "string",
+                                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                                    "description": "The timeout applied to individual network operations."
+                                  }
                                 },
-                                "description": "Gets a list of query parameter names that are not redacted during logging."
+                                "description": "Gets the client retry options."
                               }
                             },
-                            "description": "Gets the client diagnostic options."
+                            "description": "Provides the client configuration options for connecting to Azure Queue Storage"
                           },
-                          "EnableTenantDiscovery": {
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string used to connect to the queue service."
+                          },
+                          "DisableHealthChecks": {
                             "type": "boolean",
-                            "description": "Enables tenant discovery through the authorization challenge when the client is configured to use a TokenCredential. When enabled, the client will attempt an initial un-authorized request to prompt a challenge in order to discover the correct tenant for the resource."
+                            "description": "Gets or sets a boolean value that indicates whether the Queues Storage health check is disabled or not.",
+                            "default": false
                           },
-                          "GeoRedundantSecondaryUri": {
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "QueueName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the Queue."
+                          },
+                          "ServiceUri": {
                             "type": "string",
                             "format": "uri",
-                            "description": "Gets or sets the secondary storage 'System.Uri' that can be read from for the storage account if the account is enabled for RA-GRS.\n\nIf this property is set, the secondary Uri will be used for GET or HEAD requests during retries. If the status of the response from the secondary Uri is a 404, then subsequent retries for the request will not use the secondary Uri again, as this indicates that the resource may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth between primary and secondary Uri."
-                          },
-                          "MessageEncoding": {
-                            "enum": [
-                              "None",
-                              "Base64"
-                            ],
-                            "description": "Gets or sets a message encoding that determines how 'Azure.Storage.Queues.Models.QueueMessage.Body' is represented in HTTP requests and responses. The default is 'Azure.Storage.Queues.QueueMessageEncoding.None'."
-                          },
-                          "Retry": {
-                            "type": "object",
-                            "properties": {
-                              "Delay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The delay between retry attempts for a fixed approach or the delay on which to base calculations for a backoff-based approach. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxDelay": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The maximum permissible delay between retry attempts when the service does not provide a Retry-After response header. If the service provides a Retry-After response header, the next retry will be delayed by the duration specified by the header value."
-                              },
-                              "MaxRetries": {
-                                "type": "integer",
-                                "description": "The maximum number of retry attempts before giving up."
-                              },
-                              "Mode": {
-                                "enum": [
-                                  "Fixed",
-                                  "Exponential"
-                                ],
-                                "description": "The approach to use for calculating retry delays."
-                              },
-                              "NetworkTimeout": {
-                                "type": "string",
-                                "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                                "description": "The timeout applied to individual network operations."
-                              }
-                            },
-                            "description": "Gets the client retry options."
+                            "description": "A 'System.Uri' referencing the queue service. This is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
                           }
                         },
-                        "description": "Provides the client configuration options for connecting to Azure Queue Storage"
-                      },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string used to connect to the queue service."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the Queues Storage health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "QueueName": {
-                        "type": "string",
-                        "description": "Gets or sets the name of the Queue."
-                      },
-                      "ServiceUri": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "A 'System.Uri' referencing the queue service. This is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
+                        "description": "Provides the client configuration settings for connecting to an Azure Storage queue."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to an Azure Storage queue."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Confluent.Kafka/ConfigurationSchema.json
+++ b/src/Components/Aspire.Confluent.Kafka/ConfigurationSchema.json
@@ -19,944 +19,996 @@
               "type": "object",
               "properties": {
                 "Consumer": {
+                  "definitions": {
+                    "settings": {
+                      "type": "object",
+                      "properties": {
+                        "Config": {
+                          "type": "object",
+                          "properties": {
+                            "Acks": {
+                              "enum": [
+                                "None",
+                                "Leader",
+                                "All"
+                              ],
+                              "description": "This field indicates the number of acknowledgements the leader broker must receive from ISR brokers\nbefore responding to the request: Zero=Broker does not send any response/ack to client, One=The\nleader will write the record to its local log but will respond without awaiting full acknowledgement\nfrom all followers. All=Broker will block until message is committed by all in sync replicas (ISRs).\nIf there are less than min.insync.replicas (broker configuration) in the ISR set the produce request\nwill fail."
+                            },
+                            "AllowAutoCreateTopics": {
+                              "type": "boolean",
+                              "description": "Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics. The broker must also be configured with `auto.create.topics.enable=true` for this configuration to take effect. Note: the default value (true) for the producer is different from the default value (false) for the consumer. Further, the consumer default value is different from the Java consumer (true), and this property is not supported by the Java producer. Requires broker version &gt;= 0.11.0.0, for older broker versions only the broker configuration applies.\n\ndefault: false\nimportance: low"
+                            },
+                            "ApiVersionFallbackMs": {
+                              "type": "integer",
+                              "description": "Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).\n\ndefault: 0\nimportance: medium"
+                            },
+                            "ApiVersionRequest": {
+                              "type": "boolean",
+                              "description": "Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version &gt;=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.\n\ndefault: true\nimportance: high"
+                            },
+                            "ApiVersionRequestTimeoutMs": {
+                              "type": "integer",
+                              "description": "Timeout for broker API version requests.\n\ndefault: 10000\nimportance: low"
+                            },
+                            "AutoCommitIntervalMs": {
+                              "type": "integer",
+                              "description": "The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable). This setting is used by the high-level consumer.\n\ndefault: 5000\nimportance: medium"
+                            },
+                            "AutoOffsetReset": {
+                              "enum": [
+                                "Latest",
+                                "Earliest",
+                                "Error"
+                              ],
+                              "description": "Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error (ERR__AUTO_OFFSET_RESET) which is retrieved by consuming messages and checking 'message-&gt;err'.\n\ndefault: largest\nimportance: high"
+                            },
+                            "BootstrapServers": {
+                              "type": "string",
+                              "description": "Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.\n\ndefault: ''\nimportance: high"
+                            },
+                            "BrokerAddressFamily": {
+                              "enum": [
+                                "Any",
+                                "V4",
+                                "V6"
+                              ],
+                              "description": "Allowed broker IP address families: any, v4, v6\n\ndefault: any\nimportance: low"
+                            },
+                            "BrokerAddressTtl": {
+                              "type": "integer",
+                              "description": "How long to cache the broker address resolving results (milliseconds).\n\ndefault: 1000\nimportance: low"
+                            },
+                            "BrokerVersionFallback": {
+                              "type": "string",
+                              "description": "Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value &gt;= 0.10, such as 0.10.2.1, enables ApiVersionRequests.\n\ndefault: 0.10.0\nimportance: medium"
+                            },
+                            "CancellationDelayMaxMs": {
+                              "type": "integer",
+                              "description": "The maximum length of time (in milliseconds) before a cancellation request\nis acted on. Low values may result in measurably higher CPU usage.\n\ndefault: 100\nrange: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000\nimportance: low"
+                            },
+                            "CheckCrcs": {
+                              "type": "boolean",
+                              "description": "Verify CRC32 of consumed messages, ensuring no on-the-wire or on-disk corruption to the messages occurred. This check comes at slightly increased CPU usage.\n\ndefault: false\nimportance: medium"
+                            },
+                            "ClientDnsLookup": {
+                              "enum": [
+                                "UseAllDnsIps",
+                                "ResolveCanonicalBootstrapServersOnly"
+                              ],
+                              "description": "Controls how the client uses DNS lookups. By default, when the lookup returns multiple IP addresses for a hostname, they will all be attempted for connection before the connection is considered failed. This applies to both bootstrap and advertised servers. If the value is set to `resolve_canonical_bootstrap_servers_only`, each entry will be resolved and expanded into a list of canonical names. NOTE: Default here is different from the Java client's default behavior, which connects only to the first IP address returned for a hostname.\n\ndefault: use_all_dns_ips\nimportance: low"
+                            },
+                            "ClientId": {
+                              "type": "string",
+                              "description": "Client identifier.\n\ndefault: rdkafka\nimportance: low"
+                            },
+                            "ClientRack": {
+                              "type": "string",
+                              "description": "A rack identifier for this client. This can be any string value which indicates where this client is physically located. It corresponds with the broker config `broker.rack`.\n\ndefault: ''\nimportance: low"
+                            },
+                            "ConnectionsMaxIdleMs": {
+                              "type": "integer",
+                              "description": "Close broker connections after the specified time of inactivity. Disable with 0. If this property is left at its default value some heuristics are performed to determine a suitable default value, this is currently limited to identifying brokers on Azure (see librdkafka issue #3109 for more info).\n\ndefault: 0\nimportance: medium"
+                            },
+                            "ConsumeResultFields": {
+                              "type": "string",
+                              "description": "A comma separated list of fields that may be optionally set\nin 'Confluent.Kafka.ConsumeResult`2' objects returned by the 'Confluent.Kafka.Consumer`2.Consume(System.TimeSpan)' method. Disabling fields that you do not require will improve\nthroughput and reduce memory consumption. Allowed values:\nheaders, timestamp, topic, all, none\n\ndefault: all\nimportance: low"
+                            },
+                            "CoordinatorQueryIntervalMs": {
+                              "type": "integer",
+                              "description": "How often to query for the current client group coordinator. If the currently assigned coordinator is down the configured query interval will be divided by ten to more quickly recover in case of coordinator reassignment.\n\ndefault: 600000\nimportance: low"
+                            },
+                            "Debug": {
+                              "type": "string",
+                              "description": "A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch\n\ndefault: ''\nimportance: medium"
+                            },
+                            "EnableAutoCommit": {
+                              "type": "boolean",
+                              "description": "Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets. To circumvent this behaviour set specific start offsets per partition in the call to assign().\n\ndefault: true\nimportance: high"
+                            },
+                            "EnableAutoOffsetStore": {
+                              "type": "boolean",
+                              "description": "Automatically store offset of last message provided to application. The offset store is an in-memory store of the next offset to (auto-)commit for each partition.\n\ndefault: true\nimportance: high"
+                            },
+                            "EnablePartitionEof": {
+                              "type": "boolean",
+                              "description": "Emit RD_KAFKA_RESP_ERR__PARTITION_EOF event whenever the consumer reaches the end of a partition.\n\ndefault: false\nimportance: low"
+                            },
+                            "EnableRandomSeed": {
+                              "type": "boolean",
+                              "description": "If enabled librdkafka will initialize the PRNG with srand(current_time.milliseconds) on the first invocation of rd_kafka_new() (required only if rand_r() is not available on your platform). If disabled the application must call srand() prior to calling rd_kafka_new().\n\ndefault: true\nimportance: low"
+                            },
+                            "EnableSaslOauthbearerUnsecureJwt": {
+                              "type": "boolean",
+                              "description": "Enable the builtin unsecure JWT OAUTHBEARER token handler if no oauthbearer_refresh_cb has been set. This builtin handler should only be used for development or testing, and not in production.\n\ndefault: false\nimportance: low"
+                            },
+                            "EnableSslCertificateVerification": {
+                              "type": "boolean",
+                              "description": "Enable OpenSSL's builtin broker (server) certificate verification. This verification can be extended by the application by implementing a certificate_verify_cb.\n\ndefault: true\nimportance: low"
+                            },
+                            "FetchErrorBackoffMs": {
+                              "type": "integer",
+                              "description": "How long to postpone the next fetch request for a topic+partition in case of a fetch error.\n\ndefault: 500\nimportance: medium"
+                            },
+                            "FetchMaxBytes": {
+                              "type": "integer",
+                              "description": "Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in batches by the consumer and if the first message batch in the first non-empty partition of the Fetch request is larger than this value, then the message batch will still be returned to ensure the consumer can make progress. The maximum message batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least `message.max.bytes` (consumer config).\n\ndefault: 52428800\nimportance: medium"
+                            },
+                            "FetchMinBytes": {
+                              "type": "integer",
+                              "description": "Minimum number of bytes the broker responds with. If fetch.wait.max.ms expires the accumulated data will be sent to the client regardless of this setting.\n\ndefault: 1\nimportance: low"
+                            },
+                            "FetchQueueBackoffMs": {
+                              "type": "integer",
+                              "description": "How long to postpone the next fetch request for a topic+partition in case the current fetch queue thresholds (queued.min.messages or queued.max.messages.kbytes) have been exceded. This property may need to be decreased if the queue thresholds are set low and the application is experiencing long (~1s) delays between messages. Low values may increase CPU utilization.\n\ndefault: 1000\nimportance: medium"
+                            },
+                            "FetchWaitMaxMs": {
+                              "type": "integer",
+                              "description": "Maximum time the broker may wait to fill the Fetch response with fetch.min.bytes of messages.\n\ndefault: 500\nimportance: low"
+                            },
+                            "GroupId": {
+                              "type": "string",
+                              "description": "Client group id string. All clients sharing the same group.id belong to the same group.\n\ndefault: ''\nimportance: high"
+                            },
+                            "GroupInstanceId": {
+                              "type": "string",
+                              "description": "Enable static group membership. Static group members are able to leave and rejoin a group within the configured `session.timeout.ms` without prompting a group rebalance. This should be used in combination with a larger `session.timeout.ms` to avoid group rebalances caused by transient unavailability (e.g. process restarts). Requires broker version &gt;= 2.3.0.\n\ndefault: ''\nimportance: medium"
+                            },
+                            "GroupProtocolType": {
+                              "type": "string",
+                              "description": "Group protocol type. NOTE: Currently, the only supported group protocol type is `consumer`.\n\ndefault: consumer\nimportance: low"
+                            },
+                            "HeartbeatIntervalMs": {
+                              "type": "integer",
+                              "description": "Group session keepalive heartbeat interval.\n\ndefault: 3000\nimportance: low"
+                            },
+                            "InternalTerminationSignal": {
+                              "type": "integer",
+                              "description": "Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.\n\ndefault: 0\nimportance: low"
+                            },
+                            "IsolationLevel": {
+                              "enum": [
+                                "ReadUncommitted",
+                                "ReadCommitted"
+                              ],
+                              "description": "Controls how to read messages written transactionally: `read_committed` - only return transactional messages which have been committed. `read_uncommitted` - return all messages, even transactional messages which have been aborted.\n\ndefault: read_committed\nimportance: high"
+                            },
+                            "LogConnectionClose": {
+                              "type": "boolean",
+                              "description": "Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connections.max.idle.ms` value.\n\ndefault: true\nimportance: low"
+                            },
+                            "LogQueue": {
+                              "type": "boolean",
+                              "description": "Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.\n\ndefault: false\nimportance: low"
+                            },
+                            "LogThreadName": {
+                              "type": "boolean",
+                              "description": "Print internal thread name in log messages (useful for debugging librdkafka internals)\n\ndefault: true\nimportance: low"
+                            },
+                            "MaxInFlight": {
+                              "type": "integer",
+                              "description": "Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.\n\ndefault: 1000000\nimportance: low"
+                            },
+                            "MaxPartitionFetchBytes": {
+                              "type": "integer",
+                              "description": "Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.\n\ndefault: 1048576\nimportance: medium"
+                            },
+                            "MaxPollIntervalMs": {
+                              "type": "integer",
+                              "description": "Maximum allowed time between calls to consume messages (e.g., rd_kafka_consumer_poll()) for high-level consumers. If this interval is exceeded the consumer is considered failed and the group will rebalance in order to reassign the partitions to another consumer group member. Warning: Offset commits may be not possible at this point. Note: It is recommended to set `enable.auto.offset.store=false` for long-time processing applications and then explicitly store offsets (using offsets_store()) *after* message processing, to make sure offsets are not auto-committed prior to processing has finished. The interval is checked two times per second. See KIP-62 for more information.\n\ndefault: 300000\nimportance: high"
+                            },
+                            "MessageCopyMaxBytes": {
+                              "type": "integer",
+                              "description": "Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.\n\ndefault: 65535\nimportance: low"
+                            },
+                            "MessageMaxBytes": {
+                              "type": "integer",
+                              "description": "Maximum Kafka protocol request message size. Due to differing framing overhead between protocol versions the producer is unable to reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests, the broker will enforce the the topic's `max.message.bytes` limit (see Apache Kafka documentation).\n\ndefault: 1000000\nimportance: medium"
+                            },
+                            "MetadataMaxAgeMs": {
+                              "type": "integer",
+                              "description": "Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3\n\ndefault: 900000\nimportance: low"
+                            },
+                            "PartitionAssignmentStrategy": {
+                              "enum": [
+                                "Range",
+                                "RoundRobin",
+                                "CooperativeSticky"
+                              ],
+                              "description": "The name of one or more partition assignment strategies. The elected group leader will use a strategy supported by all members of the group to assign partitions to group members. If there is more than one eligible strategy, preference is determined by the order of this list (strategies earlier in the list have higher priority). Cooperative and non-cooperative (eager) strategies must not be mixed. Available strategies: range, roundrobin, cooperative-sticky.\n\ndefault: range,roundrobin\nimportance: medium"
+                            },
+                            "PluginLibraryPaths": {
+                              "type": "string",
+                              "description": "List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.\n\ndefault: ''\nimportance: low"
+                            },
+                            "QueuedMaxMessagesKbytes": {
+                              "type": "integer",
+                              "description": "Maximum number of kilobytes of queued pre-fetched messages in the local consumer queue. If using the high-level consumer this setting applies to the single consumer queue, regardless of the number of partitions. When using the legacy simple consumer or when separate partition queues are used this setting applies per partition. This value may be overshot by fetch.message.max.bytes. This property has higher priority than queued.min.messages.\n\ndefault: 65536\nimportance: medium"
+                            },
+                            "QueuedMinMessages": {
+                              "type": "integer",
+                              "description": "Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.\n\ndefault: 100000\nimportance: medium"
+                            },
+                            "ReceiveMessageMaxBytes": {
+                              "type": "integer",
+                              "description": "Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.\n\ndefault: 100000000\nimportance: medium"
+                            },
+                            "ReconnectBackoffMaxMs": {
+                              "type": "integer",
+                              "description": "The maximum time to wait before reconnecting to a broker after the connection has been closed.\n\ndefault: 10000\nimportance: medium"
+                            },
+                            "ReconnectBackoffMs": {
+                              "type": "integer",
+                              "description": "The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.\n\ndefault: 100\nimportance: medium"
+                            },
+                            "SaslKerberosKeytab": {
+                              "type": "string",
+                              "description": "Path to Kerberos keytab file. This configuration property is only used as a variable in `sasl.kerberos.kinit.cmd` as ` ... -t \"%{sasl.kerberos.keytab}\"`.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslKerberosKinitCmd": {
+                              "type": "string",
+                              "description": "Shell command to refresh or acquire the client's Kerberos ticket. This command is executed on client creation and every sasl.kerberos.min.time.before.relogin (0=disable). %{config.prop.name} is replaced by corresponding config object value.\n\ndefault: kinit -R -t \"%{sasl.kerberos.keytab}\" -k %{sasl.kerberos.principal} || kinit -t \"%{sasl.kerberos.keytab}\" -k %{sasl.kerberos.principal}\nimportance: low"
+                            },
+                            "SaslKerberosMinTimeBeforeRelogin": {
+                              "type": "integer",
+                              "description": "Minimum time in milliseconds between key refresh attempts. Disable automatic key refresh by setting this property to 0.\n\ndefault: 60000\nimportance: low"
+                            },
+                            "SaslKerberosPrincipal": {
+                              "type": "string",
+                              "description": "This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).\n\ndefault: kafkaclient\nimportance: low"
+                            },
+                            "SaslKerberosServiceName": {
+                              "type": "string",
+                              "description": "Kerberos principal name that Kafka runs as, not including /hostname@REALM\n\ndefault: kafka\nimportance: low"
+                            },
+                            "SaslMechanism": {
+                              "enum": [
+                                "Gssapi",
+                                "Plain",
+                                "ScramSha256",
+                                "ScramSha512",
+                                "OAuthBearer"
+                              ],
+                              "description": "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism."
+                            },
+                            "SaslOauthbearerClientId": {
+                              "type": "string",
+                              "description": "Public identifier for the application. Must be unique across all clients that the authorization server handles. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerClientSecret": {
+                              "type": "string",
+                              "description": "Client secret only known to the application and the authorization server. This should be a sufficiently random string that is not guessable. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerConfig": {
+                              "type": "string",
+                              "description": "SASL/OAUTHBEARER configuration. The format is implementation-dependent and must be parsed accordingly. The default unsecured token implementation (see https://tools.ietf.org/html/rfc7515#appendix-A.5) recognizes space-separated name=value pairs with valid names including principalClaimName, principal, scopeClaimName, scope, and lifeSeconds. The default value for principalClaimName is \"sub\", the default value for scopeClaimName is \"scope\", and the default value for lifeSeconds is 3600. The scope value is CSV format with the default value being no/empty scope. For example: `principalClaimName=azp principal=admin scopeClaimName=roles scope=role1,role2 lifeSeconds=600`. In addition, SASL extensions can be communicated to the broker via `extension_NAME=value`. For example: `principal=admin extension_traceId=123`\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerExtensions": {
+                              "type": "string",
+                              "description": "Allow additional information to be provided to the broker. Comma-separated list of key=value pairs. E.g., \"supportFeatureX=true,organizationId=sales-emea\".Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerMethod": {
+                              "enum": [
+                                "Default",
+                                "Oidc"
+                              ],
+                              "description": "Set to \"default\" or \"oidc\" to control which login method to be used. If set to \"oidc\", the following properties must also be be specified: `sasl.oauthbearer.client.id`, `sasl.oauthbearer.client.secret`, and `sasl.oauthbearer.token.endpoint.url`.\n\ndefault: default\nimportance: low"
+                            },
+                            "SaslOauthbearerScope": {
+                              "type": "string",
+                              "description": "Client use this to specify the scope of the access request to the broker. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerTokenEndpointUrl": {
+                              "type": "string",
+                              "description": "OAuth/OIDC issuer token endpoint HTTP(S) URI used to retrieve token. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslPassword": {
+                              "type": "string",
+                              "description": "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism\n\ndefault: ''\nimportance: high"
+                            },
+                            "SaslUsername": {
+                              "type": "string",
+                              "description": "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms\n\ndefault: ''\nimportance: high"
+                            },
+                            "SecurityProtocol": {
+                              "enum": [
+                                "Plaintext",
+                                "Ssl",
+                                "SaslPlaintext",
+                                "SaslSsl"
+                              ],
+                              "description": "Protocol used to communicate with brokers.\n\ndefault: plaintext\nimportance: high"
+                            },
+                            "SessionTimeoutMs": {
+                              "type": "integer",
+                              "description": "Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.\n\ndefault: 45000\nimportance: high"
+                            },
+                            "SocketConnectionSetupTimeoutMs": {
+                              "type": "integer",
+                              "description": "Maximum time allowed for broker connection setup (TCP connection setup as well SSL and SASL handshake). If the connection to the broker is not fully functional after this the connection will be closed and retried.\n\ndefault: 30000\nimportance: medium"
+                            },
+                            "SocketKeepaliveEnable": {
+                              "type": "boolean",
+                              "description": "Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets\n\ndefault: false\nimportance: low"
+                            },
+                            "SocketMaxFails": {
+                              "type": "integer",
+                              "description": "Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.\n\ndefault: 1\nimportance: low"
+                            },
+                            "SocketNagleDisable": {
+                              "type": "boolean",
+                              "description": "Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.\n\ndefault: false\nimportance: low"
+                            },
+                            "SocketReceiveBufferBytes": {
+                              "type": "integer",
+                              "description": "Broker socket receive buffer size. System default is used if 0.\n\ndefault: 0\nimportance: low"
+                            },
+                            "SocketSendBufferBytes": {
+                              "type": "integer",
+                              "description": "Broker socket send buffer size. System default is used if 0.\n\ndefault: 0\nimportance: low"
+                            },
+                            "SocketTimeoutMs": {
+                              "type": "integer",
+                              "description": "Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.\n\ndefault: 60000\nimportance: low"
+                            },
+                            "SslCaCertificateStores": {
+                              "type": "string",
+                              "description": "Comma-separated list of Windows Certificate stores to load CA certificates from. Certificates will be loaded in the same order as stores are specified. If no certificates can be loaded from any of the specified stores an error is logged and the OpenSSL library's default CA location is used instead. Store names are typically one or more of: MY, Root, Trust, CA.\n\ndefault: Root\nimportance: low"
+                            },
+                            "SslCaLocation": {
+                              "type": "string",
+                              "description": "File or directory path to CA certificate(s) for verifying the broker's key. Defaults: On Windows the system's CA certificates are automatically looked up in the Windows Root certificate store. On Mac OSX this configuration defaults to `probe`. It is recommended to install openssl using Homebrew, to provide CA certificates. On Linux install the distribution's ca-certificates package. If OpenSSL is statically linked or `ssl.ca.location` is set to `probe` a list of standard paths will be probed and the first one found will be used as the default CA certificate location path. If OpenSSL is dynamically linked the OpenSSL library's default path will be used (see `OPENSSLDIR` in `openssl version -a`).\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCaPem": {
+                              "type": "string",
+                              "description": "CA certificate string (PEM format) for verifying the broker's key.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCertificateLocation": {
+                              "type": "string",
+                              "description": "Path to client's public key (PEM) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCertificatePem": {
+                              "type": "string",
+                              "description": "Client's public key string (PEM format) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCipherSuites": {
+                              "type": "string",
+                              "description": "A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCrlLocation": {
+                              "type": "string",
+                              "description": "Path to CRL for verifying broker's certificate validity.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCurvesList": {
+                              "type": "string",
+                              "description": "The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL &gt;= 1.0.2 required.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslEndpointIdentificationAlgorithm": {
+                              "enum": [
+                                "None",
+                                "Https"
+                              ],
+                              "description": "Endpoint identification algorithm to validate broker hostname using broker certificate. https - Server (broker) hostname verification as specified in RFC2818. none - No endpoint verification. OpenSSL &gt;= 1.0.2 required.\n\ndefault: https\nimportance: low"
+                            },
+                            "SslEngineId": {
+                              "type": "string",
+                              "description": "OpenSSL engine id is the name used for loading engine.\n\ndefault: dynamic\nimportance: low"
+                            },
+                            "SslEngineLocation": {
+                              "type": "string",
+                              "description": "**DEPRECATED** Path to OpenSSL engine library. OpenSSL &gt;= 1.1.x required. DEPRECATED: OpenSSL engine support is deprecated and should be replaced by OpenSSL 3 providers.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeyLocation": {
+                              "type": "string",
+                              "description": "Path to client's private key (PEM) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeyPassword": {
+                              "type": "string",
+                              "description": "Private key passphrase (for use with `ssl.key.location` and `set_ssl_cert()`)\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeyPem": {
+                              "type": "string",
+                              "description": "Client's private key string (PEM format) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeystoreLocation": {
+                              "type": "string",
+                              "description": "Path to client's keystore (PKCS#12) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeystorePassword": {
+                              "type": "string",
+                              "description": "Client's keystore (PKCS#12) password.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslProviders": {
+                              "type": "string",
+                              "description": "Comma-separated list of OpenSSL 3.0.x implementation providers. E.g., \"default,legacy\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslSigalgsList": {
+                              "type": "string",
+                              "description": "The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL &gt;= 1.0.2 required.\n\ndefault: ''\nimportance: low"
+                            },
+                            "StatisticsIntervalMs": {
+                              "type": "integer",
+                              "description": "librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.\n\ndefault: 0\nimportance: high"
+                            },
+                            "TopicBlacklist": {
+                              "type": "string",
+                              "description": "Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.\n\ndefault: ''\nimportance: low"
+                            },
+                            "TopicMetadataPropagationMaxMs": {
+                              "type": "integer",
+                              "description": "Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic will seem to be non-existent and the client will mark the topic as such, failing queued produced messages with `ERR__UNKNOWN_TOPIC`. This setting delays marking a topic as non-existent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, e.g., on produce().\n\ndefault: 30000\nimportance: low"
+                            },
+                            "TopicMetadataRefreshFastIntervalMs": {
+                              "type": "integer",
+                              "description": "When a topic loses its leader a new metadata request will be enqueued immediately and then with this initial interval, exponentially increasing upto `retry.backoff.max.ms`, until the topic metadata has been refreshed. If not set explicitly, it will be defaulted to `retry.backoff.ms`. This is used to recover quickly from transitioning leader brokers.\n\ndefault: 100\nimportance: low"
+                            },
+                            "TopicMetadataRefreshIntervalMs": {
+                              "type": "integer",
+                              "description": "Period of time in milliseconds at which topic and broker metadata is refreshed in order to proactively discover any new brokers, topics, partitions or partition leader changes. Use -1 to disable the intervalled refresh (not recommended). If there are no locally referenced topics (no topic objects created, no messages produced, no subscription or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.\n\ndefault: 300000\nimportance: low"
+                            },
+                            "TopicMetadataRefreshSparse": {
+                              "type": "boolean",
+                              "description": "Sparse metadata requests (consumes less network bandwidth)\n\ndefault: true\nimportance: low"
+                            }
+                          },
+                          "description": "Gets or sets the configuration settings for the Kafka consumer."
+                        },
+                        "ConnectionString": {
+                          "type": "string",
+                          "description": "Gets or sets the connection string of the Kafka server to connect to."
+                        },
+                        "DisableHealthChecks": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the Kafka health check is disabled or not."
+                        },
+                        "DisableMetrics": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not."
+                        },
+                        "DisableTracing": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry traces are enabled or not.",
+                          "default": false
+                        }
+                      },
+                      "description": "Provides the client configuration settings for connecting to a Kafka message broker to consume messages."
+                    }
+                  },
                   "type": "object",
                   "properties": {
                     "Config": {
-                      "type": "object",
-                      "properties": {
-                        "Acks": {
-                          "enum": [
-                            "None",
-                            "Leader",
-                            "All"
-                          ],
-                          "description": "This field indicates the number of acknowledgements the leader broker must receive from ISR brokers\nbefore responding to the request: Zero=Broker does not send any response/ack to client, One=The\nleader will write the record to its local log but will respond without awaiting full acknowledgement\nfrom all followers. All=Broker will block until message is committed by all in sync replicas (ISRs).\nIf there are less than min.insync.replicas (broker configuration) in the ISR set the produce request\nwill fail."
-                        },
-                        "AllowAutoCreateTopics": {
-                          "type": "boolean",
-                          "description": "Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics. The broker must also be configured with `auto.create.topics.enable=true` for this configuration to take effect. Note: the default value (true) for the producer is different from the default value (false) for the consumer. Further, the consumer default value is different from the Java consumer (true), and this property is not supported by the Java producer. Requires broker version &gt;= 0.11.0.0, for older broker versions only the broker configuration applies.\n\ndefault: false\nimportance: low"
-                        },
-                        "ApiVersionFallbackMs": {
-                          "type": "integer",
-                          "description": "Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).\n\ndefault: 0\nimportance: medium"
-                        },
-                        "ApiVersionRequest": {
-                          "type": "boolean",
-                          "description": "Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version &gt;=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.\n\ndefault: true\nimportance: high"
-                        },
-                        "ApiVersionRequestTimeoutMs": {
-                          "type": "integer",
-                          "description": "Timeout for broker API version requests.\n\ndefault: 10000\nimportance: low"
-                        },
-                        "AutoCommitIntervalMs": {
-                          "type": "integer",
-                          "description": "The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable). This setting is used by the high-level consumer.\n\ndefault: 5000\nimportance: medium"
-                        },
-                        "AutoOffsetReset": {
-                          "enum": [
-                            "Latest",
-                            "Earliest",
-                            "Error"
-                          ],
-                          "description": "Action to take when there is no initial offset in offset store or the desired offset is out of range: 'smallest','earliest' - automatically reset the offset to the smallest offset, 'largest','latest' - automatically reset the offset to the largest offset, 'error' - trigger an error (ERR__AUTO_OFFSET_RESET) which is retrieved by consuming messages and checking 'message-&gt;err'.\n\ndefault: largest\nimportance: high"
-                        },
-                        "BootstrapServers": {
-                          "type": "string",
-                          "description": "Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.\n\ndefault: ''\nimportance: high"
-                        },
-                        "BrokerAddressFamily": {
-                          "enum": [
-                            "Any",
-                            "V4",
-                            "V6"
-                          ],
-                          "description": "Allowed broker IP address families: any, v4, v6\n\ndefault: any\nimportance: low"
-                        },
-                        "BrokerAddressTtl": {
-                          "type": "integer",
-                          "description": "How long to cache the broker address resolving results (milliseconds).\n\ndefault: 1000\nimportance: low"
-                        },
-                        "BrokerVersionFallback": {
-                          "type": "string",
-                          "description": "Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value &gt;= 0.10, such as 0.10.2.1, enables ApiVersionRequests.\n\ndefault: 0.10.0\nimportance: medium"
-                        },
-                        "CancellationDelayMaxMs": {
-                          "type": "integer",
-                          "description": "The maximum length of time (in milliseconds) before a cancellation request\nis acted on. Low values may result in measurably higher CPU usage.\n\ndefault: 100\nrange: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000\nimportance: low"
-                        },
-                        "CheckCrcs": {
-                          "type": "boolean",
-                          "description": "Verify CRC32 of consumed messages, ensuring no on-the-wire or on-disk corruption to the messages occurred. This check comes at slightly increased CPU usage.\n\ndefault: false\nimportance: medium"
-                        },
-                        "ClientDnsLookup": {
-                          "enum": [
-                            "UseAllDnsIps",
-                            "ResolveCanonicalBootstrapServersOnly"
-                          ],
-                          "description": "Controls how the client uses DNS lookups. By default, when the lookup returns multiple IP addresses for a hostname, they will all be attempted for connection before the connection is considered failed. This applies to both bootstrap and advertised servers. If the value is set to `resolve_canonical_bootstrap_servers_only`, each entry will be resolved and expanded into a list of canonical names. NOTE: Default here is different from the Java client's default behavior, which connects only to the first IP address returned for a hostname.\n\ndefault: use_all_dns_ips\nimportance: low"
-                        },
-                        "ClientId": {
-                          "type": "string",
-                          "description": "Client identifier.\n\ndefault: rdkafka\nimportance: low"
-                        },
-                        "ClientRack": {
-                          "type": "string",
-                          "description": "A rack identifier for this client. This can be any string value which indicates where this client is physically located. It corresponds with the broker config `broker.rack`.\n\ndefault: ''\nimportance: low"
-                        },
-                        "ConnectionsMaxIdleMs": {
-                          "type": "integer",
-                          "description": "Close broker connections after the specified time of inactivity. Disable with 0. If this property is left at its default value some heuristics are performed to determine a suitable default value, this is currently limited to identifying brokers on Azure (see librdkafka issue #3109 for more info).\n\ndefault: 0\nimportance: medium"
-                        },
-                        "ConsumeResultFields": {
-                          "type": "string",
-                          "description": "A comma separated list of fields that may be optionally set\nin 'Confluent.Kafka.ConsumeResult`2' objects returned by the 'Confluent.Kafka.Consumer`2.Consume(System.TimeSpan)' method. Disabling fields that you do not require will improve\nthroughput and reduce memory consumption. Allowed values:\nheaders, timestamp, topic, all, none\n\ndefault: all\nimportance: low"
-                        },
-                        "CoordinatorQueryIntervalMs": {
-                          "type": "integer",
-                          "description": "How often to query for the current client group coordinator. If the currently assigned coordinator is down the configured query interval will be divided by ten to more quickly recover in case of coordinator reassignment.\n\ndefault: 600000\nimportance: low"
-                        },
-                        "Debug": {
-                          "type": "string",
-                          "description": "A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch\n\ndefault: ''\nimportance: medium"
-                        },
-                        "EnableAutoCommit": {
-                          "type": "boolean",
-                          "description": "Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets. To circumvent this behaviour set specific start offsets per partition in the call to assign().\n\ndefault: true\nimportance: high"
-                        },
-                        "EnableAutoOffsetStore": {
-                          "type": "boolean",
-                          "description": "Automatically store offset of last message provided to application. The offset store is an in-memory store of the next offset to (auto-)commit for each partition.\n\ndefault: true\nimportance: high"
-                        },
-                        "EnablePartitionEof": {
-                          "type": "boolean",
-                          "description": "Emit RD_KAFKA_RESP_ERR__PARTITION_EOF event whenever the consumer reaches the end of a partition.\n\ndefault: false\nimportance: low"
-                        },
-                        "EnableRandomSeed": {
-                          "type": "boolean",
-                          "description": "If enabled librdkafka will initialize the PRNG with srand(current_time.milliseconds) on the first invocation of rd_kafka_new() (required only if rand_r() is not available on your platform). If disabled the application must call srand() prior to calling rd_kafka_new().\n\ndefault: true\nimportance: low"
-                        },
-                        "EnableSaslOauthbearerUnsecureJwt": {
-                          "type": "boolean",
-                          "description": "Enable the builtin unsecure JWT OAUTHBEARER token handler if no oauthbearer_refresh_cb has been set. This builtin handler should only be used for development or testing, and not in production.\n\ndefault: false\nimportance: low"
-                        },
-                        "EnableSslCertificateVerification": {
-                          "type": "boolean",
-                          "description": "Enable OpenSSL's builtin broker (server) certificate verification. This verification can be extended by the application by implementing a certificate_verify_cb.\n\ndefault: true\nimportance: low"
-                        },
-                        "FetchErrorBackoffMs": {
-                          "type": "integer",
-                          "description": "How long to postpone the next fetch request for a topic+partition in case of a fetch error.\n\ndefault: 500\nimportance: medium"
-                        },
-                        "FetchMaxBytes": {
-                          "type": "integer",
-                          "description": "Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in batches by the consumer and if the first message batch in the first non-empty partition of the Fetch request is larger than this value, then the message batch will still be returned to ensure the consumer can make progress. The maximum message batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least `message.max.bytes` (consumer config).\n\ndefault: 52428800\nimportance: medium"
-                        },
-                        "FetchMinBytes": {
-                          "type": "integer",
-                          "description": "Minimum number of bytes the broker responds with. If fetch.wait.max.ms expires the accumulated data will be sent to the client regardless of this setting.\n\ndefault: 1\nimportance: low"
-                        },
-                        "FetchQueueBackoffMs": {
-                          "type": "integer",
-                          "description": "How long to postpone the next fetch request for a topic+partition in case the current fetch queue thresholds (queued.min.messages or queued.max.messages.kbytes) have been exceded. This property may need to be decreased if the queue thresholds are set low and the application is experiencing long (~1s) delays between messages. Low values may increase CPU utilization.\n\ndefault: 1000\nimportance: medium"
-                        },
-                        "FetchWaitMaxMs": {
-                          "type": "integer",
-                          "description": "Maximum time the broker may wait to fill the Fetch response with fetch.min.bytes of messages.\n\ndefault: 500\nimportance: low"
-                        },
-                        "GroupId": {
-                          "type": "string",
-                          "description": "Client group id string. All clients sharing the same group.id belong to the same group.\n\ndefault: ''\nimportance: high"
-                        },
-                        "GroupInstanceId": {
-                          "type": "string",
-                          "description": "Enable static group membership. Static group members are able to leave and rejoin a group within the configured `session.timeout.ms` without prompting a group rebalance. This should be used in combination with a larger `session.timeout.ms` to avoid group rebalances caused by transient unavailability (e.g. process restarts). Requires broker version &gt;= 2.3.0.\n\ndefault: ''\nimportance: medium"
-                        },
-                        "GroupProtocolType": {
-                          "type": "string",
-                          "description": "Group protocol type. NOTE: Currently, the only supported group protocol type is `consumer`.\n\ndefault: consumer\nimportance: low"
-                        },
-                        "HeartbeatIntervalMs": {
-                          "type": "integer",
-                          "description": "Group session keepalive heartbeat interval.\n\ndefault: 3000\nimportance: low"
-                        },
-                        "InternalTerminationSignal": {
-                          "type": "integer",
-                          "description": "Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.\n\ndefault: 0\nimportance: low"
-                        },
-                        "IsolationLevel": {
-                          "enum": [
-                            "ReadUncommitted",
-                            "ReadCommitted"
-                          ],
-                          "description": "Controls how to read messages written transactionally: `read_committed` - only return transactional messages which have been committed. `read_uncommitted` - return all messages, even transactional messages which have been aborted.\n\ndefault: read_committed\nimportance: high"
-                        },
-                        "LogConnectionClose": {
-                          "type": "boolean",
-                          "description": "Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connections.max.idle.ms` value.\n\ndefault: true\nimportance: low"
-                        },
-                        "LogQueue": {
-                          "type": "boolean",
-                          "description": "Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.\n\ndefault: false\nimportance: low"
-                        },
-                        "LogThreadName": {
-                          "type": "boolean",
-                          "description": "Print internal thread name in log messages (useful for debugging librdkafka internals)\n\ndefault: true\nimportance: low"
-                        },
-                        "MaxInFlight": {
-                          "type": "integer",
-                          "description": "Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.\n\ndefault: 1000000\nimportance: low"
-                        },
-                        "MaxPartitionFetchBytes": {
-                          "type": "integer",
-                          "description": "Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.\n\ndefault: 1048576\nimportance: medium"
-                        },
-                        "MaxPollIntervalMs": {
-                          "type": "integer",
-                          "description": "Maximum allowed time between calls to consume messages (e.g., rd_kafka_consumer_poll()) for high-level consumers. If this interval is exceeded the consumer is considered failed and the group will rebalance in order to reassign the partitions to another consumer group member. Warning: Offset commits may be not possible at this point. Note: It is recommended to set `enable.auto.offset.store=false` for long-time processing applications and then explicitly store offsets (using offsets_store()) *after* message processing, to make sure offsets are not auto-committed prior to processing has finished. The interval is checked two times per second. See KIP-62 for more information.\n\ndefault: 300000\nimportance: high"
-                        },
-                        "MessageCopyMaxBytes": {
-                          "type": "integer",
-                          "description": "Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.\n\ndefault: 65535\nimportance: low"
-                        },
-                        "MessageMaxBytes": {
-                          "type": "integer",
-                          "description": "Maximum Kafka protocol request message size. Due to differing framing overhead between protocol versions the producer is unable to reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests, the broker will enforce the the topic's `max.message.bytes` limit (see Apache Kafka documentation).\n\ndefault: 1000000\nimportance: medium"
-                        },
-                        "MetadataMaxAgeMs": {
-                          "type": "integer",
-                          "description": "Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3\n\ndefault: 900000\nimportance: low"
-                        },
-                        "PartitionAssignmentStrategy": {
-                          "enum": [
-                            "Range",
-                            "RoundRobin",
-                            "CooperativeSticky"
-                          ],
-                          "description": "The name of one or more partition assignment strategies. The elected group leader will use a strategy supported by all members of the group to assign partitions to group members. If there is more than one eligible strategy, preference is determined by the order of this list (strategies earlier in the list have higher priority). Cooperative and non-cooperative (eager) strategies must not be mixed. Available strategies: range, roundrobin, cooperative-sticky.\n\ndefault: range,roundrobin\nimportance: medium"
-                        },
-                        "PluginLibraryPaths": {
-                          "type": "string",
-                          "description": "List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.\n\ndefault: ''\nimportance: low"
-                        },
-                        "QueuedMaxMessagesKbytes": {
-                          "type": "integer",
-                          "description": "Maximum number of kilobytes of queued pre-fetched messages in the local consumer queue. If using the high-level consumer this setting applies to the single consumer queue, regardless of the number of partitions. When using the legacy simple consumer or when separate partition queues are used this setting applies per partition. This value may be overshot by fetch.message.max.bytes. This property has higher priority than queued.min.messages.\n\ndefault: 65536\nimportance: medium"
-                        },
-                        "QueuedMinMessages": {
-                          "type": "integer",
-                          "description": "Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.\n\ndefault: 100000\nimportance: medium"
-                        },
-                        "ReceiveMessageMaxBytes": {
-                          "type": "integer",
-                          "description": "Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.\n\ndefault: 100000000\nimportance: medium"
-                        },
-                        "ReconnectBackoffMaxMs": {
-                          "type": "integer",
-                          "description": "The maximum time to wait before reconnecting to a broker after the connection has been closed.\n\ndefault: 10000\nimportance: medium"
-                        },
-                        "ReconnectBackoffMs": {
-                          "type": "integer",
-                          "description": "The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.\n\ndefault: 100\nimportance: medium"
-                        },
-                        "SaslKerberosKeytab": {
-                          "type": "string",
-                          "description": "Path to Kerberos keytab file. This configuration property is only used as a variable in `sasl.kerberos.kinit.cmd` as ` ... -t \"%{sasl.kerberos.keytab}\"`.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslKerberosKinitCmd": {
-                          "type": "string",
-                          "description": "Shell command to refresh or acquire the client's Kerberos ticket. This command is executed on client creation and every sasl.kerberos.min.time.before.relogin (0=disable). %{config.prop.name} is replaced by corresponding config object value.\n\ndefault: kinit -R -t \"%{sasl.kerberos.keytab}\" -k %{sasl.kerberos.principal} || kinit -t \"%{sasl.kerberos.keytab}\" -k %{sasl.kerberos.principal}\nimportance: low"
-                        },
-                        "SaslKerberosMinTimeBeforeRelogin": {
-                          "type": "integer",
-                          "description": "Minimum time in milliseconds between key refresh attempts. Disable automatic key refresh by setting this property to 0.\n\ndefault: 60000\nimportance: low"
-                        },
-                        "SaslKerberosPrincipal": {
-                          "type": "string",
-                          "description": "This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).\n\ndefault: kafkaclient\nimportance: low"
-                        },
-                        "SaslKerberosServiceName": {
-                          "type": "string",
-                          "description": "Kerberos principal name that Kafka runs as, not including /hostname@REALM\n\ndefault: kafka\nimportance: low"
-                        },
-                        "SaslMechanism": {
-                          "enum": [
-                            "Gssapi",
-                            "Plain",
-                            "ScramSha256",
-                            "ScramSha512",
-                            "OAuthBearer"
-                          ],
-                          "description": "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism."
-                        },
-                        "SaslOauthbearerClientId": {
-                          "type": "string",
-                          "description": "Public identifier for the application. Must be unique across all clients that the authorization server handles. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerClientSecret": {
-                          "type": "string",
-                          "description": "Client secret only known to the application and the authorization server. This should be a sufficiently random string that is not guessable. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerConfig": {
-                          "type": "string",
-                          "description": "SASL/OAUTHBEARER configuration. The format is implementation-dependent and must be parsed accordingly. The default unsecured token implementation (see https://tools.ietf.org/html/rfc7515#appendix-A.5) recognizes space-separated name=value pairs with valid names including principalClaimName, principal, scopeClaimName, scope, and lifeSeconds. The default value for principalClaimName is \"sub\", the default value for scopeClaimName is \"scope\", and the default value for lifeSeconds is 3600. The scope value is CSV format with the default value being no/empty scope. For example: `principalClaimName=azp principal=admin scopeClaimName=roles scope=role1,role2 lifeSeconds=600`. In addition, SASL extensions can be communicated to the broker via `extension_NAME=value`. For example: `principal=admin extension_traceId=123`\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerExtensions": {
-                          "type": "string",
-                          "description": "Allow additional information to be provided to the broker. Comma-separated list of key=value pairs. E.g., \"supportFeatureX=true,organizationId=sales-emea\".Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerMethod": {
-                          "enum": [
-                            "Default",
-                            "Oidc"
-                          ],
-                          "description": "Set to \"default\" or \"oidc\" to control which login method to be used. If set to \"oidc\", the following properties must also be be specified: `sasl.oauthbearer.client.id`, `sasl.oauthbearer.client.secret`, and `sasl.oauthbearer.token.endpoint.url`.\n\ndefault: default\nimportance: low"
-                        },
-                        "SaslOauthbearerScope": {
-                          "type": "string",
-                          "description": "Client use this to specify the scope of the access request to the broker. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerTokenEndpointUrl": {
-                          "type": "string",
-                          "description": "OAuth/OIDC issuer token endpoint HTTP(S) URI used to retrieve token. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslPassword": {
-                          "type": "string",
-                          "description": "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism\n\ndefault: ''\nimportance: high"
-                        },
-                        "SaslUsername": {
-                          "type": "string",
-                          "description": "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms\n\ndefault: ''\nimportance: high"
-                        },
-                        "SecurityProtocol": {
-                          "enum": [
-                            "Plaintext",
-                            "Ssl",
-                            "SaslPlaintext",
-                            "SaslSsl"
-                          ],
-                          "description": "Protocol used to communicate with brokers.\n\ndefault: plaintext\nimportance: high"
-                        },
-                        "SessionTimeoutMs": {
-                          "type": "integer",
-                          "description": "Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.\n\ndefault: 45000\nimportance: high"
-                        },
-                        "SocketConnectionSetupTimeoutMs": {
-                          "type": "integer",
-                          "description": "Maximum time allowed for broker connection setup (TCP connection setup as well SSL and SASL handshake). If the connection to the broker is not fully functional after this the connection will be closed and retried.\n\ndefault: 30000\nimportance: medium"
-                        },
-                        "SocketKeepaliveEnable": {
-                          "type": "boolean",
-                          "description": "Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets\n\ndefault: false\nimportance: low"
-                        },
-                        "SocketMaxFails": {
-                          "type": "integer",
-                          "description": "Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.\n\ndefault: 1\nimportance: low"
-                        },
-                        "SocketNagleDisable": {
-                          "type": "boolean",
-                          "description": "Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.\n\ndefault: false\nimportance: low"
-                        },
-                        "SocketReceiveBufferBytes": {
-                          "type": "integer",
-                          "description": "Broker socket receive buffer size. System default is used if 0.\n\ndefault: 0\nimportance: low"
-                        },
-                        "SocketSendBufferBytes": {
-                          "type": "integer",
-                          "description": "Broker socket send buffer size. System default is used if 0.\n\ndefault: 0\nimportance: low"
-                        },
-                        "SocketTimeoutMs": {
-                          "type": "integer",
-                          "description": "Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.\n\ndefault: 60000\nimportance: low"
-                        },
-                        "SslCaCertificateStores": {
-                          "type": "string",
-                          "description": "Comma-separated list of Windows Certificate stores to load CA certificates from. Certificates will be loaded in the same order as stores are specified. If no certificates can be loaded from any of the specified stores an error is logged and the OpenSSL library's default CA location is used instead. Store names are typically one or more of: MY, Root, Trust, CA.\n\ndefault: Root\nimportance: low"
-                        },
-                        "SslCaLocation": {
-                          "type": "string",
-                          "description": "File or directory path to CA certificate(s) for verifying the broker's key. Defaults: On Windows the system's CA certificates are automatically looked up in the Windows Root certificate store. On Mac OSX this configuration defaults to `probe`. It is recommended to install openssl using Homebrew, to provide CA certificates. On Linux install the distribution's ca-certificates package. If OpenSSL is statically linked or `ssl.ca.location` is set to `probe` a list of standard paths will be probed and the first one found will be used as the default CA certificate location path. If OpenSSL is dynamically linked the OpenSSL library's default path will be used (see `OPENSSLDIR` in `openssl version -a`).\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCaPem": {
-                          "type": "string",
-                          "description": "CA certificate string (PEM format) for verifying the broker's key.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCertificateLocation": {
-                          "type": "string",
-                          "description": "Path to client's public key (PEM) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCertificatePem": {
-                          "type": "string",
-                          "description": "Client's public key string (PEM format) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCipherSuites": {
-                          "type": "string",
-                          "description": "A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCrlLocation": {
-                          "type": "string",
-                          "description": "Path to CRL for verifying broker's certificate validity.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCurvesList": {
-                          "type": "string",
-                          "description": "The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL &gt;= 1.0.2 required.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslEndpointIdentificationAlgorithm": {
-                          "enum": [
-                            "None",
-                            "Https"
-                          ],
-                          "description": "Endpoint identification algorithm to validate broker hostname using broker certificate. https - Server (broker) hostname verification as specified in RFC2818. none - No endpoint verification. OpenSSL &gt;= 1.0.2 required.\n\ndefault: https\nimportance: low"
-                        },
-                        "SslEngineId": {
-                          "type": "string",
-                          "description": "OpenSSL engine id is the name used for loading engine.\n\ndefault: dynamic\nimportance: low"
-                        },
-                        "SslEngineLocation": {
-                          "type": "string",
-                          "description": "**DEPRECATED** Path to OpenSSL engine library. OpenSSL &gt;= 1.1.x required. DEPRECATED: OpenSSL engine support is deprecated and should be replaced by OpenSSL 3 providers.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeyLocation": {
-                          "type": "string",
-                          "description": "Path to client's private key (PEM) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeyPassword": {
-                          "type": "string",
-                          "description": "Private key passphrase (for use with `ssl.key.location` and `set_ssl_cert()`)\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeyPem": {
-                          "type": "string",
-                          "description": "Client's private key string (PEM format) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeystoreLocation": {
-                          "type": "string",
-                          "description": "Path to client's keystore (PKCS#12) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeystorePassword": {
-                          "type": "string",
-                          "description": "Client's keystore (PKCS#12) password.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslProviders": {
-                          "type": "string",
-                          "description": "Comma-separated list of OpenSSL 3.0.x implementation providers. E.g., \"default,legacy\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslSigalgsList": {
-                          "type": "string",
-                          "description": "The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL &gt;= 1.0.2 required.\n\ndefault: ''\nimportance: low"
-                        },
-                        "StatisticsIntervalMs": {
-                          "type": "integer",
-                          "description": "librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.\n\ndefault: 0\nimportance: high"
-                        },
-                        "TopicBlacklist": {
-                          "type": "string",
-                          "description": "Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.\n\ndefault: ''\nimportance: low"
-                        },
-                        "TopicMetadataPropagationMaxMs": {
-                          "type": "integer",
-                          "description": "Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic will seem to be non-existent and the client will mark the topic as such, failing queued produced messages with `ERR__UNKNOWN_TOPIC`. This setting delays marking a topic as non-existent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, e.g., on produce().\n\ndefault: 30000\nimportance: low"
-                        },
-                        "TopicMetadataRefreshFastIntervalMs": {
-                          "type": "integer",
-                          "description": "When a topic loses its leader a new metadata request will be enqueued immediately and then with this initial interval, exponentially increasing upto `retry.backoff.max.ms`, until the topic metadata has been refreshed. If not set explicitly, it will be defaulted to `retry.backoff.ms`. This is used to recover quickly from transitioning leader brokers.\n\ndefault: 100\nimportance: low"
-                        },
-                        "TopicMetadataRefreshIntervalMs": {
-                          "type": "integer",
-                          "description": "Period of time in milliseconds at which topic and broker metadata is refreshed in order to proactively discover any new brokers, topics, partitions or partition leader changes. Use -1 to disable the intervalled refresh (not recommended). If there are no locally referenced topics (no topic objects created, no messages produced, no subscription or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.\n\ndefault: 300000\nimportance: low"
-                        },
-                        "TopicMetadataRefreshSparse": {
-                          "type": "boolean",
-                          "description": "Sparse metadata requests (consumes less network bandwidth)\n\ndefault: true\nimportance: low"
-                        }
-                      },
-                      "description": "Gets or sets the configuration settings for the Kafka consumer."
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Consumer/definitions/settings/properties/Config"
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string of the Kafka server to connect to."
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Consumer/definitions/settings/properties/ConnectionString"
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Kafka health check is disabled or not."
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Consumer/definitions/settings/properties/DisableHealthChecks"
                     },
                     "DisableMetrics": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not."
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Consumer/definitions/settings/properties/DisableMetrics"
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry traces are enabled or not.",
-                      "default": false
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Consumer/definitions/settings/properties/DisableTracing"
                     }
+                  },
+                  "additionalProperties": {
+                    "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Consumer/definitions/settings"
                   },
                   "description": "Provides the client configuration settings for connecting to a Kafka message broker to consume messages."
                 },
                 "Producer": {
+                  "definitions": {
+                    "settings": {
+                      "type": "object",
+                      "properties": {
+                        "Config": {
+                          "type": "object",
+                          "properties": {
+                            "Acks": {
+                              "enum": [
+                                "None",
+                                "Leader",
+                                "All"
+                              ],
+                              "description": "This field indicates the number of acknowledgements the leader broker must receive from ISR brokers\nbefore responding to the request: Zero=Broker does not send any response/ack to client, One=The\nleader will write the record to its local log but will respond without awaiting full acknowledgement\nfrom all followers. All=Broker will block until message is committed by all in sync replicas (ISRs).\nIf there are less than min.insync.replicas (broker configuration) in the ISR set the produce request\nwill fail."
+                            },
+                            "AllowAutoCreateTopics": {
+                              "type": "boolean",
+                              "description": "Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics. The broker must also be configured with `auto.create.topics.enable=true` for this configuration to take effect. Note: the default value (true) for the producer is different from the default value (false) for the consumer. Further, the consumer default value is different from the Java consumer (true), and this property is not supported by the Java producer. Requires broker version &gt;= 0.11.0.0, for older broker versions only the broker configuration applies.\n\ndefault: false\nimportance: low"
+                            },
+                            "ApiVersionFallbackMs": {
+                              "type": "integer",
+                              "description": "Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).\n\ndefault: 0\nimportance: medium"
+                            },
+                            "ApiVersionRequest": {
+                              "type": "boolean",
+                              "description": "Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version &gt;=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.\n\ndefault: true\nimportance: high"
+                            },
+                            "ApiVersionRequestTimeoutMs": {
+                              "type": "integer",
+                              "description": "Timeout for broker API version requests.\n\ndefault: 10000\nimportance: low"
+                            },
+                            "BatchNumMessages": {
+                              "type": "integer",
+                              "description": "Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by batch.size and message.max.bytes.\n\ndefault: 10000\nimportance: medium"
+                            },
+                            "BatchSize": {
+                              "type": "integer",
+                              "description": "Maximum size (in bytes) of all messages batched in one MessageSet, including protocol framing overhead. This limit is applied after the first message has been added to the batch, regardless of the first message's size, this is to ensure that messages that exceed batch.size are produced. The total MessageSet size is also limited by batch.num.messages and message.max.bytes.\n\ndefault: 1000000\nimportance: medium"
+                            },
+                            "BootstrapServers": {
+                              "type": "string",
+                              "description": "Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.\n\ndefault: ''\nimportance: high"
+                            },
+                            "BrokerAddressFamily": {
+                              "enum": [
+                                "Any",
+                                "V4",
+                                "V6"
+                              ],
+                              "description": "Allowed broker IP address families: any, v4, v6\n\ndefault: any\nimportance: low"
+                            },
+                            "BrokerAddressTtl": {
+                              "type": "integer",
+                              "description": "How long to cache the broker address resolving results (milliseconds).\n\ndefault: 1000\nimportance: low"
+                            },
+                            "BrokerVersionFallback": {
+                              "type": "string",
+                              "description": "Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value &gt;= 0.10, such as 0.10.2.1, enables ApiVersionRequests.\n\ndefault: 0.10.0\nimportance: medium"
+                            },
+                            "CancellationDelayMaxMs": {
+                              "type": "integer",
+                              "description": "The maximum length of time (in milliseconds) before a cancellation request\nis acted on. Low values may result in measurably higher CPU usage.\n\ndefault: 100\nrange: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000\nimportance: low"
+                            },
+                            "ClientDnsLookup": {
+                              "enum": [
+                                "UseAllDnsIps",
+                                "ResolveCanonicalBootstrapServersOnly"
+                              ],
+                              "description": "Controls how the client uses DNS lookups. By default, when the lookup returns multiple IP addresses for a hostname, they will all be attempted for connection before the connection is considered failed. This applies to both bootstrap and advertised servers. If the value is set to `resolve_canonical_bootstrap_servers_only`, each entry will be resolved and expanded into a list of canonical names. NOTE: Default here is different from the Java client's default behavior, which connects only to the first IP address returned for a hostname.\n\ndefault: use_all_dns_ips\nimportance: low"
+                            },
+                            "ClientId": {
+                              "type": "string",
+                              "description": "Client identifier.\n\ndefault: rdkafka\nimportance: low"
+                            },
+                            "ClientRack": {
+                              "type": "string",
+                              "description": "A rack identifier for this client. This can be any string value which indicates where this client is physically located. It corresponds with the broker config `broker.rack`.\n\ndefault: ''\nimportance: low"
+                            },
+                            "CompressionLevel": {
+                              "type": "integer",
+                              "description": "Compression level parameter for algorithm selected by configuration property `compression.codec`. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.\n\ndefault: -1\nimportance: medium"
+                            },
+                            "CompressionType": {
+                              "enum": [
+                                "None",
+                                "Gzip",
+                                "Snappy",
+                                "Lz4",
+                                "Zstd"
+                              ],
+                              "description": "compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.\n\ndefault: none\nimportance: medium"
+                            },
+                            "ConnectionsMaxIdleMs": {
+                              "type": "integer",
+                              "description": "Close broker connections after the specified time of inactivity. Disable with 0. If this property is left at its default value some heuristics are performed to determine a suitable default value, this is currently limited to identifying brokers on Azure (see librdkafka issue #3109 for more info).\n\ndefault: 0\nimportance: medium"
+                            },
+                            "Debug": {
+                              "type": "string",
+                              "description": "A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch\n\ndefault: ''\nimportance: medium"
+                            },
+                            "DeliveryReportFields": {
+                              "type": "string",
+                              "description": "A comma separated list of fields that may be optionally set in delivery\nreports. Disabling delivery report fields that you do not require will\nimprove maximum throughput and reduce memory usage. Allowed values:\nkey, value, timestamp, headers, status, all, none.\n\ndefault: all\nimportance: low"
+                            },
+                            "EnableBackgroundPoll": {
+                              "type": "boolean",
+                              "description": "Specifies whether or not the producer should start a background poll\nthread to receive delivery reports and event notifications. Generally,\nthis should be set to true. If set to false, you will need to call\nthe Poll function manually.\n\ndefault: true\nimportance: low"
+                            },
+                            "EnableDeliveryReports": {
+                              "type": "boolean",
+                              "description": "Specifies whether to enable notification of delivery reports. Typically\nyou should set this parameter to true. Set it to false for \"fire and\nforget\" semantics and a small boost in performance.\n\ndefault: true\nimportance: low"
+                            },
+                            "EnableGaplessGuarantee": {
+                              "type": "boolean",
+                              "description": "**EXPERIMENTAL**: subject to change or removal. When set to `true`, any error that could result in a gap in the produced message series when a batch of messages fails, will raise a fatal error (ERR__GAPLESS_GUARANTEE) and stop the producer. Messages failing due to `message.timeout.ms` are not covered by this guarantee. Requires `enable.idempotence=true`.\n\ndefault: false\nimportance: low"
+                            },
+                            "EnableIdempotence": {
+                              "type": "boolean",
+                              "description": "When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Producer instantation will fail if user-supplied configuration is incompatible.\n\ndefault: false\nimportance: high"
+                            },
+                            "EnableRandomSeed": {
+                              "type": "boolean",
+                              "description": "If enabled librdkafka will initialize the PRNG with srand(current_time.milliseconds) on the first invocation of rd_kafka_new() (required only if rand_r() is not available on your platform). If disabled the application must call srand() prior to calling rd_kafka_new().\n\ndefault: true\nimportance: low"
+                            },
+                            "EnableSaslOauthbearerUnsecureJwt": {
+                              "type": "boolean",
+                              "description": "Enable the builtin unsecure JWT OAUTHBEARER token handler if no oauthbearer_refresh_cb has been set. This builtin handler should only be used for development or testing, and not in production.\n\ndefault: false\nimportance: low"
+                            },
+                            "EnableSslCertificateVerification": {
+                              "type": "boolean",
+                              "description": "Enable OpenSSL's builtin broker (server) certificate verification. This verification can be extended by the application by implementing a certificate_verify_cb.\n\ndefault: true\nimportance: low"
+                            },
+                            "InternalTerminationSignal": {
+                              "type": "integer",
+                              "description": "Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.\n\ndefault: 0\nimportance: low"
+                            },
+                            "LingerMs": {
+                              "type": [
+                                "number",
+                                "string"
+                              ],
+                              "description": "Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.\n\ndefault: 5\nimportance: high"
+                            },
+                            "LogConnectionClose": {
+                              "type": "boolean",
+                              "description": "Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connections.max.idle.ms` value.\n\ndefault: true\nimportance: low"
+                            },
+                            "LogQueue": {
+                              "type": "boolean",
+                              "description": "Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.\n\ndefault: false\nimportance: low"
+                            },
+                            "LogThreadName": {
+                              "type": "boolean",
+                              "description": "Print internal thread name in log messages (useful for debugging librdkafka internals)\n\ndefault: true\nimportance: low"
+                            },
+                            "MaxInFlight": {
+                              "type": "integer",
+                              "description": "Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.\n\ndefault: 1000000\nimportance: low"
+                            },
+                            "MessageCopyMaxBytes": {
+                              "type": "integer",
+                              "description": "Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.\n\ndefault: 65535\nimportance: low"
+                            },
+                            "MessageMaxBytes": {
+                              "type": "integer",
+                              "description": "Maximum Kafka protocol request message size. Due to differing framing overhead between protocol versions the producer is unable to reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests, the broker will enforce the the topic's `max.message.bytes` limit (see Apache Kafka documentation).\n\ndefault: 1000000\nimportance: medium"
+                            },
+                            "MessageSendMaxRetries": {
+                              "type": "integer",
+                              "description": "How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.\n\ndefault: 2147483647\nimportance: high"
+                            },
+                            "MessageTimeoutMs": {
+                              "type": "integer",
+                              "description": "Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded. The message timeout is automatically adjusted to `transaction.timeout.ms` if `transactional.id` is configured.\n\ndefault: 300000\nimportance: high"
+                            },
+                            "MetadataMaxAgeMs": {
+                              "type": "integer",
+                              "description": "Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3\n\ndefault: 900000\nimportance: low"
+                            },
+                            "Partitioner": {
+                              "enum": [
+                                "Random",
+                                "Consistent",
+                                "ConsistentRandom",
+                                "Murmur2",
+                                "Murmur2Random"
+                              ],
+                              "description": "Partitioner: `random` - random distribution, `consistent` - CRC32 hash of key (Empty and NULL keys are mapped to single partition), `consistent_random` - CRC32 hash of key (Empty and NULL keys are randomly partitioned), `murmur2` - Java Producer compatible Murmur2 hash of key (NULL keys are mapped to single partition), `murmur2_random` - Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer.), `fnv1a` - FNV-1a hash of key (NULL keys are mapped to single partition), `fnv1a_random` - FNV-1a hash of key (NULL keys are randomly partitioned).\n\ndefault: consistent_random\nimportance: high"
+                            },
+                            "PluginLibraryPaths": {
+                              "type": "string",
+                              "description": "List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.\n\ndefault: ''\nimportance: low"
+                            },
+                            "QueueBufferingBackpressureThreshold": {
+                              "type": "integer",
+                              "description": "The threshold of outstanding not yet transmitted broker requests needed to backpressure the producer's message accumulator. If the number of not yet transmitted requests equals or exceeds this number, produce request creation that would have otherwise been triggered (for example, in accordance with linger.ms) will be delayed. A lower number yields larger and more effective batches. A higher value can improve latency when using compression on slow machines.\n\ndefault: 1\nimportance: low"
+                            },
+                            "QueueBufferingMaxKbytes": {
+                              "type": "integer",
+                              "description": "Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than queue.buffering.max.messages.\n\ndefault: 1048576\nimportance: high"
+                            },
+                            "QueueBufferingMaxMessages": {
+                              "type": "integer",
+                              "description": "Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions. A value of 0 disables this limit.\n\ndefault: 100000\nimportance: high"
+                            },
+                            "ReceiveMessageMaxBytes": {
+                              "type": "integer",
+                              "description": "Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.\n\ndefault: 100000000\nimportance: medium"
+                            },
+                            "ReconnectBackoffMaxMs": {
+                              "type": "integer",
+                              "description": "The maximum time to wait before reconnecting to a broker after the connection has been closed.\n\ndefault: 10000\nimportance: medium"
+                            },
+                            "ReconnectBackoffMs": {
+                              "type": "integer",
+                              "description": "The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.\n\ndefault: 100\nimportance: medium"
+                            },
+                            "RequestTimeoutMs": {
+                              "type": "integer",
+                              "description": "The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.\n\ndefault: 30000\nimportance: medium"
+                            },
+                            "RetryBackoffMaxMs": {
+                              "type": "integer",
+                              "description": "The max backoff time in milliseconds before retrying a protocol request, this is the atmost backoff allowed for exponentially backed off requests.\n\ndefault: 1000\nimportance: medium"
+                            },
+                            "RetryBackoffMs": {
+                              "type": "integer",
+                              "description": "The backoff time in milliseconds before retrying a protocol request, this is the first backoff time, and will be backed off exponentially until number of retries is exhausted, and it's capped by retry.backoff.max.ms.\n\ndefault: 100\nimportance: medium"
+                            },
+                            "SaslKerberosKeytab": {
+                              "type": "string",
+                              "description": "Path to Kerberos keytab file. This configuration property is only used as a variable in `sasl.kerberos.kinit.cmd` as ` ... -t \"%{sasl.kerberos.keytab}\"`.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslKerberosKinitCmd": {
+                              "type": "string",
+                              "description": "Shell command to refresh or acquire the client's Kerberos ticket. This command is executed on client creation and every sasl.kerberos.min.time.before.relogin (0=disable). %{config.prop.name} is replaced by corresponding config object value.\n\ndefault: kinit -R -t \"%{sasl.kerberos.keytab}\" -k %{sasl.kerberos.principal} || kinit -t \"%{sasl.kerberos.keytab}\" -k %{sasl.kerberos.principal}\nimportance: low"
+                            },
+                            "SaslKerberosMinTimeBeforeRelogin": {
+                              "type": "integer",
+                              "description": "Minimum time in milliseconds between key refresh attempts. Disable automatic key refresh by setting this property to 0.\n\ndefault: 60000\nimportance: low"
+                            },
+                            "SaslKerberosPrincipal": {
+                              "type": "string",
+                              "description": "This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).\n\ndefault: kafkaclient\nimportance: low"
+                            },
+                            "SaslKerberosServiceName": {
+                              "type": "string",
+                              "description": "Kerberos principal name that Kafka runs as, not including /hostname@REALM\n\ndefault: kafka\nimportance: low"
+                            },
+                            "SaslMechanism": {
+                              "enum": [
+                                "Gssapi",
+                                "Plain",
+                                "ScramSha256",
+                                "ScramSha512",
+                                "OAuthBearer"
+                              ],
+                              "description": "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism."
+                            },
+                            "SaslOauthbearerClientId": {
+                              "type": "string",
+                              "description": "Public identifier for the application. Must be unique across all clients that the authorization server handles. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerClientSecret": {
+                              "type": "string",
+                              "description": "Client secret only known to the application and the authorization server. This should be a sufficiently random string that is not guessable. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerConfig": {
+                              "type": "string",
+                              "description": "SASL/OAUTHBEARER configuration. The format is implementation-dependent and must be parsed accordingly. The default unsecured token implementation (see https://tools.ietf.org/html/rfc7515#appendix-A.5) recognizes space-separated name=value pairs with valid names including principalClaimName, principal, scopeClaimName, scope, and lifeSeconds. The default value for principalClaimName is \"sub\", the default value for scopeClaimName is \"scope\", and the default value for lifeSeconds is 3600. The scope value is CSV format with the default value being no/empty scope. For example: `principalClaimName=azp principal=admin scopeClaimName=roles scope=role1,role2 lifeSeconds=600`. In addition, SASL extensions can be communicated to the broker via `extension_NAME=value`. For example: `principal=admin extension_traceId=123`\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerExtensions": {
+                              "type": "string",
+                              "description": "Allow additional information to be provided to the broker. Comma-separated list of key=value pairs. E.g., \"supportFeatureX=true,organizationId=sales-emea\".Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerMethod": {
+                              "enum": [
+                                "Default",
+                                "Oidc"
+                              ],
+                              "description": "Set to \"default\" or \"oidc\" to control which login method to be used. If set to \"oidc\", the following properties must also be be specified: `sasl.oauthbearer.client.id`, `sasl.oauthbearer.client.secret`, and `sasl.oauthbearer.token.endpoint.url`.\n\ndefault: default\nimportance: low"
+                            },
+                            "SaslOauthbearerScope": {
+                              "type": "string",
+                              "description": "Client use this to specify the scope of the access request to the broker. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslOauthbearerTokenEndpointUrl": {
+                              "type": "string",
+                              "description": "OAuth/OIDC issuer token endpoint HTTP(S) URI used to retrieve token. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SaslPassword": {
+                              "type": "string",
+                              "description": "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism\n\ndefault: ''\nimportance: high"
+                            },
+                            "SaslUsername": {
+                              "type": "string",
+                              "description": "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms\n\ndefault: ''\nimportance: high"
+                            },
+                            "SecurityProtocol": {
+                              "enum": [
+                                "Plaintext",
+                                "Ssl",
+                                "SaslPlaintext",
+                                "SaslSsl"
+                              ],
+                              "description": "Protocol used to communicate with brokers.\n\ndefault: plaintext\nimportance: high"
+                            },
+                            "SocketConnectionSetupTimeoutMs": {
+                              "type": "integer",
+                              "description": "Maximum time allowed for broker connection setup (TCP connection setup as well SSL and SASL handshake). If the connection to the broker is not fully functional after this the connection will be closed and retried.\n\ndefault: 30000\nimportance: medium"
+                            },
+                            "SocketKeepaliveEnable": {
+                              "type": "boolean",
+                              "description": "Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets\n\ndefault: false\nimportance: low"
+                            },
+                            "SocketMaxFails": {
+                              "type": "integer",
+                              "description": "Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.\n\ndefault: 1\nimportance: low"
+                            },
+                            "SocketNagleDisable": {
+                              "type": "boolean",
+                              "description": "Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.\n\ndefault: false\nimportance: low"
+                            },
+                            "SocketReceiveBufferBytes": {
+                              "type": "integer",
+                              "description": "Broker socket receive buffer size. System default is used if 0.\n\ndefault: 0\nimportance: low"
+                            },
+                            "SocketSendBufferBytes": {
+                              "type": "integer",
+                              "description": "Broker socket send buffer size. System default is used if 0.\n\ndefault: 0\nimportance: low"
+                            },
+                            "SocketTimeoutMs": {
+                              "type": "integer",
+                              "description": "Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.\n\ndefault: 60000\nimportance: low"
+                            },
+                            "SslCaCertificateStores": {
+                              "type": "string",
+                              "description": "Comma-separated list of Windows Certificate stores to load CA certificates from. Certificates will be loaded in the same order as stores are specified. If no certificates can be loaded from any of the specified stores an error is logged and the OpenSSL library's default CA location is used instead. Store names are typically one or more of: MY, Root, Trust, CA.\n\ndefault: Root\nimportance: low"
+                            },
+                            "SslCaLocation": {
+                              "type": "string",
+                              "description": "File or directory path to CA certificate(s) for verifying the broker's key. Defaults: On Windows the system's CA certificates are automatically looked up in the Windows Root certificate store. On Mac OSX this configuration defaults to `probe`. It is recommended to install openssl using Homebrew, to provide CA certificates. On Linux install the distribution's ca-certificates package. If OpenSSL is statically linked or `ssl.ca.location` is set to `probe` a list of standard paths will be probed and the first one found will be used as the default CA certificate location path. If OpenSSL is dynamically linked the OpenSSL library's default path will be used (see `OPENSSLDIR` in `openssl version -a`).\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCaPem": {
+                              "type": "string",
+                              "description": "CA certificate string (PEM format) for verifying the broker's key.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCertificateLocation": {
+                              "type": "string",
+                              "description": "Path to client's public key (PEM) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCertificatePem": {
+                              "type": "string",
+                              "description": "Client's public key string (PEM format) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCipherSuites": {
+                              "type": "string",
+                              "description": "A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCrlLocation": {
+                              "type": "string",
+                              "description": "Path to CRL for verifying broker's certificate validity.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslCurvesList": {
+                              "type": "string",
+                              "description": "The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL &gt;= 1.0.2 required.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslEndpointIdentificationAlgorithm": {
+                              "enum": [
+                                "None",
+                                "Https"
+                              ],
+                              "description": "Endpoint identification algorithm to validate broker hostname using broker certificate. https - Server (broker) hostname verification as specified in RFC2818. none - No endpoint verification. OpenSSL &gt;= 1.0.2 required.\n\ndefault: https\nimportance: low"
+                            },
+                            "SslEngineId": {
+                              "type": "string",
+                              "description": "OpenSSL engine id is the name used for loading engine.\n\ndefault: dynamic\nimportance: low"
+                            },
+                            "SslEngineLocation": {
+                              "type": "string",
+                              "description": "**DEPRECATED** Path to OpenSSL engine library. OpenSSL &gt;= 1.1.x required. DEPRECATED: OpenSSL engine support is deprecated and should be replaced by OpenSSL 3 providers.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeyLocation": {
+                              "type": "string",
+                              "description": "Path to client's private key (PEM) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeyPassword": {
+                              "type": "string",
+                              "description": "Private key passphrase (for use with `ssl.key.location` and `set_ssl_cert()`)\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeyPem": {
+                              "type": "string",
+                              "description": "Client's private key string (PEM format) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeystoreLocation": {
+                              "type": "string",
+                              "description": "Path to client's keystore (PKCS#12) used for authentication.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslKeystorePassword": {
+                              "type": "string",
+                              "description": "Client's keystore (PKCS#12) password.\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslProviders": {
+                              "type": "string",
+                              "description": "Comma-separated list of OpenSSL 3.0.x implementation providers. E.g., \"default,legacy\".\n\ndefault: ''\nimportance: low"
+                            },
+                            "SslSigalgsList": {
+                              "type": "string",
+                              "description": "The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL &gt;= 1.0.2 required.\n\ndefault: ''\nimportance: low"
+                            },
+                            "StatisticsIntervalMs": {
+                              "type": "integer",
+                              "description": "librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.\n\ndefault: 0\nimportance: high"
+                            },
+                            "StickyPartitioningLingerMs": {
+                              "type": "integer",
+                              "description": "Delay in milliseconds to wait to assign new sticky partitions for each topic. By default, set to double the time of linger.ms. To disable sticky behavior, set to 0. This behavior affects messages with the key NULL in all cases, and messages with key lengths of zero when the consistent_random partitioner is in use. These messages would otherwise be assigned randomly. A higher value allows for more effective batching of these messages.\n\ndefault: 10\nimportance: low"
+                            },
+                            "TopicBlacklist": {
+                              "type": "string",
+                              "description": "Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.\n\ndefault: ''\nimportance: low"
+                            },
+                            "TopicMetadataPropagationMaxMs": {
+                              "type": "integer",
+                              "description": "Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic will seem to be non-existent and the client will mark the topic as such, failing queued produced messages with `ERR__UNKNOWN_TOPIC`. This setting delays marking a topic as non-existent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, e.g., on produce().\n\ndefault: 30000\nimportance: low"
+                            },
+                            "TopicMetadataRefreshFastIntervalMs": {
+                              "type": "integer",
+                              "description": "When a topic loses its leader a new metadata request will be enqueued immediately and then with this initial interval, exponentially increasing upto `retry.backoff.max.ms`, until the topic metadata has been refreshed. If not set explicitly, it will be defaulted to `retry.backoff.ms`. This is used to recover quickly from transitioning leader brokers.\n\ndefault: 100\nimportance: low"
+                            },
+                            "TopicMetadataRefreshIntervalMs": {
+                              "type": "integer",
+                              "description": "Period of time in milliseconds at which topic and broker metadata is refreshed in order to proactively discover any new brokers, topics, partitions or partition leader changes. Use -1 to disable the intervalled refresh (not recommended). If there are no locally referenced topics (no topic objects created, no messages produced, no subscription or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.\n\ndefault: 300000\nimportance: low"
+                            },
+                            "TopicMetadataRefreshSparse": {
+                              "type": "boolean",
+                              "description": "Sparse metadata requests (consumes less network bandwidth)\n\ndefault: true\nimportance: low"
+                            },
+                            "TransactionTimeoutMs": {
+                              "type": "integer",
+                              "description": "The maximum amount of time in milliseconds that the transaction coordinator will wait for a transaction status update from the producer before proactively aborting the ongoing transaction. If this value is larger than the `transaction.max.timeout.ms` setting in the broker, the init_transactions() call will fail with ERR_INVALID_TRANSACTION_TIMEOUT. The transaction timeout automatically adjusts `message.timeout.ms` and `socket.timeout.ms`, unless explicitly configured in which case they must not exceed the transaction timeout (`socket.timeout.ms` must be at least 100ms lower than `transaction.timeout.ms`). This is also the default timeout value if no timeout (-1) is supplied to the transactional API methods.\n\ndefault: 60000\nimportance: medium"
+                            },
+                            "TransactionalId": {
+                              "type": "string",
+                              "description": "Enables the transactional producer. The transactional.id is used to identify the same transactional producer instance across process restarts. It allows the producer to guarantee that transactions corresponding to earlier instances of the same producer have been finalized prior to starting any new transactions, and that any zombie instances are fenced off. If no transactional.id is provided, then the producer is limited to idempotent delivery (if enable.idempotence is set). Requires broker version &gt;= 0.11.0.\n\ndefault: ''\nimportance: high"
+                            }
+                          },
+                          "description": "Gets or sets the configuration settings for the Kafka producer."
+                        },
+                        "ConnectionString": {
+                          "type": "string",
+                          "description": "Gets or sets the connection string of the Kafka server to connect to."
+                        },
+                        "DisableHealthChecks": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the Kafka health check is disabled or not.",
+                          "default": false
+                        },
+                        "DisableMetrics": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
+                          "default": false
+                        },
+                        "DisableTracing": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry traces are enabled or not.",
+                          "default": false
+                        }
+                      },
+                      "description": "Provides the client configuration settings for connecting to a Kafka message broker to produce messages."
+                    }
+                  },
                   "type": "object",
                   "properties": {
                     "Config": {
-                      "type": "object",
-                      "properties": {
-                        "Acks": {
-                          "enum": [
-                            "None",
-                            "Leader",
-                            "All"
-                          ],
-                          "description": "This field indicates the number of acknowledgements the leader broker must receive from ISR brokers\nbefore responding to the request: Zero=Broker does not send any response/ack to client, One=The\nleader will write the record to its local log but will respond without awaiting full acknowledgement\nfrom all followers. All=Broker will block until message is committed by all in sync replicas (ISRs).\nIf there are less than min.insync.replicas (broker configuration) in the ISR set the produce request\nwill fail."
-                        },
-                        "AllowAutoCreateTopics": {
-                          "type": "boolean",
-                          "description": "Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics. The broker must also be configured with `auto.create.topics.enable=true` for this configuration to take effect. Note: the default value (true) for the producer is different from the default value (false) for the consumer. Further, the consumer default value is different from the Java consumer (true), and this property is not supported by the Java producer. Requires broker version &gt;= 0.11.0.0, for older broker versions only the broker configuration applies.\n\ndefault: false\nimportance: low"
-                        },
-                        "ApiVersionFallbackMs": {
-                          "type": "integer",
-                          "description": "Dictates how long the `broker.version.fallback` fallback is used in the case the ApiVersionRequest fails. **NOTE**: The ApiVersionRequest is only issued when a new connection to the broker is made (such as after an upgrade).\n\ndefault: 0\nimportance: medium"
-                        },
-                        "ApiVersionRequest": {
-                          "type": "boolean",
-                          "description": "Request broker's supported API versions to adjust functionality to available protocol features. If set to false, or the ApiVersionRequest fails, the fallback version `broker.version.fallback` will be used. **NOTE**: Depends on broker version &gt;=0.10.0. If the request is not supported by (an older) broker the `broker.version.fallback` fallback is used.\n\ndefault: true\nimportance: high"
-                        },
-                        "ApiVersionRequestTimeoutMs": {
-                          "type": "integer",
-                          "description": "Timeout for broker API version requests.\n\ndefault: 10000\nimportance: low"
-                        },
-                        "BatchNumMessages": {
-                          "type": "integer",
-                          "description": "Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by batch.size and message.max.bytes.\n\ndefault: 10000\nimportance: medium"
-                        },
-                        "BatchSize": {
-                          "type": "integer",
-                          "description": "Maximum size (in bytes) of all messages batched in one MessageSet, including protocol framing overhead. This limit is applied after the first message has been added to the batch, regardless of the first message's size, this is to ensure that messages that exceed batch.size are produced. The total MessageSet size is also limited by batch.num.messages and message.max.bytes.\n\ndefault: 1000000\nimportance: medium"
-                        },
-                        "BootstrapServers": {
-                          "type": "string",
-                          "description": "Initial list of brokers as a CSV list of broker host or host:port. The application may also use `rd_kafka_brokers_add()` to add brokers during runtime.\n\ndefault: ''\nimportance: high"
-                        },
-                        "BrokerAddressFamily": {
-                          "enum": [
-                            "Any",
-                            "V4",
-                            "V6"
-                          ],
-                          "description": "Allowed broker IP address families: any, v4, v6\n\ndefault: any\nimportance: low"
-                        },
-                        "BrokerAddressTtl": {
-                          "type": "integer",
-                          "description": "How long to cache the broker address resolving results (milliseconds).\n\ndefault: 1000\nimportance: low"
-                        },
-                        "BrokerVersionFallback": {
-                          "type": "string",
-                          "description": "Older broker versions (before 0.10.0) provide no way for a client to query for supported protocol features (ApiVersionRequest, see `api.version.request`) making it impossible for the client to know what features it may use. As a workaround a user may set this property to the expected broker version and the client will automatically adjust its feature set accordingly if the ApiVersionRequest fails (or is disabled). The fallback broker version will be used for `api.version.fallback.ms`. Valid values are: 0.9.0, 0.8.2, 0.8.1, 0.8.0. Any other value &gt;= 0.10, such as 0.10.2.1, enables ApiVersionRequests.\n\ndefault: 0.10.0\nimportance: medium"
-                        },
-                        "CancellationDelayMaxMs": {
-                          "type": "integer",
-                          "description": "The maximum length of time (in milliseconds) before a cancellation request\nis acted on. Low values may result in measurably higher CPU usage.\n\ndefault: 100\nrange: 1 &lt;= dotnet.cancellation.delay.max.ms &lt;= 10000\nimportance: low"
-                        },
-                        "ClientDnsLookup": {
-                          "enum": [
-                            "UseAllDnsIps",
-                            "ResolveCanonicalBootstrapServersOnly"
-                          ],
-                          "description": "Controls how the client uses DNS lookups. By default, when the lookup returns multiple IP addresses for a hostname, they will all be attempted for connection before the connection is considered failed. This applies to both bootstrap and advertised servers. If the value is set to `resolve_canonical_bootstrap_servers_only`, each entry will be resolved and expanded into a list of canonical names. NOTE: Default here is different from the Java client's default behavior, which connects only to the first IP address returned for a hostname.\n\ndefault: use_all_dns_ips\nimportance: low"
-                        },
-                        "ClientId": {
-                          "type": "string",
-                          "description": "Client identifier.\n\ndefault: rdkafka\nimportance: low"
-                        },
-                        "ClientRack": {
-                          "type": "string",
-                          "description": "A rack identifier for this client. This can be any string value which indicates where this client is physically located. It corresponds with the broker config `broker.rack`.\n\ndefault: ''\nimportance: low"
-                        },
-                        "CompressionLevel": {
-                          "type": "integer",
-                          "description": "Compression level parameter for algorithm selected by configuration property `compression.codec`. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.\n\ndefault: -1\nimportance: medium"
-                        },
-                        "CompressionType": {
-                          "enum": [
-                            "None",
-                            "Gzip",
-                            "Snappy",
-                            "Lz4",
-                            "Zstd"
-                          ],
-                          "description": "compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.\n\ndefault: none\nimportance: medium"
-                        },
-                        "ConnectionsMaxIdleMs": {
-                          "type": "integer",
-                          "description": "Close broker connections after the specified time of inactivity. Disable with 0. If this property is left at its default value some heuristics are performed to determine a suitable default value, this is currently limited to identifying brokers on Azure (see librdkafka issue #3109 for more info).\n\ndefault: 0\nimportance: medium"
-                        },
-                        "Debug": {
-                          "type": "string",
-                          "description": "A comma-separated list of debug contexts to enable. Detailed Producer debugging: broker,topic,msg. Consumer: consumer,cgrp,topic,fetch\n\ndefault: ''\nimportance: medium"
-                        },
-                        "DeliveryReportFields": {
-                          "type": "string",
-                          "description": "A comma separated list of fields that may be optionally set in delivery\nreports. Disabling delivery report fields that you do not require will\nimprove maximum throughput and reduce memory usage. Allowed values:\nkey, value, timestamp, headers, status, all, none.\n\ndefault: all\nimportance: low"
-                        },
-                        "EnableBackgroundPoll": {
-                          "type": "boolean",
-                          "description": "Specifies whether or not the producer should start a background poll\nthread to receive delivery reports and event notifications. Generally,\nthis should be set to true. If set to false, you will need to call\nthe Poll function manually.\n\ndefault: true\nimportance: low"
-                        },
-                        "EnableDeliveryReports": {
-                          "type": "boolean",
-                          "description": "Specifies whether to enable notification of delivery reports. Typically\nyou should set this parameter to true. Set it to false for \"fire and\nforget\" semantics and a small boost in performance.\n\ndefault: true\nimportance: low"
-                        },
-                        "EnableGaplessGuarantee": {
-                          "type": "boolean",
-                          "description": "**EXPERIMENTAL**: subject to change or removal. When set to `true`, any error that could result in a gap in the produced message series when a batch of messages fails, will raise a fatal error (ERR__GAPLESS_GUARANTEE) and stop the producer. Messages failing due to `message.timeout.ms` are not covered by this guarantee. Requires `enable.idempotence=true`.\n\ndefault: false\nimportance: low"
-                        },
-                        "EnableIdempotence": {
-                          "type": "boolean",
-                          "description": "When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Producer instantation will fail if user-supplied configuration is incompatible.\n\ndefault: false\nimportance: high"
-                        },
-                        "EnableRandomSeed": {
-                          "type": "boolean",
-                          "description": "If enabled librdkafka will initialize the PRNG with srand(current_time.milliseconds) on the first invocation of rd_kafka_new() (required only if rand_r() is not available on your platform). If disabled the application must call srand() prior to calling rd_kafka_new().\n\ndefault: true\nimportance: low"
-                        },
-                        "EnableSaslOauthbearerUnsecureJwt": {
-                          "type": "boolean",
-                          "description": "Enable the builtin unsecure JWT OAUTHBEARER token handler if no oauthbearer_refresh_cb has been set. This builtin handler should only be used for development or testing, and not in production.\n\ndefault: false\nimportance: low"
-                        },
-                        "EnableSslCertificateVerification": {
-                          "type": "boolean",
-                          "description": "Enable OpenSSL's builtin broker (server) certificate verification. This verification can be extended by the application by implementing a certificate_verify_cb.\n\ndefault: true\nimportance: low"
-                        },
-                        "InternalTerminationSignal": {
-                          "type": "integer",
-                          "description": "Signal that librdkafka will use to quickly terminate on rd_kafka_destroy(). If this signal is not set then there will be a delay before rd_kafka_wait_destroyed() returns true as internal threads are timing out their system calls. If this signal is set however the delay will be minimal. The application should mask this signal as an internal signal handler is installed.\n\ndefault: 0\nimportance: low"
-                        },
-                        "LingerMs": {
-                          "type": [
-                            "number",
-                            "string"
-                          ],
-                          "description": "Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.\n\ndefault: 5\nimportance: high"
-                        },
-                        "LogConnectionClose": {
-                          "type": "boolean",
-                          "description": "Log broker disconnects. It might be useful to turn this off when interacting with 0.9 brokers with an aggressive `connections.max.idle.ms` value.\n\ndefault: true\nimportance: low"
-                        },
-                        "LogQueue": {
-                          "type": "boolean",
-                          "description": "Disable spontaneous log_cb from internal librdkafka threads, instead enqueue log messages on queue set with `rd_kafka_set_log_queue()` and serve log callbacks or events through the standard poll APIs. **NOTE**: Log messages will linger in a temporary queue until the log queue has been set.\n\ndefault: false\nimportance: low"
-                        },
-                        "LogThreadName": {
-                          "type": "boolean",
-                          "description": "Print internal thread name in log messages (useful for debugging librdkafka internals)\n\ndefault: true\nimportance: low"
-                        },
-                        "MaxInFlight": {
-                          "type": "integer",
-                          "description": "Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.\n\ndefault: 1000000\nimportance: low"
-                        },
-                        "MessageCopyMaxBytes": {
-                          "type": "integer",
-                          "description": "Maximum size for message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.\n\ndefault: 65535\nimportance: low"
-                        },
-                        "MessageMaxBytes": {
-                          "type": "integer",
-                          "description": "Maximum Kafka protocol request message size. Due to differing framing overhead between protocol versions the producer is unable to reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests, the broker will enforce the the topic's `max.message.bytes` limit (see Apache Kafka documentation).\n\ndefault: 1000000\nimportance: medium"
-                        },
-                        "MessageSendMaxRetries": {
-                          "type": "integer",
-                          "description": "How many times to retry sending a failing Message. **Note:** retrying may cause reordering unless `enable.idempotence` is set to true.\n\ndefault: 2147483647\nimportance: high"
-                        },
-                        "MessageTimeoutMs": {
-                          "type": "integer",
-                          "description": "Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time librdkafka may use to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded. The message timeout is automatically adjusted to `transaction.timeout.ms` if `transactional.id` is configured.\n\ndefault: 300000\nimportance: high"
-                        },
-                        "MetadataMaxAgeMs": {
-                          "type": "integer",
-                          "description": "Metadata cache max age. Defaults to topic.metadata.refresh.interval.ms * 3\n\ndefault: 900000\nimportance: low"
-                        },
-                        "Partitioner": {
-                          "enum": [
-                            "Random",
-                            "Consistent",
-                            "ConsistentRandom",
-                            "Murmur2",
-                            "Murmur2Random"
-                          ],
-                          "description": "Partitioner: `random` - random distribution, `consistent` - CRC32 hash of key (Empty and NULL keys are mapped to single partition), `consistent_random` - CRC32 hash of key (Empty and NULL keys are randomly partitioned), `murmur2` - Java Producer compatible Murmur2 hash of key (NULL keys are mapped to single partition), `murmur2_random` - Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer.), `fnv1a` - FNV-1a hash of key (NULL keys are mapped to single partition), `fnv1a_random` - FNV-1a hash of key (NULL keys are randomly partitioned).\n\ndefault: consistent_random\nimportance: high"
-                        },
-                        "PluginLibraryPaths": {
-                          "type": "string",
-                          "description": "List of plugin libraries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically.\n\ndefault: ''\nimportance: low"
-                        },
-                        "QueueBufferingBackpressureThreshold": {
-                          "type": "integer",
-                          "description": "The threshold of outstanding not yet transmitted broker requests needed to backpressure the producer's message accumulator. If the number of not yet transmitted requests equals or exceeds this number, produce request creation that would have otherwise been triggered (for example, in accordance with linger.ms) will be delayed. A lower number yields larger and more effective batches. A higher value can improve latency when using compression on slow machines.\n\ndefault: 1\nimportance: low"
-                        },
-                        "QueueBufferingMaxKbytes": {
-                          "type": "integer",
-                          "description": "Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than queue.buffering.max.messages.\n\ndefault: 1048576\nimportance: high"
-                        },
-                        "QueueBufferingMaxMessages": {
-                          "type": "integer",
-                          "description": "Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions. A value of 0 disables this limit.\n\ndefault: 100000\nimportance: high"
-                        },
-                        "ReceiveMessageMaxBytes": {
-                          "type": "integer",
-                          "description": "Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hickups. This value must be at least `fetch.max.bytes`  + 512 to allow for protocol overhead; the value is adjusted automatically unless the configuration property is explicitly set.\n\ndefault: 100000000\nimportance: medium"
-                        },
-                        "ReconnectBackoffMaxMs": {
-                          "type": "integer",
-                          "description": "The maximum time to wait before reconnecting to a broker after the connection has been closed.\n\ndefault: 10000\nimportance: medium"
-                        },
-                        "ReconnectBackoffMs": {
-                          "type": "integer",
-                          "description": "The initial time to wait before reconnecting to a broker after the connection has been closed. The time is increased exponentially until `reconnect.backoff.max.ms` is reached. -25% to +50% jitter is applied to each reconnect backoff. A value of 0 disables the backoff and reconnects immediately.\n\ndefault: 100\nimportance: medium"
-                        },
-                        "RequestTimeoutMs": {
-                          "type": "integer",
-                          "description": "The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `request.required.acks` being != 0.\n\ndefault: 30000\nimportance: medium"
-                        },
-                        "RetryBackoffMaxMs": {
-                          "type": "integer",
-                          "description": "The max backoff time in milliseconds before retrying a protocol request, this is the atmost backoff allowed for exponentially backed off requests.\n\ndefault: 1000\nimportance: medium"
-                        },
-                        "RetryBackoffMs": {
-                          "type": "integer",
-                          "description": "The backoff time in milliseconds before retrying a protocol request, this is the first backoff time, and will be backed off exponentially until number of retries is exhausted, and it's capped by retry.backoff.max.ms.\n\ndefault: 100\nimportance: medium"
-                        },
-                        "SaslKerberosKeytab": {
-                          "type": "string",
-                          "description": "Path to Kerberos keytab file. This configuration property is only used as a variable in `sasl.kerberos.kinit.cmd` as ` ... -t \"%{sasl.kerberos.keytab}\"`.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslKerberosKinitCmd": {
-                          "type": "string",
-                          "description": "Shell command to refresh or acquire the client's Kerberos ticket. This command is executed on client creation and every sasl.kerberos.min.time.before.relogin (0=disable). %{config.prop.name} is replaced by corresponding config object value.\n\ndefault: kinit -R -t \"%{sasl.kerberos.keytab}\" -k %{sasl.kerberos.principal} || kinit -t \"%{sasl.kerberos.keytab}\" -k %{sasl.kerberos.principal}\nimportance: low"
-                        },
-                        "SaslKerberosMinTimeBeforeRelogin": {
-                          "type": "integer",
-                          "description": "Minimum time in milliseconds between key refresh attempts. Disable automatic key refresh by setting this property to 0.\n\ndefault: 60000\nimportance: low"
-                        },
-                        "SaslKerberosPrincipal": {
-                          "type": "string",
-                          "description": "This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).\n\ndefault: kafkaclient\nimportance: low"
-                        },
-                        "SaslKerberosServiceName": {
-                          "type": "string",
-                          "description": "Kerberos principal name that Kafka runs as, not including /hostname@REALM\n\ndefault: kafka\nimportance: low"
-                        },
-                        "SaslMechanism": {
-                          "enum": [
-                            "Gssapi",
-                            "Plain",
-                            "ScramSha256",
-                            "ScramSha512",
-                            "OAuthBearer"
-                          ],
-                          "description": "SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN, SCRAM-SHA-256, SCRAM-SHA-512. **NOTE**: Despite the name, you may not configure more than one mechanism."
-                        },
-                        "SaslOauthbearerClientId": {
-                          "type": "string",
-                          "description": "Public identifier for the application. Must be unique across all clients that the authorization server handles. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerClientSecret": {
-                          "type": "string",
-                          "description": "Client secret only known to the application and the authorization server. This should be a sufficiently random string that is not guessable. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerConfig": {
-                          "type": "string",
-                          "description": "SASL/OAUTHBEARER configuration. The format is implementation-dependent and must be parsed accordingly. The default unsecured token implementation (see https://tools.ietf.org/html/rfc7515#appendix-A.5) recognizes space-separated name=value pairs with valid names including principalClaimName, principal, scopeClaimName, scope, and lifeSeconds. The default value for principalClaimName is \"sub\", the default value for scopeClaimName is \"scope\", and the default value for lifeSeconds is 3600. The scope value is CSV format with the default value being no/empty scope. For example: `principalClaimName=azp principal=admin scopeClaimName=roles scope=role1,role2 lifeSeconds=600`. In addition, SASL extensions can be communicated to the broker via `extension_NAME=value`. For example: `principal=admin extension_traceId=123`\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerExtensions": {
-                          "type": "string",
-                          "description": "Allow additional information to be provided to the broker. Comma-separated list of key=value pairs. E.g., \"supportFeatureX=true,organizationId=sales-emea\".Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerMethod": {
-                          "enum": [
-                            "Default",
-                            "Oidc"
-                          ],
-                          "description": "Set to \"default\" or \"oidc\" to control which login method to be used. If set to \"oidc\", the following properties must also be be specified: `sasl.oauthbearer.client.id`, `sasl.oauthbearer.client.secret`, and `sasl.oauthbearer.token.endpoint.url`.\n\ndefault: default\nimportance: low"
-                        },
-                        "SaslOauthbearerScope": {
-                          "type": "string",
-                          "description": "Client use this to specify the scope of the access request to the broker. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslOauthbearerTokenEndpointUrl": {
-                          "type": "string",
-                          "description": "OAuth/OIDC issuer token endpoint HTTP(S) URI used to retrieve token. Only used when `sasl.oauthbearer.method` is set to \"oidc\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SaslPassword": {
-                          "type": "string",
-                          "description": "SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism\n\ndefault: ''\nimportance: high"
-                        },
-                        "SaslUsername": {
-                          "type": "string",
-                          "description": "SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms\n\ndefault: ''\nimportance: high"
-                        },
-                        "SecurityProtocol": {
-                          "enum": [
-                            "Plaintext",
-                            "Ssl",
-                            "SaslPlaintext",
-                            "SaslSsl"
-                          ],
-                          "description": "Protocol used to communicate with brokers.\n\ndefault: plaintext\nimportance: high"
-                        },
-                        "SocketConnectionSetupTimeoutMs": {
-                          "type": "integer",
-                          "description": "Maximum time allowed for broker connection setup (TCP connection setup as well SSL and SASL handshake). If the connection to the broker is not fully functional after this the connection will be closed and retried.\n\ndefault: 30000\nimportance: medium"
-                        },
-                        "SocketKeepaliveEnable": {
-                          "type": "boolean",
-                          "description": "Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets\n\ndefault: false\nimportance: low"
-                        },
-                        "SocketMaxFails": {
-                          "type": "integer",
-                          "description": "Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established.\n\ndefault: 1\nimportance: low"
-                        },
-                        "SocketNagleDisable": {
-                          "type": "boolean",
-                          "description": "Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.\n\ndefault: false\nimportance: low"
-                        },
-                        "SocketReceiveBufferBytes": {
-                          "type": "integer",
-                          "description": "Broker socket receive buffer size. System default is used if 0.\n\ndefault: 0\nimportance: low"
-                        },
-                        "SocketSendBufferBytes": {
-                          "type": "integer",
-                          "description": "Broker socket send buffer size. System default is used if 0.\n\ndefault: 0\nimportance: low"
-                        },
-                        "SocketTimeoutMs": {
-                          "type": "integer",
-                          "description": "Default timeout for network requests. Producer: ProduceRequests will use the lesser value of `socket.timeout.ms` and remaining `message.timeout.ms` for the first message in the batch. Consumer: FetchRequests will use `fetch.wait.max.ms` + `socket.timeout.ms`. Admin: Admin requests will use `socket.timeout.ms` or explicitly set `rd_kafka_AdminOptions_set_operation_timeout()` value.\n\ndefault: 60000\nimportance: low"
-                        },
-                        "SslCaCertificateStores": {
-                          "type": "string",
-                          "description": "Comma-separated list of Windows Certificate stores to load CA certificates from. Certificates will be loaded in the same order as stores are specified. If no certificates can be loaded from any of the specified stores an error is logged and the OpenSSL library's default CA location is used instead. Store names are typically one or more of: MY, Root, Trust, CA.\n\ndefault: Root\nimportance: low"
-                        },
-                        "SslCaLocation": {
-                          "type": "string",
-                          "description": "File or directory path to CA certificate(s) for verifying the broker's key. Defaults: On Windows the system's CA certificates are automatically looked up in the Windows Root certificate store. On Mac OSX this configuration defaults to `probe`. It is recommended to install openssl using Homebrew, to provide CA certificates. On Linux install the distribution's ca-certificates package. If OpenSSL is statically linked or `ssl.ca.location` is set to `probe` a list of standard paths will be probed and the first one found will be used as the default CA certificate location path. If OpenSSL is dynamically linked the OpenSSL library's default path will be used (see `OPENSSLDIR` in `openssl version -a`).\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCaPem": {
-                          "type": "string",
-                          "description": "CA certificate string (PEM format) for verifying the broker's key.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCertificateLocation": {
-                          "type": "string",
-                          "description": "Path to client's public key (PEM) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCertificatePem": {
-                          "type": "string",
-                          "description": "Client's public key string (PEM format) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCipherSuites": {
-                          "type": "string",
-                          "description": "A cipher suite is a named combination of authentication, encryption, MAC and key exchange algorithm used to negotiate the security settings for a network connection using TLS or SSL network protocol. See manual page for `ciphers(1)` and `SSL_CTX_set_cipher_list(3).\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCrlLocation": {
-                          "type": "string",
-                          "description": "Path to CRL for verifying broker's certificate validity.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslCurvesList": {
-                          "type": "string",
-                          "description": "The supported-curves extension in the TLS ClientHello message specifies the curves (standard/named, or 'explicit' GF(2^k) or GF(p)) the client is willing to have the server use. See manual page for `SSL_CTX_set1_curves_list(3)`. OpenSSL &gt;= 1.0.2 required.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslEndpointIdentificationAlgorithm": {
-                          "enum": [
-                            "None",
-                            "Https"
-                          ],
-                          "description": "Endpoint identification algorithm to validate broker hostname using broker certificate. https - Server (broker) hostname verification as specified in RFC2818. none - No endpoint verification. OpenSSL &gt;= 1.0.2 required.\n\ndefault: https\nimportance: low"
-                        },
-                        "SslEngineId": {
-                          "type": "string",
-                          "description": "OpenSSL engine id is the name used for loading engine.\n\ndefault: dynamic\nimportance: low"
-                        },
-                        "SslEngineLocation": {
-                          "type": "string",
-                          "description": "**DEPRECATED** Path to OpenSSL engine library. OpenSSL &gt;= 1.1.x required. DEPRECATED: OpenSSL engine support is deprecated and should be replaced by OpenSSL 3 providers.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeyLocation": {
-                          "type": "string",
-                          "description": "Path to client's private key (PEM) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeyPassword": {
-                          "type": "string",
-                          "description": "Private key passphrase (for use with `ssl.key.location` and `set_ssl_cert()`)\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeyPem": {
-                          "type": "string",
-                          "description": "Client's private key string (PEM format) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeystoreLocation": {
-                          "type": "string",
-                          "description": "Path to client's keystore (PKCS#12) used for authentication.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslKeystorePassword": {
-                          "type": "string",
-                          "description": "Client's keystore (PKCS#12) password.\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslProviders": {
-                          "type": "string",
-                          "description": "Comma-separated list of OpenSSL 3.0.x implementation providers. E.g., \"default,legacy\".\n\ndefault: ''\nimportance: low"
-                        },
-                        "SslSigalgsList": {
-                          "type": "string",
-                          "description": "The client uses the TLS ClientHello signature_algorithms extension to indicate to the server which signature/hash algorithm pairs may be used in digital signatures. See manual page for `SSL_CTX_set1_sigalgs_list(3)`. OpenSSL &gt;= 1.0.2 required.\n\ndefault: ''\nimportance: low"
-                        },
-                        "StatisticsIntervalMs": {
-                          "type": "integer",
-                          "description": "librdkafka statistics emit interval. The application also needs to register a stats callback using `rd_kafka_conf_set_stats_cb()`. The granularity is 1000ms. A value of 0 disables statistics.\n\ndefault: 0\nimportance: high"
-                        },
-                        "StickyPartitioningLingerMs": {
-                          "type": "integer",
-                          "description": "Delay in milliseconds to wait to assign new sticky partitions for each topic. By default, set to double the time of linger.ms. To disable sticky behavior, set to 0. This behavior affects messages with the key NULL in all cases, and messages with key lengths of zero when the consistent_random partitioner is in use. These messages would otherwise be assigned randomly. A higher value allows for more effective batching of these messages.\n\ndefault: 10\nimportance: low"
-                        },
-                        "TopicBlacklist": {
-                          "type": "string",
-                          "description": "Topic blacklist, a comma-separated list of regular expressions for matching topic names that should be ignored in broker metadata information as if the topics did not exist.\n\ndefault: ''\nimportance: low"
-                        },
-                        "TopicMetadataPropagationMaxMs": {
-                          "type": "integer",
-                          "description": "Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic will seem to be non-existent and the client will mark the topic as such, failing queued produced messages with `ERR__UNKNOWN_TOPIC`. This setting delays marking a topic as non-existent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, e.g., on produce().\n\ndefault: 30000\nimportance: low"
-                        },
-                        "TopicMetadataRefreshFastIntervalMs": {
-                          "type": "integer",
-                          "description": "When a topic loses its leader a new metadata request will be enqueued immediately and then with this initial interval, exponentially increasing upto `retry.backoff.max.ms`, until the topic metadata has been refreshed. If not set explicitly, it will be defaulted to `retry.backoff.ms`. This is used to recover quickly from transitioning leader brokers.\n\ndefault: 100\nimportance: low"
-                        },
-                        "TopicMetadataRefreshIntervalMs": {
-                          "type": "integer",
-                          "description": "Period of time in milliseconds at which topic and broker metadata is refreshed in order to proactively discover any new brokers, topics, partitions or partition leader changes. Use -1 to disable the intervalled refresh (not recommended). If there are no locally referenced topics (no topic objects created, no messages produced, no subscription or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.\n\ndefault: 300000\nimportance: low"
-                        },
-                        "TopicMetadataRefreshSparse": {
-                          "type": "boolean",
-                          "description": "Sparse metadata requests (consumes less network bandwidth)\n\ndefault: true\nimportance: low"
-                        },
-                        "TransactionTimeoutMs": {
-                          "type": "integer",
-                          "description": "The maximum amount of time in milliseconds that the transaction coordinator will wait for a transaction status update from the producer before proactively aborting the ongoing transaction. If this value is larger than the `transaction.max.timeout.ms` setting in the broker, the init_transactions() call will fail with ERR_INVALID_TRANSACTION_TIMEOUT. The transaction timeout automatically adjusts `message.timeout.ms` and `socket.timeout.ms`, unless explicitly configured in which case they must not exceed the transaction timeout (`socket.timeout.ms` must be at least 100ms lower than `transaction.timeout.ms`). This is also the default timeout value if no timeout (-1) is supplied to the transactional API methods.\n\ndefault: 60000\nimportance: medium"
-                        },
-                        "TransactionalId": {
-                          "type": "string",
-                          "description": "Enables the transactional producer. The transactional.id is used to identify the same transactional producer instance across process restarts. It allows the producer to guarantee that transactions corresponding to earlier instances of the same producer have been finalized prior to starting any new transactions, and that any zombie instances are fenced off. If no transactional.id is provided, then the producer is limited to idempotent delivery (if enable.idempotence is set). Requires broker version &gt;= 0.11.0.\n\ndefault: ''\nimportance: high"
-                        }
-                      },
-                      "description": "Gets or sets the configuration settings for the Kafka producer."
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Producer/definitions/settings/properties/Config"
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string of the Kafka server to connect to."
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Producer/definitions/settings/properties/ConnectionString"
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Kafka health check is disabled or not.",
-                      "default": false
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Producer/definitions/settings/properties/DisableHealthChecks"
                     },
                     "DisableMetrics": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-                      "default": false
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Producer/definitions/settings/properties/DisableMetrics"
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry traces are enabled or not.",
-                      "default": false
+                      "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Producer/definitions/settings/properties/DisableTracing"
                     }
+                  },
+                  "additionalProperties": {
+                    "$ref": "#/properties/Aspire/properties/Confluent/properties/Kafka/properties/Producer/definitions/settings"
                   },
                   "description": "Provides the client configuration settings for connecting to a Kafka message broker to produce messages."
                 }

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AssemblyInfo.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AssemblyInfo.cs
@@ -5,5 +5,6 @@ using Aspire;
 using Aspire.Microsoft.Azure.Cosmos;
 
 [assembly: ConfigurationSchema("Aspire:Microsoft:Azure:Cosmos", typeof(MicrosoftAzureCosmosSettings))]
+[assembly: ConfigurationSchema("Aspire:Microsoft:Azure:Cosmos:*", typeof(MicrosoftAzureCosmosSettings))]
 
 [assembly: LoggingCategories("Azure-Cosmos-Operation-Request-Diagnostics")]

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
@@ -45,7 +45,35 @@
                       "default": false
                     }
                   },
-                  "description": "The settings relevant to accessing Azure Cosmos DB."
+                  "description": "The settings relevant to accessing Azure Cosmos DB.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "AccountEndpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string of the Azure Cosmos database to connect to."
+                      },
+                      "ContainerName": {
+                        "type": "string",
+                        "description": "Gets or sets the name of the container to connect to."
+                      },
+                      "DatabaseName": {
+                        "type": "string",
+                        "description": "Gets or sets the name of the database to connect to."
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      }
+                    },
+                    "description": "The settings relevant to accessing Azure Cosmos DB."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
@@ -23,56 +23,100 @@
                   "type": "object",
                   "properties": {
                     "AccountEndpoint": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/Azure/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string of the Azure Cosmos database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string of the Azure Cosmos database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/Azure/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ContainerName": {
-                      "type": "string",
-                      "description": "Gets or sets the name of the container to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the name of the container to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/Azure/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DatabaseName": {
-                      "type": "string",
-                      "description": "Gets or sets the name of the database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the name of the database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/Azure/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/Azure/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "The settings relevant to accessing Azure Cosmos DB.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "AccountEndpoint": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
                       },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string of the Azure Cosmos database to connect to."
-                      },
-                      "ContainerName": {
-                        "type": "string",
-                        "description": "Gets or sets the name of the container to connect to."
-                      },
-                      "DatabaseName": {
-                        "type": "string",
-                        "description": "Gets or sets the name of the database to connect to."
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
+                      {
+                        "type": "object",
+                        "properties": {
+                          "AccountEndpoint": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string of the Azure Cosmos database to connect to."
+                          },
+                          "ContainerName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the container to connect to."
+                          },
+                          "DatabaseName": {
+                            "type": "string",
+                            "description": "Gets or sets the name of the database to connect to."
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          }
+                        },
+                        "description": "The settings relevant to accessing Azure Cosmos DB."
                       }
-                    },
-                    "description": "The settings relevant to accessing Azure Cosmos DB."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/AssemblyInfo.cs
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using Aspire;
 using Aspire.Microsoft.Data.SqlClient;
 
 [assembly: ConfigurationSchema("Aspire:Microsoft:Data:SqlClient", typeof(MicrosoftDataSqlClientSettings))]
+[assembly: ConfigurationSchema("Aspire:Microsoft:Data:SqlClient:*", typeof(MicrosoftDataSqlClientSettings))]

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/ConfigurationSchema.json
@@ -14,40 +14,70 @@
                   "type": "object",
                   "properties": {
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string of the SQL Server database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string of the SQL Server database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/Data/properties/SqlClient/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/Data/properties/SqlClient/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/Data/properties/SqlClient/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a SQL Server database using SqlClient.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string of the SQL Server database to connect to."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
                       },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
+                      {
+                        "type": "object",
+                        "properties": {
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string of the SQL Server database to connect to."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          }
+                        },
+                        "description": "Provides the client configuration settings for connecting to a SQL Server database using SqlClient."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to a SQL Server database using SqlClient."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/ConfigurationSchema.json
@@ -28,7 +28,27 @@
                       "default": false
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to a SQL Server database using SqlClient."
+                  "description": "Provides the client configuration settings for connecting to a SQL Server database using SqlClient.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string of the SQL Server database to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a SQL Server database using SqlClient."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AssemblyInfo.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire;
 using Aspire.Microsoft.EntityFrameworkCore.Cosmos;
 
 [assembly: ConfigurationSchema("Aspire:Microsoft:EntityFrameworkCore:Cosmos", typeof(EntityFrameworkCoreCosmosSettings))]
+[assembly: ConfigurationSchema("Aspire:Microsoft:EntityFrameworkCore:Cosmos:*", typeof(EntityFrameworkCoreCosmosSettings))]
 
 [assembly: LoggingCategories(
     "Azure-Cosmos-Operation-Request-Diagnostics",

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
@@ -68,7 +68,40 @@
                       "description": "Gets or sets the time to wait for the response to come back from the network peer."
                     }
                   },
-                  "description": "The settings relevant to accessing Azure Cosmos DB database using EntityFrameworkCore."
+                  "description": "The settings relevant to accessing Azure Cosmos DB database using EntityFrameworkCore.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "AccountEndpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "The connection string of the Azure Cosmos DB server database to connect to."
+                      },
+                      "DatabaseName": {
+                        "type": "string",
+                        "description": "The name of the database to connect to."
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "Region": {
+                        "type": "string",
+                        "description": "Gets or sets a string value that indicates what Azure region this client will run in."
+                      },
+                      "RequestTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Gets or sets the time to wait for the response to come back from the network peer."
+                      }
+                    },
+                    "description": "The settings relevant to accessing Azure Cosmos DB database using EntityFrameworkCore."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
@@ -41,66 +41,117 @@
                   "type": "object",
                   "properties": {
                     "AccountEndpoint": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "The connection string of the Azure Cosmos DB server database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "The connection string of the Azure Cosmos DB server database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DatabaseName": {
-                      "type": "string",
-                      "description": "The name of the database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "The name of the database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "Region": {
-                      "type": "string",
-                      "description": "Gets or sets a string value that indicates what Azure region this client will run in."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets a string value that indicates what Azure region this client will run in."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "RequestTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Gets or sets the time to wait for the response to come back from the network peer."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Gets or sets the time to wait for the response to come back from the network peer."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/Cosmos/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "The settings relevant to accessing Azure Cosmos DB database using EntityFrameworkCore.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "AccountEndpoint": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
                       },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "The connection string of the Azure Cosmos DB server database to connect to."
-                      },
-                      "DatabaseName": {
-                        "type": "string",
-                        "description": "The name of the database to connect to."
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "Region": {
-                        "type": "string",
-                        "description": "Gets or sets a string value that indicates what Azure region this client will run in."
-                      },
-                      "RequestTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Gets or sets the time to wait for the response to come back from the network peer."
+                      {
+                        "type": "object",
+                        "properties": {
+                          "AccountEndpoint": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "The connection string of the Azure Cosmos DB server database to connect to."
+                          },
+                          "DatabaseName": {
+                            "type": "string",
+                            "description": "The name of the database to connect to."
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "Region": {
+                            "type": "string",
+                            "description": "Gets or sets a string value that indicates what Azure region this client will run in."
+                          },
+                          "RequestTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Gets or sets the time to wait for the response to come back from the network peer."
+                          }
+                        },
+                        "description": "The settings relevant to accessing Azure Cosmos DB database using EntityFrameworkCore."
                       }
-                    },
-                    "description": "The settings relevant to accessing Azure Cosmos DB database using EntityFrameworkCore."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AssemblyInfo.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire;
 using Aspire.Microsoft.EntityFrameworkCore.SqlServer;
 
 [assembly: ConfigurationSchema("Aspire:Microsoft:EntityFrameworkCore:SqlServer", typeof(MicrosoftEntityFrameworkCoreSqlServerSettings))]
+[assembly: ConfigurationSchema("Aspire:Microsoft:EntityFrameworkCore:SqlServer:*", typeof(MicrosoftEntityFrameworkCoreSqlServerSettings))]
 
 [assembly: LoggingCategories(
     "Microsoft.EntityFrameworkCore",

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/ConfigurationSchema.json
@@ -56,58 +56,102 @@
                   "type": "object",
                   "properties": {
                     "CommandTimeout": {
-                      "type": "integer",
-                      "description": "Gets or sets the time in seconds to wait for the command to execute."
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "description": "Gets or sets the time in seconds to wait for the command to execute."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/SqlServer/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "The connection string of the SQL server database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "The connection string of the SQL server database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/SqlServer/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/SqlServer/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableRetry": {
-                      "type": "boolean",
-                      "description": "Gets or sets whether retries should be disabled.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets whether retries should be disabled.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/SqlServer/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Microsoft/properties/EntityFrameworkCore/properties/SqlServer/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a SQL Server database using EntityFrameworkCore.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "CommandTimeout": {
-                        "type": "integer",
-                        "description": "Gets or sets the time in seconds to wait for the command to execute."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
                       },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "The connection string of the SQL server database to connect to."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableRetry": {
-                        "type": "boolean",
-                        "description": "Gets or sets whether retries should be disabled.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
+                      {
+                        "type": "object",
+                        "properties": {
+                          "CommandTimeout": {
+                            "type": "integer",
+                            "description": "Gets or sets the time in seconds to wait for the command to execute."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "The connection string of the SQL server database to connect to."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableRetry": {
+                            "type": "boolean",
+                            "description": "Gets or sets whether retries should be disabled.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          }
+                        },
+                        "description": "Provides the client configuration settings for connecting to a SQL Server database using EntityFrameworkCore."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to a SQL Server database using EntityFrameworkCore."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/ConfigurationSchema.json
@@ -79,7 +79,36 @@
                       "default": false
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to a SQL Server database using EntityFrameworkCore."
+                  "description": "Provides the client configuration settings for connecting to a SQL Server database using EntityFrameworkCore.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "CommandTimeout": {
+                        "type": "integer",
+                        "description": "Gets or sets the time in seconds to wait for the command to execute."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "The connection string of the SQL server database to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableRetry": {
+                        "type": "boolean",
+                        "description": "Gets or sets whether retries should be disabled.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a SQL Server database using EntityFrameworkCore."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Milvus.Client/AssemblyInfo.cs
+++ b/src/Components/Aspire.Milvus.Client/AssemblyInfo.cs
@@ -5,5 +5,6 @@ using Aspire;
 using Aspire.Milvus.Client;
 
 [assembly: ConfigurationSchema("Aspire:Milvus:Client", typeof(MilvusClientSettings))]
+[assembly: ConfigurationSchema("Aspire:Milvus:Client:*", typeof(MilvusClientSettings))]
 
 [assembly: LoggingCategories("Milvus.Client")]

--- a/src/Components/Aspire.Milvus.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.Milvus.Client/ConfigurationSchema.json
@@ -38,7 +38,31 @@
                   "description": "The auth Key of the Milvus server to connect to."
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a Milvus server using MilvusClient."
+              "description": "Provides the client configuration settings for connecting to a Milvus server using MilvusClient.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "Database": {
+                    "type": "string",
+                    "description": "The database name of the Milvus server to connect to."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the Milvus client health check is disabled or not.",
+                    "default": false
+                  },
+                  "Endpoint": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The endpoint URI string of the Milvus server to connect to."
+                  },
+                  "Key": {
+                    "type": "string",
+                    "description": "The auth Key of the Milvus server to connect to."
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a Milvus server using MilvusClient."
+              }
             }
           }
         }

--- a/src/Components/Aspire.Milvus.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.Milvus.Client/ConfigurationSchema.json
@@ -20,48 +20,85 @@
               "type": "object",
               "properties": {
                 "Database": {
-                  "type": "string",
-                  "description": "The database name of the Milvus server to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "The database name of the Milvus server to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Milvus/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the Milvus client health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the Milvus client health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Milvus/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "Endpoint": {
-                  "type": "string",
-                  "format": "uri",
-                  "description": "The endpoint URI string of the Milvus server to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "The endpoint URI string of the Milvus server to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Milvus/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "Key": {
-                  "type": "string",
-                  "description": "The auth Key of the Milvus server to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "The auth Key of the Milvus server to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Milvus/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a Milvus server using MilvusClient.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "Database": {
-                    "type": "string",
-                    "description": "The database name of the Milvus server to connect to."
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
                   },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the Milvus client health check is disabled or not.",
-                    "default": false
-                  },
-                  "Endpoint": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The endpoint URI string of the Milvus server to connect to."
-                  },
-                  "Key": {
-                    "type": "string",
-                    "description": "The auth Key of the Milvus server to connect to."
+                  {
+                    "type": "object",
+                    "properties": {
+                      "Database": {
+                        "type": "string",
+                        "description": "The database name of the Milvus server to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the Milvus client health check is disabled or not.",
+                        "default": false
+                      },
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The endpoint URI string of the Milvus server to connect to."
+                      },
+                      "Key": {
+                        "type": "string",
+                        "description": "The auth Key of the Milvus server to connect to."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a Milvus server using MilvusClient."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a Milvus server using MilvusClient."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.MongoDB.Driver.v2/ConfigurationSchema.json
+++ b/src/Components/Aspire.MongoDB.Driver.v2/ConfigurationSchema.json
@@ -35,48 +35,85 @@
               "type": "object",
               "properties": {
                 "ConnectionString": {
-                  "type": "string",
-                  "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/Driver/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/Driver/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/Driver/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "HealthCheckTimeout": {
-                  "type": "integer",
-                  "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/Driver/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
                   },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
-                    "default": false
-                  },
-                  "DisableTracing": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                    "default": false
-                  },
-                  "HealthCheckTimeout": {
-                    "type": "integer",
-                    "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "HealthCheckTimeout": {
+                        "type": "integer",
+                        "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.MongoDB.Driver.v2/ConfigurationSchema.json
+++ b/src/Components/Aspire.MongoDB.Driver.v2/ConfigurationSchema.json
@@ -53,7 +53,31 @@
                   "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
+              "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  },
+                  "HealthCheckTimeout": {
+                    "type": "integer",
+                    "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
+              }
             }
           }
         }

--- a/src/Components/Aspire.MongoDB.Driver/AssemblyInfo.cs
+++ b/src/Components/Aspire.MongoDB.Driver/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire;
 using Aspire.MongoDB.Driver;
 
 [assembly: ConfigurationSchema("Aspire:MongoDB:Driver", typeof(MongoDBSettings))]
+[assembly: ConfigurationSchema("Aspire:MongoDB:Driver:*", typeof(MongoDBSettings))]
 
 [assembly: LoggingCategories(
     "MongoDB",

--- a/src/Components/Aspire.MongoDB.Driver/ConfigurationSchema.json
+++ b/src/Components/Aspire.MongoDB.Driver/ConfigurationSchema.json
@@ -35,48 +35,85 @@
               "type": "object",
               "properties": {
                 "ConnectionString": {
-                  "type": "string",
-                  "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/Driver/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/Driver/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/Driver/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "HealthCheckTimeout": {
-                  "type": "integer",
-                  "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/Driver/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
                   },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
-                    "default": false
-                  },
-                  "DisableTracing": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                    "default": false
-                  },
-                  "HealthCheckTimeout": {
-                    "type": "integer",
-                    "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "HealthCheckTimeout": {
+                        "type": "integer",
+                        "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.MongoDB.Driver/ConfigurationSchema.json
+++ b/src/Components/Aspire.MongoDB.Driver/ConfigurationSchema.json
@@ -53,7 +53,31 @@
                   "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
+              "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  },
+                  "HealthCheckTimeout": {
+                    "type": "integer",
+                    "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
+              }
             }
           }
         }

--- a/src/Components/Aspire.MongoDB.EntityFrameworkCore/AssemblyInfo.cs
+++ b/src/Components/Aspire.MongoDB.EntityFrameworkCore/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire;
 using Aspire.MongoDB.EntityFrameworkCore;
 
 [assembly: ConfigurationSchema("Aspire:MongoDB:EntityFrameworkCore", typeof(MongoDBEntityFrameworkCoreSettings))]
+[assembly: ConfigurationSchema("Aspire:MongoDB:EntityFrameworkCore:*", typeof(MongoDBEntityFrameworkCoreSettings))]
 
 [assembly: LoggingCategories(
     "Microsoft.EntityFrameworkCore",
@@ -19,4 +20,3 @@ using Aspire.MongoDB.EntityFrameworkCore;
     "Microsoft.EntityFrameworkCore.Model.Validation",
     "Microsoft.EntityFrameworkCore.Query",
     "Microsoft.EntityFrameworkCore.Update")]
-

--- a/src/Components/Aspire.MongoDB.EntityFrameworkCore/ConfigurationSchema.json
+++ b/src/Components/Aspire.MongoDB.EntityFrameworkCore/ConfigurationSchema.json
@@ -75,7 +75,35 @@
                   "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a MongoDB database using EntityFrameworkCore."
+              "description": "Provides the client configuration settings for connecting to a MongoDB database using EntityFrameworkCore.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                  },
+                  "DatabaseName": {
+                    "type": "string",
+                    "description": "Gets or sets the name of the MongoDB database to connect to."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  },
+                  "HealthCheckTimeout": {
+                    "type": "integer",
+                    "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a MongoDB database using EntityFrameworkCore."
+              }
             }
           }
         }

--- a/src/Components/Aspire.MongoDB.EntityFrameworkCore/ConfigurationSchema.json
+++ b/src/Components/Aspire.MongoDB.EntityFrameworkCore/ConfigurationSchema.json
@@ -53,56 +53,100 @@
               "type": "object",
               "properties": {
                 "ConnectionString": {
-                  "type": "string",
-                  "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DatabaseName": {
-                  "type": "string",
-                  "description": "Gets or sets the name of the MongoDB database to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "Gets or sets the name of the MongoDB database to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "HealthCheckTimeout": {
-                  "type": "integer",
-                  "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/MongoDB/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a MongoDB database using EntityFrameworkCore.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
                   },
-                  "DatabaseName": {
-                    "type": "string",
-                    "description": "Gets or sets the name of the MongoDB database to connect to."
-                  },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
-                    "default": false
-                  },
-                  "DisableTracing": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                    "default": false
-                  },
-                  "HealthCheckTimeout": {
-                    "type": "integer",
-                    "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                      },
+                      "DatabaseName": {
+                        "type": "string",
+                        "description": "Gets or sets the name of the MongoDB database to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "HealthCheckTimeout": {
+                        "type": "integer",
+                        "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a MongoDB database using EntityFrameworkCore."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a MongoDB database using EntityFrameworkCore."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.MySqlConnector/AssemblyInfo.cs
+++ b/src/Components/Aspire.MySqlConnector/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire.MySqlConnector;
 using Aspire;
 
 [assembly: ConfigurationSchema("Aspire:MySqlConnector", typeof(MySqlConnectorSettings))]
+[assembly: ConfigurationSchema("Aspire:MySqlConnector:*", typeof(MySqlConnectorSettings))]
 
 [assembly: LoggingCategories(
     "MySqlConnector",

--- a/src/Components/Aspire.MySqlConnector/ConfigurationSchema.json
+++ b/src/Components/Aspire.MySqlConnector/ConfigurationSchema.json
@@ -32,50 +32,87 @@
           "type": "object",
           "properties": {
             "ConnectionString": {
-              "type": "string",
-              "description": "The connection string of the MySQL database to connect to."
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "The connection string of the MySQL database to connect to."
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/MySqlConnector/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "DisableHealthChecks": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-              "default": false
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                  "default": false
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/MySqlConnector/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "DisableMetrics": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
-              "default": false
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                  "default": false
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/MySqlConnector/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "DisableTracing": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-              "default": false
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                  "default": false
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/MySqlConnector/additionalProperties/anyOf/1"
+                }
+              ]
             }
           },
           "description": "Provides the client configuration settings for connecting to a MySQL database using MySqlConnector.",
           "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "ConnectionString": {
-                "type": "string",
-                "description": "The connection string of the MySQL database to connect to."
+            "anyOf": [
+              {
+                "not": {
+                  "type": "object"
+                }
               },
-              "DisableHealthChecks": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                "default": false
-              },
-              "DisableMetrics": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
-                "default": false
-              },
-              "DisableTracing": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                "default": false
+              {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "The connection string of the MySQL database to connect to."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableMetrics": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a MySQL database using MySqlConnector."
               }
-            },
-            "description": "Provides the client configuration settings for connecting to a MySQL database using MySqlConnector."
+            ]
           }
         }
       }

--- a/src/Components/Aspire.MySqlConnector/ConfigurationSchema.json
+++ b/src/Components/Aspire.MySqlConnector/ConfigurationSchema.json
@@ -51,7 +51,32 @@
               "default": false
             }
           },
-          "description": "Provides the client configuration settings for connecting to a MySQL database using MySqlConnector."
+          "description": "Provides the client configuration settings for connecting to a MySQL database using MySqlConnector.",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "ConnectionString": {
+                "type": "string",
+                "description": "The connection string of the MySQL database to connect to."
+              },
+              "DisableHealthChecks": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                "default": false
+              },
+              "DisableMetrics": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                "default": false
+              },
+              "DisableTracing": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                "default": false
+              }
+            },
+            "description": "Provides the client configuration settings for connecting to a MySQL database using MySqlConnector."
+          }
         }
       }
     }

--- a/src/Components/Aspire.NATS.Net/AssemblyInfo.cs
+++ b/src/Components/Aspire.NATS.Net/AssemblyInfo.cs
@@ -5,5 +5,6 @@ using Aspire;
 using Aspire.NATS.Net;
 
 [assembly: ConfigurationSchema("Aspire:NATS:Net", typeof(NatsClientSettings))]
+[assembly: ConfigurationSchema("Aspire:NATS:Net:*", typeof(NatsClientSettings))]
 
 [assembly: LoggingCategories("NATS")]

--- a/src/Components/Aspire.NATS.Net/ConfigurationSchema.json
+++ b/src/Components/Aspire.NATS.Net/ConfigurationSchema.json
@@ -20,40 +20,70 @@
               "type": "object",
               "properties": {
                 "ConnectionString": {
-                  "type": "string",
-                  "description": "Gets or sets the connection string of the NATS cluster to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "Gets or sets the connection string of the NATS cluster to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/NATS/properties/Net/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the NATS health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the NATS health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/NATS/properties/Net/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/NATS/properties/Net/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a NATS cluster.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "Gets or sets the connection string of the NATS cluster to connect to."
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
                   },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the NATS health check is disabled or not.",
-                    "default": false
-                  },
-                  "DisableTracing": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                    "default": false
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string of the NATS cluster to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the NATS health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a NATS cluster."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a NATS cluster."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.NATS.Net/ConfigurationSchema.json
+++ b/src/Components/Aspire.NATS.Net/ConfigurationSchema.json
@@ -34,7 +34,27 @@
                   "default": false
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a NATS cluster."
+              "description": "Provides the client configuration settings for connecting to a NATS cluster.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string of the NATS cluster to connect to."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the NATS health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a NATS cluster."
+              }
             }
           }
         }

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AssemblyInfo.cs
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire;
 using Aspire.Npgsql.EntityFrameworkCore.PostgreSQL;
 
 [assembly: ConfigurationSchema("Aspire:Npgsql:EntityFrameworkCore:PostgreSQL", typeof(NpgsqlEntityFrameworkCorePostgreSQLSettings))]
+[assembly: ConfigurationSchema("Aspire:Npgsql:EntityFrameworkCore:PostgreSQL:*", typeof(NpgsqlEntityFrameworkCorePostgreSQLSettings))]
 
 [assembly: LoggingCategories(
   "Microsoft.EntityFrameworkCore",

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/ConfigurationSchema.json
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/ConfigurationSchema.json
@@ -56,68 +56,119 @@
                   "type": "object",
                   "properties": {
                     "CommandTimeout": {
-                      "type": "integer",
-                      "description": "Gets or sets the time in seconds to wait for the command to execute."
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "description": "Gets or sets the time in seconds to wait for the command to execute."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Npgsql/properties/EntityFrameworkCore/properties/PostgreSQL/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string of the PostgreSQL database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string of the PostgreSQL database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Npgsql/properties/EntityFrameworkCore/properties/PostgreSQL/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Npgsql/properties/EntityFrameworkCore/properties/PostgreSQL/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableMetrics": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Npgsql/properties/EntityFrameworkCore/properties/PostgreSQL/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableRetry": {
-                      "type": "boolean",
-                      "description": "Gets or sets whether retries should be disabled.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets whether retries should be disabled.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Npgsql/properties/EntityFrameworkCore/properties/PostgreSQL/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Npgsql/properties/EntityFrameworkCore/properties/PostgreSQL/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a PostgreSQL database using EntityFrameworkCore.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "CommandTimeout": {
-                        "type": "integer",
-                        "description": "Gets or sets the time in seconds to wait for the command to execute."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
                       },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string of the PostgreSQL database to connect to."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableMetrics": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
-                        "default": false
-                      },
-                      "DisableRetry": {
-                        "type": "boolean",
-                        "description": "Gets or sets whether retries should be disabled.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
+                      {
+                        "type": "object",
+                        "properties": {
+                          "CommandTimeout": {
+                            "type": "integer",
+                            "description": "Gets or sets the time in seconds to wait for the command to execute."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string of the PostgreSQL database to connect to."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableMetrics": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                            "default": false
+                          },
+                          "DisableRetry": {
+                            "type": "boolean",
+                            "description": "Gets or sets whether retries should be disabled.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          }
+                        },
+                        "description": "Provides the client configuration settings for connecting to a PostgreSQL database using EntityFrameworkCore."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to a PostgreSQL database using EntityFrameworkCore."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/ConfigurationSchema.json
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/ConfigurationSchema.json
@@ -84,7 +84,41 @@
                       "default": false
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to a PostgreSQL database using EntityFrameworkCore."
+                  "description": "Provides the client configuration settings for connecting to a PostgreSQL database using EntityFrameworkCore.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "CommandTimeout": {
+                        "type": "integer",
+                        "description": "Gets or sets the time in seconds to wait for the command to execute."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string of the PostgreSQL database to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableMetrics": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                        "default": false
+                      },
+                      "DisableRetry": {
+                        "type": "boolean",
+                        "description": "Gets or sets whether retries should be disabled.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a PostgreSQL database using EntityFrameworkCore."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Npgsql/AssemblyInfo.cs
+++ b/src/Components/Aspire.Npgsql/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire.Npgsql;
 using Aspire;
 
 [assembly: ConfigurationSchema("Aspire:Npgsql", typeof(NpgsqlSettings))]
+[assembly: ConfigurationSchema("Aspire:Npgsql:*", typeof(NpgsqlSettings))]
 
 [assembly: LoggingCategories(
     "Npgsql",

--- a/src/Components/Aspire.Npgsql/ConfigurationSchema.json
+++ b/src/Components/Aspire.Npgsql/ConfigurationSchema.json
@@ -35,50 +35,87 @@
           "type": "object",
           "properties": {
             "ConnectionString": {
-              "type": "string",
-              "description": "The connection string of the PostgreSQL database to connect to."
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "The connection string of the PostgreSQL database to connect to."
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/Npgsql/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "DisableHealthChecks": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-              "default": false
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                  "default": false
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/Npgsql/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "DisableMetrics": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
-              "default": false
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                  "default": false
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/Npgsql/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "DisableTracing": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-              "default": false
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                  "default": false
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/Npgsql/additionalProperties/anyOf/1"
+                }
+              ]
             }
           },
           "description": "Provides the client configuration settings for connecting to a PostgreSQL database using Npgsql.",
           "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "ConnectionString": {
-                "type": "string",
-                "description": "The connection string of the PostgreSQL database to connect to."
+            "anyOf": [
+              {
+                "not": {
+                  "type": "object"
+                }
               },
-              "DisableHealthChecks": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                "default": false
-              },
-              "DisableMetrics": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
-                "default": false
-              },
-              "DisableTracing": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                "default": false
+              {
+                "type": "object",
+                "properties": {
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "The connection string of the PostgreSQL database to connect to."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableMetrics": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a PostgreSQL database using Npgsql."
               }
-            },
-            "description": "Provides the client configuration settings for connecting to a PostgreSQL database using Npgsql."
+            ]
           }
         }
       }

--- a/src/Components/Aspire.Npgsql/ConfigurationSchema.json
+++ b/src/Components/Aspire.Npgsql/ConfigurationSchema.json
@@ -54,7 +54,32 @@
               "default": false
             }
           },
-          "description": "Provides the client configuration settings for connecting to a PostgreSQL database using Npgsql."
+          "description": "Provides the client configuration settings for connecting to a PostgreSQL database using Npgsql.",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "ConnectionString": {
+                "type": "string",
+                "description": "The connection string of the PostgreSQL database to connect to."
+              },
+              "DisableHealthChecks": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                "default": false
+              },
+              "DisableMetrics": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                "default": false
+              },
+              "DisableTracing": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                "default": false
+              }
+            },
+            "description": "Provides the client configuration settings for connecting to a PostgreSQL database using Npgsql."
+          }
         }
       }
     }

--- a/src/Components/Aspire.OpenAI/AssemblyInfo.cs
+++ b/src/Components/Aspire.OpenAI/AssemblyInfo.cs
@@ -7,3 +7,5 @@ using OpenAI;
 
 [assembly: ConfigurationSchema("Aspire:OpenAI", typeof(OpenAISettings))]
 [assembly: ConfigurationSchema("Aspire:OpenAI:ClientOptions", typeof(OpenAIClientOptions))]
+[assembly: ConfigurationSchema("Aspire:OpenAI:*", typeof(OpenAISettings))]
+[assembly: ConfigurationSchema("Aspire:OpenAI:*:ClientOptions", typeof(OpenAIClientOptions))]

--- a/src/Components/Aspire.OpenAI/ConfigurationSchema.json
+++ b/src/Components/Aspire.OpenAI/ConfigurationSchema.json
@@ -8,190 +8,241 @@
           "type": "object",
           "properties": {
             "ClientOptions": {
-              "type": "object",
-              "properties": {
-                "ClientLoggingOptions": {
+              "anyOf": [
+                {
                   "type": "object",
                   "properties": {
-                    "AllowedHeaderNames": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
+                    "ClientLoggingOptions": {
+                      "type": "object",
+                      "properties": {
+                        "AllowedHeaderNames": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Gets or sets a list of header names that are not redacted during logging."
+                        },
+                        "AllowedQueryParameters": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Gets or sets a list of query parameter names that are not redacted during logging."
+                        },
+                        "EnableLogging": {
+                          "type": "boolean",
+                          "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                        },
+                        "EnableMessageContentLogging": {
+                          "type": "boolean",
+                          "description": "Gets or sets value indicating if request and response content should be logged."
+                        },
+                        "EnableMessageLogging": {
+                          "type": "boolean",
+                          "description": "Gets or sets value indicating if request and response uri and header information should be logged."
+                        },
+                        "MessageContentSizeLimit": {
+                          "type": "integer",
+                          "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                        }
                       },
-                      "description": "Gets or sets a list of header names that are not redacted during logging."
+                      "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
                     },
-                    "AllowedQueryParameters": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "Gets or sets a list of query parameter names that are not redacted during logging."
-                    },
-                    "EnableLogging": {
+                    "EnableDistributedTracing": {
                       "type": "boolean",
-                      "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                      "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
                     },
-                    "EnableMessageContentLogging": {
-                      "type": "boolean",
-                      "description": "Gets or sets value indicating if request and response content should be logged."
+                    "Endpoint": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "The service endpoint that the client will send requests to. If not set, the default endpoint will be used."
                     },
-                    "EnableMessageLogging": {
-                      "type": "boolean",
-                      "description": "Gets or sets value indicating if request and response uri and header information should be logged."
+                    "NetworkTimeout": {
+                      "type": "string",
+                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                      "description": "The timeout applied to an individual network operation."
                     },
-                    "MessageContentSizeLimit": {
-                      "type": "integer",
-                      "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                    "OrganizationId": {
+                      "type": "string",
+                      "description": "The value to use for the OpenAI-Organization request header. Users who belong to multiple organizations can set this value to specify which organization is used for an API request. Usage from these API requests will count against the specified organization's quota. If not set, the header will be omitted, and the default organization will be billed. You can change your default organization in your user settings. Learn more."
+                    },
+                    "ProjectId": {
+                      "type": "string",
+                      "description": "The value to use for the OpenAI-Project request header. Users who are accessing their projects through their legacy user API key can set this value to specify which project is used for an API request. Usage from these API requests will count as usage for the specified project. If not set, the header will be omitted, and the default project will be accessed."
+                    },
+                    "UserAgentApplicationId": {
+                      "type": "string",
+                      "description": "An optional application ID to use as part of the request User-Agent header."
                     }
                   },
-                  "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
+                  "description": "The options to configure the client."
                 },
-                "EnableDistributedTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
-                },
-                "Endpoint": {
-                  "type": "string",
-                  "format": "uri",
-                  "description": "The service endpoint that the client will send requests to. If not set, the default endpoint will be used."
-                },
-                "NetworkTimeout": {
-                  "type": "string",
-                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                  "description": "The timeout applied to an individual network operation."
-                },
-                "OrganizationId": {
-                  "type": "string",
-                  "description": "The value to use for the OpenAI-Organization request header. Users who belong to multiple organizations can set this value to specify which organization is used for an API request. Usage from these API requests will count against the specified organization's quota. If not set, the header will be omitted, and the default organization will be billed. You can change your default organization in your user settings. Learn more."
-                },
-                "ProjectId": {
-                  "type": "string",
-                  "description": "The value to use for the OpenAI-Project request header. Users who are accessing their projects through their legacy user API key can set this value to specify which project is used for an API request. Usage from these API requests will count as usage for the specified project. If not set, the header will be omitted, and the default project will be accessed."
-                },
-                "UserAgentApplicationId": {
-                  "type": "string",
-                  "description": "An optional application ID to use as part of the request User-Agent header."
+                {
+                  "$ref": "#/properties/Aspire/properties/OpenAI/additionalProperties/anyOf/1"
                 }
-              },
-              "description": "The options to configure the client."
+              ]
             },
             "DisableMetrics": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not."
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not."
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/OpenAI/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "DisableTracing": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not."
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not."
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/OpenAI/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "EnableSensitiveTelemetryData": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/OpenAI/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "Endpoint": {
-              "type": "string",
-              "format": "uri",
-              "description": "Gets or sets a 'System.Uri' referencing the OpenAI REST API endpoint. Leave empty to connect to OpenAI, or set it to use a service using an API compatible with OpenAI."
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Gets or sets a 'System.Uri' referencing the OpenAI REST API endpoint. Leave empty to connect to OpenAI, or set it to use a service using an API compatible with OpenAI."
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/OpenAI/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "Key": {
-              "type": "string",
-              "description": "Gets or sets a the API key to used to authenticate with the service."
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "Gets or sets a the API key to used to authenticate with the service."
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/OpenAI/additionalProperties/anyOf/1"
+                }
+              ]
             }
           },
           "description": "The settings relevant to accessing OpenAI.",
           "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "ClientOptions": {
+            "anyOf": [
+              {
+                "not": {
+                  "type": "object"
+                }
+              },
+              {
                 "type": "object",
                 "properties": {
-                  "ClientLoggingOptions": {
+                  "ClientOptions": {
                     "type": "object",
                     "properties": {
-                      "AllowedHeaderNames": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
+                      "ClientLoggingOptions": {
+                        "type": "object",
+                        "properties": {
+                          "AllowedHeaderNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Gets or sets a list of header names that are not redacted during logging."
+                          },
+                          "AllowedQueryParameters": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Gets or sets a list of query parameter names that are not redacted during logging."
+                          },
+                          "EnableLogging": {
+                            "type": "boolean",
+                            "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                          },
+                          "EnableMessageContentLogging": {
+                            "type": "boolean",
+                            "description": "Gets or sets value indicating if request and response content should be logged."
+                          },
+                          "EnableMessageLogging": {
+                            "type": "boolean",
+                            "description": "Gets or sets value indicating if request and response uri and header information should be logged."
+                          },
+                          "MessageContentSizeLimit": {
+                            "type": "integer",
+                            "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                          }
                         },
-                        "description": "Gets or sets a list of header names that are not redacted during logging."
+                        "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
                       },
-                      "AllowedQueryParameters": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "Gets or sets a list of query parameter names that are not redacted during logging."
-                      },
-                      "EnableLogging": {
+                      "EnableDistributedTracing": {
                         "type": "boolean",
-                        "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                        "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
                       },
-                      "EnableMessageContentLogging": {
-                        "type": "boolean",
-                        "description": "Gets or sets value indicating if request and response content should be logged."
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The service endpoint that the client will send requests to. If not set, the default endpoint will be used."
                       },
-                      "EnableMessageLogging": {
-                        "type": "boolean",
-                        "description": "Gets or sets value indicating if request and response uri and header information should be logged."
+                      "NetworkTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "The timeout applied to an individual network operation."
                       },
-                      "MessageContentSizeLimit": {
-                        "type": "integer",
-                        "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                      "OrganizationId": {
+                        "type": "string",
+                        "description": "The value to use for the OpenAI-Organization request header. Users who belong to multiple organizations can set this value to specify which organization is used for an API request. Usage from these API requests will count against the specified organization's quota. If not set, the header will be omitted, and the default organization will be billed. You can change your default organization in your user settings. Learn more."
+                      },
+                      "ProjectId": {
+                        "type": "string",
+                        "description": "The value to use for the OpenAI-Project request header. Users who are accessing their projects through their legacy user API key can set this value to specify which project is used for an API request. Usage from these API requests will count as usage for the specified project. If not set, the header will be omitted, and the default project will be accessed."
+                      },
+                      "UserAgentApplicationId": {
+                        "type": "string",
+                        "description": "An optional application ID to use as part of the request User-Agent header."
                       }
                     },
-                    "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
+                    "description": "The options to configure the client."
                   },
-                  "EnableDistributedTracing": {
+                  "DisableMetrics": {
                     "type": "boolean",
-                    "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not."
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not."
+                  },
+                  "EnableSensitiveTelemetryData": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
                   },
                   "Endpoint": {
                     "type": "string",
                     "format": "uri",
-                    "description": "The service endpoint that the client will send requests to. If not set, the default endpoint will be used."
+                    "description": "Gets or sets a 'System.Uri' referencing the OpenAI REST API endpoint. Leave empty to connect to OpenAI, or set it to use a service using an API compatible with OpenAI."
                   },
-                  "NetworkTimeout": {
+                  "Key": {
                     "type": "string",
-                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                    "description": "The timeout applied to an individual network operation."
-                  },
-                  "OrganizationId": {
-                    "type": "string",
-                    "description": "The value to use for the OpenAI-Organization request header. Users who belong to multiple organizations can set this value to specify which organization is used for an API request. Usage from these API requests will count against the specified organization's quota. If not set, the header will be omitted, and the default organization will be billed. You can change your default organization in your user settings. Learn more."
-                  },
-                  "ProjectId": {
-                    "type": "string",
-                    "description": "The value to use for the OpenAI-Project request header. Users who are accessing their projects through their legacy user API key can set this value to specify which project is used for an API request. Usage from these API requests will count as usage for the specified project. If not set, the header will be omitted, and the default project will be accessed."
-                  },
-                  "UserAgentApplicationId": {
-                    "type": "string",
-                    "description": "An optional application ID to use as part of the request User-Agent header."
+                    "description": "Gets or sets a the API key to used to authenticate with the service."
                   }
                 },
-                "description": "The options to configure the client."
-              },
-              "DisableMetrics": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not."
-              },
-              "DisableTracing": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not."
-              },
-              "EnableSensitiveTelemetryData": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
-              },
-              "Endpoint": {
-                "type": "string",
-                "format": "uri",
-                "description": "Gets or sets a 'System.Uri' referencing the OpenAI REST API endpoint. Leave empty to connect to OpenAI, or set it to use a service using an API compatible with OpenAI."
-              },
-              "Key": {
-                "type": "string",
-                "description": "Gets or sets a the API key to used to authenticate with the service."
+                "description": "The settings relevant to accessing OpenAI."
               }
-            },
-            "description": "The settings relevant to accessing OpenAI."
+            ]
           }
         }
       }

--- a/src/Components/Aspire.OpenAI/ConfigurationSchema.json
+++ b/src/Components/Aspire.OpenAI/ConfigurationSchema.json
@@ -97,7 +97,102 @@
               "description": "Gets or sets a the API key to used to authenticate with the service."
             }
           },
-          "description": "The settings relevant to accessing OpenAI."
+          "description": "The settings relevant to accessing OpenAI.",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "ClientOptions": {
+                "type": "object",
+                "properties": {
+                  "ClientLoggingOptions": {
+                    "type": "object",
+                    "properties": {
+                      "AllowedHeaderNames": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Gets or sets a list of header names that are not redacted during logging."
+                      },
+                      "AllowedQueryParameters": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Gets or sets a list of query parameter names that are not redacted during logging."
+                      },
+                      "EnableLogging": {
+                        "type": "boolean",
+                        "description": "Gets or sets value indicating if logging should be enabled in this client pipeline."
+                      },
+                      "EnableMessageContentLogging": {
+                        "type": "boolean",
+                        "description": "Gets or sets value indicating if request and response content should be logged."
+                      },
+                      "EnableMessageLogging": {
+                        "type": "boolean",
+                        "description": "Gets or sets value indicating if request and response uri and header information should be logged."
+                      },
+                      "MessageContentSizeLimit": {
+                        "type": "integer",
+                        "description": "Gets or sets value indicating maximum size of content to log in bytes."
+                      }
+                    },
+                    "description": "The options to be used to configure logging within the 'System.ClientModel.Primitives.ClientPipeline'."
+                  },
+                  "EnableDistributedTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets whether distributed tracing should be enabled. If null, this value will be treated as true. The default is null."
+                  },
+                  "Endpoint": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The service endpoint that the client will send requests to. If not set, the default endpoint will be used."
+                  },
+                  "NetworkTimeout": {
+                    "type": "string",
+                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                    "description": "The timeout applied to an individual network operation."
+                  },
+                  "OrganizationId": {
+                    "type": "string",
+                    "description": "The value to use for the OpenAI-Organization request header. Users who belong to multiple organizations can set this value to specify which organization is used for an API request. Usage from these API requests will count against the specified organization's quota. If not set, the header will be omitted, and the default organization will be billed. You can change your default organization in your user settings. Learn more."
+                  },
+                  "ProjectId": {
+                    "type": "string",
+                    "description": "The value to use for the OpenAI-Project request header. Users who are accessing their projects through their legacy user API key can set this value to specify which project is used for an API request. Usage from these API requests will count as usage for the specified project. If not set, the header will be omitted, and the default project will be accessed."
+                  },
+                  "UserAgentApplicationId": {
+                    "type": "string",
+                    "description": "An optional application ID to use as part of the request User-Agent header."
+                  }
+                },
+                "description": "The options to configure the client."
+              },
+              "DisableMetrics": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not."
+              },
+              "DisableTracing": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not."
+              },
+              "EnableSensitiveTelemetryData": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value indicating whether potentially sensitive information should be included in telemetry."
+              },
+              "Endpoint": {
+                "type": "string",
+                "format": "uri",
+                "description": "Gets or sets a 'System.Uri' referencing the OpenAI REST API endpoint. Leave empty to connect to OpenAI, or set it to use a service using an API compatible with OpenAI."
+              },
+              "Key": {
+                "type": "string",
+                "description": "Gets or sets a the API key to used to authenticate with the service."
+              }
+            },
+            "description": "The settings relevant to accessing OpenAI."
+          }
         }
       }
     }

--- a/src/Components/Aspire.OpenAI/ConfigurationSchema.json
+++ b/src/Components/Aspire.OpenAI/ConfigurationSchema.json
@@ -78,7 +78,52 @@
                   "description": "The options to configure the client."
                 },
                 {
-                  "$ref": "#/properties/Aspire/properties/OpenAI/additionalProperties/anyOf/1"
+                  "allOf": [
+                    {
+                      "$ref": "#/properties/Aspire/properties/OpenAI/additionalProperties/anyOf/1"
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "Endpoint"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "OrganizationId"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "ProjectId"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "UserAgentApplicationId"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "NetworkTimeout"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "ClientLoggingOptions"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "EnableDistributedTracing"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             },

--- a/src/Components/Aspire.Oracle.EntityFrameworkCore/AssemblyInfo.cs
+++ b/src/Components/Aspire.Oracle.EntityFrameworkCore/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire.Oracle.EntityFrameworkCore;
 using Aspire;
 
 [assembly: ConfigurationSchema("Aspire:Oracle:EntityFrameworkCore", typeof(OracleEntityFrameworkCoreSettings))]
+[assembly: ConfigurationSchema("Aspire:Oracle:EntityFrameworkCore:*", typeof(OracleEntityFrameworkCoreSettings))]
 
 [assembly: LoggingCategories(
     "Microsoft.EntityFrameworkCore",

--- a/src/Components/Aspire.Oracle.EntityFrameworkCore/ConfigurationSchema.json
+++ b/src/Components/Aspire.Oracle.EntityFrameworkCore/ConfigurationSchema.json
@@ -76,7 +76,36 @@
                   "default": false
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a Oracle database using EntityFrameworkCore."
+              "description": "Provides the client configuration settings for connecting to a Oracle database using EntityFrameworkCore.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "CommandTimeout": {
+                    "type": "integer",
+                    "description": "Gets or sets the time in seconds to wait for the command to execute."
+                  },
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "The connection string of the Oracle database to connect to."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableRetry": {
+                    "type": "boolean",
+                    "description": "Gets or sets whether retries should be disabled.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a Oracle database using EntityFrameworkCore."
+              }
             }
           }
         }

--- a/src/Components/Aspire.Oracle.EntityFrameworkCore/ConfigurationSchema.json
+++ b/src/Components/Aspire.Oracle.EntityFrameworkCore/ConfigurationSchema.json
@@ -53,58 +53,102 @@
               "type": "object",
               "properties": {
                 "CommandTimeout": {
-                  "type": "integer",
-                  "description": "Gets or sets the time in seconds to wait for the command to execute."
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "description": "Gets or sets the time in seconds to wait for the command to execute."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Oracle/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "ConnectionString": {
-                  "type": "string",
-                  "description": "The connection string of the Oracle database to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "The connection string of the Oracle database to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Oracle/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Oracle/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableRetry": {
-                  "type": "boolean",
-                  "description": "Gets or sets whether retries should be disabled.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets whether retries should be disabled.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Oracle/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Oracle/properties/EntityFrameworkCore/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a Oracle database using EntityFrameworkCore.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "CommandTimeout": {
-                    "type": "integer",
-                    "description": "Gets or sets the time in seconds to wait for the command to execute."
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
                   },
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "The connection string of the Oracle database to connect to."
-                  },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                    "default": false
-                  },
-                  "DisableRetry": {
-                    "type": "boolean",
-                    "description": "Gets or sets whether retries should be disabled.",
-                    "default": false
-                  },
-                  "DisableTracing": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                    "default": false
+                  {
+                    "type": "object",
+                    "properties": {
+                      "CommandTimeout": {
+                        "type": "integer",
+                        "description": "Gets or sets the time in seconds to wait for the command to execute."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "The connection string of the Oracle database to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableRetry": {
+                        "type": "boolean",
+                        "description": "Gets or sets whether retries should be disabled.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a Oracle database using EntityFrameworkCore."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a Oracle database using EntityFrameworkCore."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/AssemblyInfo.cs
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/AssemblyInfo.cs
@@ -5,6 +5,7 @@ using Aspire;
 using Aspire.Pomelo.EntityFrameworkCore.MySql;
 
 [assembly: ConfigurationSchema("Aspire:Pomelo:EntityFrameworkCore:MySql", typeof(PomeloEntityFrameworkCoreMySqlSettings))]
+[assembly: ConfigurationSchema("Aspire:Pomelo:EntityFrameworkCore:MySql:*", typeof(PomeloEntityFrameworkCoreMySqlSettings))]
 
 [assembly: LoggingCategories(
     "Microsoft.EntityFrameworkCore",

--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/ConfigurationSchema.json
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/ConfigurationSchema.json
@@ -88,7 +88,45 @@
                       "description": "Gets or sets the server version of the MySQL database to connect to."
                     }
                   },
-                  "description": "Provides the client configuration settings for connecting to a MySQL database using EntityFrameworkCore."
+                  "description": "Provides the client configuration settings for connecting to a MySQL database using EntityFrameworkCore.",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "CommandTimeout": {
+                        "type": "integer",
+                        "description": "Gets or sets the time in seconds to wait for the command to execute."
+                      },
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the connection string of the MySQL database to connect to."
+                      },
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                        "default": false
+                      },
+                      "DisableMetrics": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                        "default": false
+                      },
+                      "DisableRetry": {
+                        "type": "boolean",
+                        "description": "Gets or sets whether retries should be disabled.",
+                        "default": false
+                      },
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
+                      },
+                      "ServerVersion": {
+                        "type": "string",
+                        "description": "Gets or sets the server version of the MySQL database to connect to."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a MySQL database using EntityFrameworkCore."
+                  }
                 }
               }
             }

--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/ConfigurationSchema.json
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/ConfigurationSchema.json
@@ -56,76 +56,134 @@
                   "type": "object",
                   "properties": {
                     "CommandTimeout": {
-                      "type": "integer",
-                      "description": "Gets or sets the time in seconds to wait for the command to execute."
+                      "anyOf": [
+                        {
+                          "type": "integer",
+                          "description": "Gets or sets the time in seconds to wait for the command to execute."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Pomelo/properties/EntityFrameworkCore/properties/MySql/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string",
-                      "description": "Gets or sets the connection string of the MySQL database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the connection string of the MySQL database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Pomelo/properties/EntityFrameworkCore/properties/MySql/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableHealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Pomelo/properties/EntityFrameworkCore/properties/MySql/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableMetrics": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Pomelo/properties/EntityFrameworkCore/properties/MySql/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableRetry": {
-                      "type": "boolean",
-                      "description": "Gets or sets whether retries should be disabled.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets whether retries should be disabled.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Pomelo/properties/EntityFrameworkCore/properties/MySql/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "DisableTracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                      "default": false
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Pomelo/properties/EntityFrameworkCore/properties/MySql/additionalProperties/anyOf/1"
+                        }
+                      ]
                     },
                     "ServerVersion": {
-                      "type": "string",
-                      "description": "Gets or sets the server version of the MySQL database to connect to."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "Gets or sets the server version of the MySQL database to connect to."
+                        },
+                        {
+                          "$ref": "#/properties/Aspire/properties/Pomelo/properties/EntityFrameworkCore/properties/MySql/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a MySQL database using EntityFrameworkCore.",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "CommandTimeout": {
-                        "type": "integer",
-                        "description": "Gets or sets the time in seconds to wait for the command to execute."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
                       },
-                      "ConnectionString": {
-                        "type": "string",
-                        "description": "Gets or sets the connection string of the MySQL database to connect to."
-                      },
-                      "DisableHealthChecks": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
-                        "default": false
-                      },
-                      "DisableMetrics": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
-                        "default": false
-                      },
-                      "DisableRetry": {
-                        "type": "boolean",
-                        "description": "Gets or sets whether retries should be disabled.",
-                        "default": false
-                      },
-                      "DisableTracing": {
-                        "type": "boolean",
-                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                        "default": false
-                      },
-                      "ServerVersion": {
-                        "type": "string",
-                        "description": "Gets or sets the server version of the MySQL database to connect to."
+                      {
+                        "type": "object",
+                        "properties": {
+                          "CommandTimeout": {
+                            "type": "integer",
+                            "description": "Gets or sets the time in seconds to wait for the command to execute."
+                          },
+                          "ConnectionString": {
+                            "type": "string",
+                            "description": "Gets or sets the connection string of the MySQL database to connect to."
+                          },
+                          "DisableHealthChecks": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                            "default": false
+                          },
+                          "DisableMetrics": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                            "default": false
+                          },
+                          "DisableRetry": {
+                            "type": "boolean",
+                            "description": "Gets or sets whether retries should be disabled.",
+                            "default": false
+                          },
+                          "DisableTracing": {
+                            "type": "boolean",
+                            "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                            "default": false
+                          },
+                          "ServerVersion": {
+                            "type": "string",
+                            "description": "Gets or sets the server version of the MySQL database to connect to."
+                          }
+                        },
+                        "description": "Provides the client configuration settings for connecting to a MySQL database using EntityFrameworkCore."
                       }
-                    },
-                    "description": "Provides the client configuration settings for connecting to a MySQL database using EntityFrameworkCore."
+                    ]
                   }
                 }
               }

--- a/src/Components/Aspire.Qdrant.Client/AssemblyInfo.cs
+++ b/src/Components/Aspire.Qdrant.Client/AssemblyInfo.cs
@@ -5,5 +5,6 @@ using Aspire;
 using Aspire.Qdrant.Client;
 
 [assembly: ConfigurationSchema("Aspire:Qdrant:Client", typeof(QdrantClientSettings))]
+[assembly: ConfigurationSchema("Aspire:Qdrant:Client:*", typeof(QdrantClientSettings))]
 
 [assembly: LoggingCategories("Qdrant.Client")]

--- a/src/Components/Aspire.Qdrant.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.Qdrant.Client/ConfigurationSchema.json
@@ -39,7 +39,32 @@
                   "description": "The API Key of the Qdrant server to connect to."
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a Qdrant server using QdrantClient."
+              "description": "Provides the client configuration settings for connecting to a Qdrant server using QdrantClient.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the Qdrant client health check is disabled or not.",
+                    "default": false
+                  },
+                  "Endpoint": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The endpoint URI string of the Qdrant server to connect to."
+                  },
+                  "HealthCheckTimeout": {
+                    "type": "string",
+                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                    "description": "Gets or sets the timeout duration for the health check."
+                  },
+                  "Key": {
+                    "type": "string",
+                    "description": "The API Key of the Qdrant server to connect to."
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a Qdrant server using QdrantClient."
+              }
             }
           }
         }

--- a/src/Components/Aspire.Qdrant.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.Qdrant.Client/ConfigurationSchema.json
@@ -20,50 +20,87 @@
               "type": "object",
               "properties": {
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the Qdrant client health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the Qdrant client health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Qdrant/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "Endpoint": {
-                  "type": "string",
-                  "format": "uri",
-                  "description": "The endpoint URI string of the Qdrant server to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "The endpoint URI string of the Qdrant server to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Qdrant/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "HealthCheckTimeout": {
-                  "type": "string",
-                  "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                  "description": "Gets or sets the timeout duration for the health check."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                      "description": "Gets or sets the timeout duration for the health check."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Qdrant/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "Key": {
-                  "type": "string",
-                  "description": "The API Key of the Qdrant server to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "The API Key of the Qdrant server to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/Qdrant/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a Qdrant server using QdrantClient.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the Qdrant client health check is disabled or not.",
-                    "default": false
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
                   },
-                  "Endpoint": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The endpoint URI string of the Qdrant server to connect to."
-                  },
-                  "HealthCheckTimeout": {
-                    "type": "string",
-                    "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                    "description": "Gets or sets the timeout duration for the health check."
-                  },
-                  "Key": {
-                    "type": "string",
-                    "description": "The API Key of the Qdrant server to connect to."
+                  {
+                    "type": "object",
+                    "properties": {
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the Qdrant client health check is disabled or not.",
+                        "default": false
+                      },
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The endpoint URI string of the Qdrant server to connect to."
+                      },
+                      "HealthCheckTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Gets or sets the timeout duration for the health check."
+                      },
+                      "Key": {
+                        "type": "string",
+                        "description": "The API Key of the Qdrant server to connect to."
+                      }
+                    },
+                    "description": "Provides the client configuration settings for connecting to a Qdrant server using QdrantClient."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a Qdrant server using QdrantClient."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.RabbitMQ.Client.v6/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client.v6/ConfigurationSchema.json
@@ -332,7 +332,147 @@
                       "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
                     },
                     {
-                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                      "allOf": [
+                        {
+                          "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "DefaultAmqpUriSslProtocols"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "AmqpUriSslProtocols"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "DefaultAddressFamily"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "AutomaticRecoveryEnabled"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "DispatchConsumersAsync"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ConsumerDispatchConcurrency"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "HostName"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "NetworkRecoveryInterval"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "HandshakeContinuationTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ContinuationTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Port"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "RequestedConnectionTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "SocketReadTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "SocketWriteTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Ssl"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "TopologyRecoveryEnabled"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Endpoint"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "UserName"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Password"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "RequestedChannelMax"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "RequestedFrameMax"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "RequestedHeartbeat"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "VirtualHost"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "MaxMessageSize"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Uri"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ClientProvidedName"
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
                     }
                   ]
                 },

--- a/src/Components/Aspire.RabbitMQ.Client.v6/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client.v6/ConfigurationSchema.json
@@ -20,97 +20,41 @@
               "type": "object",
               "properties": {
                 "ConnectionFactory": {
-                  "type": "object",
-                  "properties": {
-                    "AmqpUriSslProtocols": {
-                      "enum": [
-                        "None",
-                        "Ssl2",
-                        "Ssl3",
-                        "Tls",
-                        "Default",
-                        "Tls11",
-                        "Tls12",
-                        "Tls13"
-                      ],
-                      "description": "The AMQP URI SSL protocols."
-                    },
-                    "AutomaticRecoveryEnabled": {
-                      "type": "boolean",
-                      "description": "Set to false to disable automatic connection recovery. Defaults to true."
-                    },
-                    "ClientProvidedName": {
-                      "type": "string",
-                      "description": "Default client provided name to be used for connections."
-                    },
-                    "ConsumerDispatchConcurrency": {
-                      "type": "integer",
-                      "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
-                    },
-                    "ContinuationTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Amount of time protocol  operations (e.g. queue.declare) are allowed to take before timing out."
-                    },
-                    "DefaultAddressFamily": {
-                      "enum": [
-                        "Unknown",
-                        "Unspecified",
-                        "Unix",
-                        "InterNetwork",
-                        "ImpLink",
-                        "Pup",
-                        "Chaos",
-                        "Ipx",
-                        "NS",
-                        "Iso",
-                        "Osi",
-                        "Ecma",
-                        "DataKit",
-                        "Ccitt",
-                        "Sna",
-                        "DecNet",
-                        "DataLink",
-                        "Lat",
-                        "HyperChannel",
-                        "AppleTalk",
-                        "NetBios",
-                        "VoiceView",
-                        "FireFox",
-                        "Banyan",
-                        "Atm",
-                        "InterNetworkV6",
-                        "Cluster",
-                        "Ieee12844",
-                        "Irda",
-                        "NetworkDesigners",
-                        "Max",
-                        "Packet",
-                        "ControllerAreaNetwork"
-                      ],
-                      "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
-                    },
-                    "DefaultAmqpUriSslProtocols": {
-                      "enum": [
-                        "None",
-                        "Ssl2",
-                        "Ssl3",
-                        "Tls",
-                        "Default",
-                        "Tls11",
-                        "Tls12",
-                        "Tls13"
-                      ],
-                      "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
-                    },
-                    "DispatchConsumersAsync": {
-                      "type": "boolean",
-                      "description": "Set to true will enable a asynchronous consumer dispatcher which is compatible with 'RabbitMQ.Client.IAsyncBasicConsumer'. Defaults to false."
-                    },
-                    "Endpoint": {
+                  "anyOf": [
+                    {
                       "type": "object",
                       "properties": {
-                        "AddressFamily": {
+                        "AmqpUriSslProtocols": {
+                          "enum": [
+                            "None",
+                            "Ssl2",
+                            "Ssl3",
+                            "Tls",
+                            "Default",
+                            "Tls11",
+                            "Tls12",
+                            "Tls13"
+                          ],
+                          "description": "The AMQP URI SSL protocols."
+                        },
+                        "AutomaticRecoveryEnabled": {
+                          "type": "boolean",
+                          "description": "Set to false to disable automatic connection recovery. Defaults to true."
+                        },
+                        "ClientProvidedName": {
+                          "type": "string",
+                          "description": "Default client provided name to be used for connections."
+                        },
+                        "ConsumerDispatchConcurrency": {
+                          "type": "integer",
+                          "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
+                        },
+                        "ContinuationTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Amount of time protocol  operations (e.g. queue.declare) are allowed to take before timing out."
+                        },
+                        "DefaultAddressFamily": {
                           "enum": [
                             "Unknown",
                             "Unspecified",
@@ -146,15 +90,178 @@
                             "Packet",
                             "ControllerAreaNetwork"
                           ],
-                          "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                          "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                        },
+                        "DefaultAmqpUriSslProtocols": {
+                          "enum": [
+                            "None",
+                            "Ssl2",
+                            "Ssl3",
+                            "Tls",
+                            "Default",
+                            "Tls11",
+                            "Tls12",
+                            "Tls13"
+                          ],
+                          "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
+                        },
+                        "DispatchConsumersAsync": {
+                          "type": "boolean",
+                          "description": "Set to true will enable a asynchronous consumer dispatcher which is compatible with 'RabbitMQ.Client.IAsyncBasicConsumer'. Defaults to false."
+                        },
+                        "Endpoint": {
+                          "type": "object",
+                          "properties": {
+                            "AddressFamily": {
+                              "enum": [
+                                "Unknown",
+                                "Unspecified",
+                                "Unix",
+                                "InterNetwork",
+                                "ImpLink",
+                                "Pup",
+                                "Chaos",
+                                "Ipx",
+                                "NS",
+                                "Iso",
+                                "Osi",
+                                "Ecma",
+                                "DataKit",
+                                "Ccitt",
+                                "Sna",
+                                "DecNet",
+                                "DataLink",
+                                "Lat",
+                                "HyperChannel",
+                                "AppleTalk",
+                                "NetBios",
+                                "VoiceView",
+                                "FireFox",
+                                "Banyan",
+                                "Atm",
+                                "InterNetworkV6",
+                                "Cluster",
+                                "Ieee12844",
+                                "Irda",
+                                "NetworkDesigners",
+                                "Max",
+                                "Packet",
+                                "ControllerAreaNetwork"
+                              ],
+                              "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                            },
+                            "HostName": {
+                              "type": "string",
+                              "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                            },
+                            "Port": {
+                              "type": "integer",
+                              "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                            },
+                            "Ssl": {
+                              "type": "object",
+                              "properties": {
+                                "AcceptablePolicyErrors": {
+                                  "enum": [
+                                    "None",
+                                    "RemoteCertificateNotAvailable",
+                                    "RemoteCertificateNameMismatch",
+                                    "RemoteCertificateChainErrors"
+                                  ],
+                                  "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
+                                },
+                                "CertPassphrase": {
+                                  "type": "string",
+                                  "description": "Retrieve or set the client certificate passphrase."
+                                },
+                                "CertPath": {
+                                  "type": "string",
+                                  "description": "Retrieve or set the path to client certificate."
+                                },
+                                "CheckCertificateRevocation": {
+                                  "type": "boolean",
+                                  "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
+                                },
+                                "Enabled": {
+                                  "type": "boolean",
+                                  "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
+                                },
+                                "ServerName": {
+                                  "type": "string",
+                                  "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
+                                },
+                                "Version": {
+                                  "enum": [
+                                    "None",
+                                    "Ssl2",
+                                    "Ssl3",
+                                    "Tls",
+                                    "Default",
+                                    "Tls11",
+                                    "Tls12",
+                                    "Tls13"
+                                  ],
+                                  "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
+                                }
+                              },
+                              "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                            }
+                          },
+                          "description": "Connection endpoint."
+                        },
+                        "HandshakeContinuationTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Amount of time protocol handshake operations are allowed to take before timing out."
                         },
                         "HostName": {
                           "type": "string",
-                          "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                          "description": "The host to connect to."
+                        },
+                        "MaxMessageSize": {
+                          "type": "integer",
+                          "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the rabbit.max_message_size setting."
+                        },
+                        "NetworkRecoveryInterval": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Amount of time client will wait for before re-trying  to recover connection."
+                        },
+                        "Password": {
+                          "type": "string",
+                          "description": "Password to use when authenticating to the server."
                         },
                         "Port": {
                           "type": "integer",
-                          "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                          "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
+                        },
+                        "RequestedChannelMax": {
+                          "type": "integer",
+                          "description": "Maximum channel number to ask for."
+                        },
+                        "RequestedConnectionTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Timeout setting for connection attempts."
+                        },
+                        "RequestedFrameMax": {
+                          "type": "integer",
+                          "description": "Frame-max parameter to ask for (in bytes)."
+                        },
+                        "RequestedHeartbeat": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Heartbeat timeout to use when negotiating with the server."
+                        },
+                        "SocketReadTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Timeout setting for socket read operations."
+                        },
+                        "SocketWriteTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Timeout setting for socket write operations."
                         },
                         "Ssl": {
                           "type": "object",
@@ -202,253 +309,137 @@
                               "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
                             }
                           },
-                          "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                          "description": "TLS options setting."
+                        },
+                        "TopologyRecoveryEnabled": {
+                          "type": "boolean",
+                          "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
+                        },
+                        "Uri": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The uri to use for the connection."
+                        },
+                        "UserName": {
+                          "type": "string",
+                          "description": "Username to use when authenticating to the server."
+                        },
+                        "VirtualHost": {
+                          "type": "string",
+                          "description": "Virtual host to access during this connection."
                         }
                       },
-                      "description": "Connection endpoint."
+                      "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
                     },
-                    "HandshakeContinuationTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Amount of time protocol handshake operations are allowed to take before timing out."
-                    },
-                    "HostName": {
-                      "type": "string",
-                      "description": "The host to connect to."
-                    },
-                    "MaxMessageSize": {
-                      "type": "integer",
-                      "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the rabbit.max_message_size setting."
-                    },
-                    "NetworkRecoveryInterval": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Amount of time client will wait for before re-trying  to recover connection."
-                    },
-                    "Password": {
-                      "type": "string",
-                      "description": "Password to use when authenticating to the server."
-                    },
-                    "Port": {
-                      "type": "integer",
-                      "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
-                    },
-                    "RequestedChannelMax": {
-                      "type": "integer",
-                      "description": "Maximum channel number to ask for."
-                    },
-                    "RequestedConnectionTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Timeout setting for connection attempts."
-                    },
-                    "RequestedFrameMax": {
-                      "type": "integer",
-                      "description": "Frame-max parameter to ask for (in bytes)."
-                    },
-                    "RequestedHeartbeat": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Heartbeat timeout to use when negotiating with the server."
-                    },
-                    "SocketReadTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Timeout setting for socket read operations."
-                    },
-                    "SocketWriteTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Timeout setting for socket write operations."
-                    },
-                    "Ssl": {
-                      "type": "object",
-                      "properties": {
-                        "AcceptablePolicyErrors": {
-                          "enum": [
-                            "None",
-                            "RemoteCertificateNotAvailable",
-                            "RemoteCertificateNameMismatch",
-                            "RemoteCertificateChainErrors"
-                          ],
-                          "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
-                        },
-                        "CertPassphrase": {
-                          "type": "string",
-                          "description": "Retrieve or set the client certificate passphrase."
-                        },
-                        "CertPath": {
-                          "type": "string",
-                          "description": "Retrieve or set the path to client certificate."
-                        },
-                        "CheckCertificateRevocation": {
-                          "type": "boolean",
-                          "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
-                        },
-                        "Enabled": {
-                          "type": "boolean",
-                          "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
-                        },
-                        "ServerName": {
-                          "type": "string",
-                          "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
-                        },
-                        "Version": {
-                          "enum": [
-                            "None",
-                            "Ssl2",
-                            "Ssl3",
-                            "Tls",
-                            "Default",
-                            "Tls11",
-                            "Tls12",
-                            "Tls13"
-                          ],
-                          "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
-                        }
-                      },
-                      "description": "TLS options setting."
-                    },
-                    "TopologyRecoveryEnabled": {
-                      "type": "boolean",
-                      "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
-                    },
-                    "Uri": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "The uri to use for the connection."
-                    },
-                    "UserName": {
-                      "type": "string",
-                      "description": "Username to use when authenticating to the server."
-                    },
-                    "VirtualHost": {
-                      "type": "string",
-                      "description": "Virtual host to access during this connection."
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
                     }
-                  },
-                  "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
+                  ]
                 },
                 "ConnectionString": {
-                  "type": "string",
-                  "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableAutoActivation": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
-                  "default": true
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                      "default": true
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "MaxConnectRetryCount": {
-                  "type": "integer",
-                  "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "ConnectionFactory": {
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
+                  },
+                  {
                     "type": "object",
                     "properties": {
-                      "AmqpUriSslProtocols": {
-                        "enum": [
-                          "None",
-                          "Ssl2",
-                          "Ssl3",
-                          "Tls",
-                          "Default",
-                          "Tls11",
-                          "Tls12",
-                          "Tls13"
-                        ],
-                        "description": "The AMQP URI SSL protocols."
-                      },
-                      "AutomaticRecoveryEnabled": {
-                        "type": "boolean",
-                        "description": "Set to false to disable automatic connection recovery. Defaults to true."
-                      },
-                      "ClientProvidedName": {
-                        "type": "string",
-                        "description": "Default client provided name to be used for connections."
-                      },
-                      "ConsumerDispatchConcurrency": {
-                        "type": "integer",
-                        "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
-                      },
-                      "ContinuationTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Amount of time protocol  operations (e.g. queue.declare) are allowed to take before timing out."
-                      },
-                      "DefaultAddressFamily": {
-                        "enum": [
-                          "Unknown",
-                          "Unspecified",
-                          "Unix",
-                          "InterNetwork",
-                          "ImpLink",
-                          "Pup",
-                          "Chaos",
-                          "Ipx",
-                          "NS",
-                          "Iso",
-                          "Osi",
-                          "Ecma",
-                          "DataKit",
-                          "Ccitt",
-                          "Sna",
-                          "DecNet",
-                          "DataLink",
-                          "Lat",
-                          "HyperChannel",
-                          "AppleTalk",
-                          "NetBios",
-                          "VoiceView",
-                          "FireFox",
-                          "Banyan",
-                          "Atm",
-                          "InterNetworkV6",
-                          "Cluster",
-                          "Ieee12844",
-                          "Irda",
-                          "NetworkDesigners",
-                          "Max",
-                          "Packet",
-                          "ControllerAreaNetwork"
-                        ],
-                        "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
-                      },
-                      "DefaultAmqpUriSslProtocols": {
-                        "enum": [
-                          "None",
-                          "Ssl2",
-                          "Ssl3",
-                          "Tls",
-                          "Default",
-                          "Tls11",
-                          "Tls12",
-                          "Tls13"
-                        ],
-                        "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
-                      },
-                      "DispatchConsumersAsync": {
-                        "type": "boolean",
-                        "description": "Set to true will enable a asynchronous consumer dispatcher which is compatible with 'RabbitMQ.Client.IAsyncBasicConsumer'. Defaults to false."
-                      },
-                      "Endpoint": {
+                      "ConnectionFactory": {
                         "type": "object",
                         "properties": {
-                          "AddressFamily": {
+                          "AmqpUriSslProtocols": {
+                            "enum": [
+                              "None",
+                              "Ssl2",
+                              "Ssl3",
+                              "Tls",
+                              "Default",
+                              "Tls11",
+                              "Tls12",
+                              "Tls13"
+                            ],
+                            "description": "The AMQP URI SSL protocols."
+                          },
+                          "AutomaticRecoveryEnabled": {
+                            "type": "boolean",
+                            "description": "Set to false to disable automatic connection recovery. Defaults to true."
+                          },
+                          "ClientProvidedName": {
+                            "type": "string",
+                            "description": "Default client provided name to be used for connections."
+                          },
+                          "ConsumerDispatchConcurrency": {
+                            "type": "integer",
+                            "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
+                          },
+                          "ContinuationTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Amount of time protocol  operations (e.g. queue.declare) are allowed to take before timing out."
+                          },
+                          "DefaultAddressFamily": {
                             "enum": [
                               "Unknown",
                               "Unspecified",
@@ -484,15 +475,178 @@
                               "Packet",
                               "ControllerAreaNetwork"
                             ],
-                            "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                            "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                          },
+                          "DefaultAmqpUriSslProtocols": {
+                            "enum": [
+                              "None",
+                              "Ssl2",
+                              "Ssl3",
+                              "Tls",
+                              "Default",
+                              "Tls11",
+                              "Tls12",
+                              "Tls13"
+                            ],
+                            "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
+                          },
+                          "DispatchConsumersAsync": {
+                            "type": "boolean",
+                            "description": "Set to true will enable a asynchronous consumer dispatcher which is compatible with 'RabbitMQ.Client.IAsyncBasicConsumer'. Defaults to false."
+                          },
+                          "Endpoint": {
+                            "type": "object",
+                            "properties": {
+                              "AddressFamily": {
+                                "enum": [
+                                  "Unknown",
+                                  "Unspecified",
+                                  "Unix",
+                                  "InterNetwork",
+                                  "ImpLink",
+                                  "Pup",
+                                  "Chaos",
+                                  "Ipx",
+                                  "NS",
+                                  "Iso",
+                                  "Osi",
+                                  "Ecma",
+                                  "DataKit",
+                                  "Ccitt",
+                                  "Sna",
+                                  "DecNet",
+                                  "DataLink",
+                                  "Lat",
+                                  "HyperChannel",
+                                  "AppleTalk",
+                                  "NetBios",
+                                  "VoiceView",
+                                  "FireFox",
+                                  "Banyan",
+                                  "Atm",
+                                  "InterNetworkV6",
+                                  "Cluster",
+                                  "Ieee12844",
+                                  "Irda",
+                                  "NetworkDesigners",
+                                  "Max",
+                                  "Packet",
+                                  "ControllerAreaNetwork"
+                                ],
+                                "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                              },
+                              "HostName": {
+                                "type": "string",
+                                "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                              },
+                              "Port": {
+                                "type": "integer",
+                                "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                              },
+                              "Ssl": {
+                                "type": "object",
+                                "properties": {
+                                  "AcceptablePolicyErrors": {
+                                    "enum": [
+                                      "None",
+                                      "RemoteCertificateNotAvailable",
+                                      "RemoteCertificateNameMismatch",
+                                      "RemoteCertificateChainErrors"
+                                    ],
+                                    "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
+                                  },
+                                  "CertPassphrase": {
+                                    "type": "string",
+                                    "description": "Retrieve or set the client certificate passphrase."
+                                  },
+                                  "CertPath": {
+                                    "type": "string",
+                                    "description": "Retrieve or set the path to client certificate."
+                                  },
+                                  "CheckCertificateRevocation": {
+                                    "type": "boolean",
+                                    "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
+                                  },
+                                  "Enabled": {
+                                    "type": "boolean",
+                                    "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
+                                  },
+                                  "ServerName": {
+                                    "type": "string",
+                                    "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
+                                  },
+                                  "Version": {
+                                    "enum": [
+                                      "None",
+                                      "Ssl2",
+                                      "Ssl3",
+                                      "Tls",
+                                      "Default",
+                                      "Tls11",
+                                      "Tls12",
+                                      "Tls13"
+                                    ],
+                                    "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
+                                  }
+                                },
+                                "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                              }
+                            },
+                            "description": "Connection endpoint."
+                          },
+                          "HandshakeContinuationTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Amount of time protocol handshake operations are allowed to take before timing out."
                           },
                           "HostName": {
                             "type": "string",
-                            "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                            "description": "The host to connect to."
+                          },
+                          "MaxMessageSize": {
+                            "type": "integer",
+                            "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the rabbit.max_message_size setting."
+                          },
+                          "NetworkRecoveryInterval": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Amount of time client will wait for before re-trying  to recover connection."
+                          },
+                          "Password": {
+                            "type": "string",
+                            "description": "Password to use when authenticating to the server."
                           },
                           "Port": {
                             "type": "integer",
-                            "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                            "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
+                          },
+                          "RequestedChannelMax": {
+                            "type": "integer",
+                            "description": "Maximum channel number to ask for."
+                          },
+                          "RequestedConnectionTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Timeout setting for connection attempts."
+                          },
+                          "RequestedFrameMax": {
+                            "type": "integer",
+                            "description": "Frame-max parameter to ask for (in bytes)."
+                          },
+                          "RequestedHeartbeat": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Heartbeat timeout to use when negotiating with the server."
+                          },
+                          "SocketReadTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Timeout setting for socket read operations."
+                          },
+                          "SocketWriteTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Timeout setting for socket write operations."
                           },
                           "Ssl": {
                             "type": "object",
@@ -540,158 +694,55 @@
                                 "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
                               }
                             },
-                            "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                            "description": "TLS options setting."
+                          },
+                          "TopologyRecoveryEnabled": {
+                            "type": "boolean",
+                            "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
+                          },
+                          "Uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The uri to use for the connection."
+                          },
+                          "UserName": {
+                            "type": "string",
+                            "description": "Username to use when authenticating to the server."
+                          },
+                          "VirtualHost": {
+                            "type": "string",
+                            "description": "Virtual host to access during this connection."
                           }
                         },
-                        "description": "Connection endpoint."
+                        "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
                       },
-                      "HandshakeContinuationTimeout": {
+                      "ConnectionString": {
                         "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Amount of time protocol handshake operations are allowed to take before timing out."
+                        "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
                       },
-                      "HostName": {
-                        "type": "string",
-                        "description": "The host to connect to."
-                      },
-                      "MaxMessageSize": {
-                        "type": "integer",
-                        "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the rabbit.max_message_size setting."
-                      },
-                      "NetworkRecoveryInterval": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Amount of time client will wait for before re-trying  to recover connection."
-                      },
-                      "Password": {
-                        "type": "string",
-                        "description": "Password to use when authenticating to the server."
-                      },
-                      "Port": {
-                        "type": "integer",
-                        "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
-                      },
-                      "RequestedChannelMax": {
-                        "type": "integer",
-                        "description": "Maximum channel number to ask for."
-                      },
-                      "RequestedConnectionTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Timeout setting for connection attempts."
-                      },
-                      "RequestedFrameMax": {
-                        "type": "integer",
-                        "description": "Frame-max parameter to ask for (in bytes)."
-                      },
-                      "RequestedHeartbeat": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Heartbeat timeout to use when negotiating with the server."
-                      },
-                      "SocketReadTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Timeout setting for socket read operations."
-                      },
-                      "SocketWriteTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Timeout setting for socket write operations."
-                      },
-                      "Ssl": {
-                        "type": "object",
-                        "properties": {
-                          "AcceptablePolicyErrors": {
-                            "enum": [
-                              "None",
-                              "RemoteCertificateNotAvailable",
-                              "RemoteCertificateNameMismatch",
-                              "RemoteCertificateChainErrors"
-                            ],
-                            "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
-                          },
-                          "CertPassphrase": {
-                            "type": "string",
-                            "description": "Retrieve or set the client certificate passphrase."
-                          },
-                          "CertPath": {
-                            "type": "string",
-                            "description": "Retrieve or set the path to client certificate."
-                          },
-                          "CheckCertificateRevocation": {
-                            "type": "boolean",
-                            "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
-                          },
-                          "Enabled": {
-                            "type": "boolean",
-                            "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
-                          },
-                          "ServerName": {
-                            "type": "string",
-                            "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
-                          },
-                          "Version": {
-                            "enum": [
-                              "None",
-                              "Ssl2",
-                              "Ssl3",
-                              "Tls",
-                              "Default",
-                              "Tls11",
-                              "Tls12",
-                              "Tls13"
-                            ],
-                            "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
-                          }
-                        },
-                        "description": "TLS options setting."
-                      },
-                      "TopologyRecoveryEnabled": {
+                      "DisableAutoActivation": {
                         "type": "boolean",
-                        "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
+                        "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                        "default": true
                       },
-                      "Uri": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "The uri to use for the connection."
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
+                        "default": false
                       },
-                      "UserName": {
-                        "type": "string",
-                        "description": "Username to use when authenticating to the server."
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
                       },
-                      "VirtualHost": {
-                        "type": "string",
-                        "description": "Virtual host to access during this connection."
+                      "MaxConnectRetryCount": {
+                        "type": "integer",
+                        "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
                       }
                     },
-                    "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
-                  },
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
-                  },
-                  "DisableAutoActivation": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
-                    "default": true
-                  },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
-                    "default": false
-                  },
-                  "DisableTracing": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                    "default": false
-                  },
-                  "MaxConnectRetryCount": {
-                    "type": "integer",
-                    "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
+                    "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.RabbitMQ.Client.v6/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client.v6/ConfigurationSchema.json
@@ -353,7 +353,346 @@
                   "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."
+              "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionFactory": {
+                    "type": "object",
+                    "properties": {
+                      "AmqpUriSslProtocols": {
+                        "enum": [
+                          "None",
+                          "Ssl2",
+                          "Ssl3",
+                          "Tls",
+                          "Default",
+                          "Tls11",
+                          "Tls12",
+                          "Tls13"
+                        ],
+                        "description": "The AMQP URI SSL protocols."
+                      },
+                      "AutomaticRecoveryEnabled": {
+                        "type": "boolean",
+                        "description": "Set to false to disable automatic connection recovery. Defaults to true."
+                      },
+                      "ClientProvidedName": {
+                        "type": "string",
+                        "description": "Default client provided name to be used for connections."
+                      },
+                      "ConsumerDispatchConcurrency": {
+                        "type": "integer",
+                        "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
+                      },
+                      "ContinuationTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Amount of time protocol  operations (e.g. queue.declare) are allowed to take before timing out."
+                      },
+                      "DefaultAddressFamily": {
+                        "enum": [
+                          "Unknown",
+                          "Unspecified",
+                          "Unix",
+                          "InterNetwork",
+                          "ImpLink",
+                          "Pup",
+                          "Chaos",
+                          "Ipx",
+                          "NS",
+                          "Iso",
+                          "Osi",
+                          "Ecma",
+                          "DataKit",
+                          "Ccitt",
+                          "Sna",
+                          "DecNet",
+                          "DataLink",
+                          "Lat",
+                          "HyperChannel",
+                          "AppleTalk",
+                          "NetBios",
+                          "VoiceView",
+                          "FireFox",
+                          "Banyan",
+                          "Atm",
+                          "InterNetworkV6",
+                          "Cluster",
+                          "Ieee12844",
+                          "Irda",
+                          "NetworkDesigners",
+                          "Max",
+                          "Packet",
+                          "ControllerAreaNetwork"
+                        ],
+                        "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                      },
+                      "DefaultAmqpUriSslProtocols": {
+                        "enum": [
+                          "None",
+                          "Ssl2",
+                          "Ssl3",
+                          "Tls",
+                          "Default",
+                          "Tls11",
+                          "Tls12",
+                          "Tls13"
+                        ],
+                        "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
+                      },
+                      "DispatchConsumersAsync": {
+                        "type": "boolean",
+                        "description": "Set to true will enable a asynchronous consumer dispatcher which is compatible with 'RabbitMQ.Client.IAsyncBasicConsumer'. Defaults to false."
+                      },
+                      "Endpoint": {
+                        "type": "object",
+                        "properties": {
+                          "AddressFamily": {
+                            "enum": [
+                              "Unknown",
+                              "Unspecified",
+                              "Unix",
+                              "InterNetwork",
+                              "ImpLink",
+                              "Pup",
+                              "Chaos",
+                              "Ipx",
+                              "NS",
+                              "Iso",
+                              "Osi",
+                              "Ecma",
+                              "DataKit",
+                              "Ccitt",
+                              "Sna",
+                              "DecNet",
+                              "DataLink",
+                              "Lat",
+                              "HyperChannel",
+                              "AppleTalk",
+                              "NetBios",
+                              "VoiceView",
+                              "FireFox",
+                              "Banyan",
+                              "Atm",
+                              "InterNetworkV6",
+                              "Cluster",
+                              "Ieee12844",
+                              "Irda",
+                              "NetworkDesigners",
+                              "Max",
+                              "Packet",
+                              "ControllerAreaNetwork"
+                            ],
+                            "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                          },
+                          "HostName": {
+                            "type": "string",
+                            "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                          },
+                          "Port": {
+                            "type": "integer",
+                            "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                          },
+                          "Ssl": {
+                            "type": "object",
+                            "properties": {
+                              "AcceptablePolicyErrors": {
+                                "enum": [
+                                  "None",
+                                  "RemoteCertificateNotAvailable",
+                                  "RemoteCertificateNameMismatch",
+                                  "RemoteCertificateChainErrors"
+                                ],
+                                "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
+                              },
+                              "CertPassphrase": {
+                                "type": "string",
+                                "description": "Retrieve or set the client certificate passphrase."
+                              },
+                              "CertPath": {
+                                "type": "string",
+                                "description": "Retrieve or set the path to client certificate."
+                              },
+                              "CheckCertificateRevocation": {
+                                "type": "boolean",
+                                "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
+                              },
+                              "Enabled": {
+                                "type": "boolean",
+                                "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
+                              },
+                              "ServerName": {
+                                "type": "string",
+                                "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
+                              },
+                              "Version": {
+                                "enum": [
+                                  "None",
+                                  "Ssl2",
+                                  "Ssl3",
+                                  "Tls",
+                                  "Default",
+                                  "Tls11",
+                                  "Tls12",
+                                  "Tls13"
+                                ],
+                                "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
+                              }
+                            },
+                            "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                          }
+                        },
+                        "description": "Connection endpoint."
+                      },
+                      "HandshakeContinuationTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Amount of time protocol handshake operations are allowed to take before timing out."
+                      },
+                      "HostName": {
+                        "type": "string",
+                        "description": "The host to connect to."
+                      },
+                      "MaxMessageSize": {
+                        "type": "integer",
+                        "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the rabbit.max_message_size setting."
+                      },
+                      "NetworkRecoveryInterval": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Amount of time client will wait for before re-trying  to recover connection."
+                      },
+                      "Password": {
+                        "type": "string",
+                        "description": "Password to use when authenticating to the server."
+                      },
+                      "Port": {
+                        "type": "integer",
+                        "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
+                      },
+                      "RequestedChannelMax": {
+                        "type": "integer",
+                        "description": "Maximum channel number to ask for."
+                      },
+                      "RequestedConnectionTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Timeout setting for connection attempts."
+                      },
+                      "RequestedFrameMax": {
+                        "type": "integer",
+                        "description": "Frame-max parameter to ask for (in bytes)."
+                      },
+                      "RequestedHeartbeat": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Heartbeat timeout to use when negotiating with the server."
+                      },
+                      "SocketReadTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Timeout setting for socket read operations."
+                      },
+                      "SocketWriteTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Timeout setting for socket write operations."
+                      },
+                      "Ssl": {
+                        "type": "object",
+                        "properties": {
+                          "AcceptablePolicyErrors": {
+                            "enum": [
+                              "None",
+                              "RemoteCertificateNotAvailable",
+                              "RemoteCertificateNameMismatch",
+                              "RemoteCertificateChainErrors"
+                            ],
+                            "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
+                          },
+                          "CertPassphrase": {
+                            "type": "string",
+                            "description": "Retrieve or set the client certificate passphrase."
+                          },
+                          "CertPath": {
+                            "type": "string",
+                            "description": "Retrieve or set the path to client certificate."
+                          },
+                          "CheckCertificateRevocation": {
+                            "type": "boolean",
+                            "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
+                          },
+                          "Enabled": {
+                            "type": "boolean",
+                            "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
+                          },
+                          "ServerName": {
+                            "type": "string",
+                            "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
+                          },
+                          "Version": {
+                            "enum": [
+                              "None",
+                              "Ssl2",
+                              "Ssl3",
+                              "Tls",
+                              "Default",
+                              "Tls11",
+                              "Tls12",
+                              "Tls13"
+                            ],
+                            "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
+                          }
+                        },
+                        "description": "TLS options setting."
+                      },
+                      "TopologyRecoveryEnabled": {
+                        "type": "boolean",
+                        "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
+                      },
+                      "Uri": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The uri to use for the connection."
+                      },
+                      "UserName": {
+                        "type": "string",
+                        "description": "Username to use when authenticating to the server."
+                      },
+                      "VirtualHost": {
+                        "type": "string",
+                        "description": "Virtual host to access during this connection."
+                      }
+                    },
+                    "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
+                  },
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
+                  },
+                  "DisableAutoActivation": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                    "default": true
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  },
+                  "MaxConnectRetryCount": {
+                    "type": "integer",
+                    "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."
+              }
             }
           }
         }

--- a/src/Components/Aspire.RabbitMQ.Client/AssemblyInfo.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/AssemblyInfo.cs
@@ -8,5 +8,8 @@ using RabbitMQ.Client;
 [assembly: ConfigurationSchema("Aspire:RabbitMQ:Client", typeof(RabbitMQClientSettings))]
 [assembly: ConfigurationSchema("Aspire:RabbitMQ:Client:ConnectionFactory", typeof(ConnectionFactory),
     exclusionPaths: ["ClientProperties", "Ssl:ClientCertificateContext", "Endpoint:Ssl:ClientCertificateContext"])]
+[assembly: ConfigurationSchema("Aspire:RabbitMQ:Client:*", typeof(RabbitMQClientSettings))]
+[assembly: ConfigurationSchema("Aspire:RabbitMQ:Client:*:ConnectionFactory", typeof(ConnectionFactory),
+    exclusionPaths: ["ClientProperties", "Ssl:ClientCertificateContext", "Endpoint:Ssl:ClientCertificateContext"])]
 
 [assembly: LoggingCategories("RabbitMQ.Client")]

--- a/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
@@ -349,7 +349,342 @@
                   "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."
+              "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConnectionFactory": {
+                    "type": "object",
+                    "properties": {
+                      "AmqpUriSslProtocols": {
+                        "enum": [
+                          "None",
+                          "Ssl2",
+                          "Ssl3",
+                          "Tls",
+                          "Default",
+                          "Tls11",
+                          "Tls12",
+                          "Tls13"
+                        ],
+                        "description": "The AMQP URI SSL protocols."
+                      },
+                      "AutomaticRecoveryEnabled": {
+                        "type": "boolean",
+                        "description": "Set to false to disable automatic connection recovery. Defaults to true."
+                      },
+                      "ClientProvidedName": {
+                        "type": "string",
+                        "description": "Default client provided name to be used for connections."
+                      },
+                      "ConsumerDispatchConcurrency": {
+                        "type": "integer",
+                        "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IAsyncBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
+                      },
+                      "ContinuationTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Amount of time protocol operations (e.g. queue.declare) are allowed to take before timing out."
+                      },
+                      "DefaultAddressFamily": {
+                        "enum": [
+                          "Unknown",
+                          "Unspecified",
+                          "Unix",
+                          "InterNetwork",
+                          "ImpLink",
+                          "Pup",
+                          "Chaos",
+                          "Ipx",
+                          "NS",
+                          "Iso",
+                          "Osi",
+                          "Ecma",
+                          "DataKit",
+                          "Ccitt",
+                          "Sna",
+                          "DecNet",
+                          "DataLink",
+                          "Lat",
+                          "HyperChannel",
+                          "AppleTalk",
+                          "NetBios",
+                          "VoiceView",
+                          "FireFox",
+                          "Banyan",
+                          "Atm",
+                          "InterNetworkV6",
+                          "Cluster",
+                          "Ieee12844",
+                          "Irda",
+                          "NetworkDesigners",
+                          "Max",
+                          "Packet",
+                          "ControllerAreaNetwork"
+                        ],
+                        "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                      },
+                      "DefaultAmqpUriSslProtocols": {
+                        "enum": [
+                          "None",
+                          "Ssl2",
+                          "Ssl3",
+                          "Tls",
+                          "Default",
+                          "Tls11",
+                          "Tls12",
+                          "Tls13"
+                        ],
+                        "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
+                      },
+                      "Endpoint": {
+                        "type": "object",
+                        "properties": {
+                          "AddressFamily": {
+                            "enum": [
+                              "Unknown",
+                              "Unspecified",
+                              "Unix",
+                              "InterNetwork",
+                              "ImpLink",
+                              "Pup",
+                              "Chaos",
+                              "Ipx",
+                              "NS",
+                              "Iso",
+                              "Osi",
+                              "Ecma",
+                              "DataKit",
+                              "Ccitt",
+                              "Sna",
+                              "DecNet",
+                              "DataLink",
+                              "Lat",
+                              "HyperChannel",
+                              "AppleTalk",
+                              "NetBios",
+                              "VoiceView",
+                              "FireFox",
+                              "Banyan",
+                              "Atm",
+                              "InterNetworkV6",
+                              "Cluster",
+                              "Ieee12844",
+                              "Irda",
+                              "NetworkDesigners",
+                              "Max",
+                              "Packet",
+                              "ControllerAreaNetwork"
+                            ],
+                            "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                          },
+                          "HostName": {
+                            "type": "string",
+                            "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                          },
+                          "Port": {
+                            "type": "integer",
+                            "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                          },
+                          "Ssl": {
+                            "type": "object",
+                            "properties": {
+                              "AcceptablePolicyErrors": {
+                                "enum": [
+                                  "None",
+                                  "RemoteCertificateNotAvailable",
+                                  "RemoteCertificateNameMismatch",
+                                  "RemoteCertificateChainErrors"
+                                ],
+                                "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
+                              },
+                              "CertPassphrase": {
+                                "type": "string",
+                                "description": "Retrieve or set the client certificate passphrase."
+                              },
+                              "CertPath": {
+                                "type": "string",
+                                "description": "Retrieve or set the path to client certificate."
+                              },
+                              "CheckCertificateRevocation": {
+                                "type": "boolean",
+                                "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
+                              },
+                              "Enabled": {
+                                "type": "boolean",
+                                "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
+                              },
+                              "ServerName": {
+                                "type": "string",
+                                "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
+                              },
+                              "Version": {
+                                "enum": [
+                                  "None",
+                                  "Ssl2",
+                                  "Ssl3",
+                                  "Tls",
+                                  "Default",
+                                  "Tls11",
+                                  "Tls12",
+                                  "Tls13"
+                                ],
+                                "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
+                              }
+                            },
+                            "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                          }
+                        },
+                        "description": "Connection endpoint."
+                      },
+                      "HandshakeContinuationTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Amount of time protocol handshake operations are allowed to take before timing out."
+                      },
+                      "HostName": {
+                        "type": "string",
+                        "description": "The host to connect to."
+                      },
+                      "MaxInboundMessageBodySize": {
+                        "type": "integer",
+                        "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the ConnectionFactory.DefaultMaxMessageSize setting."
+                      },
+                      "NetworkRecoveryInterval": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Amount of time client will wait for before re-trying  to recover connection."
+                      },
+                      "Password": {
+                        "type": "string",
+                        "description": "Password to use when authenticating to the server."
+                      },
+                      "Port": {
+                        "type": "integer",
+                        "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
+                      },
+                      "RequestedChannelMax": {
+                        "type": "integer",
+                        "description": "Maximum channel number to ask for."
+                      },
+                      "RequestedConnectionTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Timeout setting for connection attempts."
+                      },
+                      "RequestedFrameMax": {
+                        "type": "integer",
+                        "description": "Frame-max parameter to ask for (in bytes)."
+                      },
+                      "RequestedHeartbeat": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Heartbeat timeout to use when negotiating with the server."
+                      },
+                      "SocketReadTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Timeout setting for socket read operations."
+                      },
+                      "SocketWriteTimeout": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Timeout setting for socket write operations."
+                      },
+                      "Ssl": {
+                        "type": "object",
+                        "properties": {
+                          "AcceptablePolicyErrors": {
+                            "enum": [
+                              "None",
+                              "RemoteCertificateNotAvailable",
+                              "RemoteCertificateNameMismatch",
+                              "RemoteCertificateChainErrors"
+                            ],
+                            "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
+                          },
+                          "CertPassphrase": {
+                            "type": "string",
+                            "description": "Retrieve or set the client certificate passphrase."
+                          },
+                          "CertPath": {
+                            "type": "string",
+                            "description": "Retrieve or set the path to client certificate."
+                          },
+                          "CheckCertificateRevocation": {
+                            "type": "boolean",
+                            "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
+                          },
+                          "Enabled": {
+                            "type": "boolean",
+                            "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
+                          },
+                          "ServerName": {
+                            "type": "string",
+                            "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
+                          },
+                          "Version": {
+                            "enum": [
+                              "None",
+                              "Ssl2",
+                              "Ssl3",
+                              "Tls",
+                              "Default",
+                              "Tls11",
+                              "Tls12",
+                              "Tls13"
+                            ],
+                            "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
+                          }
+                        },
+                        "description": "TLS options setting."
+                      },
+                      "TopologyRecoveryEnabled": {
+                        "type": "boolean",
+                        "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
+                      },
+                      "Uri": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The uri to use for the connection."
+                      },
+                      "UserName": {
+                        "type": "string",
+                        "description": "Username to use when authenticating to the server."
+                      },
+                      "VirtualHost": {
+                        "type": "string",
+                        "description": "Virtual host to access during this connection."
+                      }
+                    },
+                    "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
+                  },
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
+                  },
+                  "DisableAutoActivation": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                    "default": true
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  },
+                  "MaxConnectRetryCount": {
+                    "type": "integer",
+                    "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."
+              }
             }
           }
         }

--- a/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
@@ -20,93 +20,41 @@
               "type": "object",
               "properties": {
                 "ConnectionFactory": {
-                  "type": "object",
-                  "properties": {
-                    "AmqpUriSslProtocols": {
-                      "enum": [
-                        "None",
-                        "Ssl2",
-                        "Ssl3",
-                        "Tls",
-                        "Default",
-                        "Tls11",
-                        "Tls12",
-                        "Tls13"
-                      ],
-                      "description": "The AMQP URI SSL protocols."
-                    },
-                    "AutomaticRecoveryEnabled": {
-                      "type": "boolean",
-                      "description": "Set to false to disable automatic connection recovery. Defaults to true."
-                    },
-                    "ClientProvidedName": {
-                      "type": "string",
-                      "description": "Default client provided name to be used for connections."
-                    },
-                    "ConsumerDispatchConcurrency": {
-                      "type": "integer",
-                      "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IAsyncBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
-                    },
-                    "ContinuationTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Amount of time protocol operations (e.g. queue.declare) are allowed to take before timing out."
-                    },
-                    "DefaultAddressFamily": {
-                      "enum": [
-                        "Unknown",
-                        "Unspecified",
-                        "Unix",
-                        "InterNetwork",
-                        "ImpLink",
-                        "Pup",
-                        "Chaos",
-                        "Ipx",
-                        "NS",
-                        "Iso",
-                        "Osi",
-                        "Ecma",
-                        "DataKit",
-                        "Ccitt",
-                        "Sna",
-                        "DecNet",
-                        "DataLink",
-                        "Lat",
-                        "HyperChannel",
-                        "AppleTalk",
-                        "NetBios",
-                        "VoiceView",
-                        "FireFox",
-                        "Banyan",
-                        "Atm",
-                        "InterNetworkV6",
-                        "Cluster",
-                        "Ieee12844",
-                        "Irda",
-                        "NetworkDesigners",
-                        "Max",
-                        "Packet",
-                        "ControllerAreaNetwork"
-                      ],
-                      "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
-                    },
-                    "DefaultAmqpUriSslProtocols": {
-                      "enum": [
-                        "None",
-                        "Ssl2",
-                        "Ssl3",
-                        "Tls",
-                        "Default",
-                        "Tls11",
-                        "Tls12",
-                        "Tls13"
-                      ],
-                      "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
-                    },
-                    "Endpoint": {
+                  "anyOf": [
+                    {
                       "type": "object",
                       "properties": {
-                        "AddressFamily": {
+                        "AmqpUriSslProtocols": {
+                          "enum": [
+                            "None",
+                            "Ssl2",
+                            "Ssl3",
+                            "Tls",
+                            "Default",
+                            "Tls11",
+                            "Tls12",
+                            "Tls13"
+                          ],
+                          "description": "The AMQP URI SSL protocols."
+                        },
+                        "AutomaticRecoveryEnabled": {
+                          "type": "boolean",
+                          "description": "Set to false to disable automatic connection recovery. Defaults to true."
+                        },
+                        "ClientProvidedName": {
+                          "type": "string",
+                          "description": "Default client provided name to be used for connections."
+                        },
+                        "ConsumerDispatchConcurrency": {
+                          "type": "integer",
+                          "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IAsyncBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
+                        },
+                        "ContinuationTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Amount of time protocol operations (e.g. queue.declare) are allowed to take before timing out."
+                        },
+                        "DefaultAddressFamily": {
                           "enum": [
                             "Unknown",
                             "Unspecified",
@@ -142,15 +90,174 @@
                             "Packet",
                             "ControllerAreaNetwork"
                           ],
-                          "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                          "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                        },
+                        "DefaultAmqpUriSslProtocols": {
+                          "enum": [
+                            "None",
+                            "Ssl2",
+                            "Ssl3",
+                            "Tls",
+                            "Default",
+                            "Tls11",
+                            "Tls12",
+                            "Tls13"
+                          ],
+                          "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
+                        },
+                        "Endpoint": {
+                          "type": "object",
+                          "properties": {
+                            "AddressFamily": {
+                              "enum": [
+                                "Unknown",
+                                "Unspecified",
+                                "Unix",
+                                "InterNetwork",
+                                "ImpLink",
+                                "Pup",
+                                "Chaos",
+                                "Ipx",
+                                "NS",
+                                "Iso",
+                                "Osi",
+                                "Ecma",
+                                "DataKit",
+                                "Ccitt",
+                                "Sna",
+                                "DecNet",
+                                "DataLink",
+                                "Lat",
+                                "HyperChannel",
+                                "AppleTalk",
+                                "NetBios",
+                                "VoiceView",
+                                "FireFox",
+                                "Banyan",
+                                "Atm",
+                                "InterNetworkV6",
+                                "Cluster",
+                                "Ieee12844",
+                                "Irda",
+                                "NetworkDesigners",
+                                "Max",
+                                "Packet",
+                                "ControllerAreaNetwork"
+                              ],
+                              "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                            },
+                            "HostName": {
+                              "type": "string",
+                              "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                            },
+                            "Port": {
+                              "type": "integer",
+                              "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                            },
+                            "Ssl": {
+                              "type": "object",
+                              "properties": {
+                                "AcceptablePolicyErrors": {
+                                  "enum": [
+                                    "None",
+                                    "RemoteCertificateNotAvailable",
+                                    "RemoteCertificateNameMismatch",
+                                    "RemoteCertificateChainErrors"
+                                  ],
+                                  "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
+                                },
+                                "CertPassphrase": {
+                                  "type": "string",
+                                  "description": "Retrieve or set the client certificate passphrase."
+                                },
+                                "CertPath": {
+                                  "type": "string",
+                                  "description": "Retrieve or set the path to client certificate."
+                                },
+                                "CheckCertificateRevocation": {
+                                  "type": "boolean",
+                                  "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
+                                },
+                                "Enabled": {
+                                  "type": "boolean",
+                                  "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
+                                },
+                                "ServerName": {
+                                  "type": "string",
+                                  "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
+                                },
+                                "Version": {
+                                  "enum": [
+                                    "None",
+                                    "Ssl2",
+                                    "Ssl3",
+                                    "Tls",
+                                    "Default",
+                                    "Tls11",
+                                    "Tls12",
+                                    "Tls13"
+                                  ],
+                                  "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
+                                }
+                              },
+                              "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                            }
+                          },
+                          "description": "Connection endpoint."
+                        },
+                        "HandshakeContinuationTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Amount of time protocol handshake operations are allowed to take before timing out."
                         },
                         "HostName": {
                           "type": "string",
-                          "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                          "description": "The host to connect to."
+                        },
+                        "MaxInboundMessageBodySize": {
+                          "type": "integer",
+                          "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the ConnectionFactory.DefaultMaxMessageSize setting."
+                        },
+                        "NetworkRecoveryInterval": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Amount of time client will wait for before re-trying  to recover connection."
+                        },
+                        "Password": {
+                          "type": "string",
+                          "description": "Password to use when authenticating to the server."
                         },
                         "Port": {
                           "type": "integer",
-                          "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                          "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
+                        },
+                        "RequestedChannelMax": {
+                          "type": "integer",
+                          "description": "Maximum channel number to ask for."
+                        },
+                        "RequestedConnectionTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Timeout setting for connection attempts."
+                        },
+                        "RequestedFrameMax": {
+                          "type": "integer",
+                          "description": "Frame-max parameter to ask for (in bytes)."
+                        },
+                        "RequestedHeartbeat": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Heartbeat timeout to use when negotiating with the server."
+                        },
+                        "SocketReadTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Timeout setting for socket read operations."
+                        },
+                        "SocketWriteTimeout": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Timeout setting for socket write operations."
                         },
                         "Ssl": {
                           "type": "object",
@@ -198,249 +305,137 @@
                               "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
                             }
                           },
-                          "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                          "description": "TLS options setting."
+                        },
+                        "TopologyRecoveryEnabled": {
+                          "type": "boolean",
+                          "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
+                        },
+                        "Uri": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "The uri to use for the connection."
+                        },
+                        "UserName": {
+                          "type": "string",
+                          "description": "Username to use when authenticating to the server."
+                        },
+                        "VirtualHost": {
+                          "type": "string",
+                          "description": "Virtual host to access during this connection."
                         }
                       },
-                      "description": "Connection endpoint."
+                      "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
                     },
-                    "HandshakeContinuationTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Amount of time protocol handshake operations are allowed to take before timing out."
-                    },
-                    "HostName": {
-                      "type": "string",
-                      "description": "The host to connect to."
-                    },
-                    "MaxInboundMessageBodySize": {
-                      "type": "integer",
-                      "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the ConnectionFactory.DefaultMaxMessageSize setting."
-                    },
-                    "NetworkRecoveryInterval": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Amount of time client will wait for before re-trying  to recover connection."
-                    },
-                    "Password": {
-                      "type": "string",
-                      "description": "Password to use when authenticating to the server."
-                    },
-                    "Port": {
-                      "type": "integer",
-                      "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
-                    },
-                    "RequestedChannelMax": {
-                      "type": "integer",
-                      "description": "Maximum channel number to ask for."
-                    },
-                    "RequestedConnectionTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Timeout setting for connection attempts."
-                    },
-                    "RequestedFrameMax": {
-                      "type": "integer",
-                      "description": "Frame-max parameter to ask for (in bytes)."
-                    },
-                    "RequestedHeartbeat": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Heartbeat timeout to use when negotiating with the server."
-                    },
-                    "SocketReadTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Timeout setting for socket read operations."
-                    },
-                    "SocketWriteTimeout": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Timeout setting for socket write operations."
-                    },
-                    "Ssl": {
-                      "type": "object",
-                      "properties": {
-                        "AcceptablePolicyErrors": {
-                          "enum": [
-                            "None",
-                            "RemoteCertificateNotAvailable",
-                            "RemoteCertificateNameMismatch",
-                            "RemoteCertificateChainErrors"
-                          ],
-                          "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
-                        },
-                        "CertPassphrase": {
-                          "type": "string",
-                          "description": "Retrieve or set the client certificate passphrase."
-                        },
-                        "CertPath": {
-                          "type": "string",
-                          "description": "Retrieve or set the path to client certificate."
-                        },
-                        "CheckCertificateRevocation": {
-                          "type": "boolean",
-                          "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
-                        },
-                        "Enabled": {
-                          "type": "boolean",
-                          "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
-                        },
-                        "ServerName": {
-                          "type": "string",
-                          "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
-                        },
-                        "Version": {
-                          "enum": [
-                            "None",
-                            "Ssl2",
-                            "Ssl3",
-                            "Tls",
-                            "Default",
-                            "Tls11",
-                            "Tls12",
-                            "Tls13"
-                          ],
-                          "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
-                        }
-                      },
-                      "description": "TLS options setting."
-                    },
-                    "TopologyRecoveryEnabled": {
-                      "type": "boolean",
-                      "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
-                    },
-                    "Uri": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "The uri to use for the connection."
-                    },
-                    "UserName": {
-                      "type": "string",
-                      "description": "Username to use when authenticating to the server."
-                    },
-                    "VirtualHost": {
-                      "type": "string",
-                      "description": "Virtual host to access during this connection."
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
                     }
-                  },
-                  "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
+                  ]
                 },
                 "ConnectionString": {
-                  "type": "string",
-                  "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableAutoActivation": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
-                  "default": true
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                      "default": true
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "MaxConnectRetryCount": {
-                  "type": "integer",
-                  "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "ConnectionFactory": {
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
+                  },
+                  {
                     "type": "object",
                     "properties": {
-                      "AmqpUriSslProtocols": {
-                        "enum": [
-                          "None",
-                          "Ssl2",
-                          "Ssl3",
-                          "Tls",
-                          "Default",
-                          "Tls11",
-                          "Tls12",
-                          "Tls13"
-                        ],
-                        "description": "The AMQP URI SSL protocols."
-                      },
-                      "AutomaticRecoveryEnabled": {
-                        "type": "boolean",
-                        "description": "Set to false to disable automatic connection recovery. Defaults to true."
-                      },
-                      "ClientProvidedName": {
-                        "type": "string",
-                        "description": "Default client provided name to be used for connections."
-                      },
-                      "ConsumerDispatchConcurrency": {
-                        "type": "integer",
-                        "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IAsyncBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
-                      },
-                      "ContinuationTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Amount of time protocol operations (e.g. queue.declare) are allowed to take before timing out."
-                      },
-                      "DefaultAddressFamily": {
-                        "enum": [
-                          "Unknown",
-                          "Unspecified",
-                          "Unix",
-                          "InterNetwork",
-                          "ImpLink",
-                          "Pup",
-                          "Chaos",
-                          "Ipx",
-                          "NS",
-                          "Iso",
-                          "Osi",
-                          "Ecma",
-                          "DataKit",
-                          "Ccitt",
-                          "Sna",
-                          "DecNet",
-                          "DataLink",
-                          "Lat",
-                          "HyperChannel",
-                          "AppleTalk",
-                          "NetBios",
-                          "VoiceView",
-                          "FireFox",
-                          "Banyan",
-                          "Atm",
-                          "InterNetworkV6",
-                          "Cluster",
-                          "Ieee12844",
-                          "Irda",
-                          "NetworkDesigners",
-                          "Max",
-                          "Packet",
-                          "ControllerAreaNetwork"
-                        ],
-                        "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
-                      },
-                      "DefaultAmqpUriSslProtocols": {
-                        "enum": [
-                          "None",
-                          "Ssl2",
-                          "Ssl3",
-                          "Tls",
-                          "Default",
-                          "Tls11",
-                          "Tls12",
-                          "Tls13"
-                        ],
-                        "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
-                      },
-                      "Endpoint": {
+                      "ConnectionFactory": {
                         "type": "object",
                         "properties": {
-                          "AddressFamily": {
+                          "AmqpUriSslProtocols": {
+                            "enum": [
+                              "None",
+                              "Ssl2",
+                              "Ssl3",
+                              "Tls",
+                              "Default",
+                              "Tls11",
+                              "Tls12",
+                              "Tls13"
+                            ],
+                            "description": "The AMQP URI SSL protocols."
+                          },
+                          "AutomaticRecoveryEnabled": {
+                            "type": "boolean",
+                            "description": "Set to false to disable automatic connection recovery. Defaults to true."
+                          },
+                          "ClientProvidedName": {
+                            "type": "string",
+                            "description": "Default client provided name to be used for connections."
+                          },
+                          "ConsumerDispatchConcurrency": {
+                            "type": "integer",
+                            "description": "Set to a value greater than one to enable concurrent processing. For a concurrency greater than one 'RabbitMQ.Client.IAsyncBasicConsumer' will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading. 'RabbitMQ.Client.IAsyncBasicConsumer' can handle concurrency much more efficiently due to the non-blocking nature of the consumer. Defaults to 1."
+                          },
+                          "ContinuationTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Amount of time protocol operations (e.g. queue.declare) are allowed to take before timing out."
+                          },
+                          "DefaultAddressFamily": {
                             "enum": [
                               "Unknown",
                               "Unspecified",
@@ -476,15 +471,174 @@
                               "Packet",
                               "ControllerAreaNetwork"
                             ],
-                            "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                            "description": "Address family used by default. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                          },
+                          "DefaultAmqpUriSslProtocols": {
+                            "enum": [
+                              "None",
+                              "Ssl2",
+                              "Ssl3",
+                              "Tls",
+                              "Default",
+                              "Tls11",
+                              "Tls12",
+                              "Tls13"
+                            ],
+                            "description": "TLS versions enabled by default: TLSv1.2, v1.1, v1.0."
+                          },
+                          "Endpoint": {
+                            "type": "object",
+                            "properties": {
+                              "AddressFamily": {
+                                "enum": [
+                                  "Unknown",
+                                  "Unspecified",
+                                  "Unix",
+                                  "InterNetwork",
+                                  "ImpLink",
+                                  "Pup",
+                                  "Chaos",
+                                  "Ipx",
+                                  "NS",
+                                  "Iso",
+                                  "Osi",
+                                  "Ecma",
+                                  "DataKit",
+                                  "Ccitt",
+                                  "Sna",
+                                  "DecNet",
+                                  "DataLink",
+                                  "Lat",
+                                  "HyperChannel",
+                                  "AppleTalk",
+                                  "NetBios",
+                                  "VoiceView",
+                                  "FireFox",
+                                  "Banyan",
+                                  "Atm",
+                                  "InterNetworkV6",
+                                  "Cluster",
+                                  "Ieee12844",
+                                  "Irda",
+                                  "NetworkDesigners",
+                                  "Max",
+                                  "Packet",
+                                  "ControllerAreaNetwork"
+                                ],
+                                "description": "Used to force the address family of the endpoint. Use 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4. Use 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6. Or use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
+                              },
+                              "HostName": {
+                                "type": "string",
+                                "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                              },
+                              "Port": {
+                                "type": "integer",
+                                "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                              },
+                              "Ssl": {
+                                "type": "object",
+                                "properties": {
+                                  "AcceptablePolicyErrors": {
+                                    "enum": [
+                                      "None",
+                                      "RemoteCertificateNotAvailable",
+                                      "RemoteCertificateNameMismatch",
+                                      "RemoteCertificateChainErrors"
+                                    ],
+                                    "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
+                                  },
+                                  "CertPassphrase": {
+                                    "type": "string",
+                                    "description": "Retrieve or set the client certificate passphrase."
+                                  },
+                                  "CertPath": {
+                                    "type": "string",
+                                    "description": "Retrieve or set the path to client certificate."
+                                  },
+                                  "CheckCertificateRevocation": {
+                                    "type": "boolean",
+                                    "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
+                                  },
+                                  "Enabled": {
+                                    "type": "boolean",
+                                    "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
+                                  },
+                                  "ServerName": {
+                                    "type": "string",
+                                    "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
+                                  },
+                                  "Version": {
+                                    "enum": [
+                                      "None",
+                                      "Ssl2",
+                                      "Ssl3",
+                                      "Tls",
+                                      "Default",
+                                      "Tls11",
+                                      "Tls12",
+                                      "Tls13"
+                                    ],
+                                    "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
+                                  }
+                                },
+                                "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                              }
+                            },
+                            "description": "Connection endpoint."
+                          },
+                          "HandshakeContinuationTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Amount of time protocol handshake operations are allowed to take before timing out."
                           },
                           "HostName": {
                             "type": "string",
-                            "description": "Retrieve or set the hostname of this 'RabbitMQ.Client.AmqpTcpEndpoint'."
+                            "description": "The host to connect to."
+                          },
+                          "MaxInboundMessageBodySize": {
+                            "type": "integer",
+                            "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the ConnectionFactory.DefaultMaxMessageSize setting."
+                          },
+                          "NetworkRecoveryInterval": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Amount of time client will wait for before re-trying  to recover connection."
+                          },
+                          "Password": {
+                            "type": "string",
+                            "description": "Password to use when authenticating to the server."
                           },
                           "Port": {
                             "type": "integer",
-                            "description": "Retrieve or set the port number of this AmqpTcpEndpoint. A port number of -1 causes the default port number."
+                            "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
+                          },
+                          "RequestedChannelMax": {
+                            "type": "integer",
+                            "description": "Maximum channel number to ask for."
+                          },
+                          "RequestedConnectionTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Timeout setting for connection attempts."
+                          },
+                          "RequestedFrameMax": {
+                            "type": "integer",
+                            "description": "Frame-max parameter to ask for (in bytes)."
+                          },
+                          "RequestedHeartbeat": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Heartbeat timeout to use when negotiating with the server."
+                          },
+                          "SocketReadTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Timeout setting for socket read operations."
+                          },
+                          "SocketWriteTimeout": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Timeout setting for socket write operations."
                           },
                           "Ssl": {
                             "type": "object",
@@ -532,158 +686,55 @@
                                 "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
                               }
                             },
-                            "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
+                            "description": "TLS options setting."
+                          },
+                          "TopologyRecoveryEnabled": {
+                            "type": "boolean",
+                            "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
+                          },
+                          "Uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The uri to use for the connection."
+                          },
+                          "UserName": {
+                            "type": "string",
+                            "description": "Username to use when authenticating to the server."
+                          },
+                          "VirtualHost": {
+                            "type": "string",
+                            "description": "Virtual host to access during this connection."
                           }
                         },
-                        "description": "Connection endpoint."
+                        "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
                       },
-                      "HandshakeContinuationTimeout": {
+                      "ConnectionString": {
                         "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Amount of time protocol handshake operations are allowed to take before timing out."
+                        "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
                       },
-                      "HostName": {
-                        "type": "string",
-                        "description": "The host to connect to."
-                      },
-                      "MaxInboundMessageBodySize": {
-                        "type": "integer",
-                        "description": "Maximum allowed message size, in bytes, from RabbitMQ. Corresponds to the ConnectionFactory.DefaultMaxMessageSize setting."
-                      },
-                      "NetworkRecoveryInterval": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Amount of time client will wait for before re-trying  to recover connection."
-                      },
-                      "Password": {
-                        "type": "string",
-                        "description": "Password to use when authenticating to the server."
-                      },
-                      "Port": {
-                        "type": "integer",
-                        "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
-                      },
-                      "RequestedChannelMax": {
-                        "type": "integer",
-                        "description": "Maximum channel number to ask for."
-                      },
-                      "RequestedConnectionTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Timeout setting for connection attempts."
-                      },
-                      "RequestedFrameMax": {
-                        "type": "integer",
-                        "description": "Frame-max parameter to ask for (in bytes)."
-                      },
-                      "RequestedHeartbeat": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Heartbeat timeout to use when negotiating with the server."
-                      },
-                      "SocketReadTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Timeout setting for socket read operations."
-                      },
-                      "SocketWriteTimeout": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Timeout setting for socket write operations."
-                      },
-                      "Ssl": {
-                        "type": "object",
-                        "properties": {
-                          "AcceptablePolicyErrors": {
-                            "enum": [
-                              "None",
-                              "RemoteCertificateNotAvailable",
-                              "RemoteCertificateNameMismatch",
-                              "RemoteCertificateChainErrors"
-                            ],
-                            "description": "Retrieve or set the set of TLS policy (peer verification) errors that are deemed acceptable."
-                          },
-                          "CertPassphrase": {
-                            "type": "string",
-                            "description": "Retrieve or set the client certificate passphrase."
-                          },
-                          "CertPath": {
-                            "type": "string",
-                            "description": "Retrieve or set the path to client certificate."
-                          },
-                          "CheckCertificateRevocation": {
-                            "type": "boolean",
-                            "description": "Attempts to check certificate revocation status. Default is false. Set to true to check peer certificate for revocation."
-                          },
-                          "Enabled": {
-                            "type": "boolean",
-                            "description": "Controls if TLS should indeed be used. Set to false to disable TLS on the connection."
-                          },
-                          "ServerName": {
-                            "type": "string",
-                            "description": "Retrieve or set server's expected name. This MUST match the Subject Alternative Name (SAN) or CN on the peer's (server's) leaf certificate, otherwise the TLS connection will fail."
-                          },
-                          "Version": {
-                            "enum": [
-                              "None",
-                              "Ssl2",
-                              "Ssl3",
-                              "Tls",
-                              "Default",
-                              "Tls11",
-                              "Tls12",
-                              "Tls13"
-                            ],
-                            "description": "Retrieve or set the TLS protocol version. The client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None'. If this option is disabled, e.g.see via app context, the client will attempt to fall back to TLSv1.2."
-                          }
-                        },
-                        "description": "TLS options setting."
-                      },
-                      "TopologyRecoveryEnabled": {
+                      "DisableAutoActivation": {
                         "type": "boolean",
-                        "description": "Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc). Defaults to true."
+                        "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                        "default": true
                       },
-                      "Uri": {
-                        "type": "string",
-                        "format": "uri",
-                        "description": "The uri to use for the connection."
+                      "DisableHealthChecks": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
+                        "default": false
                       },
-                      "UserName": {
-                        "type": "string",
-                        "description": "Username to use when authenticating to the server."
+                      "DisableTracing": {
+                        "type": "boolean",
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
                       },
-                      "VirtualHost": {
-                        "type": "string",
-                        "description": "Virtual host to access during this connection."
+                      "MaxConnectRetryCount": {
+                        "type": "integer",
+                        "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
                       }
                     },
-                    "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
-                  },
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
-                  },
-                  "DisableAutoActivation": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
-                    "default": true
-                  },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
-                    "default": false
-                  },
-                  "DisableTracing": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                    "default": false
-                  },
-                  "MaxConnectRetryCount": {
-                    "type": "integer",
-                    "description": "Gets or sets the maximum number of connection retry attempts.\n\nDefault value is 5, set it to 0 to disable the retry mechanism."
+                    "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
@@ -328,7 +328,142 @@
                       "description": "Main entry point to the RabbitMQ .NET AMQP client API. Constructs 'RabbitMQ.Client.IConnection' instances."
                     },
                     {
-                      "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                      "allOf": [
+                        {
+                          "$ref": "#/properties/Aspire/properties/RabbitMQ/properties/Client/additionalProperties/anyOf/1"
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "DefaultAmqpUriSslProtocols"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "AmqpUriSslProtocols"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "DefaultAddressFamily"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "AutomaticRecoveryEnabled"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ConsumerDispatchConcurrency"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "HostName"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "NetworkRecoveryInterval"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "HandshakeContinuationTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ContinuationTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Port"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "RequestedConnectionTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "SocketReadTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "SocketWriteTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Ssl"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "TopologyRecoveryEnabled"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Endpoint"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "UserName"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Password"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "RequestedChannelMax"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "RequestedFrameMax"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "RequestedHeartbeat"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "VirtualHost"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "MaxInboundMessageBodySize"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Uri"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ClientProvidedName"
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
                     }
                   ]
                 },

--- a/src/Components/Aspire.Seq/AspireSeqExtensions.cs
+++ b/src/Components/Aspire.Seq/AspireSeqExtensions.cs
@@ -41,8 +41,11 @@ public static class AspireSeqExtensions
         settings.Traces.ExportProcessorType = ExportProcessorType.Batch;
 
         var configSection = builder.Configuration.GetSection(DefaultConfigSectionName);
-        var namedConfigSection = builder.Configuration.GetSection(connectionName);
+        var legacyNamedConfigSection = builder.Configuration.GetSection(connectionName);
+        var namedConfigSection = configSection.GetSection(connectionName);
         configSection.Bind(settings);
+        // Preserve the legacy root-level named section while preferring the standard integration-specific section.
+        legacyNamedConfigSection.Bind(settings);
         namedConfigSection.Bind(settings);
 
         if (builder.Configuration.GetConnectionString(connectionName) is string connectionString)

--- a/src/Components/Aspire.Seq/AssemblyInfo.cs
+++ b/src/Components/Aspire.Seq/AssemblyInfo.cs
@@ -5,5 +5,6 @@ using Aspire;
 using Aspire.Seq;
 
 [assembly: ConfigurationSchema("Aspire:Seq", typeof(SeqSettings))]
+[assembly: ConfigurationSchema("Aspire:Seq:*", typeof(SeqSettings))]
 
 [assembly: LoggingCategories("Seq")]

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -97,7 +97,52 @@
                   "description": "Gets OTLP exporter options for logs."
                 },
                 {
-                  "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
+                  "allOf": [
+                    {
+                      "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "Endpoint"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "Headers"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "TimeoutMilliseconds"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "Protocol"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "UserAgentProductIdentifier"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "ExportProcessorType"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "BatchExportProcessorOptions"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -170,7 +215,52 @@
                   "description": "Gets OTLP exporter options for traces."
                 },
                 {
-                  "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
+                  "allOf": [
+                    {
+                      "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "Endpoint"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "Headers"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "TimeoutMilliseconds"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "Protocol"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "UserAgentProductIdentifier"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "ExportProcessorType"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "BatchExportProcessorOptions"
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -17,258 +17,302 @@
           "type": "object",
           "properties": {
             "ApiKey": {
-              "type": "string",
-              "description": "Gets or sets a Seq API key that authenticates the client to the Seq server."
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "Gets or sets a Seq API key that authenticates the client to the Seq server."
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "DisableHealthChecks": {
-              "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the Seq server health check is disabled or not.",
-              "default": false
+              "anyOf": [
+                {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the Seq server health check is disabled or not.",
+                  "default": false
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "Logs": {
-              "type": "object",
-              "properties": {
-                "BatchExportProcessorOptions": {
+              "anyOf": [
+                {
                   "type": "object",
                   "properties": {
-                    "ExporterTimeoutMilliseconds": {
-                      "type": "integer"
+                    "BatchExportProcessorOptions": {
+                      "type": "object",
+                      "properties": {
+                        "ExporterTimeoutMilliseconds": {
+                          "type": "integer"
+                        },
+                        "MaxExportBatchSize": {
+                          "type": "integer"
+                        },
+                        "MaxQueueSize": {
+                          "type": "integer"
+                        },
+                        "ScheduledDelayMilliseconds": {
+                          "type": "integer"
+                        }
+                      },
+                      "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
                     },
-                    "MaxExportBatchSize": {
-                      "type": "integer"
+                    "Endpoint": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Gets or sets the target to which the exporter is going to send telemetry."
                     },
-                    "MaxQueueSize": {
-                      "type": "integer"
+                    "ExportProcessorType": {
+                      "enum": [
+                        "Simple",
+                        "Batch"
+                      ],
+                      "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
                     },
-                    "ScheduledDelayMilliseconds": {
-                      "type": "integer"
+                    "Headers": {
+                      "type": "string",
+                      "description": "Gets or sets optional headers for the connection."
+                    },
+                    "Protocol": {
+                      "enum": [
+                        "Grpc",
+                        "HttpProtobuf"
+                      ],
+                      "description": "Gets or sets the OTLP transport protocol."
+                    },
+                    "TimeoutMilliseconds": {
+                      "type": "integer",
+                      "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
+                    },
+                    "UserAgentProductIdentifier": {
+                      "type": "string",
+                      "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
                     }
                   },
-                  "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                  "description": "Gets OTLP exporter options for logs."
                 },
-                "Endpoint": {
-                  "type": "string",
-                  "format": "uri",
-                  "description": "Gets or sets the target to which the exporter is going to send telemetry."
-                },
-                "ExportProcessorType": {
-                  "enum": [
-                    "Simple",
-                    "Batch"
-                  ],
-                  "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
-                },
-                "Headers": {
-                  "type": "string",
-                  "description": "Gets or sets optional headers for the connection."
-                },
-                "Protocol": {
-                  "enum": [
-                    "Grpc",
-                    "HttpProtobuf"
-                  ],
-                  "description": "Gets or sets the OTLP transport protocol."
-                },
-                "TimeoutMilliseconds": {
-                  "type": "integer",
-                  "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
-                },
-                "UserAgentProductIdentifier": {
-                  "type": "string",
-                  "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
+                {
+                  "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
                 }
-              },
-              "description": "Gets OTLP exporter options for logs."
+              ]
             },
             "ServerUrl": {
-              "type": "string",
-              "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789. Overrides endpoints set on Logs and Traces.\""
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789. Overrides endpoints set on Logs and Traces.\""
+                },
+                {
+                  "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
+                }
+              ]
             },
             "Traces": {
-              "type": "object",
-              "properties": {
-                "BatchExportProcessorOptions": {
+              "anyOf": [
+                {
                   "type": "object",
                   "properties": {
-                    "ExporterTimeoutMilliseconds": {
-                      "type": "integer"
+                    "BatchExportProcessorOptions": {
+                      "type": "object",
+                      "properties": {
+                        "ExporterTimeoutMilliseconds": {
+                          "type": "integer"
+                        },
+                        "MaxExportBatchSize": {
+                          "type": "integer"
+                        },
+                        "MaxQueueSize": {
+                          "type": "integer"
+                        },
+                        "ScheduledDelayMilliseconds": {
+                          "type": "integer"
+                        }
+                      },
+                      "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
                     },
-                    "MaxExportBatchSize": {
-                      "type": "integer"
+                    "Endpoint": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Gets or sets the target to which the exporter is going to send telemetry."
                     },
-                    "MaxQueueSize": {
-                      "type": "integer"
+                    "ExportProcessorType": {
+                      "enum": [
+                        "Simple",
+                        "Batch"
+                      ],
+                      "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
                     },
-                    "ScheduledDelayMilliseconds": {
-                      "type": "integer"
+                    "Headers": {
+                      "type": "string",
+                      "description": "Gets or sets optional headers for the connection."
+                    },
+                    "Protocol": {
+                      "enum": [
+                        "Grpc",
+                        "HttpProtobuf"
+                      ],
+                      "description": "Gets or sets the OTLP transport protocol."
+                    },
+                    "TimeoutMilliseconds": {
+                      "type": "integer",
+                      "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
+                    },
+                    "UserAgentProductIdentifier": {
+                      "type": "string",
+                      "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
                     }
                   },
-                  "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                  "description": "Gets OTLP exporter options for traces."
                 },
-                "Endpoint": {
-                  "type": "string",
-                  "format": "uri",
-                  "description": "Gets or sets the target to which the exporter is going to send telemetry."
-                },
-                "ExportProcessorType": {
-                  "enum": [
-                    "Simple",
-                    "Batch"
-                  ],
-                  "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
-                },
-                "Headers": {
-                  "type": "string",
-                  "description": "Gets or sets optional headers for the connection."
-                },
-                "Protocol": {
-                  "enum": [
-                    "Grpc",
-                    "HttpProtobuf"
-                  ],
-                  "description": "Gets or sets the OTLP transport protocol."
-                },
-                "TimeoutMilliseconds": {
-                  "type": "integer",
-                  "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
-                },
-                "UserAgentProductIdentifier": {
-                  "type": "string",
-                  "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
+                {
+                  "$ref": "#/properties/Aspire/properties/Seq/additionalProperties/anyOf/1"
                 }
-              },
-              "description": "Gets OTLP exporter options for traces."
+              ]
             }
           },
           "description": "Provides the client configuration settings for connecting telemetry to a Seq server.",
           "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "ApiKey": {
-                "type": "string",
-                "description": "Gets or sets a Seq API key that authenticates the client to the Seq server."
+            "anyOf": [
+              {
+                "not": {
+                  "type": "object"
+                }
               },
-              "DisableHealthChecks": {
-                "type": "boolean",
-                "description": "Gets or sets a boolean value that indicates whether the Seq server health check is disabled or not.",
-                "default": false
-              },
-              "Logs": {
+              {
                 "type": "object",
                 "properties": {
-                  "BatchExportProcessorOptions": {
+                  "ApiKey": {
+                    "type": "string",
+                    "description": "Gets or sets a Seq API key that authenticates the client to the Seq server."
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the Seq server health check is disabled or not.",
+                    "default": false
+                  },
+                  "Logs": {
                     "type": "object",
                     "properties": {
-                      "ExporterTimeoutMilliseconds": {
-                        "type": "integer"
+                      "BatchExportProcessorOptions": {
+                        "type": "object",
+                        "properties": {
+                          "ExporterTimeoutMilliseconds": {
+                            "type": "integer"
+                          },
+                          "MaxExportBatchSize": {
+                            "type": "integer"
+                          },
+                          "MaxQueueSize": {
+                            "type": "integer"
+                          },
+                          "ScheduledDelayMilliseconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
                       },
-                      "MaxExportBatchSize": {
-                        "type": "integer"
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Gets or sets the target to which the exporter is going to send telemetry."
                       },
-                      "MaxQueueSize": {
-                        "type": "integer"
+                      "ExportProcessorType": {
+                        "enum": [
+                          "Simple",
+                          "Batch"
+                        ],
+                        "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
                       },
-                      "ScheduledDelayMilliseconds": {
-                        "type": "integer"
+                      "Headers": {
+                        "type": "string",
+                        "description": "Gets or sets optional headers for the connection."
+                      },
+                      "Protocol": {
+                        "enum": [
+                          "Grpc",
+                          "HttpProtobuf"
+                        ],
+                        "description": "Gets or sets the OTLP transport protocol."
+                      },
+                      "TimeoutMilliseconds": {
+                        "type": "integer",
+                        "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
+                      },
+                      "UserAgentProductIdentifier": {
+                        "type": "string",
+                        "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
                       }
                     },
-                    "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                    "description": "Gets OTLP exporter options for logs."
                   },
-                  "Endpoint": {
+                  "ServerUrl": {
                     "type": "string",
-                    "format": "uri",
-                    "description": "Gets or sets the target to which the exporter is going to send telemetry."
+                    "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789. Overrides endpoints set on Logs and Traces.\""
                   },
-                  "ExportProcessorType": {
-                    "enum": [
-                      "Simple",
-                      "Batch"
-                    ],
-                    "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
-                  },
-                  "Headers": {
-                    "type": "string",
-                    "description": "Gets or sets optional headers for the connection."
-                  },
-                  "Protocol": {
-                    "enum": [
-                      "Grpc",
-                      "HttpProtobuf"
-                    ],
-                    "description": "Gets or sets the OTLP transport protocol."
-                  },
-                  "TimeoutMilliseconds": {
-                    "type": "integer",
-                    "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
-                  },
-                  "UserAgentProductIdentifier": {
-                    "type": "string",
-                    "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
-                  }
-                },
-                "description": "Gets OTLP exporter options for logs."
-              },
-              "ServerUrl": {
-                "type": "string",
-                "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789. Overrides endpoints set on Logs and Traces.\""
-              },
-              "Traces": {
-                "type": "object",
-                "properties": {
-                  "BatchExportProcessorOptions": {
+                  "Traces": {
                     "type": "object",
                     "properties": {
-                      "ExporterTimeoutMilliseconds": {
-                        "type": "integer"
+                      "BatchExportProcessorOptions": {
+                        "type": "object",
+                        "properties": {
+                          "ExporterTimeoutMilliseconds": {
+                            "type": "integer"
+                          },
+                          "MaxExportBatchSize": {
+                            "type": "integer"
+                          },
+                          "MaxQueueSize": {
+                            "type": "integer"
+                          },
+                          "ScheduledDelayMilliseconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
                       },
-                      "MaxExportBatchSize": {
-                        "type": "integer"
+                      "Endpoint": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Gets or sets the target to which the exporter is going to send telemetry."
                       },
-                      "MaxQueueSize": {
-                        "type": "integer"
+                      "ExportProcessorType": {
+                        "enum": [
+                          "Simple",
+                          "Batch"
+                        ],
+                        "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
                       },
-                      "ScheduledDelayMilliseconds": {
-                        "type": "integer"
+                      "Headers": {
+                        "type": "string",
+                        "description": "Gets or sets optional headers for the connection."
+                      },
+                      "Protocol": {
+                        "enum": [
+                          "Grpc",
+                          "HttpProtobuf"
+                        ],
+                        "description": "Gets or sets the OTLP transport protocol."
+                      },
+                      "TimeoutMilliseconds": {
+                        "type": "integer",
+                        "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
+                      },
+                      "UserAgentProductIdentifier": {
+                        "type": "string",
+                        "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
                       }
                     },
-                    "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
-                  },
-                  "Endpoint": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "Gets or sets the target to which the exporter is going to send telemetry."
-                  },
-                  "ExportProcessorType": {
-                    "enum": [
-                      "Simple",
-                      "Batch"
-                    ],
-                    "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
-                  },
-                  "Headers": {
-                    "type": "string",
-                    "description": "Gets or sets optional headers for the connection."
-                  },
-                  "Protocol": {
-                    "enum": [
-                      "Grpc",
-                      "HttpProtobuf"
-                    ],
-                    "description": "Gets or sets the OTLP transport protocol."
-                  },
-                  "TimeoutMilliseconds": {
-                    "type": "integer",
-                    "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
-                  },
-                  "UserAgentProductIdentifier": {
-                    "type": "string",
-                    "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
+                    "description": "Gets OTLP exporter options for traces."
                   }
                 },
-                "description": "Gets OTLP exporter options for traces."
+                "description": "Provides the client configuration settings for connecting telemetry to a Seq server."
               }
-            },
-            "description": "Provides the client configuration settings for connecting telemetry to a Seq server."
+            ]
           }
         }
       }

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -140,7 +140,136 @@
               "description": "Gets OTLP exporter options for traces."
             }
           },
-          "description": "Provides the client configuration settings for connecting telemetry to a Seq server."
+          "description": "Provides the client configuration settings for connecting telemetry to a Seq server.",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "ApiKey": {
+                "type": "string",
+                "description": "Gets or sets a Seq API key that authenticates the client to the Seq server."
+              },
+              "DisableHealthChecks": {
+                "type": "boolean",
+                "description": "Gets or sets a boolean value that indicates whether the Seq server health check is disabled or not.",
+                "default": false
+              },
+              "Logs": {
+                "type": "object",
+                "properties": {
+                  "BatchExportProcessorOptions": {
+                    "type": "object",
+                    "properties": {
+                      "ExporterTimeoutMilliseconds": {
+                        "type": "integer"
+                      },
+                      "MaxExportBatchSize": {
+                        "type": "integer"
+                      },
+                      "MaxQueueSize": {
+                        "type": "integer"
+                      },
+                      "ScheduledDelayMilliseconds": {
+                        "type": "integer"
+                      }
+                    },
+                    "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                  },
+                  "Endpoint": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Gets or sets the target to which the exporter is going to send telemetry."
+                  },
+                  "ExportProcessorType": {
+                    "enum": [
+                      "Simple",
+                      "Batch"
+                    ],
+                    "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
+                  },
+                  "Headers": {
+                    "type": "string",
+                    "description": "Gets or sets optional headers for the connection."
+                  },
+                  "Protocol": {
+                    "enum": [
+                      "Grpc",
+                      "HttpProtobuf"
+                    ],
+                    "description": "Gets or sets the OTLP transport protocol."
+                  },
+                  "TimeoutMilliseconds": {
+                    "type": "integer",
+                    "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
+                  },
+                  "UserAgentProductIdentifier": {
+                    "type": "string",
+                    "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
+                  }
+                },
+                "description": "Gets OTLP exporter options for logs."
+              },
+              "ServerUrl": {
+                "type": "string",
+                "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789. Overrides endpoints set on Logs and Traces.\""
+              },
+              "Traces": {
+                "type": "object",
+                "properties": {
+                  "BatchExportProcessorOptions": {
+                    "type": "object",
+                    "properties": {
+                      "ExporterTimeoutMilliseconds": {
+                        "type": "integer"
+                      },
+                      "MaxExportBatchSize": {
+                        "type": "integer"
+                      },
+                      "MaxQueueSize": {
+                        "type": "integer"
+                      },
+                      "ScheduledDelayMilliseconds": {
+                        "type": "integer"
+                      }
+                    },
+                    "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                  },
+                  "Endpoint": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Gets or sets the target to which the exporter is going to send telemetry."
+                  },
+                  "ExportProcessorType": {
+                    "enum": [
+                      "Simple",
+                      "Batch"
+                    ],
+                    "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
+                  },
+                  "Headers": {
+                    "type": "string",
+                    "description": "Gets or sets optional headers for the connection."
+                  },
+                  "Protocol": {
+                    "enum": [
+                      "Grpc",
+                      "HttpProtobuf"
+                    ],
+                    "description": "Gets or sets the OTLP transport protocol."
+                  },
+                  "TimeoutMilliseconds": {
+                    "type": "integer",
+                    "description": "Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. Default value: 10000."
+                  },
+                  "UserAgentProductIdentifier": {
+                    "type": "string",
+                    "description": "Gets or sets a custom user agent identifier. This will be prepended to the default user agent string."
+                  }
+                },
+                "description": "Gets OTLP exporter options for traces."
+              }
+            },
+            "description": "Provides the client configuration settings for connecting telemetry to a Seq server."
+          }
         }
       }
     }

--- a/src/Components/Aspire.StackExchange.Redis/AssemblyInfo.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AssemblyInfo.cs
@@ -7,5 +7,7 @@ using StackExchange.Redis;
 
 [assembly: ConfigurationSchema("Aspire:StackExchange:Redis", typeof(StackExchangeRedisSettings))]
 [assembly: ConfigurationSchema("Aspire:StackExchange:Redis:ConfigurationOptions", typeof(ConfigurationOptions))]
+[assembly: ConfigurationSchema("Aspire:StackExchange:Redis:*", typeof(StackExchangeRedisSettings))]
+[assembly: ConfigurationSchema("Aspire:StackExchange:Redis:*:ConfigurationOptions", typeof(ConfigurationOptions))]
 
 [assembly: LoggingCategories("StackExchange.Redis")]

--- a/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
+++ b/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
@@ -192,7 +192,185 @@
                   "default": false
                 }
               },
-              "description": "Provides the client configuration settings for connecting to a Redis server."
+              "description": "Provides the client configuration settings for connecting to a Redis server.",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "ConfigurationOptions": {
+                    "type": "object",
+                    "properties": {
+                      "AbortOnConnectFail": {
+                        "type": "boolean",
+                        "description": "Gets or sets whether connect/configuration timeouts should be explicitly notified via a TimeoutException."
+                      },
+                      "AllowAdmin": {
+                        "type": "boolean",
+                        "description": "Indicates whether admin operations should be allowed."
+                      },
+                      "AsyncTimeout": {
+                        "type": "integer",
+                        "description": "Specifies the time in milliseconds that the system should allow for asynchronous operations (defaults to SyncTimeout)."
+                      },
+                      "ChannelPrefix": {
+                        "type": "object",
+                        "properties": {
+                          "UseImplicitAutoPattern": {
+                            "type": "boolean",
+                            "description": "Indicates whether channels should use 'StackExchange.Redis.RedisChannel.PatternMode.Auto' when no 'StackExchange.Redis.RedisChannel.PatternMode' is specified; this is enabled by default, but can be disabled to avoid unexpected wildcard scenarios."
+                          }
+                        },
+                        "description": "Automatically encodes and decodes channels."
+                      },
+                      "CheckCertificateRevocation": {
+                        "type": "boolean",
+                        "description": "A Boolean value that specifies whether the certificate revocation list is checked during authentication."
+                      },
+                      "ClientName": {
+                        "type": "string",
+                        "description": "The client name to use for all connections."
+                      },
+                      "ConfigCheckSeconds": {
+                        "type": "integer",
+                        "description": "Check configuration every n seconds (every minute by default)."
+                      },
+                      "ConfigurationChannel": {
+                        "type": "string",
+                        "description": "Channel to use for broadcasting and listening for configuration change notification."
+                      },
+                      "ConnectRetry": {
+                        "type": "integer",
+                        "description": "The number of times to repeat the initial connect cycle if no servers respond promptly."
+                      },
+                      "ConnectTimeout": {
+                        "type": "integer",
+                        "description": "Specifies the time in milliseconds that should be allowed for connection (defaults to 5 seconds unless SyncTimeout is higher)."
+                      },
+                      "DefaultDatabase": {
+                        "type": "integer",
+                        "description": "Specifies the default database to be used when calling 'StackExchange.Redis.ConnectionMultiplexer.GetDatabase(System.Int32,System.Object)' without any parameters."
+                      },
+                      "DefaultVersion": {
+                        "type": "string",
+                        "description": "The server version to assume."
+                      },
+                      "HeartbeatConsistencyChecks": {
+                        "type": "boolean",
+                        "description": "Whether to enable ECHO checks on every heartbeat to ensure network stream consistency. This is a rare measure to react to any potential network traffic drops ASAP, terminating the connection."
+                      },
+                      "HeartbeatInterval": {
+                        "type": "string",
+                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                        "description": "Controls how often the connection heartbeats. A heartbeat includes: - Evaluating if any messages have timed out. - Evaluating connection status (checking for failures). - Sending a server message to keep the connection alive if needed."
+                      },
+                      "HighIntegrity": {
+                        "type": "boolean",
+                        "description": "A Boolean value that specifies whether to use per-command validation of strict protocol validity. This sends an additional command after EVERY command which incurs measurable overhead."
+                      },
+                      "IncludeDetailInExceptions": {
+                        "type": "boolean",
+                        "description": "Whether exceptions include identifiable details (key names, additional .Data annotations)."
+                      },
+                      "IncludePerformanceCountersInExceptions": {
+                        "type": "boolean",
+                        "description": "Whether exceptions include performance counter details."
+                      },
+                      "KeepAlive": {
+                        "type": "integer",
+                        "description": "Specifies the time in seconds at which connections should be pinged to ensure validity. -1 Defaults to 60 Seconds."
+                      },
+                      "LibraryName": {
+                        "type": "string",
+                        "description": "Gets or sets the library name to use for CLIENT SETINFO lib-name calls to Redis during handshake. Defaults to \"SE.Redis\"."
+                      },
+                      "Password": {
+                        "type": "string",
+                        "description": "The password to use to authenticate with the server."
+                      },
+                      "Protocol": {
+                        "enum": [
+                          "Resp2",
+                          "Resp3"
+                        ],
+                        "description": "Specify the redis protocol type."
+                      },
+                      "Proxy": {
+                        "enum": [
+                          "None",
+                          "Twemproxy",
+                          "Envoyproxy"
+                        ],
+                        "description": "Type of proxy to use (if any); for example 'StackExchange.Redis.Proxy.Twemproxy'."
+                      },
+                      "ResolveDns": {
+                        "type": "boolean",
+                        "description": "Indicates whether endpoints should be resolved via DNS before connecting. If enabled the ConnectionMultiplexer will not re-resolve DNS when attempting to re-connect after a connection failure."
+                      },
+                      "ServiceName": {
+                        "type": "string",
+                        "description": "The service name used to resolve a service via sentinel."
+                      },
+                      "SetClientLibrary": {
+                        "type": "boolean",
+                        "description": "Gets or sets whether the library should identify itself by library-name/version when possible."
+                      },
+                      "Ssl": {
+                        "type": "boolean",
+                        "description": "Indicates whether the connection should be encrypted."
+                      },
+                      "SslHost": {
+                        "type": "string",
+                        "description": "The target-host to use when validating SSL certificate; setting a value here enables SSL mode."
+                      },
+                      "SslProtocols": {
+                        "enum": [
+                          "None",
+                          "Ssl2",
+                          "Ssl3",
+                          "Tls",
+                          "Default",
+                          "Tls11",
+                          "Tls12",
+                          "Tls13"
+                        ],
+                        "description": "Configures which SSL/TLS protocols should be allowed.  If not set, defaults are chosen by the .NET framework."
+                      },
+                      "SyncTimeout": {
+                        "type": "integer",
+                        "description": "Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds)."
+                      },
+                      "TieBreaker": {
+                        "type": "string",
+                        "description": "Tie-breaker used to choose between primaries (must match the endpoint exactly)."
+                      },
+                      "User": {
+                        "type": "string",
+                        "description": "The username to use to authenticate with the server."
+                      }
+                    },
+                    "description": "The options relevant to a set of redis connections."
+                  },
+                  "ConnectionString": {
+                    "type": "string",
+                    "description": "Gets or sets the comma-delimited configuration string used to connect to the Redis server."
+                  },
+                  "DisableAutoActivation": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                    "default": true
+                  },
+                  "DisableHealthChecks": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the Redis health check is disabled or not.",
+                    "default": false
+                  },
+                  "DisableTracing": {
+                    "type": "boolean",
+                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                    "default": false
+                  }
+                },
+                "description": "Provides the client configuration settings for connecting to a Redis server."
+              }
             }
           }
         }

--- a/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
+++ b/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
@@ -20,356 +20,400 @@
               "type": "object",
               "properties": {
                 "ConfigurationOptions": {
-                  "type": "object",
-                  "properties": {
-                    "AbortOnConnectFail": {
-                      "type": "boolean",
-                      "description": "Gets or sets whether connect/configuration timeouts should be explicitly notified via a TimeoutException."
-                    },
-                    "AllowAdmin": {
-                      "type": "boolean",
-                      "description": "Indicates whether admin operations should be allowed."
-                    },
-                    "AsyncTimeout": {
-                      "type": "integer",
-                      "description": "Specifies the time in milliseconds that the system should allow for asynchronous operations (defaults to SyncTimeout)."
-                    },
-                    "ChannelPrefix": {
+                  "anyOf": [
+                    {
                       "type": "object",
                       "properties": {
-                        "UseImplicitAutoPattern": {
+                        "AbortOnConnectFail": {
                           "type": "boolean",
-                          "description": "Indicates whether channels should use 'StackExchange.Redis.RedisChannel.PatternMode.Auto' when no 'StackExchange.Redis.RedisChannel.PatternMode' is specified; this is enabled by default, but can be disabled to avoid unexpected wildcard scenarios."
+                          "description": "Gets or sets whether connect/configuration timeouts should be explicitly notified via a TimeoutException."
+                        },
+                        "AllowAdmin": {
+                          "type": "boolean",
+                          "description": "Indicates whether admin operations should be allowed."
+                        },
+                        "AsyncTimeout": {
+                          "type": "integer",
+                          "description": "Specifies the time in milliseconds that the system should allow for asynchronous operations (defaults to SyncTimeout)."
+                        },
+                        "ChannelPrefix": {
+                          "type": "object",
+                          "properties": {
+                            "UseImplicitAutoPattern": {
+                              "type": "boolean",
+                              "description": "Indicates whether channels should use 'StackExchange.Redis.RedisChannel.PatternMode.Auto' when no 'StackExchange.Redis.RedisChannel.PatternMode' is specified; this is enabled by default, but can be disabled to avoid unexpected wildcard scenarios."
+                            }
+                          },
+                          "description": "Automatically encodes and decodes channels."
+                        },
+                        "CheckCertificateRevocation": {
+                          "type": "boolean",
+                          "description": "A Boolean value that specifies whether the certificate revocation list is checked during authentication."
+                        },
+                        "ClientName": {
+                          "type": "string",
+                          "description": "The client name to use for all connections."
+                        },
+                        "ConfigCheckSeconds": {
+                          "type": "integer",
+                          "description": "Check configuration every n seconds (every minute by default)."
+                        },
+                        "ConfigurationChannel": {
+                          "type": "string",
+                          "description": "Channel to use for broadcasting and listening for configuration change notification."
+                        },
+                        "ConnectRetry": {
+                          "type": "integer",
+                          "description": "The number of times to repeat the initial connect cycle if no servers respond promptly."
+                        },
+                        "ConnectTimeout": {
+                          "type": "integer",
+                          "description": "Specifies the time in milliseconds that should be allowed for connection (defaults to 5 seconds unless SyncTimeout is higher)."
+                        },
+                        "DefaultDatabase": {
+                          "type": "integer",
+                          "description": "Specifies the default database to be used when calling 'StackExchange.Redis.ConnectionMultiplexer.GetDatabase(System.Int32,System.Object)' without any parameters."
+                        },
+                        "DefaultVersion": {
+                          "type": "string",
+                          "description": "The server version to assume."
+                        },
+                        "HeartbeatConsistencyChecks": {
+                          "type": "boolean",
+                          "description": "Whether to enable ECHO checks on every heartbeat to ensure network stream consistency. This is a rare measure to react to any potential network traffic drops ASAP, terminating the connection."
+                        },
+                        "HeartbeatInterval": {
+                          "type": "string",
+                          "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                          "description": "Controls how often the connection heartbeats. A heartbeat includes: - Evaluating if any messages have timed out. - Evaluating connection status (checking for failures). - Sending a server message to keep the connection alive if needed."
+                        },
+                        "HighIntegrity": {
+                          "type": "boolean",
+                          "description": "A Boolean value that specifies whether to use per-command validation of strict protocol validity. This sends an additional command after EVERY command which incurs measurable overhead."
+                        },
+                        "IncludeDetailInExceptions": {
+                          "type": "boolean",
+                          "description": "Whether exceptions include identifiable details (key names, additional .Data annotations)."
+                        },
+                        "IncludePerformanceCountersInExceptions": {
+                          "type": "boolean",
+                          "description": "Whether exceptions include performance counter details."
+                        },
+                        "KeepAlive": {
+                          "type": "integer",
+                          "description": "Specifies the time in seconds at which connections should be pinged to ensure validity. -1 Defaults to 60 Seconds."
+                        },
+                        "LibraryName": {
+                          "type": "string",
+                          "description": "Gets or sets the library name to use for CLIENT SETINFO lib-name calls to Redis during handshake. Defaults to \"SE.Redis\"."
+                        },
+                        "Password": {
+                          "type": "string",
+                          "description": "The password to use to authenticate with the server."
+                        },
+                        "Protocol": {
+                          "enum": [
+                            "Resp2",
+                            "Resp3"
+                          ],
+                          "description": "Specify the redis protocol type."
+                        },
+                        "Proxy": {
+                          "enum": [
+                            "None",
+                            "Twemproxy",
+                            "Envoyproxy"
+                          ],
+                          "description": "Type of proxy to use (if any); for example 'StackExchange.Redis.Proxy.Twemproxy'."
+                        },
+                        "ResolveDns": {
+                          "type": "boolean",
+                          "description": "Indicates whether endpoints should be resolved via DNS before connecting. If enabled the ConnectionMultiplexer will not re-resolve DNS when attempting to re-connect after a connection failure."
+                        },
+                        "ServiceName": {
+                          "type": "string",
+                          "description": "The service name used to resolve a service via sentinel."
+                        },
+                        "SetClientLibrary": {
+                          "type": "boolean",
+                          "description": "Gets or sets whether the library should identify itself by library-name/version when possible."
+                        },
+                        "Ssl": {
+                          "type": "boolean",
+                          "description": "Indicates whether the connection should be encrypted."
+                        },
+                        "SslHost": {
+                          "type": "string",
+                          "description": "The target-host to use when validating SSL certificate; setting a value here enables SSL mode."
+                        },
+                        "SslProtocols": {
+                          "enum": [
+                            "None",
+                            "Ssl2",
+                            "Ssl3",
+                            "Tls",
+                            "Default",
+                            "Tls11",
+                            "Tls12",
+                            "Tls13"
+                          ],
+                          "description": "Configures which SSL/TLS protocols should be allowed.  If not set, defaults are chosen by the .NET framework."
+                        },
+                        "SyncTimeout": {
+                          "type": "integer",
+                          "description": "Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds)."
+                        },
+                        "TieBreaker": {
+                          "type": "string",
+                          "description": "Tie-breaker used to choose between primaries (must match the endpoint exactly)."
+                        },
+                        "User": {
+                          "type": "string",
+                          "description": "The username to use to authenticate with the server."
                         }
                       },
-                      "description": "Automatically encodes and decodes channels."
+                      "description": "The options relevant to a set of redis connections."
                     },
-                    "CheckCertificateRevocation": {
-                      "type": "boolean",
-                      "description": "A Boolean value that specifies whether the certificate revocation list is checked during authentication."
-                    },
-                    "ClientName": {
-                      "type": "string",
-                      "description": "The client name to use for all connections."
-                    },
-                    "ConfigCheckSeconds": {
-                      "type": "integer",
-                      "description": "Check configuration every n seconds (every minute by default)."
-                    },
-                    "ConfigurationChannel": {
-                      "type": "string",
-                      "description": "Channel to use for broadcasting and listening for configuration change notification."
-                    },
-                    "ConnectRetry": {
-                      "type": "integer",
-                      "description": "The number of times to repeat the initial connect cycle if no servers respond promptly."
-                    },
-                    "ConnectTimeout": {
-                      "type": "integer",
-                      "description": "Specifies the time in milliseconds that should be allowed for connection (defaults to 5 seconds unless SyncTimeout is higher)."
-                    },
-                    "DefaultDatabase": {
-                      "type": "integer",
-                      "description": "Specifies the default database to be used when calling 'StackExchange.Redis.ConnectionMultiplexer.GetDatabase(System.Int32,System.Object)' without any parameters."
-                    },
-                    "DefaultVersion": {
-                      "type": "string",
-                      "description": "The server version to assume."
-                    },
-                    "HeartbeatConsistencyChecks": {
-                      "type": "boolean",
-                      "description": "Whether to enable ECHO checks on every heartbeat to ensure network stream consistency. This is a rare measure to react to any potential network traffic drops ASAP, terminating the connection."
-                    },
-                    "HeartbeatInterval": {
-                      "type": "string",
-                      "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                      "description": "Controls how often the connection heartbeats. A heartbeat includes: - Evaluating if any messages have timed out. - Evaluating connection status (checking for failures). - Sending a server message to keep the connection alive if needed."
-                    },
-                    "HighIntegrity": {
-                      "type": "boolean",
-                      "description": "A Boolean value that specifies whether to use per-command validation of strict protocol validity. This sends an additional command after EVERY command which incurs measurable overhead."
-                    },
-                    "IncludeDetailInExceptions": {
-                      "type": "boolean",
-                      "description": "Whether exceptions include identifiable details (key names, additional .Data annotations)."
-                    },
-                    "IncludePerformanceCountersInExceptions": {
-                      "type": "boolean",
-                      "description": "Whether exceptions include performance counter details."
-                    },
-                    "KeepAlive": {
-                      "type": "integer",
-                      "description": "Specifies the time in seconds at which connections should be pinged to ensure validity. -1 Defaults to 60 Seconds."
-                    },
-                    "LibraryName": {
-                      "type": "string",
-                      "description": "Gets or sets the library name to use for CLIENT SETINFO lib-name calls to Redis during handshake. Defaults to \"SE.Redis\"."
-                    },
-                    "Password": {
-                      "type": "string",
-                      "description": "The password to use to authenticate with the server."
-                    },
-                    "Protocol": {
-                      "enum": [
-                        "Resp2",
-                        "Resp3"
-                      ],
-                      "description": "Specify the redis protocol type."
-                    },
-                    "Proxy": {
-                      "enum": [
-                        "None",
-                        "Twemproxy",
-                        "Envoyproxy"
-                      ],
-                      "description": "Type of proxy to use (if any); for example 'StackExchange.Redis.Proxy.Twemproxy'."
-                    },
-                    "ResolveDns": {
-                      "type": "boolean",
-                      "description": "Indicates whether endpoints should be resolved via DNS before connecting. If enabled the ConnectionMultiplexer will not re-resolve DNS when attempting to re-connect after a connection failure."
-                    },
-                    "ServiceName": {
-                      "type": "string",
-                      "description": "The service name used to resolve a service via sentinel."
-                    },
-                    "SetClientLibrary": {
-                      "type": "boolean",
-                      "description": "Gets or sets whether the library should identify itself by library-name/version when possible."
-                    },
-                    "Ssl": {
-                      "type": "boolean",
-                      "description": "Indicates whether the connection should be encrypted."
-                    },
-                    "SslHost": {
-                      "type": "string",
-                      "description": "The target-host to use when validating SSL certificate; setting a value here enables SSL mode."
-                    },
-                    "SslProtocols": {
-                      "enum": [
-                        "None",
-                        "Ssl2",
-                        "Ssl3",
-                        "Tls",
-                        "Default",
-                        "Tls11",
-                        "Tls12",
-                        "Tls13"
-                      ],
-                      "description": "Configures which SSL/TLS protocols should be allowed.  If not set, defaults are chosen by the .NET framework."
-                    },
-                    "SyncTimeout": {
-                      "type": "integer",
-                      "description": "Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds)."
-                    },
-                    "TieBreaker": {
-                      "type": "string",
-                      "description": "Tie-breaker used to choose between primaries (must match the endpoint exactly)."
-                    },
-                    "User": {
-                      "type": "string",
-                      "description": "The username to use to authenticate with the server."
+                    {
+                      "$ref": "#/properties/Aspire/properties/StackExchange/properties/Redis/additionalProperties/anyOf/1"
                     }
-                  },
-                  "description": "The options relevant to a set of redis connections."
+                  ]
                 },
                 "ConnectionString": {
-                  "type": "string",
-                  "description": "Gets or sets the comma-delimited configuration string used to connect to the Redis server."
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "description": "Gets or sets the comma-delimited configuration string used to connect to the Redis server."
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/StackExchange/properties/Redis/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableAutoActivation": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
-                  "default": true
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                      "default": true
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/StackExchange/properties/Redis/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableHealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the Redis health check is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the Redis health check is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/StackExchange/properties/Redis/additionalProperties/anyOf/1"
+                    }
+                  ]
                 },
                 "DisableTracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                  "default": false
+                  "anyOf": [
+                    {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    {
+                      "$ref": "#/properties/Aspire/properties/StackExchange/properties/Redis/additionalProperties/anyOf/1"
+                    }
+                  ]
                 }
               },
               "description": "Provides the client configuration settings for connecting to a Redis server.",
               "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "ConfigurationOptions": {
+                "anyOf": [
+                  {
+                    "not": {
+                      "type": "object"
+                    }
+                  },
+                  {
                     "type": "object",
                     "properties": {
-                      "AbortOnConnectFail": {
-                        "type": "boolean",
-                        "description": "Gets or sets whether connect/configuration timeouts should be explicitly notified via a TimeoutException."
-                      },
-                      "AllowAdmin": {
-                        "type": "boolean",
-                        "description": "Indicates whether admin operations should be allowed."
-                      },
-                      "AsyncTimeout": {
-                        "type": "integer",
-                        "description": "Specifies the time in milliseconds that the system should allow for asynchronous operations (defaults to SyncTimeout)."
-                      },
-                      "ChannelPrefix": {
+                      "ConfigurationOptions": {
                         "type": "object",
                         "properties": {
-                          "UseImplicitAutoPattern": {
+                          "AbortOnConnectFail": {
                             "type": "boolean",
-                            "description": "Indicates whether channels should use 'StackExchange.Redis.RedisChannel.PatternMode.Auto' when no 'StackExchange.Redis.RedisChannel.PatternMode' is specified; this is enabled by default, but can be disabled to avoid unexpected wildcard scenarios."
+                            "description": "Gets or sets whether connect/configuration timeouts should be explicitly notified via a TimeoutException."
+                          },
+                          "AllowAdmin": {
+                            "type": "boolean",
+                            "description": "Indicates whether admin operations should be allowed."
+                          },
+                          "AsyncTimeout": {
+                            "type": "integer",
+                            "description": "Specifies the time in milliseconds that the system should allow for asynchronous operations (defaults to SyncTimeout)."
+                          },
+                          "ChannelPrefix": {
+                            "type": "object",
+                            "properties": {
+                              "UseImplicitAutoPattern": {
+                                "type": "boolean",
+                                "description": "Indicates whether channels should use 'StackExchange.Redis.RedisChannel.PatternMode.Auto' when no 'StackExchange.Redis.RedisChannel.PatternMode' is specified; this is enabled by default, but can be disabled to avoid unexpected wildcard scenarios."
+                              }
+                            },
+                            "description": "Automatically encodes and decodes channels."
+                          },
+                          "CheckCertificateRevocation": {
+                            "type": "boolean",
+                            "description": "A Boolean value that specifies whether the certificate revocation list is checked during authentication."
+                          },
+                          "ClientName": {
+                            "type": "string",
+                            "description": "The client name to use for all connections."
+                          },
+                          "ConfigCheckSeconds": {
+                            "type": "integer",
+                            "description": "Check configuration every n seconds (every minute by default)."
+                          },
+                          "ConfigurationChannel": {
+                            "type": "string",
+                            "description": "Channel to use for broadcasting and listening for configuration change notification."
+                          },
+                          "ConnectRetry": {
+                            "type": "integer",
+                            "description": "The number of times to repeat the initial connect cycle if no servers respond promptly."
+                          },
+                          "ConnectTimeout": {
+                            "type": "integer",
+                            "description": "Specifies the time in milliseconds that should be allowed for connection (defaults to 5 seconds unless SyncTimeout is higher)."
+                          },
+                          "DefaultDatabase": {
+                            "type": "integer",
+                            "description": "Specifies the default database to be used when calling 'StackExchange.Redis.ConnectionMultiplexer.GetDatabase(System.Int32,System.Object)' without any parameters."
+                          },
+                          "DefaultVersion": {
+                            "type": "string",
+                            "description": "The server version to assume."
+                          },
+                          "HeartbeatConsistencyChecks": {
+                            "type": "boolean",
+                            "description": "Whether to enable ECHO checks on every heartbeat to ensure network stream consistency. This is a rare measure to react to any potential network traffic drops ASAP, terminating the connection."
+                          },
+                          "HeartbeatInterval": {
+                            "type": "string",
+                            "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
+                            "description": "Controls how often the connection heartbeats. A heartbeat includes: - Evaluating if any messages have timed out. - Evaluating connection status (checking for failures). - Sending a server message to keep the connection alive if needed."
+                          },
+                          "HighIntegrity": {
+                            "type": "boolean",
+                            "description": "A Boolean value that specifies whether to use per-command validation of strict protocol validity. This sends an additional command after EVERY command which incurs measurable overhead."
+                          },
+                          "IncludeDetailInExceptions": {
+                            "type": "boolean",
+                            "description": "Whether exceptions include identifiable details (key names, additional .Data annotations)."
+                          },
+                          "IncludePerformanceCountersInExceptions": {
+                            "type": "boolean",
+                            "description": "Whether exceptions include performance counter details."
+                          },
+                          "KeepAlive": {
+                            "type": "integer",
+                            "description": "Specifies the time in seconds at which connections should be pinged to ensure validity. -1 Defaults to 60 Seconds."
+                          },
+                          "LibraryName": {
+                            "type": "string",
+                            "description": "Gets or sets the library name to use for CLIENT SETINFO lib-name calls to Redis during handshake. Defaults to \"SE.Redis\"."
+                          },
+                          "Password": {
+                            "type": "string",
+                            "description": "The password to use to authenticate with the server."
+                          },
+                          "Protocol": {
+                            "enum": [
+                              "Resp2",
+                              "Resp3"
+                            ],
+                            "description": "Specify the redis protocol type."
+                          },
+                          "Proxy": {
+                            "enum": [
+                              "None",
+                              "Twemproxy",
+                              "Envoyproxy"
+                            ],
+                            "description": "Type of proxy to use (if any); for example 'StackExchange.Redis.Proxy.Twemproxy'."
+                          },
+                          "ResolveDns": {
+                            "type": "boolean",
+                            "description": "Indicates whether endpoints should be resolved via DNS before connecting. If enabled the ConnectionMultiplexer will not re-resolve DNS when attempting to re-connect after a connection failure."
+                          },
+                          "ServiceName": {
+                            "type": "string",
+                            "description": "The service name used to resolve a service via sentinel."
+                          },
+                          "SetClientLibrary": {
+                            "type": "boolean",
+                            "description": "Gets or sets whether the library should identify itself by library-name/version when possible."
+                          },
+                          "Ssl": {
+                            "type": "boolean",
+                            "description": "Indicates whether the connection should be encrypted."
+                          },
+                          "SslHost": {
+                            "type": "string",
+                            "description": "The target-host to use when validating SSL certificate; setting a value here enables SSL mode."
+                          },
+                          "SslProtocols": {
+                            "enum": [
+                              "None",
+                              "Ssl2",
+                              "Ssl3",
+                              "Tls",
+                              "Default",
+                              "Tls11",
+                              "Tls12",
+                              "Tls13"
+                            ],
+                            "description": "Configures which SSL/TLS protocols should be allowed.  If not set, defaults are chosen by the .NET framework."
+                          },
+                          "SyncTimeout": {
+                            "type": "integer",
+                            "description": "Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds)."
+                          },
+                          "TieBreaker": {
+                            "type": "string",
+                            "description": "Tie-breaker used to choose between primaries (must match the endpoint exactly)."
+                          },
+                          "User": {
+                            "type": "string",
+                            "description": "The username to use to authenticate with the server."
                           }
                         },
-                        "description": "Automatically encodes and decodes channels."
+                        "description": "The options relevant to a set of redis connections."
                       },
-                      "CheckCertificateRevocation": {
+                      "ConnectionString": {
+                        "type": "string",
+                        "description": "Gets or sets the comma-delimited configuration string used to connect to the Redis server."
+                      },
+                      "DisableAutoActivation": {
                         "type": "boolean",
-                        "description": "A Boolean value that specifies whether the certificate revocation list is checked during authentication."
+                        "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
+                        "default": true
                       },
-                      "ClientName": {
-                        "type": "string",
-                        "description": "The client name to use for all connections."
-                      },
-                      "ConfigCheckSeconds": {
-                        "type": "integer",
-                        "description": "Check configuration every n seconds (every minute by default)."
-                      },
-                      "ConfigurationChannel": {
-                        "type": "string",
-                        "description": "Channel to use for broadcasting and listening for configuration change notification."
-                      },
-                      "ConnectRetry": {
-                        "type": "integer",
-                        "description": "The number of times to repeat the initial connect cycle if no servers respond promptly."
-                      },
-                      "ConnectTimeout": {
-                        "type": "integer",
-                        "description": "Specifies the time in milliseconds that should be allowed for connection (defaults to 5 seconds unless SyncTimeout is higher)."
-                      },
-                      "DefaultDatabase": {
-                        "type": "integer",
-                        "description": "Specifies the default database to be used when calling 'StackExchange.Redis.ConnectionMultiplexer.GetDatabase(System.Int32,System.Object)' without any parameters."
-                      },
-                      "DefaultVersion": {
-                        "type": "string",
-                        "description": "The server version to assume."
-                      },
-                      "HeartbeatConsistencyChecks": {
+                      "DisableHealthChecks": {
                         "type": "boolean",
-                        "description": "Whether to enable ECHO checks on every heartbeat to ensure network stream consistency. This is a rare measure to react to any potential network traffic drops ASAP, terminating the connection."
+                        "description": "Gets or sets a boolean value that indicates whether the Redis health check is disabled or not.",
+                        "default": false
                       },
-                      "HeartbeatInterval": {
-                        "type": "string",
-                        "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
-                        "description": "Controls how often the connection heartbeats. A heartbeat includes: - Evaluating if any messages have timed out. - Evaluating connection status (checking for failures). - Sending a server message to keep the connection alive if needed."
-                      },
-                      "HighIntegrity": {
+                      "DisableTracing": {
                         "type": "boolean",
-                        "description": "A Boolean value that specifies whether to use per-command validation of strict protocol validity. This sends an additional command after EVERY command which incurs measurable overhead."
-                      },
-                      "IncludeDetailInExceptions": {
-                        "type": "boolean",
-                        "description": "Whether exceptions include identifiable details (key names, additional .Data annotations)."
-                      },
-                      "IncludePerformanceCountersInExceptions": {
-                        "type": "boolean",
-                        "description": "Whether exceptions include performance counter details."
-                      },
-                      "KeepAlive": {
-                        "type": "integer",
-                        "description": "Specifies the time in seconds at which connections should be pinged to ensure validity. -1 Defaults to 60 Seconds."
-                      },
-                      "LibraryName": {
-                        "type": "string",
-                        "description": "Gets or sets the library name to use for CLIENT SETINFO lib-name calls to Redis during handshake. Defaults to \"SE.Redis\"."
-                      },
-                      "Password": {
-                        "type": "string",
-                        "description": "The password to use to authenticate with the server."
-                      },
-                      "Protocol": {
-                        "enum": [
-                          "Resp2",
-                          "Resp3"
-                        ],
-                        "description": "Specify the redis protocol type."
-                      },
-                      "Proxy": {
-                        "enum": [
-                          "None",
-                          "Twemproxy",
-                          "Envoyproxy"
-                        ],
-                        "description": "Type of proxy to use (if any); for example 'StackExchange.Redis.Proxy.Twemproxy'."
-                      },
-                      "ResolveDns": {
-                        "type": "boolean",
-                        "description": "Indicates whether endpoints should be resolved via DNS before connecting. If enabled the ConnectionMultiplexer will not re-resolve DNS when attempting to re-connect after a connection failure."
-                      },
-                      "ServiceName": {
-                        "type": "string",
-                        "description": "The service name used to resolve a service via sentinel."
-                      },
-                      "SetClientLibrary": {
-                        "type": "boolean",
-                        "description": "Gets or sets whether the library should identify itself by library-name/version when possible."
-                      },
-                      "Ssl": {
-                        "type": "boolean",
-                        "description": "Indicates whether the connection should be encrypted."
-                      },
-                      "SslHost": {
-                        "type": "string",
-                        "description": "The target-host to use when validating SSL certificate; setting a value here enables SSL mode."
-                      },
-                      "SslProtocols": {
-                        "enum": [
-                          "None",
-                          "Ssl2",
-                          "Ssl3",
-                          "Tls",
-                          "Default",
-                          "Tls11",
-                          "Tls12",
-                          "Tls13"
-                        ],
-                        "description": "Configures which SSL/TLS protocols should be allowed.  If not set, defaults are chosen by the .NET framework."
-                      },
-                      "SyncTimeout": {
-                        "type": "integer",
-                        "description": "Specifies the time in milliseconds that the system should allow for synchronous operations (defaults to 5 seconds)."
-                      },
-                      "TieBreaker": {
-                        "type": "string",
-                        "description": "Tie-breaker used to choose between primaries (must match the endpoint exactly)."
-                      },
-                      "User": {
-                        "type": "string",
-                        "description": "The username to use to authenticate with the server."
+                        "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                        "default": false
                       }
                     },
-                    "description": "The options relevant to a set of redis connections."
-                  },
-                  "ConnectionString": {
-                    "type": "string",
-                    "description": "Gets or sets the comma-delimited configuration string used to connect to the Redis server."
-                  },
-                  "DisableAutoActivation": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether auto activation is disabled or not.",
-                    "default": true
-                  },
-                  "DisableHealthChecks": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the Redis health check is disabled or not.",
-                    "default": false
-                  },
-                  "DisableTracing": {
-                    "type": "boolean",
-                    "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
-                    "default": false
+                    "description": "Provides the client configuration settings for connecting to a Redis server."
                   }
-                },
-                "description": "Provides the client configuration settings for connecting to a Redis server."
+                ]
               }
             }
           }

--- a/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
+++ b/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
@@ -175,7 +175,172 @@
                       "description": "The options relevant to a set of redis connections."
                     },
                     {
-                      "$ref": "#/properties/Aspire/properties/StackExchange/properties/Redis/additionalProperties/anyOf/1"
+                      "allOf": [
+                        {
+                          "$ref": "#/properties/Aspire/properties/StackExchange/properties/Redis/additionalProperties/anyOf/1"
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "AbortOnConnectFail"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "AllowAdmin"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "AsyncTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "SetClientLibrary"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "LibraryName"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ChannelPrefix"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "CheckCertificateRevocation"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "HighIntegrity"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ClientName"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ConnectRetry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ConfigurationChannel"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ConnectTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "DefaultDatabase"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "DefaultVersion"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "HeartbeatConsistencyChecks"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "HeartbeatInterval"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "IncludeDetailInExceptions"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "IncludePerformanceCountersInExceptions"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "KeepAlive"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "User"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Password"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Proxy"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ResolveDns"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ServiceName"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Ssl"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "SslHost"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "SslProtocols"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "SyncTimeout"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "TieBreaker"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "ConfigCheckSeconds"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "Protocol"
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
                     }
                   ]
                 },

--- a/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -203,15 +203,13 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
             {
                 foreach (var property in propertiesNode.ToArray())
                 {
+                    var defaultSettingsNode = property.Value?.DeepClone();
                     propertiesNode[property.Key] = new JsonObject
                     {
                         ["anyOf"] = new JsonArray
                         {
-                            property.Value?.DeepClone(),
-                            new JsonObject
-                            {
-                                ["$ref"] = namedSettingsReference
-                            }
+                            defaultSettingsNode,
+                            CreateNamedSettingsAlternative(defaultSettingsNode, namedSettingsReference)
                         }
                     };
                 }
@@ -235,6 +233,47 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
                 }
             };
         }
+    }
+
+    private static JsonObject CreateNamedSettingsAlternative(JsonNode? defaultSettingsNode, string namedSettingsReference)
+    {
+        var referenceNode = new JsonObject
+        {
+            ["$ref"] = namedSettingsReference
+        };
+
+        if (defaultSettingsNode is not JsonObject defaultSettingsObject ||
+            defaultSettingsObject["properties"] is not JsonObject { Count: > 0 } defaultProperties)
+        {
+            return referenceNode;
+        }
+
+        var recognizedDefaultProperties = new JsonArray();
+        foreach (var property in defaultProperties)
+        {
+            recognizedDefaultProperties.Add(new JsonObject
+            {
+                ["required"] = new JsonArray { property.Key }
+            });
+        }
+
+        // Object-valued shared settings and named resources can occupy the same property. Once a
+        // shared setting's property is present, keep validating that branch so its semantic errors
+        // cannot be hidden by the more permissive named-resource schema.
+        return new JsonObject
+        {
+            ["allOf"] = new JsonArray
+            {
+                referenceNode,
+                new JsonObject
+                {
+                    ["not"] = new JsonObject
+                    {
+                        ["anyOf"] = recognizedDefaultProperties
+                    }
+                }
+            }
+        };
     }
 
     private static string GetJsonPointer(JsonNode rootNode, JsonNode targetNode)

--- a/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -35,6 +35,7 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
     private readonly Compilation _compilation = compilation;
     private readonly Stack<TypeSpec> _visitedTypes = new();
     private readonly string[] _exclusionPaths = CreateExclusionPaths(spec.ExclusionPaths);
+    private readonly List<JsonObject> _wildcardParentNodes = [];
 
     [GeneratedRegex(@"(\s*)(?:\r?\n\s*\r?\n)(\s*)")]
     private static partial Regex BlankLinesInDocComment();
@@ -44,6 +45,7 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
         var root = new JsonObject();
         GenerateLogCategories(root);
         GenerateGraph(root);
+        NormalizeWildcardSchemas(root);
 
         return JsonSerializer.Serialize(root, s_serializerOptions);
     }
@@ -157,6 +159,11 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
         }
 
         var hasGenerated = GeneratePathSegment(pathSegmentNode, type, pathSegments);
+        if (hasGenerated && isAsterisk && !_wildcardParentNodes.Any(node => ReferenceEquals(node, currentNode)))
+        {
+            _wildcardParentNodes.Add(currentNode);
+        }
+
         if (!hasGenerated)
         {
             RestoreBackup(backupTypeNode, "type", currentNode);
@@ -178,6 +185,116 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
 
         return hasGenerated;
     }
+
+    private void NormalizeWildcardSchemas(JsonObject rootNode)
+    {
+        // Wildcard paths are generated into additionalProperties first so nested wildcard paths can
+        // merge into the same schema. Normalize outer wildcards first so nested wildcard references
+        // use their final JSON Pointer after their parent schema has been wrapped.
+        foreach (var parentNode in _wildcardParentNodes)
+        {
+            if (parentNode["additionalProperties"] is not JsonObject namedSettingsNode)
+            {
+                continue;
+            }
+
+            var namedSettingsReference = $"{GetJsonPointer(rootNode, parentNode)}/additionalProperties/anyOf/1";
+            if (parentNode["properties"] is JsonObject propertiesNode)
+            {
+                foreach (var property in propertiesNode.ToArray())
+                {
+                    propertiesNode[property.Key] = new JsonObject
+                    {
+                        ["anyOf"] = new JsonArray
+                        {
+                            property.Value?.DeepClone(),
+                            new JsonObject
+                            {
+                                ["$ref"] = namedSettingsReference
+                            }
+                        }
+                    };
+                }
+            }
+
+            parentNode.Remove("additionalProperties");
+            parentNode["additionalProperties"] = new JsonObject
+            {
+                ["anyOf"] = new JsonArray
+                {
+                    // Configuration schemas have historically permitted undeclared scalar values.
+                    // Restrict only undeclared objects, which represent named resource settings.
+                    new JsonObject
+                    {
+                        ["not"] = new JsonObject
+                        {
+                            ["type"] = "object"
+                        }
+                    },
+                    namedSettingsNode
+                }
+            };
+        }
+    }
+
+    private static string GetJsonPointer(JsonNode rootNode, JsonNode targetNode)
+    {
+        var pathSegments = new List<string>();
+        if (!TryFindJsonPointer(rootNode, targetNode, pathSegments))
+        {
+            throw new InvalidOperationException("The wildcard schema node is not attached to the generated schema.");
+        }
+
+        return $"#/{string.Join('/', pathSegments.Select(EscapeJsonPointerSegment))}";
+    }
+
+    private static bool TryFindJsonPointer(JsonNode currentNode, JsonNode targetNode, List<string> pathSegments)
+    {
+        if (ReferenceEquals(currentNode, targetNode))
+        {
+            return true;
+        }
+
+        if (currentNode is JsonObject objectNode)
+        {
+            foreach (var property in objectNode)
+            {
+                if (property.Value is null)
+                {
+                    continue;
+                }
+
+                pathSegments.Add(property.Key);
+                if (TryFindJsonPointer(property.Value, targetNode, pathSegments))
+                {
+                    return true;
+                }
+                pathSegments.RemoveAt(pathSegments.Count - 1);
+            }
+        }
+        else if (currentNode is JsonArray arrayNode)
+        {
+            for (var i = 0; i < arrayNode.Count; i++)
+            {
+                if (arrayNode[i] is not { } item)
+                {
+                    continue;
+                }
+
+                pathSegments.Add(i.ToString(CultureInfo.InvariantCulture));
+                if (TryFindJsonPointer(item, targetNode, pathSegments))
+                {
+                    return true;
+                }
+                pathSegments.RemoveAt(pathSegments.Count - 1);
+            }
+        }
+
+        return false;
+    }
+
+    private static string EscapeJsonPointerSegment(string segment)
+        => segment.Replace("~", "~0", StringComparison.Ordinal).Replace("/", "~1", StringComparison.Ordinal);
 
     private bool GenerateType(JsonObject currentNode, TypeSpec type)
     {

--- a/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.TestUtilities/ConformanceTests.cs
@@ -431,11 +431,16 @@ public abstract class ConformanceTests<TService, TOptions>
         {
             using var config = JsonDocument.Parse(json);
             var results = schema.Evaluate(config.RootElement, DefaultEvaluationOptions);
-            // EvaluationResults.HasErrors was removed in JsonSchema.Net 8.x; use the Errors dictionary directly.
-            var detail = results.Details?.FirstOrDefault(x => x.Errors is { Count: > 0 });
 
-            Assert.NotNull(detail);
-            Assert.Equal(error, detail.Errors!.First().Value);
+            // Schema unions can report a branch type error before the more specific nested error.
+            // OutputFormat.List retains every branch's errors, so verify the intended semantic error is present.
+            var errors = results.Details?
+                .Where(detail => detail.Errors is { Count: > 0 })
+                .SelectMany(detail => detail.Errors!.Values)
+                .ToArray() ?? [];
+
+            Assert.False(results.IsValid, json);
+            Assert.Contains(error, errors);
         }
     }
 

--- a/tests/Aspire.Confluent.Kafka.Tests/ConsumerConformanceTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/ConsumerConformanceTests.cs
@@ -69,6 +69,14 @@ public class ConsumerConformanceTests : ConformanceTests<IConsumer<string, strin
                                     "DisableMetrics": false,
                                     "Config": {
                                         "GroupId": "test"
+                                    },
+                                    "orders": {
+                                        "ConnectionString": "localhost:9093",
+                                        "DisableHealthChecks": true,
+                                        "DisableMetrics": true,
+                                        "Config": {
+                                            "GroupId": "orders"
+                                        }
                                     }
                                 }
                             }
@@ -80,7 +88,8 @@ public class ConsumerConformanceTests : ConformanceTests<IConsumer<string, strin
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
             ("""{"Aspire": { "Confluent":{ "Kafka": { "Consumer": { "DisableMetrics": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
-            ("""{"Aspire": { "Confluent":{ "Kafka": { "Consumer": { "DisableHealthChecks": 0}}}}}""", "Value is \"integer\" but should be \"boolean\"")
+            ("""{"Aspire": { "Confluent":{ "Kafka": { "Consumer": { "DisableHealthChecks": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
+            ("""{"Aspire": { "Confluent":{ "Kafka": { "Consumer": { "orders": { "DisableMetrics": 0}}}}}}""", "Value is \"integer\" but should be \"boolean\"")
         };
 
     [Fact]

--- a/tests/Aspire.Confluent.Kafka.Tests/ProducerConformanceTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/ProducerConformanceTests.cs
@@ -66,7 +66,12 @@ public class ProducerConformanceTests : ConformanceTests<IProducer<string, strin
                                 "Producer": {
                                     "ConnectionString": "localhost:9092",
                                     "DisableHealthChecks": false,
-                                    "DisableMetrics": false
+                                    "DisableMetrics": false,
+                                    "orders": {
+                                        "ConnectionString": "localhost:9093",
+                                        "DisableHealthChecks": true,
+                                        "DisableMetrics": true
+                                    }
                                 }
                             }
                         }
@@ -76,7 +81,8 @@ public class ProducerConformanceTests : ConformanceTests<IProducer<string, strin
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
             ("""{"Aspire": { "Confluent":{ "Kafka": { "Producer": { "DisableMetrics": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
-            ("""{"Aspire": { "Confluent":{ "Kafka": { "Producer": { "DisableHealthChecks": 0}}}}}""", "Value is \"integer\" but should be \"boolean\"")
+            ("""{"Aspire": { "Confluent":{ "Kafka": { "Producer": { "DisableHealthChecks": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
+            ("""{"Aspire": { "Confluent":{ "Kafka": { "Producer": { "orders": { "DisableMetrics": 0}}}}}}""", "Value is \"integer\" but should be \"boolean\"")
         };
 
     [Fact]

--- a/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
+++ b/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
@@ -72,6 +72,39 @@ public class SeqTests
     }
 
     [Fact]
+    public void NamedConfigurationUsesIntegrationSection()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("Aspire:Seq:DisableHealthChecks", "true"),
+            new KeyValuePair<string, string?>("Aspire:Seq:ApiKey", "shared"),
+            new KeyValuePair<string, string?>("seq:ApiKey", "legacy"),
+            new KeyValuePair<string, string?>("Aspire:Seq:seq:ApiKey", "named")
+        ]);
+
+        SeqSettings settings = new();
+        builder.AddSeqEndpoint("seq", configuredSettings => settings = configuredSettings);
+
+        Assert.Equal("named", settings.ApiKey);
+    }
+
+    [Fact]
+    public void LegacyRootNamedConfigurationIsStillSupported()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("Aspire:Seq:DisableHealthChecks", "true"),
+            new KeyValuePair<string, string?>("Aspire:Seq:ApiKey", "shared"),
+            new KeyValuePair<string, string?>("seq:ApiKey", "legacy")
+        ]);
+
+        SeqSettings settings = new();
+        builder.AddSeqEndpoint("seq", configuredSettings => settings = configuredSettings);
+
+        Assert.Equal("legacy", settings.ApiKey);
+    }
+
+    [Fact]
     public async Task HealthCheckDescriptionDoesNotExposeCredentialsFromServerUrl()
     {
         using var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -1623,7 +1623,22 @@ public partial class GeneratorTests
                           }
                         },
                         {
-                          "$ref": "#/properties/Components/additionalProperties/anyOf/1"
+                          "allOf": [
+                            {
+                              "$ref": "#/properties/Components/additionalProperties/anyOf/1"
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "RetryCount"
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ]
                         }
                       ]
                     },

--- a/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -1556,6 +1556,71 @@ public partial class GeneratorTests
             """);
     }
 
+    [Fact]
+    public void CanGenerateNestedSchemaForNamedOptionsWithDefaultOptions()
+    {
+        var source =
+            """
+            [assembly: Aspire.ConfigurationSchema("Components", typeof(ComponentSettings))]
+            [assembly: Aspire.ConfigurationSchema("Components:ClientOptions", typeof(ClientOptions))]
+            [assembly: Aspire.ConfigurationSchema("Components:*", typeof(ComponentSettings))]
+            [assembly: Aspire.ConfigurationSchema("Components:*:ClientOptions", typeof(ClientOptions))]
+
+            public class ComponentSettings
+            {
+                public string? ConnectionString { get; set; }
+            }
+
+            public class ClientOptions
+            {
+                public int RetryCount { get; set; }
+            }
+            """;
+
+        var schema = GenerateSchemaFromCode(source, []);
+
+        AssertIsJson(schema,
+            """
+            {
+              "type": "object",
+              "properties": {
+                "Components": {
+                  "type": "object",
+                  "properties": {
+                    "ClientOptions": {
+                      "type": "object",
+                      "properties": {
+                        "RetryCount": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "ConnectionString": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "ClientOptions": {
+                        "type": "object",
+                        "properties": {
+                          "RetryCount": {
+                            "type": "integer"
+                          }
+                        }
+                      },
+                      "ConnectionString": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+    }
+
     private static string GenerateSchemaFromCode(string sourceText, IEnumerable<MetadataReference> references)
     {
         var sourceSyntaxTree = SyntaxFactory.ParseSyntaxTree(SourceText.From(sourceText));

--- a/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -1495,13 +1495,22 @@ public partial class GeneratorTests
                 "Certificates": {
                   "type": "object",
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "PrivateKey": {
-                        "type": "string",
-                        "description": "The private key of the certificate, in base64 format."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "PrivateKey": {
+                            "type": "string",
+                            "description": "The private key of the certificate, in base64 format."
+                          }
+                        }
                       }
-                    }
+                    ]
                   }
                 }
               }
@@ -1537,18 +1546,34 @@ public partial class GeneratorTests
                   "type": "object",
                   "properties": {
                     "PrivateKey": {
-                      "type": "string",
-                      "description": "The private key of the certificate, in base64 format."
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "description": "The private key of the certificate, in base64 format."
+                        },
+                        {
+                          "$ref": "#/properties/Certificates/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "PrivateKey": {
-                        "type": "string",
-                        "description": "The private key of the certificate, in base64 format."
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "PrivateKey": {
+                            "type": "string",
+                            "description": "The private key of the certificate, in base64 format."
+                          }
+                        }
                       }
-                    }
+                    ]
                   }
                 }
               }
@@ -1588,32 +1613,55 @@ public partial class GeneratorTests
                   "type": "object",
                   "properties": {
                     "ClientOptions": {
-                      "type": "object",
-                      "properties": {
-                        "RetryCount": {
-                          "type": "integer"
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "RetryCount": {
+                              "type": "integer"
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "#/properties/Components/additionalProperties/anyOf/1"
                         }
-                      }
+                      ]
                     },
                     "ConnectionString": {
-                      "type": "string"
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "$ref": "#/properties/Components/additionalProperties/anyOf/1"
+                        }
+                      ]
                     }
                   },
                   "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "ClientOptions": {
-                        "type": "object",
-                        "properties": {
-                          "RetryCount": {
-                            "type": "integer"
-                          }
+                    "anyOf": [
+                      {
+                        "not": {
+                          "type": "object"
                         }
                       },
-                      "ConnectionString": {
-                        "type": "string"
+                      {
+                        "type": "object",
+                        "properties": {
+                          "ClientOptions": {
+                            "type": "object",
+                            "properties": {
+                              "RetryCount": {
+                                "type": "integer"
+                              }
+                            }
+                          },
+                          "ConnectionString": {
+                            "type": "string"
+                          }
+                        }
                       }
-                    }
+                    ]
                   }
                 }
               }


### PR DESCRIPTION
## Description

Integration configuration schemas currently describe only the shared settings section, so editors cannot validate or autocomplete settings under a named resource such as `Aspire:StackExchange:Redis:cache`. This change adds named-resource schema coverage across the applicable integrations while preserving existing configuration behavior.

The schema declarations now include wildcard paths for named resources and their nested options. Generated schemas were refreshed, including the additional service-key level used by Web PubSub and derived resource settings used by Azure Storage integrations. Kafka's hand-authored schema uses non-recursive definitions for direct and named consumer/producer settings. Seq now binds the standard integration-specific named section after the legacy root-level section, preserving compatibility while giving the standard path precedence.

### User-facing usage

Editors can now provide schema validation and autocomplete for named configuration sections such as:

```json
{
  "Aspire": {
    "StackExchange": {
      "Redis": {
        "cache": {
          "DisableHealthChecks": true
        }
      }
    }
  }
}
```

Validation included the configuration schema generator suite, focused integration tests for Kafka, Seq, Azure Storage, and Web PubSub, JSON parsing of all changed schemas, and a full repository build.

Fixes: #8377

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No