### PR TITLE
Add resource icons to all hosting integration packages

### DIFF
--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -82,6 +82,7 @@ public static class AzureAppConfigurationExtensions
 
         var resource = new AzureAppConfigurationResource(name, configureInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("Settings")
             .WithDefaultRoleAssignments(AppConfigurationBuiltInRole.GetBuiltInRoleName,
                 AppConfigurationBuiltInRole.AppConfigurationDataOwner);
     }

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppExtensions.cs
@@ -1200,7 +1200,7 @@ public static class AzureContainerAppExtensions
         var resource = new AzureContainerRegistryResource(name, configureInfrastructure);
         if (builder.ExecutionContext.IsPublishMode)
         {
-            builder.AddResource(resource);
+            builder.AddResource(resource).WithIconName("Archive");
         }
         return resource;
     }

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -298,7 +298,7 @@ public static partial class AzureAppServiceEnvironmentExtensions
 
         // Create the resource builder first, then attach the registry to avoid recreating builders
         var appServiceEnvBuilder = builder.ExecutionContext.IsPublishMode
-            ? builder.AddResource(resource)
+            ? builder.AddResource(resource).WithIconName("Globe")
             : builder.CreateResourceBuilder(resource);
 
         appServiceEnvBuilder.WithCrossScopeAcrPullIdentity(

--- a/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentExtensions.cs
@@ -551,7 +551,7 @@ public static partial class AzureAppServiceEnvironmentExtensions
         var resource = new AzureContainerRegistryResource(name, ContainerRegistryInfrastructure.ConfigureContainerRegistry);
         if (builder.ExecutionContext.IsPublishMode)
         {
-            builder.AddResource(resource);
+            builder.AddResource(resource).WithIconName("Archive");
         }
         return resource;
     }

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -114,7 +114,8 @@ public static class AzureApplicationInsightsExtensions
 
         var resource = new AzureApplicationInsightsResource(name, configureInfrastructure);
 
-        var rb = builder.AddResource(resource);
+        var rb = builder.AddResource(resource)
+            .WithIconName("ChartMultiple");
 
         if (logAnalyticsWorkspace != null)
         {

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -116,6 +116,7 @@ public static class AzureOpenAIExtensions
 
         var resource = new AzureOpenAIResource(name, configureInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("BrainCircuit")
             .WithDefaultRoleAssignments(CognitiveServicesBuiltInRole.GetBuiltInRoleName,
                 CognitiveServicesBuiltInRole.CognitiveServicesOpenAIUser);
     }
@@ -197,7 +198,8 @@ public static class AzureOpenAIExtensions
         var deployment = new AzureOpenAIDeploymentResource(name, modelName, modelVersion, builder.Resource);
         builder.Resource.AddDeployment(deployment);
 
-        return builder.ApplicationBuilder.AddResource(deployment);
+        return builder.ApplicationBuilder.AddResource(deployment)
+            .WithIconName("BrainCircuit");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ContainerRegistry/AzureContainerRegistryExtensions.cs
@@ -49,6 +49,7 @@ public static class AzureContainerRegistryExtensions
         else
         {
             resourceBuilder = builder.AddResource(resource)
+                .WithIconName("Archive")
                 .WithAnnotation(new DefaultRoleAssignmentsAnnotation(new HashSet<RoleDefinition>()));
         }
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -43,6 +43,7 @@ public static class AzureCosmosExtensions
 
         var resource = new AzureCosmosDBResource(name, ConfigureCosmosDBInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("DatabaseMultiple")
             .WithAnnotation(new DefaultRoleAssignmentsAnnotation(new HashSet<RoleDefinition>()));
     }
 
@@ -354,7 +355,8 @@ public static class AzureCosmosExtensions
         var database = new AzureCosmosDBDatabaseResource(name, databaseName, builder.Resource);
         builder.Resource.Databases.Add(database);
 
-        return builder.ApplicationBuilder.AddResource(database);
+        return builder.ApplicationBuilder.AddResource(database)
+            .WithIconName("Database");
     }
 
     /// <summary>
@@ -378,7 +380,8 @@ public static class AzureCosmosExtensions
         var container = new AzureCosmosDBContainerResource(name, containerName, partitionKeyPath, builder.Resource);
         builder.Resource.Containers.Add(container);
 
-        return builder.ApplicationBuilder.AddResource(container);
+        return builder.ApplicationBuilder.AddResource(container)
+            .WithIconName("Box");
     }
 
     /// <summary>
@@ -435,7 +438,8 @@ public static class AzureCosmosExtensions
 
         builder.Resource.Containers.Add(container);
 
-        return builder.ApplicationBuilder.AddResource(container);
+        return builder.ApplicationBuilder.AddResource(container)
+            .WithIconName("Box");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -127,6 +127,7 @@ public static class AzureEventHubsExtensions
 
         var resource = new AzureEventHubsResource(name, configureInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("MailMultiple")
             .WithDefaultRoleAssignments(EventHubsBuiltInRole.GetBuiltInRoleName,
                 EventHubsBuiltInRole.AzureEventHubsDataOwner);
     }
@@ -168,7 +169,8 @@ public static class AzureEventHubsExtensions
         var hub = new AzureEventHubResource(name, hubName, builder.Resource);
         builder.Resource.Hubs.Add(hub);
 
-        return builder.ApplicationBuilder.AddResource(hub);
+        return builder.ApplicationBuilder.AddResource(hub)
+            .WithIconName("Mail");
     }
 
     /// <summary>
@@ -212,7 +214,8 @@ public static class AzureEventHubsExtensions
         var consumerGroup = new AzureEventHubConsumerGroupResource(name, groupName, builder.Resource);
         builder.Resource.ConsumerGroups.Add(consumerGroup);
 
-        return builder.ApplicationBuilder.AddResource(consumerGroup);
+        return builder.ApplicationBuilder.AddResource(consumerGroup)
+            .WithIconName("Mail");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
+++ b/src/Aspire.Hosting.Azure.FrontDoor/AzureFrontDoorExtensions.cs
@@ -155,7 +155,7 @@ public static class AzureFrontDoorExtensions
         var resource = new AzureFrontDoorResource(name, configureInfrastructure);
 
         return builder.ExecutionContext.IsPublishMode
-            ? builder.AddResource(resource)
+            ? builder.AddResource(resource).WithIconName("GlobeArrowForward")
             : builder.CreateResourceBuilder(resource);
     }
 

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -187,6 +187,7 @@ public static class AzureFunctionsProjectResourceExtensions
 
 #pragma warning disable ASPIREEXTENSION001 // WithDebugSupport is experimental
         var functionsBuilder = builder.AddResource(resource)
+            .WithIconName("Flash")
             .WithAnnotation(projectMetadata)
             .WithAnnotation(new AzureFunctionsAnnotation())
             .WithDebugSupport(mode => new AzureFunctionsLaunchConfiguration { ProjectPath = projectMetadata.ProjectPath, Mode = mode }, "azure-functions");

--- a/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskResourceExtensions.cs
@@ -35,7 +35,8 @@ public static class DurableTaskResourceExtensions
 
         scheduler.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
 
-        return builder.AddResource(scheduler);
+        return builder.AddResource(scheduler)
+            .WithIconName("CalendarClock");
     }
 
     /// <summary>
@@ -220,7 +221,8 @@ public static class DurableTaskResourceExtensions
 
         hub.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
 
-        var hubBuilder = builder.ApplicationBuilder.AddResource(hub);
+        var hubBuilder = builder.ApplicationBuilder.AddResource(hub)
+            .WithIconName("CalendarClock");
 
         hubBuilder.OnResourceReady(
             async (r, e, ct) =>

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -143,6 +143,7 @@ public static partial class AzureKeyVaultResourceExtensions
 
         var resource = new AzureKeyVaultResource(name, configureInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("Vault")
             .WithDefaultRoleAssignments(KeyVaultBuiltInRole.GetBuiltInRoleName,
                 KeyVaultBuiltInRole.KeyVaultSecretsUser);
     }
@@ -297,7 +298,7 @@ public static partial class AzureKeyVaultResourceExtensions
         var secret = new AzureKeyVaultSecretResource(name, name, builder.Resource, parameterResource);
         builder.Resource.Secrets.Add(secret);
 
-        return builder.ApplicationBuilder.AddResource(secret).ExcludeFromManifest();
+        return builder.ApplicationBuilder.AddResource(secret).WithIconName("LockClosed").ExcludeFromManifest();
     }
 
     /// <summary>
@@ -318,7 +319,7 @@ public static partial class AzureKeyVaultResourceExtensions
         var secret = new AzureKeyVaultSecretResource(name, name, builder.Resource, value);
         builder.Resource.Secrets.Add(secret);
 
-        return builder.ApplicationBuilder.AddResource(secret).ExcludeFromManifest();
+        return builder.ApplicationBuilder.AddResource(secret).WithIconName("LockClosed").ExcludeFromManifest();
     }
 
     /// <summary>
@@ -357,7 +358,7 @@ public static partial class AzureKeyVaultResourceExtensions
         var secret = new AzureKeyVaultSecretResource(name, secretName, builder.Resource, parameterResource);
         builder.Resource.Secrets.Add(secret);
 
-        return builder.ApplicationBuilder.AddResource(secret).ExcludeFromManifest();
+        return builder.ApplicationBuilder.AddResource(secret).WithIconName("LockClosed").ExcludeFromManifest();
     }
 
     /// <summary>
@@ -379,7 +380,7 @@ public static partial class AzureKeyVaultResourceExtensions
         var secret = new AzureKeyVaultSecretResource(name, secretName, builder.Resource, value);
         builder.Resource.Secrets.Add(secret);
 
-        return builder.ApplicationBuilder.AddResource(secret).ExcludeFromManifest();
+        return builder.ApplicationBuilder.AddResource(secret).WithIconName("LockClosed").ExcludeFromManifest();
     }
 
     private static void ValidateSecretName(string secretName)

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
@@ -186,6 +186,7 @@ public static class AzureKubernetesEnvironmentExtensions
         }
 
         return builder.ApplicationBuilder.AddResource(nodePool)
+            .WithIconName("Cpu")
             .ExcludeFromManifest();
     }
 
@@ -477,6 +478,7 @@ public static class AzureKubernetesEnvironmentExtensions
         }
 
         return builder.ApplicationBuilder.AddResource(lb)
+            .WithIconName("GlobeArrowForward")
             .ExcludeFromManifest();
     }
 

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentExtensions.cs
@@ -131,7 +131,8 @@ public static class AzureKubernetesEnvironmentExtensions
             }
         }));
 
-        return builder.AddResource(resource);
+        return builder.AddResource(resource)
+            .WithIconName("ServerMultiple");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -161,6 +161,7 @@ public partial class AzureKubernetesEnvironmentResource
 
         var defaultPool = new AksNodePoolResource("workload", defaultConfig, environment);
         defaultPool.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
+        defaultPool.Annotations.Add(new ResourceIconAnnotation("Cpu"));
         appModel.Resources.Add(defaultPool);
         return defaultPool;
     }
@@ -188,6 +189,7 @@ public partial class AzureKubernetesEnvironmentResource
         var config = environment.NodePools.First(p => p.Name == poolName);
         var pool = new AksNodePoolResource(poolName, config, environment);
         pool.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
+        pool.Annotations.Add(new ResourceIconAnnotation("Cpu"));
         appModel.Resources.Add(pool);
         return pool;
     }

--- a/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Kusto/AzureKustoBuilderExtensions.cs
@@ -88,7 +88,8 @@ public static class AzureKustoBuilderExtensions
         };
 
         var resource = new AzureKustoClusterResource(name, configureInfrastructure);
-        var resourceBuilder = builder.AddResource(resource);
+        var resourceBuilder = builder.AddResource(resource)
+            .WithIconName("DatabaseMultiple");
 
         AddKustoHealthChecksAndLifecycleManagement(resourceBuilder);
         AddKustoCustomCommands(resourceBuilder);
@@ -116,7 +117,8 @@ public static class AzureKustoBuilderExtensions
 
         var kustoDatabase = new AzureKustoReadWriteDatabaseResource(name, databaseName, builder.Resource);
         builder.Resource.Databases.Add(kustoDatabase);
-        var resourceBuilder = builder.ApplicationBuilder.AddResource(kustoDatabase);
+        var resourceBuilder = builder.ApplicationBuilder.AddResource(kustoDatabase)
+            .WithIconName("Database");
 
         // Register a health check that will be used to verify database is available
         KustoConnectionStringBuilder? kcsb = null;

--- a/src/Aspire.Hosting.Azure.Network/AzureNetworkSecurityGroupExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureNetworkSecurityGroupExtensions.cs
@@ -52,7 +52,8 @@ public static class AzureNetworkSecurityGroupExtensions
             return builder.CreateResourceBuilder(resource);
         }
 
-        return builder.AddResource(resource);
+        return builder.AddResource(resource)
+            .WithIconName("ShieldLock");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -106,7 +106,8 @@ public static class AzureVirtualNetworkExtensions
             return builder.CreateResourceBuilder(resource);
         }
 
-        return builder.AddResource(resource);
+        return builder.AddResource(resource)
+            .WithIconName("Router");
     }
 
     private static void ConfigureVirtualNetwork(AzureResourceInfrastructure infra)

--- a/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Network/AzureVirtualNetworkExtensions.cs
@@ -275,6 +275,7 @@ public static class AzureVirtualNetworkExtensions
         }
 
         return builder.ApplicationBuilder.AddResource(subnet)
+            .WithIconName("Router")
             .ExcludeFromManifest();
     }
 

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
@@ -59,6 +59,7 @@ public static class AzureLogAnalyticsWorkspaceExtensions
         };
 
         var resource = new AzureLogAnalyticsWorkspaceResource(name, configureInfrastructure);
-        return builder.AddResource(resource);
+        return builder.AddResource(resource)
+            .WithIconName("ChartMultiple");
     }
 }

--- a/src/Aspire.Hosting.Azure.Redis/AzureManagedRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureManagedRedisExtensions.cs
@@ -57,6 +57,7 @@ public static class AzureManagedRedisExtensions
 
         var resource = new AzureManagedRedisResource(name, ConfigureRedisInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("Database")
             .WithAnnotation(new DefaultRoleAssignmentsAnnotation(new HashSet<RoleDefinition>()));
     }
 

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -123,6 +123,7 @@ public static class AzureRedisExtensions
 
         var resource = new AzureRedisCacheResource(name, ConfigureRedisInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("Database")
             .WithAnnotation(new DefaultRoleAssignmentsAnnotation(new HashSet<RoleDefinition>()));
     }
 

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -42,6 +42,7 @@ public static class AzureSearchExtensions
 
         AzureSearchResource resource = new(name, ConfigureSearch);
         return builder.AddResource(resource)
+            .WithIconName("Search")
             .WithDefaultRoleAssignments(SearchBuiltInRole.GetBuiltInRoleName,
                 SearchBuiltInRole.SearchIndexDataContributor,
                 SearchBuiltInRole.SearchServiceContributor);

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -139,6 +139,7 @@ public static class AzureServiceBusExtensions
 
         var resource = new AzureServiceBusResource(name, configureInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("MailMultiple")
             .WithDefaultRoleAssignments(ServiceBusBuiltInRole.GetBuiltInRoleName,
                 ServiceBusBuiltInRole.AzureServiceBusDataOwner);
     }
@@ -182,7 +183,8 @@ public static class AzureServiceBusExtensions
         var queue = new AzureServiceBusQueueResource(name, queueName, builder.Resource);
         builder.Resource.Queues.Add(queue);
 
-        return builder.ApplicationBuilder.AddResource(queue);
+        return builder.ApplicationBuilder.AddResource(queue)
+            .WithIconName("Mail");
     }
 
     /// <summary>
@@ -267,7 +269,8 @@ public static class AzureServiceBusExtensions
         var topic = new AzureServiceBusTopicResource(name, topicName, builder.Resource);
         builder.Resource.Topics.Add(topic);
 
-        return builder.ApplicationBuilder.AddResource(topic);
+        return builder.ApplicationBuilder.AddResource(topic)
+            .WithIconName("Mail");
     }
 
     /// <summary>
@@ -339,7 +342,8 @@ public static class AzureServiceBusExtensions
         var subscription = new AzureServiceBusSubscriptionResource(name, subscriptionName, builder.Resource);
         builder.Resource.Subscriptions.Add(subscription);
 
-        return builder.ApplicationBuilder.AddResource(subscription);
+        return builder.ApplicationBuilder.AddResource(subscription)
+            .WithIconName("Mail");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -124,6 +124,7 @@ public static class AzureSignalRExtensions
 
         var resource = new AzureSignalRResource(name, configureInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("MailMultiple")
             .WithDefaultRoleAssignments(SignalRBuiltInRole.GetBuiltInRoleName, defaultRoles.ToArray());
     }
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -654,6 +654,7 @@ public static class AzureStorageExtensions
 
         return builder.ApplicationBuilder
             .AddResource(resource)
+            .WithIconName("Mail")
             .WithHealthCheck(healthCheckKey)
             .OnConnectionStringAvailable(async (containerResource, @event, ct) =>
             {

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -160,6 +160,7 @@ public static class AzureStorageExtensions
         var resource = new AzureStorageResource(name, configureInfrastructure);
 
         return builder.AddResource(resource)
+            .WithIconName("HardDrive")
             .WithDefaultRoleAssignments(StorageBuiltInRole.GetBuiltInRoleName,
                 StorageBuiltInRole.StorageBlobDataContributor,
                 StorageBuiltInRole.StorageTableDataContributor,
@@ -495,6 +496,7 @@ public static class AzureStorageExtensions
 
         return builder.ApplicationBuilder
             .AddResource(resource)
+            .WithIconName("FolderOpen")
             .WithHealthCheck(healthCheckKey)
             .OnConnectionStringAvailable(async (containerResource, @event, ct) =>
             {
@@ -525,7 +527,8 @@ public static class AzureStorageExtensions
         builder.Resource.DataLakeFileSystems.Add(resource);
 
         return builder.ApplicationBuilder
-            .AddResource(resource);
+            .AddResource(resource)
+            .WithIconName("FolderOpen");
     }
 
     /// <summary>
@@ -561,7 +564,7 @@ public static class AzureStorageExtensions
             name: healthCheckKey);
 
         return builder.ApplicationBuilder
-            .AddResource(resource).WithHealthCheck(healthCheckKey);
+            .AddResource(resource).WithIconName("FolderOpen").WithHealthCheck(healthCheckKey);
     }
 
     /// <summary>
@@ -792,6 +795,7 @@ public static class AzureStorageExtensions
 
         return builder.ApplicationBuilder
             .AddResource(resource)
+            .WithIconName("DocumentMultiple")
             .WithHealthCheck(healthCheckKey)
             .OnConnectionStringAvailable(async (blobs, @event, ct) =>
             {
@@ -804,13 +808,15 @@ public static class AzureStorageExtensions
         var resource = new AzureDataLakeStorageResource(name, builder.Resource);
 
         return builder.ApplicationBuilder
-            .AddResource(resource);
+            .AddResource(resource)
+            .WithIconName("HardDrive");
     }
 
     private static IResourceBuilder<AzureTableStorageResource> CreateTableService(IResourceBuilder<AzureStorageResource> builder, string name)
     {
         var resource = new AzureTableStorageResource(name, builder.Resource);
-        return builder.ApplicationBuilder.AddResource(resource);
+        return builder.ApplicationBuilder.AddResource(resource)
+            .WithIconName("TableSimple");
     }
 
     private static IResourceBuilder<AzureQueueStorageResource> CreateQueueService(IResourceBuilder<AzureStorageResource> builder, string name)
@@ -831,6 +837,7 @@ public static class AzureStorageExtensions
 
         return builder.ApplicationBuilder
             .AddResource(resource)
+            .WithIconName("Mail")
             .WithHealthCheck(healthCheckKey)
             .OnConnectionStringAvailable(async (queues, @event, ct) =>
             {

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -149,6 +149,7 @@ public static class AzureWebPubSubExtensions
 
         var resource = new AzureWebPubSubResource(name, configureInfrastructure);
         return builder.AddResource(resource)
+            .WithIconName("MailMultiple")
             .WithDefaultRoleAssignments(WebPubSubBuiltInRole.GetBuiltInRoleName,
                 WebPubSubBuiltInRole.WebPubSubServiceOwner);
     }

--- a/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeEnvironmentExtensions.cs
@@ -97,7 +97,8 @@ public static class DockerComposeEnvironmentExtensions
             return builder.CreateResourceBuilder(resource);
         }
 
-        return builder.AddResource(resource);
+        return builder.AddResource(resource)
+            .WithIconName("BoxMultiple");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Dotnet/DotnetProjectHostingExtensions.cs
+++ b/src/Aspire.Hosting.Dotnet/DotnetProjectHostingExtensions.cs
@@ -124,6 +124,7 @@ public static class DotnetProjectHostingExtensions
 
         var resource = builder.AddResource(app)
                               .WithAnnotation(projectMetadata)
+                              .WithIconName("CodeCsRectangle")
                               .WithProjectDefaults(options);
 
         // Build the `dotnet run` command line for a non-debug launch of a DotnetProjectResource:

--- a/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/Project/ProjectBuilderExtension.cs
@@ -707,7 +707,7 @@ public static class AzureCognitiveServicesProjectExtensions
     private static AzureContainerRegistryResource CreateDefaultRegistry(IDistributedApplicationBuilder builder, string name)
     {
         var resource = new AzureContainerRegistryResource(name, ContainerRegistryInfrastructure.ConfigureContainerRegistry);
-        builder.AddResource(resource);
+        builder.AddResource(resource).WithIconName("Archive");
         return resource;
     }
 

--- a/src/Aspire.Hosting.Garnet/GarnetBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Garnet/GarnetBuilderExtensions.cs
@@ -130,6 +130,7 @@ public static class GarnetBuilderExtensions
             .WithEndpoint(port: port, targetPort: 6379, name: GarnetResource.PrimaryEndpointName)
             .WithImage(GarnetContainerImageTags.Image, GarnetContainerImageTags.Tag)
             .WithImageRegistry(GarnetContainerImageTags.Registry)
+            .WithIconName("Database")
             .WithHealthCheck(healthCheckKey)
             // see https://github.com/microsoft/aspire/issues/3838 for why the password is passed this way
             .WithEntrypoint("/bin/sh")

--- a/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
+++ b/src/Aspire.Hosting.GitHub.Models/GitHubModelsExtensions.cs
@@ -51,6 +51,7 @@ public static class GitHubModelsExtensions
         defaultApiKeyParameter.WithParentRelationship(resource);
 
         return builder.AddResource(resource)
+            .WithIconName("BrainCircuit")
             .WithInitialState(new()
             {
                 ResourceType = "GitHubModel",

--- a/src/Aspire.Hosting.Go/GoHostingExtensions.cs
+++ b/src/Aspire.Hosting.Go/GoHostingExtensions.cs
@@ -88,6 +88,7 @@ public static class GoHostingExtensions
         var resource = new GoAppResource(name, appDirectory);
 
         var rb = builder.AddResource(resource)
+            .WithIconName("Code")
             .WithArgs(ctx =>
             {
                 var programArgs = ctx.Resource.TryGetLastAnnotation<GoAppArgsAnnotation>(out var argsAnnotation)

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -76,6 +76,7 @@ public static class KafkaBuilderExtensions
             .WithEndpoint(targetPort: KafkaInternalBrokerPort, name: KafkaServerResource.InternalEndpointName)
             .WithImage(KafkaContainerImageTags.Image, KafkaContainerImageTags.Tag)
             .WithImageRegistry(KafkaContainerImageTags.Registry)
+            .WithIconName("MailMultiple")
             .WithEnvironment(context => ConfigureKafkaContainer(context, kafka))
             .WithHealthCheck(healthCheckKey);
     }
@@ -110,6 +111,7 @@ public static class KafkaBuilderExtensions
             var kafkaUiBuilder = builder.ApplicationBuilder.AddResource(kafkaUi)
                 .WithImage(KafkaContainerImageTags.KafkaUiImage, KafkaContainerImageTags.KafkaUiTag)
                 .WithImageRegistry(KafkaContainerImageTags.Registry)
+                .WithIconName("WindowDatabase")
                 .WithHttpEndpoint(targetPort: KafkaUIPort)
                 .ExcludeFromManifest();
 

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -70,6 +70,7 @@ public static class KeycloakResourceBuilderExtensions
             .WithImage(KeycloakContainerImageTags.Image)
             .WithImageRegistry(KeycloakContainerImageTags.Registry)
             .WithImageTag(KeycloakContainerImageTags.Tag)
+            .WithIconName("PersonLock")
             .WithHttpEndpoint(port: port, targetPort: DefaultContainerPort)
             .WithHttpEndpoint(targetPort: ManagementInterfaceContainerPort, name: ManagementEndpointName)
             .WithEndpoint(ManagementEndpointName, e => e.ExcludeReferenceEndpoint = true)

--- a/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
@@ -125,7 +125,7 @@ public static class CertManagerExtensions
             return builder.ApplicationBuilder.CreateResourceBuilder(resource);
         }
 
-        var resourceBuilder = builder.ApplicationBuilder.AddResource(resource).ExcludeFromManifest();
+        var resourceBuilder = builder.ApplicationBuilder.AddResource(resource).WithIconName("Certificate").ExcludeFromManifest();
 
         // Emit one kubectl-apply step per ClusterIssuer at deploy time, plus one kubectl-delete
         // step per ClusterIssuer at destroy time. The annotation factory closures capture the
@@ -167,7 +167,7 @@ public static class CertManagerExtensions
             return builder.ApplicationBuilder.CreateResourceBuilder(issuer);
         }
 
-        return builder.ApplicationBuilder.AddResource(issuer).ExcludeFromManifest();
+        return builder.ApplicationBuilder.AddResource(issuer).WithIconName("ContactCard").ExcludeFromManifest();
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
@@ -255,6 +255,7 @@ public static class KubernetesEnvironmentExtensions
         }
 
         return builder.ApplicationBuilder.AddResource(nodePool)
+            .WithIconName("ServerMultiple")
             .ExcludeFromManifest();
     }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentExtensions.cs
@@ -102,7 +102,8 @@ public static class KubernetesEnvironmentExtensions
 
         }
 
-        var resourceBuilder = builder.AddResource(resource);
+        var resourceBuilder = builder.AddResource(resource)
+            .WithIconName("ServerMultiple");
 
         // Default to Helm deployment engine if not already configured
         EnsureDefaultHelmEngine(resourceBuilder);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -46,7 +46,7 @@ public static class KubernetesGatewayExtensions
         }
 
         return builder.ApplicationBuilder.AddResource(gateway)
-            .WithIconName("ArrowRouting")
+            .WithIconName("GlobeArrowForward")
             .ExcludeFromManifest();
     }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayExtensions.cs
@@ -46,6 +46,7 @@ public static class KubernetesGatewayExtensions
         }
 
         return builder.ApplicationBuilder.AddResource(gateway)
+            .WithIconName("ArrowRouting")
             .ExcludeFromManifest();
     }
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesHelmChartExtensions.cs
@@ -83,7 +83,8 @@ public static partial class KubernetesHelmChartExtensions
             return builder.ApplicationBuilder.CreateResourceBuilder(resource);
         }
 
-        var chartBuilder = builder.ApplicationBuilder.AddResource(resource);
+        var chartBuilder = builder.ApplicationBuilder.AddResource(resource)
+            .WithIconName("Archive");
 
         chartBuilder.WithAnnotation(new PipelineStepAnnotation(_ =>
         {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressExtensions.cs
@@ -54,6 +54,7 @@ public static class KubernetesIngressExtensions
         }
 
         return builder.ApplicationBuilder.AddResource(ingress)
+            .WithIconName("GlobeArrowForward")
             .ExcludeFromManifest();
     }
 

--- a/src/Aspire.Hosting.Maui/MauiAndroidExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiAndroidExtensions.cs
@@ -196,7 +196,7 @@ public static class MauiAndroidExtensions
             "Android",
             "net10.0-android",
             () => true, // Allow on all platforms, validation happens at dotnet run time
-            "PhoneTablet",
+            "PhoneLaptop",
             additionalArgs.ToArray());
 
         resourceBuilder.WithMauiIdeLaunchConfiguration(
@@ -401,7 +401,7 @@ public static class MauiAndroidExtensions
             "Android",
             "net10.0-android",
             () => true, // Allow on all platforms, validation happens at dotnet run time
-            "PhoneTablet",
+            "PhoneLaptop",
             additionalArgs.ToArray());
 
         resourceBuilder.WithMauiIdeLaunchConfiguration(

--- a/src/Aspire.Hosting.Maui/MauiiOSExtensions.cs
+++ b/src/Aspire.Hosting.Maui/MauiiOSExtensions.cs
@@ -205,7 +205,7 @@ public static class MauiiOSExtensions
             "iOS",
             "net10.0-ios",
             OperatingSystem.IsMacOS, // iOS development requires macOS
-            "PhoneTablet",
+            "PhoneLaptop",
             additionalArgs.ToArray());
 
         resourceBuilder.WithMauiIdeLaunchConfiguration(
@@ -408,7 +408,7 @@ public static class MauiiOSExtensions
             "iOS",
             "net10.0-ios",
             OperatingSystem.IsMacOS, // iOS development requires macOS
-            "PhoneTablet",
+            "PhoneLaptop",
             additionalArgs.ToArray());
 
         resourceBuilder.WithMauiIdeLaunchConfiguration(

--- a/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
@@ -56,6 +56,7 @@ public static class MilvusBuilderExtensions
         return builder.AddResource(milvus)
             .WithImage(MilvusContainerImageTags.Image, MilvusContainerImageTags.Tag)
             .WithImageRegistry(MilvusContainerImageTags.Registry)
+            .WithIconName("DatabaseMultiple")
             .WithHttpEndpoint(port: grpcPort, targetPort: MilvusPortGrpc, name: MilvusServerResource.PrimaryEndpointName)
             .WithEndpoint(MilvusServerResource.PrimaryEndpointName, endpoint =>
             {
@@ -108,7 +109,8 @@ public static class MilvusBuilderExtensions
 
         builder.Resource.AddDatabase(name, databaseName);
         var milvusDatabaseResource = new MilvusDatabaseResource(name, databaseName, builder.Resource);
-        return builder.ApplicationBuilder.AddResource(milvusDatabaseResource);
+        return builder.ApplicationBuilder.AddResource(milvusDatabaseResource)
+            .WithIconName("Database");
     }
 
     /// <summary>
@@ -147,6 +149,7 @@ public static class MilvusBuilderExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(attuContainer)
                                                         .WithImage(MilvusContainerImageTags.AttuImage, MilvusContainerImageTags.AttuTag)
                                                         .WithImageRegistry(MilvusContainerImageTags.Registry)
+                                                        .WithIconName("WindowDatabase")
                                                         .WithHttpEndpoint(targetPort: 3000, name: "http")
                                                         .WithEnvironment(context => ConfigureAttuContainer(context, builder.Resource))
                                                         .ExcludeFromManifest();

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -87,6 +87,7 @@ public static class MongoDBBuilderExtensions
             .WithEndpoint(port: port, targetPort: DefaultContainerPort, name: MongoDBServerResource.PrimaryEndpointName)
             .WithImage(MongoDBContainerImageTags.Image, MongoDBContainerImageTags.Tag)
             .WithImageRegistry(MongoDBContainerImageTags.Registry)
+            .WithIconName("DatabaseMultiple")
             .WithEnvironment(context =>
             {
                 context.EnvironmentVariables[UserEnvVarName] = mongoDBContainer.UserNameReference;
@@ -139,6 +140,7 @@ public static class MongoDBBuilderExtensions
 
         return builder.ApplicationBuilder
             .AddResource(mongoDBDatabase)
+            .WithIconName("Database")
             .WithHealthCheck(healthCheckKey);
     }
 
@@ -165,6 +167,7 @@ public static class MongoDBBuilderExtensions
         var resourceBuilder = builder.ApplicationBuilder.AddResource(mongoExpressContainer)
                                                         .WithImage(MongoDBContainerImageTags.MongoExpressImage, MongoDBContainerImageTags.MongoExpressTag)
                                                         .WithImageRegistry(MongoDBContainerImageTags.MongoExpressRegistry)
+                                                        .WithIconName("WindowDatabase")
                                                         .WithEnvironment(context => ConfigureMongoExpressContainer(context, builder.Resource))
                                                         .WithHttpEndpoint(targetPort: 8081, name: "http")
                                                         .WithParentRelationship(builder)

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -142,6 +142,7 @@ public static class MySqlBuilderExtensions
 
         return builder.ApplicationBuilder
             .AddResource(mySqlDatabase)
+            .WithIconName("Database")
             .WithHealthCheck(healthCheckKey);
     }
 

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -97,6 +97,7 @@ public static class NatsBuilderExtensions
             .WithEndpoint(targetPort: 4222, port: port, name: NatsServerResource.PrimaryEndpointName)
             .WithImage(NatsContainerImageTags.Image, NatsContainerImageTags.Tag)
             .WithImageRegistry(NatsContainerImageTags.Registry)
+            .WithIconName("MailMultiple")
             .WithHealthCheck(healthCheckKey)
             .WithArgs(context =>
             {

--- a/src/Aspire.Hosting.OpenAI/OpenAIExtensions.cs
+++ b/src/Aspire.Hosting.OpenAI/OpenAIExtensions.cs
@@ -62,6 +62,7 @@ public static class OpenAIExtensions
             tags: ["openai", "healthcheck"]));
 
         return builder.AddResource(resource)
+            .WithIconName("BrainCircuit")
             .WithInitialState(new()
             {
                 ResourceType = "OpenAI",
@@ -110,6 +111,7 @@ public static class OpenAIExtensions
         var resource = new OpenAIModelResource(name, model, builder.Resource);
 
         return builder.ApplicationBuilder.AddResource(resource)
+            .WithIconName("BrainCircuit")
             .WithInitialState(new()
             {
                 ResourceType = "OpenAI Model",

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -90,7 +90,8 @@ public static class OracleDatabaseBuilderExtensions
 
         builder.Resource.AddDatabase(name, databaseName);
         var oracleDatabase = new OracleDatabaseResource(name, databaseName, builder.Resource);
-        return builder.ApplicationBuilder.AddResource(oracleDatabase);
+        return builder.ApplicationBuilder.AddResource(oracleDatabase)
+            .WithIconName("Database");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -174,6 +174,7 @@ public static class PostgresBuilderExtensions
 
         return builder.ApplicationBuilder
             .AddResource(postgresDatabase)
+            .WithIconName("Database")
             .WithHealthCheck(healthCheckKey);
     }
 
@@ -208,6 +209,7 @@ public static class PostgresBuilderExtensions
             var pgAdminContainerBuilder = builder.ApplicationBuilder.AddResource(pgAdminContainer)
                                                  .WithImage(PostgresContainerImageTags.PgAdminImage, PostgresContainerImageTags.PgAdminTag)
                                                  .WithImageRegistry(PostgresContainerImageTags.PgAdminRegistry)
+                                                 .WithIconName("WindowDatabase")
                                                  .WithHttpEndpoint(targetPort: 80, name: "http")
                                                  .WithEnvironment(SetPgAdminEnvironmentVariables)
                                                  .WithHttpHealthCheck("/browser")
@@ -318,6 +320,7 @@ public static class PostgresBuilderExtensions
             var pgwebContainerBuilder = builder.ApplicationBuilder.AddResource(pgwebContainer)
                                                .WithImage(PostgresContainerImageTags.PgWebImage, PostgresContainerImageTags.PgWebTag)
                                                .WithImageRegistry(PostgresContainerImageTags.PgWebRegistry)
+                                               .WithIconName("WindowDatabase")
                                                .WithHttpEndpoint(targetPort: 8081, name: "http")
                                                .WithArgs("--bookmarks-dir=/.pgweb/bookmarks")
                                                .WithArgs("--sessions")

--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -71,6 +71,7 @@ public static class QdrantBuilderExtensions
         return builder.AddResource(qdrant)
             .WithImage(QdrantContainerImageTags.Image, QdrantContainerImageTags.Tag)
             .WithImageRegistry(QdrantContainerImageTags.Registry)
+            .WithIconName("DatabaseSearch")
             .WithHttpEndpoint(port: grpcPort, targetPort: QdrantPortGrpc, name: QdrantServerResource.PrimaryEndpointName)
             .WithEndpoint(QdrantServerResource.PrimaryEndpointName, endpoint =>
             {

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -76,6 +76,7 @@ public static class RabbitMQBuilderExtensions
         var rabbitmq = builder.AddResource(rabbitMq)
                               .WithImage(RabbitMQContainerImageTags.Image, RabbitMQContainerImageTags.Tag)
                               .WithImageRegistry(RabbitMQContainerImageTags.Registry)
+                              .WithIconName("MailMultiple")
                               .WithEndpoint(port: port, targetPort: 5672, name: RabbitMQServerResource.PrimaryEndpointName)
                               .WithEnvironment(context =>
                               {

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -96,6 +96,7 @@ public static class RedisBuilderExtensions
             .WithEndpoint(port: port, targetPort: 6379, name: RedisResource.PrimaryEndpointName, scheme: RedisResource.StandardRedisScheme)
             .WithImage(RedisContainerImageTags.Image, RedisContainerImageTags.Tag)
             .WithImageRegistry(RedisContainerImageTags.Registry)
+            .WithIconName("Database")
             .WithHealthCheck(healthCheckKey)
             // see https://github.com/microsoft/aspire/issues/3838 for why the password is passed this way
             .WithEntrypoint("/bin/sh")
@@ -240,6 +241,7 @@ public static class RedisBuilderExtensions
             var resourceBuilder = builder.ApplicationBuilder.AddResource(resource)
                                       .WithImage(RedisContainerImageTags.RedisCommanderImage, RedisContainerImageTags.RedisCommanderTag)
                                       .WithImageRegistry(RedisContainerImageTags.RedisCommanderRegistry)
+                                      .WithIconName("WindowDatabase")
                                       .WithHttpEndpoint(targetPort: 8081, name: "http")
                                       .ExcludeFromManifest();
 
@@ -319,6 +321,7 @@ public static class RedisBuilderExtensions
             var resourceBuilder = builder.ApplicationBuilder.AddResource(resource)
                 .WithImage(RedisContainerImageTags.RedisInsightImage, RedisContainerImageTags.RedisInsightTag)
                 .WithImageRegistry(RedisContainerImageTags.RedisInsightRegistry)
+                .WithIconName("WindowDatabase")
                 .WithHttpEndpoint(targetPort: 5540, name: "http")
                 .WithEnvironment(context =>
                 {

--- a/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
@@ -57,6 +57,7 @@ public static class SeqBuilderExtensions
             .WithHttpEndpoint(port: port, targetPort: 80, name: SeqResource.PrimaryEndpointName)
             .WithImage(SeqContainerImageTags.Image, SeqContainerImageTags.Tag)
             .WithImageRegistry(SeqContainerImageTags.Registry)
+            .WithIconName("ClipboardPulse")
             .WithEnvironment("ACCEPT_EULA", "Y")
             .WithHttpHealthCheck("/health"); // Add health check for Seq's /health endpoint
 

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -135,6 +135,7 @@ public static partial class SqlServerBuilderExtensions
 
         return builder.ApplicationBuilder
             .AddResource(sqlServerDatabase)
+            .WithIconName("Database")
             .WithHealthCheck(healthCheckKey)
             .OnConnectionStringAvailable(async (sqlServerDatabase, @event, ct) =>
             {

--- a/src/Aspire.Hosting.Valkey/ValkeyBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Valkey/ValkeyBuilderExtensions.cs
@@ -145,6 +145,7 @@ public static class ValkeyBuilderExtensions
             .WithEndpoint(port: port, targetPort: 6379, name: ValkeyResource.PrimaryEndpointName)
             .WithImage(ValkeyContainerImageTags.Image, ValkeyContainerImageTags.Tag)
             .WithImageRegistry(ValkeyContainerImageTags.Registry)
+            .WithIconName("Database")
             .WithHealthCheck(healthCheckKey)
             // see https://github.com/microsoft/aspire/issues/3838 for why the password is passed this way
             .WithEntrypoint("/bin/sh")

--- a/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
+++ b/src/Aspire.Hosting.Yarp/YarpResourceExtensions.cs
@@ -39,6 +39,7 @@ public static class YarpResourceExtensions
                       .WithImage(YarpContainerImageTags.Image)
                       .WithImageRegistry(YarpContainerImageTags.Registry)
                       .WithImageTag(YarpContainerImageTags.Tag)
+                      .WithIconName("GlobeArrowForward")
                       .WithEnvironment("ASPNETCORE_ENVIRONMENT", builder.Environment.EnvironmentName)
                       .WithEntrypoint("dotnet")
                       .WithArgs("/app/yarp.dll")

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -4732,7 +4732,7 @@ public static class ResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrWhiteSpace(iconName);
 
-        return builder.WithAnnotation(new ResourceIconAnnotation(iconName, iconVariant));
+        return builder.WithAnnotation(new ResourceIconAnnotation(iconName, iconVariant), ResourceAnnotationMutationBehavior.Replace);
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Tests/WithIconNameTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithIconNameTests.cs
@@ -87,16 +87,15 @@ public class WithIconNameTests
                               .WithIconName("Database")
                               .WithIconName("CloudArrowUp", IconVariant.Regular);
 
-        // Should have both annotations (WithIconName adds, doesn't replace)
+        // Should replace the first annotation — only one should exist
         var iconAnnotations = container.Resource.Annotations.OfType<ResourceIconAnnotation>().ToList();
-        Assert.Equal(2, iconAnnotations.Count);
-        
-        // Get the latest one - this is what ResourceNotificationService should use
-        var latestAnnotation = iconAnnotations.Last();
-        Assert.Equal("CloudArrowUp", latestAnnotation.IconName);
-        Assert.Equal(IconVariant.Regular, latestAnnotation.IconVariant);
-        
-        // Verify that TryGetLastAnnotation returns the correct one
+        Assert.Single(iconAnnotations);
+
+        var annotation = iconAnnotations[0];
+        Assert.Equal("CloudArrowUp", annotation.IconName);
+        Assert.Equal(IconVariant.Regular, annotation.IconVariant);
+
+        // TryGetLastAnnotation should return the same result
         Assert.True(container.Resource.TryGetLastAnnotation<ResourceIconAnnotation>(out var lastAnnotation));
         Assert.Equal("CloudArrowUp", lastAnnotation.IconName);
         Assert.Equal(IconVariant.Regular, lastAnnotation.IconVariant);


### PR DESCRIPTION
## Description

Adds explicit resource icons to all Aspire hosting integration packages that didn't have them. Without these icons, resources fall back to generic type-based heuristics in the dashboard (container → box, project → code, etc.), which loses semantic meaning. With explicit icons, users can immediately tell at a glance what kind of resource they're looking at in the Aspire dashboard — whether it's a database, message broker, AI model, or cloud service.

Icons are set via `.WithIconName("IconName")` which attaches a `ResourceIconAnnotation` to the resource builder. The dashboard resolves them from the FluentUI Filled icon set.

This should fix most of #11602 

### Resource → Icon mapping

| Resource Type | Package | Icon Name | Icon |
|---|---|---|:---:|
| `RedisResource` | Aspire.Hosting.Redis | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `RedisCommanderResource` | Aspire.Hosting.Redis | `WindowDatabase` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Window%20Database/SVG/ic_fluent_window_database_20_filled.svg" height="20"> |
| `RedisInsightResource` | Aspire.Hosting.Redis | `WindowDatabase` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Window%20Database/SVG/ic_fluent_window_database_20_filled.svg" height="20"> |
| `GarnetResource` | Aspire.Hosting.Garnet | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `ValkeyResource` | Aspire.Hosting.Valkey | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `AzureRedisCacheResource` | Aspire.Hosting.Azure.Redis | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `AzureManagedRedisResource` | Aspire.Hosting.Azure.Redis | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `MongoDBServerResource` | Aspire.Hosting.MongoDB | `DatabaseMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database%20Multiple/SVG/ic_fluent_database_multiple_20_filled.svg" height="20"> |
| `MongoDBDatabaseResource` | Aspire.Hosting.MongoDB | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `MongoExpressContainerResource` | Aspire.Hosting.MongoDB | `WindowDatabase` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Window%20Database/SVG/ic_fluent_window_database_20_filled.svg" height="20"> |
| `PostgresDatabaseResource` | Aspire.Hosting.PostgreSQL | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `PgAdminContainerResource` | Aspire.Hosting.PostgreSQL | `WindowDatabase` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Window%20Database/SVG/ic_fluent_window_database_20_filled.svg" height="20"> |
| `PgWebContainerResource` | Aspire.Hosting.PostgreSQL | `WindowDatabase` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Window%20Database/SVG/ic_fluent_window_database_20_filled.svg" height="20"> |
| `MySqlDatabaseResource` | Aspire.Hosting.MySql | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `SqlServerDatabaseResource` | Aspire.Hosting.SqlServer | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `OracleDatabaseResource` | Aspire.Hosting.Oracle | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `MilvusServerResource` | Aspire.Hosting.Milvus | `DatabaseMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database%20Multiple/SVG/ic_fluent_database_multiple_20_filled.svg" height="20"> |
| `MilvusDatabaseResource` | Aspire.Hosting.Milvus | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `AttuResource` | Aspire.Hosting.Milvus | `WindowDatabase` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Window%20Database/SVG/ic_fluent_window_database_20_filled.svg" height="20"> |
| `QdrantServerResource` | Aspire.Hosting.Qdrant | `DatabaseSearch` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database%20Search/SVG/ic_fluent_database_search_20_filled.svg" height="20"> |
| `KafkaServerResource` | Aspire.Hosting.Kafka | `MailMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail%20Multiple/SVG/ic_fluent_mail_multiple_20_filled.svg" height="20"> |
| `KafkaUIContainerResource` | Aspire.Hosting.Kafka | `WindowDatabase` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Window%20Database/SVG/ic_fluent_window_database_20_filled.svg" height="20"> |
| `RabbitMQServerResource` | Aspire.Hosting.RabbitMQ | `MailMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail%20Multiple/SVG/ic_fluent_mail_multiple_20_filled.svg" height="20"> |
| `NatsServerResource` | Aspire.Hosting.Nats | `MailMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail%20Multiple/SVG/ic_fluent_mail_multiple_20_filled.svg" height="20"> |
| `SeqResource` | Aspire.Hosting.Seq | `ClipboardPulse` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Clipboard%20Pulse/SVG/ic_fluent_clipboard_pulse_20_filled.svg" height="20"> |
| `KeycloakResource` | Aspire.Hosting.Keycloak | `PersonLock` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Person%20Lock/SVG/ic_fluent_person_lock_20_filled.svg" height="20"> |
| `YarpResource` | Aspire.Hosting.Yarp | `GlobeArrowForward` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Globe%20Arrow%20Forward/SVG/ic_fluent_globe_arrow_forward_20_filled.svg" height="20"> |
| `OpenAIResource` | Aspire.Hosting.OpenAI | `BrainCircuit` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Brain%20Circuit/SVG/ic_fluent_brain_circuit_20_filled.svg" height="20"> |
| `OpenAIModelResource` | Aspire.Hosting.OpenAI | `BrainCircuit` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Brain%20Circuit/SVG/ic_fluent_brain_circuit_20_filled.svg" height="20"> |
| `GitHubModelResource` | Aspire.Hosting.GitHub.Models | `BrainCircuit` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Brain%20Circuit/SVG/ic_fluent_brain_circuit_20_filled.svg" height="20"> |
| `DotnetProjectResource` | Aspire.Hosting.Dotnet | `CodeCsRectangle` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Code%20Cs%20Rectangle/SVG/ic_fluent_code_cs_rectangle_16_filled.svg" height="20"> |
| `GoAppResource` | Aspire.Hosting.Go | `Code` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Code/SVG/ic_fluent_code_20_filled.svg" height="20"> |
| MAUI Android/iOS device resources | Aspire.Hosting.Maui | `PhoneLaptop` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Phone%20Laptop/SVG/ic_fluent_phone_laptop_20_filled.svg" height="20"> |
| `DockerComposeEnvironmentResource` | Aspire.Hosting.Docker | `BoxMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Box%20Multiple/SVG/ic_fluent_box_multiple_20_filled.svg" height="20"> |
| `KubernetesEnvironmentResource` | Aspire.Hosting.Kubernetes | `ServerMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Server%20Multiple/SVG/ic_fluent_server_multiple_20_filled.svg" height="20"> |
| `KubernetesHelmChartResource` | Aspire.Hosting.Kubernetes | `Archive` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Archive/SVG/ic_fluent_archive_20_filled.svg" height="20"> |
| `KubernetesGatewayResource` | Aspire.Hosting.Kubernetes | `GlobeArrowForward` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Globe%20Arrow%20Forward/SVG/ic_fluent_globe_arrow_forward_20_filled.svg" height="20"> |
| `KubernetesIngressResource` | Aspire.Hosting.Kubernetes | `GlobeArrowForward` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Globe%20Arrow%20Forward/SVG/ic_fluent_globe_arrow_forward_20_filled.svg" height="20"> |
| `CertManagerResource` | Aspire.Hosting.Kubernetes | `Certificate` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Certificate/SVG/ic_fluent_certificate_20_filled.svg" height="20"> |
| `CertManagerIssuerResource` | Aspire.Hosting.Kubernetes | `ContactCard` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Contact%20Card/SVG/ic_fluent_contact_card_20_filled.svg" height="20"> |
| `AzureCosmosDBResource` | Aspire.Hosting.Azure.CosmosDB | `DatabaseMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database%20Multiple/SVG/ic_fluent_database_multiple_20_filled.svg" height="20"> |
| `AzureCosmosDBDatabaseResource` | Aspire.Hosting.Azure.CosmosDB | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `AzureCosmosDBContainerResource` | Aspire.Hosting.Azure.CosmosDB | `Box` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Box/SVG/ic_fluent_box_20_filled.svg" height="20"> |
| `AzureKustoClusterResource` | Aspire.Hosting.Azure.Kusto | `DatabaseMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database%20Multiple/SVG/ic_fluent_database_multiple_20_filled.svg" height="20"> |
| `AzureKustoReadWriteDatabaseResource` | Aspire.Hosting.Azure.Kusto | `Database` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> |
| `AzureEventHubsResource` | Aspire.Hosting.Azure.EventHubs | `MailMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail%20Multiple/SVG/ic_fluent_mail_multiple_20_filled.svg" height="20"> |
| `AzureEventHubResource` | Aspire.Hosting.Azure.EventHubs | `Mail` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail/SVG/ic_fluent_mail_20_filled.svg" height="20"> |
| `AzureEventHubConsumerGroupResource` | Aspire.Hosting.Azure.EventHubs | `Mail` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail/SVG/ic_fluent_mail_20_filled.svg" height="20"> |
| `AzureServiceBusResource` | Aspire.Hosting.Azure.ServiceBus | `MailMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail%20Multiple/SVG/ic_fluent_mail_multiple_20_filled.svg" height="20"> |
| `AzureServiceBusQueueResource` | Aspire.Hosting.Azure.ServiceBus | `Mail` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail/SVG/ic_fluent_mail_20_filled.svg" height="20"> |
| `AzureServiceBusTopicResource` | Aspire.Hosting.Azure.ServiceBus | `Mail` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail/SVG/ic_fluent_mail_20_filled.svg" height="20"> |
| `AzureServiceBusSubscriptionResource` | Aspire.Hosting.Azure.ServiceBus | `Mail` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail/SVG/ic_fluent_mail_20_filled.svg" height="20"> |
| `AzureStorageResource` | Aspire.Hosting.Azure.Storage | `HardDrive` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Hard%20Drive/SVG/ic_fluent_hard_drive_20_filled.svg" height="20"> |
| `AzureBlobStorageResource` | Aspire.Hosting.Azure.Storage | `DocumentMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Document%20Multiple/SVG/ic_fluent_document_multiple_20_filled.svg" height="20"> |
| `AzureBlobStorageContainerResource` | Aspire.Hosting.Azure.Storage | `FolderOpen` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Folder%20Open/SVG/ic_fluent_folder_open_20_filled.svg" height="20"> |
| `AzureDataLakeStorageResource` | Aspire.Hosting.Azure.Storage | `HardDrive` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Hard%20Drive/SVG/ic_fluent_hard_drive_20_filled.svg" height="20"> |
| `AzureDataLakeStorageFileSystemResource` | Aspire.Hosting.Azure.Storage | `FolderOpen` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Folder%20Open/SVG/ic_fluent_folder_open_20_filled.svg" height="20"> |
| `AzureTableStorageResource` | Aspire.Hosting.Azure.Storage | `TableSimple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Table%20Simple/SVG/ic_fluent_table_simple_20_filled.svg" height="20"> |
| `AzureQueueStorageResource` | Aspire.Hosting.Azure.Storage | `Mail` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail/SVG/ic_fluent_mail_20_filled.svg" height="20"> |
| `AzureQueueStorageQueueResource` | Aspire.Hosting.Azure.Storage | `Mail` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail/SVG/ic_fluent_mail_20_filled.svg" height="20"> |
| `AzureKeyVaultResource` | Aspire.Hosting.Azure.KeyVault | `Vault` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Vault/SVG/ic_fluent_vault_20_filled.svg" height="20"> |
| `AzureKeyVaultSecretResource` | Aspire.Hosting.Azure.KeyVault | `LockClosed` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Lock%20Closed/SVG/ic_fluent_lock_closed_20_filled.svg" height="20"> |
| `AzureSearchResource` | Aspire.Hosting.Azure.Search | `Search` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Search/SVG/ic_fluent_search_20_filled.svg" height="20"> |
| `AzureAppConfigurationResource` | Aspire.Hosting.Azure.AppConfiguration | `Settings` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Settings/SVG/ic_fluent_settings_20_filled.svg" height="20"> |
| `AzureFunctionsProjectResource` | Aspire.Hosting.Azure.Functions | `Flash` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Flash/SVG/ic_fluent_flash_20_filled.svg" height="20"> |
| `DurableTaskSchedulerResource` | Aspire.Hosting.Azure.Functions | `CalendarClock` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Calendar%20Clock/SVG/ic_fluent_calendar_clock_20_filled.svg" height="20"> |
| `DurableTaskHubResource` | Aspire.Hosting.Azure.Functions | `CalendarClock` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Calendar%20Clock/SVG/ic_fluent_calendar_clock_20_filled.svg" height="20"> |
| `AzureOpenAIResource` | Aspire.Hosting.Azure.CognitiveServices | `BrainCircuit` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Brain%20Circuit/SVG/ic_fluent_brain_circuit_20_filled.svg" height="20"> |
| `AzureOpenAIDeploymentResource` | Aspire.Hosting.Azure.CognitiveServices | `BrainCircuit` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Brain%20Circuit/SVG/ic_fluent_brain_circuit_20_filled.svg" height="20"> |
| `AzureApplicationInsightsResource` | Aspire.Hosting.Azure.ApplicationInsights | `ChartMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Chart%20Multiple/SVG/ic_fluent_chart_multiple_20_filled.svg" height="20"> |
| `AzureLogAnalyticsWorkspaceResource` | Aspire.Hosting.Azure.OperationalInsights | `ChartMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Chart%20Multiple/SVG/ic_fluent_chart_multiple_20_filled.svg" height="20"> |
| `AzureContainerRegistryResource` | Aspire.Hosting.Azure.ContainerRegistry | `Archive` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Archive/SVG/ic_fluent_archive_20_filled.svg" height="20"> |
| `AzureVirtualNetworkResource` | Aspire.Hosting.Azure.Network | `Router` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Router/SVG/ic_fluent_router_20_filled.svg" height="20"> |
| `AzureNetworkSecurityGroupResource` | Aspire.Hosting.Azure.Network | `ShieldLock` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Shield%20Lock/SVG/ic_fluent_shield_lock_20_filled.svg" height="20"> |
| `AzureKubernetesEnvironmentResource` | Aspire.Hosting.Azure.Kubernetes | `ServerMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Server%20Multiple/SVG/ic_fluent_server_multiple_20_filled.svg" height="20"> |
| `AzureAppServiceEnvironmentResource` | Aspire.Hosting.Azure.AppService | `Globe` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Globe/SVG/ic_fluent_globe_20_filled.svg" height="20"> |
| `AzureFrontDoorResource` | Aspire.Hosting.Azure.FrontDoor | `GlobeArrowForward` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Globe%20Arrow%20Forward/SVG/ic_fluent_globe_arrow_forward_20_filled.svg" height="20"> |
| `AzureSignalRResource` | Aspire.Hosting.Azure.SignalR | `MailMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail%20Multiple/SVG/ic_fluent_mail_multiple_20_filled.svg" height="20"> |
| `AzureWebPubSubResource` | Aspire.Hosting.Azure.WebPubSub | `MailMultiple` | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail%20Multiple/SVG/ic_fluent_mail_multiple_20_filled.svg" height="20"> |

### Icon semantics

| Icon | `Database` | `DatabaseMultiple` | `DatabaseSearch` | `WindowDatabase` | `MailMultiple` | `Mail` | `BrainCircuit` |
|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database/SVG/ic_fluent_database_20_filled.svg" height="20"> | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database%20Multiple/SVG/ic_fluent_database_multiple_20_filled.svg" height="20"> | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Database%20Search/SVG/ic_fluent_database_search_20_filled.svg" height="20"> | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Window%20Database/SVG/ic_fluent_window_database_20_filled.svg" height="20"> | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail%20Multiple/SVG/ic_fluent_mail_multiple_20_filled.svg" height="20"> | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Mail/SVG/ic_fluent_mail_20_filled.svg" height="20"> | <img src="https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets/Brain%20Circuit/SVG/ic_fluent_brain_circuit_20_filled.svg" height="20"> |
| Meaning | Single DB / cache | DB server / cluster | Vector search DB | DB admin UI | Message broker | Queue / topic / hub | AI / ML model |

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

