### PR TITLE
Seal CommandProgressOptions

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandOptions.cs
@@ -114,7 +114,7 @@ public class CommandOptions
 /// Options for displaying a progress dialog while a command is executing.
 /// </summary>
 [AspireDto]
-public class CommandProgressOptions
+public sealed class CommandProgressOptions
 {
     /// <summary>
     /// Gets or sets the message to display in the progress dialog.


### PR DESCRIPTION
## Description

Seals `CommandProgressOptions` before its API surface ships. The DTO has no protected or virtual extensibility points, and repository-wide usage only constructs it directly, so there is no supported inheritance scenario to preserve.

This addresses the type-design finding in [the automated API surface review](https://github.com/microsoft/aspire/pull/17846#discussion_r3708127771). The generated `api/*.cs` baseline is intentionally unchanged.

Validation:

- Built `src/Aspire.Hosting/Aspire.Hosting.csproj`
- Passed all 50 `ResourceCommandServiceTests`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
