### PR TITLE
Show runtime unhealthy resources as warnings in VS Code

### DIFF
--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -22,6 +22,7 @@ import {
     codeLensResourceStoppedError,
     codeLensResourceStoppedErrorWithExitCode,
     codeLensResourceFailedToStart,
+    codeLensResourceFailedToStartError,
     codeLensResourceRuntimeUnhealthy,
     codeLensRestart,
     codeLensStop,
@@ -374,7 +375,7 @@ export function getCodeLensStateLabel(state: string, stateStyle: string, exitCod
         case ResourceState.NotStarted:
             return codeLensResourceNotStarted;
         case ResourceState.FailedToStart:
-            return codeLensResourceFailedToStart;
+            return exitCode != null && exitCode !== 0 ? codeLensResourceFailedToStartError : codeLensResourceFailedToStart;
         case ResourceState.RuntimeUnhealthy:
             return codeLensResourceRuntimeUnhealthy;
         case ResourceState.Stopping:

--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -22,6 +22,7 @@ import {
     codeLensResourceStoppedError,
     codeLensResourceStoppedErrorWithExitCode,
     codeLensResourceError,
+    codeLensResourceRuntimeUnhealthy,
     codeLensRestart,
     codeLensStop,
     codeLensStart,
@@ -373,8 +374,9 @@ export function getCodeLensStateLabel(state: string, stateStyle: string, exitCod
         case ResourceState.NotStarted:
             return codeLensResourceNotStarted;
         case ResourceState.FailedToStart:
-        case ResourceState.RuntimeUnhealthy:
             return codeLensResourceError;
+        case ResourceState.RuntimeUnhealthy:
+            return codeLensResourceRuntimeUnhealthy;
         case ResourceState.Stopping:
             return codeLensResourceStopping;
         case ResourceState.Finished:

--- a/extension/src/editor/AspireCodeLensProvider.ts
+++ b/extension/src/editor/AspireCodeLensProvider.ts
@@ -21,7 +21,7 @@ import {
     codeLensResourceStoppedWithExitCode,
     codeLensResourceStoppedError,
     codeLensResourceStoppedErrorWithExitCode,
-    codeLensResourceError,
+    codeLensResourceFailedToStart,
     codeLensResourceRuntimeUnhealthy,
     codeLensRestart,
     codeLensStop,
@@ -374,7 +374,7 @@ export function getCodeLensStateLabel(state: string, stateStyle: string, exitCod
         case ResourceState.NotStarted:
             return codeLensResourceNotStarted;
         case ResourceState.FailedToStart:
-            return codeLensResourceError;
+            return codeLensResourceFailedToStart;
         case ResourceState.RuntimeUnhealthy:
             return codeLensResourceRuntimeUnhealthy;
         case ResourceState.Stopping:

--- a/extension/src/editor/AspireGutterDecorationProvider.ts
+++ b/extension/src/editor/AspireGutterDecorationProvider.ts
@@ -71,7 +71,7 @@ const decorationTypes = Object.fromEntries(
     })])
 ) as Record<GutterCategory, vscode.TextEditorDecorationType>;
 
-function classifyState(state: string, stateStyle: string, healthStatus: string, exitCode?: number | null): GutterCategory {
+export function classifyState(state: string, stateStyle: string, healthStatus: string, exitCode?: number | null): GutterCategory {
     switch (state) {
         case ResourceState.Running:
         case ResourceState.Active:
@@ -83,8 +83,9 @@ function classifyState(state: string, stateStyle: string, healthStatus: string, 
             }
             return 'running';
         case ResourceState.FailedToStart:
-        case ResourceState.RuntimeUnhealthy:
             return 'error';
+        case ResourceState.RuntimeUnhealthy:
+            return 'warning';
         case ResourceState.Starting:
         case ResourceState.Stopping:
         case ResourceState.Building:

--- a/extension/src/editor/AspireGutterDecorationProvider.ts
+++ b/extension/src/editor/AspireGutterDecorationProvider.ts
@@ -83,7 +83,6 @@ export function classifyState(state: string, stateStyle: string, healthStatus: s
             }
             return 'running';
         case ResourceState.FailedToStart:
-            return 'error';
         case ResourceState.RuntimeUnhealthy:
             return 'warning';
         case ResourceState.Starting:

--- a/extension/src/editor/AspireGutterDecorationProvider.ts
+++ b/extension/src/editor/AspireGutterDecorationProvider.ts
@@ -83,6 +83,7 @@ export function classifyState(state: string, stateStyle: string, healthStatus: s
             }
             return 'running';
         case ResourceState.FailedToStart:
+            return exitCode != null && exitCode !== 0 ? 'error' : 'warning';
         case ResourceState.RuntimeUnhealthy:
             return 'warning';
         case ResourceState.Starting:

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -211,6 +211,7 @@ export const codeLensResourceStoppedWithExitCode = (exitCode: number) => vscode.
 export const codeLensResourceStoppedError = vscode.l10n.t('$(error)\u200A Stopped');
 export const codeLensResourceStoppedErrorWithExitCode = (exitCode: number) => vscode.l10n.t('$(error)\u200A Stopped (Exit Code: {0})', exitCode);
 export const codeLensResourceError = vscode.l10n.t('$(error)\u200A Error');
+export const codeLensResourceRuntimeUnhealthy = vscode.l10n.t('$(warning)\u200A Runtime unhealthy');
 export const codeLensResourceValueMissing = vscode.l10n.t('$(warning)\u200A Value missing');
 export const codeLensRestart = vscode.l10n.t('$(debug-restart)\u200A Restart');
 export const codeLensStop = vscode.l10n.t('$(debug-stop)\u200A Stop');

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -211,6 +211,7 @@ export const codeLensResourceStoppedWithExitCode = (exitCode: number) => vscode.
 export const codeLensResourceStoppedError = vscode.l10n.t('$(error)\u200A Stopped');
 export const codeLensResourceStoppedErrorWithExitCode = (exitCode: number) => vscode.l10n.t('$(error)\u200A Stopped (Exit Code: {0})', exitCode);
 export const codeLensResourceFailedToStart = vscode.l10n.t('$(warning)\u200A Failed to start');
+export const codeLensResourceFailedToStartError = vscode.l10n.t('$(error)\u200A Failed to start');
 export const codeLensResourceRuntimeUnhealthy = vscode.l10n.t('$(warning)\u200A Runtime unhealthy');
 export const codeLensResourceValueMissing = vscode.l10n.t('$(warning)\u200A Value missing');
 export const codeLensRestart = vscode.l10n.t('$(debug-restart)\u200A Restart');

--- a/extension/src/loc/strings.ts
+++ b/extension/src/loc/strings.ts
@@ -210,7 +210,7 @@ export const codeLensResourceStopped = vscode.l10n.t('$(circle-outline)\u200A St
 export const codeLensResourceStoppedWithExitCode = (exitCode: number) => vscode.l10n.t('$(circle-outline)\u200A Stopped (Exit Code: {0})', exitCode);
 export const codeLensResourceStoppedError = vscode.l10n.t('$(error)\u200A Stopped');
 export const codeLensResourceStoppedErrorWithExitCode = (exitCode: number) => vscode.l10n.t('$(error)\u200A Stopped (Exit Code: {0})', exitCode);
-export const codeLensResourceError = vscode.l10n.t('$(error)\u200A Error');
+export const codeLensResourceFailedToStart = vscode.l10n.t('$(warning)\u200A Failed to start');
 export const codeLensResourceRuntimeUnhealthy = vscode.l10n.t('$(warning)\u200A Runtime unhealthy');
 export const codeLensResourceValueMissing = vscode.l10n.t('$(warning)\u200A Value missing');
 export const codeLensRestart = vscode.l10n.t('$(debug-restart)\u200A Restart');

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1655,9 +1655,11 @@ suite('getResourceIcon', () => {
         assert.strictEqual(icon.id, 'circle-outline');
     });
 
-    test('FailedToStart shows error icon', () => {
+    test('FailedToStart shows warning icon', () => {
         const icon = getResourceIcon(makeResource({ state: ResourceState.FailedToStart }));
-        assert.strictEqual(icon.id, 'error');
+        assert.strictEqual(icon.id, 'warning');
+        assert.ok(icon.color instanceof vscode.ThemeColor);
+        assert.strictEqual(icon.color.id, 'list.warningForeground');
     });
 
     test('RuntimeUnhealthy shows warning icon', () => {

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1662,6 +1662,27 @@ suite('getResourceIcon', () => {
         assert.strictEqual(icon.color.id, 'list.warningForeground');
     });
 
+    test('FailedToStart with exit code 0 shows warning icon', () => {
+        const icon = getResourceIcon(makeResource({ state: ResourceState.FailedToStart, exitCode: 0 }));
+        assert.strictEqual(icon.id, 'warning');
+        assert.ok(icon.color instanceof vscode.ThemeColor);
+        assert.strictEqual(icon.color.id, 'list.warningForeground');
+    });
+
+    test('FailedToStart with exit code -1 shows error icon', () => {
+        const icon = getResourceIcon(makeResource({ state: ResourceState.FailedToStart, exitCode: -1 }));
+        assert.strictEqual(icon.id, 'error');
+        assert.ok(icon.color instanceof vscode.ThemeColor);
+        assert.strictEqual(icon.color.id, 'list.errorForeground');
+    });
+
+    test('FailedToStart with a non-zero exit code shows error icon', () => {
+        const icon = getResourceIcon(makeResource({ state: ResourceState.FailedToStart, exitCode: 1 }));
+        assert.strictEqual(icon.id, 'error');
+        assert.ok(icon.color instanceof vscode.ThemeColor);
+        assert.strictEqual(icon.color.id, 'list.errorForeground');
+    });
+
     test('RuntimeUnhealthy shows warning icon', () => {
         const icon = getResourceIcon(makeResource({ state: ResourceState.RuntimeUnhealthy }));
         assert.strictEqual(icon.id, 'warning');

--- a/extension/src/test/appHostTreeView.test.ts
+++ b/extension/src/test/appHostTreeView.test.ts
@@ -1660,9 +1660,11 @@ suite('getResourceIcon', () => {
         assert.strictEqual(icon.id, 'error');
     });
 
-    test('RuntimeUnhealthy shows error icon', () => {
+    test('RuntimeUnhealthy shows warning icon', () => {
         const icon = getResourceIcon(makeResource({ state: ResourceState.RuntimeUnhealthy }));
-        assert.strictEqual(icon.id, 'error');
+        assert.strictEqual(icon.id, 'warning');
+        assert.ok(icon.color instanceof vscode.ThemeColor);
+        assert.strictEqual(icon.color.id, 'list.warningForeground');
     });
 
     test('Starting shows loading spinner', () => {

--- a/extension/src/test/aspireGutterDecorationProvider.test.ts
+++ b/extension/src/test/aspireGutterDecorationProvider.test.ts
@@ -129,6 +129,10 @@ suite('AspireGutterDecorationProvider', () => {
         assert.strictEqual(classifyState(ResourceState.RuntimeUnhealthy, '', ''), 'warning');
     });
 
+    test('FailedToStart uses the warning decoration category', () => {
+        assert.strictEqual(classifyState(ResourceState.FailedToStart, '', ''), 'warning');
+    });
+
     test('does not emit resource decorations from a different running AppHost', () => {
         const runningHostPath = p('repo', 'RunningAppHost', 'AppHost.csproj');
         const stoppedHostPath = p('repo', 'StoppedAppHost', 'AppHost.cs');

--- a/extension/src/test/aspireGutterDecorationProvider.test.ts
+++ b/extension/src/test/aspireGutterDecorationProvider.test.ts
@@ -5,7 +5,8 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import waitForExpect from 'wait-for-expect';
-import { AspireGutterDecorationProvider } from '../editor/AspireGutterDecorationProvider';
+import { AspireGutterDecorationProvider, classifyState } from '../editor/AspireGutterDecorationProvider';
+import { ResourceState } from '../editor/resourceConstants';
 import { AspireAppHostTreeProvider } from '../views/AspireAppHostTreeProvider';
 import { AppHostDisplayInfo, ResourceJson } from '../views/AppHostDataRepository';
 
@@ -122,6 +123,10 @@ suite('AspireGutterDecorationProvider', () => {
 
     teardown(() => {
         sandbox.restore();
+    });
+
+    test('RuntimeUnhealthy uses the warning decoration category', () => {
+        assert.strictEqual(classifyState(ResourceState.RuntimeUnhealthy, '', ''), 'warning');
     });
 
     test('does not emit resource decorations from a different running AppHost', () => {

--- a/extension/src/test/aspireGutterDecorationProvider.test.ts
+++ b/extension/src/test/aspireGutterDecorationProvider.test.ts
@@ -133,6 +133,22 @@ suite('AspireGutterDecorationProvider', () => {
         assert.strictEqual(classifyState(ResourceState.FailedToStart, '', ''), 'warning');
     });
 
+    test('FailedToStart with a null exit code uses the warning decoration category', () => {
+        assert.strictEqual(classifyState(ResourceState.FailedToStart, '', '', null), 'warning');
+    });
+
+    test('FailedToStart with exit code 0 uses the warning decoration category', () => {
+        assert.strictEqual(classifyState(ResourceState.FailedToStart, '', '', 0), 'warning');
+    });
+
+    test('FailedToStart with exit code -1 uses the error decoration category', () => {
+        assert.strictEqual(classifyState(ResourceState.FailedToStart, '', '', -1), 'error');
+    });
+
+    test('FailedToStart with a non-zero exit code uses the error decoration category', () => {
+        assert.strictEqual(classifyState(ResourceState.FailedToStart, '', '', 1), 'error');
+    });
+
     test('does not emit resource decorations from a different running AppHost', () => {
         const runningHostPath = p('repo', 'RunningAppHost', 'AppHost.csproj');
         const stoppedHostPath = p('repo', 'StoppedAppHost', 'AppHost.cs');

--- a/extension/src/test/codeLens.test.ts
+++ b/extension/src/test/codeLens.test.ts
@@ -13,6 +13,7 @@ import {
     codeLensResourceStoppedError,
     codeLensResourceStoppedErrorWithExitCode,
     codeLensResourceFailedToStart,
+    codeLensResourceFailedToStartError,
     codeLensResourceRuntimeUnhealthy,
     codeLensResourceValueMissing,
 } from '../loc/strings';
@@ -68,6 +69,24 @@ suite('getCodeLensStateLabel', () => {
     test('FailedToStart returns warning label', () => {
         assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, ''), codeLensResourceFailedToStart);
         assert.ok(codeLensResourceFailedToStart.includes('$(warning)'));
+    });
+
+    test('FailedToStart with a null exit code returns warning label', () => {
+        assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, '', null), codeLensResourceFailedToStart);
+    });
+
+    test('FailedToStart with exit code 0 returns warning label', () => {
+        assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, '', 0), codeLensResourceFailedToStart);
+    });
+
+    test('FailedToStart with exit code -1 returns error label', () => {
+        assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, '', -1), codeLensResourceFailedToStartError);
+        assert.ok(codeLensResourceFailedToStartError.includes('$(error)'));
+    });
+
+    test('FailedToStart with a non-zero exit code returns error label', () => {
+        assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, '', 1), codeLensResourceFailedToStartError);
+        assert.ok(codeLensResourceFailedToStartError.includes('$(error)'));
     });
 
     test('RuntimeUnhealthy returns warning label', () => {

--- a/extension/src/test/codeLens.test.ts
+++ b/extension/src/test/codeLens.test.ts
@@ -12,7 +12,7 @@ import {
     codeLensResourceStoppedWithExitCode,
     codeLensResourceStoppedError,
     codeLensResourceStoppedErrorWithExitCode,
-    codeLensResourceError,
+    codeLensResourceFailedToStart,
     codeLensResourceRuntimeUnhealthy,
     codeLensResourceValueMissing,
 } from '../loc/strings';
@@ -63,10 +63,11 @@ suite('getCodeLensStateLabel', () => {
         assert.strictEqual(getCodeLensStateLabel(ResourceState.NotStarted, ''), codeLensResourceNotStarted);
     });
 
-    // --- Error states ---
+    // --- Warning states ---
 
-    test('FailedToStart returns error label', () => {
-        assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, ''), codeLensResourceError);
+    test('FailedToStart returns warning label', () => {
+        assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, ''), codeLensResourceFailedToStart);
+        assert.ok(codeLensResourceFailedToStart.includes('$(warning)'));
     });
 
     test('RuntimeUnhealthy returns warning label', () => {
@@ -146,6 +147,6 @@ suite('getCodeLensStateLabel', () => {
     });
 
     test('FailedToStart ignores stateStyle', () => {
-        assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, StateStyle.Warning), codeLensResourceError);
+        assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, StateStyle.Error), codeLensResourceFailedToStart);
     });
 });

--- a/extension/src/test/codeLens.test.ts
+++ b/extension/src/test/codeLens.test.ts
@@ -13,6 +13,7 @@ import {
     codeLensResourceStoppedError,
     codeLensResourceStoppedErrorWithExitCode,
     codeLensResourceError,
+    codeLensResourceRuntimeUnhealthy,
     codeLensResourceValueMissing,
 } from '../loc/strings';
 import { ResourceState, StateStyle } from '../editor/resourceConstants';
@@ -68,8 +69,9 @@ suite('getCodeLensStateLabel', () => {
         assert.strictEqual(getCodeLensStateLabel(ResourceState.FailedToStart, ''), codeLensResourceError);
     });
 
-    test('RuntimeUnhealthy returns error label', () => {
-        assert.strictEqual(getCodeLensStateLabel(ResourceState.RuntimeUnhealthy, ''), codeLensResourceError);
+    test('RuntimeUnhealthy returns warning label', () => {
+        assert.strictEqual(getCodeLensStateLabel(ResourceState.RuntimeUnhealthy, ''), codeLensResourceRuntimeUnhealthy);
+        assert.ok(codeLensResourceRuntimeUnhealthy.includes('$(warning)'));
     });
 
     // --- Stopped states ---

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -477,6 +477,10 @@ export function getResourceIcon(resource: ResourceJson): vscode.ThemeIcon {
             // as a green check, just in slightly different greens).
             return new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('descriptionForeground'));
         case ResourceState.FailedToStart:
+            if (resource.exitCode != null && resource.exitCode !== 0) {
+                return new vscode.ThemeIcon('error', new vscode.ThemeColor('list.errorForeground'));
+            }
+            return new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'));
         case ResourceState.RuntimeUnhealthy:
             return new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'));
         case ResourceState.Starting:

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -477,8 +477,9 @@ export function getResourceIcon(resource: ResourceJson): vscode.ThemeIcon {
             // as a green check, just in slightly different greens).
             return new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('descriptionForeground'));
         case ResourceState.FailedToStart:
-        case ResourceState.RuntimeUnhealthy:
             return new vscode.ThemeIcon('error', new vscode.ThemeColor('list.errorForeground'));
+        case ResourceState.RuntimeUnhealthy:
+            return new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'));
         case ResourceState.Starting:
         case ResourceState.Stopping:
         case ResourceState.Building:

--- a/extension/src/views/AspireAppHostTreeProvider.ts
+++ b/extension/src/views/AspireAppHostTreeProvider.ts
@@ -477,7 +477,6 @@ export function getResourceIcon(resource: ResourceJson): vscode.ThemeIcon {
             // as a green check, just in slightly different greens).
             return new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('descriptionForeground'));
         case ResourceState.FailedToStart:
-            return new vscode.ThemeIcon('error', new vscode.ThemeColor('list.errorForeground'));
         case ResourceState.RuntimeUnhealthy:
             return new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground'));
         case ResourceState.Starting:


### PR DESCRIPTION
## Description

Treats the `RuntimeUnhealthy` and `FailedToStart` resource states as warnings in the VS Code resource tree, CodeLens, and editor gutter, matching the dashboard severity.

Focused Extension Host tests cover both states across all three state-to-presentation mappings. A screenshot is not included because reliably producing `RuntimeUnhealthy` requires changing the host container-runtime state; the mappings are exercised directly in the extension test host.

Fixes #18909

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - [ ] Did you have a discussion and approval from the Aspire team before introducing new public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - [ ] Did you have a discussion and approval from the Aspire team before introducing new security assumptions or guarantees?
  - [x] No
