### PR TITLE
Stop leaking orphaned aspire-managed NuGet search helpers

### DIFF
--- a/src/Aspire.Cli/Commands/LsCommand.cs
+++ b/src/Aspire.Cli/Commands/LsCommand.cs
@@ -19,7 +19,7 @@ internal sealed class LsCommand : BaseCommand, IPackageMetaPrefetchingCommand
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
 
     /// <summary>
-    /// LsCommand lists resources of a running AppHost and never uses template package metadata.
+    /// LsCommand discovers candidate AppHost project files and never uses template package metadata.
     /// </summary>
     public bool PrefetchesTemplatePackageMetadata => false;
 

--- a/src/Aspire.Cli/Commands/LsCommand.cs
+++ b/src/Aspire.Cli/Commands/LsCommand.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.Globalization;
 using System.Text.Json;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.NuGet;
 using Aspire.Cli.Projects;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Telemetry;
@@ -13,9 +14,19 @@ using Spectre.Console;
 
 namespace Aspire.Cli.Commands;
 
-internal sealed class LsCommand : BaseCommand
+internal sealed class LsCommand : BaseCommand, IPackageMetaPrefetchingCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
+
+    /// <summary>
+    /// LsCommand lists resources of a running AppHost and never uses template package metadata.
+    /// </summary>
+    public bool PrefetchesTemplatePackageMetadata => false;
+
+    /// <summary>
+    /// LsCommand does not display update notifications, so it does not need CLI package metadata.
+    /// </summary>
+    public bool PrefetchesCliPackageMetadata => false;
 
     private readonly IProjectLocator _projectLocator;
     private readonly CliExecutionContext _executionContext;

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Aspire.Cli.Bundles;
 using Aspire.Cli.Interaction;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
@@ -27,6 +28,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     private readonly INewCommandPrompter _prompter;
     private readonly ITemplateProvider _templateProvider;
     private readonly ITemplate[] _templates;
+    private readonly IBundleService _bundleService;
     private readonly IPackagingService _packagingService;
     private readonly AgentInitCommand _agentInitCommand;
     private readonly ICliHostEnvironment _hostEnvironment;
@@ -74,6 +76,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     public NewCommand(
         INewCommandPrompter prompter,
         ITemplateProvider templateProvider,
+        IBundleService bundleService,
         IPackagingService packagingService,
         AgentInitCommand agentInitCommand,
         ICliHostEnvironment hostEnvironment,
@@ -83,6 +86,7 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
     {
         _prompter = prompter;
         _templateProvider = templateProvider;
+        _bundleService = bundleService;
         _packagingService = packagingService;
         _agentInitCommand = agentInitCommand;
         _hostEnvironment = hostEnvironment;
@@ -522,6 +526,13 @@ internal sealed class NewCommand : BaseCommand, IPackageMetaPrefetchingCommand
             Language = selectedLanguageId
         };
         var templateResult = await template.ApplyTemplateAsync(inputs, parseResult, cancellationToken);
+
+        // Generated AppHosts can be run directly by dotnet, which cannot trigger lazy bundle
+        // extraction. Ensure the bundle is ready instead of relying on best-effort prefetching.
+        if (templateResult.ExitCode == CliExitCodes.Success)
+        {
+            await _bundleService.EnsureExtractedAsync(cancellationToken);
+        }
 
         var workspaceRoot = new DirectoryInfo(templateResult.OutputPath ?? ExecutionContext.WorkingDirectory.FullName);
         var agentInitBinding = PromptBinding.CreateInvertedBoolConfirm(parseResult, s_suppressAgentInitOption, defaultValue: true);

--- a/src/Aspire.Cli/Commands/PsCommand.cs
+++ b/src/Aspire.Cli/Commands/PsCommand.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Interaction;
+using Aspire.Cli.NuGet;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Utils;
 using Microsoft.Extensions.Logging;
@@ -68,9 +69,20 @@ internal sealed partial class PsCommandJsonContext : JsonSerializerContext
     });
 }
 
-internal sealed partial class PsCommand : BaseCommand
+internal sealed partial class PsCommand : BaseCommand, IPackageMetaPrefetchingCommand
 {
     internal override HelpGroup HelpGroup => HelpGroup.AppCommands;
+
+    /// <summary>
+    /// PsCommand lists running AppHosts and never uses template package metadata.
+    /// </summary>
+    public bool PrefetchesTemplatePackageMetadata => false;
+
+    /// <summary>
+    /// PsCommand does not display update notifications, so it does not need CLI package metadata.
+    /// </summary>
+    public bool PrefetchesCliPackageMetadata => false;
+
     private readonly IAuxiliaryBackchannelMonitor _backchannelMonitor;
     private readonly IEnvironment _environment;
     private readonly OrphanedAppHostCollector _collector;

--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -16,6 +16,11 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
     {
         // Wait for command to be selected
         var command = await WaitForCommandSelectionAsync(stoppingToken);
+        if (command is null)
+        {
+            // Selection only fails when the CLI is shutting down, so there is nothing left to prefetch for.
+            return;
+        }
 
         var shouldPrefetchTemplates = ShouldPrefetchTemplatePackages(command);
         var shouldPrefetchCli = ShouldPrefetchCliPackages(command);
@@ -95,21 +100,18 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
         }
     }
 
+    /// <summary>
+    /// Waits for the command to be selected, which happens once its action runs. Returns <see langword="null"/>
+    /// only when the CLI shuts down first.
+    /// </summary>
     private async Task<SystemCommand?> WaitForCommandSelectionAsync(CancellationToken cancellationToken)
     {
         try
         {
-            // Wait for command to be selected, with a timeout
-            // If timeout occurs, proceed with default behavior (no command)
-            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-            using var combined = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
-
-            var command = await executionContext.CommandSelected.Task.WaitAsync(combined.Token);
-            return command;
+            return await executionContext.CommandSelected.Task.WaitAsync(cancellationToken);
         }
         catch (OperationCanceledException)
         {
-            // Timeout or cancellation occurred - proceed with no command (default behavior)
             return null;
         }
     }

--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -10,7 +10,7 @@ using SystemCommand = System.CommandLine.Command;
 
 namespace Aspire.Cli.NuGet;
 
-internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> logger, CliExecutionContext executionContext, IFeatures features, IPackagingService packagingService, ICliUpdateNotifier cliUpdateNotifier) : BackgroundService
+internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> logger, TimeProvider timeProvider, CliExecutionContext executionContext, IFeatures features, IPackagingService packagingService, ICliUpdateNotifier cliUpdateNotifier) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -108,7 +108,7 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
     {
         try
         {
-            return await executionContext.CommandSelected.Task.WaitAsync(cancellationToken);
+            return await executionContext.CommandSelected.Task.WaitAsync(Timeout.InfiniteTimeSpan, timeProvider, cancellationToken);
         }
         catch (OperationCanceledException)
         {

--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -77,17 +77,21 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
             }, stoppingToken));
         }
 
-        // Stay running until the prefetches finish. BackgroundService.StopAsync cancels stoppingToken and
-        // then awaits this method, so the CLI cannot exit while a prefetch still owns a NuGet search child
-        // process: cancellation tears that child down instead of orphaning it.
+        await PreventOrphanedPrefetchingAsync(prefetchTasks, stoppingToken);
+    }
+
+    /// <summary>
+    /// Holds the service open until prefetching finishes, so the CLI cannot exit and leave a NuGet
+    /// search child process behind.
+    /// </summary>
+    private static async Task PreventOrphanedPrefetchingAsync(List<Task> prefetchTasks, CancellationToken stoppingToken)
+    {
         try
         {
             await Task.WhenAll(prefetchTasks);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
-            // Task.Run cancels a queued callback outright when shutdown wins the race to the token,
-            // which surfaces here rather than in the per-prefetch handlers above.
         }
     }
 

--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -20,10 +20,12 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
         var shouldPrefetchTemplates = ShouldPrefetchTemplatePackages(command);
         var shouldPrefetchCli = ShouldPrefetchCliPackages(command);
 
+        var prefetchTasks = new List<Task>(capacity: 2);
+
         // Prefetch template packages if needed
         if (shouldPrefetchTemplates)
         {
-            _ = Task.Run(async () =>
+            prefetchTasks.Add(Task.Run(async () =>
             {
                 try
                 {
@@ -46,13 +48,13 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
                     // background service will exit gracefully. Code paths that depend on this
                     // data will handle the absence of pre-fetched packages gracefully.
                 }
-            }, stoppingToken);
+            }, stoppingToken));
         }
 
         // Prefetch CLI packages if needed
         if (shouldPrefetchCli)
         {
-            _ = Task.Run(async () =>
+            prefetchTasks.Add(Task.Run(async () =>
             {
                 if (features.IsFeatureEnabled(KnownFeatures.UpdateNotificationsEnabled, true))
                 {
@@ -72,7 +74,20 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
                         logger.LogDebug(ex, "Non-fatal error while prefetching CLI packages. This is not critical to the operation of the CLI.");
                     }
                 }
-            }, stoppingToken);
+            }, stoppingToken));
+        }
+
+        // Stay running until the prefetches finish. BackgroundService.StopAsync cancels stoppingToken and
+        // then awaits this method, so the CLI cannot exit while a prefetch still owns a NuGet search child
+        // process: cancellation tears that child down instead of orphaning it.
+        try
+        {
+            await Task.WhenAll(prefetchTasks);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Task.Run cancels a queued callback outright when shutdown wins the race to the token,
+            // which surfaces here rather than in the per-prefetch handlers above.
         }
     }
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1412,6 +1412,44 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task NewCommandWaitsForBundleExtractionAfterCreatingAppHost()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var extractionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowExtraction = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            EnsureExtractedAsyncCallback = async cancellationToken =>
+            {
+                extractionStarted.SetResult();
+                await allowExtraction.Task.WaitAsync(cancellationToken);
+            }
+        };
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.BundleServiceFactory = _ => bundleService;
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output --localhost-tld false --suppress-agent-init");
+        var invocationTask = result.InvokeAsync();
+
+        await extractionStarted.Task.DefaultTimeout();
+
+        var appHostCreated = File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.cs"));
+        var commandCompletedBeforeExtraction = invocationTask.IsCompleted;
+
+        allowExtraction.SetResult();
+        var exitCode = await invocationTask.DefaultTimeout();
+
+        Assert.True(appHostCreated);
+        Assert.False(commandCompletedBeforeExtraction);
+        Assert.Equal(CliExitCodes.Success, exitCode);
+    }
+
+    [Fact]
     public async Task NewCommandWithCSharpEmptyTemplateEmitsAppHostRunJsonAndAspireConfigJsonWithoutDuplicateProfiles()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -185,6 +185,11 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
         await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
     }
 
+    // The tests below resolve the real commands and drive the real NuGetPackagePrefetcher rather than
+    // going through TestNuGetPrefetcher at the bottom of this file. That helper re-implements the
+    // production prefetch decision instead of calling it, and has already drifted from it: its
+    // IsRuntimeOnlyCommand is missing "do". Tests written against the copy pass no matter what the
+    // production code decides, which is exactly the behaviour these tests need to pin down.
     [Theory]
     [InlineData(typeof(LsCommand))]
     [InlineData(typeof(PsCommand))]

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -4,13 +4,16 @@
 using System.CommandLine;
 using System.Diagnostics;
 using Aspire.Cli.Commands;
+using Aspire.Cli.Configuration;
 using Aspire.Cli.NuGet;
 using Aspire.Cli.Packaging;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Cli.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aspire.Cli.Tests.NuGet;
 
@@ -74,7 +77,6 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
     public async Task PrefetchingCancellationDueToShutdownLogsCleanMessage()
     {
         var sink = new TestSink();
-        var logger = new TestLogger<NuGetPackagePrefetcher>(new TestLoggerFactory(sink, enabled: true));
 
         using var stoppingCts = new CancellationTokenSource();
         var executionContext = CreateExecutionContext();
@@ -129,12 +131,12 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
             }
         };
 
-        var prefetcher = new NuGetPackagePrefetcher(
-            logger,
+        var prefetcher = CreatePrefetcher(
             executionContext,
             features,
             packagingService,
-            updateNotifier);
+            updateNotifier,
+            sink);
 
         await prefetcher.StartAsync(stoppingCts.Token).DefaultTimeout();
 
@@ -148,7 +150,6 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
     public async Task TemplatePrefetchingNonCancellationExceptionLogsExceptionDetails()
     {
         var sink = new TestSink();
-        var logger = new TestLogger<NuGetPackagePrefetcher>(new TestLoggerFactory(sink, enabled: true));
 
         var executionContext = CreateExecutionContext();
         executionContext.CommandSelected.TrySetResult(new TestCommand("new"));
@@ -170,12 +171,12 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
             }
         };
 
-        var prefetcher = new NuGetPackagePrefetcher(
-            logger,
+        var prefetcher = CreatePrefetcher(
             executionContext,
             new TestFeatures(),
             packagingService,
-            new TestCliUpdateNotifier());
+            new TestCliUpdateNotifier(),
+            sink);
 
         await prefetcher.StartAsync(CancellationToken.None).DefaultTimeout();
 
@@ -241,8 +242,7 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
             }
         };
 
-        var prefetcher = new NuGetPackagePrefetcher(
-            CreateLogger(new TestSink()),
+        var prefetcher = CreatePrefetcher(
             executionContext,
             features,
             packagingService,
@@ -258,8 +258,8 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
 
     // Command selection happens in BaseCommand's action, which the host reaches only after the first-run
     // banner has played. The banner spends 1660ms in fixed delays, so a prefetcher that gave up waiting
-    // after a second would fall back to the null default and prefetch for `ls`/`ps` anyway. The delay below
-    // is the point of the test: it has to outlast the timeout that used to be here.
+    // after a second would fall back to the null default and prefetch for `ls`/`ps` anyway. Advance the
+    // clock past that former timeout before selecting the command.
     [Fact]
     public async Task CommandSelectedAfterABannerLengthDelayStillDisablesPrefetching()
     {
@@ -268,6 +268,7 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
         using var provider = services.BuildServiceProvider();
 
         var executionContext = CreateExecutionContext();
+        var timeProvider = new FakeTimeProvider();
 
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.UpdateNotificationsEnabled, true);
@@ -292,16 +293,18 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
             }
         };
 
-        var prefetcher = new NuGetPackagePrefetcher(
-            CreateLogger(new TestSink()),
+        var prefetcher = CreatePrefetcher(
             executionContext,
             features,
             packagingService,
-            updateNotifier);
+            updateNotifier,
+            timeProvider: timeProvider);
 
         await prefetcher.StartAsync(CancellationToken.None).DefaultTimeout();
 
-        await Task.Delay(TimeSpan.FromMilliseconds(1500));
+        // The removed timeout was one second. 1500ms crosses that boundary without coupling
+        // this test to every delay that contributes to the banner's full 1660ms duration.
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1500));
 
         executionContext.CommandSelected.TrySetResult(provider.GetRequiredService<LsCommand>());
 
@@ -360,8 +363,7 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
             }
         };
 
-        var prefetcher = new NuGetPackagePrefetcher(
-            CreateLogger(new TestSink()),
+        var prefetcher = CreatePrefetcher(
             executionContext,
             features,
             packagingService,
@@ -376,6 +378,23 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
 
         Assert.True(templateFinished.Task.IsCompletedSuccessfully);
         Assert.True(cliFinished.Task.IsCompletedSuccessfully);
+    }
+
+    private static NuGetPackagePrefetcher CreatePrefetcher(
+        CliExecutionContext executionContext,
+        IFeatures features,
+        IPackagingService packagingService,
+        ICliUpdateNotifier updateNotifier,
+        TestSink? sink = null,
+        TimeProvider? timeProvider = null)
+    {
+        return new NuGetPackagePrefetcher(
+            CreateLogger(sink ?? new TestSink()),
+            timeProvider ?? TimeProvider.System,
+            executionContext,
+            features,
+            packagingService,
+            updateNotifier);
     }
 
     private static TestLogger<NuGetPackagePrefetcher> CreateLogger(TestSink sink)

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -256,6 +256,62 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
         Assert.False(cliStarted);
     }
 
+    // Command selection happens in BaseCommand's action, which the host reaches only after the first-run
+    // banner has played. The banner spends 1660ms in fixed delays, so a prefetcher that gave up waiting
+    // after a second would fall back to the null default and prefetch for `ls`/`ps` anyway. The delay below
+    // is the point of the test: it has to outlast the timeout that used to be here.
+    [Fact]
+    public async Task CommandSelectedAfterABannerLengthDelayStillDisablesPrefetching()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var executionContext = CreateExecutionContext();
+
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.UpdateNotificationsEnabled, true);
+
+        var templateStarted = false;
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                templateStarted = true;
+                return Task.FromResult(Enumerable.Empty<PackageChannel>());
+            }
+        };
+
+        var cliStarted = false;
+        var updateNotifier = new TestCliUpdateNotifier
+        {
+            CheckForCliUpdatesAsyncCallback = (_, _) =>
+            {
+                cliStarted = true;
+                return Task.CompletedTask;
+            }
+        };
+
+        var prefetcher = new NuGetPackagePrefetcher(
+            CreateLogger(new TestSink()),
+            executionContext,
+            features,
+            packagingService,
+            updateNotifier);
+
+        await prefetcher.StartAsync(CancellationToken.None).DefaultTimeout();
+
+        await Task.Delay(TimeSpan.FromMilliseconds(1500));
+
+        executionContext.CommandSelected.TrySetResult(provider.GetRequiredService<LsCommand>());
+
+        await prefetcher.ExecuteTask!.DefaultTimeout();
+        await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
+
+        Assert.False(templateStarted);
+        Assert.False(cliStarted);
+    }
+
     [Fact]
     public async Task InFlightPrefetchingCompletesBeforeTheServiceStops()
     {

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -5,14 +5,16 @@ using System.CommandLine;
 using System.Diagnostics;
 using Aspire.Cli.Commands;
 using Aspire.Cli.NuGet;
+using Aspire.Cli.Packaging;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Cli.Tests.NuGet;
 
-public class NuGetPackagePrefetcherTests
+public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
 {
     [Fact]
     public void CliExecutionContextSetsCommand()
@@ -182,6 +184,141 @@ public class NuGetPackagePrefetcherTests
 
         await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
     }
+
+    [Theory]
+    [InlineData(typeof(LsCommand))]
+    [InlineData(typeof(PsCommand))]
+    public void ReadOnlyCommandsDisablePackageMetadataPrefetching(Type commandType)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var command = provider.GetRequiredService(commandType);
+
+        var prefetchingCommand = Assert.IsAssignableFrom<IPackageMetaPrefetchingCommand>(command);
+        Assert.False(prefetchingCommand.PrefetchesTemplatePackageMetadata);
+        Assert.False(prefetchingCommand.PrefetchesCliPackageMetadata);
+    }
+
+    [Theory]
+    [InlineData(typeof(LsCommand))]
+    [InlineData(typeof(PsCommand))]
+    public async Task ReadOnlyCommandsStartNoPrefetching(Type commandType)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var executionContext = CreateExecutionContext();
+        executionContext.CommandSelected.TrySetResult((Command)provider.GetRequiredService(commandType));
+
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.UpdateNotificationsEnabled, true);
+
+        var templateStarted = false;
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                templateStarted = true;
+                return Task.FromResult(Enumerable.Empty<PackageChannel>());
+            }
+        };
+
+        var cliStarted = false;
+        var updateNotifier = new TestCliUpdateNotifier
+        {
+            CheckForCliUpdatesAsyncCallback = (_, _) =>
+            {
+                cliStarted = true;
+                return Task.CompletedTask;
+            }
+        };
+
+        var prefetcher = new NuGetPackagePrefetcher(
+            CreateLogger(new TestSink()),
+            executionContext,
+            features,
+            packagingService,
+            updateNotifier);
+
+        await prefetcher.StartAsync(CancellationToken.None).DefaultTimeout();
+        await prefetcher.ExecuteTask!.DefaultTimeout();
+        await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
+
+        Assert.False(templateStarted);
+        Assert.False(cliStarted);
+    }
+
+    [Fact]
+    public async Task InFlightPrefetchingCompletesBeforeTheServiceStops()
+    {
+        var executionContext = CreateExecutionContext();
+        executionContext.CommandSelected.TrySetResult(new TestCommand("new"));
+
+        var features = new TestFeatures();
+        features.SetFeature(KnownFeatures.UpdateNotificationsEnabled, true);
+
+        var templateEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var templateFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cliEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cliFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = async token =>
+            {
+                templateEntered.SetResult();
+                try
+                {
+                    await AsyncTestHelpers.WaitForCancellationAsync(token);
+                }
+                finally
+                {
+                    templateFinished.SetResult();
+                }
+
+                throw new UnreachableException();
+            }
+        };
+
+        var updateNotifier = new TestCliUpdateNotifier
+        {
+            CheckForCliUpdatesAsyncCallback = async (_, token) =>
+            {
+                cliEntered.SetResult();
+                try
+                {
+                    await AsyncTestHelpers.WaitForCancellationAsync(token);
+                }
+                finally
+                {
+                    cliFinished.SetResult();
+                }
+            }
+        };
+
+        var prefetcher = new NuGetPackagePrefetcher(
+            CreateLogger(new TestSink()),
+            executionContext,
+            features,
+            packagingService,
+            updateNotifier);
+
+        await prefetcher.StartAsync(CancellationToken.None).DefaultTimeout();
+        await Task.WhenAll(templateEntered.Task, cliEntered.Task).DefaultTimeout();
+
+        Assert.False(prefetcher.ExecuteTask!.IsCompleted);
+
+        await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
+
+        Assert.True(templateFinished.Task.IsCompletedSuccessfully);
+        Assert.True(cliFinished.Task.IsCompletedSuccessfully);
+    }
+
+    private static TestLogger<NuGetPackagePrefetcher> CreateLogger(TestSink sink)
+        => new(new TestLoggerFactory(sink, enabled: true));
 
     private static CliExecutionContext CreateExecutionContext()
     {

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -796,7 +796,10 @@ internal sealed class TestBundleService(bool isBundle) : IBundleService
 
     public Exception? EnsureExtractedException { get; set; }
 
-    public Task EnsureExtractedAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Func<CancellationToken, Task>? EnsureExtractedAsyncCallback { get; set; }
+
+    public Task EnsureExtractedAsync(CancellationToken cancellationToken = default)
+        => EnsureExtractedAsyncCallback?.Invoke(cancellationToken) ?? Task.CompletedTask;
 
     public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
         => Task.FromResult(isBundle ? BundleExtractResult.AlreadyUpToDate : BundleExtractResult.NoPayload);


### PR DESCRIPTION
## Description

Fixes #18948. Same root cause as #18779.

`aspire ls` and `aspire ps` spawn an `aspire-managed nuget search` helper that never exits. They accumulate — 19 over six days in the original report, 47 overnight on my machine — each holding lock files under `$TMPDIR/NuGetScratch/lock`, until an unrelated `dotnet restore` deadlocks at "Determining projects to restore...". Repro steps are in #18948.

Three things combine.

**The prefetch is never awaited.** `NuGetPackagePrefetcher.ExecuteAsync` fired both prefetches as discarded `Task.Run` ([L26](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs#L26), [L55](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs#L55)), so it returned immediately, `BackgroundService.StopAsync` awaited an already-completed `ExecuteTask`, and the CLI exited with the search still running. The log in #18948 shows it: the helper is launched and, unlike every other subprocess in that log, never gets an exit entry. Fixed by collecting both tasks and awaiting them.

The teardown path was already correct — nothing ever ran it. The token flows unbroken to [`LayoutProcessRunner.cs#L58`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/Layout/LayoutProcessRunner.cs#L58), where cancelling `WaitForExitAsync` unwinds into the `await using` and [`ProcessExecution.cs#L533`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/DotNet/ProcessExecution.cs#L533) kills the tree. Cancellation already reaps the helper. Nothing was cancelling it.

**Read-only commands opted in by default.** `ls` and `ps` don't implement `IPackageMetaPrefetchingCommand`, so they hit the default at [L108](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs#L108) — prefetch for everything except run/publish/deploy/do. Neither uses template metadata, and neither overrides `UpdateNotificationsEnabled` (default `false`), so neither reaches the notification site at `BaseCommand.cs:202` and the CLI-package search is wasted too. Both now implement the interface with both flags `false`, matching `NewCommand`, `McpInitCommand` and `AgentInitCommand`.

**One second wasn't long enough to learn the command.** `WaitForCommandSelectionAsync` gave up after 1000 ms and fell back to the null default, which enables both prefetches. Selection happens when the command's action runs (`BaseCommand.cs:61`), and the first-run banner plays before that, spending 1660 ms in fixed delays — so the opt-out above was bypassable on a first run or with `--banner`. It now waits until shutdown. Caught by Copilot review; [arithmetic here](https://github.com/microsoft/aspire/pull/18958#discussion_r3698236204).

Why the existing protection misses all this: on non-Windows the cooperative parent-liveness watchdog is the sole mechanism ([`LayoutProcessRunner.cs#L38-L49`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/Layout/LayoutProcessRunner.cs#L38-L49)), and the leaked helpers sit in state `T`. A stopped process is never scheduled, so it cannot notice its parent died, and `SIGTERM` is not delivered to it — only `SIGKILL` clears them. #18566 tightened several leak paths, but not this one.

### What this does not guarantee

Release builds cap host shutdown at 200 ms ([`Program.cs#L317-L323`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Cli/Program.cs#L317-L323)). Cancel → kill → drain normally fits inside that, but if it overruns, the helper is still abandoned. Strictly better than today, where nothing cancels it at all — not a hard guarantee. I can add an explicit shutdown step with its own budget if you want one.

### One behaviour change to rule on

Waiting for selection instead of guessing means invocations where no command action ever runs — `--help`, `--version`, a parse error — no longer prefetch CLI update metadata. Nothing displays an update notification on those paths, so I read it as dead work removed rather than a regression. It does change what those invocations do to the update cache, which is your call rather than mine. Say so and I will restore a bounded fallback.

### Tests

Four tests in `NuGetPackagePrefetcherTests`, each written against `main` first:

- `InFlightPrefetchingCompletesBeforeTheServiceStops` — `ExecuteTask` is still running while a prefetch is in flight, and both callbacks have unwound by the time `StopAsync` returns. The regression test for the leak; fails deterministically on `main`.
- `ReadOnlyCommandsDisablePackageMetadataPrefetching` (`ls`, `ps`) — resolves the real commands from the real DI graph. Fails deterministically on `main`.
- `ReadOnlyCommandsStartNoPrefetching` (`ls`, `ps`) — drives the real prefetcher with those instances. Only deterministic once the prefetch tasks are awaited, since that is what makes `ExecuteTask` a barrier; on `main` it fails for `ps` but can pass for `ls` on scheduling luck. Its value is as a guard after the fix.
- `CommandSelectedAfterABannerLengthDelayStillDisablesPrefetching` — waits 1500 ms before selecting the command. The delay is the point: it has to outlast the timeout that used to be there.

macOS arm64, .NET SDK 10.0.302. Prefetcher plus `LsCommandTests` and `PsCommandTests`: 69/69, no warnings. Full `Aspire.Cli.Tests` (`--filter-not-trait quarantined=true --filter-not-trait outerloop=true`): 4695 tests, 4661 pass, 32 skipped, 2 failures — `CliPathHelperTests.ResolveSymlinkToFullPath_NonLink_ReturnsNormalizedFullPath` and `InstallationDiscoveryDiscoverAllTests.DiscoverAllAsync_RunningCliIsAlwaysFirst`, both of which fail identically on an unmodified checkout here (macOS `/private/tmp` symlink normalization, and a running-CLI assumption).

I did not touch stdin or the TTY. #16791 / #17562 is the complementary fix for *why* an orphaned helper ends up stopped rather than exiting; this stops it being orphaned.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
  - [x] No
