### PR TITLE
Clarify interaction API documentation

### DIFF
--- a/src/Aspire.Hosting/Ats/InteractionExports.cs
+++ b/src/Aspire.Hosting/Ats/InteractionExports.cs
@@ -554,6 +554,7 @@ internal sealed class CreateInteractionInputOptions
 
     /// <summary>
     /// Gets or sets the file type filter for file inputs. Uses the same format as the HTML accept attribute.
+    /// The CLI validates only dot-prefixed extension filters and does not validate MIME type patterns such as "image/*".
     /// </summary>
     public string? FileFilter { get; init; }
 }

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -915,6 +915,7 @@ internal sealed class PublishingPromptInput
 
     /// <summary>
     /// Gets the file type filter for File inputs. Uses the same format as the HTML accept attribute.
+    /// The CLI validates only dot-prefixed extension filters and does not validate MIME type patterns such as "image/*".
     /// </summary>
     public string? FileFilter { get; init; }
 

--- a/src/Aspire.Hosting/IInteractionService.cs
+++ b/src/Aspire.Hosting/IInteractionService.cs
@@ -378,7 +378,7 @@ public sealed class InteractionInput
     public bool AllowCustomChoice { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether a custom choice is allowed. Only used by <see cref="InputType.Choice"/> inputs.
+    /// Gets or sets a value indicating whether the input is disabled.
     /// </summary>
     public bool Disabled { get; set; }
 
@@ -407,7 +407,8 @@ public sealed class InteractionInput
     /// <summary>
     /// Gets or sets the file type filter for <see cref="InputType.File"/> inputs.
     /// Uses the same format as the HTML <c>accept</c> attribute, e.g. <c>".pem,.pfx,.crt"</c> or <c>"image/*"</c>.
-    /// When set, the file picker restricts selectable files and the CLI validates that chosen files match.
+    /// When set, the file picker restricts selectable files. The CLI validates only dot-prefixed extension filters
+    /// and does not validate MIME type patterns such as <c>"image/*"</c>.
     /// </summary>
     public string? FileFilter { get; init; }
 

--- a/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
+++ b/tests/Aspire.Hosting.CodeGeneration.TypeScript.Tests/Snapshots/TwoPassScanningGeneratedAspire.verified.ts
@@ -935,7 +935,7 @@ export interface CreateInteractionInputOptions {
     maxFileSize?: number | null;
     /** Gets or sets a value indicating whether multiple files can be selected. Only used by file inputs. */
     allowMultipleFiles?: boolean | null;
-    /** Gets or sets the file type filter for file inputs. Uses the same format as the HTML accept attribute. */
+    /** Gets or sets the file type filter for file inputs. Uses the same format as the HTML accept attribute. The CLI validates only dot-prefixed extension filters and does not validate MIME type patterns such as "image/*". */
     fileFilter?: string | null;
 }
 


### PR DESCRIPTION
## Description

Corrects the public interaction API documentation identified during the API surface review of #17846:

- `InteractionInput.Disabled` now describes whether the input is disabled instead of duplicating `AllowCustomChoice`.
- `InteractionInput.FileFilter` now states that CLI validation enforces only dot-prefixed extension filters and does not validate MIME patterns such as `image/*`.
- ATS and internal backchannel DTO documentation carries the same file-filter limitation.

This is a documentation-only change. Generated API and ATS baselines are unchanged.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
