### PR TITLE
Allow descriptions on connection string parameters

### DIFF
--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -218,6 +218,34 @@ public static class ParameterResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Sets the description of a connection string parameter resource.
+    /// </summary>
+    /// <param name="builder">Resource builder for the connection string parameter.</param>
+    /// <param name="description">The parameter description.</param>
+    /// <param name="enableMarkdown">
+    /// A value indicating whether the description should be rendered as Markdown.
+    /// <c>true</c> allows the description to contain Markdown elements such as links, text decoration and lists.
+    /// </param>
+    /// <returns>Resource builder for the connection string parameter.</returns>
+    /// <exception cref="ArgumentException">The resource is not a parameter resource.</exception>
+    [AspireExportIgnore(Reason = "Polyglot app hosts use the internal addConnectionString dispatcher export.")]
+    public static IResourceBuilder<IResourceWithConnectionString> WithDescription(this IResourceBuilder<IResourceWithConnectionString> builder, string description, bool enableMarkdown = false)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(description);
+
+        if (builder.Resource is not ParameterResource parameter)
+        {
+            throw new ArgumentException("The resource must be a parameter resource.", nameof(builder));
+        }
+
+        parameter.Description = description;
+        parameter.EnableDescriptionMarkdown = enableMarkdown;
+
+        return builder;
+    }
+
+    /// <summary>
     /// Sets a custom input generator function for the parameter resource.
     /// </summary>
     /// <param name="builder">Resource builder for the parameter.</param>

--- a/src/Aspire.Hosting/api/Aspire.Hosting.cs
+++ b/src/Aspire.Hosting/api/Aspire.Hosting.cs
@@ -982,6 +982,9 @@ namespace Aspire.Hosting
 
         [AspireExport]
         public static ApplicationModel.IResourceBuilder<ApplicationModel.ParameterResource> WithDescription(this ApplicationModel.IResourceBuilder<ApplicationModel.ParameterResource> builder, string description, bool enableMarkdown = false) { throw null; }
+
+        [AspireExportIgnore(Reason = "Polyglot app hosts use the internal addConnectionString dispatcher export.")]
+        public static ApplicationModel.IResourceBuilder<ApplicationModel.IResourceWithConnectionString> WithDescription(this ApplicationModel.IResourceBuilder<ApplicationModel.IResourceWithConnectionString> builder, string description, bool enableMarkdown = false) { throw null; }
     }
 
     public static partial class ProjectResourceBuilderExtensions

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -392,6 +392,19 @@ public class AddParameterTests
     }
 
     [Fact]
+    public void ConnectionStringParameterWithDescription_SetsDescriptionAndMarkupProperties()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var parameter = appBuilder.AddConnectionString("database")
+            .WithDescription("The database connection string.", enableMarkdown: true);
+
+        var parameterResource = Assert.IsAssignableFrom<ParameterResource>(parameter.Resource);
+        Assert.Equal("The database connection string.", parameterResource.Description);
+        Assert.True(parameterResource.EnableDescriptionMarkdown);
+    }
+
+    [Fact]
     public void ParameterWithDescriptionAndCustomInput_AddsInputGeneratorAnnotation()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add `WithDescription` support to the parameter-based `AddConnectionString` overload
- preserve Markdown description support
- add coverage for the new fluent API

Fixes #18704

## Validation
- `dotnet build tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-restore`
- Focused test run was attempted, but the local bundled VSTest host is missing `Microsoft.TestPlatform.CommunicationUtilities`.