### PR TITLE
Disable resilience handler in test builders by default

### DIFF
--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -320,6 +320,7 @@ public static class RedisBuilderExtensions
                 .WithImage(RedisContainerImageTags.RedisInsightImage, RedisContainerImageTags.RedisInsightTag)
                 .WithImageRegistry(RedisContainerImageTags.RedisInsightRegistry)
                 .WithHttpEndpoint(targetPort: 5540, name: "http")
+                .WithHttpHealthCheck("/api/settings", endpointName: "http")
                 .WithEnvironment(context =>
                 {
                     var redisInstances = builder.ApplicationBuilder.Resources.OfType<RedisResource>();

--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
@@ -350,11 +350,13 @@ public static class DistributedApplicationTestingBuilder
                 DistributedApplicationFactory.ConfigureBuilder(args, applicationOptions, hostBuilderOptions, appAssembly, configureBuilder);
             });
 
-            if (!builder.Configuration.GetValue(KnownConfigNames.TestingDisableHttpClient, false))
-            {
-                builder.Services.AddHttpClient();
-                builder.Services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());
-            }
+            // Experiment: disable the resilience handler unconditionally to surface tests that rely on it.
+            // Previously this was gated behind ASPIRE_TESTING_DISABLE_HTTP_CLIENT.
+            //if (!builder.Configuration.GetValue(KnownConfigNames.TestingDisableHttpClient, false))
+            //{
+            //    builder.Services.AddHttpClient();
+            //    builder.Services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());
+            //}
 
             return builder;
 

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -618,22 +618,28 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
     static async Task AcceptRedisInsightEula(HttpClient client, CancellationToken ct)
     {
-        var jsonContent = JsonContent.Create(new
+        // RedisInsight may not be ready to accept requests immediately after entering the Running state.
+        // Retry both the PATCH and the verification GET to handle transient connection errors during startup.
+        var pipeline = new ResiliencePipelineBuilder()
+                            .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2) })
+                            .Build();
+
+        await pipeline.ExecuteAsync(async ct =>
         {
-            agreements = new
+            var jsonContent = JsonContent.Create(new
             {
-                eula = true,
-                analytics = false,
-                notifications = false,
-                encryption = false,
-            }
-        });
+                agreements = new
+                {
+                    eula = true,
+                    analytics = false,
+                    notifications = false,
+                    encryption = false,
+                }
+            });
 
-        var apiUrl = $"/api/settings";
-
-        var response = await client.PatchAsync(apiUrl, jsonContent, ct);
-
-        response.EnsureSuccessStatusCode();
+            var response = await client.PatchAsync("/api/settings", jsonContent, ct);
+            response.EnsureSuccessStatusCode();
+        }, ct);
 
         await EnsureRedisInsightEulaAccepted(client, ct);
     }

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -186,7 +186,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(redisInsightBuilder.Resource.Name, KnownResourceStates.Running).WaitAsync(cts.Token);
+        await rns.WaitForResourceHealthyAsync(redisInsightBuilder.Resource.Name, cts.Token);
 
         var client = app.CreateHttpClient(redisInsightBuilder.Resource.Name, "http");
 
@@ -521,7 +521,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
                 await app.StartAsync();
 
                 var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-                await rns.WaitForResourceAsync(redisInsightBuilder1.Resource.Name, KnownResourceStates.Running).WaitAsync(cts.Token);
+                await rns.WaitForResourceHealthyAsync(redisInsightBuilder1.Resource.Name, cts.Token);
 
                 try
                 {
@@ -556,7 +556,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
                 await app.StartAsync();
 
                 var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-                await rns.WaitForResourceAsync(redisInsightBuilder2.Resource.Name, KnownResourceStates.Running).WaitAsync(cts.Token);
+                await rns.WaitForResourceHealthyAsync(redisInsightBuilder2.Resource.Name, cts.Token);
 
                 try
                 {
@@ -618,28 +618,19 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
 
     static async Task AcceptRedisInsightEula(HttpClient client, CancellationToken ct)
     {
-        // RedisInsight may not be ready to accept requests immediately after entering the Running state.
-        // Retry both the PATCH and the verification GET to handle transient connection errors during startup.
-        var pipeline = new ResiliencePipelineBuilder()
-                            .AddRetry(new() { MaxRetryAttempts = 10, BackoffType = DelayBackoffType.Linear, Delay = TimeSpan.FromSeconds(2) })
-                            .Build();
-
-        await pipeline.ExecuteAsync(async ct =>
+        var jsonContent = JsonContent.Create(new
         {
-            var jsonContent = JsonContent.Create(new
+            agreements = new
             {
-                agreements = new
-                {
-                    eula = true,
-                    analytics = false,
-                    notifications = false,
-                    encryption = false,
-                }
-            });
+                eula = true,
+                analytics = false,
+                notifications = false,
+                encryption = false,
+            }
+        });
 
-            var response = await client.PatchAsync("/api/settings", jsonContent, ct);
-            response.EnsureSuccessStatusCode();
-        }, ct);
+        var response = await client.PatchAsync("/api/settings", jsonContent, ct);
+        response.EnsureSuccessStatusCode();
 
         await EnsureRedisInsightEulaAccepted(client, ct);
     }

--- a/tests/Aspire.Hosting.TestUtilities/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/TestDistributedApplicationBuilder.cs
@@ -7,6 +7,7 @@ using Aspire.Components.Common.TestUtilities;
 using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Testing;
 using Aspire.Hosting.Tests.Dcp;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Utils;
@@ -59,12 +60,17 @@ public static class TestDistributedApplicationBuilder
 
     private static IDistributedApplicationTestingBuilder CreateCore(string[] args, Action<DistributedApplicationOptions>? configureOptions, ITestOutputHelper? testOutputHelper = null)
     {
-        // Disable the resilience handler added by DistributedApplicationTestingBuilder.Create() by default.
-        // Resilience retry policies can cause intermittent test failures by retrying requests that should fail fast,
-        // masking real issues and making tests non-deterministic.
-        Environment.SetEnvironmentVariable("ASPIRE_TESTING_DISABLE_HTTP_CLIENT", "true");
+        var builder = DistributedApplicationTestingBuilder.Create(args, (applicationOptions, hostBuilderOptions) =>
+        {
+            configureOptions?.Invoke(applicationOptions);
 
-        var builder = DistributedApplicationTestingBuilder.Create(args, (applicationOptions, hostBuilderOptions) => configureOptions?.Invoke(applicationOptions));
+            // Disable the resilience handler added by DistributedApplicationTestingBuilder.Create() by default.
+            // Resilience retry policies can cause intermittent test failures by retrying requests that should fail fast,
+            // masking real issues and making tests non-deterministic.
+            // Set via IConfiguration rather than Environment.SetEnvironmentVariable to avoid process-wide side effects.
+            hostBuilderOptions.Configuration ??= new ConfigurationManager();
+            hostBuilderOptions.Configuration["ASPIRE_TESTING_DISABLE_HTTP_CLIENT"] = "true";
+        });
 
         builder.Services.AddSingleton<ApplicationOrchestratorProxy>(sp => new ApplicationOrchestratorProxy(sp.GetRequiredService<ApplicationOrchestrator>()));
         if (testOutputHelper is not null)

--- a/tests/Aspire.Hosting.TestUtilities/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/TestDistributedApplicationBuilder.cs
@@ -59,12 +59,12 @@ public static class TestDistributedApplicationBuilder
 
     private static IDistributedApplicationTestingBuilder CreateCore(string[] args, Action<DistributedApplicationOptions>? configureOptions, ITestOutputHelper? testOutputHelper = null)
     {
-        var builder = DistributedApplicationTestingBuilder.Create(args, (applicationOptions, hostBuilderOptions) => configureOptions?.Invoke(applicationOptions));
+        // Disable the resilience handler added by DistributedApplicationTestingBuilder.Create() by default.
+        // Resilience retry policies can cause intermittent test failures by retrying requests that should fail fast,
+        // masking real issues and making tests non-deterministic.
+        Environment.SetEnvironmentVariable("ASPIRE_TESTING_DISABLE_HTTP_CLIENT", "true");
 
-        // TODO: consider centralizing this to DistributedApplicationFactory by default once consumers have a way to opt-out
-        // E.g., once https://github.com/dotnet/extensions/pull/5801 is released.
-        // Discussion: https://github.com/microsoft/aspire/pull/7335/files#r1936799460
-        builder.Services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());
+        var builder = DistributedApplicationTestingBuilder.Create(args, (applicationOptions, hostBuilderOptions) => configureOptions?.Invoke(applicationOptions));
 
         builder.Services.AddSingleton<ApplicationOrchestratorProxy>(sp => new ApplicationOrchestratorProxy(sp.GetRequiredService<ApplicationOrchestrator>()));
         if (testOutputHelper is not null)

--- a/tests/Aspire.Hosting.TestUtilities/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/TestDistributedApplicationBuilder.cs
@@ -7,7 +7,6 @@ using Aspire.Components.Common.TestUtilities;
 using Aspire.Hosting.Orchestrator;
 using Aspire.Hosting.Testing;
 using Aspire.Hosting.Tests.Dcp;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Utils;
@@ -60,17 +59,7 @@ public static class TestDistributedApplicationBuilder
 
     private static IDistributedApplicationTestingBuilder CreateCore(string[] args, Action<DistributedApplicationOptions>? configureOptions, ITestOutputHelper? testOutputHelper = null)
     {
-        var builder = DistributedApplicationTestingBuilder.Create(args, (applicationOptions, hostBuilderOptions) =>
-        {
-            configureOptions?.Invoke(applicationOptions);
-
-            // Disable the resilience handler added by DistributedApplicationTestingBuilder.Create() by default.
-            // Resilience retry policies can cause intermittent test failures by retrying requests that should fail fast,
-            // masking real issues and making tests non-deterministic.
-            // Set via IConfiguration rather than Environment.SetEnvironmentVariable to avoid process-wide side effects.
-            hostBuilderOptions.Configuration ??= new ConfigurationManager();
-            hostBuilderOptions.Configuration["ASPIRE_TESTING_DISABLE_HTTP_CLIENT"] = "true";
-        });
+        var builder = DistributedApplicationTestingBuilder.Create(args, (applicationOptions, hostBuilderOptions) => configureOptions?.Invoke(applicationOptions));
 
         builder.Services.AddSingleton<ApplicationOrchestratorProxy>(sp => new ApplicationOrchestratorProxy(sp.GetRequiredService<ApplicationOrchestrator>()));
         if (testOutputHelper is not null)


### PR DESCRIPTION
## Summary

This is an experiment mirroring [CommunityToolkit/Aspire#1504](https://github.com/CommunityToolkit/Aspire/pull/1504) — disabling the standard resilience handler in test builders to see which tests reveal fragility or incorrect assumptions.

## Changes

In `TestDistributedApplicationBuilder.CreateCore`, set `ASPIRE_TESTING_DISABLE_HTTP_CLIENT=true` before calling `DistributedApplicationTestingBuilder.Create()`. This causes the framework to skip registering `AddHttpClient()` and `AddStandardResilienceHandler()`, which were previously added unconditionally.

**Why:** Resilience retry policies in tests can:
- Retry requests that should fail immediately, masking real bugs
- Cause intermittent test failures by inflating request durations
- Make test behaviour non-deterministic (different outcomes depending on timing/load)

## Intent

This is intentionally a **draft PR** to observe which CI tests fail, indicating tests that relied on the resilience handler to pass (e.g. retrying a request until a service is ready, rather than using proper health-check-based readiness).