### PR TITLE
Rename Azure scope factories

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
@@ -43,7 +43,7 @@ public sealed class AzureBicepResourceScope
     /// </summary>
     /// <param name="subscription">The subscription identifier for subscription-level resources.</param>
     /// <returns>A new <see cref="AzureBicepResourceScope"/> scoped to the subscription.</returns>
-    public static AzureBicepResourceScope ForSubscription(object subscription)
+    public static AzureBicepResourceScope CreateForSubscription(object subscription)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
@@ -54,7 +54,7 @@ public sealed class AzureBicepResourceScope
     /// Creates a scope for tenant-level resources in the current tenant.
     /// </summary>
     /// <returns>A new <see cref="AzureBicepResourceScope"/> scoped to the current tenant.</returns>
-    public static AzureBicepResourceScope ForTenant()
+    public static AzureBicepResourceScope CreateForTenant()
     {
         return new AzureBicepResourceScope(resourceGroup: null, subscription: null, isTenantScope: true);
     }
@@ -80,14 +80,14 @@ public sealed class AzureBicepResourceScope
 
         if (annotation.IsTenantScope)
         {
-            return ForTenant();
+            return CreateForTenant();
         }
 
         return (annotation.ResourceGroup, annotation.Subscription) switch
         {
             ({ } resourceGroup, { } subscription) => new AzureBicepResourceScope(resourceGroup, subscription),
             ({ } resourceGroup, null) => new AzureBicepResourceScope(resourceGroup),
-            (null, { } subscription) => ForSubscription(subscription),
+            (null, { } subscription) => CreateForSubscription(subscription),
             _ => null
         };
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -160,7 +160,7 @@ public class AzureBicepProvisionerTests
             targetScope = 'subscription'
             output result string = 'ok'
             """);
-        resource.Scope = AzureBicepResourceScope.ForSubscription(subscription.Id.Name);
+        resource.Scope = AzureBicepResourceScope.CreateForSubscription(subscription.Id.Name);
 
         var provisioner = CreateProvisioner(services);
         var context = ProvisioningTestHelpers.CreateTestProvisioningContext(
@@ -195,7 +195,7 @@ public class AzureBicepProvisionerTests
             targetScope = 'tenant'
             output result string = 'ok'
             """);
-        resource.Scope = AzureBicepResourceScope.ForTenant();
+        resource.Scope = AzureBicepResourceScope.CreateForTenant();
 
         var provisioner = CreateProvisioner(services);
         var context = ProvisioningTestHelpers.CreateTestProvisioningContext(
@@ -293,7 +293,7 @@ public class AzureBicepProvisionerTests
             targetScope = 'subscription'
             output result string = 'ok'
             """);
-        resource.Scope = AzureBicepResourceScope.ForSubscription(subscription.Id.Name);
+        resource.Scope = AzureBicepResourceScope.CreateForSubscription(subscription.Id.Name);
 
         var provisioner = CreateProvisioner(services, DistributedApplicationOperation.Run);
         var context = ProvisioningTestHelpers.CreateTestProvisioningContext(
@@ -671,7 +671,7 @@ public class AzureBicepProvisionerTests
         var tenant = new TestTenantResource();
         var resource = new AzureBicepResource("subscriptionDeployment", templateString: "output name string = 'subscriptionDeployment'")
         {
-            Scope = AzureBicepResourceScope.ForSubscription(subscription.Id.Name)
+            Scope = AzureBicepResourceScope.CreateForSubscription(subscription.Id.Name)
         };
 
         var provisioner = new BicepProvisioner(

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
@@ -200,7 +200,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
 
             output value string = 'subscription'
             """);
-        subscriptionScoped.Resource.Scope = AzureBicepResourceScope.ForSubscription(subscription.Resource);
+        subscriptionScoped.Resource.Scope = AzureBicepResourceScope.CreateForSubscription(subscription.Resource);
 
         var tenantScoped = builder.AddBicepTemplateString("tenantScoped",
             """
@@ -210,7 +210,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
 
             output value string = 'tenant'
             """);
-        tenantScoped.Resource.Scope = AzureBicepResourceScope.ForTenant();
+        tenantScoped.Resource.Scope = AzureBicepResourceScope.CreateForTenant();
 
         var app = builder.Build();
         app.Run();

--- a/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
@@ -364,7 +364,7 @@ public class BicepUtilitiesTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
-        bicep.Scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+        bicep.Scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
         var scope = new JsonObject();
 
@@ -379,7 +379,7 @@ public class BicepUtilitiesTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
-        bicep.Scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+        bicep.Scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
         var scope = new JsonObject
         {
@@ -398,7 +398,7 @@ public class BicepUtilitiesTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
-        bicep.Scope = AzureBicepResourceScope.ForTenant();
+        bicep.Scope = AzureBicepResourceScope.CreateForTenant();
 
         var scope = new JsonObject();
 
@@ -489,7 +489,7 @@ public class BicepUtilitiesTests
         await BicepUtilities.SetParametersAsync(legacyParameters, bicep);
         var legacyChecksum = BicepUtilities.GetChecksum(bicep, legacyParameters, scope: null);
 
-        bicep.Scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+        bicep.Scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
         var configurationBuilder = new ConfigurationBuilder();
         configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -585,7 +585,7 @@ public class ExistingAzureResourceTests
             output id string = 'subscription'
             """)
             .WithParameter("value", "unused");
-        resource.Resource.Scope = AzureBicepResourceScope.ForSubscription(existingSubscriptionId.Resource);
+        resource.Resource.Scope = AzureBicepResourceScope.CreateForSubscription(existingSubscriptionId.Resource);
 
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(resource.Resource, skipPreparer: true);
 
@@ -604,7 +604,7 @@ public class ExistingAzureResourceTests
 
             output id string = 'tenant'
             """);
-        resource.Resource.Scope = AzureBicepResourceScope.ForTenant();
+        resource.Resource.Scope = AzureBicepResourceScope.CreateForTenant();
 
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(resource.Resource, skipPreparer: true);
 


### PR DESCRIPTION
## Description

Aligns the new Azure Bicep resource scope factories with .NET member naming guidelines before they ship. `ForSubscription` and `ForTenant` are renamed to the verb-phrase names requested in API review: `CreateForSubscription` and `CreateForTenant`.

The implementation and all C# call sites are updated. Existing TypeScript capability generation remains unchanged because these factories are not exported as generated-language capabilities.

### User-facing usage

```csharp
subscriptionResource.Scope = AzureBicepResourceScope.CreateForSubscription(subscriptionId);
tenantResource.Scope = AzureBicepResourceScope.CreateForTenant();
```

Validation:

- 120 targeted `Aspire.Hosting.Azure.Tests` tests passed.
- 2 targeted Azure scope TypeScript code-generation tests passed.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
