### PR TITLE
Preserve unique suffixes in App Service site names

### DIFF
--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -196,11 +196,6 @@ public static partial class AzureAppServiceEnvironmentExtensions
                 Value = plan.Id.ToBicepExpression()
             });
 
-            infra.Add(new ProvisioningOutput("webSiteSuffix", typeof(string))
-            {
-                Value = AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()
-            });
-
             infra.Add(new ProvisioningOutput("AZURE_CONTAINER_REGISTRY_NAME", typeof(string))
             {
                 Value = containerRegistry.Name.ToBicepExpression()

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -508,7 +508,13 @@ public class AzureAppServiceEnvironmentResource :
     public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference)
     {
         var resource = endpointReference.Resource;
-        return ReferenceExpression.Create($"{resource.Name.ToLowerInvariant()}-{WebSiteSuffix}.azurewebsites.net");
+        var websiteNamePrefix = resource.Name.ToLowerInvariant();
+        if (websiteNamePrefix.Length > AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength)
+        {
+            websiteNamePrefix = websiteNamePrefix[..AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength];
+        }
+
+        return ReferenceExpression.Create($"{websiteNamePrefix}-{WebSiteSuffix}.azurewebsites.net");
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs
@@ -368,8 +368,6 @@ public class AzureAppServiceEnvironmentResource :
     /// <summary>
     /// Gets the suffix added to each web app created in this App Service Environment.
     /// </summary>
-    internal BicepOutputReference WebSiteSuffix => new("webSiteSuffix", this);
-
     /// <summary>
     /// Gets the delegated subnet ID configured for this environment, if any.
     /// </summary>
@@ -448,8 +446,8 @@ public class AzureAppServiceEnvironmentResource :
     public BicepOutputReference AzureAppInsightsConnectionStringReference =>
         new("AZURE_APPLICATION_INSIGHTS_CONNECTION_STRING", this);
 
-    internal static BicepValue<string> GetWebSiteSuffixBicep() =>
-        BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id);
+    internal static BicepValue<string> GetWebSiteSuffixBicep(string resourceName) =>
+        BicepFunction.GetUniqueString(BicepFunction.ToLower(resourceName), BicepFunction.GetResourceGroup().Id);
 
     /// <summary>
     /// Gets the default container registry for this environment.
@@ -508,13 +506,13 @@ public class AzureAppServiceEnvironmentResource :
     public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference)
     {
         var resource = endpointReference.Resource;
-        var websiteNamePrefix = resource.Name.ToLowerInvariant();
-        if (websiteNamePrefix.Length > AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength)
+        var deploymentTarget = resource.GetDeploymentTargetAnnotation(this)?.DeploymentTarget;
+        if (deploymentTarget is not AzureAppServiceWebSiteResource website)
         {
-            websiteNamePrefix = websiteNamePrefix[..AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength];
+            throw new InvalidOperationException($"Resource '{resource.Name}' does not have an Azure App Service deployment target.");
         }
 
-        return ReferenceExpression.Create($"{websiteNamePrefix}-{WebSiteSuffix}.azurewebsites.net");
+        return ReferenceExpression.Create($"{website.NameOutputReference}.azurewebsites.net");
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
@@ -17,8 +17,9 @@ internal static class AzureAppServiceEnvironmentUtility
 
     public static BicepValue<string> GetDashboardHostName(string aspireResourceName)
     {
-        return BicepFunction.Take(
-    BicepFunction.Interpolate($"{BicepFunction.ToLower(aspireResourceName)}-{BicepFunction.ToLower(ResourceName)}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}"), 60);
+        var dashboardPrefix = BicepFunction.Interpolate($"{BicepFunction.ToLower(aspireResourceName)}-{BicepFunction.ToLower(ResourceName)}");
+        return BicepFunction.Interpolate(
+            $"{BicepFunction.Take(dashboardPrefix, AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength)}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}");
     }
 
     public static WebSite AddDashboard(AzureResourceInfrastructure infra,

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentUtility.cs
@@ -19,7 +19,7 @@ internal static class AzureAppServiceEnvironmentUtility
     {
         var dashboardPrefix = BicepFunction.Interpolate($"{BicepFunction.ToLower(aspireResourceName)}-{BicepFunction.ToLower(ResourceName)}");
         return BicepFunction.Interpolate(
-            $"{BicepFunction.Take(dashboardPrefix, AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength)}-{BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id)}");
+            $"{BicepFunction.Take(dashboardPrefix, AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep(aspireResourceName)}");
     }
 
     public static WebSite AddDashboard(AzureResourceInfrastructure infra,

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -112,7 +112,7 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     {
         var computerEnv = (AzureAppServiceEnvironmentResource)TargetResource.GetDeploymentTargetAnnotation()!.ComputeEnvironment!;
         var websiteSuffix = await computerEnv.WebSiteSuffix.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
-        return TruncateToMaxLength($"{TargetResource.Name.ToLowerInvariant()}-{websiteSuffix}", 60);
+        return $"{TruncateToMaxLength(TargetResource.Name.ToLowerInvariant(), MaxWebSiteNamePrefixLength)}-{websiteSuffix}";
     }
 
     private static string GetAppServiceWebsiteName(string websiteName, string? deploymentSlot = null)
@@ -141,4 +141,5 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     // Source of truth: https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites?path=%2Fsrc%2FHosting%2FAdministrationService%2FMicrosoft.Web.Hosting.Administration.Api%2FCommonConstants.cs&_a=contents&version=GBdev
     internal const int MaxHostPrefixLengthWithSlot = 59;
     internal const int MaxWebSiteNamePrefixLengthWithSlot = 40;
+    internal const int MaxWebSiteNamePrefixLength = 46;
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebSiteResource.cs
@@ -103,6 +103,8 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     /// </summary>
     public IResource TargetResource { get; }
 
+    internal BicepOutputReference NameOutputReference => new("name", this);
+
     /// <summary>
     /// Gets the base Azure App Service website name without any deployment slot suffix.
     /// </summary>
@@ -110,9 +112,7 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     /// <returns>A task that represents the asynchronous operation. The task result contains the website name.</returns>
     private async Task<string> GetAppServiceWebsiteBaseNameAsync(PipelineStepContext context)
     {
-        var computerEnv = (AzureAppServiceEnvironmentResource)TargetResource.GetDeploymentTargetAnnotation()!.ComputeEnvironment!;
-        var websiteSuffix = await computerEnv.WebSiteSuffix.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
-        return $"{TruncateToMaxLength(TargetResource.Name.ToLowerInvariant(), MaxWebSiteNamePrefixLength)}-{websiteSuffix}";
+        return (await NameOutputReference.GetValueAsync(context.CancellationToken).ConfigureAwait(false))!;
     }
 
     private static string GetAppServiceWebsiteName(string websiteName, string? deploymentSlot = null)
@@ -142,4 +142,5 @@ public class AzureAppServiceWebSiteResource : AzureProvisioningResource
     internal const int MaxHostPrefixLengthWithSlot = 59;
     internal const int MaxWebSiteNamePrefixLengthWithSlot = 40;
     internal const int MaxWebSiteNamePrefixLength = 46;
+    internal const int MaxWebSiteNamePrefixLengthWithSlotUniqueSuffix = 26;
 }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -38,7 +38,7 @@ internal sealed class AzureAppServiceWebsiteContext(
     // within the naming spec for the app service. Truncate the resource-name prefix before appending the suffix so that the
     // suffix is never truncated away.
     private BicepValue<string> HostName => BicepFunction.Interpolate(
-        $"{BicepFunction.Take(BicepFunction.ToLower(resource.Name), AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}");
+        $"{BicepFunction.Take(BicepFunction.ToLower(resource.Name), AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep(resource.Name)}");
 
     /// <summary>
     /// Gets the hostname for a deployment slot by appending the slot name to the base website name.
@@ -47,8 +47,8 @@ internal sealed class AzureAppServiceWebsiteContext(
     /// <returns>A <see cref="BicepValue{T}"/> representing the slot hostname, truncated to the maximum allowed length.</returns>
     public BicepValue<string> GetSlotHostName(BicepValue<string> deploymentSlot)
     {
-        var websitePrefix = BicepFunction.Take(
-            BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLengthWithSlot);
+        var websitePrefix = BicepFunction.Interpolate(
+            $"{BicepFunction.Take(BicepFunction.ToLower(resource.Name), AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLengthWithSlotUniqueSuffix)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep(resource.Name)}");
 
         return BicepFunction.Take(
             BicepFunction.Interpolate($"{websitePrefix}-{BicepFunction.ToLower(deploymentSlot)}"), AzureAppServiceWebSiteResource.MaxHostPrefixLengthWithSlot);
@@ -325,6 +325,11 @@ internal sealed class AzureAppServiceWebsiteContext(
     public void BuildWebSite(AzureResourceInfrastructure infra)
     {
         _infrastructure = infra;
+
+        infra.Add(new ProvisioningOutput("name", typeof(string))
+        {
+            Value = HostName
+        });
 
         // Check for deployment slot
         // If specified, update hostnames to endpoint references

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceWebsiteContext.cs
@@ -34,10 +34,11 @@ internal sealed class AzureAppServiceWebsiteContext(
     private AzureResourceInfrastructure? _infrastructure;
     public AzureResourceInfrastructure Infra => _infrastructure ?? throw new InvalidOperationException("Infra is not set");
 
-    // Naming the app service is globally unique (domain names), so we use the resource group ID to create a unique name
-    // within the naming spec for the app service.
-    private BicepValue<string> HostName => BicepFunction.Take(
-        BicepFunction.Interpolate($"{BicepFunction.ToLower(resource.Name)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}"), 60);
+    // Naming the app service is globally unique (domain names), so we use the resource group ID to create a unique suffix
+    // within the naming spec for the app service. Truncate the resource-name prefix before appending the suffix so that the
+    // suffix is never truncated away.
+    private BicepValue<string> HostName => BicepFunction.Interpolate(
+        $"{BicepFunction.Take(BicepFunction.ToLower(resource.Name), AzureAppServiceWebSiteResource.MaxWebSiteNamePrefixLength)}-{AzureAppServiceEnvironmentResource.GetWebSiteSuffixBicep()}");
 
     /// <summary>
     /// Gets the hostname for a deployment slot by appending the slot name to the base website name.

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -1113,41 +1113,51 @@ public class AzureAppServiceTests(ITestOutputHelper outputHelper)
 
         var project = builder
             .AddProject<Project>("project1", launchProfileName: null)
-            .WithHttpEndpoint();
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
 
         var endpointReferenceEx = env.Resource.GetHostAddressExpression(project.GetEndpoint("http"));
         Assert.NotNull(endpointReferenceEx);
 
-        Assert.Equal("project1-{0}.azurewebsites.net", endpointReferenceEx.Format);
+        Assert.Equal("{0}.azurewebsites.net", endpointReferenceEx.Format);
         var provider = Assert.Single(endpointReferenceEx.ValueProviders);
         var output = Assert.IsType<BicepOutputReference>(provider);
-        Assert.Equal(env.Resource, output.Resource);
-        Assert.Equal("webSiteSuffix", output.Name);
+        var target = Assert.IsType<AzureAppServiceWebSiteResource>(project.Resource.GetDeploymentTargetAnnotation()!.DeploymentTarget);
+        Assert.Equal(target, output.Resource);
+        Assert.Equal("name", output.Name);
     }
 
     [Fact]
     public async Task AppServiceWebsiteName_PreservesUniqueSuffixForLongResourceNames()
     {
-        const string resourceName = "project-with-a-name-longer-than-forty-six-characters";
+        const string sharedPrefix = "project-with-a-name-longer-than-forty-six-characters";
+        var firstResourceName = $"{sharedPrefix}-one";
+        var secondResourceName = $"{sharedPrefix}-two";
 
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
-        var env = builder.AddAzureAppServiceEnvironment("env");
-        var project = builder
-            .AddProject<Project>(resourceName, launchProfileName: null)
-            .WithHttpEndpoint();
+        builder.AddAzureAppServiceEnvironment("env");
+        var firstProject = builder
+            .AddProject<Project>(firstResourceName, launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
+        var secondProject = builder
+            .AddProject<Project>(secondResourceName, launchProfileName: null)
+            .WithHttpEndpoint()
+            .WithExternalHttpEndpoints();
 
         using var app = builder.Build();
         await ExecuteBeforeStartHooksAsync(app, default);
 
-        var target = project.Resource.GetDeploymentTargetAnnotation();
-        Assert.NotNull(target);
-        var website = Assert.IsAssignableFrom<AzureProvisioningResource>(target.DeploymentTarget);
-        var (_, bicep) = await GetManifestWithBicep(website);
+        var firstWebsite = Assert.IsAssignableFrom<AzureProvisioningResource>(firstProject.Resource.GetDeploymentTargetAnnotation()!.DeploymentTarget);
+        var secondWebsite = Assert.IsAssignableFrom<AzureProvisioningResource>(secondProject.Resource.GetDeploymentTargetAnnotation()!.DeploymentTarget);
+        var (_, firstBicep) = await GetManifestWithBicep(firstWebsite);
+        var (_, secondBicep) = await GetManifestWithBicep(secondWebsite);
 
-        Assert.Contains($"name: '${{take(toLower('{resourceName}'), 46)}}-${{uniqueString(resourceGroup().id)}}'", bicep);
-
-        var hostAddress = env.Resource.GetHostAddressExpression(project.GetEndpoint("http"));
-        Assert.Equal("project-with-a-name-longer-than-forty-six-char-{0}.azurewebsites.net", hostAddress.Format);
+        Assert.Contains($"name: '${{take(toLower('{firstResourceName}'), 46)}}-${{uniqueString(toLower('{firstResourceName}'), resourceGroup().id)}}'", firstBicep);
+        Assert.Contains($"name: '${{take(toLower('{secondResourceName}'), 46)}}-${{uniqueString(toLower('{secondResourceName}'), resourceGroup().id)}}'", secondBicep);
     }
 
     [Theory]
@@ -1164,12 +1174,17 @@ public class AzureAppServiceTests(ITestOutputHelper outputHelper)
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         var env = builder.AddAzureAppServiceEnvironment("env");
-        env.Resource.Outputs["webSiteSuffix"] = "website123";
-        env.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
 
         var project = builder
             .AddProject<Project>("project1", launchProfileName: null)
             .WithEndpoint(port: 8080, targetPort: 5000, scheme: "http", name: "http", isExternal: true);
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var website = Assert.IsType<AzureAppServiceWebSiteResource>(project.Resource.GetDeploymentTargetAnnotation()!.DeploymentTarget);
+        website.Outputs["name"] = "project1-website123";
+        website.ProvisioningTaskCompletionSource?.TrySetResult();
 
 #pragma warning disable ASPIRECOMPUTE002
         var expression = env.Resource.GetEndpointPropertyExpression(project.GetEndpoint("http").Property(property));

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppServiceTests.cs
@@ -1125,6 +1125,31 @@ public class AzureAppServiceTests(ITestOutputHelper outputHelper)
         Assert.Equal("webSiteSuffix", output.Name);
     }
 
+    [Fact]
+    public async Task AppServiceWebsiteName_PreservesUniqueSuffixForLongResourceNames()
+    {
+        const string resourceName = "project-with-a-name-longer-than-forty-six-characters";
+
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var env = builder.AddAzureAppServiceEnvironment("env");
+        var project = builder
+            .AddProject<Project>(resourceName, launchProfileName: null)
+            .WithHttpEndpoint();
+
+        using var app = builder.Build();
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var target = project.Resource.GetDeploymentTargetAnnotation();
+        Assert.NotNull(target);
+        var website = Assert.IsAssignableFrom<AzureProvisioningResource>(target.DeploymentTarget);
+        var (_, bicep) = await GetManifestWithBicep(website);
+
+        Assert.Contains($"name: '${{take(toLower('{resourceName}'), 46)}}-${{uniqueString(resourceGroup().id)}}'", bicep);
+
+        var hostAddress = env.Resource.GetHostAddressExpression(project.GetEndpoint("http"));
+        Assert.Equal("project-with-a-name-longer-than-forty-six-char-{0}.azurewebsites.net", hostAddress.Format);
+    }
+
     [Theory]
     [InlineData(EndpointProperty.Url, "https://project1-website123.azurewebsites.net")]
     [InlineData(EndpointProperty.Host, "project1-website123.azurewebsites.net")]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceContainerWithoutTargetPortUsesDefaultPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceContainerWithoutTargetPortUsesDefaultPort.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -30,7 +30,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('container1')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('container1'), 46)}-${uniqueString(toLower('container1'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -102,3 +102,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('container1'), 46)}-${uniqueString(toLower('container1'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceEnvironmentWithoutDashboardAddsEnvironmentResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceEnvironmentWithoutDashboardAddsEnvironmentResource.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''
@@ -44,8 +44,6 @@ resource env_asplan 'Microsoft.Web/serverfarms@2025-03-01' = {
 output name string = env_asplan.name
 
 output planId string = env_asplan.id
-
-output webSiteSuffix string = uniqueString(resourceGroup().id)
 
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithApplicationInsightsSetsAppSettings.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithApplicationInsightsSetsAppSettings.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -36,7 +36,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -132,3 +132,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithoutTargetPortUsesContainerPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceProjectWithoutTargetPortUsesContainerPort.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -32,7 +32,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -116,3 +116,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceToEnvironmentWithoutDashboard.verified.bicep
@@ -26,7 +26,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -54,11 +54,11 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'PROJECT1_HTTP'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'services__project1__http__0'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -85,3 +85,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsDefaultLocation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsDefaultLocation.verified.bicep
@@ -56,7 +56,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_asplan.id
@@ -150,8 +150,6 @@ output name string = env_asplan.name
 
 output planId string = env_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -164,7 +162,7 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'
 
 output AZURE_APPLICATION_INSIGHTS_INSTRUMENTATIONKEY string = env_ai.properties.InstrumentationKey
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocation.verified.bicep
@@ -56,7 +56,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_asplan.id
@@ -150,8 +150,6 @@ output name string = env_asplan.name
 
 output planId string = env_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -164,7 +162,7 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'
 
 output AZURE_APPLICATION_INSIGHTS_INSTRUMENTATIONKEY string = env_ai.properties.InstrumentationKey
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocationParam.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsLocationParam.verified.bicep
@@ -58,7 +58,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_asplan.id
@@ -152,8 +152,6 @@ output name string = env_asplan.name
 
 output planId string = env_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -166,7 +164,7 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'
 
 output AZURE_APPLICATION_INSIGHTS_INSTRUMENTATIONKEY string = env_ai.properties.InstrumentationKey
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsNormalizesBicepIdentifiers.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithApplicationInsightsNormalizesBicepIdentifiers.verified.bicep
@@ -56,7 +56,7 @@ resource env_1_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env-1')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env-1')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env-1'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_1_asplan.id
@@ -150,8 +150,6 @@ output name string = env_1_asplan.name
 
 output planId string = env_1_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_1_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_1_acr.properties.loginServer
@@ -164,7 +162,7 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_1_contributor_
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_1_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env-1')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env-1')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env-1'), resourceGroup().id)}'}.azurewebsites.net'
 
 output AZURE_APPLICATION_INSIGHTS_INSTRUMENTATIONKEY string = env_1_ai.properties.InstrumentationKey
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithArgs.verified.bicep
@@ -36,7 +36,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -64,11 +64,11 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'PROJECT1_HTTP'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'services__project1__http__0'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -130,3 +130,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDelegatedSubnet.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDelegatedSubnet.verified.bicep
@@ -100,7 +100,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_asplan.id
@@ -174,8 +174,6 @@ output name string = env_asplan.name
 
 output planId string = env_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -188,7 +186,7 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'
 
 // App Service website
 @description('The location for the resource(s) to be deployed.')
@@ -229,7 +227,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 
 @onlyIfNotExists()
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -412,3 +410,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDelegatedSubnetWithoutDeploymentSlot.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDelegatedSubnetWithoutDeploymentSlot.verified.bicep
@@ -100,7 +100,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_asplan.id
@@ -174,8 +174,6 @@ output name string = env_asplan.name
 
 output planId string = env_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -188,7 +186,7 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'
 
 // App Service website
 @description('The location for the resource(s) to be deployed.')
@@ -227,7 +225,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -312,3 +310,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlot.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlot.verified.bicep
@@ -34,7 +34,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 
 @onlyIfNotExists()
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -207,3 +207,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlotParameter.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithDeploymentSlotParameter.verified.bicep
@@ -36,7 +36,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 
 @onlyIfNotExists()
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -209,3 +209,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithExistingApplicationInsights.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithExistingApplicationInsights.verified.bicep
@@ -58,7 +58,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_asplan.id
@@ -135,8 +135,6 @@ output name string = env_asplan.name
 
 output planId string = env_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -149,7 +147,7 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'
 
 output AZURE_APPLICATION_INSIGHTS_INSTRUMENTATIONKEY string = existingAppInsights.properties.InstrumentationKey
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPort.verified.bicep
@@ -30,7 +30,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -58,19 +58,19 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'PROJECT1_HTTPS'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'services__project1__https__0'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'PROJECT1_HTTP'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'services__project1__http__0'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -134,3 +134,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPortMultipleEndpoints.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddAppServiceWithTargetPortMultipleEndpoints.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -30,7 +30,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -118,3 +118,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsDeploymentTargetWithContainerAppToProjectResources.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -32,7 +32,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -117,3 +117,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsEnvironmentResource.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddContainerAppEnvironmentAddsEnvironmentResource.verified.bicep
@@ -56,7 +56,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_asplan.id
@@ -129,8 +129,6 @@ output name string = env_asplan.name
 
 output planId string = env_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -143,4 +141,4 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddDockerfileWithAppServiceInfrastructureAddsDeploymentTargetWithAppServiceToContainerResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AddDockerfileWithAppServiceInfrastructureAddsDeploymentTargetWithAppServiceToContainerResources.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -30,7 +30,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -106,3 +106,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesEnvWithExistingPlanAndRegistry.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AsExisting_WithExplicitContainerRegistry_PublishGeneratesEnvWithExistingPlanAndRegistry.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''
@@ -40,8 +40,6 @@ resource env 'Microsoft.Web/serverfarms@2025-03-01' existing = {
 output name string = env.name
 
 output planId string = env.id
-
-output webSiteSuffix string = uniqueString(resourceGroup().id)
 
 output AZURE_CONTAINER_REGISTRY_NAME string = acr.name
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#01.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#01.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''
@@ -51,7 +51,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env.id
@@ -124,8 +124,6 @@ output name string = env.name
 
 output planId string = env.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -138,4 +136,4 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#02.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanPublishExistingAppServicePlan#02.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -32,7 +32,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -116,3 +116,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanReferenceExistingAppServicePlan.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceEnvironmentCanReferenceExistingAppServicePlan.verified.bicep
@@ -51,7 +51,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env.id
@@ -124,8 +124,6 @@ output name string = env.name
 
 output planId string = env.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -138,4 +136,4 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceSupportBaitAndSwitchResources.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.AzureAppServiceSupportBaitAndSwitchResources.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -30,7 +30,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -114,3 +114,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.CanPreserveHttpSchemeUsingWithHttpsUpgrade.verified.bicep
@@ -30,7 +30,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -58,19 +58,19 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'PROJECT1_HTTPS'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'services__project1__https__0'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'PROJECT1_HTTP'
-          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'http://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'services__project1__http__0'
-          value: 'http://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'http://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -134,3 +134,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.ConditionalExpressionWithParameterCondition.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.ConditionalExpressionWithParameterCondition.verified.bicep
@@ -34,7 +34,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -122,3 +122,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferenceToFoundryHostedAgentIsResolvedAcrossComputeEnvironments.verified.bicep
@@ -38,7 +38,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('web')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('web'), 46)}-${uniqueString(toLower('web'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -146,3 +146,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('web'), 46)}-${uniqueString(toLower('web'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferencesAreResolvedAcrossProjects.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.EndpointReferencesAreResolvedAcrossProjects.verified.bicep
@@ -32,7 +32,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project2')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -60,11 +60,11 @@ resource webapp 'Microsoft.Web/sites@2025-03-01' = {
         }
         {
           name: 'PROJECT1_HTTP'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'services__project1__http__0'
-          value: 'https://${take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+          value: 'https://${'${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'}.azurewebsites.net'
         }
         {
           name: 'ASPIRE_ENVIRONMENT_NAME'
@@ -126,3 +126,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project2'), 46)}-${uniqueString(toLower('project2'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.KeyvaultReferenceHandling.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -68,7 +68,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -174,3 +174,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.PublishAsAzureAppServiceWebsite_CanOverrideEnvironmentDelegatedSubnet.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.PublishAsAzureAppServiceWebsite_CanOverrideEnvironmentDelegatedSubnet.verified.bicep
@@ -36,7 +36,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 
 @onlyIfNotExists()
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -219,3 +219,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.ResourceWithProbes.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.ResourceWithProbes.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -32,7 +32,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('project1')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -117,3 +117,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('project1'), 46)}-${uniqueString(toLower('project1'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.UnknownManifestExpressionProviderIsHandledWithAllocateParameter.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.UnknownManifestExpressionProviderIsHandledWithAllocateParameter.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param env_outputs_azure_container_registry_endpoint string
@@ -34,7 +34,7 @@ resource mainContainer 'Microsoft.Web/sites/sitecontainers@2025-03-01' = {
 }
 
 resource webapp 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('api')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_outputs_planid
@@ -122,3 +122,5 @@ resource slotConfigNames 'Microsoft.Web/sites/config@2025-03-01' = {
   }
   parent: webapp
 }
+
+output name string = '${take(toLower('api'), 46)}-${uniqueString(toLower('api'), resourceGroup().id)}'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_AsExisting_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_AsExisting_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''
@@ -28,8 +28,6 @@ resource env 'Microsoft.Web/serverfarms@2025-03-01' existing = {
 output name string = env.name
 
 output planId string = env.id
-
-output webSiteSuffix string = uniqueString(resourceGroup().id)
 
 output AZURE_CONTAINER_REGISTRY_NAME string = acr.name
 

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureAppServiceTests.WithAcrPullIdentity_PublishGeneratesEnvWithSuppliedIdentity.verified.bicep
@@ -1,4 +1,4 @@
-@description('The location for the resource(s) to be deployed.')
+﻿@description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
 param userPrincipalId string = ''
@@ -44,7 +44,7 @@ resource env_ra 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 resource dashboard 'Microsoft.Web/sites@2025-03-01' = {
-  name: take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)
+  name: '${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'
   location: location
   properties: {
     serverFarmId: env_asplan.id
@@ -117,8 +117,6 @@ output name string = env_asplan.name
 
 output planId string = env_asplan.id
 
-output webSiteSuffix string = uniqueString(resourceGroup().id)
-
 output AZURE_CONTAINER_REGISTRY_NAME string = env_acr.name
 
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = env_acr.properties.loginServer
@@ -131,4 +129,4 @@ output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_ID string = env_contributor_mi
 
 output AZURE_WEBSITE_CONTRIBUTOR_MANAGED_IDENTITY_PRINCIPAL_ID string = env_contributor_mi.properties.principalId
 
-output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${take('${toLower('env')}-${toLower('aspiredashboard')}-${uniqueString(resourceGroup().id)}', 60)}.azurewebsites.net'
+output AZURE_APP_SERVICE_DASHBOARD_URI string = 'https://${'${take('${toLower('env')}-${toLower('aspiredashboard')}', 46)}-${uniqueString(toLower('env'), resourceGroup().id)}'}.azurewebsites.net'


### PR DESCRIPTION
## Summary
- truncate App Service resource-name prefixes before appending the resource-group uniqueness suffix
- keep generated Bicep, service-discovery expressions, deployment summaries, and dashboard names consistent
- add coverage for long resource names

Fixes #18750

## Validation
- `dotnet build tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-restore`
- Focused test run was attempted, but the local bundled VSTest host is missing `Microsoft.TestPlatform.CommunicationUtilities`.