### PR TITLE
Allow assigning parent account roles to Foundry project identities

### DIFF
--- a/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryExtensions.cs
@@ -270,13 +270,7 @@ public static class FoundryExtensions
         var builtInRoles = new CognitiveServicesBuiltInRole[roles.Length];
         for (var i = 0; i < roles.Length; i++)
         {
-            builtInRoles[i] = roles[i] switch
-            {
-                FoundryRole.CognitiveServicesOpenAIContributor => CognitiveServicesBuiltInRole.CognitiveServicesOpenAIContributor,
-                FoundryRole.CognitiveServicesOpenAIUser => CognitiveServicesBuiltInRole.CognitiveServicesOpenAIUser,
-                FoundryRole.CognitiveServicesUser => CognitiveServicesBuiltInRole.CognitiveServicesUser,
-                _ => throw new ArgumentException($"'{roles[i]}' is not a valid {nameof(FoundryRole)} value.", nameof(roles))
-            };
+            builtInRoles[i] = roles[i].ToBuiltInRole();
         }
 
         return builder.WithRoleAssignments(target, builtInRoles);

--- a/src/Aspire.Hosting.Foundry/FoundryRole.cs
+++ b/src/Aspire.Hosting.Foundry/FoundryRole.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Foundry;
+using Azure.Provisioning.CognitiveServices;
+
 namespace Aspire.Hosting;
 
 /// <summary>
@@ -8,6 +11,11 @@ namespace Aspire.Hosting;
 /// </summary>
 internal enum FoundryRole
 {
+    /// <summary>
+    /// Allows building and testing with models and agents in Microsoft Foundry.
+    /// </summary>
+    FoundryUser,
+
     /// <summary>
     /// Allows full management of Azure OpenAI resources.
     /// </summary>
@@ -22,4 +30,25 @@ internal enum FoundryRole
     /// Allows access to Azure Cognitive Services resources.
     /// </summary>
     CognitiveServicesUser,
+}
+
+/// <summary>
+/// Converts ATS-compatible Microsoft Foundry roles to Azure Provisioning role values.
+/// </summary>
+internal static class FoundryRoleExtensions
+{
+    /// <summary>
+    /// Converts a Microsoft Foundry role to its Azure Provisioning equivalent.
+    /// </summary>
+    internal static CognitiveServicesBuiltInRole ToBuiltInRole(this FoundryRole role)
+    {
+        return role switch
+        {
+            FoundryRole.FoundryUser => (CognitiveServicesBuiltInRole)AzureHostedAgentResource.FoundryUserRoleDefinitionId,
+            FoundryRole.CognitiveServicesOpenAIContributor => CognitiveServicesBuiltInRole.CognitiveServicesOpenAIContributor,
+            FoundryRole.CognitiveServicesOpenAIUser => CognitiveServicesBuiltInRole.CognitiveServicesOpenAIUser,
+            FoundryRole.CognitiveServicesUser => CognitiveServicesBuiltInRole.CognitiveServicesUser,
+            _ => throw new ArgumentException($"'{role}' is not a valid {nameof(FoundryRole)} value.", nameof(role))
+        };
+    }
 }

--- a/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs
@@ -25,10 +25,10 @@ namespace Aspire.Hosting.Foundry;
 /// </summary>
 public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
 {
-    // The "Azure AI User" built-in role (data-plane access to Foundry agents/inference). Granted to
+    // The "Foundry User" built-in role (data-plane access to Foundry agents/inference). Granted to
     // the agent's own instance identity below, and to consumers that reference the agent (see
     // HostedAgentResourceBuilderExtensions.GrantHostedAgentConsumerRoles).
-    internal const string AzureAIUserRoleDefinitionId = "53ca6127-db72-4b80-b1b0-d745d6d5456d";
+    internal const string FoundryUserRoleDefinitionId = "53ca6127-db72-4b80-b1b0-d745d6d5456d";
     internal const string DefaultResponsesProtocolVersion = "2.0.0";
 
     /// <summary>
@@ -258,7 +258,7 @@ public class AzureHostedAgentResource : Resource, IResourceWithEnvironment
 
         var subscriptionResourceId = provisioningContext.Subscription.Id.ToString();
         var roleDefinitionId = new ResourceIdentifier(
-            $"{subscriptionResourceId}/providers/Microsoft.Authorization/roleDefinitions/{AzureAIUserRoleDefinitionId}");
+            $"{subscriptionResourceId}/providers/Microsoft.Authorization/roleDefinitions/{FoundryUserRoleDefinitionId}");
 
         var assignmentName = StableGuid(principalId, roleDefinitionId.ToString(), foundryResourceId);
 

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -503,7 +503,7 @@ public static class HostedAgentResourceBuilderExtensions
         // Unlike referencing a first-class Azure resource, it does not give the consumer a managed
         // identity or any RBAC on the Foundry account, so calls to the agent's invocation endpoint
         // fail with 401/403 at runtime. Stamp a ReferenceRoleAssignmentAnnotation on the agent's
-        // target so AzureResourcePreparer grants the "Azure AI User" role on the owning Foundry
+        // target so AzureResourcePreparer grants the "Foundry User" role on the owning Foundry
         // account to every consumer that references this agent, and provisions the identity that
         // makes ACA inject AZURE_CLIENT_ID.
         StampHostedAgentConsumerRoleAnnotation(target, projectResource.Parent);
@@ -511,17 +511,17 @@ public static class HostedAgentResourceBuilderExtensions
 
     private static void StampHostedAgentConsumerRoleAnnotation(IResourceWithEnvironment target, FoundryResource account)
     {
-        // Grant only the "Azure AI User" role required to invoke the hosted agent. We deliberately do
+        // Grant only the "Foundry User" role required to invoke the hosted agent. We deliberately do
         // not union the account's default data-plane roles here:
         //  - A consumer that also references the account directly still receives those defaults through
         //    AzureResourcePreparer's normal reference walk (they are preserved when GetAllRoleAssignments
         //    unions per target).
         //  - A consumer that declares explicit role assignments on the account intentionally suppresses
         //    the account defaults; folding them back in here would defeat that suppression.
-        // So the minimal, least-privilege grant for a pure agent consumer is "Azure AI User" alone.
+        // So the minimal, least-privilege grant for a pure agent consumer is "Foundry User" alone.
         var roles = new HashSet<RoleDefinition>
         {
-            new(AzureHostedAgentResource.AzureAIUserRoleDefinitionId, "Azure AI User")
+            new(AzureHostedAgentResource.FoundryUserRoleDefinitionId, "Foundry User")
         };
 
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates.

--- a/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
@@ -59,6 +59,74 @@ public static class AzureCognitiveServicesProjectExtensions
     }
 
     /// <summary>
+    /// Assigns roles on the parent Microsoft Foundry account to the Microsoft Foundry project's managed identity.
+    /// </summary>
+    /// <param name="builder">The resource builder for the Microsoft Foundry project.</param>
+    /// <param name="roles">The built-in Cognitive Services roles to assign to the project identity.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// Role assignments are scoped to the parent Microsoft Foundry account and use the project's own managed identity.
+    /// </remarks>
+    /// <example>
+    /// Grant the project identity the Foundry User role required by Foundry Memory:
+    /// <code lang="csharp">
+    /// var foundryUserRole = (CognitiveServicesBuiltInRole)"53ca6127-db72-4b80-b1b0-d745d6d5456d";
+    ///
+    /// var project = builder.AddFoundry("foundry")
+    ///     .AddProject("my-project")
+    ///     .WithRoleAssignments(foundryUserRole);
+    /// </code>
+    /// </example>
+    [AspireExportIgnore(Reason = "CognitiveServicesBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the FoundryRole-based overload instead.")]
+    public static IResourceBuilder<AzureCognitiveServicesProjectResource> WithRoleAssignments(
+        this IResourceBuilder<AzureCognitiveServicesProjectResource> builder,
+        params CognitiveServicesBuiltInRole[] roles)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        if (roles is null || roles.Length == 0)
+        {
+            return builder;
+        }
+
+        foreach (var role in roles)
+        {
+            var roleId = role.ToString();
+            var roleName = string.Equals(roleId, AzureHostedAgentResource.FoundryUserRoleDefinitionId, StringComparison.OrdinalIgnoreCase)
+                ? "Foundry User"
+                : CognitiveServicesBuiltInRole.GetBuiltInRoleName(role);
+            builder.Resource.ParentRoleAssignments.Add(new RoleDefinition(roleId, roleName));
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Assigns Microsoft Foundry roles on the parent account to the project's managed identity.
+    /// </summary>
+    /// <param name="builder">The resource builder for the Microsoft Foundry project.</param>
+    /// <param name="roles">The Microsoft Foundry roles to assign to the project identity.</param>
+    /// <returns>The resource builder.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    [AspireExport("withFoundryProjectRoleAssignments")]
+    internal static IResourceBuilder<AzureCognitiveServicesProjectResource> WithRoleAssignments(
+        this IResourceBuilder<AzureCognitiveServicesProjectResource> builder,
+        params FoundryRole[] roles)
+    {
+        if (roles is null || roles.Length == 0)
+        {
+            return builder.WithRoleAssignments(Array.Empty<CognitiveServicesBuiltInRole>());
+        }
+
+        var builtInRoles = new CognitiveServicesBuiltInRole[roles.Length];
+        for (var i = 0; i < roles.Length; i++)
+        {
+            builtInRoles[i] = roles[i].ToBuiltInRole();
+        }
+
+        return builder.WithRoleAssignments(builtInRoles);
+    }
+
+    /// <summary>
     /// Adds a reference to a Microsoft Foundry project resource to the destination resource.
     /// </summary>
     /// <remarks>This overload is not available in polyglot app hosts. Use the standard <c>WithReference</c> overload instead.</remarks>
@@ -417,6 +485,20 @@ public static class AzureCognitiveServicesProjectExtensions
         {
             Value = projectPrincipalId
         });
+
+        foreach (var role in aspireResource.ParentRoleAssignments)
+        {
+            var roleDefinitionId = BicepFunction.GetSubscriptionResourceId("Microsoft.Authorization/roleDefinitions", role.Id);
+            var roleAssignment = new RoleAssignment(Infrastructure.NormalizeBicepIdentifier($"{prefix}_{role.Name}"))
+            {
+                Name = BicepFunction.CreateGuid(account.Id, project.Id, roleDefinitionId),
+                Scope = new IdentifierExpression(account.BicepIdentifier),
+                PrincipalType = RoleManagementPrincipalType.ServicePrincipal,
+                PrincipalId = projectPrincipalId,
+                RoleDefinitionId = roleDefinitionId
+            };
+            infra.Add(roleAssignment);
+        }
 
         /*
          * Container registry for hosted agents

--- a/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectResource.cs
@@ -144,6 +144,11 @@ public class AzureCognitiveServicesProjectResource :
     /// </summary>
     public BicepOutputReference PrincipalId => new("principalId", this);
 
+    /// <summary>
+    /// Gets the roles granted on the parent Microsoft Foundry account to this project's managed identity.
+    /// </summary>
+    internal HashSet<RoleDefinition> ParentRoleAssignments { get; } = [];
+
     internal BicepOutputReference ContainerRegistryUrl => new("AZURE_CONTAINER_REGISTRY_ENDPOINT", this);
     internal BicepOutputReference ContainerRegistryName => new("AZURE_CONTAINER_REGISTRY_NAME", this);
     // Mnaged identity used for client access to container registry

--- a/src/Aspire.Hosting.Foundry/README.md
+++ b/src/Aspire.Hosting.Foundry/README.md
@@ -115,6 +115,15 @@ var project = foundry.AddProject("my-project")
                      .WithKeyVault(keyVault);
 ```
 
+Some Foundry features call other services through the project's managed identity. Assign the required role on the parent Foundry account directly to that identity:
+
+```csharp
+var foundryUserRole = (CognitiveServicesBuiltInRole)"53ca6127-db72-4b80-b1b0-d745d6d5456d";
+
+var project = foundry.AddProject("my-project")
+                     .WithRoleAssignments(foundryUserRole);
+```
+
 ## Hosted agent usage
 
 To deploy a containerized application as a hosted agent in Microsoft Foundry:

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -684,7 +684,7 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
-    public void AsHostedAgent_StampsReferenceRoleAssignmentAnnotationOnTarget_WithAzureAIUserRole()
+    public void AsHostedAgent_StampsReferenceRoleAssignmentAnnotationOnTarget_WithFoundryUserRole()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var project = builder.AddFoundry("account")
@@ -700,12 +700,12 @@ public class HostedAgentExtensionTests
         var annotation = Assert.Single(hostedAgent.Target.Annotations.OfType<ReferenceRoleAssignmentAnnotation>());
         Assert.Same(account, annotation.Target);
         Assert.Contains(annotation.Roles, role =>
-            string.Equals(role.Id, AzureHostedAgentResource.AzureAIUserRoleDefinitionId, StringComparison.OrdinalIgnoreCase));
+            string.Equals(role.Id, AzureHostedAgentResource.FoundryUserRoleDefinitionId, StringComparison.OrdinalIgnoreCase));
 #pragma warning restore ASPIREAZURE003
     }
 
     [Fact]
-    public void AsHostedAgent_ReferenceRoleAssignmentAnnotation_GrantsOnlyAzureAIUserRole()
+    public void AsHostedAgent_ReferenceRoleAssignmentAnnotation_GrantsOnlyFoundryUserRole()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var project = builder.AddFoundry("account")
@@ -721,9 +721,9 @@ public class HostedAgentExtensionTests
 #pragma warning disable ASPIREAZURE003 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         var annotation = Assert.Single(hostedAgent.Target.Annotations.OfType<ReferenceRoleAssignmentAnnotation>());
 
-        // The implied grant is least-privilege: only "Azure AI User" is required to invoke the agent.
+        // The implied grant is least-privilege: only "Foundry User" is required to invoke the agent.
         var role = Assert.Single(annotation.Roles);
-        Assert.Equal(AzureHostedAgentResource.AzureAIUserRoleDefinitionId, role.Id, ignoreCase: true);
+        Assert.Equal(AzureHostedAgentResource.FoundryUserRoleDefinitionId, role.Id, ignoreCase: true);
 
         // The account's default data-plane roles must NOT be folded in here. A consumer that references
         // the account directly still receives them via the preparer's normal walk, and a consumer that

--- a/tests/Aspire.Hosting.Foundry.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/ProjectResourceTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Utils;
+using Azure.Provisioning.CognitiveServices;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Foundry.Tests;
@@ -233,6 +234,37 @@ public class ProjectResourceTests
 
         Assert.NotNull(project.Resource.CapabilityHostConfiguration);
         Assert.Same(foundry.Resource, project.Resource.CapabilityHostConfiguration.AzureOpenAI);
+    }
+
+    [Fact]
+    public async Task WithRoleAssignments_GrantsRoleToProjectIdentityOnParentAccount()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var foundryUserRole = (CognitiveServicesBuiltInRole)AzureHostedAgentResource.FoundryUserRoleDefinitionId;
+
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project")
+            .WithRoleAssignments(foundryUserRole);
+
+        var role = Assert.Single(project.Resource.ParentRoleAssignments);
+        Assert.Equal(AzureHostedAgentResource.FoundryUserRoleDefinitionId, role.Id);
+        Assert.Equal("Foundry User", role.Name);
+
+        await Verify(project.Resource.GetBicepTemplateString(), "bicep");
+    }
+
+    [Fact]
+    public void WithRoleAssignments_FoundryRoleMapsToFoundryUser()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project")
+            .WithRoleAssignments(FoundryRole.FoundryUser);
+
+        var role = Assert.Single(project.Resource.ParentRoleAssignments);
+        Assert.Equal(AzureHostedAgentResource.FoundryUserRoleDefinitionId, role.Id);
+        Assert.Equal("Foundry User", role.Name);
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ExecuteBeforeStartHooksAsync")]

--- a/tests/Aspire.Hosting.Foundry.Tests/Snapshots/ProjectResourceTests.WithRoleAssignments_GrantsRoleToProjectIdentityOnParentAccount.verified.bicep
+++ b/tests/Aspire.Hosting.Foundry.Tests/Snapshots/ProjectResourceTests.WithRoleAssignments_GrantsRoleToProjectIdentityOnParentAccount.verified.bicep
@@ -1,0 +1,86 @@
+﻿@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param tags object = { }
+
+param userPrincipalId string = ''
+
+param account_outputs_name string
+
+resource account 'Microsoft.CognitiveServices/accounts@2025-09-01' existing = {
+  name: account_outputs_name
+}
+
+resource my_project 'Microsoft.CognitiveServices/accounts/projects@2025-09-01' = {
+  name: 'my-project'
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    displayName: 'my-project'
+  }
+  tags: {
+    'aspire-resource-name': 'my-project'
+  }
+  parent: account
+}
+
+resource my_project_Foundry_User 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(account.id, my_project.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '53ca6127-db72-4b80-b1b0-d745d6d5456d'))
+  properties: {
+    principalId: my_project.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '53ca6127-db72-4b80-b1b0-d745d6d5456d')
+    principalType: 'ServicePrincipal'
+  }
+  scope: account
+}
+
+resource my_project_ai 'Microsoft.Insights/components@2020-02-02' = {
+  name: 'my-project-ai'
+  kind: 'web'
+  location: location
+  properties: {
+    Application_Type: 'web'
+  }
+  tags: tags
+}
+
+resource my_project_ai_MonitoringMetricsPublisher 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(my_project_ai.id, my_project.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3913510d-42f4-4e42-8a64-420c390055eb'))
+  properties: {
+    principalId: my_project.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3913510d-42f4-4e42-8a64-420c390055eb')
+    principalType: 'ServicePrincipal'
+  }
+  scope: my_project_ai
+}
+
+resource my_project_ai_conn 'Microsoft.CognitiveServices/accounts/projects/connections@2026-03-01' = {
+  name: 'my-project-ai-conn'
+  properties: {
+    isSharedToAll: false
+    metadata: {
+      ApiType: 'Azure'
+      ResourceId: my_project_ai.id
+      location: my_project_ai.location
+    }
+    target: my_project_ai.id
+    authType: 'ApiKey'
+    credentials: {
+      key: my_project_ai.properties.ConnectionString
+    }
+    category: 'AppInsights'
+  }
+  parent: my_project
+}
+
+output id string = my_project.id
+
+output name string = '${account_outputs_name}/my-project'
+
+output endpoint string = my_project.properties.endpoints['AI Foundry API']
+
+output principalId string = my_project.identity.principalId
+
+output APPLICATION_INSIGHTS_CONNECTION_STRING string = my_project_ai.properties.ConnectionString


### PR DESCRIPTION
## Description

Add a project-specific `WithRoleAssignments` overload that grants Cognitive Services roles on the parent Microsoft Foundry account to the Foundry project's own managed identity.

Foundry features such as Memory authenticate through the project's managed identity. The existing generic role-assignment path only grants permissions to resources that reference a target, so calling it on a Foundry project did not emit a role assignment. Using the raw Foundry User GUID in a manual workaround could also produce an invalid Bicep identifier.

This change:

- records requested parent-account roles on `AzureCognitiveServicesProjectResource`
- emits deterministic, normalized Bicep role assignments for the project identity
- adds the Foundry User role to the ATS-compatible role mapping
- uses the current Foundry User role name in hosted-agent code
- documents the Foundry Memory scenario
- verifies the generated Bicep scope, principal, and role definition

The API is explicit and opt-in. It does not broaden the default permissions assigned to Foundry projects.

Fixes microsoft/aspire#18938
Addresses microsoft/aspire#10871

## Validation

- `Aspire.Hosting.Foundry.Tests`: 119 passed
- `Aspire.Hosting.Foundry.Tests.csproj` build: succeeded with 0 warnings and 0 errors
- `dotnet format --verify-no-changes`: passed for the changed C# files
- `git diff --check`: passed

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No

The security-sensitive behavior is limited to explicit role requests. The generated assignment uses the requested built-in role, the project's managed identity, and the parent Foundry account scope.
