### PR TITLE
Properly process object update notifications from DCP

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Aspire.Dashboard.Model;
@@ -158,6 +159,151 @@ public sealed record CustomResourceSnapshot
             // If any of the reports is null (first health check has not returned), the health status is unhealthy.
             : healthReports.MinBy(r => r.Status)?.Status
                 ?? Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy;
+    }
+
+    /// <summary>
+    /// Determines whether this snapshot describes the same resource state as <paramref name="other"/>,
+    /// ignoring <see cref="Version"/>.
+    /// </summary>
+    /// <remarks>
+    /// The generated record equality is not usable for this. Every snapshot rebuilds its collections
+    /// from scratch (see <c>ResourceSnapshotBuilder</c>), and <see cref="ImmutableArray{T}"/> equality
+    /// compares the underlying array <em>reference</em>, so two snapshots describing an identical
+    /// resource practically never compare equal.
+    /// </remarks>
+    internal bool ContentEquals(CustomResourceSnapshot other)
+    {
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (!PropertiesContentEqual(Properties, other.Properties) ||
+            !EnvironmentVariables.SequenceEqual(other.EnvironmentVariables) ||
+            !Urls.SequenceEqual(other.Urls) ||
+            !Volumes.SequenceEqual(other.Volumes) ||
+            !Commands.SequenceEqual(other.Commands) ||
+            !Relationships.SequenceEqual(other.Relationships) ||
+            !HealthReports.SequenceEqual(other.HealthReports))
+        {
+            return false;
+        }
+
+        // Every member compared above is blanked out so the generated record equality can cover
+        // everything that is left. Blanking rather than listing the remaining members keeps this
+        // method correct as the record grows: a member added later simply participates in the record
+        // equality below instead of being silently ignored.
+        // HealthStatus needs no separate handling because it is derived from HealthReports and State,
+        // both of which are compared.
+        return WithoutCollections(this) == WithoutCollections(other);
+
+        static CustomResourceSnapshot WithoutCollections(CustomResourceSnapshot snapshot) => snapshot with
+        {
+            // Version counts publications rather than describing the resource, so it is not content.
+            Version = 0,
+            Properties = [],
+            EnvironmentVariables = [],
+            Urls = [],
+            Volumes = [],
+            Commands = [],
+            Relationships = [],
+            HealthReports = []
+        };
+    }
+
+    private static bool PropertiesContentEqual(ImmutableArray<ResourcePropertySnapshot> x, ImmutableArray<ResourcePropertySnapshot> y)
+    {
+        if (x.Length != y.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < x.Length; i++)
+        {
+            // ResourcePropertySnapshot.Value is weakly typed, so compare it separately and let the
+            // generated record equality cover the remaining members.
+            if (!ReferenceEquals(x[i], y[i]) &&
+                (!PropertyValueContentEquals(x[i].Value, y[i].Value) ||
+                 (x[i] with { Value = null }) != (y[i] with { Value = null })))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Compares two weakly typed property values by content.
+    /// </summary>
+    /// <remarks>
+    /// Property values are frequently collections that are rebuilt for every snapshot - container
+    /// ports as an <see cref="ImmutableArray{T}"/>, container and executable arguments as a
+    /// <see cref="List{T}"/>. None of those compare by value, so they have to be compared element-wise.
+    /// </remarks>
+    private static bool PropertyValueContentEquals(object? x, object? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        // Arrays and ImmutableArray<T> implement IStructuralEquatable, which compares element-wise and
+        // copes with an uninitialized ImmutableArray.
+        if (x is IStructuralEquatable structuralX && y is IStructuralEquatable)
+        {
+            return structuralX.Equals(y, StructuralComparisons.StructuralEqualityComparer);
+        }
+
+        // Other collections, such as the List<string> used for effective arguments, still compare by
+        // reference. A string is excluded because it is an IEnumerable that already compares by value.
+        if (x is IEnumerable sequenceX and not string && y is IEnumerable sequenceY and not string)
+        {
+            return SequenceContentEquals(sequenceX, sequenceY);
+        }
+
+        return x.Equals(y);
+    }
+
+    private static bool SequenceContentEquals(IEnumerable x, IEnumerable y)
+    {
+        var enumeratorX = x.GetEnumerator();
+        var enumeratorY = y.GetEnumerator();
+
+        try
+        {
+            while (true)
+            {
+                var hasX = enumeratorX.MoveNext();
+                var hasY = enumeratorY.MoveNext();
+
+                if (hasX != hasY)
+                {
+                    return false;
+                }
+
+                if (!hasX)
+                {
+                    return true;
+                }
+
+                // Recurse so nested collections are compared by content too.
+                if (!PropertyValueContentEquals(enumeratorX.Current, enumeratorY.Current))
+                {
+                    return false;
+                }
+            }
+        }
+        finally
+        {
+            (enumeratorX as IDisposable)?.Dispose();
+            (enumeratorY as IDisposable)?.Dispose();
+        }
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -178,13 +178,19 @@ public sealed record CustomResourceSnapshot
             return true;
         }
 
-        // Every collection compared below is omitted so the generated record equality can cover
-        // everything that is left. Omitting collections than listing the remaining members keeps this
-        // method correct as the record grows: a member added later simply participates in the record
-        // equality instead of being silently ignored. Run this first so common scalar changes such as
-        // State and ExitCode avoid allocating comparison clones for every property.
-        // HealthStatus needs no separate handling because it is derived from HealthReports and State.
-        if (WithoutCollections(this) != WithoutCollections(other))
+        // Version counts publications rather than describing the resource. HealthStatus is derived
+        // from State and HealthReports, so neither property needs an independent comparison.
+        if (ResourceType != other.ResourceType ||
+            CreationTimeStamp != other.CreationTimeStamp ||
+            StartTimeStamp != other.StartTimeStamp ||
+            StopTimeStamp != other.StopTimeStamp ||
+            State != other.State ||
+            ExitCode != other.ExitCode ||
+            ResourceReadyEvent != other.ResourceReadyEvent ||
+            IsHidden != other.IsHidden ||
+            SupportsDetailedTelemetry != other.SupportsDetailedTelemetry ||
+            IconName != other.IconName ||
+            IconVariant != other.IconVariant)
         {
             return false;
         }
@@ -196,19 +202,6 @@ public sealed record CustomResourceSnapshot
             Commands.SequenceEqual(other.Commands) &&
             Relationships.SequenceEqual(other.Relationships) &&
             HealthReports.SequenceEqual(other.HealthReports);
-
-        static CustomResourceSnapshot WithoutCollections(CustomResourceSnapshot snapshot) => snapshot with
-        {
-            // Version counts publications rather than describing the resource, so it is not content.
-            Version = 0,
-            Properties = [],
-            EnvironmentVariables = [],
-            Urls = [],
-            Volumes = [],
-            Commands = [],
-            Relationships = [],
-            HealthReports = []
-        };
     }
 
     private static bool PropertiesContentEqual(ImmutableArray<ResourcePropertySnapshot> x, ImmutableArray<ResourcePropertySnapshot> y)
@@ -220,17 +213,24 @@ public sealed record CustomResourceSnapshot
 
         for (var i = 0; i < x.Length; i++)
         {
-            // ResourcePropertySnapshot.Value is weakly typed, so compare it separately and let the
-            // generated record equality cover the remaining members.
-            if (!ReferenceEquals(x[i], y[i]) &&
-                (!PropertyValueContentEquals(x[i].Value, y[i].Value) ||
-                 (x[i] with { Value = null }) != (y[i] with { Value = null })))
+            if (!ResourcePropertyContentEquals(x[i], y[i]))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool ResourcePropertyContentEquals(ResourcePropertySnapshot x, ResourcePropertySnapshot y)
+    {
+        return ReferenceEquals(x, y) ||
+            (x.Name == y.Name &&
+             x.DisplayName == y.DisplayName &&
+             x.IsSensitive == y.IsSensitive &&
+             x.IsHighlighted == y.IsHighlighted &&
+             x.SortOrder == y.SortOrder &&
+             PropertyValueContentEquals(x.Value, y.Value));
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -178,24 +178,24 @@ public sealed record CustomResourceSnapshot
             return true;
         }
 
-        if (!PropertiesContentEqual(Properties, other.Properties) ||
-            !EnvironmentVariables.SequenceEqual(other.EnvironmentVariables) ||
-            !Urls.SequenceEqual(other.Urls) ||
-            !Volumes.SequenceEqual(other.Volumes) ||
-            !Commands.SequenceEqual(other.Commands) ||
-            !Relationships.SequenceEqual(other.Relationships) ||
-            !HealthReports.SequenceEqual(other.HealthReports))
+        // Every collection compared below is omitted so the generated record equality can cover
+        // everything that is left. Omitting collections than listing the remaining members keeps this
+        // method correct as the record grows: a member added later simply participates in the record
+        // equality instead of being silently ignored. Run this first so common scalar changes such as
+        // State and ExitCode avoid allocating comparison clones for every property.
+        // HealthStatus needs no separate handling because it is derived from HealthReports and State.
+        if (WithoutCollections(this) != WithoutCollections(other))
         {
             return false;
         }
 
-        // Every member compared above is blanked out so the generated record equality can cover
-        // everything that is left. Blanking rather than listing the remaining members keeps this
-        // method correct as the record grows: a member added later simply participates in the record
-        // equality below instead of being silently ignored.
-        // HealthStatus needs no separate handling because it is derived from HealthReports and State,
-        // both of which are compared.
-        return WithoutCollections(this) == WithoutCollections(other);
+        return PropertiesContentEqual(Properties, other.Properties) &&
+            EnvironmentVariables.SequenceEqual(other.EnvironmentVariables) &&
+            Urls.SequenceEqual(other.Urls) &&
+            Volumes.SequenceEqual(other.Volumes) &&
+            Commands.SequenceEqual(other.Commands) &&
+            Relationships.SequenceEqual(other.Relationships) &&
+            HealthReports.SequenceEqual(other.HealthReports);
 
         static CustomResourceSnapshot WithoutCollections(CustomResourceSnapshot snapshot) => snapshot with
         {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -821,9 +821,6 @@ public class ResourceNotificationService : IDisposable
                 };
             }
 
-            // Increment the snapshot version, this is a per resource version.
-            newState = newState with { Version = notificationState.GetNextVersion() };
-
             newState = UpdateCommands(resource, newState);
 
             newState = UpdateIcons(resource, newState);
@@ -837,6 +834,23 @@ public class ResourceNotificationService : IDisposable
                     Properties = newState.Properties.SetResourceProperty(KnownProperties.Resource.ExcludeFromMcp, true)
                 };
             }
+
+            // Producers can recompute a snapshot that is identical to the one already published. DCP is
+            // the common case: its watches are periodically torn down and re-established, and each fresh
+            // watch replays every object that exists, so a resource that never changes again keeps
+            // arriving here. Publishing those would bump the version and wake every subscriber without
+            // anything having changed. Subscribers that start watching later are still seeded from
+            // LastSnapshot, so suppressing here cannot cost anyone an update.
+            // See https://github.com/microsoft/aspire/issues/18869.
+            if (notificationState.LastSnapshot is { } lastSnapshot && lastSnapshot.ContentEquals(newState))
+            {
+                _logger.LogTrace("Resource {ResourceName}/{ResourceId} update skipped because the snapshot is unchanged.", resource.Name, resourceId);
+
+                return Task.CompletedTask;
+            }
+
+            // Increment the snapshot version, this is a per resource version.
+            newState = newState with { Version = notificationState.GetNextVersion() };
 
             notificationState.LastSnapshot = newState;
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -799,6 +799,10 @@ public class ResourceNotificationService : IDisposable
     /// <param name="resource">The resource to update</param>
     /// <param name="resourceId"> The id of the resource.</param>
     /// <param name="stateFactory">A factory that creates the new state based on the previous state.</param>
+    /// <remarks>
+    /// If the resulting snapshot has the same content as the current snapshot, the update is not
+    /// published and the snapshot version is not incremented.
+    /// </remarks>
     public Task PublishUpdateAsync(IResource resource, string resourceId, Func<CustomResourceSnapshot, CustomResourceSnapshot> stateFactory)
     {
         var notificationState = GetResourceNotificationState(resourceId, resource);
@@ -844,7 +848,10 @@ public class ResourceNotificationService : IDisposable
             // See https://github.com/microsoft/aspire/issues/18869.
             if (notificationState.LastSnapshot is { } lastSnapshot && lastSnapshot.ContentEquals(newState))
             {
-                _logger.LogTrace("Resource {ResourceName}/{ResourceId} update skipped because the snapshot is unchanged.", resource.Name, resourceId);
+                if (_logger.IsEnabled(LogLevel.Trace))
+                {
+                    _logger.LogTrace("Resource {ResourceName}/{ResourceId} update skipped because the snapshot is unchanged.", resource.Name, resourceId);
+                }
 
                 return Task.CompletedTask;
             }
@@ -1193,6 +1200,10 @@ public class ResourceNotificationService : IDisposable
     /// </summary>
     /// <param name="resource">The resource to update</param>
     /// <param name="stateFactory">A factory that creates the new state based on the previous state.</param>
+    /// <remarks>
+    /// If the resulting snapshot has the same content as the current snapshot, the update is not
+    /// published and the snapshot version is not incremented.
+    /// </remarks>
     public async Task PublishUpdateAsync(IResource resource, Func<CustomResourceSnapshot, CustomResourceSnapshot> stateFactory)
     {
         var resourceNames = resource.GetResolvedResourceNames();

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -46,6 +46,8 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
     // Holds names of resources that reached terminal state and logs have already been flushed for them. 
     // Prevents re-reading DCP's log store every time an already-terminal resource is reported again.
+    // Point-in-time FailedToStart reads and incomplete attempts are intentionally not recorded so a later terminal
+    // notification can retry them.
     private readonly ConcurrentDictionary<string, bool> _allLogsFlushed = new();
     private Task? _resourceWatchTask;
 
@@ -303,19 +305,22 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     // depending on the ordering, and GetAllAsync can still query DCP's external log
                     // store later without this extra read on every terminal transition.
                     //
-                    // Flush at most once for resources in terminal state. Every further notification for a resource
-                    // that is already terminal describes logs we have read, and the flush is awaited
-                    // while holding the watcher's single output semaphore, so repeating it stalls the
-                    // Container, Executable, ContainerExec, Service and Endpoint watches alike for up
-                    // to TerminalLogFlushTimeout. The marker is cleared below if the resource is restarted, 
-                    // so a restarted resource is flushed again when it terminates.
+                    // A successfully completed follow stream needs to run only once per terminal period.
+                    // The flush is awaited while holding the watcher's single output semaphore, so repeating
+                    // a completed flush would stall all resource watches. Point-in-time FailedToStart reads
+                    // and incomplete attempts remain retryable because they cannot guarantee all logs were read.
+                    // The marker is cleared below if the resource is restarted.
                     if (status.State is not null && KnownResourceStates.TerminalStates.Contains(status.State))
                     {
                         if (HasLogsAvailable(resource) &&
                             _loggerService.HasActiveSubscribers(resource.Metadata.Name) &&
-                            _allLogsFlushed.TryAdd(resource.Metadata.Name, true))
+                            !_allLogsFlushed.ContainsKey(resource.Metadata.Name))
                         {
-                            await FlushCurrentLogsAsync(resource, status, _shutdownToken).ConfigureAwait(false);
+                            var completed = await FlushCurrentLogsAsync(resource, status, _shutdownToken).ConfigureAwait(false);
+                            if (completed)
+                            {
+                                _allLogsFlushed.TryAdd(resource.Metadata.Name, true);
+                            }
                         }
                     }
                     else
@@ -361,10 +366,13 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         }
     }
 
-    private async Task FlushCurrentLogsAsync<T>(T resource, ResourceStatus status, CancellationToken cancellationToken)
+    private async Task<bool> FlushCurrentLogsAsync<T>(T resource, ResourceStatus status, CancellationToken cancellationToken)
         where T : CustomResource, IKubernetesStaticMetadata
     {
         var logEntries = new List<LogEntry>();
+        var follow = status.State != KnownResourceStates.FailedToStart;
+        var completed = false;
+
         // The resource watcher serializes all resource-change handling through one semaphore in
         // Start(). A follow stream gives the strongest DCP guarantee for terminal logs, but it is
         // still an external stream: if DCP stalls or the resource disappears mid-stream, waiting
@@ -381,10 +389,9 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             // race with DCP's own cleanup/log-drain work.
             //
             // FailedToStart is different: the process never starts, so there may be no completing
-            // process log stream to follow. DCP emits the system failure logs before the FailedToStart
-            // state is observed, so use a current snapshot there to avoid blocking terminal state
-            // publication indefinitely.
-            var follow = status.State != KnownResourceStates.FailedToStart;
+            // process log stream to follow. Use a current snapshot there to avoid blocking terminal
+            // state publication indefinitely. A later resource notification retries the snapshot
+            // because, unlike a completed follow stream, it cannot prove all logs were drained.
             var logSource = new ResourceLogSource<T>(_logger, _kubernetesService, resource, follow: follow);
 
             // Treat the flush as best-effort: logs collected before the timeout are still forwarded
@@ -393,6 +400,11 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             {
                 logEntries.AddRange(CreateLogEntries(batch));
             }
+
+            // ResourceLogSource treats cancellation as an expected stream shutdown, so explicitly
+            // distinguish that from DCP completing every follow stream.
+            timeoutCts.Token.ThrowIfCancellationRequested();
+            completed = true;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -416,6 +428,9 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         // the same DCP log source again.
         SetPendingFollowLogDeduplication(resource.Metadata.Name, logEntries);
         _loggerService.AddLogEntries(resource.Metadata.Name, logEntries, inMemorySource: false, skipExisting: true);
+
+        // Only normal completion of a follow stream proves DCP has no more logs to deliver.
+        return follow && completed;
     }
 
     private static bool HasLogsAvailable(CustomResource resource)

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -39,6 +39,14 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
     private readonly ConcurrentDictionary<string, (CancellationTokenSource Cancellation, Task Task)> _logStreams = new();
     private readonly ConcurrentDictionary<string, PendingFollowLogDeduplication> _pendingFollowLogDeduplications = new();
+
+    // Last resource version seen for each DCP object, keyed by (object kind, object name). Used to
+    // recognize and drop watch replays. See ProcessResourceChange.
+    private readonly ConcurrentDictionary<(string Kind, string Name), string?> _resourceVersions = new();
+
+    // Holds names of resources that reached terminal state and logs have already been flushed for them. 
+    // Prevents re-reading DCP's log store every time an already-terminal resource is reported again.
+    private readonly ConcurrentDictionary<string, bool> _allLogsFlushed = new();
     private Task? _resourceWatchTask;
 
     private readonly record struct LogInformationEntry(string ResourceName, bool? LogsAvailable, bool? HasSubscribers);
@@ -265,6 +273,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     }
 
                     _pendingFollowLogDeduplications.TryRemove(resource.Metadata.Name, out _);
+                    _allLogsFlushed.TryRemove(resource.Metadata.Name, out _);
 
                     // TODO: Handle resource deletion
                     if (_logger.IsEnabled(LogLevel.Trace))
@@ -293,12 +302,25 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     // Only do this when a subscriber is active. Without subscribers there is no caller
                     // depending on the ordering, and GetAllAsync can still query DCP's external log
                     // store later without this extra read on every terminal transition.
-                    if (HasLogsAvailable(resource) &&
-                        status.State is not null &&
-                        KnownResourceStates.TerminalStates.Contains(status.State) &&
-                        _loggerService.HasActiveSubscribers(resource.Metadata.Name))
+                    //
+                    // Flush at most once for resources in terminal state. Every further notification for a resource
+                    // that is already terminal describes logs we have read, and the flush is awaited
+                    // while holding the watcher's single output semaphore, so repeating it stalls the
+                    // Container, Executable, ContainerExec, Service and Endpoint watches alike for up
+                    // to TerminalLogFlushTimeout. The marker is cleared below if the resource is restarted, 
+                    // so a restarted resource is flushed again when it terminates.
+                    if (status.State is not null && KnownResourceStates.TerminalStates.Contains(status.State))
                     {
-                        await FlushCurrentLogsAsync(resource, status, _shutdownToken).ConfigureAwait(false);
+                        if (HasLogsAvailable(resource) &&
+                            _loggerService.HasActiveSubscribers(resource.Metadata.Name) &&
+                            _allLogsFlushed.TryAdd(resource.Metadata.Name, true))
+                        {
+                            await FlushCurrentLogsAsync(resource, status, _shutdownToken).ConfigureAwait(false);
+                        }
+                    }
+                    else
+                    {
+                        _allLogsFlushed.TryRemove(resource.Metadata.Name, out _);
                     }
 
                     await _executorEvents.PublishAsync(new OnResourceChangedContext(_shutdownToken, resourceType, appModelResource, resource.Metadata.Name, status, s => snapshotFactory(resource, s))).ConfigureAwait(false);
@@ -710,20 +732,55 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         }
     }
 
-    private static bool ProcessResourceChange<T>(ConcurrentDictionary<string, T> map, WatchEventType watchEventType, T resource)
-            where T : CustomResource
+    private bool ProcessResourceChange<T>(ConcurrentDictionary<string, T> map, WatchEventType watchEventType, T resource)
+            where T : CustomResource, IKubernetesStaticMetadata
     {
+        var resourceKey = (T.ObjectKind, resource.Metadata.Name);
+
         switch (watchEventType)
         {
             case WatchEventType.Added:
-                map.TryAdd(resource.Metadata.Name, resource);
-                break;
-
             case WatchEventType.Modified:
+                // DCP watches are torn down and re-established every few minutes (see
+                // KubernetesService.WatchAsync, which wraps the watch in PeriodicRestartAsyncEnumerable).
+                // A watch is backed by a list-and-watch request, so each fresh watch re-delivers every
+                // object that currently exists, and those replays are indistinguishable from real
+                // updates. Without this check a resource that never changes again - a container stuck
+                // in FailedToStart, for example - keeps producing snapshot versions and keeps re-reading
+                // DCP's log store for as long as the AppHost runs.
+                // See https://github.com/microsoft/aspire/issues/18869.
+                //
+                // resourceVersion is the standard mechanism for detecting this: the server changes it
+                // whenever the stored object changes and leaves it alone otherwise, so a replay of an
+                // unchanged object carries the version we have already seen.
+                // https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
+                var resourceVersion = resource.Metadata.ResourceVersion;
+
+                // The value is opaque, so it is only compared for equality; ordering is explicitly not defined. 
+                // An empty value means the server did not supply one, which is treated as "cannot tell", 
+                // so the event is processed rather than risk suppressing a real change.
+                if (!string.IsNullOrEmpty(resourceVersion) &&
+                    _resourceVersions.TryGetValue(resourceKey, out var previousResourceVersion) &&
+                    string.Equals(previousResourceVersion, resourceVersion, StringComparison.Ordinal))
+                {
+                    if (_logger.IsEnabled(LogLevel.Trace))
+                    {
+                        _logger.LogTrace("Ignoring {ResourceKind} resource {ResourceName} reported by the DCP watch because its resource version {ResourceVersion} is unchanged.", T.ObjectKind, resource.Metadata.Name, resourceVersion);
+                    }
+
+                    return false;
+                }
+
+                // Added is treated like Modified rather than using TryAdd. A watch restart replays
+                // existing objects as Added, and if such an object changed while the watch was down,
+                // keeping the stale instance would leave the map disagreeing with both the version
+                // recorded here and the snapshot published to subscribers.
+                _resourceVersions[resourceKey] = resourceVersion;
                 map[resource.Metadata.Name] = resource;
                 break;
 
             case WatchEventType.Deleted:
+                _resourceVersions.TryRemove(resourceKey, out _);
                 map.Remove(resource.Metadata.Name, out _);
                 break;
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1547,13 +1547,28 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         builder.AddContainer("other", "image");
 
         string? blockingDcpResourceName = null;
+        var normalStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blockingFlushAttempts = 0;
         var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
         {
             if (obj.Metadata.Name == blockingDcpResourceName &&
-                obj is Container { Status.State: ContainerState.Exited } &&
+                obj is Container container &&
+                container.Status?.State != ContainerState.Exited &&
+                logStreamType == Logs.StreamTypeSystem &&
                 follow == true)
             {
-                return new Pipe().Reader.AsStream();
+                normalStreamStarted.TrySetResult();
+            }
+
+            if (obj.Metadata.Name == blockingDcpResourceName &&
+                obj is Container { Status.State: ContainerState.Exited } &&
+                logStreamType == Logs.StreamTypeStdErr &&
+                follow == true)
+            {
+                if (Interlocked.Increment(ref blockingFlushAttempts) == 1)
+                {
+                    return new Pipe().Reader.AsStream();
+                }
             }
 
             return new MemoryStream();
@@ -1563,14 +1578,22 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var dcpOptions = new DcpOptions { DashboardPath = "./dashboard" };
         var resourceLoggerService = new ResourceLoggerService();
         var otherTerminalNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blockingTerminalNotifications = 0;
         string? otherDcpResourceName = null;
 
         var events = new DcpExecutorEvents();
         events.Subscribe<OnResourceChangedContext>(context =>
         {
-            if (context.DcpResourceName == otherDcpResourceName && context.Status.State == ContainerState.Exited)
+            if (context.Status.State == ContainerState.Exited)
             {
-                otherTerminalNotification.TrySetResult();
+                if (context.DcpResourceName == blockingDcpResourceName)
+                {
+                    Interlocked.Increment(ref blockingTerminalNotifications);
+                }
+                else if (context.DcpResourceName == otherDcpResourceName)
+                {
+                    otherTerminalNotification.TrySetResult();
+                }
             }
 
             return Task.CompletedTask;
@@ -1586,6 +1609,9 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         otherDcpResourceName = otherContainer.Metadata.Name;
 
         using var subscription = resourceLoggerService.Subscribe(blockingDcpResourceName, _ => { });
+        blockingContainer.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(blockingContainer);
+        await normalStreamStarted.Task.DefaultTimeout();
 
         blockingContainer.Status = new ContainerStatus { State = ContainerState.Exited };
         kubernetesService.PushResourceModified(blockingContainer);
@@ -1594,6 +1620,16 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         kubernetesService.PushResourceModified(otherContainer);
 
         await otherTerminalNotification.Task.DefaultTimeout();
+
+        blockingContainer.Status = new ContainerStatus { State = ContainerState.Exited, ExitCode = 1 };
+        kubernetesService.PushResourceModified(blockingContainer);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => Volatile.Read(ref blockingTerminalNotifications) >= 2,
+            "The terminal state change after a timed-out flush should be reported.");
+
+        Assert.Equal(2, Volatile.Read(ref blockingTerminalNotifications));
+        Assert.Equal(2, Volatile.Read(ref blockingFlushAttempts));
     }
 
     [Fact]
@@ -1725,8 +1761,10 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         kubernetesService.PushResourceUnchanged(container);
 
         await AsyncTestHelpers.AssertIsTrueRetryAsync(
-            () => observedStates.Count(s => s == ContainerState.Exited) == 2,
+            () => observedStates.Count(s => s == ContainerState.Exited) >= 2,
             "Events without a resource version should always be processed.");
+
+        Assert.Equal(2, observedStates.Count(s => s == ContainerState.Exited));
     }
 
     [Fact]
@@ -1781,6 +1819,59 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         await AsyncTestHelpers.AssertIsTrueRetryAsync(
             () => observedStates.Contains(ContainerState.Exited),
             "The state change to Exited should be reported.");
+
+        AssertStatesReportedAfter(observedStates, ContainerState.Running, ContainerState.Exited);
+    }
+
+    [Fact]
+    public async Task ResourceWatch_RecreatedResourceWithPreviouslySeenVersionIsProcessed()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var observedStates = new ConcurrentQueue<string?>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.Resource.Name == "database")
+            {
+                observedStates.Enqueue(context.Status.State);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+
+        container.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => observedStates.Contains(ContainerState.Running),
+            "The state change to Running should be reported.");
+
+        // Resource versions are opaque, so a recreated object can carry a value that was already
+        // observed for the previous object with the same kind and name. The Deleted event must clear
+        // that version before the recreated object is delivered as Added.
+        kubernetesService.PushResourceDeleted(container);
+        container.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceUnchanged(container, k8s.WatchEventType.Added);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => observedStates.Contains(ContainerState.Exited),
+            "The recreated resource should be reported even when its resource version was seen before deletion.");
 
         AssertStatesReportedAfter(observedStates, ContainerState.Running, ContainerState.Exited);
     }
@@ -1844,7 +1935,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ResourceWatch_TerminalLogsAreFlushedOnlyOncePerTerminalPeriod()
+    public async Task ResourceWatch_FailedToStartLogsAreRetriedForEachChangedTerminalNotification()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -1853,12 +1944,12 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         builder.AddContainer("database", "image");
 
-        // A FailedToStart resource is flushed with a non-follow stream, so counting non-follow
-        // stream opens counts terminal log flushes without picking up normal log streaming.
         var flushStreamOpens = 0;
         var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
         {
-            if (follow == false)
+            if (obj is Container { Status.State: ContainerState.FailedToStart } &&
+                logStreamType == Logs.StreamTypeSystem &&
+                follow == false)
             {
                 Interlocked.Increment(ref flushStreamOpens);
             }
@@ -1898,21 +1989,118 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         kubernetesService.PushResourceModified(container);
 
         await AsyncTestHelpers.AssertIsTrueRetryAsync(
-            () => flushesAtNotification.Count == 1,
+            () => !flushesAtNotification.IsEmpty,
             "The terminal state should be reported.");
 
-        // A later change to a resource that is already terminal describes logs that were already
-        // read, so it must not trigger another read of the DCP log store.
+        // FailedToStart uses a point-in-time snapshot because there is no process stream that can
+        // complete. A later changed notification must retry in case DCP drained more logs meanwhile.
         container.Status = new ContainerStatus { State = ContainerState.FailedToStart, ExitCode = 1 };
         kubernetesService.PushResourceModified(container);
 
         await AsyncTestHelpers.AssertIsTrueRetryAsync(
-            () => flushesAtNotification.Count == 2,
+            () => flushesAtNotification.Count >= 2,
             "The follow-up change should be reported.");
 
-        var flushes = flushesAtNotification.ToArray();
-        Assert.True(flushes[0] > 0, "Entering the terminal state should flush the current logs.");
-        Assert.Equal(flushes[0], flushes[1]);
+        Assert.Equal([1, 2], flushesAtNotification.ToArray());
+    }
+
+    [Fact]
+    public async Task ResourceWatch_TerminalLogsAreFlushedOnlyOncePerTerminalPeriod()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        var normalStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var flushStreamOpens = 0;
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (obj is Container container &&
+                container.Status?.State != ContainerState.Exited &&
+                logStreamType == Logs.StreamTypeSystem &&
+                follow == true)
+            {
+                normalStreamStarted.TrySetResult();
+            }
+
+            if (obj is Container { Status.State: ContainerState.Exited } &&
+                logStreamType == Logs.StreamTypeSystem &&
+                follow == true)
+            {
+                Interlocked.Increment(ref flushStreamOpens);
+            }
+
+            return new MemoryStream();
+        });
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resourceLoggerService = new ResourceLoggerService();
+
+        string? dcpResourceName = null;
+        var flushesAtNotification = new ConcurrentQueue<int>();
+        var runningNotifications = 0;
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.DcpResourceName == dcpResourceName)
+            {
+                if (context.Status.State == ContainerState.Exited)
+                {
+                    flushesAtNotification.Enqueue(Volatile.Read(ref flushStreamOpens));
+                }
+                else if (context.Status.State == ContainerState.Running)
+                {
+                    Interlocked.Increment(ref runningNotifications);
+                }
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, resourceLoggerService: resourceLoggerService, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        dcpResourceName = container.Metadata.Name;
+
+        using var subscription = resourceLoggerService.Subscribe(dcpResourceName, _ => { });
+        container.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(container);
+        await normalStreamStarted.Task.DefaultTimeout();
+
+        container.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => !flushesAtNotification.IsEmpty,
+            "The first terminal state should be reported.");
+
+        container.Status = new ContainerStatus { State = ContainerState.Exited, ExitCode = 1 };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => flushesAtNotification.Count >= 2,
+            "The changed terminal state should be reported.");
+
+        container.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(container);
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => Volatile.Read(ref runningNotifications) >= 2,
+            "The resource restart should be reported.");
+
+        container.Status = new ContainerStatus { State = ContainerState.Exited, ExitCode = 2 };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => flushesAtNotification.Count >= 3,
+            "The terminal state after restart should be reported.");
+
+        Assert.Equal([1, 1, 2], flushesAtNotification.ToArray());
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1679,6 +1679,262 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceWatch_ResourceWithoutResourceVersionIsAlwaysProcessed()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var observedStates = new ConcurrentQueue<string?>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.Resource.Name == "database")
+            {
+                observedStates.Enqueue(context.Status.State);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+
+        container.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => observedStates.Contains(ContainerState.Running),
+            "The state change to Running should be reported.");
+
+        // Without a resource version there is no way to tell a replay from a change, so the watcher
+        // must fall back to processing the event. Suppressing it instead would freeze the resource.
+        container.Metadata.ResourceVersion = null;
+        container.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceUnchanged(container);
+        kubernetesService.PushResourceUnchanged(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => observedStates.Count(s => s == ContainerState.Exited) == 2,
+            "Events without a resource version should always be processed.");
+    }
+
+    [Fact]
+    public async Task ResourceWatch_UnchangedResourceNotificationIsIgnored()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var observedStates = new ConcurrentQueue<string?>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.Resource.Name == "database")
+            {
+                observedStates.Enqueue(context.Status.State);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+
+        container.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => observedStates.Contains(ContainerState.Running),
+            "The state change to Running should be reported.");
+
+        // Re-delivering the resource without a new resource version means nothing was stored, so it
+        // does not describe a change no matter which event type carries it.
+        kubernetesService.PushResourceUnchanged(container);
+        kubernetesService.PushResourceUnchanged(container, k8s.WatchEventType.Added);
+
+        // Pushing a real change afterwards acts as a barrier: the container watch is processed in
+        // order, so once Exited is observed the replays above have already been handled or dropped.
+        container.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => observedStates.Contains(ContainerState.Exited),
+            "The state change to Exited should be reported.");
+
+        AssertStatesReportedAfter(observedStates, ContainerState.Running, ContainerState.Exited);
+    }
+
+    [Fact]
+    public async Task ResourceWatch_WatchRestartDoesNotRepublishUnchangedResources()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var observedStates = new ConcurrentQueue<string?>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.Resource.Name == "database")
+            {
+                observedStates.Enqueue(context.Status.State);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+
+        // Park the container in a terminal state it will never leave, which is the situation
+        // described in https://github.com/microsoft/aspire/issues/18869.
+        container.Status = new ContainerStatus { State = ContainerState.FailedToStart };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => observedStates.Contains(ContainerState.FailedToStart),
+            "The state change to FailedToStart should be reported.");
+
+        // Re-establishing a watch replays every existing object, over and over for as long as the
+        // AppHost runs. None of those replays describe a change.
+        kubernetesService.SimulateWatchRestart();
+        kubernetesService.SimulateWatchRestart();
+
+        // A real change afterwards acts as a barrier: the container watch is processed in order, so
+        // once Exited is observed the replays above have already been handled or dropped.
+        container.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => observedStates.Contains(ContainerState.Exited),
+            "The state change to Exited should be reported.");
+
+        AssertStatesReportedAfter(observedStates, ContainerState.FailedToStart, ContainerState.Exited);
+    }
+
+    [Fact]
+    public async Task ResourceWatch_TerminalLogsAreFlushedOnlyOncePerTerminalPeriod()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        // A FailedToStart resource is flushed with a non-follow stream, so counting non-follow
+        // stream opens counts terminal log flushes without picking up normal log streaming.
+        var flushStreamOpens = 0;
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (follow == false)
+            {
+                Interlocked.Increment(ref flushStreamOpens);
+            }
+
+            return new MemoryStream();
+        });
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resourceLoggerService = new ResourceLoggerService();
+
+        string? dcpResourceName = null;
+        var flushesAtNotification = new ConcurrentQueue<int>();
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            // The flush completes before the resource change is published, so the count read here
+            // includes any flush performed for this notification.
+            if (context.DcpResourceName == dcpResourceName && context.Status.State == ContainerState.FailedToStart)
+            {
+                flushesAtNotification.Enqueue(Volatile.Read(ref flushStreamOpens));
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, resourceLoggerService: resourceLoggerService, events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        dcpResourceName = container.Metadata.Name;
+
+        using var subscription = resourceLoggerService.Subscribe(dcpResourceName, _ => { });
+
+        container.Status = new ContainerStatus { State = ContainerState.FailedToStart };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => flushesAtNotification.Count == 1,
+            "The terminal state should be reported.");
+
+        // A later change to a resource that is already terminal describes logs that were already
+        // read, so it must not trigger another read of the DCP log store.
+        container.Status = new ContainerStatus { State = ContainerState.FailedToStart, ExitCode = 1 };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => flushesAtNotification.Count == 2,
+            "The follow-up change should be reported.");
+
+        var flushes = flushesAtNotification.ToArray();
+        Assert.True(flushes[0] > 0, "Entering the terminal state should flush the current logs.");
+        Assert.Equal(flushes[0], flushes[1]);
+    }
+
+    /// <summary>
+    /// Asserts that the only states reported after the first occurrence of <paramref name="afterState"/>
+    /// are <paramref name="expectedStates"/>.
+    /// </summary>
+    /// <remarks>
+    /// Anchoring on a state instead of clearing the queue keeps the assertion independent of the
+    /// notifications raised while the app was starting, without racing against the watcher. The queue
+    /// must not be cleared here: <see cref="ConcurrentQueue{T}.Clear"/> is not safe to call while
+    /// another thread is still enqueuing.
+    /// </remarks>
+    private static void AssertStatesReportedAfter(ConcurrentQueue<string?> observedStates, string afterState, params string?[] expectedStates)
+    {
+        var states = observedStates.ToArray();
+        var anchor = Array.IndexOf(states, afterState);
+
+        Assert.True(anchor >= 0, $"Expected '{afterState}' to be reported but saw: {string.Join(", ", states)}");
+        Assert.Equal(expectedStates, states.Skip(anchor + 1));
+    }
+
+    [Fact]
     public async Task ResourceLogging_SystemStream_FormatsWithSysPrefix()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -156,6 +156,15 @@ internal sealed class TestKubernetesService : IKubernetesService
     }
 
     /// <summary>
+    /// Delivers a resource to the watchers as a <see cref="WatchEventType.Deleted"/> event without
+    /// assigning a new resource version.
+    /// </summary>
+    public void PushResourceDeleted(CustomResource resource)
+    {
+        PushResourceUnchanged(resource, WatchEventType.Deleted);
+    }
+
+    /// <summary>
     /// Replays every existing resource to the watchers as an <see cref="WatchEventType.Added"/> event,
     /// each carrying the resource version it already has.
     /// </summary>

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -217,6 +217,10 @@ internal sealed class TestKubernetesService : IKubernetesService
             service.Status ??= new ServiceStatus();
             service.Status.EffectiveAddress = service.Spec.Address ?? "localhost";
             service.Status.EffectivePort = hostPort ?? Interlocked.Increment(ref _nextPort);
+
+            // Made a change to the service, so it needs a new resource version.
+            StampResourceVersion(service);
+
             modifiedResources.Add(service);
         }
 

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -6,6 +6,7 @@ using Aspire.Hosting.Dcp.Model;
 using k8s;
 using System.Threading.Channels;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text;
@@ -28,6 +29,7 @@ internal sealed class TestKubernetesService : IKubernetesService
     private readonly Func<CustomResource, string, bool?, Stream> _startStream;
     private readonly bool _ignoreDeletes;
     private int _nextPort = StartOfAutoPortRange;
+    private int _nextResourceVersion;
 
     public TestKubernetesService(
         Func<CustomResource, string, Stream>? startStream = null,
@@ -64,14 +66,7 @@ internal sealed class TestKubernetesService : IKubernetesService
 
     public Task<T> CreateAsync<T>(T obj, CancellationToken cancellationToken = default) where T : CustomResource, IKubernetesStaticMetadata
     {
-        static T Clone(T r)
-        {
-            var serialized = JsonSerializer.Serialize(r);
-            var clone = JsonSerializer.Deserialize<T>(serialized);
-            return clone!;
-        }
-
-        var res = Clone(obj);
+        var res = Copy(obj);
 
         // "Allocate" port for a service.
         if (res is Service svc)
@@ -106,13 +101,18 @@ internal sealed class TestKubernetesService : IKubernetesService
         lock (CreatedResources)
         {
             var modifiedResources = AllocateProxylessContainerServicePorts(res);
+            StampResourceVersion(res);
             CreatedResources.Enqueue(res);
             foreach (var c in _watchChannels)
             {
-                c.Writer.TryWrite((WatchEventType.Added, res));
+                // Deliver a copy. A real DCP watch event carries an object deserialized from the
+                // response body, so it is never affected by later changes to the stored resource.
+                // Handing out the stored instance instead would let a test that mutates a resource
+                // change the content of events that were already queued.
+                c.Writer.TryWrite((WatchEventType.Added, Copy(res)));
                 foreach (var modifiedResource in modifiedResources)
                 {
-                    c.Writer.TryWrite((WatchEventType.Modified, modifiedResource));
+                    c.Writer.TryWrite((WatchEventType.Modified, Copy(modifiedResource)));
                 }
             }
         }
@@ -120,15 +120,79 @@ internal sealed class TestKubernetesService : IKubernetesService
         return Task.FromResult(res);
     }
 
+    /// <summary>
+    /// Delivers a resource to the watchers as a <see cref="WatchEventType.Modified"/> event, recording
+    /// it as a change by assigning a new resource version.
+    /// </summary>
     public void PushResourceModified(CustomResource resource)
+    {
+        lock (CreatedResources)
+        {
+            StampResourceVersion(resource);
+
+            foreach (var c in _watchChannels)
+            {
+                // Deliver a copy so the event content is fixed at the moment of the push, the same
+                // way a real DCP watch event is. Tests routinely mutate a resource and push it again,
+                // and without this the later mutation would also be seen by the earlier event.
+                c.Writer.TryWrite((WatchEventType.Modified, Copy(resource)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Re-delivers a resource to the watchers without recording a change, so the event carries the
+    /// resource version the resource already has.
+    /// </summary>
+    public void PushResourceUnchanged(CustomResource resource, WatchEventType eventType = WatchEventType.Modified)
     {
         lock (CreatedResources)
         {
             foreach (var c in _watchChannels)
             {
-                c.Writer.TryWrite((WatchEventType.Modified, resource));
+                c.Writer.TryWrite((eventType, Copy(resource)));
             }
         }
+    }
+
+    /// <summary>
+    /// Replays every existing resource to the watchers as an <see cref="WatchEventType.Added"/> event,
+    /// each carrying the resource version it already has.
+    /// </summary>
+    /// <remarks>
+    /// A DCP watch is backed by a list-and-watch request, so whenever the watch is re-established
+    /// every object that currently exists is delivered again. Aspire re-establishes its watches
+    /// periodically, which is what made https://github.com/microsoft/aspire/issues/18869 visible.
+    /// </remarks>
+    public void SimulateWatchRestart()
+    {
+        lock (CreatedResources)
+        {
+            foreach (var res in CreatedResources.Where(r => !DeletedResources.Contains(r.Metadata.Name)))
+            {
+                foreach (var c in _watchChannels)
+                {
+                    c.Writer.TryWrite((WatchEventType.Added, Copy(res)));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Assigns the next resource version to a resource, the way an API server does when it stores a
+    /// change. Real DCP populates this on every object it returns; the value is opaque to clients and
+    /// is only ever compared for equality.
+    /// </summary>
+    private void StampResourceVersion(CustomResource resource)
+    {
+        resource.Metadata.ResourceVersion = Interlocked.Increment(ref _nextResourceVersion).ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static T Copy<T>(T resource) where T : CustomResource
+    {
+        // Serialize against the runtime type so this also works when T is an abstract base type.
+        var type = resource.GetType();
+        return (T)JsonSerializer.Deserialize(JsonSerializer.Serialize(resource, type), type)!;
     }
 
     private List<CustomResource> AllocateProxylessContainerServicePorts(CustomResource resource)

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -264,7 +264,9 @@ internal sealed class TestKubernetesService : IKubernetesService
             _watchChannels.Add(chan);
             foreach (var res in CreatedResources.OfType<T>())
             {
-                chan.Writer.TryWrite((WatchEventType.Added, res));
+                // Deliver a copy, the same way the other fan-out sites do, so the content of this event is
+                // fixed at the moment it is produced instead of tracking later changes to the resource.
+                chan.Writer.TryWrite((WatchEventType.Added, Copy(res)));
             }
         }
 
@@ -323,11 +325,17 @@ internal sealed class TestKubernetesService : IKubernetesService
 
             var result = jsonPatch.Apply<T, T>(res);
 
+            // A patch changes the stored object, so it needs a new resource version. No watch event is
+            // emitted here - tests push one themselves when they need it - but leaving the version behind
+            // would make a later replay of this object look unchanged and be discarded by the watcher.
             if (res is Executable exe && result is Executable eu)
             {
+                var changed = false;
+
                 if (eu.Spec.Start is not null)
                 {
                     exe.Spec.Start = eu.Spec.Start;
+                    changed = true;
                 }
 
                 if (eu.Spec.Stop == true)
@@ -338,14 +346,23 @@ internal sealed class TestKubernetesService : IKubernetesService
                         exe.Status = new ExecutableStatus();
                     }
                     exe.Status.State = ExecutableState.Finished;
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    StampResourceVersion(exe);
                 }
             }
 
             if (res is Container ctr && result is Container cu)
             {
+                var changed = false;
+
                 if (cu.Spec.Start is not null)
                 {
                     ctr.Spec.Start = cu.Spec.Start;
+                    changed = true;
                 }
 
                 if (cu.Spec.Stop == true)
@@ -356,6 +373,12 @@ internal sealed class TestKubernetesService : IKubernetesService
                         ctr.Status = new ContainerStatus();
                     }
                     ctr.Status.State = ContainerState.Exited;
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    StampResourceVersion(ctr);
                 }
             }
 

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Aspire.Dashboard.Model;
+using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Utils;
 using Aspire.Hosting.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
@@ -1214,21 +1217,47 @@ public class ResourceNotificationTests
         var resource = new CustomResource("myResource");
         var notificationService = ResourceNotificationServiceTestHelpers.Create();
 
+        // UpdateCommands rebuilds command snapshots while retaining the annotation-owned arguments.
+        // Keep that same ownership shape here rather than defining deep equality for mutable inputs.
+        var commandArguments = Array.Empty<InteractionInput>();
+
         // Producers rebuild the snapshot collections every time. ImmutableArray equality compares the
         // underlying array reference, and a property value can itself be a collection, so this is the
         // case that plain record equality gets wrong. List<T> is covered explicitly because it does
         // not implement IStructuralEquatable: it is the shape DCP uses for effective arguments.
-        static CustomResourceSnapshot BuildSnapshot(CustomResourceSnapshot snapshot) => snapshot with
+        CustomResourceSnapshot BuildSnapshot(CustomResourceSnapshot snapshot) => snapshot with
         {
             State = "SomeState",
             Properties =
             [
-                new("Ports", ImmutableArray.Create(8080, 8081)),
+                new("Ports", ImmutableArray.Create(8080, 8081))
+                {
+                    DisplayName = "Ports",
+                    IsSensitive = true,
+                    IsHighlighted = true,
+                    SortOrder = 1
+                },
                 new("Args", new List<string> { "--verbose", "--port", "8080" }),
                 new("Tags", new[] { "a", "b" })
             ],
-            Urls = [new UrlSnapshot("ep", "http://localhost:8080", IsInternal: false)],
-            EnvironmentVariables = [new("Key", "Value", IsFromSpec: true)]
+            EnvironmentVariables = [new("Key", "Value", IsFromSpec: true)],
+            Urls =
+            [
+                new UrlSnapshot("ep", "http://localhost:8080", IsInternal: false)
+                {
+                    DisplayProperties = new("Endpoint", 1)
+                }
+            ],
+            Volumes = [new("/source", "/target", VolumeMountType.Bind, IsReadOnly: true)],
+            Commands = [CreateTestCommand(commandArguments)],
+            Relationships = [new("parent", "Parent")],
+            HealthReports =
+            [
+                new("health", HealthStatus.Healthy, "Healthy", ExceptionText: null)
+                {
+                    LastRunAt = DateTime.UnixEpoch
+                }
+            ]
         };
 
         await notificationService.PublishUpdateAsync(resource, BuildSnapshot).DefaultTimeout();
@@ -1254,9 +1283,301 @@ public class ResourceNotificationTests
         Assert.True(changed.Snapshot.Version > initial.Snapshot.Version, "A changed value inside a List<T> property should publish a new version.");
     }
 
+    [Fact]
+    public async Task PublishUpdateAsyncIgnoresVersionOnlyChanges()
+    {
+        var resource = new CustomResource("myResource");
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, static snapshot => snapshot).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState(resource.Name, out var initial));
+
+        await notificationService.PublishUpdateAsync(resource, snapshot => snapshot with
+        {
+            Version = snapshot.Version + 100
+        }).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState(resource.Name, out var unchanged));
+        Assert.Equal(initial.Snapshot.Version, unchanged.Snapshot.Version);
+    }
+
+    [Theory]
+    [MemberData(nameof(SnapshotContentPropertyNames))]
+    public async Task PublishUpdateAsyncPublishesEverySnapshotContentChange(string propertyName)
+    {
+        var property = GetContentProperty(
+            typeof(CustomResourceSnapshot),
+            propertyName,
+            s_snapshotContentPropertyExclusions);
+        var resource = new CustomResource("myResource");
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, static snapshot => snapshot).DefaultTimeout();
+        Assert.True(notificationService.TryGetCurrentState(resource.Name, out var initial));
+
+        await notificationService.PublishUpdateAsync(resource, snapshot => MutateProperty(snapshot, property)).DefaultTimeout();
+        Assert.True(notificationService.TryGetCurrentState(resource.Name, out var changed));
+
+        Assert.True(
+            changed.Snapshot.Version > initial.Snapshot.Version,
+            $"Changing {nameof(CustomResourceSnapshot)}.{propertyName} should publish a new snapshot.");
+    }
+
+    [Theory]
+    [MemberData(nameof(ResourcePropertyContentPropertyNames))]
+    public async Task PublishUpdateAsyncPublishesEveryResourcePropertyContentChange(string propertyName)
+    {
+        var property = GetContentProperty(typeof(ResourcePropertySnapshot), propertyName);
+        var resource = new CustomResource("myResource");
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, snapshot => snapshot with
+        {
+            Properties =
+            [
+                new ResourcePropertySnapshot("property", new List<string> { "original" })
+                {
+                    DisplayName = "Property",
+                    SortOrder = 1
+                }
+            ]
+        }).DefaultTimeout();
+        Assert.True(notificationService.TryGetCurrentState(resource.Name, out var initial));
+
+        await notificationService.PublishUpdateAsync(resource, snapshot => snapshot with
+        {
+            Properties = [MutateProperty(snapshot.Properties.Single(), property)]
+        }).DefaultTimeout();
+        Assert.True(notificationService.TryGetCurrentState(resource.Name, out var changed));
+
+        Assert.True(
+            changed.Snapshot.Version > initial.Snapshot.Version,
+            $"Changing {nameof(ResourcePropertySnapshot)}.{propertyName} should publish a new snapshot.");
+    }
+
     private static string[] GetWaitingForDependencies(ResourceEvent resourceEvent)
     {
         var property = resourceEvent.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.WaitingFor);
         return property?.Value is IEnumerable<string> dependencyNames ? dependencyNames.ToArray() : [];
+    }
+
+    public static TheoryData<string> SnapshotContentPropertyNames =>
+        CreatePropertyTheoryData(typeof(CustomResourceSnapshot), s_snapshotContentPropertyExclusions);
+
+    public static TheoryData<string> ResourcePropertyContentPropertyNames =>
+        CreatePropertyTheoryData(typeof(ResourcePropertySnapshot));
+
+    private static readonly string[] s_snapshotContentPropertyExclusions =
+    [
+        nameof(CustomResourceSnapshot.Version),
+        nameof(CustomResourceSnapshot.HealthStatus)
+    ];
+
+    private static TheoryData<string> CreatePropertyTheoryData(Type type, params string[] excludedPropertyNames)
+    {
+        var data = new TheoryData<string>();
+        foreach (var property in GetContentProperties(type, excludedPropertyNames))
+        {
+            data.Add(property.Name);
+        }
+
+        return data;
+    }
+
+    private static PropertyInfo GetContentProperty(Type type, string propertyName, params string[] excludedPropertyNames)
+    {
+        return GetContentProperties(type, excludedPropertyNames).Single(property => property.Name == propertyName);
+    }
+
+    private static PropertyInfo[] GetContentProperties(Type type, params string[] excludedPropertyNames)
+    {
+        const BindingFlags Flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+        var properties = type.GetProperties(Flags)
+            // EqualityContract is generated for records and describes their runtime type rather than
+            // snapshot content. Other get-only properties remain in the data so they fail loudly unless
+            // their mutation is implemented or they are intentionally excluded.
+            .Where(property => property.Name != "EqualityContract" ||
+                property.GetMethod?.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false) is not true)
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        var unknownExclusions = excludedPropertyNames
+            .Except(properties.Select(property => property.Name), StringComparer.Ordinal)
+            .ToArray();
+        if (unknownExclusions.Length > 0)
+        {
+            throw new InvalidOperationException($"Unknown excluded properties for {type}: {string.Join(", ", unknownExclusions)}.");
+        }
+
+        return properties
+            .Where(property => !excludedPropertyNames.Contains(property.Name, StringComparer.Ordinal))
+            .ToArray();
+    }
+
+    private static CustomResourceSnapshot MutateProperty(CustomResourceSnapshot snapshot, PropertyInfo property)
+    {
+        EnsurePropertyCanBeMutated(property);
+
+        var mutated = snapshot with { };
+        property.SetValue(mutated, CreateDifferentValue(property, property.GetValue(snapshot)));
+        return mutated;
+    }
+
+    private static ResourcePropertySnapshot MutateProperty(ResourcePropertySnapshot snapshot, PropertyInfo property)
+    {
+        EnsurePropertyCanBeMutated(property);
+
+        var mutated = snapshot with { };
+        property.SetValue(mutated, CreateDifferentValue(property, property.GetValue(snapshot)));
+        return mutated;
+    }
+
+    private static void EnsurePropertyCanBeMutated(PropertyInfo property)
+    {
+        if (property.GetSetMethod(nonPublic: true) is null)
+        {
+            throw new NotSupportedException(
+                $"{property.DeclaringType}.{property.Name} cannot be dynamically mutated. " +
+                $"Implement its mutation or add it to the intentional exclusions.");
+        }
+    }
+
+    private static object? CreateDifferentValue(PropertyInfo property, object? currentValue)
+    {
+        var type = property.PropertyType;
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ImmutableArray<>))
+        {
+            var elementType = type.GetGenericArguments()[0];
+            var addMethod = type.GetMethod(nameof(ImmutableArray<int>.Add), [elementType])
+                ?? throw new InvalidOperationException($"Could not find {type}.{nameof(ImmutableArray<int>.Add)}.");
+
+            // A fresh empty array would only change storage identity. Adding an element guarantees the
+            // snapshot's collection content is different and recursively exercises child record equality.
+            return addMethod.Invoke(currentValue, [CreateValue(elementType)]);
+        }
+
+        if (currentValue is null)
+        {
+            return CreateValue(type);
+        }
+
+        if (Nullable.GetUnderlyingType(type) is not null ||
+            (!type.IsValueType && new NullabilityInfoContext().Create(property).WriteState == NullabilityState.Nullable))
+        {
+            // The current value is non-null, so null is always a distinct value without requiring
+            // type-specific knowledge about the property's contents.
+            return null;
+        }
+
+        if (type == typeof(string))
+        {
+            return currentValue + "-changed";
+        }
+
+        if (type == typeof(bool))
+        {
+            return !(bool)currentValue;
+        }
+
+        if (type.IsEnum)
+        {
+            var values = Enum.GetValues(type);
+            if (values.Length < 2)
+            {
+                throw new NotSupportedException($"Cannot create a different value for single-value enum {type}.");
+            }
+
+            var currentIndex = Enumerable.Range(0, values.Length)
+                .Single(index => Equals(values.GetValue(index), currentValue));
+            return values.GetValue((currentIndex + 1) % values.Length);
+        }
+
+        var value = CreateValue(type);
+        if (Equals(currentValue, value))
+        {
+            throw new NotSupportedException($"Cannot create a different value for {type}. Extend {nameof(CreateDifferentValue)}.");
+        }
+
+        return value;
+    }
+
+    private static object CreateValue(Type type)
+    {
+        if (Nullable.GetUnderlyingType(type) is { } underlyingType)
+        {
+            return CreateValue(underlyingType);
+        }
+
+        if (type == typeof(string))
+        {
+            return "__comparison_test";
+        }
+
+        if (type == typeof(object))
+        {
+            return new object();
+        }
+
+        if (type == typeof(bool))
+        {
+            return true;
+        }
+
+        if (type == typeof(int))
+        {
+            return 1;
+        }
+
+        if (type == typeof(long))
+        {
+            return 1L;
+        }
+
+        if (type == typeof(DateTime))
+        {
+            return DateTime.UnixEpoch;
+        }
+
+        if (type == typeof(Task))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (type.IsEnum)
+        {
+            return Enum.GetValues(type).GetValue(0)
+                ?? throw new NotSupportedException($"Enum {type} has no values.");
+        }
+
+        // Snapshot child records expose a primary constructor and a generated copy constructor.
+        // Exclude the copy constructor because value generation has no existing instance to supply.
+        var constructor = type
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(constructor =>
+            {
+                var parameters = constructor.GetParameters();
+                return parameters.Length != 1 || parameters[0].ParameterType != type;
+            })
+            .OrderByDescending(constructor => constructor.GetParameters().Length)
+            .FirstOrDefault()
+            ?? throw new NotSupportedException($"Cannot create a value for {type}. Extend {nameof(CreateValue)}.");
+        var arguments = constructor.GetParameters()
+            .Select(parameter => CreateValue(parameter.ParameterType))
+            .ToArray();
+
+        return constructor.Invoke(arguments);
+    }
+
+    private static ResourceCommandSnapshot CreateTestCommand(IReadOnlyList<InteractionInput> arguments)
+    {
+#pragma warning disable CS0618 // Parameter remains part of the compatibility constructor.
+        return new("command", ResourceCommandState.Enabled, "Command", DisplayDescription: null, Parameter: null, ConfirmationMessage: null, IconName: null, IconVariant: null, IsHighlighted: false)
+        {
+            Arguments = arguments
+        };
+#pragma warning restore CS0618
     }
 }

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Utils;
 using Aspire.Hosting.Tests.Utils;
@@ -1183,6 +1184,74 @@ public class ResourceNotificationTests
         {
             _stoppingCts.Dispose();
         }
+    }
+
+    [Fact]
+    public async Task PublishUpdateAsyncSkipsSnapshotsThatDidNotChange()
+    {
+        var resource = new CustomResource("myResource");
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        await notificationService.PublishUpdateAsync(resource, snapshot => snapshot with { State = "SomeState" }).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("myResource", out var initial));
+
+        await notificationService.PublishUpdateAsync(resource, snapshot => snapshot with { State = "SomeState" }).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("myResource", out var unchanged));
+        Assert.Equal(initial.Snapshot.Version, unchanged.Snapshot.Version);
+
+        await notificationService.PublishUpdateAsync(resource, snapshot => snapshot with { State = "SomeOtherState" }).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("myResource", out var changed));
+        Assert.True(changed.Snapshot.Version > initial.Snapshot.Version, "A real change should publish a new version.");
+        Assert.Equal("SomeOtherState", changed.Snapshot.State?.Text);
+    }
+
+    [Fact]
+    public async Task PublishUpdateAsyncSkipsUnchangedSnapshotsWithRebuiltCollections()
+    {
+        var resource = new CustomResource("myResource");
+        var notificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        // Producers rebuild the snapshot collections every time. ImmutableArray equality compares the
+        // underlying array reference, and a property value can itself be a collection, so this is the
+        // case that plain record equality gets wrong. List<T> is covered explicitly because it does
+        // not implement IStructuralEquatable: it is the shape DCP uses for effective arguments.
+        static CustomResourceSnapshot BuildSnapshot(CustomResourceSnapshot snapshot) => snapshot with
+        {
+            State = "SomeState",
+            Properties =
+            [
+                new("Ports", ImmutableArray.Create(8080, 8081)),
+                new("Args", new List<string> { "--verbose", "--port", "8080" }),
+                new("Tags", new[] { "a", "b" })
+            ],
+            Urls = [new UrlSnapshot("ep", "http://localhost:8080", IsInternal: false)],
+            EnvironmentVariables = [new("Key", "Value", IsFromSpec: true)]
+        };
+
+        await notificationService.PublishUpdateAsync(resource, BuildSnapshot).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("myResource", out var initial));
+
+        await notificationService.PublishUpdateAsync(resource, BuildSnapshot).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("myResource", out var unchanged));
+        Assert.Equal(initial.Snapshot.Version, unchanged.Snapshot.Version);
+
+        await notificationService.PublishUpdateAsync(resource, snapshot => BuildSnapshot(snapshot) with
+        {
+            Properties =
+            [
+                new("Ports", ImmutableArray.Create(8080, 8081)),
+                new("Args", new List<string> { "--verbose", "--port", "9090" }),
+                new("Tags", new[] { "a", "b" })
+            ]
+        }).DefaultTimeout();
+
+        Assert.True(notificationService.TryGetCurrentState("myResource", out var changed));
+        Assert.True(changed.Snapshot.Version > initial.Snapshot.Version, "A changed value inside a List<T> property should publish a new version.");
     }
 
     private static string[] GetWaitingForDependencies(ResourceEvent resourceEvent)


### PR DESCRIPTION
## Description

Fixes an issue where Aspire model would repeatedly emit object update notifications for unchanged objects.

Fixes https://github.com/microsoft/aspire/issues/18869

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
