### PR TITLE
Update Fluent UI to 4.14.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -119,8 +119,8 @@
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.1" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.4" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.14.4" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" /> <!-- No stable release available -->
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -9,7 +9,7 @@ using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components;
 
-public partial class AspireMenu : FluentComponentBase, IAsyncDisposable
+public partial class AspireMenu : FluentComponentBase
 {
     private FluentMenu? _menu;
 
@@ -46,9 +46,6 @@ public partial class AspireMenu : FluentComponentBase, IAsyncDisposable
 
     [Inject]
     public required IJSRuntime JS { get; init; }
-
-    [Inject]
-    public required IServiceProvider ServiceProvider { get; init; }
 
     // Each menu item is approximately 32px tall, plus 16px padding for the menu container.
     private const int EstimatedItemHeight = 32;
@@ -142,22 +139,5 @@ public partial class AspireMenu : FluentComponentBase, IAsyncDisposable
         {
             await OpenChanged.InvokeAsync(open);
         }
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        if (_menu is { } menu)
-        {
-            // Remove this workaround once FluentMenu unregisters itself: https://github.com/microsoft/aspire/issues/18852
-            if (ServiceProvider.GetService<IMenuService>() is { } menuService)
-            {
-                menuService.Remove(menu);
-                menuService.OnMenuUpdated();
-            }
-
-            _menu = null;
-        }
-
-        return ValueTask.CompletedTask;
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
@@ -14,7 +14,7 @@ namespace Aspire.Dashboard.Components.Tests.Controls;
 public class AspireMenuTests : DashboardTestContext
 {
     [Fact]
-    public async Task DisposeAsync_RemovesFluentMenuFromMenuProvider()
+    public async Task RemoveAspireMenu_UnregistersFluentMenuFromMenuProvider()
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
         FluentUISetupHelpers.SetupFluentUIComponents(this);


### PR DESCRIPTION
## Description

Updates `Microsoft.FluentUI.AspNetCore.Components` and `Microsoft.FluentUI.AspNetCore.Components.Icons` from 4.14.1 to 4.14.4.

Fluent UI 4.14.4 unregisters disposed menus from `IMenuService`, so this also removes the Aspire workaround added in #18853. The existing component test remains as regression coverage for the upstream disposal behavior.

Validation:

- `Aspire.Dashboard.Tests`: 1,525 passed, 1 skipped because Playwright WebKit is unavailable
- `Aspire.Dashboard.Components.Tests`: 190 passed

Fixes #18852

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No