### PR TITLE
Default Oracle database resources to FREEPDB1

### DIFF
--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -13,6 +13,7 @@ namespace Aspire.Hosting;
 public static class OracleDatabaseBuilderExtensions
 {
     private const string PasswordEnvVarName = "ORACLE_PWD";
+    private const string DefaultDatabaseName = "FREEPDB1";
 
     /// <summary>
     /// Adds a Oracle Server resource to the application model. A container is used for local development.
@@ -73,7 +74,7 @@ public static class OracleDatabaseBuilderExtensions
     /// </summary>
     /// <param name="builder">The Oracle Database server resource builder.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
-    /// <param name="databaseName">The name of the database. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
+    /// <param name="databaseName">The name of the database. If not provided, this defaults to the Oracle Free container's default pluggable database, <c>FREEPDB1</c>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
     [AspireExport]
@@ -85,8 +86,7 @@ public static class OracleDatabaseBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        // Use the resource name as the database name if it's not provided
-        databaseName ??= name;
+        databaseName ??= DefaultDatabaseName;
 
         builder.Resource.AddDatabase(name, databaseName);
         var oracleDatabase = new OracleDatabaseResource(name, databaseName, builder.Resource);

--- a/src/Aspire.Hosting.Oracle/README.md
+++ b/src/Aspire.Hosting.Oracle/README.md
@@ -19,7 +19,7 @@ In the AppHost, add an Oracle database resource and reference it from another re
 **C#**
 
 ```csharp
-var db = builder.AddOracle("oracle").AddDatabase("mydb");
+var db = builder.AddOracle("oracle").AddDatabase("db");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(db);
@@ -28,11 +28,13 @@ var myService = builder.AddProject<Projects.MyService>()
 **TypeScript**
 
 ```typescript
-const db = await builder.addOracle("oracle").addDatabase("mydb");
+const db = await builder.addOracle("oracle").addDatabase("db");
 
 const myService = await builder.addNodeApp("myService", "../my-service", "server.js")
                        .withReference(db);
 ```
+
+By default, `AddDatabase` connects to the Oracle Free container's default pluggable database, `FREEPDB1`. To connect to a different service or pluggable database that your container creates, pass it with the `databaseName` parameter.
 
 ## Connection Properties
 

--- a/tests/Aspire.Hosting.Oracle.Tests/AddOracleTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/AddOracleTests.cs
@@ -145,8 +145,9 @@ public class AddOracleTests
         var oracleDatabaseConnectionStringResource = (IResourceWithConnectionString)oracleDatabaseResource;
         var dbConnectionString = await oracleDatabaseConnectionStringResource.GetConnectionStringAsync();
 
-        Assert.Equal("{orcl.connectionString}/db", oracleDatabaseConnectionStringResource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal(oracleConnectionString + "/db", dbConnectionString);
+        Assert.Equal("FREEPDB1", oracleDatabaseResource.DatabaseName);
+        Assert.Equal("{orcl.connectionString}/FREEPDB1", oracleDatabaseConnectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal(oracleConnectionString + "/FREEPDB1", dbConnectionString);
     }
 
     [Fact]
@@ -222,7 +223,7 @@ public class AddOracleTests
         expectedManifest = """
             {
               "type": "value.v0",
-              "connectionString": "{oracle.connectionString}/db"
+              "connectionString": "{oracle.connectionString}/FREEPDB1"
             }
             """;
         Assert.Equal(expectedManifest, dbManifest.ToString());
@@ -296,6 +297,19 @@ public class AddOracleTests
 
         Assert.Equal("{oracle1.connectionString}/customers1", db1.Resource.ConnectionStringExpression.ValueExpression);
         Assert.Equal("{oracle1.connectionString}/customers2", db2.Resource.ConnectionStringExpression.ValueExpression);
+    }
+
+    [Fact]
+    public void AddDatabaseDefaultsToOracleFreePluggableDatabase()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var db = builder.AddOracle("oracle")
+            .AddDatabase("appdb");
+
+        Assert.Equal("appdb", db.Resource.Name);
+        Assert.Equal("FREEPDB1", db.Resource.DatabaseName);
+        Assert.Equal("{oracle.connectionString}/FREEPDB1", db.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -35,11 +35,9 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
 
         using var builder = TestDistributedApplicationBuilder.Create(o => { }, testOutputHelper);
 
-        var oracleDbName = "freepdb1";
-
         var oracle = builder.AddOracle("oracle");
 
-        var db = oracle.AddDatabase(oracleDbName);
+        var db = oracle.AddDatabase("db");
 
         using var app = builder.Build();
 


### PR DESCRIPTION
Fixes #15024

Updates the Oracle hosting integration so AddDatabase(...) defaults to the Oracle Free container's default pluggable database, FREEPDB1, instead of deriving the service name from the Aspire resource name.

Also updates tests and README guidance. Explicit databaseName values remain supported for custom services or setup scripts.

Testing:
- dotnet test --project tests/Aspire.Hosting.Oracle.Tests/Aspire.Hosting.Oracle.Tests.csproj --no-restore -- --filter-not-class "*OracleFunctionalTests" passed
- Docker-backed functional tests not run locally because Docker is not installed/on PATH