### PR TITLE
Enable running container tests on Podman-only machines

### DIFF
--- a/docs/ci/azdo-public-pipeline.md
+++ b/docs/ci/azdo-public-pipeline.md
@@ -279,21 +279,24 @@ Since AzDO tests don't run on PRs, changes can silently break the pipeline. The 
 
 **What to watch for**: Changes to `DOTNET_ROOT`, `PATH`, or SDK version settings in `BuildAndTest.yml`, `tests/Directory.Build.targets`, or helix targets. If a change works by relying on the system dotnet or GitHub Actions' pre-installed SDK, it will likely break AzDO/Helix.
 
-### 3. Docker/Buildx Availability Differences
+### 3. Container Runtime Availability Differences
 
-**Pattern**: Tests that require Docker or Docker Buildx pass on GitHub Actions but fail on AzDO/Helix agents where Docker capabilities differ. The `RequiresFeatureAttribute` and `TestFeature` enum (`tests/Aspire.TestUtilities/TestFeature.cs`) provide the mechanism to declare these dependencies:
+**Pattern**: Tests that require a container runtime or image-building support pass on GitHub Actions but fail on AzDO/Helix agents where those capabilities differ. The `RequiresFeatureAttribute` and `TestFeature` enum (`tests/Aspire.TestUtilities/TestFeature.cs`) provide the mechanism to declare these dependencies:
 
-- **`[RequiresFeature(TestFeature.Docker)]`** — test needs Docker. Supported on Linux (local + CI) but **not on Windows CI** (AzDO/Helix Windows agents don't have Docker).
-- **`[RequiresFeature(TestFeature.DockerPluginBuildx)]`** — test needs `docker buildx`. **Not available on any AzDO/Helix agent** (`IsDockerPluginBuildxSupported()` returns `false` when `PlatformDetection.IsRunningFromAzdo`).
+- **`[RequiresFeature(TestFeature.ContainerRuntime)]`** — test needs a container runtime, satisfied by either Docker or Podman. Supported on Linux (local + CI) but **not on Windows CI** (AzDO/Helix Windows agents don't have a container runtime). This is the right choice for most container tests.
+- **`[RequiresFeature(TestFeature.ContainerImageBuild)]`** — test builds an image from a Dockerfile. Under Docker this needs the buildx plugin, which is **not available on any AzDO/Helix agent** (`IsContainerImageBuildSupported()` returns `false` when `PlatformDetection.IsRunningFromAzdo`). Podman builds natively and needs no plugin.
+- **`[RequiresFeature(TestFeature.Docker)]`** — test needs Docker *specifically* rather than containers in general, e.g. it bind-mounts `/var/run/docker.sock` or shells out to the `docker` CLI. Use this only when Podman genuinely cannot satisfy the test.
 
-If a test depends on a Docker capability not covered by these (e.g., a new Docker plugin or compose feature), a new `TestFeature` flag must be added to the enum and the detection logic added to `RequiresFeatureAttribute.IsSupported()`.
+On CI these are hard-coded *expected* values, so a container-dependent test **fails** rather than silently skipping in an environment where the runtime is expected to work. On local runs the attribute instead probes `PATH` for the `docker`/`podman` executables, so a developer machine with only one of them (or neither) skips the tests it cannot run.
+
+If a test depends on a capability not covered by these (e.g., a new plugin or compose feature), a new `TestFeature` flag must be added to the enum and the detection logic added to `RequiresFeatureAttribute.IsFeatureSupported()`.
 
 **Real incidents**:
 - `62d71279`: 51 tests had to be disabled with `ActiveIssue` because they required Docker buildx (not installed on AzDO), testcontainers with specific images, or Azure deployment infrastructure
 - `6832752429`: `VerifyPnpmDockerfileBuildSucceeds` test skipped on AzDO due to missing buildx
 - `8692e43b`: Docker runtime detection (`docker info`) behaved differently on AzDO
 
-**What to watch for**: New tests that use `WithDockerfile`, Docker buildx, testcontainers, or `DOCKER_BUILDKIT`. Every such test **must** have `[RequiresFeature(TestFeature.Docker)]` or `[RequiresFeature(TestFeature.DockerPluginBuildx)]` as appropriate. Without this attribute, the test will attempt to run on environments where Docker is unavailable and fail. If the test depends on a Docker capability not covered by existing `TestFeature` values, add a new flag.
+**What to watch for**: New tests that use `WithDockerfile`, buildx, testcontainers, or `DOCKER_BUILDKIT`. Every such test **must** have `[RequiresFeature(TestFeature.ContainerRuntime)]` or `[RequiresFeature(TestFeature.ContainerImageBuild)]` as appropriate. Without this attribute, the test will attempt to run on environments where no container runtime is available and fail. Reach for `TestFeature.Docker` only when the test truly cannot run under Podman. If the test depends on a capability not covered by existing `TestFeature` values, add a new flag.
 
 ### 4. Incorrect RunOnAzdoHelix* Overrides
 

--- a/docs/ci/azdo-public-pipeline.md
+++ b/docs/ci/azdo-public-pipeline.md
@@ -285,18 +285,21 @@ Since AzDO tests don't run on PRs, changes can silently break the pipeline. The 
 
 - **`[RequiresFeature(TestFeature.ContainerRuntime)]`** — test needs a container runtime, satisfied by either Docker or Podman. Supported on Linux (local + CI) but **not on Windows CI** (AzDO/Helix Windows agents don't have a container runtime). This is the right choice for most container tests.
 - **`[RequiresFeature(TestFeature.ContainerImageBuild)]`** — test builds an image from a Dockerfile. Under Docker this needs the buildx plugin, which is **not available on any AzDO/Helix agent** (`IsContainerImageBuildSupported()` returns `false` when `PlatformDetection.IsRunningFromAzdo`). Podman builds natively and needs no plugin.
+- **`[RequiresFeature(TestFeature.Testcontainers)]`** — test is backed by a Testcontainers fixture. Stricter than `ContainerRuntime`: see below.
 - **`[RequiresFeature(TestFeature.Docker)]`** — test needs Docker *specifically* rather than containers in general, e.g. it bind-mounts `/var/run/docker.sock` or shells out to the `docker` CLI. Use this only when Podman genuinely cannot satisfy the test.
 
 On CI these are hard-coded *expected* values, so a container-dependent test **fails** rather than silently skipping in an environment where the runtime is expected to work. On local runs the attribute instead probes `PATH` for the `docker`/`podman` executables, so a developer machine with only one of them (or neither) skips the tests it cannot run.
 
 If a test depends on a capability not covered by these (e.g., a new plugin or compose feature), a new `TestFeature` flag must be added to the enum and the detection logic added to `RequiresFeatureAttribute.IsFeatureSupported()`.
 
+**Testcontainers-backed suites**: Testcontainers talks to a Docker-compatible HTTP API rather than driving a CLI, and it cannot discover Podman on its own — its endpoint discovery only probes `docker.sock` paths — so on a Podman-only machine those fixtures would fail with `DockerUnavailableException`. This is handled by calling into `TestcontainersPodmanConfiguration` helper, which points Testcontainers at the Podman socket and disables Ryuk (which cannot work against rootless Podman). Docker is preferred on machines with Windows and Podman. Windows, Podman-only machines are not supported because Testcontainers 4.x cannot drive Podman over a Windows named pipe.
+
 **Real incidents**:
 - `62d71279`: 51 tests had to be disabled with `ActiveIssue` because they required Docker buildx (not installed on AzDO), testcontainers with specific images, or Azure deployment infrastructure
 - `6832752429`: `VerifyPnpmDockerfileBuildSucceeds` test skipped on AzDO due to missing buildx
 - `8692e43b`: Docker runtime detection (`docker info`) behaved differently on AzDO
 
-**What to watch for**: New tests that use `WithDockerfile`, buildx, testcontainers, or `DOCKER_BUILDKIT`. Every such test **must** have `[RequiresFeature(TestFeature.ContainerRuntime)]` or `[RequiresFeature(TestFeature.ContainerImageBuild)]` as appropriate. Without this attribute, the test will attempt to run on environments where no container runtime is available and fail. Reach for `TestFeature.Docker` only when the test truly cannot run under Podman. If the test depends on a capability not covered by existing `TestFeature` values, add a new flag.
+**What to watch for**: New tests that use `WithDockerfile`, buildx, testcontainers, or `DOCKER_BUILDKIT`. Every such test **must** have `[RequiresFeature(TestFeature.ContainerRuntime)]`, `[RequiresFeature(TestFeature.ContainerImageBuild)]`, or `[RequiresFeature(TestFeature.Testcontainers)]` as appropriate. Without these attributes, the test will attempt to run on environments where no container runtime is available and fail. Reach for `TestFeature.Docker` only when the test truly cannot run under Podman. If the test depends on a capability not covered by existing `TestFeature` values, add a new flag.
 
 ### 4. Incorrect RunOnAzdoHelix* Overrides
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -1362,19 +1362,33 @@ public static class ResourceExtensions
     }
 
     /// <summary>
-    /// Gets the archive file path for a container image.
+    /// Gets the archive file path for a container image. This is the single calculation shared by the
+    /// container runtimes that write the archive and by <see cref="ContainerImageReference"/>, which hands
+    /// the path to consumers.
     /// </summary>
     /// <param name="outputPath">The output directory path.</param>
-    /// <param name="imageName">The image name.</param>
-    /// <param name="imageTag">The image tag (optional, defaults to "latest" if provided).</param>
+    /// <param name="imageName">The image name. May be registry-qualified and may include the tag.</param>
+    /// <param name="imageTag">The image tag, when it is not already part of <paramref name="imageName"/>.</param>
     /// <returns>The full path to the archive file with .tar extension.</returns>
+    /// <remarks>
+    /// Producers and consumers must agree on this path, otherwise the archive is written to one location
+    /// and looked up at another. Callers supply the image name in one of two shapes — combined
+    /// (<c>myapp:latest</c>) or split (<c>myapp</c> + <c>latest</c>) — and both must resolve identically,
+    /// which they do because <c>:</c> flattens to the same separator the split form joins with.
+    /// </remarks>
     internal static string GetContainerImageArchivePath(string outputPath, string imageName, string? imageTag = null)
     {
         var fileName = string.IsNullOrEmpty(imageTag)
-            ? $"{imageName}.tar"
-            : $"{imageName}-{imageTag}.tar";
+            ? $"{FlattenContainerImageName(imageName)}.tar"
+            : $"{FlattenContainerImageName(imageName)}-{FlattenContainerImageName(imageTag)}.tar";
         return Path.Combine(outputPath, fileName);
     }
+
+    /// <summary>
+    /// Flattens a <c>&lt;registry&gt;/&lt;repository&gt;:&lt;tag&gt;</c> image name into a single
+    /// file-name-safe segment, so that neither a repository segment nor the tag turns into a directory.
+    /// </summary>
+    internal static string FlattenContainerImageName(string imageName) => imageName.Replace('/', '-').Replace(':', '-');
 
     /// <summary>
     /// Gets a logger for the specified resource using the provided service provider.

--- a/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
+++ b/src/Aspire.Hosting/Publishing/ContainerRuntimeBase.cs
@@ -19,16 +19,23 @@ namespace Aspire.Hosting.Publishing;
 internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where TLogger : class
 {
     private readonly ILogger<TLogger> _logger;
+    private readonly IProcessRunner _processRunner;
 
-    protected ContainerRuntimeBase(ILogger<TLogger> logger)
+    protected ContainerRuntimeBase(ILogger<TLogger> logger, IProcessRunner processRunner)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
     }
 
     /// <summary>
     /// Gets the logger instance for use in derived classes.
     /// </summary>
     protected ILogger<TLogger> Logger => _logger;
+
+    /// <summary>
+    /// Gets the process runner used for container runtime commands.
+    /// </summary>
+    protected IProcessRunner ProcessRunner => _processRunner;
 
     /// <summary>
     /// Gets the name of the container runtime executable (e.g., "docker", "podman").
@@ -114,7 +121,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
 
         _logger.LogDebug("Running {RuntimeName} with arguments: {Arguments}", RuntimeExecutable, arguments);
         _logger.LogDebug("Password length being passed to stdin: {PasswordLength}", password?.Length ?? 0);
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+        var (pendingProcessResult, processDisposable) = _processRunner.Run(spec);
 
         await using (processDisposable)
         {
@@ -159,7 +166,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         var spec = CreateProcessSpec(arguments, retainOutput: true);
 
         _logger.LogDebug("Running {RuntimeName} with arguments: {ArgumentList}", Name, spec.Arguments);
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+        var (pendingProcessResult, processDisposable) = _processRunner.Run(spec);
 
         await using (processDisposable)
         {
@@ -291,7 +298,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
         }
 
         _logger.LogDebug("Running {RuntimeName} with arguments: {ArgumentList}", Name, spec.Arguments);
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+        var (pendingProcessResult, processDisposable) = _processRunner.Run(spec);
 
         await using (processDisposable)
         {
@@ -359,7 +366,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
             },
         };
 
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+        var (pendingProcessResult, processDisposable) = _processRunner.Run(spec);
 
         await using (processDisposable)
         {
@@ -418,7 +425,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
             },
         };
 
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+        var (pendingProcessResult, processDisposable) = _processRunner.Run(spec);
 
         await using (processDisposable)
         {
@@ -469,7 +476,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
             }
         };
 
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+        var (pendingProcessResult, processDisposable) = _processRunner.Run(spec);
 
         await using (processDisposable)
         {
@@ -601,7 +608,7 @@ internal abstract class ContainerRuntimeBase<TLogger> : IContainerRuntime where 
                 InheritEnv = true
             };
 
-            var (pendingResult, processDisposable) = ProcessUtil.Run(spec);
+            var (pendingResult, processDisposable) = _processRunner.Run(spec);
             await using (processDisposable)
             {
                 var result = await pendingResult.ConfigureAwait(false);

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -25,7 +25,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
             : options?.ImageName ?? throw new ArgumentException("ImageName must be provided in options.", nameof(options));
 
         string? builderName = null;
-        var resourceName = imageName.Replace('/', '-').Replace(':', '-');
+        var resourceName = GetArchiveResourceName(imageName);
 
         // Docker requires a custom buildkit instance for the image when
         // targeting the OCI format so we construct it and remove it here.
@@ -69,7 +69,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
 
                 if (!string.IsNullOrEmpty(options?.OutputPath))
                 {
-                    var archivePath = ResourceExtensions.GetContainerImageArchivePath(options.OutputPath, resourceName, imageTag: null);
+                    var archivePath = GetArchivePath(options.OutputPath, imageName);
                     outputType += $",dest={archivePath}";
                 }
 
@@ -151,6 +151,19 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
     {
         return await CheckDockerDaemonAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Flattens a <c>&lt;registry&gt;/&lt;repository&gt;:&lt;tag&gt;</c> image name into a single file-name-safe
+    /// segment, so neither the tag nor any repository segment turns into a directory.
+    /// </summary>
+    internal static string GetArchiveResourceName(string imageName) => imageName.Replace('/', '-').Replace(':', '-');
+
+    /// <summary>
+    /// Gets the archive file path for an image. <see cref="PodmanContainerRuntime"/> must agree with this,
+    /// otherwise the two runtimes write archives to different paths for the same resource.
+    /// </summary>
+    internal static string GetArchivePath(string outputPath, string imageName)
+        => ResourceExtensions.GetContainerImageArchivePath(outputPath, GetArchiveResourceName(imageName), imageTag: null);
 
     private async Task<bool> CheckDockerDaemonAsync(CancellationToken cancellationToken)
     {

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp.Process;
 using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 
@@ -12,7 +13,7 @@ namespace Aspire.Hosting.Publishing;
 
 internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContainerRuntime>
 {
-    public DockerContainerRuntime(ILogger<DockerContainerRuntime> logger) : base(logger)
+    public DockerContainerRuntime(ILogger<DockerContainerRuntime> logger, IProcessRunner processRunner) : base(logger, processRunner)
     {
     }
 
@@ -162,7 +163,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
                 "Docker daemon is running.",
                 cancellationToken,
                 Array.Empty<object>()).ConfigureAwait(false);
-            
+
             return exitCode == 0;
         }
         catch

--- a/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/DockerContainerRuntime.cs
@@ -25,7 +25,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
             : options?.ImageName ?? throw new ArgumentException("ImageName must be provided in options.", nameof(options));
 
         string? builderName = null;
-        var resourceName = GetArchiveResourceName(imageName);
+        var resourceName = ResourceExtensions.FlattenContainerImageName(imageName);
 
         // Docker requires a custom buildkit instance for the image when
         // targeting the OCI format so we construct it and remove it here.
@@ -69,7 +69,7 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
 
                 if (!string.IsNullOrEmpty(options?.OutputPath))
                 {
-                    var archivePath = GetArchivePath(options.OutputPath, imageName);
+                    var archivePath = ResourceExtensions.GetContainerImageArchivePath(options.OutputPath, imageName);
                     outputType += $",dest={archivePath}";
                 }
 
@@ -151,19 +151,6 @@ internal sealed class DockerContainerRuntime : ContainerRuntimeBase<DockerContai
     {
         return await CheckDockerDaemonAsync(cancellationToken).ConfigureAwait(false);
     }
-
-    /// <summary>
-    /// Flattens a <c>&lt;registry&gt;/&lt;repository&gt;:&lt;tag&gt;</c> image name into a single file-name-safe
-    /// segment, so neither the tag nor any repository segment turns into a directory.
-    /// </summary>
-    internal static string GetArchiveResourceName(string imageName) => imageName.Replace('/', '-').Replace(':', '-');
-
-    /// <summary>
-    /// Gets the archive file path for an image. <see cref="PodmanContainerRuntime"/> must agree with this,
-    /// otherwise the two runtimes write archives to different paths for the same resource.
-    /// </summary>
-    internal static string GetArchivePath(string outputPath, string imageName)
-        => ResourceExtensions.GetContainerImageArchivePath(outputPath, GetArchiveResourceName(imageName), imageTag: null);
 
     private async Task<bool> CheckDockerDaemonAsync(CancellationToken cancellationToken)
     {

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -6,6 +6,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Shared;
 using Microsoft.Extensions.Logging;
@@ -268,9 +269,9 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
             _ => throw new ArgumentOutOfRangeException(nameof(options), options.ImageFormat, "Invalid container image format")
         };
 
-        // Derive the archive path through DockerContainerRuntime's helper so both runtimes write the same
-        // file for the same resource.
-        var archivePath = DockerContainerRuntime.GetArchivePath(options.OutputPath!, imageName);
+        // Derive the archive path through the shared helper so that this runtime, the Docker runtime, and
+        // ContainerImageReference (which hands the path to consumers) all resolve the same file.
+        var archivePath = ResourceExtensions.GetContainerImageArchivePath(options.OutputPath!, imageName);
 
         return $"save --format \"{format}\" --output \"{archivePath}\" \"{imageName}\"";
     }

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Publishing;
 
 internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContainerRuntime>
 {
-    public PodmanContainerRuntime(ILogger<PodmanContainerRuntime> logger) : base(logger)
+    public PodmanContainerRuntime(ILogger<PodmanContainerRuntime> logger, IProcessRunner processRunner) : base(logger, processRunner)
     {
     }
 
@@ -56,7 +56,7 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
             }
         };
 
-        var (pendingProcessResult, processDisposable) = ProcessUtil.Run(spec);
+        var (pendingProcessResult, processDisposable) = ProcessRunner.Run(spec);
 
         await using (processDisposable)
         {
@@ -147,6 +147,11 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
         var imageName = !string.IsNullOrEmpty(options?.Tag)
             ? $"{options.ImageName}:{options.Tag}"
             : options?.ImageName ?? throw new ArgumentException("ImageName must be provided in options.", nameof(options));
+
+        if (options.ImageFormat == ContainerImageFormat.Oci && string.IsNullOrEmpty(options.OutputPath))
+        {
+            throw new ArgumentException("OutputPath must be provided when ImageFormat is Oci.", nameof(options));
+        }
 
         var arguments = $"build --file \"{dockerfilePath}\" --tag \"{imageName}\"";
 
@@ -298,7 +303,7 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
                 "Podman is running and healthy.",
                 cancellationToken,
                 Array.Empty<object>()).ConfigureAwait(false);
-            
+
             return exitCode == 0;
         }
         catch

--- a/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
+++ b/src/Aspire.Hosting/Publishing/PodmanContainerRuntime.cs
@@ -167,13 +167,17 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
             arguments += $" --format \"{format}\"";
         }
 
-        // Add output support if specified
-        if (!string.IsNullOrEmpty(options?.OutputPath))
-        {
-            // Extract resource name from imageName for the file name
-            var resourceName = imageName.Split('/').Last().Split(':').First();
-            arguments += $" --output \"{Path.Combine(options.OutputPath, resourceName)}.tar\"";
-        }
+        // Archive output is deliberately NOT handled here.
+        //
+        // `podman build` has no image-archive output flag. Its `--output`/`-o` is a *filesystem* export
+        // (`-o type=local,dest=...`), not the image-archive equivalent of
+        // `docker buildx build --output type=oci,dest=...`, and it is rejected outright when talking to
+        // a remote/machine-backed service:
+        //   Error: '--output' option is not supported in remote mode
+        // The image-archive equivalent is a normal tagged build followed by `podman save`, which
+        // RunPodmanSaveAsync performs once the build below succeeds.
+        // See https://docs.podman.io/en/latest/markdown/podman-build.1.html and
+        // https://docs.podman.io/en/latest/markdown/podman-save.1.html
 
         // Add build arguments if specified
         arguments += BuildArgumentsString(buildArguments);
@@ -213,6 +217,62 @@ internal sealed class PodmanContainerRuntime : ContainerRuntimeBase<PodmanContai
                 processResult.ProcessOutput,
                 processResult.TotalProcessOutputLineCount);
         }
+
+        if (!string.IsNullOrEmpty(options?.OutputPath))
+        {
+            await RunPodmanSaveAsync(imageName, options, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Exports an already-built image to an archive, which is how Podman produces the equivalent of
+    /// <c>docker buildx build --output type=oci,dest=...</c>.
+    /// </summary>
+    private async Task RunPodmanSaveAsync(string imageName, ContainerImageBuildOptions options, CancellationToken cancellationToken)
+    {
+        var arguments = BuildSaveArguments(imageName, options);
+
+        var processResult = await ExecuteContainerCommandWithResultAsync(
+            arguments,
+            "Podman save for {ImageName} failed with exit code {ExitCode}.",
+            "Podman save for {ImageName} succeeded.",
+            cancellationToken,
+            new object[] { imageName },
+            retainOutput: true).ConfigureAwait(false);
+
+        if (processResult.ExitCode != 0)
+        {
+            throw new ProcessFailedException(
+                $"Podman save failed with exit code {processResult.ExitCode}.",
+                processResult.ExitCode,
+                processResult.ProcessOutput,
+                processResult.TotalProcessOutputLineCount);
+        }
+    }
+
+    /// <summary>
+    /// Builds the <c>podman save</c> arguments that export <paramref name="imageName"/> to an image archive.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// save --format "oci-archive" --output "/out/myapp-latest.tar" "myapp:latest"
+    /// </code>
+    /// </example>
+    internal static string BuildSaveArguments(string imageName, ContainerImageBuildOptions options)
+    {
+        var format = options.ImageFormat switch
+        {
+            ContainerImageFormat.Oci => "oci-archive",
+            // The .NET SDK and Docker both treat an unspecified format as the Docker manifest type.
+            ContainerImageFormat.Docker or null => "docker-archive",
+            _ => throw new ArgumentOutOfRangeException(nameof(options), options.ImageFormat, "Invalid container image format")
+        };
+
+        // Derive the archive path through DockerContainerRuntime's helper so both runtimes write the same
+        // file for the same resource.
+        var archivePath = DockerContainerRuntime.GetArchivePath(options.OutputPath!, imageName);
+
+        return $"save --format \"{format}\" --output \"{archivePath}\" \"{imageName}\"";
     }
 
     public override async Task BuildImageAsync(string contextPath, string dockerfilePath, ContainerImageBuildOptions? options, Dictionary<string, string?> buildArguments, Dictionary<string, BuildImageSecretValue> buildSecrets, string? stage, CancellationToken cancellationToken)

--- a/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -48,7 +48,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
         "Npgsql.Exception"
     };
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override string ValidJsonConfig => """
         {
@@ -78,7 +78,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -131,7 +131,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
                 RunWithConnectionString(connectionStringToUse, obj =>

--- a/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -48,7 +48,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
         "Npgsql.Exception"
     };
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override string ValidJsonConfig => """
         {
@@ -78,7 +78,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -131,7 +131,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, AzureNpgsqlEntit
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
                 RunWithConnectionString(connectionStringToUse, obj =>

--- a/tests/Aspire.Azure.Npgsql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Npgsql.Tests/ConformanceTests.cs
@@ -33,7 +33,7 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, AzureNpgsqlSe
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override string? ConfigurationSectionName => "Aspire:Npgsql";
 
@@ -55,7 +55,7 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, AzureNpgsqlSe
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -127,14 +127,14 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, AzureNpgsqlSe
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),

--- a/tests/Aspire.Azure.Npgsql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Npgsql.Tests/ConformanceTests.cs
@@ -33,7 +33,7 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, AzureNpgsqlSe
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override string? ConfigurationSectionName => "Aspire:Npgsql";
 
@@ -55,7 +55,7 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, AzureNpgsqlSe
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -127,14 +127,14 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, AzureNpgsqlSe
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),

--- a/tests/Aspire.Azure.Npgsql.Tests/PostgreSQLContainerFixture.cs
+++ b/tests/Aspire.Azure.Npgsql.Tests/PostgreSQLContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class PostgreSQLContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new PostgreSqlBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{PostgresContainerImageTags.Image}:{PostgresContainerImageTags.Tag}")

--- a/tests/Aspire.Azure.Npgsql.Tests/PostgreSQLContainerFixture.cs
+++ b/tests/Aspire.Azure.Npgsql.Tests/PostgreSQLContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class PostgreSQLContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = new PostgreSqlBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{PostgresContainerImageTags.Image}:{PostgresContainerImageTags.Tag}")

--- a/tests/Aspire.Confluent.Kafka.Tests/KafkaContainerFixture.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/KafkaContainerFixture.cs
@@ -88,7 +88,7 @@ public partial class KafkaContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new ConfluentLocalKafkaBuilder().Build();
             await Container.StartAsync();

--- a/tests/Aspire.Confluent.Kafka.Tests/KafkaContainerFixture.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/KafkaContainerFixture.cs
@@ -88,7 +88,7 @@ public partial class KafkaContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = new ConfluentLocalKafkaBuilder().Build();
             await Container.StartAsync();

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
@@ -24,7 +24,7 @@ public class OtelMetricsTests
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [InlineData(true)]
     [InlineData(false)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
@@ -24,7 +24,7 @@ public class OtelMetricsTests
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
@@ -26,7 +26,7 @@ public class OtelTracesTests
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [InlineData(true)]
     [InlineData(false)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
@@ -26,7 +26,7 @@ public class OtelTracesTests
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
@@ -21,7 +21,7 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
 
     [Theory]
     [OuterloopTest("EndToEnd tests require Docker and are slow")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [Trait("scenario", "basicservices")]
     [InlineData(TestResourceNames.postgres)]
     [InlineData(TestResourceNames.efnpgsql)]
@@ -46,7 +46,7 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
 
     [Fact]
     [OuterloopTest("EndToEnd tests require Docker and are slow")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [Trait("scenario", "basicservices")]
     public Task VerifyHealthyOnIntegrationServiceA()
         => RunTestAsync(async (cancellationToken) =>

--- a/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kusto.Tests/KustoFunctionalTests.cs
@@ -39,7 +39,7 @@ public class KustoFunctionalTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task KustoEmulator_Starts()
     {
@@ -89,7 +89,7 @@ public class KustoFunctionalTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/15509", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithDatabase_CanReadIngestedData()
@@ -168,7 +168,7 @@ public class KustoFunctionalTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task KustoEmulator_WithDatabaseThatAlreadyExists_ErrorIsIgnored()
     {
@@ -195,7 +195,7 @@ public class KustoFunctionalTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/15509", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithInvalidDatabase_LogsErrorAndContinues()
@@ -228,7 +228,7 @@ public class KustoFunctionalTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/15509", typeof(PlatformDetection), nameof(PlatformDetection.IsLinux))]
     public async Task KustoEmulator_WithBindMount_IsUsedForPersistence()

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -20,7 +20,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
     [Theory]
     // [InlineData(true)] // "Using CosmosDB emulator in integration tests leads to flaky tests - https://github.com/microsoft/aspire/issues/5820"
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/18898")]
     public async Task VerifyWaitForOnCosmosDBEmulatorBlocksDependentResources(bool usePreview)
     {
@@ -63,7 +63,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
     [Theory(Skip = "Using CosmosDB emulator in integration tests leads to flaky tests - https://github.com/microsoft/aspire/issues/5820")]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyCosmosResource(bool usePreview)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -133,7 +133,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
     [Theory(Skip = "Using CosmosDB emulator in integration tests leads to flaky tests - https://github.com/microsoft/aspire/issues/5820")]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataVolumeShouldPersistStateBetweenUsages(bool usePreview)
     {
         // Use a volume to do a snapshot save
@@ -268,7 +268,7 @@ public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHe
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/7178")]
     public async Task AddAzureCosmosDB_RunAsEmulator_CreatesDatabase()
     {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureDeployerTests.cs
@@ -192,7 +192,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerImageBuild)]
     public async Task DeployAsync_WithAzureStorageResourcesWorks()
     {
         // Arrange
@@ -849,7 +849,7 @@ public class AzureDeployerTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerImageBuild)]
     public async Task DeployAsync_WithSingleRedisCache_CallsDeployingComputeResources()
     {
         // Arrange

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEventHubsExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace Aspire.Hosting.Azure.Tests;
 public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnEventHubsEmulatorBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -62,7 +62,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true, null)]
     [InlineData(false, "random")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyAzureEventHubsEmulatorResource(bool referenceHub, string? hubName)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -112,7 +112,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureEventHubsHealthChecksUsesSettingsEventHubName(bool useSettings)
     {
         const string hubName = "myhub";
@@ -333,7 +333,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureEventHubsEmulatorResourceGeneratesConfigJson()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -387,7 +387,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureEventHubsEmulatorResourceGeneratesConfigJsonWithCustomizations()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -445,7 +445,7 @@ public class AzureEventHubsExtensionsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureEventHubsEmulator_WithConfigurationFile()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -155,7 +155,7 @@ public class AzureFunctionsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddAzureFunctionsProject_RemoveDefaultHostStorageWhenUseHostStorageIsUsed()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -182,7 +182,7 @@ public class AzureFunctionsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddAzureFunctionsProject_WorksWithMultipleProjects()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -740,7 +740,7 @@ public class AzureFunctionsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddAzureFunctionsProject_WithProjectPath_CanUseCustomHostStorage()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -70,7 +70,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact(Skip = "Azure ServiceBus emulator is not reliable in CI - https://github.com/microsoft/aspire/issues/7066")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnServiceBusEmulatorBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -113,7 +113,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     [Theory(Skip = "Azure ServiceBus emulator is not reliable in CI - https://github.com/microsoft/aspire/issues/7066")]
     [InlineData(null)]
     [InlineData("other")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyAzureServiceBusEmulatorResource(string? queueName)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -307,7 +307,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureServiceBusEmulatorResourceGeneratesConfigJson()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -448,7 +448,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureServiceBusEmulatorResourceGeneratesConfigJsonOnlyChangedProperties()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -500,7 +500,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureServiceBusEmulatorResourceGeneratesConfigJsonWithCustomizations()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -550,7 +550,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureServiceBusEmulator_WithConfigurationFile()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -803,7 +803,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
     }
 
     [Fact(Skip = "Azure ServiceBus emulator is not reliable in CI - https://github.com/microsoft/aspire/issues/7066")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AzureServiceBusEmulator_WithCustomConfig()
     {
         const string queueName = "queue456";

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSignalREmulatorFunctionalTest.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSignalREmulatorFunctionalTest.cs
@@ -36,7 +36,7 @@ public class AzureSignalREmulatorFunctionalTest(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnAzureSignalREmulatorBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -72,7 +72,7 @@ public class AzureSignalREmulatorFunctionalTest(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyAzureSignalREmulatorResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlPrincipalReconciliationTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlPrincipalReconciliationTests.cs
@@ -26,7 +26,7 @@ public class AzureSqlPrincipalReconciliationTests(SqlServerContainerFixture fixt
     private const string HarnessPassword = "Pa55w0rd!Harness";
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task ReconciliationCreatesThePrincipalWithTheIdentityObjectIdAsItsSid()
     {
         var principalName = NewPrincipalName();
@@ -42,7 +42,7 @@ public class AzureSqlPrincipalReconciliationTests(SqlServerContainerFixture fixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task ReconciliationHandlesPrincipalNamesRequiringEscaping()
     {
         // A user principal is a UPN and can contain an apostrophe, which has to survive the T-SQL
@@ -61,7 +61,7 @@ public class AzureSqlPrincipalReconciliationTests(SqlServerContainerFixture fixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task ReconciliationIsANoOpWhenTheScriptRunsAgain()
     {
         // Changing the script content changes the deploymentScripts resource definition, so ARM
@@ -81,7 +81,7 @@ public class AzureSqlPrincipalReconciliationTests(SqlServerContainerFixture fixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task ReconciliationReplacesThePrincipalWhenTheIdentityObjectIdChanges()
     {
         var principalName = NewPrincipalName();
@@ -105,7 +105,7 @@ public class AzureSqlPrincipalReconciliationTests(SqlServerContainerFixture fixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task ReconciliationLeavesPrincipalsItDidNotCreateIntact()
     {
         var principalName = NewPrincipalName();
@@ -134,7 +134,7 @@ public class AzureSqlPrincipalReconciliationTests(SqlServerContainerFixture fixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task ReconciliationRollsBackWhenTheUserCannotBeRecreated()
     {
         var principalName = NewPrincipalName();
@@ -157,7 +157,7 @@ public class AzureSqlPrincipalReconciliationTests(SqlServerContainerFixture fixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task ReconciliationFailsWithoutDamageWhenThePrincipalOwnsASchema()
     {
         var principalName = NewPrincipalName();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureStorageEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureStorageEmulatorFunctionalTests.cs
@@ -17,7 +17,7 @@ namespace Aspire.Hosting.Azure.Tests;
 public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnAzureStorageEmulatorForBlobsBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -66,7 +66,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnAzureStorageEmulatorForBlobContainersBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -109,7 +109,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnAzureStorageEmulatorForQueueBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -152,7 +152,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyAzureStorageEmulatorResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -208,7 +208,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyAzureStorageEmulator_blobcontainer_auto_created()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -248,7 +248,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyAzureStorageEmulator_queue_auto_created()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -286,7 +286,7 @@ public class AzureStorageEmulatorFunctionalTests(ITestOutputHelper testOutputHel
         Assert.Equal(blobNameAndContent, peekMessage.Value.Body.ToString());
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task AzureStorageEmulator_WithPersistentLifetime_ReusesContainersAndPorts()
     {
         return PersistentContainerTestHelpers.AssertResourcesReuseContainersAsync(

--- a/tests/Aspire.Hosting.Azure.Tests/SqlServerContainerFixture.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/SqlServerContainerFixture.cs
@@ -19,7 +19,7 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new MsSqlBuilder()
                             .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}:{SqlServerContainerImageTags.Tag}")

--- a/tests/Aspire.Hosting.Containers.Tests/Aspire.Hosting.Containers.Tests.csproj
+++ b/tests/Aspire.Hosting.Containers.Tests/Aspire.Hosting.Containers.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="Verify.XunitV3" />
     <!-- Provides FakeLogCollector/FakeLogger. Previously inherited transitively via

--- a/tests/Aspire.Hosting.Containers.Tests/ContainerRuntimeLogPatternsTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ContainerRuntimeLogPatternsTests.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+
+namespace Aspire.Hosting.Containers.Tests;
+
+/// <summary>
+/// Locks in the container runtime output formats that <see cref="ContainerRuntimeLogPatterns"/>
+/// recognizes. The sample lines are verbatim captures, including the timestamp prefix that the
+/// resource logger adds, so a runtime changing its wording fails here rather than in a functional
+/// test where the cause is much harder to see.
+/// </summary>
+public class ContainerRuntimeLogPatternsTests
+{
+    [Theory]
+    // Docker, registry does not resolve.
+    [InlineData(@"2026-07-31T17:40:30.9610000Z Error response from daemon: Get ""https://does.not.exist.internal/v2/"": dial tcp: lookup does.not.exist.internal: no such host")]
+    // Docker, registry rejects anonymous access.
+    [InlineData("2026-07-31T17:40:30.9610000Z Error response from daemon: unauthorized: authentication required")]
+    // Podman 6.0.2, registry does not resolve.
+    [InlineData(@"2026-07-31T17:40:30.9610000Z Error: unable to copy from source docker://does.not.exist.internal/does-not-exist:latest: initializing source docker://does.not.exist.internal/does-not-exist:latest: fetching manifest latest in does.not.exist.internal/does-not-exist: pinging container registry does.not.exist.internal: Get ""https://does.not.exist.internal/v2/"": dial tcp: lookup does.not.exist.internal: no such host")]
+    // Podman 6.0.2, registry rejects anonymous access.
+    [InlineData("2026-07-31T17:40:30.9610000Z Error: unable to copy from source docker://cgr.dev/mattermost.com/go-msft-fips:1.24.6: initializing source docker://cgr.dev/mattermost.com/go-msft-fips:1.24.6: fetching manifest 1.24.6 in cgr.dev/mattermost.com/go-msft-fips: unable to retrieve auth token: invalid username/password: unauthorized: Authentication required")]
+    // Podman 5.x, which lacked the outer "unable to copy from source" wrapper.
+    [InlineData("2026-07-30T22:57:47.7100000Z Error: initializing source docker://does.not.exist.internal/does-not-exist:latest: pinging container registry does.not.exist.internal: no such host")]
+    public void IsImagePullFailure_MatchesRuntimeFailureOutput(string line)
+    {
+        Assert.True(ContainerRuntimeLogPatterns.IsImagePullFailure(line));
+    }
+
+    [Theory]
+    // Successful Podman pull: no error marker and no docker:// source reference.
+    [InlineData("2026-07-31T17:40:30.9610000Z Trying to pull docker.io/library/hello-world:latest...")]
+    [InlineData("2026-07-31T17:40:30.9610000Z Getting image source signatures")]
+    [InlineData("2026-07-31T17:40:30.9610000Z Copying blob sha256:58dee6a49ef1c01bb8a00180d70f55b3527c8e7326a05b3c5135c4ff60cfb6d6")]
+    [InlineData("2026-07-31T17:40:30.9610000Z Writing manifest to image destination")]
+    // An unrelated error must not be mistaken for a pull failure.
+    [InlineData("2026-07-31T17:40:30.9610000Z Error: container exited with code 1")]
+    // A docker:// reference on its own is not a failure.
+    [InlineData("2026-07-31T17:40:30.9610000Z Resolved docker://docker.io/library/redis:8.6")]
+    public void IsImagePullFailure_DoesNotMatchUnrelatedOutput(string line)
+    {
+        Assert.False(ContainerRuntimeLogPatterns.IsImagePullFailure(line));
+    }
+
+    [Theory]
+    // Docker BuildKit.
+    [InlineData("2026-07-31T17:41:35.2070000Z #1 [internal] load build definition from Dockerfile")]
+    // Podman/Buildah, multi-stage build.
+    [InlineData("2026-07-31T17:41:35.2070000Z [1/2] STEP 1/5: FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS builder")]
+    [InlineData(@"2026-07-31T17:41:39.0250000Z [2/2] STEP 6/6: LABEL ""com.microsoft.developer.usvc-dev.build""=""0.25.9""")]
+    // Podman/Buildah, single-stage build has no stage prefix.
+    [InlineData("2026-07-31T17:41:35.2070000Z STEP 1/3: FROM alpine")]
+    public void IsBuildProgress_MatchesRuntimeBuildOutput(string line)
+    {
+        Assert.True(ContainerRuntimeLogPatterns.IsBuildProgress(line));
+    }
+
+    [Theory]
+    // Build output that merely contains the word STEP must not count as build progress.
+    [InlineData("2026-07-31T17:41:35.2070000Z STEP: starting application")]
+    [InlineData("2026-07-31T17:41:35.2070000Z Running STEP 2 of the deployment script")]
+    // Buildah output that is not a step line.
+    [InlineData("2026-07-31T17:41:39.0360000Z Successfully tagged localhost/testcontainer:50a50dfc")]
+    [InlineData("2026-07-31T17:41:35.2070000Z Getting image source signatures")]
+    public void IsBuildProgress_DoesNotMatchUnrelatedOutput(string line)
+    {
+        Assert.False(ContainerRuntimeLogPatterns.IsBuildProgress(line));
+    }
+}

--- a/tests/Aspire.Hosting.Containers.Tests/DockerSocketBindMountTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/DockerSocketBindMountTests.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Containers.Tests;
 public class DockerSocketBindMountTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.Docker | TestFeature.ContainerImageBuild)]
     public async Task WithDockerSocketBindMountAllowsDockerCliInContainer()
     {
         var dockerfile = """

--- a/tests/Aspire.Hosting.Containers.Tests/ResourceFailureLoggingTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/ResourceFailureLoggingTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Hosting.Containers.Tests;
 public class ContainerResourceFailureLoggingTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task BadContainerRuntimeArg()
     {
         using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.DefaultOrchestratorTestLongTimeout);
@@ -39,7 +39,7 @@ public class ContainerResourceFailureLoggingTests(ITestOutputHelper testOutputHe
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task BadImage()
     {
         using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.DefaultOrchestratorTestLongTimeout);
@@ -59,11 +59,11 @@ public class ContainerResourceFailureLoggingTests(ITestOutputHelper testOutputHe
         }
 
         var logLines = GetLogLines(logCollector);
-        Assert.Contains(logLines, x => x.Contains("Error response from daemon"));
+        Assert.Contains(logLines, ContainerRuntimeLogPatterns.IsImagePullFailure);
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task NeedsAuthentication()
     {
         using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.DefaultOrchestratorTestLongTimeout);
@@ -83,11 +83,11 @@ public class ContainerResourceFailureLoggingTests(ITestOutputHelper testOutputHe
         }
 
         var logLines = GetLogLines(logCollector);
-        Assert.Contains(logLines, x => x.Contains("Error response from daemon"));
+        Assert.Contains(logLines, ContainerRuntimeLogPatterns.IsImagePullFailure);
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ContainerExitsImmediatelyAfterStart()
     {
         using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.DefaultOrchestratorTestLongTimeout);

--- a/tests/Aspire.Hosting.Containers.Tests/TestcontainersPodmanConfigurationTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/TestcontainersPodmanConfigurationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.TestUtilities;
+using Microsoft.DotNet.RemoteExecutor;
 
 namespace Aspire.Hosting.Containers.Tests;
 
@@ -25,6 +26,19 @@ public class TestcontainersPodmanConfigurationTests
 
     // The macOS `podman machine` layout, which is what the CLI fallback reports.
     private const string PodmanMachineSocket = "/var/folders/_h/xxxx/T/podman/podman-machine-default-api.sock";
+
+    [Fact]
+    public void IsFeatureSupported_ContainerRuntime_DoesNotInitializeTestcontainersConfiguration()
+    {
+        RemoteExecutor.Invoke(static () =>
+        {
+            Assert.False(TestcontainersPodmanConfiguration.IsConfigurationInitialized);
+
+            _ = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+
+            Assert.False(TestcontainersPodmanConfiguration.IsConfigurationInitialized);
+        }).Dispose();
+    }
 
     [Fact]
     public void Decide_OnWindowsWithAPodmanSocket_ReportsNoEndpoint()

--- a/tests/Aspire.Hosting.Containers.Tests/TestcontainersPodmanConfigurationTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/TestcontainersPodmanConfigurationTests.cs
@@ -1,0 +1,264 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TestUtilities;
+
+namespace Aspire.Hosting.Containers.Tests;
+
+/// <summary>
+/// Covers <see cref="TestcontainersPodmanConfiguration.Decide"/>, which decides how to point
+/// Testcontainers at a container runtime. CI always has a Docker socket, so it only ever exercises the
+/// no-op branch; without these tests every Podman branch would ship unverified.
+/// </summary>
+/// <remarks>
+/// Socket paths that the production code assembles with <see cref="Path.Combine(string[])"/> are built the
+/// same way here, because the separator it inserts is platform dependent and these tests run everywhere.
+/// Paths the production code hard-codes are hard-coded here too.
+/// </remarks>
+public class TestcontainersPodmanConfigurationTests
+{
+    private const string DockerHostVariable = "DOCKER_HOST";
+    private const string RyukDisabledVariable = "TESTCONTAINERS_RYUK_DISABLED";
+
+    private const string HomeDirectory = "/home/tester";
+    private const string XdgRuntimeDirectory = "/run/user/1000";
+
+    // The macOS `podman machine` layout, which is what the CLI fallback reports.
+    private const string PodmanMachineSocket = "/var/folders/_h/xxxx/T/podman/podman-machine-default-api.sock";
+
+    [Fact]
+    public void Decide_OnWindowsWithAPodmanSocket_ReportsNoEndpoint()
+    {
+        // The socket is one the non-Windows path would happily adopt, so this fails if the Windows guard
+        // is ever dropped. Testcontainers 4.8.1 cannot drive Podman over a named pipe, and there is no
+        // Unix socket to point it at, so the fixtures have to be skipped.
+        var decision = Decide(isWindows: true, environment: [], existingSockets: ["/run/podman/podman.sock"]);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: false), decision);
+    }
+
+    [Fact]
+    public void Decide_OnWindowsWithDockerHostPointingAtDocker_ReportsEndpointWithoutChangingEnvironment()
+    {
+        var decision = Decide(
+            isWindows: true,
+            environment: new() { [DockerHostVariable] = "npipe://./pipe/docker_engine" },
+            existingSockets: []);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: true), decision);
+    }
+
+    [Fact]
+    public void Decide_OnWindowsWithDockerHostPointingAtPodman_ReportsNoEndpoint()
+    {
+        // Off Windows this same value would be adopted and Ryuk turned off; on Windows Testcontainers
+        // cannot use it at all, so claiming an endpoint would just trade a skip for a hard failure.
+        var decision = Decide(
+            isWindows: true,
+            environment: new() { [DockerHostVariable] = "npipe:////./pipe/podman-machine-default" },
+            existingSockets: []);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: false), decision);
+    }
+
+    [Fact]
+    public void Decide_WithDockerHostPointingAtDocker_LeavesRyukEnabled()
+    {
+        var decision = Decide(
+            isWindows: false,
+            environment: new() { [DockerHostVariable] = "unix:///var/run/docker.sock" },
+            existingSockets: []);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: true), decision);
+    }
+
+    [Theory]
+    [InlineData("unix:///run/user/1000/podman/podman.sock")]
+    [InlineData("unix:///run/podman/podman.sock")]
+    [InlineData("unix:///var/folders/_h/xxxx/T/podman/podman-machine-default-api.sock")]
+    [InlineData("unix:///home/tester/.local/share/containers/Podman/machine/podman.sock")]
+    public void Decide_WithDockerHostPointingAtPodman_DisablesRyuk(string dockerHost)
+    {
+        // `podman machine start` prints an `export DOCKER_HOST=...` hint, so this is the normal way a
+        // developer ends up on Podman - and Ryuk cannot bind-mount a rootless Podman socket.
+        var decision = Decide(
+            isWindows: false,
+            environment: new() { [DockerHostVariable] = dockerHost },
+            existingSockets: []);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: true, DockerHost: null, DisableRyuk: true), decision);
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("false")]
+    public void Decide_WithDockerHostPointingAtPodman_DoesNotOverrideAnExplicitRyukSetting(string ryukDisabled)
+    {
+        var decision = Decide(
+            isWindows: false,
+            environment: new()
+            {
+                [DockerHostVariable] = "unix:///run/podman/podman.sock",
+                [RyukDisabledVariable] = ryukDisabled,
+            },
+            existingSockets: []);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: true), decision);
+    }
+
+    // Attribute arguments cannot contain a nested array, so the multi-segment candidates come through
+    // MemberData rather than InlineData.
+    public static TheoryData<string[]> DockerSocketCandidates => new()
+    {
+        new[] { "/var/run/docker.sock" },
+        new[] { XdgRuntimeDirectory, "docker.sock" },
+        new[] { HomeDirectory, ".docker", "run", "docker.sock" },
+        new[] { HomeDirectory, ".docker", "desktop", "docker.sock" },
+    };
+
+    [Theory]
+    [MemberData(nameof(DockerSocketCandidates))]
+    public void Decide_WithADockerSocket_LeavesTestcontainersAlone(string[] socketPathParts)
+    {
+        var decision = Decide(isWindows: false, environment: [], existingSockets: [Path.Combine(socketPathParts)]);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: true), decision);
+    }
+
+    public static TheoryData<string[]> PodmanSocketCandidates => new()
+    {
+        new[] { XdgRuntimeDirectory, "podman", "podman.sock" },
+        new[] { "/run/podman/podman.sock" },
+        new[] { HomeDirectory, ".local", "share", "containers", "podman", "machine", "podman.sock" },
+    };
+
+    [Theory]
+    [MemberData(nameof(PodmanSocketCandidates))]
+    public void Decide_WithAPodmanSocket_PointsTestcontainersAtIt(string[] socketPathParts)
+    {
+        var podmanSocket = Path.Combine(socketPathParts);
+
+        var decision = Decide(isWindows: false, environment: [], existingSockets: [podmanSocket]);
+
+        Assert.Equal(
+            new PodmanConfigurationDecision(HasUsableEndpoint: true, DockerHost: $"unix://{podmanSocket}", DisableRyuk: true),
+            decision);
+    }
+
+    [Fact]
+    public void Decide_WithAPodmanSocket_DoesNotOverrideAnExplicitRyukSetting()
+    {
+        var decision = Decide(
+            isWindows: false,
+            environment: new() { [RyukDisabledVariable] = "false" },
+            existingSockets: ["/run/podman/podman.sock"]);
+
+        Assert.Equal(
+            new PodmanConfigurationDecision(HasUsableEndpoint: true, DockerHost: "unix:///run/podman/podman.sock"),
+            decision);
+    }
+
+    [Fact]
+    public void Decide_WithBothSockets_PrefersDocker()
+    {
+        var decision = Decide(
+            isWindows: false,
+            environment: [],
+            existingSockets: ["/var/run/docker.sock", "/run/podman/podman.sock"]);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: true), decision);
+    }
+
+    [Fact]
+    public void Decide_WithNoWellKnownSocket_FallsBackToThePodmanCli()
+    {
+        var decision = Decide(
+            isWindows: false,
+            environment: [],
+            existingSockets: [],
+            podmanSocketFromCli: PodmanMachineSocket);
+
+        Assert.Equal(
+            new PodmanConfigurationDecision(HasUsableEndpoint: true, DockerHost: $"unix://{PodmanMachineSocket}", DisableRyuk: true),
+            decision);
+    }
+
+    [Fact]
+    public void Decide_WithAWellKnownSocket_DoesNotConsultThePodmanCli()
+    {
+        // Shelling out costs a process launch on every test run, so the well-known paths have to win.
+        var cliInvoked = false;
+
+        var decision = TestcontainersPodmanConfiguration.Decide(
+            isWindows: false,
+            HomeDirectory,
+            _ => null,
+            path => path == "/run/podman/podman.sock",
+            () =>
+            {
+                cliInvoked = true;
+                return null;
+            });
+
+        Assert.Equal(
+            new PodmanConfigurationDecision(HasUsableEndpoint: true, DockerHost: "unix:///run/podman/podman.sock", DisableRyuk: true),
+            decision);
+        Assert.False(cliInvoked);
+    }
+
+    [Fact]
+    public void Decide_WithNoRuntimeAtAll_ReportsNoEndpoint()
+    {
+        var decision = Decide(isWindows: false, environment: [], existingSockets: []);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: false), decision);
+    }
+
+    [Fact]
+    public void Decide_WithoutAHomeDirectory_SkipsTheHomeRelativeCandidates()
+    {
+        // Path.Combine throws on a null root, so a home directory that cannot be resolved has to be
+        // dropped from the candidate list rather than fed into it.
+        var dockerDesktopSocket = Path.Combine(HomeDirectory, ".docker", "desktop", "docker.sock");
+
+        var decision = TestcontainersPodmanConfiguration.Decide(
+            isWindows: false,
+            homeDirectory: null,
+            _ => null,
+            path => path == dockerDesktopSocket,
+            () => null);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: false), decision);
+    }
+
+    [Fact]
+    public void Decide_WithoutXdgRuntimeDir_SkipsTheXdgRelativeCandidates()
+    {
+        var rootlessPodmanSocket = Path.Combine(XdgRuntimeDirectory, "podman", "podman.sock");
+
+        var decision = TestcontainersPodmanConfiguration.Decide(
+            isWindows: false,
+            HomeDirectory,
+            _ => null,
+            path => path == rootlessPodmanSocket,
+            () => null);
+
+        Assert.Equal(new PodmanConfigurationDecision(HasUsableEndpoint: false), decision);
+    }
+
+    private static PodmanConfigurationDecision Decide(
+        bool isWindows,
+        Dictionary<string, string> environment,
+        string[] existingSockets,
+        string? podmanSocketFromCli = null)
+    {
+        environment.TryAdd("XDG_RUNTIME_DIR", XdgRuntimeDirectory);
+
+        return TestcontainersPodmanConfiguration.Decide(
+            isWindows,
+            HomeDirectory,
+            variable => environment.GetValueOrDefault(variable),
+            path => path is not null && existingSockets.Contains(path),
+            () => podmanSocketFromCli);
+    }
+}

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -19,7 +19,7 @@ namespace Aspire.Hosting.Containers.Tests;
 public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task WithBuildSecretPopulatesSecretFilesCorrectly()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -50,7 +50,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task ContainerBuildLogsAreStreamedToAppHost()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -81,8 +81,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         var collector = app.Services.GetFakeLogCollector();
         var logs = collector.GetSnapshot();
 
-        // Just looking for a common message in Docker build output.
-        Assert.Contains(logs, log => log.Message.Contains("load build definition from Dockerfile"));
+        // Just looking for a build progress message, which Docker and Podman word differently.
+        Assert.Contains(logs, log => ContainerRuntimeLogPatterns.IsBuildProgress(log.Message));
 
         await app.StopAsync();
     }
@@ -189,7 +189,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task WithDockerfileLaunchesContainerSuccessfully()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -224,7 +224,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task AddDockerfileLaunchesContainerSuccessfully()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -451,7 +451,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task WithDockerfileWithParameterLaunchesContainerSuccessfully()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -523,7 +523,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task AddDockerfileWithParameterLaunchesContainerSuccessfully()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
+++ b/tests/Aspire.Hosting.Docker.Tests/DockerComposeTests.cs
@@ -305,7 +305,7 @@ public class DockerComposeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task DockerComposeProjectNameIncludesAppHostShaInArguments()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -402,7 +402,7 @@ public class DockerComposeTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/15078", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task DeployWithDashboard_PrintsDashboardAndServiceEndpoints()
     {

--- a/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Garnet.Tests/GarnetFunctionalTests.cs
@@ -17,7 +17,7 @@ namespace Aspire.Hosting.Garnet.Tests;
 public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnGarnetBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -55,7 +55,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyGarnetResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
@@ -100,7 +100,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
@@ -252,7 +252,7 @@ public class GarnetFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Garnet_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.GitHub.Models.Tests/GitHubModelsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.GitHub.Models.Tests/GitHubModelsFunctionalTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.GitHub.Models.Tests;
 public class GitHubModelsFunctionalTests
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task DependentResourceWaitsForGitHubModelResourceWithHealthCheckToBeHealthy()
     {
         using var cts = new CancellationTokenSource(TestConstants.LongTimeoutDuration);

--- a/tests/Aspire.Hosting.JavaScript.Tests/AddJavaScriptAppTests.cs
+++ b/tests/Aspire.Hosting.JavaScript.Tests/AddJavaScriptAppTests.cs
@@ -531,7 +531,7 @@ public class AddJavaScriptAppTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+	[RequiresFeature(TestFeature.Docker | TestFeature.ContainerImageBuild)]
     [OuterloopTest("Builds a Docker image to verify the generated pnpm Dockerfile works")]
     public async Task VerifyPnpmDockerfileBuildSucceeds()
     {
@@ -627,7 +627,7 @@ public class AddJavaScriptAppTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.Docker | TestFeature.ContainerImageBuild)]
     [OuterloopTest("Builds and runs a Docker image to verify the generated pnpm PublishAsPackageScript Dockerfile works")]
     public async Task VerifyPnpmDockerfileWhenPublishedAsPackageScriptRunsWithoutNetwork()
     {

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -19,7 +19,7 @@ namespace Aspire.Hosting.Kafka.Tests;
 public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task VerifyWaitForOnKafkaBlocksDependentResources()
     {
@@ -57,7 +57,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task VerifyKafkaResource()
     {
@@ -115,7 +115,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
@@ -275,7 +275,7 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Kafka_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakFunctionalTests.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Keycloak.Tests;
 public class KeycloakFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Keycloak_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -17,7 +17,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
     private const string CollectionName = "book";
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyMilvusResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -67,7 +67,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var dbname = "milvusdbtest";
@@ -205,7 +205,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Milvus_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -29,7 +29,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
         ];
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnMongoBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -66,7 +66,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyMongoDBResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -104,7 +104,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var dbName = "testdb";
@@ -248,7 +248,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithInitBindMount()
     {
         // Creates a script that should be executed when the container is initialized.
@@ -355,7 +355,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithInitFiles()
     {
         // Creates a script that should be executed when the container is initialized.
@@ -461,7 +461,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task MongoDB_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -26,7 +26,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     private static readonly Predicate<string> s_mySqlReadyText = log => log.Contains("ready for connections") && log.Contains("port: 3306");
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnMySqlBlocksDependentResources()
     {
         using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan);
@@ -64,7 +64,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyMySqlResource()
     {
         using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2);
@@ -114,7 +114,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var mySqlDbName = "tempdb";
@@ -298,7 +298,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithInitBindMount()
     {
         // Creates a script that should be executed when the container is initialized.
@@ -393,7 +393,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithInitFiles()
     {
         // Creates a script that should be executed when the container is initialized.
@@ -477,7 +477,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyEfMySql()
     {
         using var cts = new CancellationTokenSource(TestConstants.ExtraLongTimeoutTimeSpan * 2);
@@ -547,7 +547,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task MySql_WithPersistentLifetime_ReusesContainers(bool useMultipleInstances)
     {
         // When WithPhpMyAdmin in invoked with 2 and two or more MySql instances are created,
@@ -620,7 +620,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesNewDatabaseWithCustomScript(bool addEnvVar)
     {
         var mySqlDbName = "my-test-db";
@@ -697,7 +697,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesDatabaseResiliently()
     {
         // Creating the database multiple times should not fail
@@ -780,7 +780,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesMultipleDatabases()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
@@ -828,7 +828,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesDatabaseWithSpecialNames()
     {
         const string databaseName = "!']`'[\"";
@@ -865,7 +865,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(ConnectionState.Open, conn.State);
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task MySql_WithPersistentLifetime_ReusesContainerWithDefaults()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
@@ -22,7 +22,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
     private const string SubjectName = "test-subject";
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyNatsResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -60,7 +60,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(null, null)]
     [InlineData("nats", null)]
     [InlineData(null, "password")]
@@ -104,7 +104,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData("user", "wrong-password")]
     [InlineData("wrong-user", "password")]
     [InlineData(null, null)]
@@ -154,7 +154,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         string? volumeName = null;
@@ -324,7 +324,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnNatsBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -361,7 +361,7 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync();
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Nats_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.OpenAI.Tests/OpenAIFunctionalTests.cs
+++ b/tests/Aspire.Hosting.OpenAI.Tests/OpenAIFunctionalTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.OpenAI.Tests;
 public class OpenAIFunctionalTests
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/10977")]
     public async Task DependentResourceWaitsForOpenAIModelResourceWithHealthCheckToBeHealthy()
     {
@@ -56,7 +56,7 @@ public class OpenAIFunctionalTests
     }
     
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task DependentResourceWaitsForOpenAIResourceWithHealthCheckToBeHealthy()
     {
         using var cts = new CancellationTokenSource(TestConstants.LongTimeoutDuration);

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -28,7 +28,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
     private const string DatabaseReadyText = "Completed: ALTER DATABASE OPEN";
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyEfOracle()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(15));
@@ -72,7 +72,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false, Skip = "https://github.com/microsoft/aspire/issues/5191")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var oracleDbName = "freepdb1";
@@ -249,7 +249,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithInitBindMount()
     {
         // Creates a script that should be executed when the container is initialized.
@@ -347,7 +347,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false, Skip = "https://github.com/microsoft/aspire/issues/5190")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithInitFiles(bool init)
     {
         // Creates a script that should be executed when the container is initialized.
@@ -442,7 +442,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnOracleBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -479,7 +479,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync();
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Oracle_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -24,7 +24,7 @@ namespace Aspire.Hosting.PostgreSQL.Tests;
 public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnPostgresServerBlocksDependentResources()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -72,7 +72,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyPgAdminResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -95,7 +95,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyPostgresResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -143,7 +143,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithPgWeb()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -186,7 +186,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var postgresDbName = "tempdb";
@@ -358,7 +358,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithInitBindMount()
     {
         // Creates a script that should be executed when the container is initialized.
@@ -454,7 +454,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithInitFiles()
     {
         // Creates a script that should be executed when the container is initialized.
@@ -538,7 +538,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task Postgres_WithPersistentLifetime_ReusesContainers()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -595,7 +595,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesDatabaseWithCustomScript()
     {
         const string databaseName = "newdb";
@@ -647,7 +647,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesDatabaseWithSpecialNames()
     {
         const string databaseName = "!']`'[\"";
@@ -689,7 +689,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesDatabaseResiliently()
     {
         // Creating the database multiple times should not fail
@@ -774,7 +774,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesMultipleDatabases()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
@@ -821,7 +821,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Postgres_WithPersistentLifetime_ReusesContainerWithDefaults()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -23,7 +23,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
     private static readonly float[] s_testVector = { 0.10022575f, -0.23998135f };
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyQdrantResource()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -88,7 +88,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -224,7 +224,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddQdrantWithDefaultsAddsUrlAnnotations()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -253,7 +253,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnQdrantBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -290,7 +290,7 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync();
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Qdrant_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -19,7 +19,7 @@ namespace Aspire.Hosting.RabbitMQ.Tests;
 public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnRabbitMQBlocksDependentResources()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -56,7 +56,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyRabbitMQResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -94,7 +94,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -236,7 +236,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task RabbitMQ_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(
@@ -247,7 +247,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task RabbitMQ_WithPersistentLifetimeAndRandomizedPorts_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -28,7 +28,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
        UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnRedisBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -66,7 +66,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyRedisCommanderResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -96,7 +96,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyRedisResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -133,7 +133,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithModuleLoadsNativeModule()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -168,7 +168,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithRedisInsightImportDatabases()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
@@ -230,7 +230,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataVolumeShouldPersistStateBetweenUsages()
     {
         // Use a volume to do a snapshot save
@@ -317,7 +317,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataBindMountShouldPersistStateBetweenUsages()
     {
         var bindMountPath = Directory.CreateTempSubdirectory().FullName;
@@ -404,7 +404,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task PersistenceIsDisabledByDefault()
     {
         // Checks that without enabling Redis Persistence the tests fail
@@ -478,7 +478,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task RedisInsightWithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
@@ -657,7 +657,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithRedisCommanderShouldWorkWithPassword()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
@@ -699,7 +699,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
         public string? Name { get; set; }
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Redis_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(
@@ -710,7 +710,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Redis_WithPersistentLifetimeAndRandomizedPorts_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Seq.Tests/SeqFunctionalTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.Seq.Tests;
 public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifySeqResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -73,7 +73,7 @@ public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         string? volumeName = null;
@@ -187,7 +187,7 @@ public class SeqFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Seq_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -21,7 +21,7 @@ namespace Aspire.Hosting.SqlServer.Tests;
 public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWaitForOnSqlServerBlocksDependentResources()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
@@ -59,7 +59,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifySqlServerResource()
     {
         const string databaseName = "newdb";
@@ -122,7 +122,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
         const string databaseName = "db";
@@ -335,7 +335,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesDatabaseWithCustomScript()
     {
         const string databaseName = "newdb";
@@ -408,7 +408,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesDatabaseWithSpecialNames()
     {
         const string databaseName = "!'][\"";
@@ -458,7 +458,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesDatabaseResiliently()
     {
         // Creating the database multiple times should not fail
@@ -542,7 +542,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddDatabaseCreatesMultipleDatabases()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
@@ -589,7 +589,7 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
         }
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task SqlServer_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.TestUtilities/Publishing/FakeContainerRuntimeExtensions.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Publishing/FakeContainerRuntimeExtensions.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIRECONTAINERRUNTIME001
+
+using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Testing;
+using Aspire.Shared;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Tests.Publishing;
+
+/// <summary>
+/// Registration helpers that make a <see cref="FakeContainerRuntime"/> the runtime seen by
+/// production code, regardless of which container runtime is installed on the host.
+/// </summary>
+public static class FakeContainerRuntimeExtensions
+{
+    /// <summary>
+    /// Registers <paramref name="runtime"/> as the container runtime used by the application.
+    /// </summary>
+    /// <remarks>
+    /// Registering only the keyed <see cref="IContainerRuntime"/> under <c>"docker"</c> is not enough:
+    /// production code resolves the runtime through <see cref="IContainerRuntimeResolver"/>, which
+    /// auto-detects the installed runtime and then looks up the keyed service for whichever runtime it
+    /// found. On a machine with Podman but no Docker that lookup uses the <c>"podman"</c> key, so a fake
+    /// registered only under <c>"docker"</c> is silently bypassed and the real runtime executes.
+    /// Overriding the resolver itself keeps tests independent of the host's container runtime.
+    /// </remarks>
+    public static IServiceCollection AddFakeContainerRuntime(this IServiceCollection services, FakeContainerRuntime runtime)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(runtime);
+
+        services.AddKeyedSingleton<IContainerRuntime>(KnownContainerRuntimes.Docker, runtime);
+        services.AddKeyedSingleton<IContainerRuntime>(KnownContainerRuntimes.Podman, runtime);
+        services.AddSingleton<IContainerRuntimeResolver>(runtime);
+
+        return services;
+    }
+
+    /// <inheritdoc cref="AddFakeContainerRuntime(IServiceCollection, FakeContainerRuntime)"/>
+    public static IDistributedApplicationTestingBuilder WithFakeContainerRuntime(this IDistributedApplicationTestingBuilder builder, FakeContainerRuntime runtime)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.AddFakeContainerRuntime(runtime);
+
+        return builder;
+    }
+}

--- a/tests/Aspire.Hosting.TestUtilities/Publishing/FakeContainerRuntimeExtensions.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Publishing/FakeContainerRuntimeExtensions.cs
@@ -4,7 +4,6 @@
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
 using Aspire.Hosting.Publishing;
-using Aspire.Hosting.Testing;
 using Aspire.Shared;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -37,15 +36,5 @@ public static class FakeContainerRuntimeExtensions
         services.AddSingleton<IContainerRuntimeResolver>(runtime);
 
         return services;
-    }
-
-    /// <inheritdoc cref="AddFakeContainerRuntime(IServiceCollection, FakeContainerRuntime)"/>
-    public static IDistributedApplicationTestingBuilder WithFakeContainerRuntime(this IDistributedApplicationTestingBuilder builder, FakeContainerRuntime runtime)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-
-        builder.Services.AddFakeContainerRuntime(runtime);
-
-        return builder;
     }
 }

--- a/tests/Aspire.Hosting.TestUtilities/Utils/ContainerRuntimeLogPatterns.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/ContainerRuntimeLogPatterns.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+
+namespace Aspire.Hosting.Utils;
+
+/// <summary>
+/// Recognizes container runtime output that Aspire surfaces verbatim in resource logs.
+/// </summary>
+/// <remarks>
+/// DCP streams the runtime's raw stdout/stderr into the resource log stream without normalizing it,
+/// so assertions over those logs have to account for Docker and Podman describing the same condition
+/// differently. Docker is a CLI over a daemon REST API and uses BuildKit; Podman is daemonless and
+/// builds with Buildah.
+/// <para>
+/// Each predicate accepts any supported runtime's phrasing rather than selecting one by the detected
+/// runtime. The phrasings are mutually exclusive, so a test still fails when no runtime produced the
+/// expected output, and this keeps the checks working regardless of which runtime DCP picked.
+/// </para>
+/// <para>
+/// The resource logger prefixes each line with a timestamp, so patterns must match anywhere in the
+/// line rather than being anchored to its start. For example:
+/// <c>2026-07-31T17:40:30.9610000Z Error: unable to copy from source docker://...</c>
+/// </para>
+/// </remarks>
+public static partial class ContainerRuntimeLogPatterns
+{
+    /// <summary>
+    /// Matches a line reporting that pulling an image from a registry failed.
+    /// </summary>
+    /// <remarks>
+    /// Docker attributes the failure to the daemon that serviced the request:
+    /// <code>
+    /// Error response from daemon: Get "https://does.not.exist.internal/v2/": dial tcp: lookup does.not.exist.internal: no such host
+    /// </code>
+    /// Podman has no daemon and instead surfaces the containers/image copy pipeline, which names the
+    /// remote image using the <c>docker://</c> transport. Two observed forms, from a registry that does
+    /// not resolve and from one that rejects anonymous access:
+    /// <code>
+    /// Error: unable to copy from source docker://does.not.exist.internal/does-not-exist:latest: initializing source docker://does.not.exist.internal/does-not-exist:latest: fetching manifest latest in does.not.exist.internal/does-not-exist: pinging container registry does.not.exist.internal: Get "https://does.not.exist.internal/v2/": dial tcp: lookup does.not.exist.internal: no such host
+    /// Error: unable to copy from source docker://cgr.dev/mattermost.com/go-msft-fips:1.24.6: initializing source docker://cgr.dev/mattermost.com/go-msft-fips:1.24.6: fetching manifest 1.24.6 in cgr.dev/mattermost.com/go-msft-fips: unable to retrieve auth token: invalid username/password: unauthorized: Authentication required
+    /// </code>
+    /// The outer wrapper is version-dependent — Podman 5.x started at <c>Error: initializing source</c>
+    /// while 6.0.2 wraps that in <c>Error: unable to copy from source</c> — so match the two parts that
+    /// are stable across both: the <c>Error:</c> marker and a <c>docker://</c> source reference.
+    /// Requiring both keeps this off successful pulls, which mention neither:
+    /// <code>
+    /// Trying to pull docker.io/library/hello-world:latest...
+    /// Getting image source signatures
+    /// Copying blob sha256:58dee6a49ef1c01bb8a00180d70f55b3527c8e7326a05b3c5135c4ff60cfb6d6
+    /// Writing manifest to image destination
+    /// </code>
+    /// </remarks>
+    public static bool IsImagePullFailure(string line)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        return line.Contains("Error response from daemon", StringComparison.Ordinal)
+            || PodmanImagePullFailureRegex().IsMatch(line);
+    }
+
+    /// <summary>
+    /// Matches a line of image build progress, used to prove build output reaches the app host.
+    /// </summary>
+    /// <remarks>
+    /// Docker builds with BuildKit, which emits numbered internal steps:
+    /// <code>
+    /// #1 [internal] load build definition from Dockerfile
+    /// </code>
+    /// Podman builds with Buildah, which emits one line per Dockerfile instruction as
+    /// <c>STEP &lt;n&gt;/&lt;total&gt;:</c>, prefixed with <c>[&lt;stage&gt;/&lt;stages&gt;]</c> for a
+    /// multi-stage build:
+    /// <code>
+    /// [1/2] STEP 1/5: FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS builder
+    /// [2/2] STEP 6/6: LABEL "com.microsoft.developer.usvc-dev.build"="0.25.9"
+    /// STEP 1/3: FROM alpine
+    /// </code>
+    /// The step counter is matched explicitly rather than looking for a bare <c>STEP</c>, so that build
+    /// output which merely contains that word — say a <c>RUN echo</c> in the Dockerfile under test —
+    /// does not satisfy the assertion.
+    /// </remarks>
+    public static bool IsBuildProgress(string line)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        return line.Contains("load build definition from Dockerfile", StringComparison.Ordinal)
+            || PodmanBuildStepRegex().IsMatch(line);
+    }
+
+    [GeneratedRegex(@"Error:.*\bdocker://")]
+    private static partial Regex PodmanImagePullFailureRegex();
+
+    [GeneratedRegex(@"\bSTEP \d+/\d+:")]
+    private static partial Regex PodmanBuildStepRegex();
+}

--- a/tests/Aspire.Hosting.TestUtilities/Utils/DockerUtils.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/DockerUtils.cs
@@ -14,7 +14,7 @@ public sealed class DockerUtils
 
     // `volume rm` / `volume inspect` are spelled identically by Docker and Podman, so the only thing that
     // varies is the executable. Resolved once because every functional test that uses a volume calls this.
-    private static readonly Lazy<string?> s_runtimeExecutable = new(ResolveRuntimeExecutable);
+    private static readonly Lazy<RuntimeResolution> s_runtimeResolution = new(ResolveRuntimeExecutable);
 
     /// <summary>
     /// Resolves the container runtime the app host itself would have used, so volumes are removed with the
@@ -30,31 +30,48 @@ public sealed class DockerUtils
     /// <c>DcpPublisher:ContainerRuntime</c> key is deliberately not honoured — this is a static helper with
     /// no <c>IConfiguration</c>, and no test that sets that key creates volumes.
     /// </remarks>
-    private static string? ResolveRuntimeExecutable()
-    {
-        var configuredRuntime = GetConfiguredRuntime();
+    private static RuntimeResolution ResolveRuntimeExecutable()
+        => ResolveRuntimeExecutable(static (configuredRuntime, cancellationToken) =>
+            ContainerRuntimeDetector.FindAvailableRuntimeAsync(configuredRuntime, cancellationToken: cancellationToken));
 
-        // Detection is async and spawns processes. Task.Run keeps the blocking wait off any ambient
-        // synchronization context, since callers are synchronous test teardown paths.
-        using var cts = new CancellationTokenSource(s_runtimeDetectionTimeout);
-        ContainerRuntimeInfo? detected;
+    internal static RuntimeResolution ResolveRuntimeExecutable(
+        Func<string?, CancellationToken, Task<ContainerRuntimeInfo?>> runtimeDetector)
+    {
+        ArgumentNullException.ThrowIfNull(runtimeDetector);
+
+        string? configuredRuntime = null;
         try
         {
-            detected = Task.Run(
-                () => ContainerRuntimeDetector.FindAvailableRuntimeAsync(configuredRuntime, cancellationToken: cts.Token),
+            configuredRuntime = GetConfiguredRuntime();
+
+            // Detection is async and spawns processes. Task.Run keeps the blocking wait off any ambient
+            // synchronization context, since callers are synchronous test teardown paths.
+            using var cts = new CancellationTokenSource(s_runtimeDetectionTimeout);
+            var detected = Task.Run(
+                () => runtimeDetector(configuredRuntime, cts.Token),
                 cts.Token).GetAwaiter().GetResult();
-        }
-        catch (OperationCanceledException)
-        {
-            return null;
-        }
 
-        if (detected is not { IsInstalled: true })
-        {
-            return null;
-        }
+            if (detected is not { IsInstalled: true })
+            {
+                return RuntimeResolution.Failed(DescribeMissingRuntime(configuredRuntime));
+            }
 
-        return PathLookupHelper.FindFullPathFromPath(detected.Executable);
+            return PathLookupHelper.FindFullPathFromPath(detected.Executable) is { } executable
+                ? RuntimeResolution.Succeeded(executable)
+                : RuntimeResolution.Failed(DescribeMissingRuntime(configuredRuntime));
+        }
+        catch (OperationCanceledException exception)
+        {
+            return RuntimeResolution.Failed("container runtime detection timed out.", exception);
+        }
+        catch (Exception exception)
+        {
+            // This is a best-effort cleanup boundary. Preserve unexpected probe failures as data so the
+            // Lazy does not cache a thrown exception that can later replace the test's original failure.
+            return RuntimeResolution.Failed(
+                $"container runtime detection failed with {exception.GetType().Name}: {exception.Message}",
+                exception);
+        }
     }
 
     /// <summary>
@@ -72,20 +89,23 @@ public sealed class DockerUtils
     /// Explains why no runtime could be used, so a failing cleanup does not look like a missing install
     /// when the runtime was actually pinned by configuration.
     /// </summary>
-    private static string DescribeMissingRuntime()
-        => GetConfiguredRuntime() is { } configuredRuntime
+    private static string DescribeMissingRuntime(string? configuredRuntime)
+        => configuredRuntime is not null
             ? $"the container runtime configured by {KnownConfigNames.ContainerRuntime} ('{configuredRuntime}') is not available."
             : "no container runtime was found on PATH.";
 
     public static void AttemptDeleteDockerVolume(string volumeName, bool throwOnFailure = false)
     {
-        if (s_runtimeExecutable.Value is not string runtime)
+        var runtimeResolution = s_runtimeResolution.Value;
+        if (runtimeResolution.Executable is not string runtime)
         {
+            var message = $"Failed to delete the volume named '{volumeName}': {runtimeResolution.FailureReason}";
             if (throwOnFailure)
             {
-                throw new InvalidOperationException($"Failed to delete the volume named '{volumeName}': {DescribeMissingRuntime()}");
+                throw new InvalidOperationException(message, runtimeResolution.DetectionException);
             }
 
+            Console.WriteLine(message);
             return;
         }
 
@@ -132,5 +152,17 @@ public sealed class DockerUtils
                 throw new InvalidOperationException($"Failed to inspect the deleted volume named '{volumeName}', the inspect process did not start.");
             }
         }
+    }
+
+    internal readonly record struct RuntimeResolution(
+        string? Executable,
+        string? FailureReason,
+        Exception? DetectionException)
+    {
+        public static RuntimeResolution Succeeded(string executable)
+            => new(executable, FailureReason: null, DetectionException: null);
+
+        public static RuntimeResolution Failed(string failureReason, Exception? detectionException = null)
+            => new(Executable: null, FailureReason: failureReason, DetectionException: detectionException);
     }
 }

--- a/tests/Aspire.Hosting.TestUtilities/Utils/DockerUtils.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/DockerUtils.cs
@@ -8,11 +8,74 @@ namespace Aspire.Hosting.Utils;
 
 public sealed class DockerUtils
 {
+    // Bounds the one-off runtime probe below. ContainerRuntimeDetector already caps each individual
+    // process at 10s, but a machine with several wedged CLIs could still stall test cleanup for a while.
+    private static readonly TimeSpan s_runtimeDetectionTimeout = TimeSpan.FromSeconds(30);
+
     // `volume rm` / `volume inspect` are spelled identically by Docker and Podman, so the only thing that
     // varies is the executable. Resolved once because every functional test that uses a volume calls this.
-    private static readonly Lazy<string?> s_runtimeExecutable = new(static () =>
-        PathLookupHelper.FindFullPathFromPath(KnownContainerRuntimes.Docker)
-        ?? PathLookupHelper.FindFullPathFromPath(KnownContainerRuntimes.Podman));
+    private static readonly Lazy<string?> s_runtimeExecutable = new(ResolveRuntimeExecutable);
+
+    /// <summary>
+    /// Resolves the container runtime the app host itself would have used, so volumes are removed with the
+    /// same engine that created them.
+    /// </summary>
+    /// <remarks>
+    /// Picking the first CLI on PATH is not good enough: with both CLIs installed and
+    /// <c>ASPIRE_CONTAINER_RUNTIME=podman</c>, Aspire creates a Podman volume, and the same happens when
+    /// Docker is installed but unhealthy and detection falls back to Podman. Either way a PATH-order guess
+    /// would run <c>docker volume rm</c> against a volume Docker does not have, silently leaking it.
+    /// <see cref="ContainerRuntimeDetector"/> is exactly what <c>ContainerRuntimeResolver</c> uses, and the
+    /// configured-runtime precedence mirrors <c>DcpOptions</c>. The in-memory
+    /// <c>DcpPublisher:ContainerRuntime</c> key is deliberately not honoured — this is a static helper with
+    /// no <c>IConfiguration</c>, and no test that sets that key creates volumes.
+    /// </remarks>
+    private static string? ResolveRuntimeExecutable()
+    {
+        var configuredRuntime = GetConfiguredRuntime();
+
+        // Detection is async and spawns processes. Task.Run keeps the blocking wait off any ambient
+        // synchronization context, since callers are synchronous test teardown paths.
+        using var cts = new CancellationTokenSource(s_runtimeDetectionTimeout);
+        ContainerRuntimeInfo? detected;
+        try
+        {
+            detected = Task.Run(
+                () => ContainerRuntimeDetector.FindAvailableRuntimeAsync(configuredRuntime, cancellationToken: cts.Token),
+                cts.Token).GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+
+        if (detected is not { IsInstalled: true })
+        {
+            return null;
+        }
+
+        return PathLookupHelper.FindFullPathFromPath(detected.Executable);
+    }
+
+    /// <summary>
+    /// Reads the explicitly configured container runtime, using the same precedence as <c>DcpOptions</c>.
+    /// </summary>
+    private static string? GetConfiguredRuntime()
+    {
+        var configuredRuntime = Environment.GetEnvironmentVariable(KnownConfigNames.ContainerRuntime)
+            ?? Environment.GetEnvironmentVariable(KnownConfigNames.Legacy.ContainerRuntime);
+
+        return string.IsNullOrEmpty(configuredRuntime) ? null : configuredRuntime;
+    }
+
+    /// <summary>
+    /// Explains why no runtime could be used, so a failing cleanup does not look like a missing install
+    /// when the runtime was actually pinned by configuration.
+    /// </summary>
+    private static string DescribeMissingRuntime()
+        => GetConfiguredRuntime() is { } configuredRuntime
+            ? $"the container runtime configured by {KnownConfigNames.ContainerRuntime} ('{configuredRuntime}') is not available."
+            : "no container runtime was found on PATH.";
 
     public static void AttemptDeleteDockerVolume(string volumeName, bool throwOnFailure = false)
     {
@@ -20,7 +83,7 @@ public sealed class DockerUtils
         {
             if (throwOnFailure)
             {
-                throw new InvalidOperationException($"Failed to delete the volume named '{volumeName}': no container runtime was found on PATH.");
+                throw new InvalidOperationException($"Failed to delete the volume named '{volumeName}': {DescribeMissingRuntime()}");
             }
 
             return;

--- a/tests/Aspire.Hosting.TestUtilities/Utils/DockerUtils.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/DockerUtils.cs
@@ -2,13 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Shared;
 
 namespace Aspire.Hosting.Utils;
 
 public sealed class DockerUtils
 {
+    // `volume rm` / `volume inspect` are spelled identically by Docker and Podman, so the only thing that
+    // varies is the executable. Resolved once because every functional test that uses a volume calls this.
+    private static readonly Lazy<string?> s_runtimeExecutable = new(static () =>
+        PathLookupHelper.FindFullPathFromPath(KnownContainerRuntimes.Docker)
+        ?? PathLookupHelper.FindFullPathFromPath(KnownContainerRuntimes.Podman));
+
     public static void AttemptDeleteDockerVolume(string volumeName, bool throwOnFailure = false)
     {
+        if (s_runtimeExecutable.Value is not string runtime)
+        {
+            if (throwOnFailure)
+            {
+                throw new InvalidOperationException($"Failed to delete the volume named '{volumeName}': no container runtime was found on PATH.");
+            }
+
+            return;
+        }
+
         for (var i = 0; i < 3; i++)
         {
             if (i != 0)
@@ -16,7 +33,7 @@ public sealed class DockerUtils
                 Thread.Sleep(1000);
             }
 
-            if (Process.Start("docker", $"volume rm {volumeName}") is { } process)
+            if (Process.Start(runtime, $"volume rm {volumeName}") is { } process)
             {
                 var exited = process.WaitForExit(TimeSpan.FromSeconds(3));
                 var done = exited && process.ExitCode == 0;
@@ -32,7 +49,7 @@ public sealed class DockerUtils
 
         if (throwOnFailure)
         {
-            if (Process.Start("docker", $"volume inspect {volumeName}") is { } process)
+            if (Process.Start(runtime, $"volume inspect {volumeName}") is { } process)
             {
                 var exited = process.WaitForExit(TimeSpan.FromSeconds(3));
                 var exitCode = process.ExitCode;
@@ -44,7 +61,7 @@ public sealed class DockerUtils
                 }
                 if (exitCode == 0)
                 {
-                    throw new InvalidOperationException($"Failed to delete docker volume named '{volumeName}'. Attempted to inspect the volume and it still exists.");
+                    throw new InvalidOperationException($"Failed to delete the volume named '{volumeName}'. Attempted to inspect the volume and it still exists.");
                 }
             }
             else

--- a/tests/Aspire.Hosting.TestUtilities/Utils/TestProcessRunner.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/TestProcessRunner.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dcp.Process;
+
+namespace Aspire.Hosting.Tests.Utils;
+
+internal sealed class TestProcessRunner : IProcessRunner
+{
+    private readonly object _lock = new();
+    private readonly Queue<TestProcessRun> _runs = [];
+    private readonly List<ProcessSpec> _processSpecs = [];
+    private readonly List<TestProcessDisposable> _disposables = [];
+
+    public IReadOnlyList<ProcessSpec> ProcessSpecs
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _processSpecs];
+            }
+        }
+    }
+
+    public IReadOnlyList<TestProcessDisposable> Disposables
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _disposables];
+            }
+        }
+    }
+
+    public TaskCompletionSource<ProcessSpec> RunStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public void EnqueueResult(
+        int exitCode = 0,
+        IReadOnlyList<string>? output = null,
+        IReadOnlyList<string>? error = null,
+        int? totalOutputLineCount = null,
+        IReadOnlyList<TestProcessOutput>? outputEvents = null)
+    {
+        lock (_lock)
+        {
+            _runs.Enqueue(TestProcessRun.Result(exitCode, output, error, totalOutputLineCount, outputEvents));
+        }
+    }
+
+    public void EnqueueException(Exception exception)
+    {
+        lock (_lock)
+        {
+            _runs.Enqueue(TestProcessRun.Failed(exception));
+        }
+    }
+
+    public void EnqueuePending(Task<ProcessResult> processResult)
+    {
+        lock (_lock)
+        {
+            _runs.Enqueue(TestProcessRun.Pending(processResult));
+        }
+    }
+
+    public (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec)
+    {
+        TestProcessRun run;
+        TestProcessDisposable disposable;
+        lock (_lock)
+        {
+            _processSpecs.Add(processSpec);
+
+            disposable = new TestProcessDisposable();
+            _disposables.Add(disposable);
+
+            run = _runs.Count > 0 ? _runs.Dequeue() : TestProcessRun.Result();
+        }
+
+        RunStarted.TrySetResult(processSpec);
+
+        if (run.FailureException is { } exception)
+        {
+            throw exception;
+        }
+
+        if (run.PendingResult is { } pendingResult)
+        {
+            return (pendingResult, disposable);
+        }
+
+        foreach (var output in run.OutputEvents)
+        {
+            if (output.IsError)
+            {
+                processSpec.OnErrorData?.Invoke(output.Value);
+            }
+            else
+            {
+                processSpec.OnOutputData?.Invoke(output.Value);
+            }
+        }
+
+        var processOutput = run.OutputEvents.Select(static output => output.Value).ToArray();
+        var processResult = new ProcessResult(run.ExitCode, processOutput, run.TotalOutputLineCount);
+
+        return (Task.FromResult(processResult), disposable);
+    }
+
+    private sealed record TestProcessRun(
+        int ExitCode,
+        IReadOnlyList<TestProcessOutput> OutputEvents,
+        int? TotalOutputLineCount,
+        Exception? FailureException,
+        Task<ProcessResult>? PendingResult)
+    {
+        public static TestProcessRun Result(
+            int exitCode = 0,
+            IReadOnlyList<string>? output = null,
+            IReadOnlyList<string>? error = null,
+            int? totalOutputLineCount = null,
+            IReadOnlyList<TestProcessOutput>? outputEvents = null)
+        {
+            outputEvents ??=
+            [
+                .. (output ?? Array.Empty<string>()).Select(static value => new TestProcessOutput(IsError: false, Value: value)),
+                .. (error ?? Array.Empty<string>()).Select(static value => new TestProcessOutput(IsError: true, Value: value))
+            ];
+
+            return new TestProcessRun(exitCode, outputEvents, totalOutputLineCount, null, null);
+        }
+
+        public static TestProcessRun Failed(Exception exception)
+            => new(0, [], null, exception, null);
+
+        public static TestProcessRun Pending(Task<ProcessResult> pendingResult)
+            => new(0, [], null, null, pendingResult);
+    }
+}
+
+internal sealed record TestProcessOutput(bool IsError, string Value);
+
+internal sealed class TestProcessDisposable : IAsyncDisposable
+{
+    public int DisposeCallCount { get; private set; }
+
+    public ValueTask DisposeAsync()
+    {
+        DisposeCallCount++;
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -35,7 +35,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/dotnet/dnceng/issues/6232", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnAzdoBuildMachine))]
     public async Task CanLoadFromDirectoryOutsideOfAppContextBaseDirectory()
     {
@@ -82,7 +82,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(false)]
     [InlineData(true)]
     public async Task CreateAsyncWithOptions(bool genericEntryPoint)
@@ -129,7 +129,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(false)]
     [InlineData(true)]
     public async Task HasEndPoints(bool genericEntryPoint)
@@ -153,7 +153,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(false)]
     [InlineData(true)]
     public async Task CanGetResources(bool genericEntryPoint)
@@ -171,7 +171,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(false)]
     [InlineData(true)]
     public async Task HttpClientGetTest(bool genericEntryPoint)
@@ -197,7 +197,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(false)]
     [InlineData(true)]
     public async Task GetHttpClientBeforeStart(bool genericEntryPoint)
@@ -214,7 +214,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     /// Tests that arguments propagate into the application host.
     /// </summary>
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(false, false)]
     [InlineData(false, true)]
     [InlineData(true, false)]
@@ -260,7 +260,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     /// Tests that arguments propagate into the application host.
     /// </summary>
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     public async Task ArgsPropagateToAppHostConfigurationAdHocBuilder(bool directArgs)
@@ -300,7 +300,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     /// populating in configuration.
     /// </summary>
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData("http", false)]
     [InlineData("http", true)]
     [InlineData("https", false)]
@@ -349,7 +349,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     /// populating in configuration.
     /// </summary>
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData("http", false)]
     [InlineData("http", true)]
     [InlineData("https", false)]
@@ -396,7 +396,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(false)]
     [InlineData(true)]
     public async Task SetsCorrectContentRoot(bool genericEntryPoint)
@@ -412,7 +412,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(false)]
     [InlineData(true)]
     public async Task SelectsFirstLaunchProfile(bool genericEntryPoint)
@@ -443,7 +443,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
 
     // Tests that DistributedApplicationTestingBuilder throws exceptions at the right times when the app crashes.
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true, "before-build")]
     [InlineData(true, "after-build")]
     [InlineData(true, "after-start")]
@@ -496,7 +496,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     /// Checks that DisposeAsync does not throw an exception when the application is disposed with a still on-going StartAsync call.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task StartAsyncAbandonedAfterCrash()
     {
         var timeout = TimeSpan.FromMinutes(5);
@@ -517,7 +517,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task StartAsyncAbandonedAfterHang()
     {
         var timeout = TimeSpan.FromMinutes(5);
@@ -571,7 +571,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task DashboardEnabledInTestingBuilderShouldWorkWithDynamicPorts()
     {
         var builder = DistributedApplicationTestingBuilder.Create([], (options, _) =>
@@ -594,7 +594,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData("https://127.0.0.1:0", "127.0.0.1")]
     [InlineData("https://[::1]:0", "[::1]")]
     public async Task LoopbackWithDynamicPorts(string endpointUrl, string expectedHost)
@@ -622,7 +622,7 @@ public class TestingBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task NonLocalResourceServiceEndpointThrows()
     {
         var builder = DistributedApplicationTestingBuilder.Create([], (opt, _) =>

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Testing.Tests;
 public class TestingFactoryCrashTests
 {
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData("before-build")]
     [InlineData("after-build")]
     [InlineData("after-start")]

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -16,7 +16,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     private readonly DistributedApplication _app = fixture.Application;
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void HasEndPoints()
     {
         // Get an endpoint from a resource
@@ -26,7 +26,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task CanGetConnectionStringFromAddConnectionString()
     {
         // Get a connection string from a resource
@@ -37,7 +37,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void CanGetResources()
     {
         var appModel = _app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -45,7 +45,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task HttpClientGetTest()
     {
         // Wait for the application to be ready
@@ -59,7 +59,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void SetsCorrectContentRoot()
     {
         var appModel = _app.Services.GetRequiredService<IHostEnvironment>();
@@ -67,7 +67,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/4650")]
     public async Task SelectsFirstLaunchProfile()
     {

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelTests.cs
@@ -303,7 +303,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task CallResourceMcpToolAsyncThrowsWhenResourceNotFound()
     {
         // This test verifies that CallResourceMcpToolAsync throws when resource is not found
@@ -344,7 +344,7 @@ public class AuxiliaryBackchannelTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task CallResourceMcpToolAsyncThrowsWhenResourceHasNoMcpAnnotation()
     {
         // This test verifies that CallResourceMcpToolAsync throws when resource has no MCP annotation

--- a/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerTunnelTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Tests;
 public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task ContainerTunnelWorksWithYarp()
     {
         const string testName = "container-tunnel-works-with-yarp";
@@ -44,7 +44,7 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task ProxylessEndpointWorksWithContainerTunnel()
     {
         var port = await Helpers.Network.GetAvailablePortAsync();
@@ -83,7 +83,7 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task WaitingContainersCanUseTunnel()
     {
         const string testName = "waiting-containers-can-use-tunnel";
@@ -119,7 +119,7 @@ public class ContainerTunnelTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task HostResourceCanWaitForTunnelDependentContainers()
     {
         const string testName = "host-resource-waits-for-tunnel-container";

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -514,7 +514,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ExplicitStart_StartContainer()
     {
         const string testName = "explicit-start-container";
@@ -597,7 +597,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ExplicitStart_StartPersistentContainer()
     {
         foreach (var firstRun in new[] { true, false })
@@ -816,7 +816,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyContainerArgs()
     {
         using var testProgram = CreateTestProgram("verify-container-args");
@@ -844,7 +844,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyContainerCreateFile()
     {
         using var testProgram = CreateTestProgram("verify-container-create-file", trustDeveloperCertificate: false);
@@ -909,7 +909,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyRedisWithCertificateKeyPair()
     {
         const string testName = "verify-redis-with-certificate";
@@ -954,7 +954,7 @@ public class DistributedApplicationTests
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [RequiresFeature(TestFeature.DevCert)]
     [InlineData(false, false, false, false, CertificateTrustScope.Append)]
     [InlineData(false, true, true, false, CertificateTrustScope.Append)]
@@ -1080,7 +1080,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyContainerSucceedsWithCreateFileContinueOnError()
     {
         using var testProgram = CreateTestProgram("verify-container-continue-on-error", trustDeveloperCertificate: false);
@@ -1109,7 +1109,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [RequiresFeature(TestFeature.DevCert)]
     public async Task VerifyEnvironmentVariablesAvailableInCertificateTrustConfigCallback()
     {
@@ -1155,7 +1155,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyEnvironmentVariablesAppliedWithoutCertificateTrustConfig()
     {
         // Don't apply developer certificate trust so the config callback shouldn't be invoked
@@ -1194,7 +1194,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyContainerStopStartWorks()
     {
         using var testProgram = CreateTestProgram("container-start-stop", randomizePorts: false);
@@ -1279,7 +1279,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task SpecifyingEnvPortInEndpointFlowsToEnv()
     {
         const string testName = "ports-flow-to-env";
@@ -1497,7 +1497,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyDockerWithEntrypointWorks()
     {
         const string testName = "docker-entrypoint";
@@ -1524,7 +1524,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyDockerWithBindMountWorksWithAbsolutePaths()
     {
         const string testName = "docker-bindmount-absolute";
@@ -1553,7 +1553,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyDockerWithBindMountWorksWithRelativePaths()
     {
         const string testName = "docker-bindmount-relative";
@@ -1582,7 +1582,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyDockerWithVolumeWorksWithName()
     {
         const string testName = "docker-volume";
@@ -1610,7 +1610,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task KubernetesHasResourceNameForContainersAndExes()
     {
         const string testName = "kube-resource-names";
@@ -1812,7 +1812,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [OuterloopTest("Long-running container test")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ProxylessContainerCanBeReferenced()
     {
         const string testName = "proxyless-container";
@@ -1891,7 +1891,7 @@ public class DistributedApplicationTests
 
     [Fact]
     [OuterloopTest("Long-running endpoint proxy test")]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WithEndpointProxySupportDisablesProxies()
     {
         const string testName = "endpoint-proxy-support";
@@ -1969,7 +1969,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ProxylessContainerWithoutPortThrows()
     {
         const string testName = "proxyless-container-without-ports";
@@ -1989,7 +1989,7 @@ public class DistributedApplicationTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task PersistentNetworkCreatedIfPersistentContainers(bool createPersistentContainer)
     {
         const string testName = "persistent-network-if-persistent-containers";
@@ -2021,7 +2021,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ParentProcessLifetimeScopesExecutableAndContainerToParentProcess()
     {
         const string testName = "parent-process-lifetime-scope";
@@ -2070,7 +2070,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ParentProcessLifetimeReusesResourcesAcrossAppRestartsAndStopsWhenParentExits()
     {
         const string testName = "parent-process-lifetime-reuse";
@@ -2188,7 +2188,7 @@ public class DistributedApplicationTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AfterResourcesCreatedLifecycleHookWorks()
     {
         const string testName = "lifecycle-hook-after-resource-created";
@@ -2281,7 +2281,7 @@ public class DistributedApplicationTests
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(0)] // Success exit code
     [InlineData(100)] // Failing (non-zero) exit code
     public async Task ContainerExitsImmediatelyAfterStart(int exitCode)

--- a/tests/Aspire.Hosting.Tests/DockerUtilsTests.cs
+++ b/tests/Aspire.Hosting.Tests/DockerUtilsTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Aspire.Shared;
+using Microsoft.DotNet.RemoteExecutor;
+
+namespace Aspire.Hosting.Tests;
+
+public class DockerUtilsTests
+{
+    [Fact]
+    public void ResolveRuntimeExecutable_WhenDetectorThrows_ReturnsFailure()
+    {
+        var expectedException = new InvalidOperationException("probe failed");
+
+        var resolution = DockerUtils.ResolveRuntimeExecutable(
+            (_, _) => Task.FromException<ContainerRuntimeInfo?>(expectedException));
+
+        Assert.Null(resolution.Executable);
+        Assert.Equal("container runtime detection failed with InvalidOperationException: probe failed", resolution.FailureReason);
+        Assert.Same(expectedException, resolution.DetectionException);
+    }
+
+    [Fact]
+    public void AttemptDeleteDockerVolume_WhenRuntimeIsUnavailable_ReportsSkippedCleanup()
+    {
+        const string MissingRuntime = "aspire-missing-container-runtime";
+        var options = new RemoteInvokeOptions();
+        options.StartInfo.Environment[KnownConfigNames.ContainerRuntime] = MissingRuntime;
+
+        RemoteExecutor.Invoke(static () =>
+        {
+            using var output = new StringWriter();
+            Console.SetOut(output);
+
+            DockerUtils.AttemptDeleteDockerVolume("test-volume");
+
+            Assert.Equal(
+                $"Failed to delete the volume named 'test-volume': the container runtime configured by {KnownConfigNames.ContainerRuntime} ('{MissingRuntime}') is not available.",
+                output.ToString().Trim());
+        }, options).Dispose();
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
+++ b/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
@@ -174,7 +174,7 @@ public class DistributedApplicationBuilderEventingTests(ITestOutputHelper testOu
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ResourceEventsForContainersFireForSpecificResources()
     {
         var beforeResourceStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -198,7 +198,7 @@ public class DistributedApplicationBuilderEventingTests(ITestOutputHelper testOu
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ResourceEventsForContainersFireForAllResources()
     {
         var countdownEvent = new CountdownEvent(2);
@@ -336,7 +336,7 @@ public class DistributedApplicationBuilderEventingTests(ITestOutputHelper testOu
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ResourceStoppedEventFiresWhenResourceStops()
     {
         var resourceStoppedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Aspire.Hosting.Tests/HealthCheckTests.cs
+++ b/tests/Aspire.Hosting.Tests/HealthCheckTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Hosting.Tests;
 public class HealthCheckTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void WithHttpHealthCheckThrowsIfReferencingEndpointByNameThatIsNotHttpScheme()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -36,7 +36,7 @@ public class HealthCheckTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void WithHttpHealthCheckThrowsIfReferencingEndpointThatIsNotHttpScheme()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -56,7 +56,7 @@ public class HealthCheckTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void WithHttpsHealthCheckThrowsIfReferencingEndpointThatIsNotHttpsScheme()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -109,7 +109,7 @@ public class HealthCheckTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task VerifyWithHttpHealthCheckBlocksDependentResources()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);

--- a/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ContainerRuntimeBaseTests.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREPIPELINES003
 #pragma warning disable ASPIRECONTAINERRUNTIME001
 
+using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -25,7 +26,8 @@ public class ContainerRuntimeBaseTests
         Assert.Contains("stderr-final-line", exception.Message);
     }
 
-    private sealed class TestContainerRuntime(string? runtimeExecutable = null) : ContainerRuntimeBase<TestContainerRuntime>(NullLogger<TestContainerRuntime>.Instance)
+    private sealed class TestContainerRuntime(string? runtimeExecutable = null)
+        : ContainerRuntimeBase<TestContainerRuntime>(NullLogger<TestContainerRuntime>.Instance, new DefaultProcessRunner())
     {
         protected override string RuntimeExecutable => runtimeExecutable ?? (OperatingSystem.IsWindows() ? "cmd" : "sh");
 

--- a/tests/Aspire.Hosting.Tests/Publishing/PodmanSaveArgumentsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PodmanSaveArgumentsTests.cs
@@ -5,6 +5,8 @@
 #pragma warning disable ASPIREPIPELINES003
 
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Tests.Publishing;
 
@@ -76,8 +78,54 @@ public class PodmanSaveArgumentsTests
 
         var arguments = PodmanContainerRuntime.BuildSaveArguments("registry.example.com/team/myapp:1.2.3", options);
 
-        var dockerArchivePath = DockerContainerRuntime.GetArchivePath(outputPath, "registry.example.com/team/myapp:1.2.3");
+        var dockerArchivePath = ResourceExtensions.GetContainerImageArchivePath(outputPath, "registry.example.com/team/myapp:1.2.3");
         Assert.Contains($"--output \"{dockerArchivePath}\"", arguments, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildSaveArguments_ArchivePathMatchesContainerImageReference()
+    {
+        // The runtimes write the archive, but ContainerImageReference is what tells consumers where to
+        // find it, so the producer and the consumer have to resolve the same file. A registry-qualified
+        // image name is the case where they used to diverge: the runtimes flattened the repository
+        // segments while ContainerImageReference left the '/' in place, pointing consumers at a nested
+        // path nothing ever wrote.
+        var outputPath = Path.Combine("out", "archives");
+        const string ImageName = "registry.example.com/team/myapp";
+        const string ImageTag = "1.2.3";
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var container = builder.AddContainer("myapp", ImageName)
+            .WithContainerBuildOptions(ctx =>
+            {
+                ctx.Destination = ContainerImageDestination.Archive;
+                ctx.ImageFormat = ContainerImageFormat.Oci;
+                ctx.OutputPath = outputPath;
+                ctx.LocalImageName = ImageName;
+                ctx.LocalImageTag = ImageTag;
+            });
+
+        using var app = builder.Build();
+
+        IValueProvider imageReference = new ContainerImageReference(container.Resource);
+        var consumerPath = await imageReference.GetValueAsync(
+            new ValueProviderContext { ExecutionContext = app.Services.GetRequiredService<DistributedApplicationExecutionContext>() },
+            CancellationToken.None);
+
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = ImageName,
+            Tag = ImageTag,
+            OutputPath = outputPath,
+            ImageFormat = ContainerImageFormat.Oci
+        };
+
+        var arguments = PodmanContainerRuntime.BuildSaveArguments($"{ImageName}:{ImageTag}", options);
+
+        Assert.Equal(
+            $"save --format \"oci-archive\" --output \"{consumerPath}\" \"{ImageName}:{ImageTag}\"",
+            arguments);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Publishing/PodmanSaveArgumentsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PodmanSaveArgumentsTests.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIRECONTAINERRUNTIME001
+#pragma warning disable ASPIREPIPELINES003
+
+using Aspire.Hosting.Publishing;
+
+namespace Aspire.Hosting.Tests.Publishing;
+
+public class PodmanSaveArgumentsTests
+{
+    [Fact]
+    public void BuildSaveArguments_OciFormat_UsesOciArchive()
+    {
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "myapp",
+            Tag = "latest",
+            OutputPath = Path.Combine("out", "archives"),
+            ImageFormat = ContainerImageFormat.Oci
+        };
+
+        var arguments = PodmanContainerRuntime.BuildSaveArguments("myapp:latest", options);
+
+        var expectedPath = Path.Combine("out", "archives", "myapp-latest.tar");
+        Assert.Equal($"save --format \"oci-archive\" --output \"{expectedPath}\" \"myapp:latest\"", arguments);
+    }
+
+    [Fact]
+    public void BuildSaveArguments_DockerFormat_UsesDockerArchive()
+    {
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "myapp",
+            Tag = "latest",
+            OutputPath = Path.Combine("out", "archives"),
+            ImageFormat = ContainerImageFormat.Docker
+        };
+
+        var arguments = PodmanContainerRuntime.BuildSaveArguments("myapp:latest", options);
+
+        var expectedPath = Path.Combine("out", "archives", "myapp-latest.tar");
+        Assert.Equal($"save --format \"docker-archive\" --output \"{expectedPath}\" \"myapp:latest\"", arguments);
+    }
+
+    [Fact]
+    public void BuildSaveArguments_UnspecifiedFormat_DefaultsToDockerArchive()
+    {
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "myapp",
+            Tag = "latest",
+            OutputPath = Path.Combine("out", "archives")
+        };
+
+        var arguments = PodmanContainerRuntime.BuildSaveArguments("myapp:latest", options);
+
+        var expectedPath = Path.Combine("out", "archives", "myapp-latest.tar");
+        Assert.Equal($"save --format \"docker-archive\" --output \"{expectedPath}\" \"myapp:latest\"", arguments);
+    }
+
+    [Fact]
+    public void BuildSaveArguments_ArchivePathMatchesDockerRuntime()
+    {
+        // Both runtimes must write the same archive file for the same resource, otherwise consumers that
+        // resolve the archive path cannot find what Podman produced.
+        var outputPath = Path.Combine("out", "archives");
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "registry.example.com/team/myapp",
+            Tag = "1.2.3",
+            OutputPath = outputPath,
+            ImageFormat = ContainerImageFormat.Oci
+        };
+
+        var arguments = PodmanContainerRuntime.BuildSaveArguments("registry.example.com/team/myapp:1.2.3", options);
+
+        var dockerArchivePath = DockerContainerRuntime.GetArchivePath(outputPath, "registry.example.com/team/myapp:1.2.3");
+        Assert.Contains($"--output \"{dockerArchivePath}\"", arguments, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildSaveArguments_TagIsPreservedInArchiveName()
+    {
+        // Dropping the tag would place the archive at a path nothing else resolves to.
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "container",
+            Tag = "abc123",
+            OutputPath = "out",
+            ImageFormat = ContainerImageFormat.Oci
+        };
+
+        var arguments = PodmanContainerRuntime.BuildSaveArguments("container:abc123", options);
+
+        Assert.Contains($"--output \"{Path.Combine("out", "container-abc123.tar")}\"", arguments, StringComparison.Ordinal);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Publishing/PodmanSaveArgumentsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PodmanSaveArgumentsTests.cs
@@ -5,8 +5,10 @@
 #pragma warning disable ASPIREPIPELINES003
 
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Tests.Publishing;
 
@@ -144,4 +146,129 @@ public class PodmanSaveArgumentsTests
 
         Assert.Contains($"--output \"{Path.Combine("out", "container-abc123.tar")}\"", arguments, StringComparison.Ordinal);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task BuildImageAsync_OciFormatWithoutOutputPath_ThrowsBeforeBuild(string? outputPath)
+    {
+        var processRunner = new TestProcessRunner();
+        var runtime = CreateRuntime(processRunner);
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "myapp",
+            Tag = "latest",
+            OutputPath = outputPath,
+            ImageFormat = ContainerImageFormat.Oci
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => BuildImageAsync(runtime, options));
+
+        Assert.Equal("options", exception.ParamName);
+        Assert.Empty(processRunner.ProcessSpecs);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task BuildImageAsync_WithoutOutputPath_DoesNotSave(string? outputPath)
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        var runtime = CreateRuntime(processRunner);
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "myapp",
+            Tag = "latest",
+            OutputPath = outputPath,
+            ImageFormat = ContainerImageFormat.Docker
+        };
+
+        await BuildImageAsync(runtime, options);
+
+        var buildSpec = Assert.Single(processRunner.ProcessSpecs);
+        Assert.StartsWith("build ", Assert.IsType<string>(buildSpec.Arguments), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildImageAsync_WithOutputPath_BuildsThenSaves()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        processRunner.EnqueueResult();
+        var runtime = CreateRuntime(processRunner);
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "myapp",
+            Tag = "latest",
+            OutputPath = "out",
+            ImageFormat = ContainerImageFormat.Oci
+        };
+
+        await BuildImageAsync(runtime, options);
+
+        Assert.Collection(
+            processRunner.ProcessSpecs,
+            buildSpec => Assert.StartsWith("build ", Assert.IsType<string>(buildSpec.Arguments), StringComparison.Ordinal),
+            saveSpec => Assert.Equal(PodmanContainerRuntime.BuildSaveArguments("myapp:latest", options), saveSpec.Arguments));
+    }
+
+    [Fact]
+    public async Task BuildImageAsync_WhenBuildFails_DoesNotSave()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult(exitCode: 17, output: ["build failed"]);
+        var runtime = CreateRuntime(processRunner);
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "myapp",
+            Tag = "latest",
+            OutputPath = "out",
+            ImageFormat = ContainerImageFormat.Oci
+        };
+
+        var exception = await Assert.ThrowsAsync<ProcessFailedException>(() => BuildImageAsync(runtime, options));
+
+        Assert.Equal(17, exception.ExitCode);
+        Assert.Contains("build failed", exception.Message);
+        Assert.Single(processRunner.ProcessSpecs);
+    }
+
+    [Fact]
+    public async Task BuildImageAsync_WhenSaveFails_ThrowsProcessFailedException()
+    {
+        var processRunner = new TestProcessRunner();
+        processRunner.EnqueueResult();
+        processRunner.EnqueueResult(exitCode: 23, output: ["save failed"]);
+        var runtime = CreateRuntime(processRunner);
+        var options = new ContainerImageBuildOptions
+        {
+            ImageName = "myapp",
+            Tag = "latest",
+            OutputPath = "out",
+            ImageFormat = ContainerImageFormat.Oci
+        };
+
+        var exception = await Assert.ThrowsAsync<ProcessFailedException>(() => BuildImageAsync(runtime, options));
+
+        Assert.Equal(23, exception.ExitCode);
+        Assert.Contains("save failed", exception.Message);
+        Assert.Collection(
+            processRunner.ProcessSpecs,
+            buildSpec => Assert.StartsWith("build ", Assert.IsType<string>(buildSpec.Arguments), StringComparison.Ordinal),
+            saveSpec => Assert.StartsWith("save ", Assert.IsType<string>(saveSpec.Arguments), StringComparison.Ordinal));
+    }
+
+    private static PodmanContainerRuntime CreateRuntime(TestProcessRunner processRunner)
+        => new(NullLogger<PodmanContainerRuntime>.Instance, processRunner);
+
+    private static Task BuildImageAsync(PodmanContainerRuntime runtime, ContainerImageBuildOptions options)
+        => runtime.BuildImageAsync(
+            contextPath: "context",
+            dockerfilePath: "Dockerfile",
+            options: options,
+            buildArguments: [],
+            buildSecrets: [],
+            stage: null,
+            cancellationToken: CancellationToken.None);
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -251,6 +251,8 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         // Ensure no error logs were produced during the build process
         Assert.DoesNotContain(logs, log => log.Level >= LogLevel.Error &&
             log.Message.Contains("Failed to build container image"));
+
+        AssertImageArchiveWasWritten(container.Resource, tempOutputPath);
     }
 
     [Fact]
@@ -269,11 +271,12 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         var tempContextPath = tempDockerfileContext.ContextPath;
         var tempDockerfilePath = tempDockerfileContext.DockerfilePath;
         using var workspace = TemporaryWorkspace.Create(output);
+        var tempOutputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "NewFolder"); // tests that the folder is created if it doesn't exist
         var container = builder.AddDockerfile("container", tempContextPath, tempDockerfilePath)
             .WithContainerBuildOptions(ctx =>
             {
                 ctx.ImageFormat = ContainerImageFormat.Oci;
-                ctx.OutputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "NewFolder"); // tests that the folder is created if it doesn't exist
+                ctx.OutputPath = tempOutputPath;
                 ctx.TargetPlatform = ContainerTargetPlatform.LinuxAmd64;
             });
 
@@ -293,6 +296,8 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         // Ensure no error logs were produced during the build process
         Assert.DoesNotContain(logs, log => log.Level >= LogLevel.Error &&
             log.Message.Contains("Failed to build container image"));
+
+        AssertImageArchiveWasWritten(container.Resource, tempOutputPath);
     }
 
     [Theory]
@@ -1550,6 +1555,32 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         Assert.NotEqual(-1, newlineIndex);
         Assert.Equal($"{containerRuntime.Name} build failed with exit code {ex.ExitCode}.", ex.Message[..newlineIndex]);
         Assert.Equal(ex.GetFormattedOutput(), ex.Message[(newlineIndex + Environment.NewLine.Length)..]);
+    }
+
+    /// <summary>
+    /// Asserts that the container runtime actually produced an image archive at the path consumers resolve.
+    /// </summary>
+    /// <remarks>
+    /// Log-only assertions are not enough here: Podman used to pass <c>--output</c> to <c>podman build</c>,
+    /// which is a *filesystem* export rather than an image archive, so the build "succeeded" without ever
+    /// writing the archive. Checking the file also pins the Docker/Podman archive-path agreement at runtime
+    /// rather than only through a string comparison in <c>PodmanSaveArgumentsTests</c>.
+    /// </remarks>
+    private static void AssertImageArchiveWasWritten(IResource resource, string outputPath)
+    {
+        Assert.True(resource.TryGetContainerImageName(out var builtImageName));
+
+        var expectedArchivePath = ResourceExtensions.GetContainerImageArchivePath(outputPath, builtImageName);
+
+        // Only a bounded sample of archives is listed, because one of the callers writes into the shared
+        // system temp directory.
+        var actualArchives = Directory.Exists(outputPath)
+            ? string.Join(", ", Directory.EnumerateFiles(outputPath, "*.tar").Select(Path.GetFileName).Take(10))
+            : "<output directory does not exist>";
+
+        Assert.True(
+            File.Exists(expectedArchivePath),
+            $"Expected an image archive at '{expectedArchivePath}'. '{outputPath}' contains: {actualArchives}.");
     }
 }
 

--- a/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/ResourceContainerImageManagerTests.cs
@@ -19,7 +19,7 @@ namespace Aspire.Hosting.Tests.Publishing;
 public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromProjectResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -48,7 +48,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromProjectResourceWithCustomBaseImage()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -81,7 +81,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromDockerfileResource()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -115,7 +115,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromProjectResourceWithOptions()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -154,7 +154,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromProjectResource_WithDockerImageFormat()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -184,7 +184,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromProjectResource_WithLinuxArm64Platform()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -214,7 +214,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromDockerfileResource_WithCustomOutputPath()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -254,7 +254,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromDockerfileResource_WithAllOptionsSet()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -298,7 +298,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     [Theory]
     [InlineData(ContainerImageFormat.Docker)]
     [InlineData(ContainerImageFormat.Oci)]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromProjectResource_WithDifferentImageFormats(ContainerImageFormat imageFormat)
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -330,7 +330,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     [Theory]
     [InlineData(ContainerTargetPlatform.LinuxAmd64)]
     [InlineData(ContainerTargetPlatform.LinuxArm64)]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromProjectResource_WithDifferentTargetPlatforms(ContainerTargetPlatform targetPlatform)
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -360,7 +360,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task BuildImageAsync_WithNullOptions_UsesDefaults()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -406,7 +406,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromDockerfileResource_WithTrailingSlashContextPath()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
@@ -449,7 +449,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create(output);
 
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         var testResource = builder.AddContainer("test-image", "test-image:latest");
 
@@ -473,7 +473,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         using var builder = TestDistributedApplicationBuilder.Create(output);
 
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: true);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         var testResource = builder.AddContainer("test-image", "test-image:latest");
 
@@ -503,7 +503,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Create a fake container runtime that would fail if called
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: true);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         var servicea = builder.AddProject<Projects.ServiceA>("servicea")
             .WithContainerBuildOptions(ctx =>
@@ -538,7 +538,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Create a fake container runtime that tracks health check calls
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
         var tempContextPath = tempDockerfileContext.ContextPath;
@@ -569,7 +569,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Create a fake container runtime that captures the actual context path used
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
         var tempContextPath = tempDockerfileContext.ContextPath;
@@ -609,7 +609,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
             logging.AddXunit(output);
         });
 
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", new FakeContainerRuntime(shouldFail: true));
+        builder.Services.AddFakeContainerRuntime(new FakeContainerRuntime(shouldFail: true));
 
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
         var tempContextPath = tempDockerfileContext.ContextPath;
@@ -680,7 +680,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         });
 
         var fakeContainerRuntime = new FakeContainerRuntime(name: "PODMAN");
-        builder.Services.AddSingleton<IContainerRuntimeResolver>(fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var workspace = TemporaryWorkspace.Create(output);
 
@@ -708,7 +708,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task CanBuildImageFromDockerfileWithBuildArgsSecretsAndStage()
     {
         using var builder = TestDistributedApplicationBuilder.Create(output);
@@ -721,7 +721,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Create a fake container runtime to capture build arguments and secrets
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
         var tempContextPath = tempDockerfileContext.ContextPath;
@@ -783,7 +783,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Create a fake container runtime to capture build arguments
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
         var tempContextPath = tempDockerfileContext.ContextPath;
@@ -893,7 +893,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Create a fake container runtime to capture build secrets
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
         var tempContextPath = tempDockerfileContext.ContextPath;
@@ -940,7 +940,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Create a fake container runtime to capture build secrets
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
         var tempContextPath = tempDockerfileContext.ContextPath;
@@ -1324,7 +1324,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Use FakeContainerRuntime that simulates Docker not running
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false, isRunning: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var workspace = TemporaryWorkspace.Create(output);
 
@@ -1376,7 +1376,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Use FakeContainerRuntime that simulates Docker not running
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false, isRunning: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         var servicea = builder.AddProject<Projects.ServiceA>("servicea")
             .WithContainerBuildOptions(ctx =>
@@ -1412,7 +1412,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Use FakeContainerRuntime that simulates Docker not running
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false, isRunning: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var tempDockerfileContext = await DockerfileUtils.CreateTemporaryDockerfileAsync(output);
         var tempContextPath = tempDockerfileContext.ContextPath;
@@ -1447,7 +1447,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Use FakeContainerRuntime that simulates Docker not running
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false, isRunning: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         using var workspace = TemporaryWorkspace.Create(output);
 
@@ -1490,7 +1490,7 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
 
         // Use FakeContainerRuntime that simulates Docker not running
         var fakeContainerRuntime = new FakeContainerRuntime(shouldFail: false, isRunning: false);
-        builder.Services.AddKeyedSingleton<IContainerRuntime>("docker", fakeContainerRuntime);
+        builder.Services.AddFakeContainerRuntime(fakeContainerRuntime);
 
         // Project without any destination set should default to requiring Docker
         var servicea = builder.AddProject<Projects.ServiceA>("servicea");
@@ -1511,8 +1511,8 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
-    public async Task DockerBuildFailureIncludesProcessOutputInException()
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
+    public async Task ContainerBuildFailureIncludesProcessOutputInException()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(output);
 
@@ -1542,9 +1542,13 @@ public class ResourceContainerImageBuilderTests(ITestOutputHelper output)
         Assert.NotEqual(0, ex.ExitCode);
         Assert.NotEmpty(ex.ProcessOutput);
 
+        // Each runtime prefixes the failure with its own display name ("Docker build failed…",
+        // "Podman build failed…"), so resolve whichever one actually ran.
+        var containerRuntime = await app.Services.GetRequiredService<IContainerRuntimeResolver>().ResolveAsync(cts.Token);
+
         var newlineIndex = ex.Message.IndexOf(Environment.NewLine, StringComparison.Ordinal);
         Assert.NotEqual(-1, newlineIndex);
-        Assert.Equal($"Docker build failed with exit code {ex.ExitCode}.", ex.Message[..newlineIndex]);
+        Assert.Equal($"{containerRuntime.Name} build failed with exit code {ex.ExitCode}.", ex.Message[..newlineIndex]);
         Assert.Equal(ex.GetFormattedOutput(), ex.Message[(newlineIndex + Environment.NewLine.Length)..]);
     }
 }

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Hosting.Tests;
 public class WaitForTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task ResourceThatFailsToStartDueToExceptionDoesNotCauseStartAsyncToThrow()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -81,7 +81,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitingForParameterResourceCompletesImmediately()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
@@ -119,7 +119,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitingForConnectionStringResourceWaitsForReferencedResources()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
@@ -149,7 +149,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task EnsureDependentResourceMovesIntoWaitingState()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -197,7 +197,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     [InlineData(nameof(KnownResourceStates.FailedToStart))]
     [InlineData(nameof(KnownResourceStates.RuntimeUnhealthy))]
     [InlineData(nameof(KnownResourceStates.Finished))]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForBehaviorStopOnResourceUnavailable(string status)
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -227,7 +227,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
    [Fact]
-   [RequiresFeature(TestFeature.Docker)]
+   [RequiresFeature(TestFeature.ContainerRuntime)]
    public async Task WhenWaitBehaviorIsStopOnResourceUnavailableWaitForResourceHealthyAsyncShouldThrowWhenResourceFailsToStart()
    {
       using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -251,7 +251,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
    }
 
    [Fact]
-   [RequiresFeature(TestFeature.Docker)]
+   [RequiresFeature(TestFeature.ContainerRuntime)]
    public async Task WhenWaitBehaviorIsWaitOnResourceUnavailableWaitForResourceHealthyAsyncShouldThrowWhenResourceFailsToStart()
    {
       using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -275,7 +275,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
    }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(WaitBehavior.WaitOnResourceUnavailable, typeof(TimeoutException), "The operation has timed out.")]
     [InlineData(WaitBehavior.StopOnResourceUnavailable, typeof(DistributedApplicationException), "Stopped waiting for resource 'redis' to become healthy because it failed to start.")]
     public async Task WhenWaitBehaviorIsMissingWaitForResourceHealthyAsyncShouldUseDefaultWaitBehavior(WaitBehavior defaultWaitBehavior, Type exceptionType, string exceptionMessage)
@@ -308,7 +308,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     [InlineData(nameof(KnownResourceStates.FailedToStart))]
     [InlineData(nameof(KnownResourceStates.RuntimeUnhealthy))]
     [InlineData(nameof(KnownResourceStates.Finished))]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForBehaviorStopOnDependencyIsDefaultWithNoDashboardFailure(string status)
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -342,7 +342,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     [InlineData(nameof(KnownResourceStates.FailedToStart))]
     [InlineData(nameof(KnownResourceStates.RuntimeUnhealthy))]
     [InlineData(nameof(KnownResourceStates.Finished))]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForBehaviorWaitOnResourceUnavailable(string status)
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -384,7 +384,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     [InlineData(nameof(KnownResourceStates.FailedToStart))]
     [InlineData(nameof(KnownResourceStates.RuntimeUnhealthy))]
     [InlineData(nameof(KnownResourceStates.Finished))]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForBehaviorWaitOnResourceUnavailableViaOptions(string status)
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -427,7 +427,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForCompletionWaitsForTerminalStateOfDependencyResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -474,7 +474,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForThrowsIfResourceMovesToTerminalStateBeforeRunning()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -521,7 +521,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForObservedResultOfResourceReadyEvent()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -583,7 +583,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task EnsureDependencyResourceThatReturnsNonMatchingExitCodeResultsInDependentResourceFailingToStart()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -629,7 +629,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task DependencyWithGreaterThan1ReplicaAnnotationWaitsForAll()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -682,7 +682,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task DependencyWithGreaterThan1ReplicaAnnotationWaitsForAllToComplete()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -735,7 +735,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForCompletionSucceedsIfDependentResourceEntersTerminalStateWithoutAnExitCode()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);
@@ -845,7 +845,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task WaitForStartOnlyWaitsForRunningState()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);

--- a/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithProcessCommandTests.cs
@@ -4,8 +4,8 @@
 using System.Text.Json;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Diagnostics;
-using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Testing;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
@@ -1510,126 +1510,9 @@ public class WithProcessCommandTests(ITestOutputHelper testOutputHelper)
         };
     }
 
-    private sealed class TestProcessRunner : IProcessRunner
-    {
-        private readonly Queue<TestProcessRun> _runs = [];
-        private readonly List<TestProcessDisposable> _disposables = [];
-
-        public List<ProcessSpec> ProcessSpecs { get; } = [];
-
-        public IReadOnlyList<TestProcessDisposable> Disposables => _disposables;
-
-        public TaskCompletionSource<ProcessSpec> RunStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public void EnqueueResult(
-            int exitCode = 0,
-            IReadOnlyList<string>? output = null,
-            IReadOnlyList<string>? error = null,
-            int? totalOutputLineCount = null,
-            IReadOnlyList<TestProcessOutput>? outputEvents = null)
-        {
-            _runs.Enqueue(TestProcessRun.Result(exitCode, output, error, totalOutputLineCount, outputEvents));
-        }
-
-        public void EnqueueException(Exception exception)
-        {
-            _runs.Enqueue(TestProcessRun.Failed(exception));
-        }
-
-        public void EnqueuePending(Task<ProcessResult> processResult)
-        {
-            _runs.Enqueue(TestProcessRun.Pending(processResult));
-        }
-
-        public (Task<ProcessResult>, IAsyncDisposable) Run(ProcessSpec processSpec)
-        {
-            ProcessSpecs.Add(processSpec);
-            RunStarted.TrySetResult(processSpec);
-
-            var disposable = new TestProcessDisposable();
-            _disposables.Add(disposable);
-
-            var run = _runs.Count > 0 ? _runs.Dequeue() : TestProcessRun.Result();
-            if (run.FailureException is { } exception)
-            {
-                throw exception;
-            }
-
-            if (run.PendingResult is { } pendingResult)
-            {
-                return (pendingResult, disposable);
-            }
-
-            foreach (var output in run.OutputEvents)
-            {
-                if (output.IsError)
-                {
-                    processSpec.OnErrorData?.Invoke(output.Value);
-                }
-                else
-                {
-                    processSpec.OnOutputData?.Invoke(output.Value);
-                }
-            }
-
-            var processOutput = run.OutputEvents.Select(static output => output.Value).ToArray();
-            var processResult = new ProcessResult(run.ExitCode, processOutput, run.TotalOutputLineCount);
-
-            return (Task.FromResult(processResult), disposable);
-        }
-    }
-
-    private sealed record TestProcessRun(
-        int ExitCode,
-        IReadOnlyList<TestProcessOutput> OutputEvents,
-        int? TotalOutputLineCount,
-        Exception? FailureException,
-        Task<ProcessResult>? PendingResult)
-    {
-        public static TestProcessRun Result(
-            int exitCode = 0,
-            IReadOnlyList<string>? output = null,
-            IReadOnlyList<string>? error = null,
-            int? totalOutputLineCount = null,
-            IReadOnlyList<TestProcessOutput>? outputEvents = null)
-        {
-            outputEvents ??=
-            [
-                .. (output ?? Array.Empty<string>()).Select(Output),
-                .. (error ?? Array.Empty<string>()).Select(Error)
-            ];
-
-            return new TestProcessRun(exitCode, outputEvents, totalOutputLineCount, null, null);
-        }
-
-        public static TestProcessRun Failed(Exception exception)
-        {
-            return new TestProcessRun(0, [], null, exception, null);
-        }
-
-        public static TestProcessRun Pending(Task<ProcessResult> pendingResult)
-        {
-            return new TestProcessRun(0, [], null, null, pendingResult);
-        }
-    }
-
     private static TestProcessOutput Output(string value) => new(false, value);
 
     private static TestProcessOutput Error(string value) => new(true, value);
-
-    private sealed record TestProcessOutput(bool IsError, string Value);
-
-    private sealed class TestProcessDisposable : IAsyncDisposable
-    {
-        public int DisposeCallCount { get; private set; }
-
-        public ValueTask DisposeAsync()
-        {
-            DisposeCallCount++;
-
-            return ValueTask.CompletedTask;
-        }
-    }
 
     private sealed class CustomResource(string name) : Resource(name)
     {

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -19,7 +19,7 @@ namespace Aspire.Hosting.Valkey.Tests;
 public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task VerifyValkeyResource()
     {
@@ -61,7 +61,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task WithDataShouldPersistStateBetweenUsages(bool useVolume)
     {
@@ -201,7 +201,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task VerifyWaitForOnValkeyBlocksDependentResources()
     {
@@ -239,7 +239,7 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync();
     }
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public Task Valkey_WithPersistentLifetime_ReusesContainer()
     {
         return PersistentContainerTestHelpers.AssertResourceReusesContainerAsync(

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpConfigGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpConfigGeneratorTests.cs
@@ -260,7 +260,7 @@ public class YarpConfigGeneratorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker | TestFeature.DockerPluginBuildx)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.ContainerImageBuild)]
     public async Task GenerateEnvVariablesConfigurationDockerCompose()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Yarp.Tests/YarpFunctionalTests.cs
@@ -16,7 +16,7 @@ public class YarpFunctionalTests(ITestOutputHelper testOutputHelper)
     private const string BackendImage = "mcr.microsoft.com/dotnet/samples:aspnetapp-8.0";
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [QuarantinedTest("https://github.com/microsoft/aspire/issues/17020")]
     public async Task VerifyYarpResourceExtensionsConfig()
     {

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
@@ -15,7 +15,7 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
 {
     private readonly SqlServerContainerFixture? _containerFixture;
     private string ConnectionString { get; set; }
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Scoped;
 
     // https://github.com/open-telemetry/opentelemetry-dotnet/blob/031ed48714e16ba4a5b099b6e14647994a0b9c1b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs#L31
@@ -51,7 +51,7 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
     public ConformanceTests(SqlServerContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -93,14 +93,14 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
@@ -15,7 +15,7 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
 {
     private readonly SqlServerContainerFixture? _containerFixture;
     private string ConnectionString { get; set; }
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Scoped;
 
     // https://github.com/open-telemetry/opentelemetry-dotnet/blob/031ed48714e16ba4a5b099b6e14647994a0b9c1b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs#L31
@@ -51,7 +51,7 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
     public ConformanceTests(SqlServerContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -93,14 +93,14 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
@@ -17,7 +17,7 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = new MsSqlBuilder()
                             .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}:{SqlServerContainerImageTags.Tag}")

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
@@ -17,7 +17,7 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new MsSqlBuilder()
                             .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}:{SqlServerContainerImageTags.Tag}")

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
@@ -17,7 +17,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
     private readonly SqlServerContainerFixture? _containerFixture;
     protected string ConnectionString { get; private set; }
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
     // https://github.com/open-telemetry/opentelemetry-dotnet/blob/031ed48714e16ba4a5b099b6e14647994a0b9c1b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs#L31
@@ -64,7 +64,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
     public ConformanceTests(SqlServerContainerFixture? fixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = fixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -114,7 +114,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
@@ -17,7 +17,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
     private readonly SqlServerContainerFixture? _containerFixture;
     protected string ConnectionString { get; private set; }
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
     // https://github.com/open-telemetry/opentelemetry-dotnet/blob/031ed48714e16ba4a5b099b6e14647994a0b9c1b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs#L31
@@ -64,7 +64,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
     public ConformanceTests(SqlServerContainerFixture? fixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = fixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -114,7 +114,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),

--- a/tests/Aspire.Milvus.Client.Tests/AspireMilvusExtensionTests.cs
+++ b/tests/Aspire.Milvus.Client.Tests/AspireMilvusExtensionTests.cs
@@ -16,7 +16,7 @@ public class AspireMilvusExtensionTests : IClassFixture<MilvusContainerFixture>
     internal const string DefaultKeyName = "milvus";
     internal const string DefaultApiKey = "root:Milvus";
 
-    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
+    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers)
                                         ? _containerFixture.GetConnectionString()
                                         : $"Endpoint=http://localhost:19530/;Key={DefaultApiKey}";
 

--- a/tests/Aspire.Milvus.Client.Tests/AspireMilvusExtensionTests.cs
+++ b/tests/Aspire.Milvus.Client.Tests/AspireMilvusExtensionTests.cs
@@ -16,7 +16,7 @@ public class AspireMilvusExtensionTests : IClassFixture<MilvusContainerFixture>
     internal const string DefaultKeyName = "milvus";
     internal const string DefaultApiKey = "root:Milvus";
 
-    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker)
+    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
                                         ? _containerFixture.GetConnectionString()
                                         : $"Endpoint=http://localhost:19530/;Key={DefaultApiKey}";
 

--- a/tests/Aspire.Milvus.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Milvus.Client.Tests/ConformanceTests.cs
@@ -19,7 +19,7 @@ public class ConformanceTests : ConformanceTests<MilvusClient, MilvusClientSetti
     public ConformanceTests(MilvusContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : $"Endpoint=http://localhost:19530;Key=root:Milvus";
     }
@@ -27,7 +27,7 @@ public class ConformanceTests : ConformanceTests<MilvusClient, MilvusClientSetti
 
     protected override bool CanCreateClientWithoutConnectingToServer => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 

--- a/tests/Aspire.Milvus.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Milvus.Client.Tests/ConformanceTests.cs
@@ -19,7 +19,7 @@ public class ConformanceTests : ConformanceTests<MilvusClient, MilvusClientSetti
     public ConformanceTests(MilvusContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : $"Endpoint=http://localhost:19530;Key=root:Milvus";
     }
@@ -27,7 +27,7 @@ public class ConformanceTests : ConformanceTests<MilvusClient, MilvusClientSetti
 
     protected override bool CanCreateClientWithoutConnectingToServer => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 

--- a/tests/Aspire.Milvus.Client.Tests/MilvusContainerFixture.cs
+++ b/tests/Aspire.Milvus.Client.Tests/MilvusContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class MilvusContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = new MilvusBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{MilvusContainerImageTags.Image}:{MilvusContainerImageTags.Tag}")

--- a/tests/Aspire.Milvus.Client.Tests/MilvusContainerFixture.cs
+++ b/tests/Aspire.Milvus.Client.Tests/MilvusContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class MilvusContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new MilvusBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{MilvusContainerImageTags.Image}:{MilvusContainerImageTags.Tag}")

--- a/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
@@ -116,7 +116,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task AddMongoDBDataSource_HealthCheckShouldBeRegisteredWhenEnabled()
     {
         var builder = CreateBuilder(DefaultConnectionString);
@@ -139,7 +139,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void AddKeyedMongoDBDataSource_HealthCheckShouldNotBeRegisteredWhenDisabled()
     {
         var builder = CreateBuilder(DefaultConnectionString);
@@ -158,7 +158,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task AddKeyedMongoDBDataSource_HealthCheckShouldBeRegisteredWhenEnabled()
     {
         var key = DefaultConnectionName;
@@ -183,7 +183,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void AddMongoDBDataSource_HealthCheckShouldNotBeRegisteredWhenDisabled()
     {
         var builder = CreateBuilder(DefaultConnectionString);

--- a/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
@@ -116,7 +116,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddMongoDBDataSource_HealthCheckShouldBeRegisteredWhenEnabled()
     {
         var builder = CreateBuilder(DefaultConnectionString);
@@ -139,7 +139,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void AddKeyedMongoDBDataSource_HealthCheckShouldNotBeRegisteredWhenDisabled()
     {
         var builder = CreateBuilder(DefaultConnectionString);
@@ -158,7 +158,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddKeyedMongoDBDataSource_HealthCheckShouldBeRegisteredWhenEnabled()
     {
         var key = DefaultConnectionName;
@@ -183,7 +183,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void AddMongoDBDataSource_HealthCheckShouldNotBeRegisteredWhenDisabled()
     {
         var builder = CreateBuilder(DefaultConnectionString);

--- a/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
@@ -21,7 +21,7 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override string? ConfigurationSectionName => "Aspire:MongoDB:Driver";
 
@@ -73,7 +73,7 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
 
     private string GetConnectionString()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             var builder = new UriBuilder(_containerFixture.GetConnectionString());
             builder.Path = "test_db";

--- a/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
@@ -21,7 +21,7 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override string? ConfigurationSectionName => "Aspire:MongoDB:Driver";
 
@@ -73,7 +73,7 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
 
     private string GetConnectionString()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             var builder = new UriBuilder(_containerFixture.GetConnectionString());
             builder.Path = "test_db";

--- a/tests/Aspire.MongoDB.Driver.Tests/MongoDbContainerFixture.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/MongoDbContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class MongoDbContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             // testcontainers uses mongo:mongo by default,
             // resetting that for tests

--- a/tests/Aspire.MongoDB.Driver.Tests/MongoDbContainerFixture.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/MongoDbContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class MongoDbContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             // testcontainers uses mongo:mongo by default,
             // resetting that for tests

--- a/tests/Aspire.MongoDB.EntityFrameworkCore.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MongoDB.EntityFrameworkCore.Tests/ConformanceTests.cs
@@ -20,7 +20,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MongoDBEntityFra
     protected string DatabaseName { get; private set; }
     protected override ServiceLifetime ServiceLifetime { get; }
     protected override string ActivitySourceName => "MongoDB.Driver.Core.Extensions.DiagnosticSources";
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override RequiredLogCategory[] RequiredLogCategories =>
     [
@@ -68,7 +68,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MongoDBEntityFra
     public ConformanceTests(MongoDbContainerFixture? containerFixture)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
             ? _containerFixture.GetConnectionString()
             : "mongodb://localhost:27017/test_aspire_mongodb";
         DatabaseName = "test_db";

--- a/tests/Aspire.MongoDB.EntityFrameworkCore.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MongoDB.EntityFrameworkCore.Tests/ConformanceTests.cs
@@ -20,7 +20,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MongoDBEntityFra
     protected string DatabaseName { get; private set; }
     protected override ServiceLifetime ServiceLifetime { get; }
     protected override string ActivitySourceName => "MongoDB.Driver.Core.Extensions.DiagnosticSources";
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override RequiredLogCategory[] RequiredLogCategories =>
     [
@@ -68,7 +68,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MongoDBEntityFra
     public ConformanceTests(MongoDbContainerFixture? containerFixture)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
             ? _containerFixture.GetConnectionString()
             : "mongodb://localhost:27017/test_aspire_mongodb";
         DatabaseName = "test_db";

--- a/tests/Aspire.MySqlConnector.Tests/AspireMySqlConnectorExtensionsTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/AspireMySqlConnectorExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.MySqlConnector.Tests;
 public class AspireMySqlConnectorExtensionsTests : IClassFixture<MySqlContainerFixture>
 {
     private readonly MySqlContainerFixture _containerFixture;
-    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker)
+    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;Database=test_aspire_mysql";
     private string NormalizedConnectionString => new MySqlConnectionStringBuilder(ConnectionString).ConnectionString;

--- a/tests/Aspire.MySqlConnector.Tests/AspireMySqlConnectorExtensionsTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/AspireMySqlConnectorExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.MySqlConnector.Tests;
 public class AspireMySqlConnectorExtensionsTests : IClassFixture<MySqlContainerFixture>
 {
     private readonly MySqlContainerFixture _containerFixture;
-    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
+    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers)
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;Database=test_aspire_mysql";
     private string NormalizedConnectionString => new MySqlConnectionStringBuilder(ConnectionString).ConnectionString;

--- a/tests/Aspire.MySqlConnector.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/ConformanceTests.cs
@@ -32,7 +32,7 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override string? ConfigurationSectionName => "Aspire:MySqlConnector";
 
@@ -58,7 +58,7 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
     public ConformanceTests(MySqlContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -124,14 +124,14 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),

--- a/tests/Aspire.MySqlConnector.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/ConformanceTests.cs
@@ -32,7 +32,7 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override string? ConfigurationSectionName => "Aspire:MySqlConnector";
 
@@ -58,7 +58,7 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
     public ConformanceTests(MySqlContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -124,14 +124,14 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),

--- a/tests/Aspire.MySqlConnector.Tests/MySqlContainerFixture.cs
+++ b/tests/Aspire.MySqlConnector.Tests/MySqlContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class MySqlContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new MySqlBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{MySqlContainerImageTags.Image}:{MySqlContainerImageTags.Tag}")

--- a/tests/Aspire.MySqlConnector.Tests/MySqlContainerFixture.cs
+++ b/tests/Aspire.MySqlConnector.Tests/MySqlContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class MySqlContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = new MySqlBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{MySqlContainerImageTags.Image}:{MySqlContainerImageTags.Tag}")

--- a/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
@@ -24,7 +24,7 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
     public AspireNatsClientExtensionsTests(NatsContainerFixture containerFixture)
     {
         _containerFixture = containerFixture;
-        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker)
+        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
             ? _containerFixture.GetConnectionString()
             : "nats://aspire-host:4222";
     }
@@ -245,7 +245,7 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void NatsInstrumentationEndToEnd()
     {
         RemoteExecutor.Invoke(async (connectionString) =>

--- a/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
@@ -24,7 +24,7 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
     public AspireNatsClientExtensionsTests(NatsContainerFixture containerFixture)
     {
         _containerFixture = containerFixture;
-        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
+        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers)
             ? _containerFixture.GetConnectionString()
             : "nats://aspire-host:4222";
     }
@@ -245,7 +245,7 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void NatsInstrumentationEndToEnd()
     {
         RemoteExecutor.Invoke(async (connectionString) =>

--- a/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
@@ -18,7 +18,7 @@ public class ConformanceTests : ConformanceTests<INatsConnection, NatsClientSett
     public ConformanceTests(NatsContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker)
+        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
             ? _containerFixture.GetConnectionString()
             : "nats://user:password@apire-host:4222";
     }
@@ -57,7 +57,7 @@ public class ConformanceTests : ConformanceTests<INatsConnection, NatsClientSett
 
     protected override bool CanCreateClientWithoutConnectingToServer => false;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override void TriggerActivity(INatsConnection service)
     {

--- a/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
@@ -18,7 +18,7 @@ public class ConformanceTests : ConformanceTests<INatsConnection, NatsClientSett
     public ConformanceTests(NatsContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
+        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers)
             ? _containerFixture.GetConnectionString()
             : "nats://user:password@apire-host:4222";
     }
@@ -57,7 +57,7 @@ public class ConformanceTests : ConformanceTests<INatsConnection, NatsClientSett
 
     protected override bool CanCreateClientWithoutConnectingToServer => false;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override void TriggerActivity(INatsConnection service)
     {

--- a/tests/Aspire.NATS.Net.Tests/NatsContainerFixture.cs
+++ b/tests/Aspire.NATS.Net.Tests/NatsContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class NatsContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = new NatsBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{NatsContainerImageTags.Image}:{NatsContainerImageTags.Tag}")

--- a/tests/Aspire.NATS.Net.Tests/NatsContainerFixture.cs
+++ b/tests/Aspire.NATS.Net.Tests/NatsContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class NatsContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new NatsBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{NatsContainerImageTags.Image}:{NatsContainerImageTags.Tag}")

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -51,7 +51,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
         "Npgsql.Exception"
     };
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override string ValidJsonConfig => """
         {
@@ -81,7 +81,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -134,7 +134,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -51,7 +51,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
         "Npgsql.Exception"
     };
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override string ValidJsonConfig => """
         {
@@ -81,7 +81,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -134,7 +134,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),

--- a/tests/Aspire.Npgsql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.Tests/ConformanceTests.cs
@@ -33,7 +33,7 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override string? ConfigurationSectionName => "Aspire:Npgsql";
 
@@ -59,7 +59,7 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -125,14 +125,14 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),

--- a/tests/Aspire.Npgsql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.Tests/ConformanceTests.cs
@@ -33,7 +33,7 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override string? ConfigurationSectionName => "Aspire:Npgsql";
 
@@ -59,7 +59,7 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -125,14 +125,14 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),

--- a/tests/Aspire.Npgsql.Tests/PostgreSQLContainerFixture.cs
+++ b/tests/Aspire.Npgsql.Tests/PostgreSQLContainerFixture.cs
@@ -25,7 +25,7 @@ public sealed class PostgreSQLContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = new PostgreSqlBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{PostgresContainerImageTags.Image}:{PostgresContainerImageTags.Tag}")

--- a/tests/Aspire.Npgsql.Tests/PostgreSQLContainerFixture.cs
+++ b/tests/Aspire.Npgsql.Tests/PostgreSQLContainerFixture.cs
@@ -25,7 +25,7 @@ public sealed class PostgreSQLContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new PostgreSqlBuilder()
                 .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{PostgresContainerImageTags.Image}:{PostgresContainerImageTags.Tag}")

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
@@ -41,7 +41,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
         new("Microsoft.EntityFrameworkCore.Migrations"),
     ];
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override string ValidJsonConfig => """
         {
@@ -98,7 +98,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
     {
         _containerFixture = containerFixture;
         _testOutputHelper = testOutputHelper;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=oracle;Password=oracle;Database=FREEPDB1";
     }
@@ -126,7 +126,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
     {
         RemoteInvokeWithLogging(static connectionStringToUse =>
@@ -135,7 +135,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingHasSemanticConventions()
     {
         RemoteInvokeWithLogging(static connectionStringToUse =>

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
@@ -41,7 +41,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
         new("Microsoft.EntityFrameworkCore.Migrations"),
     ];
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override string ValidJsonConfig => """
         {
@@ -98,7 +98,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
     {
         _containerFixture = containerFixture;
         _testOutputHelper = testOutputHelper;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=oracle;Password=oracle;Database=FREEPDB1";
     }
@@ -126,7 +126,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
     {
         RemoteInvokeWithLogging(static connectionStringToUse =>
@@ -135,7 +135,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingHasSemanticConventions()
     {
         RemoteInvokeWithLogging(static connectionStringToUse =>

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
@@ -26,7 +26,7 @@ public sealed class OracleContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             _diagnosticMessageSink.OnMessage(new DiagnosticMessage("Oracle container initialization starting..."));
             Container = new OracleBuilder()

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
@@ -26,7 +26,7 @@ public sealed class OracleContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             _diagnosticMessageSink.OnMessage(new DiagnosticMessage("Oracle container initialization starting..."));
             Container = new OracleBuilder()

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -16,7 +16,7 @@ using Xunit.Sdk;
 
 namespace Aspire.Playground.Tests;
 
-[RequiresFeature(TestFeature.Docker)]
+[RequiresFeature(TestFeature.ContainerRuntime)]
 public class AppHostTests
 {
     private readonly ITestOutputHelper _testOutput;

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -56,11 +56,14 @@
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.Hosting.TestUtilities\Utils\LoggerNotificationExtensions.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)src\Shared\PathLookupHelper.cs" />
     <Compile Condition="'$(RepoRoot)' == ''" Include="$(MSBuildThisFileDirectory)..\..\src\Shared\PathLookupHelper.cs" />
+    <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)src\Shared\KnownContainerRuntimes.cs" />
+    <Compile Condition="'$(RepoRoot)' == ''" Include="$(MSBuildThisFileDirectory)..\..\src\Shared\KnownContainerRuntimes.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\FileUtil.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\PlatformDetection.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\QuarantinedTestAttribute.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\OuterloopTestAttribute.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\Requires*.cs" />
+    <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\TestcontainersPodmanConfiguration.cs" />
     <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)tests\Aspire.TestUtilities\TestFeature.cs" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" />
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
@@ -115,6 +118,7 @@
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\QuarantinedTestAttribute.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\OuterloopTestAttribute.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\Requires*.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(RepoRoot)tests\Aspire.TestUtilities\TestcontainersPodmanConfiguration.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)tests\Aspire.TestUtilities\TestFeature.cs" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
 
     <None Include="..\helix\xunit.runner.json" Link="$(DeployOutsideOfRepoSupportFilesRelativeDir)tests\$(MSBuildProjectName)\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />

--- a/tests/Aspire.Playground.Tests/BlazorWasmHostingTests.cs
+++ b/tests/Aspire.Playground.Tests/BlazorWasmHostingTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Aspire.Playground.Tests;
 
-[RequiresFeature(TestFeature.Docker)]
+[RequiresFeature(TestFeature.ContainerRuntime)]
 public class BlazorWasmHostingTests(ITestOutputHelper testOutput)
 {
     [Fact]

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Aspire.Playground.Tests;
 
-[RequiresFeature(TestFeature.Docker)]
+[RequiresFeature(TestFeature.ContainerRuntime)]
 public class ProjectSpecificTests(ITestOutputHelper _testOutput)
 {
     [Fact]
@@ -58,7 +58,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [RequiresTools(["func"])]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/9243")]
     public async Task AzureFunctionsTest()

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
@@ -22,7 +22,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
     private static readonly MySqlServerVersion s_serverVersion = new(new Version(MySqlContainerImageTags.Tag));
     private static readonly string s_serverVersionString = s_serverVersion.ToString();
     private readonly MySqlContainerFixture _containerFixture;
-    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
+    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers)
                                             ? _containerFixture.GetConnectionString()
                                             : "Server=localhost;User ID=root;Password=pass;Database=test";
 

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
@@ -22,7 +22,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
     private static readonly MySqlServerVersion s_serverVersion = new(new Version(MySqlContainerImageTags.Tag));
     private static readonly string s_serverVersionString = s_serverVersion.ToString();
     private readonly MySqlContainerFixture _containerFixture;
-    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker)
+    private string ConnectionString => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
                                             ? _containerFixture.GetConnectionString()
                                             : "Server=localhost;User ID=root;Password=pass;Database=test";
 

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
@@ -44,7 +44,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
         new("MySqlConnector.MySqlDataSource"),
     ];
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override string ValidJsonConfig => """
         {
@@ -74,7 +74,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
     public ConformanceTests(MySqlContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -127,7 +127,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
@@ -44,7 +44,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
         new("MySqlConnector.MySqlDataSource"),
     ];
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override string ValidJsonConfig => """
         {
@@ -74,7 +74,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
     public ConformanceTests(MySqlContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                         ? _containerFixture.GetConnectionString()
                                         : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
     }
@@ -127,7 +127,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),

--- a/tests/Aspire.Qdrant.Client.Tests/AspireQdrantClientExtensionsTest.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/AspireQdrantClientExtensionsTest.cs
@@ -23,12 +23,12 @@ public class AspireQdrantClientExtensionsTest : IClassFixture<QdrantContainerFix
     }
 
     private string DefaultConnectionString =>
-            RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime) ? _containerFixture.GetConnectionString() : "Endpoint=http://localhost1:6331;Key=pass";
+            RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers) ? _containerFixture.GetConnectionString() : "Endpoint=http://localhost1:6331;Key=pass";
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task AddQdrantClient_HealthCheckShouldBeRegisteredWhenEnabled(bool useKeyed)
     {
         var key = DefaultConnectionName;

--- a/tests/Aspire.Qdrant.Client.Tests/AspireQdrantClientExtensionsTest.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/AspireQdrantClientExtensionsTest.cs
@@ -23,12 +23,12 @@ public class AspireQdrantClientExtensionsTest : IClassFixture<QdrantContainerFix
     }
 
     private string DefaultConnectionString =>
-            RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker) ? _containerFixture.GetConnectionString() : "Endpoint=http://localhost1:6331;Key=pass";
+            RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime) ? _containerFixture.GetConnectionString() : "Endpoint=http://localhost1:6331;Key=pass";
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddQdrantClient_HealthCheckShouldBeRegisteredWhenEnabled(bool useKeyed)
     {
         var key = DefaultConnectionName;

--- a/tests/Aspire.Qdrant.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/ConformanceTests.cs
@@ -21,7 +21,7 @@ public class ConformanceTests : ConformanceTests<QdrantClient, QdrantClientSetti
 
     protected override bool CanCreateClientWithoutConnectingToServer => false;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
@@ -34,7 +34,7 @@ public class ConformanceTests : ConformanceTests<QdrantClient, QdrantClientSetti
     public ConformanceTests(QdrantContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime) ?
+        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers) ?
             $"{_containerFixture.GetConnectionString()}" :
             "Endpoint=http://localhost:6334;Key=pass";
     }

--- a/tests/Aspire.Qdrant.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/ConformanceTests.cs
@@ -21,7 +21,7 @@ public class ConformanceTests : ConformanceTests<QdrantClient, QdrantClientSetti
 
     protected override bool CanCreateClientWithoutConnectingToServer => false;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
@@ -34,7 +34,7 @@ public class ConformanceTests : ConformanceTests<QdrantClient, QdrantClientSetti
     public ConformanceTests(QdrantContainerFixture containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker) ?
+        _connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime) ?
             $"{_containerFixture.GetConnectionString()}" :
             "Endpoint=http://localhost:6334;Key=pass";
     }

--- a/tests/Aspire.Qdrant.Client.Tests/QdrantContainerFixture.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/QdrantContainerFixture.cs
@@ -29,7 +29,7 @@ public sealed class QdrantContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = new ContainerBuilder()
               .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{QdrantContainerImageTags.Image}:{QdrantContainerImageTags.Tag}")

--- a/tests/Aspire.Qdrant.Client.Tests/QdrantContainerFixture.cs
+++ b/tests/Aspire.Qdrant.Client.Tests/QdrantContainerFixture.cs
@@ -29,7 +29,7 @@ public sealed class QdrantContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = new ContainerBuilder()
               .WithImage($"{ComponentTestConstants.AspireTestContainerRegistry}/{QdrantContainerImageTags.Image}:{QdrantContainerImageTags.Tag}")

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQExtensionsTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQExtensionsTests.cs
@@ -23,7 +23,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     public void ReadsFromConnectionStringsCorrectly(bool useKeyed)
@@ -51,7 +51,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     public void ConnectionStringCanBeSetInCode(bool useKeyed)
@@ -80,7 +80,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     public void ConnectionNameWinsOverConfigSection(bool useKeyed)
@@ -160,7 +160,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task CanAddMultipleKeyedServices()
     {
         await using var container2 = await RabbitMQContainerFixture.CreateContainerAsync();
@@ -197,7 +197,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(false, false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AutoActivationCanSet(bool useKeyed, bool autoActivate)
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -234,7 +234,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AutoActivationDisabledByDefault()
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQExtensionsTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQExtensionsTests.cs
@@ -23,7 +23,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [InlineData(true)]
     [InlineData(false)]
     public void ReadsFromConnectionStringsCorrectly(bool useKeyed)
@@ -51,7 +51,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [InlineData(true)]
     [InlineData(false)]
     public void ConnectionStringCanBeSetInCode(bool useKeyed)
@@ -80,7 +80,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [InlineData(true)]
     [InlineData(false)]
     public void ConnectionNameWinsOverConfigSection(bool useKeyed)
@@ -160,7 +160,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task CanAddMultipleKeyedServices()
     {
         await using var container2 = await RabbitMQContainerFixture.CreateContainerAsync();
@@ -197,7 +197,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(false, false)]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task AutoActivationCanSet(bool useKeyed, bool autoActivate)
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -234,7 +234,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task AutoActivationDisabledByDefault()
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -31,7 +31,7 @@ public class AspireRabbitMQLoggingTests
     /// and then stop the container. This will cause the RabbitMQ client to log an error message.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task EndToEndLoggingTest()
     {

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -31,7 +31,7 @@ public class AspireRabbitMQLoggingTests
     /// and then stop the container. This will cause the RabbitMQ client to log an error message.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [ActiveIssue("https://github.com/microsoft/aspire/issues/11820", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningFromAzdo))]
     public async Task EndToEndLoggingTest()
     {

--- a/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
@@ -25,7 +25,7 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
     public ConformanceTests(RabbitMQContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
                                     ? _containerFixture.GetConnectionString()
                                     : "amqp://localhost:5672";
     }
@@ -35,7 +35,7 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
     // IConnectionMultiplexer can be created only via call to ConnectionMultiplexer.Connect
     protected override bool CanCreateClientWithoutConnectingToServer => false;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override bool SupportsKeyedRegistrations => true;
 
@@ -143,14 +143,14 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
 
 #if !RABBITMQ_V6
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, static obj => obj.RunActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, static obj => obj.RunActivitySourceTest(key: "key")),

--- a/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
@@ -25,7 +25,7 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
     public ConformanceTests(RabbitMQContainerFixture? containerFixture, ITestOutputHelper? output = null) : base(output)
     {
         _containerFixture = containerFixture;
-        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        ConnectionString = (_containerFixture is not null && RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
                                     ? _containerFixture.GetConnectionString()
                                     : "amqp://localhost:5672";
     }
@@ -35,7 +35,7 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
     // IConnectionMultiplexer can be created only via call to ConnectionMultiplexer.Connect
     protected override bool CanCreateClientWithoutConnectingToServer => false;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override bool SupportsKeyedRegistrations => true;
 
@@ -143,14 +143,14 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
 
 #if !RABBITMQ_V6
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, static obj => obj.RunActivitySourceTest(key: null)),
             ConnectionString, Output);
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void TracingEnablesTheRightActivitySource_Keyed()
         => RemoteInvokeWithLogging(static connectionStringToUse =>
             RunWithConnectionString(connectionStringToUse, static obj => obj.RunActivitySourceTest(key: "key")),

--- a/tests/Aspire.RabbitMQ.Client.Tests/RabbitMQContainerFixture.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/RabbitMQContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class RabbitMQContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             _container = await CreateContainerAsync();
         }

--- a/tests/Aspire.RabbitMQ.Client.Tests/RabbitMQContainerFixture.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/RabbitMQContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class RabbitMQContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             _container = await CreateContainerAsync();
         }

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/AspireRedisDistributedCacheExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/AspireRedisDistributedCacheExtensionsTests.cs
@@ -42,7 +42,7 @@ public class AspireRedisDistributedCacheExtensionsTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task AddsRedisBuilderDistributedCacheCanConfigure()
     {
         await using var container = await RedisContainerFixture.CreateContainerAsync();
@@ -69,7 +69,7 @@ public class AspireRedisDistributedCacheExtensionsTests
     /// Tests that you can use keyed services for distributed caches.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task CanAddMultipleKeyedCachingServicesBuilder()
     {
         await using var container1 = await RedisContainerFixture.CreateContainerAsync();

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/AspireRedisDistributedCacheExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/AspireRedisDistributedCacheExtensionsTests.cs
@@ -42,7 +42,7 @@ public class AspireRedisDistributedCacheExtensionsTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AddsRedisBuilderDistributedCacheCanConfigure()
     {
         await using var container = await RedisContainerFixture.CreateContainerAsync();
@@ -69,7 +69,7 @@ public class AspireRedisDistributedCacheExtensionsTests
     /// Tests that you can use keyed services for distributed caches.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task CanAddMultipleKeyedCachingServicesBuilder()
     {
         await using var container1 = await RedisContainerFixture.CreateContainerAsync();

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
@@ -38,7 +38,7 @@ public class DistributedCacheConformanceTests : ConformanceTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void WorksWithOpenTelemetryTracing()
     {
         RemoteExecutor.Invoke(async (connectionString) =>

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
@@ -38,7 +38,7 @@ public class DistributedCacheConformanceTests : ConformanceTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void WorksWithOpenTelemetryTracing()
     {
         RemoteExecutor.Invoke(async (connectionString) =>

--- a/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
@@ -38,7 +38,7 @@ public class OutputCacheConformanceTests : ConformanceTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void WorksWithOpenTelemetryTracing()
     {
         RemoteExecutor.Invoke(async (connectionString) =>

--- a/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
@@ -38,7 +38,7 @@ public class OutputCacheConformanceTests : ConformanceTests
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void WorksWithOpenTelemetryTracing()
     {
         RemoteExecutor.Invoke(async (connectionString) =>

--- a/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
@@ -33,7 +33,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void AllowsConfigureConfigurationOptions()
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -53,7 +53,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     public void ReadsFromConnectionStringsCorrectly(bool useKeyed)
@@ -81,7 +81,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     public void ConnectionStringCanBeSetInCode(bool useKeyed)
@@ -112,7 +112,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     [InlineData(true)]
     [InlineData(false)]
     public void ConnectionNameWinsOverConfigSection(bool useKeyed)
@@ -261,7 +261,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public void KeyedServiceRedisInstrumentationEndToEnd()
     {
         RemoteExecutor.Invoke(async (connectionString) =>
@@ -298,7 +298,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task CanAddMultipleKeyedServices()
     {
         await using var container2 = await RedisContainerFixture.CreateContainerAsync();
@@ -334,7 +334,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     /// Tests that you can use a keyed service for a distributed cache, another for an output cache, while also adding a plain Redis service.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task CanAddMultipleKeyedCachingServices()
     {
         await using var container1 = await RedisContainerFixture.CreateContainerAsync();
@@ -388,7 +388,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     /// using the Builder APIs.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task CanAddMultipleKeyedCachingServicesBuilder()
     {
         await using var container1 = await RedisContainerFixture.CreateContainerAsync();
@@ -442,7 +442,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(false, false)]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AutoActivationCanSet(bool useKeyed, bool autoActivate)
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -474,7 +474,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.Docker)]
+    [RequiresFeature(TestFeature.ContainerRuntime)]
     public async Task AutoActivationDisabledByDefault()
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);

--- a/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
@@ -33,7 +33,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void AllowsConfigureConfigurationOptions()
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -53,7 +53,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [InlineData(true)]
     [InlineData(false)]
     public void ReadsFromConnectionStringsCorrectly(bool useKeyed)
@@ -81,7 +81,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [InlineData(true)]
     [InlineData(false)]
     public void ConnectionStringCanBeSetInCode(bool useKeyed)
@@ -112,7 +112,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Theory]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     [InlineData(true)]
     [InlineData(false)]
     public void ConnectionNameWinsOverConfigSection(bool useKeyed)
@@ -261,7 +261,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public void KeyedServiceRedisInstrumentationEndToEnd()
     {
         RemoteExecutor.Invoke(async (connectionString) =>
@@ -298,7 +298,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task CanAddMultipleKeyedServices()
     {
         await using var container2 = await RedisContainerFixture.CreateContainerAsync();
@@ -334,7 +334,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     /// Tests that you can use a keyed service for a distributed cache, another for an output cache, while also adding a plain Redis service.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task CanAddMultipleKeyedCachingServices()
     {
         await using var container1 = await RedisContainerFixture.CreateContainerAsync();
@@ -388,7 +388,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     /// using the Builder APIs.
     /// </summary>
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task CanAddMultipleKeyedCachingServicesBuilder()
     {
         await using var container1 = await RedisContainerFixture.CreateContainerAsync();
@@ -442,7 +442,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(false, false)]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task AutoActivationCanSet(bool useKeyed, bool autoActivate)
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
@@ -474,7 +474,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
     }
 
     [Fact]
-    [RequiresFeature(TestFeature.ContainerRuntime)]
+    [RequiresFeature(TestFeature.Testcontainers)]
     public async Task AutoActivationDisabledByDefault()
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);

--- a/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
@@ -19,7 +19,7 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers);
 
     protected override bool SupportsKeyedRegistrations => true;
 
@@ -66,7 +66,7 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
 
     protected override void PopulateConfiguration(ConfigurationManager configuration, string? key = null)
     {
-        string connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
+        string connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers)
                                     ? _containerFixture.GetConnectionString()
                                     : "localhost";
         configuration.AddInMemoryCollection([

--- a/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
@@ -19,7 +19,7 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker);
+    protected override bool CanConnectToServer => RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime);
 
     protected override bool SupportsKeyedRegistrations => true;
 
@@ -66,7 +66,7 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
 
     protected override void PopulateConfiguration(ConfigurationManager configuration, string? key = null)
     {
-        string connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker)
+        string connectionString = RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime)
                                     ? _containerFixture.GetConnectionString()
                                     : "localhost";
         configuration.AddInMemoryCollection([

--- a/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class RedisContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Testcontainers))
         {
             Container = await CreateContainerAsync();
         }

--- a/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
@@ -18,7 +18,7 @@ public sealed class RedisContainerFixture : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.Docker))
+        if (RequiresFeatureAttribute.IsFeatureSupported(TestFeature.ContainerRuntime))
         {
             Container = await CreateContainerAsync();
         }

--- a/tests/Aspire.Templates.Tests/BuildAndRunStarterTemplateBuiltInTest.cs
+++ b/tests/Aspire.Templates.Tests/BuildAndRunStarterTemplateBuiltInTest.cs
@@ -28,7 +28,7 @@ public class BuildAndRunStarterTemplateBuiltInTest : TemplateTestsBase
 
     [Theory]
     [MemberData(nameof(TestFrameworkTypeWithConfig))]
-    [RequiresFeature(TestFeature.Docker | TestFeature.SSLCertificate)]
+    [RequiresFeature(TestFeature.ContainerRuntime | TestFeature.SSLCertificate)]
     [Trait("category", "basic-build")]
     public async Task BuildAndRunStarterTemplateBuiltInTest_Test(string config, string testType)
     {

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Aspire.Templates.Tests;
 
-[RequiresFeature(TestFeature.Docker)]
+[RequiresFeature(TestFeature.ContainerRuntime)]
 [RequiresFeature(TestFeature.SSLCertificate)]
 public class StarterTemplateWithRedisCacheTests : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture>
 {

--- a/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
+++ b/tests/Aspire.Templates.Tests/StarterTemplateWithRedisCacheTests_PreviousTFM.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Aspire.Templates.Tests;
 
-[RequiresFeature(TestFeature.Docker)]
+[RequiresFeature(TestFeature.ContainerRuntime)]
 [RequiresFeature(TestFeature.SSLCertificate)]
 public class StarterTemplateWithRedisCacheTests_PreviousTFM : StarterTemplateRunTestsBase<StarterTemplateWithRedisCacheFixture_PreviousTFM>
 {

--- a/tests/Aspire.TestUtilities/Aspire.TestUtilities.csproj
+++ b/tests/Aspire.TestUtilities/Aspire.TestUtilities.csproj
@@ -11,7 +11,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      TestcontainersPodmanConfiguration and its decision type are internal: they are an implementation
+      detail of RequiresFeatureAttribute, not something tests should call. Grant access so the decision
+      layer can be unit tested without widening the public surface.
+    -->
+    <InternalsVisibleTo Include="Aspire.Hosting.Containers.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(SharedDir)PathLookupHelper.cs" Link="PathLookupHelper.cs" />
+    <Compile Include="$(SharedDir)KnownContainerRuntimes.cs" Link="KnownContainerRuntimes.cs" />
     <Compile Include="$(SharedDir)X509Certificate2Extensions.cs" Link="Utils\X509Certificate2Extensions.cs" />
   </ItemGroup>
 

--- a/tests/Aspire.TestUtilities/RequiresFeatureAttribute.cs
+++ b/tests/Aspire.TestUtilities/RequiresFeatureAttribute.cs
@@ -100,8 +100,6 @@ public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAt
     // evaluated during discovery, once per test.
     internal static bool IsContainerRuntimeSupported()
     {
-        TestcontainersPodmanConfiguration.EnsureConfigured();
-
         if (PlatformDetection.IsRunningOnCI)
         {
             return OperatingSystem.IsLinux(); // non-linux on CI does not support containers
@@ -129,11 +127,14 @@ public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAt
     // would run them straight into DockerUnavailableException instead of skipping them.
     private static bool IsTestcontainersSupported()
     {
-        // Applies the CI expectation and, as a side effect, points Testcontainers at Podman if it can.
         if (!IsContainerRuntimeSupported())
         {
             return false;
         }
+
+        // Configuration can set process-wide environment variables, so keep it scoped to tests that
+        // actually use Testcontainers rather than generic DCP-backed container tests.
+        TestcontainersPodmanConfiguration.EnsureConfigured();
 
         if (PlatformDetection.IsRunningOnCI)
         {

--- a/tests/Aspire.TestUtilities/RequiresFeatureAttribute.cs
+++ b/tests/Aspire.TestUtilities/RequiresFeatureAttribute.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.Utils;
+using Aspire.Shared;
 using Microsoft.DotNet.XUnitExtensions;
 
 namespace Aspire.TestUtilities;
@@ -11,12 +12,6 @@ namespace Aspire.TestUtilities;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
 public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAttribute
 {
-    // Duplicated from Aspire.Shared.KnownContainerRuntimes rather than linked in, because this file is
-    // source-included by projects (e.g. Aspire.Playground.Tests) that deploy outside the repo and so
-    // cannot pull in files from src/Shared.
-    private const string DockerExecutable = "docker";
-    private const string PodmanExecutable = "podman";
-
     private static bool? s_isPlaywrightSupported;
     private static readonly ConcurrentDictionary<string, bool> s_executablesOnPath = new();
 
@@ -103,14 +98,16 @@ public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAt
     // only, Docker only, or neither, and tests should skip rather than fail against a runtime that is
     // not installed. Only PATH is inspected (no process is spawned) because trait attributes are
     // evaluated during discovery, once per test.
-    private static bool IsContainerRuntimeSupported()
+    internal static bool IsContainerRuntimeSupported()
     {
+        TestcontainersPodmanConfiguration.EnsureConfigured();
+
         if (PlatformDetection.IsRunningOnCI)
         {
             return OperatingSystem.IsLinux(); // non-linux on CI does not support containers
         }
 
-        return IsOnPath(DockerExecutable) || IsOnPath(PodmanExecutable);
+        return IsOnPath(KnownContainerRuntimes.Docker) || IsOnPath(KnownContainerRuntimes.Podman);
     }
 
     // Same CI expectation as IsContainerRuntimeSupported, but locally requires Docker itself. Used by
@@ -122,7 +119,30 @@ public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAt
             return OperatingSystem.IsLinux();
         }
 
-        return IsOnPath(DockerExecutable);
+        return IsOnPath(KnownContainerRuntimes.Docker);
+    }
+
+    // Testcontainers needs a Docker-compatible API *endpoint*, not just a CLI on PATH: it speaks HTTP to
+    // the engine rather than shelling out. A Podman-only host does not always have one — Testcontainers
+    // 4.8.1 cannot use Podman's Windows named pipe, and on Linux Podman is daemonless unless
+    // `podman system service` is running — so gating these fixtures on IsContainerRuntimeSupported() alone
+    // would run them straight into DockerUnavailableException instead of skipping them.
+    private static bool IsTestcontainersSupported()
+    {
+        // Applies the CI expectation and, as a side effect, points Testcontainers at Podman if it can.
+        if (!IsContainerRuntimeSupported())
+        {
+            return false;
+        }
+
+        if (PlatformDetection.IsRunningOnCI)
+        {
+            return true; // CI always has Docker where it has a container runtime at all.
+        }
+
+        // A Docker install always exposes the socket or named pipe Testcontainers probes by default, so
+        // the CLI being on PATH is enough. Podman only works if we managed to find an API socket for it.
+        return IsOnPath(KnownContainerRuntimes.Docker) || TestcontainersPodmanConfiguration.HasUsableEndpoint;
     }
 
     // Building an image from a Dockerfile needs the buildx plugin under Docker, which is not available on
@@ -141,7 +161,7 @@ public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAt
         }
 
         // buildx ships with modern Docker installations, so presence of either CLI is enough locally.
-        return IsOnPath(DockerExecutable) || IsOnPath(PodmanExecutable);
+        return IsOnPath(KnownContainerRuntimes.Docker) || IsOnPath(KnownContainerRuntimes.Podman);
     }
 
     private static bool IsOnPath(string executable)
@@ -177,6 +197,10 @@ public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAt
             return false;
         }
         if ((feature & TestFeature.Docker) == TestFeature.Docker && !IsDockerSupported())
+        {
+            return false;
+        }
+        if ((feature & TestFeature.Testcontainers) == TestFeature.Testcontainers && !IsTestcontainersSupported())
         {
             return false;
         }

--- a/tests/Aspire.TestUtilities/RequiresFeatureAttribute.cs
+++ b/tests/Aspire.TestUtilities/RequiresFeatureAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Security.Cryptography.X509Certificates;
 using Aspire.Hosting.Utils;
 using Microsoft.DotNet.XUnitExtensions;
@@ -10,44 +11,25 @@ namespace Aspire.TestUtilities;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
 public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAttribute
 {
+    // Duplicated from Aspire.Shared.KnownContainerRuntimes rather than linked in, because this file is
+    // source-included by projects (e.g. Aspire.Playground.Tests) that deploy outside the repo and so
+    // cannot pull in files from src/Shared.
+    private const string DockerExecutable = "docker";
+    private const string PodmanExecutable = "podman";
+
     private static bool? s_isPlaywrightSupported;
+    private static readonly ConcurrentDictionary<string, bool> s_executablesOnPath = new();
 
     public TestFeature Feature { get; } = feature;
 
     public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits()
     {
-        if (!IsSupported())
+        if (!IsFeatureSupported(Feature))
         {
             return [new KeyValuePair<string, string>(XunitConstants.Category, "failing")];
         }
 
         return [];
-    }
-
-    private bool IsSupported()
-    {
-        // Check if ALL specified features are supported
-        if ((Feature & TestFeature.SSLCertificate) == TestFeature.SSLCertificate && !IsSslCertificateSupported())
-        {
-            return false;
-        }
-        if ((Feature & TestFeature.Playwright) == TestFeature.Playwright && !IsPlaywrightSupported())
-        {
-            return false;
-        }
-        if ((Feature & TestFeature.DevCert) == TestFeature.DevCert && !IsDevCertSupported())
-        {
-            return false;
-        }
-        if ((Feature & TestFeature.Docker) == TestFeature.Docker && !IsDockerSupported())
-        {
-            return false;
-        }
-        if ((Feature & TestFeature.DockerPluginBuildx) == TestFeature.DockerPluginBuildx && !IsDockerPluginBuildxSupported())
-        {
-            return false;
-        }
-        return true;
     }
 
     // Logic from RequiresSSLCertificateAttribute
@@ -106,29 +88,66 @@ public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAt
             .Any();
     }
 
-    // Logic from RequiresDockerAttribute
-    // This property is `true` when docker is *expected* to be available.
+    // Logic from RequiresDockerAttribute, generalized to any container runtime.
     //
-    // A hard-coded *expected* value is used here to ensure that docker
-    // dependent tests *fail* if docker is not available/usable in an environment
-    // where it is expected to be available. A run-time check would allow tests
-    // to fail silently, which is not desirable.
+    // On CI a hard-coded *expected* value is used so that container-dependent tests *fail* if the runtime
+    // is not available/usable in an environment where it is expected to be available. A run-time check
+    // would let those tests skip silently, which is not desirable.
     //
     // scenarios:
-    // - Windows: assume installed only for *local* runs as docker isn't supported on CI yet
+    // - Windows: assume installed only for *local* runs as containers aren't supported on CI yet
     //                - https://github.com/microsoft/aspire/issues/4291
-    // - Linux - Local, or CI: always assume that docker is installed
-    private static bool IsDockerSupported()
+    // - Linux - Local, or CI: always assume that a container runtime is installed
+    //
+    // Locally there is no such expectation, so probe PATH instead: a developer machine may have Podman
+    // only, Docker only, or neither, and tests should skip rather than fail against a runtime that is
+    // not installed. Only PATH is inspected (no process is spawned) because trait attributes are
+    // evaluated during discovery, once per test.
+    private static bool IsContainerRuntimeSupported()
     {
-        return OperatingSystem.IsLinux() || !PlatformDetection.IsRunningOnCI; // non-linux on CI does not support docker
+        if (PlatformDetection.IsRunningOnCI)
+        {
+            return OperatingSystem.IsLinux(); // non-linux on CI does not support containers
+        }
+
+        return IsOnPath(DockerExecutable) || IsOnPath(PodmanExecutable);
     }
 
-    // Logic for DockerPluginBuildx
-    // The Docker buildx plugin is not available on Azure DevOps build machines or Helix.
-    // See: https://github.com/dotnet/dnceng/issues/6232
-    private static bool IsDockerPluginBuildxSupported()
+    // Same CI expectation as IsContainerRuntimeSupported, but locally requires Docker itself. Used by
+    // tests that depend on Docker rather than on containers in general (e.g. the Docker socket).
+    private static bool IsDockerSupported()
     {
-        return !PlatformDetection.IsRunningFromAzdo;
+        if (PlatformDetection.IsRunningOnCI)
+        {
+            return OperatingSystem.IsLinux();
+        }
+
+        return IsOnPath(DockerExecutable);
+    }
+
+    // Building an image from a Dockerfile needs the buildx plugin under Docker, which is not available on
+    // Azure DevOps build machines or Helix. See: https://github.com/dotnet/dnceng/issues/6232
+    // Podman has no such dependency — `podman build` is built into the CLI — so a Podman-only machine
+    // satisfies this feature.
+    private static bool IsContainerImageBuildSupported()
+    {
+        if (PlatformDetection.IsRunningOnCI)
+        {
+            // Deliberately does NOT also require IsContainerRuntimeSupported(): this feature only describes
+            // image-build capability, and callers that additionally need a live runtime already combine it
+            // with TestFeature.ContainerRuntime. Adding that conjunct here would stop tests which build
+            // images purely against fakes from running on GitHub Actions Windows.
+            return !PlatformDetection.IsRunningFromAzdo;
+        }
+
+        // buildx ships with modern Docker installations, so presence of either CLI is enough locally.
+        return IsOnPath(DockerExecutable) || IsOnPath(PodmanExecutable);
+    }
+
+    private static bool IsOnPath(string executable)
+    {
+        // Cached because trait attributes are constructed for every test in the assembly.
+        return s_executablesOnPath.GetOrAdd(executable, static e => FileUtil.FindFullPathFromPath(e) is not null);
     }
 
     /// <summary>
@@ -149,11 +168,15 @@ public class RequiresFeatureAttribute(TestFeature feature) : Attribute, ITraitAt
         {
             return false;
         }
-        if ((feature & TestFeature.Docker) == TestFeature.Docker && !IsDockerSupported())
+        if ((feature & TestFeature.ContainerRuntime) == TestFeature.ContainerRuntime && !IsContainerRuntimeSupported())
         {
             return false;
         }
-        if ((feature & TestFeature.DockerPluginBuildx) == TestFeature.DockerPluginBuildx && !IsDockerPluginBuildxSupported())
+        if ((feature & TestFeature.ContainerImageBuild) == TestFeature.ContainerImageBuild && !IsContainerImageBuildSupported())
+        {
+            return false;
+        }
+        if ((feature & TestFeature.Docker) == TestFeature.Docker && !IsDockerSupported())
         {
             return false;
         }

--- a/tests/Aspire.TestUtilities/TestFeature.cs
+++ b/tests/Aspire.TestUtilities/TestFeature.cs
@@ -27,5 +27,15 @@ public enum TestFeature
     /// than on containers in general — for example, ones that bind-mount the Docker socket or invoke
     /// the <c>docker</c> CLI. Otherwise use <see cref="ContainerRuntime"/>.
     /// </summary>
-    Docker = 1 << 5
+    Docker = 1 << 5,
+
+    /// <summary>
+    /// The Testcontainers library can reach a container runtime. This implies--but is stricter than--<see cref="ContainerRuntime"/>: 
+    /// Testcontainers talks to a Docker-compatible HTTP API rather than
+    /// driving a CLI, so it also needs a socket or named pipe to connect to. Podman does not always
+    /// expose one — Testcontainers 4.x cannot use its Windows named pipe, and on Linux Podman runs
+    /// daemonlessly unless <c>podman system service</c> is running — while DCP-driven container tests
+    /// are perfectly happy on those hosts. Use this for tests backed by a Testcontainers fixture.
+    /// </summary>
+    Testcontainers = 1 << 6
 }

--- a/tests/Aspire.TestUtilities/TestFeature.cs
+++ b/tests/Aspire.TestUtilities/TestFeature.cs
@@ -9,6 +9,23 @@ public enum TestFeature
     SSLCertificate = 1 << 0,
     Playwright = 1 << 1,
     DevCert = 1 << 2,
-    Docker = 1 << 3,
-    DockerPluginBuildx = 1 << 4
+
+    /// <summary>
+    /// A container runtime is available. Satisfied by either Docker or Podman, so use this for tests
+    /// that just need to run containers. Prefer it over <see cref="Docker"/>.
+    /// </summary>
+    ContainerRuntime = 1 << 3,
+
+    /// <summary>
+    /// The available container runtime can build images from a Dockerfile. Docker needs the buildx
+    /// plugin for this; Podman builds natively.
+    /// </summary>
+    ContainerImageBuild = 1 << 4,
+
+    /// <summary>
+    /// Docker specifically is available. Use this only for tests that depend on Docker itself rather
+    /// than on containers in general — for example, ones that bind-mount the Docker socket or invoke
+    /// the <c>docker</c> CLI. Otherwise use <see cref="ContainerRuntime"/>.
+    /// </summary>
+    Docker = 1 << 5
 }

--- a/tests/Aspire.TestUtilities/TestcontainersPodmanConfiguration.cs
+++ b/tests/Aspire.TestUtilities/TestcontainersPodmanConfiguration.cs
@@ -1,0 +1,319 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Shared;
+
+namespace Aspire.TestUtilities;
+
+/// <summary>
+/// Points Testcontainers at Podman on machines where Podman is the only container runtime, and reports
+/// whether Testcontainers has an endpoint to talk to at all.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Testcontainers 4.x cannot find Podman on its own. Its endpoint discovery only ever probes Docker
+/// sockets: <c>UnixEndpointAuthenticationProvider</c> checks <c>/var/run/docker.sock</c>, and
+/// <c>RootlessUnixEndpointAuthenticationProvider</c> is hard-coded to <c>docker.sock</c> file names
+/// (<c>private const string DockerSocket = "docker.sock"</c>) and is additionally gated on
+/// <c>IsOSPlatform(Linux)</c>, so on macOS it is never even tried. Nothing in the provider chain looks at
+/// a path containing "podman". Without this, every Testcontainers-backed fixture fails on a Podman-only
+/// host with <c>DockerUnavailableException</c> ("Docker is either not running or misconfigured...").
+/// See https://github.com/testcontainers/testcontainers-dotnet/blob/4.8.1/src/Testcontainers/Configurations/TestcontainersSettings.cs
+/// and https://github.com/testcontainers/testcontainers-dotnet/blob/4.8.1/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
+/// </para>
+/// <para>
+/// Configuration has to happen before the first <c>ContainerBuilder</c> is constructed, because
+/// <c>TestcontainersSettings</c> resolves its endpoint and Ryuk switches once, in its static constructor.
+/// <see cref="RequiresFeatureAttribute.IsContainerRuntimeSupported"/> is the hook for that: declaring
+/// <see cref="TestFeature.ContainerRuntime"/> is already mandatory for any test that runs a container, so
+/// every Testcontainers fixture in the repo passes through it - either by calling
+/// <see cref="RequiresFeatureAttribute.IsFeatureSupported"/> directly before building its container, or via
+/// the trait attribute, which xUnit evaluates during discovery. That makes this strictly more reliable than
+/// a module initializer, which would only cover the assemblies it happened to be compiled into.
+/// </para>
+/// <para>
+/// Podman cannot always be reached, though: Testcontainers 4.8.1 cannot drive it over a Windows named pipe,
+/// and on Linux <c>podman</c> runs daemonlessly with no API socket unless <c>podman system service</c> is
+/// running. Those hosts still run containers perfectly well through DCP, so they keep
+/// <see cref="TestFeature.ContainerRuntime"/>; it is <see cref="TestFeature.Testcontainers"/> that consults
+/// <see cref="HasUsableEndpoint"/> and skips the fixtures which would otherwise throw.
+/// </para>
+/// </remarks>
+internal static class TestcontainersPodmanConfiguration
+{
+    private const string DockerHostVariable = "DOCKER_HOST";
+    private const string RyukDisabledVariable = "TESTCONTAINERS_RYUK_DISABLED";
+
+    // Give up rather than hang the test run if the Podman CLI is wedged.
+    private static readonly TimeSpan s_podmanInspectTimeout = TimeSpan.FromSeconds(10);
+
+    // Called once per test during trait evaluation, so the probing must happen at most once per process.
+    private static readonly Lazy<bool> s_hasUsableEndpoint = new(Configure);
+
+    /// <summary>
+    /// Configures Testcontainers for Podman if required. Safe to call repeatedly; the work happens once.
+    /// </summary>
+    internal static void EnsureConfigured() => _ = s_hasUsableEndpoint.Value;
+
+    /// <summary>
+    /// Reports whether Testcontainers has a Docker-compatible API endpoint to talk to, configuring it for
+    /// Podman first if that is what it takes. Safe to call repeatedly; the work happens once.
+    /// </summary>
+    internal static bool HasUsableEndpoint => s_hasUsableEndpoint.Value;
+
+    /// <returns><inheritdoc cref="HasUsableEndpoint" path="/summary"/></returns>
+    private static bool Configure()
+    {
+        var decision = Decide(
+            OperatingSystem.IsWindows(),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            Environment.GetEnvironmentVariable,
+            SocketExists,
+            FindPodmanSocketFromCli);
+
+        // Both settings are published as environment variables rather than assigned on
+        // TestcontainersSettings, because they have to survive a process boundary. Microsoft.Testing.Platform
+        // runs the tests in a child process (for example when --hangdump is used), and that child inherits
+        // the environment but not managed static state, so an in-process assignment ends up applying to the
+        // wrong process. Going through the environment also keeps this file free of a compile-time
+        // dependency on the Testcontainers API, which Aspire.TestUtilities deliberately does not reference.
+        if (decision.DockerHost is { } dockerHost)
+        {
+            Environment.SetEnvironmentVariable(DockerHostVariable, dockerHost);
+        }
+
+        if (decision.DisableRyuk)
+        {
+            Environment.SetEnvironmentVariable(RyukDisabledVariable, "true");
+        }
+
+        return decision.HasUsableEndpoint;
+    }
+
+    /// <summary>
+    /// Works out what Testcontainers needs, without touching any ambient state. Every input is injected so
+    /// that the branches below - almost all of which are unreachable on CI, where Docker is always present -
+    /// can be exercised by unit tests.
+    /// </summary>
+    /// <param name="isWindows">Whether the host is Windows.</param>
+    /// <param name="homeDirectory">The current user's home directory, used to build socket candidates.</param>
+    /// <param name="getEnvironmentVariable">Reads an environment variable.</param>
+    /// <param name="socketExists">Reports whether a socket file exists at the given path.</param>
+    /// <param name="findPodmanSocketFromCli">Asks the Podman CLI for the machine's API socket path.</param>
+    internal static PodmanConfigurationDecision Decide(
+        bool isWindows,
+        string? homeDirectory,
+        Func<string, string?> getEnvironmentVariable,
+        Func<string?, bool> socketExists,
+        Func<string?> findPodmanSocketFromCli)
+    {
+        var dockerHost = getEnvironmentVariable(DockerHostVariable);
+
+        // Windows talks to the engine over a named pipe, and Podman-on-Windows needs fixes that are not in
+        // Testcontainers 4.8.1 (https://github.com/testcontainers/testcontainers-dotnet/issues/1438). There
+        // is nothing to configure, so the only question is whether the developer already pointed
+        // Testcontainers at something it can actually use. A Podman pipe is rejected rather than trusted,
+        // because running the fixtures against it only produces DockerUnavailableException instead of the
+        // skip the caller wants. A Docker Desktop install is handled by the caller, which additionally
+        // treats the `docker` CLI being on PATH as proof of a reachable endpoint.
+        if (isWindows)
+        {
+            return new PodmanConfigurationDecision(
+                HasUsableEndpoint: !string.IsNullOrEmpty(dockerHost) && !LooksLikePodmanEndpoint(dockerHost));
+        }
+
+        // An explicit DOCKER_HOST always wins: it is how a developer points the tests at a specific engine,
+        // and Testcontainers' EnvironmentEndpointAuthenticationProvider already honours it. This is also the
+        // branch a test host child process takes, because it inherits the values configured below.
+        if (!string.IsNullOrEmpty(dockerHost))
+        {
+            // Ryuk still has to be turned off when that endpoint is a Podman one. `podman machine start`
+            // prints an `export DOCKER_HOST=...` hint, so pointing DOCKER_HOST at Podman by hand is the
+            // normal setup rather than an exotic one.
+            return new PodmanConfigurationDecision(
+                HasUsableEndpoint: true,
+                DisableRyuk: LooksLikePodmanEndpoint(dockerHost) && !IsRyukSettingExplicit(getEnvironmentVariable));
+        }
+
+        // CI (GitHub Actions and Helix) always has Docker, so this leaves those runs on exactly the code
+        // path they use today.
+        if (DockerSocketExists(homeDirectory, getEnvironmentVariable, socketExists))
+        {
+            return new PodmanConfigurationDecision(HasUsableEndpoint: true);
+        }
+
+        if (FindPodmanSocket(homeDirectory, getEnvironmentVariable, socketExists, findPodmanSocketFromCli) is not { } podmanSocketPath)
+        {
+            return default;
+        }
+
+        return new PodmanConfigurationDecision(
+            HasUsableEndpoint: true,
+            DockerHost: $"unix://{podmanSocketPath}",
+            DisableRyuk: !IsRyukSettingExplicit(getEnvironmentVariable));
+    }
+
+    /// <summary>
+    /// Reports whether an endpoint is served by Podman rather than Docker.
+    /// </summary>
+    /// <remarks>
+    /// A substring match is the only option available without connecting: the value is an opaque URI and
+    /// Docker and Podman speak the same API over it. It holds for every layout Podman produces, all of
+    /// which name the product somewhere in the path:
+    /// <code>
+    /// unix:///run/user/1000/podman/podman.sock                                        (Linux, rootless)
+    /// unix:///run/podman/podman.sock                                                  (Linux, rootful)
+    /// unix:///var/folders/_h/.../T/podman/podman-machine-default-api.sock             (macOS machine)
+    /// npipe:////./pipe/podman-machine-default                                         (Windows machine)
+    /// </code>
+    /// A false negative only costs the Ryuk workaround below, and a false positive only skips a container
+    /// reaper the fixtures do not rely on, so neither direction breaks a test run.
+    /// </remarks>
+    private static bool LooksLikePodmanEndpoint(string dockerHost)
+        => dockerHost.Contains(KnownContainerRuntimes.Podman, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Reports whether the developer has taken ownership of the Ryuk setting, in which case their value
+    /// stands regardless of what the runtime is.
+    /// </summary>
+    private static bool IsRyukSettingExplicit(Func<string, string?> getEnvironmentVariable)
+        => !string.IsNullOrEmpty(getEnvironmentVariable(RyukDisabledVariable));
+
+    /// <summary>
+    /// Reports whether a Docker socket that Testcontainers would discover on its own already exists.
+    /// </summary>
+    private static bool DockerSocketExists(string? homeDirectory, Func<string, string?> getEnvironmentVariable, Func<string?, bool> socketExists)
+    {
+        // Mirrors the socket paths Testcontainers 4.8.1 probes on Unix, plus the Docker Desktop socket.
+        string?[] candidates =
+        [
+            "/var/run/docker.sock",
+            CombineWithEnvironmentVariable(getEnvironmentVariable, "XDG_RUNTIME_DIR", "docker.sock"),
+            CombineWithHome(homeDirectory, ".docker", "run", "docker.sock"),
+            CombineWithHome(homeDirectory, ".docker", "desktop", "docker.sock"),
+        ];
+
+        return candidates.Any(socketExists);
+    }
+
+    /// <summary>
+    /// Locates the Podman API socket, preferring well-known locations before shelling out to the CLI.
+    /// </summary>
+    private static string? FindPodmanSocket(
+        string? homeDirectory,
+        Func<string, string?> getEnvironmentVariable,
+        Func<string?, bool> socketExists,
+        Func<string?> findPodmanSocketFromCli)
+    {
+        string?[] candidates =
+        [
+            // Linux, rootless.
+            CombineWithEnvironmentVariable(getEnvironmentVariable, "XDG_RUNTIME_DIR", "podman", "podman.sock"),
+            // Linux, rootful.
+            "/run/podman/podman.sock",
+            // macOS: `podman machine` maintains this symlink to the current machine's API socket. Preferred
+            // over the link target because AF_UNIX paths are limited to ~104 bytes on macOS and the target
+            // lives under a long $TMPDIR path.
+            CombineWithHome(homeDirectory, ".local", "share", "containers", "podman", "machine", "podman.sock"),
+        ];
+
+        return candidates.FirstOrDefault(socketExists) ?? findPodmanSocketFromCli();
+    }
+
+    /// <summary>
+    /// Asks the Podman CLI where the machine's API socket lives, as a fallback for layouts this file does
+    /// not know about.
+    /// </summary>
+    private static string? FindPodmanSocketFromCli()
+    {
+        // `podman machine inspect --format {{.ConnectionInfo.PodmanSocket.Path}}` prints one absolute path
+        // per inspected machine, e.g.
+        //   /var/folders/_h/jnjmbyss12g40fn478_1k5rr0000gn/T/podman/podman-machine-default-api.sock
+        // It exits non-zero when no machine exists, and prints nothing on Linux where there is no VM.
+        var startInfo = new ProcessStartInfo(KnownContainerRuntimes.Podman)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        startInfo.ArgumentList.Add("machine");
+        startInfo.ArgumentList.Add("inspect");
+        startInfo.ArgumentList.Add("--format");
+        startInfo.ArgumentList.Add("{{.ConnectionInfo.PodmanSocket.Path}}");
+
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return null;
+            }
+
+            // Drain both streams concurrently so a full pipe buffer cannot block podman before it exits.
+            var standardOutput = process.StandardOutput.ReadToEndAsync();
+            _ = process.StandardError.ReadToEndAsync();
+
+            if (!process.WaitForExit((int)s_podmanInspectTimeout.TotalMilliseconds))
+            {
+                process.Kill(entireProcessTree: true);
+                return null;
+            }
+
+            // The overload that takes a timeout does not wait for the redirected streams to be flushed.
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                return null;
+            }
+
+            return standardOutput.GetAwaiter().GetResult()
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault(SocketExists);
+        }
+        catch (Exception)
+        {
+            // Podman is not installed, not on PATH, or otherwise unusable. Leave Testcontainers alone so it
+            // reports its own diagnostics.
+            return null;
+        }
+    }
+
+    private static bool SocketExists(string? path) => !string.IsNullOrEmpty(path) && File.Exists(path);
+
+    private static string? CombineWithEnvironmentVariable(Func<string, string?> getEnvironmentVariable, string variable, params string[] parts)
+    {
+        var root = getEnvironmentVariable(variable);
+        return string.IsNullOrEmpty(root) ? null : Path.Combine([root, .. parts]);
+    }
+
+    private static string? CombineWithHome(string? homeDirectory, params string[] parts)
+        => string.IsNullOrEmpty(homeDirectory) ? null : Path.Combine([homeDirectory, .. parts]);
+}
+
+/// <summary>
+/// What <see cref="TestcontainersPodmanConfiguration.Decide"/> concluded about the current machine.
+/// </summary>
+/// <param name="HasUsableEndpoint">
+/// Whether Testcontainers ends up with a Docker-compatible API endpoint to talk to. When this is
+/// <see langword="false"/> every Testcontainers fixture will throw <c>DockerUnavailableException</c>, so
+/// those tests should be skipped rather than run.
+/// </param>
+/// <param name="DockerHost">
+/// The value to publish as <c>DOCKER_HOST</c>, or <see langword="null"/> to leave it alone.
+/// </param>
+/// <param name="DisableRyuk">
+/// Whether to publish <c>TESTCONTAINERS_RYUK_DISABLED=true</c>. Ryuk, the resource reaper, bind-mounts the
+/// engine socket into a privileged container and always mounts it at <c>/var/run/docker.sock</c>
+/// (<c>ResourceReaper.UnixSocketMount</c>). Under rootless Podman that fails outright - "statfs ...:
+/// operation not supported" on a macOS podman machine, "permission denied" on Linux - so it has to be off.
+/// See https://github.com/testcontainers/testcontainers-dotnet/issues/876. The fixtures dispose their own
+/// containers, and Helix already disables Ryuk for Testcontainers work items
+/// (tests/helix/send-to-helix-inner.proj).
+/// </param>
+internal readonly record struct PodmanConfigurationDecision(
+    bool HasUsableEndpoint,
+    string? DockerHost = null,
+    bool DisableRyuk = false);

--- a/tests/Aspire.TestUtilities/TestcontainersPodmanConfiguration.cs
+++ b/tests/Aspire.TestUtilities/TestcontainersPodmanConfiguration.cs
@@ -25,9 +25,8 @@ namespace Aspire.TestUtilities;
 /// <para>
 /// Configuration has to happen before the first <c>ContainerBuilder</c> is constructed, because
 /// <c>TestcontainersSettings</c> resolves its endpoint and Ryuk switches once, in its static constructor.
-/// <see cref="RequiresFeatureAttribute.IsContainerRuntimeSupported"/> is the hook for that: declaring
-/// <see cref="TestFeature.ContainerRuntime"/> is already mandatory for any test that runs a container, so
-/// every Testcontainers fixture in the repo passes through it - either by calling
+/// The <see cref="TestFeature.Testcontainers"/> capability check is the hook for that, so every
+/// Testcontainers fixture in the repo passes through it - either by calling
 /// <see cref="RequiresFeatureAttribute.IsFeatureSupported"/> directly before building its container, or via
 /// the trait attribute, which xUnit evaluates during discovery. That makes this strictly more reliable than
 /// a module initializer, which would only cover the assemblies it happened to be compiled into.
@@ -50,6 +49,11 @@ internal static class TestcontainersPodmanConfiguration
 
     // Called once per test during trait evaluation, so the probing must happen at most once per process.
     private static readonly Lazy<bool> s_hasUsableEndpoint = new(Configure);
+
+    /// <summary>
+    /// Reports whether configuration has already run, without triggering it.
+    /// </summary>
+    internal static bool IsConfigurationInitialized => s_hasUsableEndpoint.IsValueCreated;
 
     /// <summary>
     /// Configures Testcontainers for Podman if required. Safe to call repeatedly; the work happens once.


### PR DESCRIPTION
## Description

One of my dev machines is Podman-only (no Docker) to reflect Aspire users who prefer Podman over Docker. This PR enables running all our container tests on such machines. 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
