### PR TITLE
Hide Orleans provider annotation

### DIFF
--- a/src/Aspire.Hosting.Orleans/OrleansProviderTypeAnnotation.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansProviderTypeAnnotation.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.Orleans;
 /// Specifies the Orleans provider type for a resource.
 /// </summary>
 /// <param name="providerType">The Orleans provider type to use for the resource.</param>
-public sealed class OrleansProviderTypeAnnotation(string providerType) : IResourceAnnotation
+internal sealed class OrleansProviderTypeAnnotation(string providerType) : IResourceAnnotation
 {
     /// <summary>
     /// Gets the Orleans provider type to use for the resource.

--- a/tests/Aspire.Hosting.Orleans.Tests/OrleansProviderTypeTests.cs
+++ b/tests/Aspire.Hosting.Orleans.Tests/OrleansProviderTypeTests.cs
@@ -64,9 +64,6 @@ public class OrleansProviderTypeTests
             .WithOrleansProviderType("Redis")
             .WithOrleansProviderType("AdoNet");
 
-        var annotation = Assert.Single(provider.Resource.Annotations.OfType<OrleansProviderTypeAnnotation>());
-        Assert.Equal("AdoNet", annotation.ProviderType);
-
         var orleans = builder.AddOrleans("orleans")
             .WithClustering(provider);
 
@@ -103,20 +100,6 @@ public class OrleansProviderTypeTests
         });
 
         var action = () => provider.WithOrleansProviderType(providerType!);
-
-        var exception = providerType is null
-            ? Assert.Throws<ArgumentNullException>(action)
-            : Assert.Throws<ArgumentException>(action);
-        Assert.Equal(nameof(providerType), exception.ParamName);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData(" ")]
-    public void CtorOrleansProviderTypeAnnotationShouldThrowWhenProviderTypeIsNullOrWhiteSpace(string? providerType)
-    {
-        var action = () => new OrleansProviderTypeAnnotation(providerType!);
 
         var exception = providerType is null
             ? Assert.Throws<ArgumentNullException>(action)


### PR DESCRIPTION
## Description

Keeps `OrleansProviderTypeAnnotation` as internal implementation plumbing while preserving `WithOrleansProviderType` as the supported public builder API.

Tests now validate provider replacement through the resulting Orleans configuration rather than constructing or inspecting the internal annotation.

Addresses https://github.com/microsoft/aspire/pull/17846#discussion_r3708127756.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
