### PR TITLE
Bound aspire doctor checks with timeouts

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -58,7 +58,11 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     }
 
     public override TrustLevel GetTrustLevel(X509Certificate2 certificate)
+        => GetTrustLevel(certificate, CancellationToken.None);
+
+    internal TrustLevel GetTrustLevel(X509Certificate2 certificate, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var sawTrustSuccess = false;
         var sawTrustFailure = false;
 
@@ -159,7 +163,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             {
                 foreach (var nssDb in nssDbs)
                 {
-                    if (IsCertificateInNssDb(certificateNickname, nssDb))
+                    if (IsCertificateInNssDb(certificateNickname, nssDb, cancellationToken))
                     {
                         sawTrustSuccess = true;
                     }
@@ -690,7 +694,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     /// <remarks>
     /// It is the caller's responsibility to ensure that <see cref="CertificateHelpers.CertUtilCommand"/> is available.
     /// </remarks>
-    private bool IsCertificateInNssDb(string nickname, NssDb nssDb)
+    private bool IsCertificateInNssDb(string nickname, NssDb nssDb, CancellationToken cancellationToken = default)
     {
         // -V will validate that a cert can be used for a given purpose, in this case, server verification.
         // There is no corresponding -V check for the "Trusted CA" status required by Firefox, so we just check for existence.
@@ -706,8 +710,12 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         try
         {
             using var process = Process.Start(startInfo)!;
-            process.WaitForExit();
+            WaitForExit(process, cancellationToken);
             return process.ExitCode == 0;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -715,6 +723,25 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             // This method is used to determine whether more trust is needed, so it's better to underestimate the amount of trust.
             return false;
         }
+    }
+
+    private static void WaitForExit(Process process, CancellationToken cancellationToken)
+    {
+        using var cancellationRegistration = cancellationToken.Register(static state =>
+        {
+            var process = (Process)state!;
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or System.ComponentModel.Win32Exception)
+            {
+                // The process either exited concurrently or could not be killed by this platform.
+            }
+        }, process);
+
+        process.WaitForExit();
+        cancellationToken.ThrowIfCancellationRequested();
     }
 
     /// <remarks>

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -45,10 +45,17 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
     private HashSet<string>? _availableCommands;
     private readonly IEnvironment _environment;
+    private readonly Func<string, ProcessStartInfo> _createCertUtilStartInfo = CreateCertUtilStartInfo;
 
     public UnixCertificateManager(ILogger logger, IEnvironment environment) : base(logger)
     {
         _environment = environment;
+    }
+
+    internal UnixCertificateManager(ILogger logger, IEnvironment environment, Func<string, ProcessStartInfo> createCertUtilStartInfo)
+        : this(logger, environment)
+    {
+        _createCertUtilStartInfo = createCertUtilStartInfo;
     }
 
     internal UnixCertificateManager(string subject, int version)
@@ -701,11 +708,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         // (The docs suggest that "-V -u A" should do this, but it seems to accept all certs.)
         var operation = nssDb.IsFirefox ? "-L" : "-V -u V";
 
-        var startInfo = new ProcessStartInfo(CertificateHelpers.CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} {operation}")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
+        var startInfo = _createCertUtilStartInfo($"-d sql:{nssDb.Path} -n {nickname} {operation}");
 
         try
         {
@@ -753,11 +756,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
         var usage = nssDb.IsFirefox ? "C" : "P";
 
         // This silently clobbers an existing entry, so there's no need to check for existence first.
-        var startInfo = new ProcessStartInfo(CertificateHelpers.CertUtilCommand, $"-d sql:{nssDb.Path} -n {nickname} -A -i {certificatePath} -t \"{usage},,\"")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
+        var startInfo = _createCertUtilStartInfo($"-d sql:{nssDb.Path} -n {nickname} -A -i {certificatePath} -t \"{usage},,\"");
 
         try
         {
@@ -777,11 +776,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
     /// </remarks>
     private bool TryRemoveCertificateFromNssDb(string nickname, NssDb nssDb)
     {
-        var startInfo = new ProcessStartInfo(CertificateHelpers.CertUtilCommand, $"-d sql:{nssDb.Path} -D -n {nickname}")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
+        var startInfo = _createCertUtilStartInfo($"-d sql:{nssDb.Path} -D -n {nickname}");
 
         try
         {
@@ -800,6 +795,15 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             Log.UnixNssDbRemovalException(nssDb.Path, ex.Message);
             return false;
         }
+    }
+
+    private static ProcessStartInfo CreateCertUtilStartInfo(string arguments)
+    {
+        return new ProcessStartInfo(CertificateHelpers.CertUtilCommand, arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
     }
 
     private IEnumerable<string> GetFirefoxProfiles(string firefoxDirectory)

--- a/src/Aspire.Cli/Certificates/CertificateService.cs
+++ b/src/Aspire.Cli/Certificates/CertificateService.cs
@@ -69,7 +69,7 @@ internal sealed class CertificateService(
 
         if (!canPerformTrust)
         {
-            var preCheck = certificateToolRunner.CheckHttpCertificate();
+            var preCheck = certificateToolRunner.CheckHttpCertificate(cancellationToken);
 
             if (!preCheck.HasCertificates && ShouldGenerateHttpsCertificate())
             {
@@ -90,7 +90,7 @@ internal sealed class CertificateService(
                 if (generateResult is EnsureCertificateResult.Succeeded or EnsureCertificateResult.ValidCertificatePresent)
                 {
                     // Refresh the check so subsequent trust-level logic reflects the newly created cert.
-                    preCheck = certificateToolRunner.CheckHttpCertificate();
+                    preCheck = certificateToolRunner.CheckHttpCertificate(cancellationToken);
                 }
                 else
                 {
@@ -136,7 +136,7 @@ internal sealed class CertificateService(
             interactionService.DisplayMessage(KnownEmojis.Warning, string.Format(CultureInfo.CurrentCulture, ErrorStrings.CertificatesMayNotBeFullyTrusted, trustResultCode));
         }
 
-        var postTrustCheck = certificateToolRunner.CheckHttpCertificate();
+        var postTrustCheck = certificateToolRunner.CheckHttpCertificate(cancellationToken);
         if (postTrustCheck.IsPartiallyTrusted && isLinux)
         {
             ConfigureSslCertDir(environmentVariables);

--- a/src/Aspire.Cli/Certificates/ICertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/ICertificateToolRunner.cs
@@ -13,7 +13,7 @@ internal interface ICertificateToolRunner
     /// <summary>
     /// Checks certificate trust status, returning structured certificate information.
     /// </summary>
-    CertificateTrustResult CheckHttpCertificate();
+    CertificateTrustResult CheckHttpCertificate(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Ensures an HTTPS development certificate exists in the personal certificate store,

--- a/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
+++ b/src/Aspire.Cli/Certificates/NativeCertificateToolRunner.cs
@@ -13,7 +13,7 @@ namespace Aspire.Cli.Certificates;
 internal sealed class NativeCertificateToolRunner(CertificateManager certificateManager, IEnvironment environment) : ICertificateToolRunner
 {
 
-    public CertificateTrustResult CheckHttpCertificate()
+    public CertificateTrustResult CheckHttpCertificate(CancellationToken cancellationToken = default)
     {
         var availableCertificates = certificateManager.ListCertificates(
             StoreName.My, StoreLocation.CurrentUser, isValid: true);
@@ -23,10 +23,21 @@ internal sealed class NativeCertificateToolRunner(CertificateManager certificate
             var now = DateTimeOffset.Now;
             var certInfos = availableCertificates.Select(cert =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var status = certificateManager.CheckCertificateState(cert);
-                var trustLevel = status.Success
-                    ? certificateManager.GetTrustLevel(cert)
-                    : CertificateManager.TrustLevel.None;
+                CertificateManager.TrustLevel trustLevel;
+                if (!status.Success)
+                {
+                    trustLevel = CertificateManager.TrustLevel.None;
+                }
+                else if (certificateManager is UnixCertificateManager unixCertificateManager)
+                {
+                    trustLevel = unixCertificateManager.GetTrustLevel(cert, cancellationToken);
+                }
+                else
+                {
+                    trustLevel = certificateManager.GetTrustLevel(cert);
+                }
 
                 return new DevCertInfo
                 {

--- a/src/Aspire.Cli/Commands/InstallationInfoOutput.cs
+++ b/src/Aspire.Cli/Commands/InstallationInfoOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Cli.Acquisition;
 using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
@@ -10,7 +11,51 @@ namespace Aspire.Cli.Commands;
 
 internal static class InstallationInfoOutput
 {
-    public static async Task<IReadOnlyList<InstallationInfo>> DiscoverAllSafelyAsync(
+    internal static readonly TimeSpan s_defaultDiscoveryTimeout = TimeSpan.FromSeconds(30);
+
+    public static Task<IReadOnlyList<InstallationInfo>> DiscoverAllSafelyAsync(
+        IInstallationDiscovery discovery,
+        WingetFirstRunProbe wingetFirstRunProbe,
+        ILogger logger,
+        CancellationToken cancellationToken)
+        => DiscoverAllSafelyAsync(discovery, wingetFirstRunProbe, logger, s_defaultDiscoveryTimeout, cancellationToken);
+
+    internal static async Task<IReadOnlyList<InstallationInfo>> DiscoverAllSafelyAsync(
+        IInstallationDiscovery discovery,
+        WingetFirstRunProbe wingetFirstRunProbe,
+        ILogger logger,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeout);
+        // DiscoverAllCoreAsync catches and logs non-cancellation exceptions, so a task that
+        // continues after WaitAsync times out cannot later produce an unobserved fault.
+        var discoveryTask = Task.Run(
+            () => DiscoverAllCoreAsync(discovery, wingetFirstRunProbe, logger, timeoutCts.Token),
+            CancellationToken.None);
+
+        try
+        {
+            return await discoveryTask.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            logger.LogWarning("Aspire CLI installation discovery timed out after {TimeoutSeconds} seconds.", timeout.TotalSeconds);
+            return CreateFailedDiscoveryRow(string.Format(
+                CultureInfo.CurrentCulture,
+                DoctorCommandStrings.InstallationDiscoveryTimedOutReasonFormat,
+                timeout.TotalSeconds));
+        }
+    }
+
+    private static async Task<IReadOnlyList<InstallationInfo>> DiscoverAllCoreAsync(
         IInstallationDiscovery discovery,
         WingetFirstRunProbe wingetFirstRunProbe,
         ILogger logger,
@@ -39,7 +84,7 @@ internal static class InstallationInfoOutput
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Could not discover Aspire CLI installations for doctor output.");
-            return CreateFailedDiscoveryRow();
+            return CreateFailedDiscoveryRow(DoctorCommandStrings.InstallationDiscoveryFailedReason);
         }
     }
 
@@ -59,7 +104,7 @@ internal static class InstallationInfoOutput
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Could not describe the running Aspire CLI installation for doctor self-probe output.");
-            return CreateFailedDiscoveryRow();
+            return CreateFailedDiscoveryRow(DoctorCommandStrings.InstallationDiscoveryFailedReason);
         }
     }
 
@@ -157,7 +202,7 @@ internal static class InstallationInfoOutput
         };
     }
 
-    private static IReadOnlyList<InstallationInfo> CreateFailedDiscoveryRow()
+    private static IReadOnlyList<InstallationInfo> CreateFailedDiscoveryRow(string reason)
     {
         return
         [
@@ -167,7 +212,7 @@ internal static class InstallationInfoOutput
                 CanonicalPath = null,
                 PathStatus = InstallationPathStatus.NotOnPath,
                 Status = InstallationInfoStatus.Failed,
-                StatusReason = DoctorCommandStrings.InstallationDiscoveryFailedReason,
+                StatusReason = reason,
             }
         ];
     }

--- a/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
+++ b/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
@@ -13,6 +13,14 @@ namespace Aspire.Cli.DotNet;
 /// </summary>
 internal sealed class DotNetSdkInstaller(IConfiguration configuration) : IDotNetSdkInstaller
 {
+    private readonly Func<string, ProcessStartInfo> _createProcessStartInfo = CreateProcessStartInfo;
+
+    internal DotNetSdkInstaller(IConfiguration configuration, Func<string, ProcessStartInfo> createProcessStartInfo)
+        : this(configuration)
+    {
+        _createProcessStartInfo = createProcessStartInfo;
+    }
+
     /// <summary>
     /// The minimum .NET SDK version required for Aspire.
     /// </summary>
@@ -29,18 +37,7 @@ internal sealed class DotNetSdkInstaller(IConfiguration configuration) : IDotNet
             var currentArch = GetCurrentArchitecture();
             var arguments = $"--list-sdks --arch {currentArch}";
 
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "dotnet",
-                    Arguments = arguments,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true
-                }
-            };
+            using var process = new Process { StartInfo = _createProcessStartInfo(arguments) };
 
             process.Start();
             var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
@@ -119,6 +116,19 @@ internal sealed class DotNetSdkInstaller(IConfiguration configuration) : IDotNet
             // If we can't start the process, the SDK is not available
             return (false, null, minimumVersion);
         }
+    }
+
+    private static ProcessStartInfo CreateProcessStartInfo(string arguments)
+    {
+        return new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
     }
 
     /// <summary>

--- a/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
+++ b/src/Aspire.Cli/DotNet/DotNetSdkInstaller.cs
@@ -43,8 +43,34 @@ internal sealed class DotNetSdkInstaller(IConfiguration configuration) : IDotNet
             };
 
             process.Start();
-            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-            await process.WaitForExitAsync(cancellationToken);
+            var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+            try
+            {
+                await Task.WhenAll(
+                    standardOutputTask,
+                    standardErrorTask,
+                    process.WaitForExitAsync(cancellationToken));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // The doctor timeout owns this process, so cancellation must not leave dotnet or
+                // any child process running after the check has returned.
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync(CancellationToken.None);
+                }
+                catch (InvalidOperationException)
+                {
+                    // The process exited between cancellation and the kill attempt.
+                }
+
+                throw;
+            }
+
+            var output = await standardOutputTask;
 
             if (process.ExitCode != 0)
             {

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.Designer.cs
@@ -609,6 +609,24 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Environment check &apos;{0}&apos; timed out after {1} seconds..
+        /// </summary>
+        public static string EnvironmentCheckTimedOutMessageFormat {
+            get {
+                return ResourceManager.GetString("EnvironmentCheckTimedOutMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Environment checks timed out after {0} seconds..
+        /// </summary>
+        public static string EnvironmentChecksTimedOutMessageFormat {
+            get {
+                return ResourceManager.GetString("EnvironmentChecksTimedOutMessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to No trusted developer certificate was available for the Developer Control Plane (DCP) developer certificate connection check.
         /// </summary>
         public static string DcpDeveloperCertificateUnavailableMessage {
@@ -875,6 +893,15 @@ namespace Aspire.Cli.Resources {
         public static string InstallationDiscoveryFailedReason {
             get {
                 return ResourceManager.GetString("InstallationDiscoveryFailedReason", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Install discovery timed out after {0} seconds. See the Aspire CLI logs for details..
+        /// </summary>
+        public static string InstallationDiscoveryTimedOutReasonFormat {
+            get {
+                return ResourceManager.GetString("InstallationDiscoveryTimedOutReasonFormat", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DoctorCommandStrings.resx
@@ -104,6 +104,14 @@
   <data name="CheckingPrerequisites" xml:space="preserve">
     <value>Checking Aspire environment...</value>
   </data>
+  <data name="EnvironmentCheckTimedOutMessageFormat" xml:space="preserve">
+    <value>Environment check '{0}' timed out after {1} seconds.</value>
+    <comment>{0} is the environment check name. {1} is the timeout in seconds.</comment>
+  </data>
+  <data name="EnvironmentChecksTimedOutMessageFormat" xml:space="preserve">
+    <value>Environment checks timed out after {0} seconds.</value>
+    <comment>{0} is the total timeout in seconds.</comment>
+  </data>
   <data name="OperatingSystemMessageFormat" xml:space="preserve">
     <value>Operating system: {0}</value>
     <comment>{0} is the operating system display name and version, for example "Windows 10.0.22631", "macOS 26.0", or "Linux Ubuntu 24.04".</comment>
@@ -356,6 +364,10 @@
   </data>
   <data name="InstallationDiscoveryFailedReason" xml:space="preserve">
     <value>Install discovery failed. See the Aspire CLI logs for details.</value>
+  </data>
+  <data name="InstallationDiscoveryTimedOutReasonFormat" xml:space="preserve">
+    <value>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</value>
+    <comment>{0} is the timeout in seconds.</comment>
   </data>
   <data name="LegacySettingsDetectedMessageFormat" xml:space="preserve">
     <value>Legacy .aspire/settings.json detected at {0}</value>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.cs.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Kontrola prostředí Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.de.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Überprüfung der Aspire-Umgebung</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.es.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Comprobación del entorno de Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.fr.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Vérification de l’environnement Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.it.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Verifica ambiente Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ja.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Aspire 環境確認</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ko.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Aspire 환경 검사</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pl.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Sprawdzanie środowiska Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.pt-BR.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Verificação de Ambiente do Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.ru.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Проверка среды Aspire</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.tr.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Aspire Ortamı Kontrolü</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hans.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Aspire 环境检查</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DoctorCommandStrings.zh-Hant.xlf
@@ -372,6 +372,16 @@
         <target state="translated">Aspire 環境檢查</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentCheckTimedOutMessageFormat">
+        <source>Environment check '{0}' timed out after {1} seconds.</source>
+        <target state="new">Environment check '{0}' timed out after {1} seconds.</target>
+        <note>{0} is the environment check name. {1} is the timeout in seconds.</note>
+      </trans-unit>
+      <trans-unit id="EnvironmentChecksTimedOutMessageFormat">
+        <source>Environment checks timed out after {0} seconds.</source>
+        <target state="new">Environment checks timed out after {0} seconds.</target>
+        <note>{0} is the total timeout in seconds.</note>
+      </trans-unit>
       <trans-unit id="HeaderInstallations">
         <source>Aspire CLI Installations</source>
         <target state="new">Aspire CLI Installations</target>
@@ -381,6 +391,11 @@
         <source>Install discovery failed. See the Aspire CLI logs for details.</source>
         <target state="new">Install discovery failed. See the Aspire CLI logs for details.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InstallationDiscoveryTimedOutReasonFormat">
+        <source>Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</source>
+        <target state="new">Install discovery timed out after {0} seconds. See the Aspire CLI logs for details.</target>
+        <note>{0} is the timeout in seconds.</note>
       </trans-unit>
       <trans-unit id="JsonOptionDescription">
         <source>Output format (Table or Json)</source>

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/DevCertsCheck.cs
@@ -36,7 +36,7 @@ internal sealed class DevCertsCheck(ILogger<DevCertsCheck> logger, ICertificateT
     {
         try
         {
-            var trustResult = certificateToolRunner.CheckHttpCertificate();
+            var trustResult = certificateToolRunner.CheckHttpCertificate(cancellationToken);
             var results = EvaluateCertificateResults(trustResult.Certificates, environment);
             await AddLinuxOpenSslCertificateCacheWarningsAsync(results, trustResult.Certificates, environment, cancellationToken).ConfigureAwait(false);
             AddLinuxCertificateToolWarnings(results, environment);

--- a/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentChecker.cs
+++ b/src/Aspire.Cli/Utils/EnvironmentChecker/EnvironmentChecker.cs
@@ -1,6 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using Aspire.Cli.Resources;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Utils.EnvironmentChecker;
@@ -8,36 +12,148 @@ namespace Aspire.Cli.Utils.EnvironmentChecker;
 /// <summary>
 /// Orchestrates environment checks using injected IEnvironmentCheck instances.
 /// </summary>
-internal sealed class EnvironmentChecker(IEnumerable<IEnvironmentCheck> checks, ILogger<EnvironmentChecker> logger) : IEnvironmentChecker
+internal sealed class EnvironmentChecker : IEnvironmentChecker
 {
-    private readonly IEnvironmentCheck[] _checks = checks.OrderBy(c => c.Order).ToArray();
+    internal static readonly TimeSpan s_defaultCheckTimeout = TimeSpan.FromSeconds(30);
+    internal static readonly TimeSpan s_defaultTotalTimeout = TimeSpan.FromMinutes(2);
+
+    private readonly IEnvironmentCheck[] _checks;
+    private readonly ILogger<EnvironmentChecker> _logger;
+    private readonly TimeSpan _checkTimeout;
+    private readonly TimeSpan _totalTimeout;
+
+    public EnvironmentChecker(IEnumerable<IEnvironmentCheck> checks, ILogger<EnvironmentChecker> logger)
+        : this(checks, logger, s_defaultCheckTimeout, s_defaultTotalTimeout)
+    {
+    }
+
+    internal EnvironmentChecker(IEnumerable<IEnvironmentCheck> checks, ILogger<EnvironmentChecker> logger, TimeSpan checkTimeout, TimeSpan totalTimeout)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(checkTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(totalTimeout, TimeSpan.Zero);
+
+        _checks = checks.OrderBy(c => c.Order).ToArray();
+        _logger = logger;
+        _checkTimeout = checkTimeout;
+        _totalTimeout = totalTimeout;
+    }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<EnvironmentCheckResult>> CheckAllAsync(CancellationToken cancellationToken = default)
     {
         var results = new List<EnvironmentCheckResult>();
+        using var totalTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        totalTimeoutCts.CancelAfter(_totalTimeout);
 
         // Run all checks in order (by Order property)
         // Continue running remaining checks even if one fails
         foreach (var check in _checks)
         {
+            var checkType = check.GetType();
+            var checkName = GetCheckName(checkType);
+            using var checkTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(totalTimeoutCts.Token);
+            checkTimeoutCts.CancelAfter(_checkTimeout);
+            var stopwatch = Stopwatch.StartNew();
+
+            _logger.LogDebug("Starting environment check {CheckType}.", checkType.Name);
+
             try
             {
-                var checkResults = await check.CheckAsync(cancellationToken);
+                // Some checks call synchronous platform APIs before returning their task. Scheduling the
+                // invocation keeps those APIs from preventing the timeout token from being observed here.
+                var checkTask = Task.Run(() => check.CheckAsync(checkTimeoutCts.Token), CancellationToken.None);
+                // WaitAsync can time out while a non-cooperative check keeps running. Observe any
+                // exception it produces later because it can no longer reach the catch block below.
+                _ = checkTask.ContinueWith(
+                    static task => _ = task.Exception,
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+
+                var checkResults = await checkTask.WaitAsync(checkTimeoutCts.Token).ConfigureAwait(false);
                 results.AddRange(checkResults);
+
+                _logger.LogDebug(
+                    "Environment check {CheckType} completed in {ElapsedMilliseconds} ms.",
+                    checkType.Name,
+                    stopwatch.ElapsedMilliseconds);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // User requested cancellation, stop all checks
                 throw;
             }
+            catch (OperationCanceledException) when (totalTimeoutCts.IsCancellationRequested)
+            {
+                _logger.LogWarning(
+                    "Environment checks timed out after {TimeoutSeconds} seconds while running {CheckType}.",
+                    _totalTimeout.TotalSeconds,
+                    checkType.Name);
+
+                results.Add(CreateTimeoutResult(
+                    "environment-checks",
+                    string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.EnvironmentChecksTimedOutMessageFormat, _totalTimeout.TotalSeconds),
+                    checkType,
+                    _totalTimeout));
+                break;
+            }
+            catch (OperationCanceledException) when (checkTimeoutCts.IsCancellationRequested)
+            {
+                _logger.LogWarning(
+                    "Environment check {CheckType} timed out after {TimeoutSeconds} seconds.",
+                    checkType.Name,
+                    _checkTimeout.TotalSeconds);
+
+                results.Add(CreateTimeoutResult(
+                    checkName,
+                    string.Format(CultureInfo.CurrentCulture, DoctorCommandStrings.EnvironmentCheckTimedOutMessageFormat, checkName, _checkTimeout.TotalSeconds),
+                    checkType,
+                    _checkTimeout));
+            }
             catch (Exception ex)
             {
                 // Log the error but continue with other checks
-                logger.LogDebug(ex, "Environment check {CheckType} failed with exception", check.GetType().Name);
+                _logger.LogDebug(ex, "Environment check {CheckType} failed with exception", checkType.Name);
             }
         }
 
         return results;
+    }
+
+    private static EnvironmentCheckResult CreateTimeoutResult(string name, string message, Type checkType, TimeSpan timeout)
+    {
+        return new EnvironmentCheckResult
+        {
+            Category = EnvironmentCheckCategories.Environment,
+            Name = name,
+            Status = EnvironmentCheckStatus.Warning,
+            Message = message,
+            Metadata = new JsonObject
+            {
+                ["checkType"] = checkType.Name,
+                ["timeoutSeconds"] = timeout.TotalSeconds,
+            }
+        };
+    }
+
+    private static string GetCheckName(Type checkType)
+    {
+        var typeName = checkType.Name.EndsWith("Check", StringComparison.Ordinal)
+            ? checkType.Name[..^"Check".Length]
+            : checkType.Name;
+        var name = new System.Text.StringBuilder(typeName.Length + 4);
+
+        for (var i = 0; i < typeName.Length; i++)
+        {
+            var character = typeName[i];
+            if (i > 0 && char.IsUpper(character) && !char.IsUpper(typeName[i - 1]))
+            {
+                name.Append('-');
+            }
+
+            name.Append(char.ToLowerInvariant(character));
+        }
+
+        return name.ToString();
     }
 }

--- a/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Cli.Certificates;
+using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Certificates.Generation;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 
@@ -11,6 +14,58 @@ namespace Aspire.Cli.Tests.Certificates;
 
 public class UnixCertificateManagerTests
 {
+    [Fact]
+    public async Task GetTrustLevel_WhenCanceled_KillsCertUtilProcessTree()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "NSS certificate trust is only exercised on Linux.");
+
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        var nssDbDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "nssdb"));
+        var parentPidFile = Path.Combine(tempDirectory.FullName, "certutil-parent.pid");
+        var childPidFile = Path.Combine(tempDirectory.FullName, "certutil-child.pid");
+        var parentPid = 0;
+        var childPid = 0;
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        try
+        {
+            var certUtilFile = await CreateBlockingCertUtilAsync(tempDirectory, parentPidFile, childPidFile);
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                ["SSL_CERT_DIR"] = tempDirectory.FullName,
+                ["DOTNET_DEV_CERTS_NSSDB_PATHS"] = nssDbDirectory.FullName
+            });
+            var manager = new UnixCertificateManager(NullLogger.Instance, environment, _ => new ProcessStartInfo(certUtilFile.FullName)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            });
+            using var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(365));
+            var trustTask = Task.Run(() => manager.GetTrustLevel(certificate, cancellationTokenSource.Token));
+
+            parentPid = await ProcessTestHelpers.WaitForProcessIdAsync(parentPidFile, TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10));
+            childPid = await ProcessTestHelpers.WaitForProcessIdAsync(childPidFile, TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10));
+
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => trustTask).DefaultTimeout();
+            Assert.True(ProcessTestHelpers.WaitForProcessExit(parentPid, TimeSpan.FromSeconds(10)), $"Expected certutil process {parentPid} to exit.");
+            Assert.True(ProcessTestHelpers.WaitForProcessExit(childPid, TimeSpan.FromSeconds(10)), $"Expected child process {childPid} to exit.");
+        }
+        finally
+        {
+            cancellationTokenSource.Cancel();
+            ProcessTestHelpers.TryKillProcess(parentPid);
+            ProcessTestHelpers.TryKillProcess(childPid);
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
     [Fact]
     public void GetTrustLevel_WithCorruptOpenSslCertificate_DoesNotThrow()
     {
@@ -146,4 +201,30 @@ public class UnixCertificateManagerTests
             openSslDirectory.Delete(recursive: true);
         }
     }
+
+    private static async Task<FileInfo> CreateBlockingCertUtilAsync(DirectoryInfo directory, string parentPidFile, string childPidFile)
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        var certUtilFile = new FileInfo(Path.Combine(directory.FullName, "certutil"));
+        var script =
+            "#!/usr/bin/env bash" + Environment.NewLine +
+            $"echo $$ > '{EscapeShellPath(parentPidFile)}'" + Environment.NewLine +
+            "sleep 60 &" + Environment.NewLine +
+            $"echo $! > '{EscapeShellPath(childPidFile)}'" + Environment.NewLine +
+            "wait $!" + Environment.NewLine;
+        await File.WriteAllTextAsync(certUtilFile.FullName, script);
+        File.SetUnixFileMode(
+            certUtilFile.FullName,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        return certUtilFile;
+    }
+
+    private static string EscapeShellPath(string path) => path.Replace("'", "'\"'\"'", StringComparison.Ordinal);
 }

--- a/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
@@ -47,9 +47,9 @@ public class UnixCertificateManagerTests
             var trustTask = Task.Run(() => manager.GetTrustLevel(certificate, cancellationTokenSource.Token));
 
             parentPid = await ProcessTestHelpers.WaitForProcessIdAsync(parentPidFile, TestContext.Current.CancellationToken)
-                .WaitAsync(TimeSpan.FromSeconds(10));
+                .DefaultTimeout();
             childPid = await ProcessTestHelpers.WaitForProcessIdAsync(childPidFile, TestContext.Current.CancellationToken)
-                .WaitAsync(TimeSpan.FromSeconds(10));
+                .DefaultTimeout();
 
             cancellationTokenSource.Cancel();
 

--- a/tests/Aspire.Cli.Tests/Commands/InstallationInfoOutputTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InstallationInfoOutputTests.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Acquisition;
+using Aspire.Cli.Commands;
+using Aspire.Cli.Tests.TestServices;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Commands;
+
+public class InstallationInfoOutputTests
+{
+    [Fact]
+    public async Task DiscoverAllSafelyAsync_TimesOutWhenDiscoveryDoesNotObserveCancellation()
+    {
+        using var releaseDiscovery = new ManualResetEventSlim();
+        var discoveryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var discoveryExited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var self = new InstallationInfo
+        {
+            Path = "/test/aspire",
+            Status = InstallationInfoStatus.Ok,
+        };
+        var discovery = new FakeInstallationDiscovery(self)
+        {
+            DiscoverAllAsyncCallback = _ =>
+            {
+                discoveryStarted.SetResult();
+                releaseDiscovery.Wait(CancellationToken.None);
+                discoveryExited.SetResult();
+                return Task.FromResult<IReadOnlyList<InstallationInfo>>([self]);
+            },
+        };
+        var wingetProbe = new WingetFirstRunProbe(
+            new TestWindowsRegistryReader(),
+            NullLogger<WingetFirstRunProbe>.Instance);
+
+        var discoveryTask = InstallationInfoOutput.DiscoverAllSafelyAsync(
+            discovery,
+            wingetProbe,
+            NullLogger.Instance,
+            TimeSpan.FromMilliseconds(100),
+            TestContext.Current.CancellationToken);
+        IReadOnlyList<InstallationInfo> results;
+        try
+        {
+            await discoveryStarted.Task.DefaultTimeout();
+            results = await discoveryTask.DefaultTimeout();
+        }
+        finally
+        {
+            releaseDiscovery.Set();
+        }
+
+        await discoveryExited.Task.DefaultTimeout();
+
+        var result = Assert.Single(results);
+        Assert.Equal(InstallationInfoStatus.Failed, result.Status);
+        Assert.Contains("timed out after", result.StatusReason, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
@@ -3,8 +3,10 @@
 
 using Microsoft.AspNetCore.InternalTesting;
 using System.Globalization;
+using System.Diagnostics;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Resources;
+using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.Configuration;
 using Semver;
 
@@ -21,6 +23,42 @@ public class DotNetSdkInstallerTests
         var (success, _, _) = await installer.CheckAsync().DefaultTimeout();
 
         Assert.True(success);
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenCanceled_KillsDotNetProcessTree()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        var parentPidFile = Path.Combine(tempDirectory.FullName, "dotnet-parent.pid");
+        var childPidFile = Path.Combine(tempDirectory.FullName, "dotnet-child.pid");
+        var parentPid = 0;
+        var childPid = 0;
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        try
+        {
+            var startInfo = await CreateBlockingDotNetShimAsync(tempDirectory, parentPidFile, childPidFile);
+            var installer = new DotNetSdkInstaller(CreateEmptyConfiguration(), _ => startInfo);
+            var checkTask = installer.CheckAsync(cancellationTokenSource.Token);
+
+            parentPid = await ProcessTestHelpers.WaitForProcessIdAsync(parentPidFile, TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10));
+            childPid = await ProcessTestHelpers.WaitForProcessIdAsync(childPidFile, TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(10));
+
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => checkTask).DefaultTimeout();
+            Assert.True(ProcessTestHelpers.WaitForProcessExit(parentPid, TimeSpan.FromSeconds(10)), $"Expected dotnet process {parentPid} to exit.");
+            Assert.True(ProcessTestHelpers.WaitForProcessExit(childPid, TimeSpan.FromSeconds(10)), $"Expected child process {childPid} to exit.");
+        }
+        finally
+        {
+            cancellationTokenSource.Cancel();
+            ProcessTestHelpers.TryKillProcess(parentPid);
+            ProcessTestHelpers.TryKillProcess(childPid);
+            tempDirectory.Delete(recursive: true);
+        }
     }
 
     [Fact]
@@ -247,4 +285,56 @@ public class DotNetSdkInstallerTests
             })
             .Build();
     }
+
+    private static async Task<ProcessStartInfo> CreateBlockingDotNetShimAsync(DirectoryInfo directory, string parentPidFile, string childPidFile)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var scriptFile = Path.Combine(directory.FullName, "dotnet-shim.ps1");
+            var script =
+                "$child = Start-Process cmd.exe -ArgumentList '/c', 'ping -n 60 127.0.0.1 > nul' -PassThru" + Environment.NewLine +
+                $"$PID | Set-Content -Path '{parentPidFile.Replace("'", "''", StringComparison.Ordinal)}'" + Environment.NewLine +
+                $"$child.Id | Set-Content -Path '{childPidFile.Replace("'", "''", StringComparison.Ordinal)}'" + Environment.NewLine +
+                "$child.WaitForExit()" + Environment.NewLine;
+            await File.WriteAllTextAsync(scriptFile, script);
+
+            var startInfo = new ProcessStartInfo("powershell.exe")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-ExecutionPolicy");
+            startInfo.ArgumentList.Add("Bypass");
+            startInfo.ArgumentList.Add("-File");
+            startInfo.ArgumentList.Add(scriptFile);
+            return startInfo;
+        }
+
+        var shellFile = Path.Combine(directory.FullName, "dotnet");
+        var shellScript =
+            "#!/usr/bin/env bash" + Environment.NewLine +
+            $"echo $$ > '{EscapeShellPath(parentPidFile)}'" + Environment.NewLine +
+            "sleep 60 &" + Environment.NewLine +
+            $"echo $! > '{EscapeShellPath(childPidFile)}'" + Environment.NewLine +
+            "wait $!" + Environment.NewLine;
+        await File.WriteAllTextAsync(shellFile, shellScript);
+        File.SetUnixFileMode(
+            shellFile,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        return new ProcessStartInfo(shellFile)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+    }
+
+    private static string EscapeShellPath(string path) => path.Replace("'", "'\"'\"'", StringComparison.Ordinal);
 }

--- a/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
+++ b/tests/Aspire.Cli.Tests/DotNetSdkInstallerTests.cs
@@ -42,9 +42,9 @@ public class DotNetSdkInstallerTests
             var checkTask = installer.CheckAsync(cancellationTokenSource.Token);
 
             parentPid = await ProcessTestHelpers.WaitForProcessIdAsync(parentPidFile, TestContext.Current.CancellationToken)
-                .WaitAsync(TimeSpan.FromSeconds(10));
+                .DefaultTimeout();
             childPid = await ProcessTestHelpers.WaitForProcessIdAsync(childPidFile, TestContext.Current.CancellationToken)
-                .WaitAsync(TimeSpan.FromSeconds(10));
+                .DefaultTimeout();
 
             cancellationTokenSource.Cancel();
 

--- a/tests/Aspire.Cli.Tests/TestServices/FakeInstallationDiscovery.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/FakeInstallationDiscovery.cs
@@ -17,6 +17,8 @@ internal sealed class FakeInstallationDiscovery : IInstallationDiscovery
     private readonly IReadOnlyList<InstallationInfo> _others;
     private readonly Exception? _discoverAllException;
 
+    public Func<CancellationToken, Task<IReadOnlyList<InstallationInfo>>>? DiscoverAllAsyncCallback { get; init; }
+
     public FakeInstallationDiscovery(InstallationInfo self, IReadOnlyList<InstallationInfo>? others = null, Exception? discoverAllException = null)
     {
         _self = self;
@@ -29,6 +31,11 @@ internal sealed class FakeInstallationDiscovery : IInstallationDiscovery
     public Task<IReadOnlyList<InstallationInfo>> DiscoverAllAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        if (DiscoverAllAsyncCallback is not null)
+        {
+            return DiscoverAllAsyncCallback(cancellationToken);
+        }
+
         if (_discoverAllException is not null)
         {
             throw _discoverAllException;

--- a/tests/Aspire.Cli.Tests/TestServices/ProcessTestHelpers.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/ProcessTestHelpers.cs
@@ -7,6 +7,32 @@ namespace Aspire.Cli.Tests.TestServices;
 
 internal static class ProcessTestHelpers
 {
+    public static async Task<int> WaitForProcessIdAsync(string pidFile, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            if (File.Exists(pidFile))
+            {
+                try
+                {
+                    using var stream = new FileStream(pidFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using var reader = new StreamReader(stream);
+                    var text = await reader.ReadToEndAsync(cancellationToken);
+                    if (int.TryParse(text.Trim(), out var pid))
+                    {
+                        return pid;
+                    }
+                }
+                catch (IOException)
+                {
+                    // The process may still be writing the file. Retry until the caller's timeout expires.
+                }
+            }
+
+            await Task.Delay(20, cancellationToken);
+        }
+    }
+
     public static bool WaitForProcessExit(int pid, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestCertificateToolRunner.cs
@@ -17,8 +17,9 @@ internal sealed class TestCertificateToolRunner : ICertificateToolRunner
     public Func<EnsureCertificateResult>? TrustHttpCertificateCallback { get; set; }
     public Func<CertificateCleanResult>? CleanHttpCertificateCallback { get; set; }
 
-    public CertificateTrustResult CheckHttpCertificate()
+    public CertificateTrustResult CheckHttpCertificate(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (CheckHttpCertificateCallback is not null)
         {
             return CheckHttpCertificateCallback();

--- a/tests/Aspire.Cli.Tests/TestServices/TestEnvironmentCheck.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestEnvironmentCheck.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Utils.EnvironmentChecker;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestEnvironmentCheck(
+    int order,
+    Func<CancellationToken, Task<IReadOnlyList<EnvironmentCheckResult>>> checkAsync) : IEnvironmentCheck
+{
+    public int Order => order;
+
+    public Task<IReadOnlyList<EnvironmentCheckResult>> CheckAsync(CancellationToken cancellationToken = default)
+        => checkAsync(cancellationToken);
+}

--- a/tests/Aspire.Cli.Tests/TestServices/TestWindowsRegistryReader.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestWindowsRegistryReader.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Acquisition;
+
+namespace Aspire.Cli.Tests.TestServices;
+
+internal sealed class TestWindowsRegistryReader(bool hasWingetAspireUninstallEntry = false) : IWindowsRegistryReader
+{
+    public bool HasWingetAspireUninstallEntry(string processPath) => hasWingetAspireUninstallEntry;
+}

--- a/tests/Aspire.Cli.Tests/Utils/EnvironmentCheckerTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/EnvironmentCheckerTests.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Tests.TestServices;
+using Aspire.Cli.Utils.EnvironmentChecker;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Cli.Tests.Utils;
+
+public class EnvironmentCheckerTests
+{
+    [Fact]
+    public async Task CheckAllAsync_TimedOutCheckReportsWarningAndContinues()
+    {
+        using var releaseCheck = new ManualResetEventSlim();
+        var checkStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkExited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completedResult = new EnvironmentCheckResult
+        {
+            Category = EnvironmentCheckCategories.Environment,
+            Name = "completed",
+            Status = EnvironmentCheckStatus.Pass,
+            Message = "Completed"
+        };
+        var checker = new EnvironmentChecker(
+            [
+                new TestEnvironmentCheck(0, _ =>
+                {
+                    checkStarted.SetResult();
+                    releaseCheck.Wait(CancellationToken.None);
+                    checkExited.SetResult();
+                    return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([]);
+                }),
+                new TestEnvironmentCheck(1, _ => Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([completedResult])),
+            ],
+            NullLogger<EnvironmentChecker>.Instance,
+            checkTimeout: TimeSpan.FromMilliseconds(100),
+            totalTimeout: TimeSpan.FromSeconds(5));
+
+        var checkAllTask = checker.CheckAllAsync(TestContext.Current.CancellationToken);
+        IReadOnlyList<EnvironmentCheckResult> results;
+        try
+        {
+            await checkStarted.Task.DefaultTimeout();
+            results = await checkAllTask.DefaultTimeout();
+        }
+        finally
+        {
+            releaseCheck.Set();
+        }
+
+        await checkExited.Task.DefaultTimeout();
+
+        Assert.Collection(
+            results,
+            timeoutResult =>
+            {
+                Assert.Equal("test-environment", timeoutResult.Name);
+                Assert.Equal(EnvironmentCheckStatus.Warning, timeoutResult.Status);
+                Assert.Equal(nameof(TestEnvironmentCheck), timeoutResult.Metadata!["checkType"]!.GetValue<string>());
+                Assert.Equal(0.1, timeoutResult.Metadata["timeoutSeconds"]!.GetValue<double>());
+            },
+            result => Assert.Same(completedResult, result));
+    }
+
+    [Fact]
+    public async Task CheckAllAsync_TotalTimeoutReportsWarningAndStops()
+    {
+        var blockedCheck = new TaskCompletionSource<IReadOnlyList<EnvironmentCheckResult>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var subsequentCheckInvoked = false;
+        var checker = new EnvironmentChecker(
+            [
+                new TestEnvironmentCheck(0, _ => blockedCheck.Task),
+                new TestEnvironmentCheck(1, _ =>
+                {
+                    subsequentCheckInvoked = true;
+                    return Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([]);
+                }),
+            ],
+            NullLogger<EnvironmentChecker>.Instance,
+            checkTimeout: TimeSpan.FromSeconds(5),
+            totalTimeout: TimeSpan.FromMilliseconds(100));
+
+        var results = await checker.CheckAllAsync(TestContext.Current.CancellationToken).DefaultTimeout();
+
+        var timeoutResult = Assert.Single(results);
+        Assert.Equal("environment-checks", timeoutResult.Name);
+        Assert.Equal(EnvironmentCheckStatus.Warning, timeoutResult.Status);
+        Assert.False(subsequentCheckInvoked);
+    }
+
+    [Fact]
+    public async Task CheckAllAsync_CallerCancellationPropagates()
+    {
+        var blockedCheck = new TaskCompletionSource<IReadOnlyList<EnvironmentCheckResult>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checker = new EnvironmentChecker(
+            [new TestEnvironmentCheck(0, _ => blockedCheck.Task)],
+            NullLogger<EnvironmentChecker>.Instance,
+            checkTimeout: TimeSpan.FromSeconds(5),
+            totalTimeout: TimeSpan.FromSeconds(10));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => checker.CheckAllAsync(cancellationTokenSource.Token));
+    }
+}


### PR DESCRIPTION
## Description

`aspire doctor` could remain at `Checking Aspire environment...` until an external job timeout when an environment check or installation discovery operation blocked indefinitely.

This change bounds individual environment checks and installation discovery to 30 seconds, with a two-minute aggregate limit for environment checks. Individual timeouts are reported as warnings and later checks continue; reaching the aggregate limit reports a warning and stops scheduling remaining checks. Timeout details are also included in JSON output metadata.

Cancellation now terminates owned `dotnet --list-sdks` and Unix `certutil` process trees so timed-out checks do not leave child processes running.

### User-facing usage

When an individual check exceeds its deadline, `aspire doctor` continues and reports:

```text
⚠ Environment check 'dot-net-sdk' timed out after 30 seconds.
```

When the aggregate deadline is reached, it reports:

```text
⚠ Environment checks timed out after 120 seconds.
```

Validation:

- `dotnet test --project .\tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile --no-restore -- --filter-class "*.DoctorCommandTests" --filter-class "*.EnvironmentCheckerTests" --filter-class "*.InstallationInfoOutputTests" --filter-class "*.DotNetSdkInstallerTests" --filter-class "*.DevCertsCheckTests" --filter-class "*.NativeCertificateToolRunnerTests" --filter-class "*.UnixCertificateManagerTests" --filter-class "*.CertificateServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (91 passed, 4 platform-specific tests skipped on Windows)
- `dotnet build .\src\Aspire.Cli\Aspire.Cli.csproj --no-restore`

Fixes #18961

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No