### PR TITLE
Fix terminal API surface

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
@@ -2,40 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.ApplicationModel;
 
+#pragma warning disable ASPIRETERMINAL001 // Internal annotation backing the experimental terminal configuration API.
+
 /// <summary>
-/// Marks a resource as having an interactive terminal session.
+/// Tracks terminal configuration and per-replica terminal hosts for a resource.
 /// </summary>
-/// <remarks>
-/// <para>
-/// When this annotation is present on a resource, the orchestrator (DCP) allocates a
-/// pseudo-terminal (PTY) per replica and a hidden <see cref="TerminalHostResource"/> per
-/// replica bridges that replica's PTY traffic over Hex1b's HMP v1 protocol so that the
-/// Aspire Dashboard and the <c>aspire terminal</c> CLI command can attach to live sessions.
-/// </para>
-/// <para>
-/// The per-replica <see cref="TerminalHostResource"/>s are NOT created at
-/// <see cref="TerminalResourceBuilderExtensions.WithTerminal{T}(IResourceBuilder{T}, Action{TerminalOptions}?)"/>
-/// time. They are created during <see cref="BeforeStartEvent"/> by reading the parent
-/// resource's final <see cref="ReplicaAnnotation"/>. This deferral is what makes
-/// <c>WithReplicas(N)</c> work correctly even when it is called <strong>after</strong>
-/// <c>WithTerminal()</c>: the model is fully built by the time the per-replica hosts are
-/// materialized, so the final replica count is always honoured. Until that initialization
-/// runs, <see cref="TerminalHosts"/> is an empty collection and <see cref="IsInitialized"/>
-/// is <c>false</c>.
-/// </para>
-/// <para>
-/// Connection direction across all UDS endpoints: the terminal host LISTENS; DCP, viewers,
-/// and the AppHost DIAL. See <see cref="TerminalHostLayout"/> for the per-host path layout.
-/// </para>
-/// </remarks>
 [DebuggerDisplay("Type = {GetType().Name,nq}, IsInitialized = {IsInitialized}, ReplicaCount = {TerminalHosts.Count}")]
-public sealed class TerminalAnnotation : IResourceAnnotation
+internal sealed class TerminalAnnotation : IResourceAnnotation
 {
     // Starts as Array.Empty<TerminalHostResource>() (the default for [] in C#) so the
-    // public TerminalHosts surface is always non-null and safely enumerable, even before
+    // TerminalHosts collection is always non-null and safely enumerable, even before
     // BeforeStartEvent has had a chance to materialize the per-replica hosts. Consumers
     // (DCP creators, dashboard data, backchannel) must guard with a Count check or an
     // index-bounds check; all of them already do.
@@ -108,9 +88,12 @@ public sealed class TerminalAnnotation : IResourceAnnotation
     }
 }
 
+#pragma warning restore ASPIRETERMINAL001
+
 /// <summary>
 /// Options for configuring a terminal session.
 /// </summary>
+[Experimental("ASPIRETERMINAL001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class TerminalOptions
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/TerminalHostLayout.cs
+++ b/src/Aspire.Hosting/ApplicationModel/TerminalHostLayout.cs
@@ -7,60 +7,10 @@ using System.Globalization;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Describes the Unix domain socket layout used by a single <see cref="TerminalHostResource"/>
-/// to bridge one parent-resource replica's PTY traffic between DCP and viewers (Dashboard,
-/// CLI).
+/// Describes the Unix domain socket and metadata paths for one terminal host.
 /// </summary>
-/// <remarks>
-/// <para>
-/// Each <see cref="TerminalHostResource"/> serves exactly one parent replica and owns four
-/// stable paths flat under <c>~/.aspire/trmnl/</c>, all sharing a per-replica
-/// <see cref="ReplicaId"/> prefix:
-/// </para>
-/// <list type="bullet">
-///   <item>
-///     <description>
-///       <c>~/.aspire/trmnl/{ReplicaId}.dcp.sock</c> (<see cref="ProducerUdsPath"/>) — the producer socket.
-///       The terminal host LISTENS on this path; DCP DIALS it to stream PTY traffic into the
-///       host.
-///     </description>
-///   </item>
-///   <item>
-///     <description>
-///       <c>~/.aspire/trmnl/{ReplicaId}.host.sock</c> (<see cref="ConsumerUdsPath"/>) — the consumer socket.
-///       The terminal host LISTENS on this path; viewers (Dashboard, CLI) DIAL it to attach.
-///     </description>
-///   </item>
-///   <item>
-///     <description>
-///       <c>~/.aspire/trmnl/{ReplicaId}.ctrl.sock</c> (<see cref="ControlUdsPath"/>) — the control socket.
-///       The terminal host LISTENS on this path; the AppHost DIALS it for status/shutdown
-///       RPC. (See <see cref="Aspire.Shared.TerminalHost.TerminalHostControlProtocol"/>.)
-///     </description>
-///   </item>
-///   <item>
-///     <description>
-///       <c>~/.aspire/trmnl/{ReplicaId}.metadata.json</c> (<see cref="MetadataPath"/>) — the descriptor sidecar
-///       written by the AppHost. Lets external tools enumerate terminals without an active
-///       backchannel.
-///     </description>
-///   </item>
-/// </list>
-/// <para>
-/// Connection direction (consistent across all three sockets): the terminal host is the
-/// LISTENER everywhere; DCP, viewers, and the AppHost are the DIALERS. This is also true
-/// of <c>TerminalSpec.UdsPath</c> in the DCP API.
-/// </para>
-/// <para>
-/// <see cref="ReplicaId"/> is an 11-character base64url hash of
-/// <c>(normalized AppHost path, parent resource name, parent replica index)</c> computed
-/// by <c>Aspire.Shared.TerminalHost.TerminalHostPaths.ComputeReplicaId</c>. The hash
-/// excludes PID and any random suffix so paths are stable across AppHost restarts —
-/// callers MUST therefore pre-delete any stale socket at the same path before binding.
-/// </para>
-/// </remarks>
 [DebuggerDisplay("Type = {GetType().Name,nq}, ParentReplicaIndex = {ParentReplicaIndex}, ReplicaId = {ReplicaId}")]
-public sealed class TerminalHostLayout
+internal sealed class TerminalHostLayout
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="TerminalHostLayout"/> class for a

--- a/src/Aspire.Hosting/ApplicationModel/TerminalHostResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/TerminalHostResource.cs
@@ -6,28 +6,10 @@ using System.Diagnostics;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// A hidden, DCP-launched executable resource that bridges <strong>one</strong> parent-resource
-/// replica's PTY traffic between DCP (the producer) and viewers like the Aspire Dashboard
-/// and the <c>aspire terminal</c> CLI command (the consumers) using Hex1b's HMP v1 muxer.
+/// Represents the hidden terminal host process for one parent-resource replica.
 /// </summary>
-/// <remarks>
-/// <para>
-/// One <see cref="TerminalHostResource"/> instance is created <strong>per replica</strong> of
-/// the target resource configured with
-/// <see cref="TerminalResourceBuilderExtensions.WithTerminal{T}(IResourceBuilder{T}, Action{TerminalOptions}?)"/>.
-/// A target with <c>N</c> replicas yields <c>N</c> independent terminal host processes,
-/// each with its own UDS triple (producer/consumer/control). The host process itself is
-/// opaque to its parent replica index — it just listens on whatever paths it's told.
-/// </para>
-/// <para>
-/// Because <see cref="TerminalHostResource"/> derives from <see cref="ExecutableResource"/>, DCP
-/// launches it like any other executable, which keeps the host process out-of-process and
-/// isolates PTY state from the AppHost. The actual binary path is resolved during
-/// <see cref="Aspire.Hosting.ApplicationModel.BeforeStartEvent"/> from <see cref="Aspire.Hosting.Dcp.DcpOptions.TerminalHostPath"/>.
-/// </para>
-/// </remarks>
 [DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, Parent = {Parent.Name}, ParentReplicaIndex = {ParentReplicaIndex}")]
-public sealed class TerminalHostResource : ExecutableResource, IResourceWithParent<IResource>
+internal sealed class TerminalHostResource : ExecutableResource, IResourceWithParent<IResource>
 {
     // The host is created before its real binary path is known (DcpOptions is not yet
     // configured at WithTerminal time). A BeforeStartEvent subscriber rewrites the

--- a/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
@@ -30,9 +30,9 @@ public static class TerminalResourceBuilderExtensions
     /// <remarks>
     /// <para>
     /// When a resource is configured with <c>.WithTerminal()</c>, DCP allocates a pseudo-terminal
-    /// (PTY) per replica and one hidden <see cref="TerminalHostResource"/> per replica bridges
-    /// the PTY traffic over Hex1b's HMP v1 protocol. The terminal session can be accessed from
-    /// the Aspire Dashboard's terminal page or via the <c>aspire terminal</c> CLI command.
+    /// (PTY) per replica and a hidden terminal host process bridges the PTY traffic over Hex1b's
+    /// HMP v1 protocol. The terminal session can be accessed from the Aspire Dashboard's terminal
+    /// page or via the <c>aspire terminal</c> CLI command.
     /// </para>
     /// <para>
     /// One terminal host process is spawned per parent replica (e.g. <c>WithReplicas(3).WithTerminal()</c>
@@ -125,6 +125,8 @@ public static class TerminalResourceBuilderExtensions
 #pragma warning disable ASPIRETERMINAL001 // Internal dispatcher into the experimental API.
         => builder.WithTerminal();
 #pragma warning restore ASPIRETERMINAL001
+
+#pragma warning disable ASPIRETERMINAL001 // Internal implementation of the experimental terminal configuration API.
 
     /// <summary>
     /// Reads the parent's final <see cref="ReplicaAnnotation"/> and creates one
@@ -434,6 +436,8 @@ public static class TerminalResourceBuilderExtensions
             return Task.CompletedTask;
         }));
     }
+
+#pragma warning restore ASPIRETERMINAL001
 
     /// <summary>
     /// Builds the per-replica UDS triple + metadata path for a single terminal host. All

--- a/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using Aspire.Hosting.Testing;
 using Aspire.Hosting.Utils;
@@ -10,6 +12,23 @@ namespace Aspire.Hosting.Tests;
 
 public class WithTerminalTests
 {
+    [Fact]
+    public void TerminalImplementationTypesAreInternal()
+    {
+        Assert.True(typeof(TerminalAnnotation).IsNotPublic);
+        Assert.True(typeof(TerminalHostResource).IsNotPublic);
+        Assert.True(typeof(TerminalHostLayout).IsNotPublic);
+    }
+
+    [Fact]
+    public void TerminalOptionsIsExperimental()
+    {
+        var attribute = Assert.Single(typeof(TerminalOptions).GetCustomAttributes<ExperimentalAttribute>());
+
+        Assert.Equal("ASPIRETERMINAL001", attribute.DiagnosticId);
+        Assert.Equal("https://aka.ms/aspire/diagnostics/{0}", attribute.UrlFormat);
+    }
+
     [Fact]
     public async Task WithTerminalAddsTerminalAnnotation()
     {


### PR DESCRIPTION
## Description

The terminal API review found that orchestration and Unix domain socket implementation types were leaking into the public `Aspire.Hosting` surface. This change keeps `TerminalAnnotation`, `TerminalHostResource`, and `TerminalHostLayout` internal while preserving terminal configuration through `WithTerminal` and `TerminalOptions`.

`TerminalOptions` now carries the same `ASPIRETERMINAL001` experimental diagnostic as `WithTerminal`, so direct use of the supporting configuration type is guarded consistently. Public XML documentation no longer links to the internal terminal host resource, and focused tests cover the intended visibility and diagnostic metadata.

### User-facing usage

Terminal configuration remains available through the existing experimental API:

```csharp
builder.AddExecutable("agent", "my-agent", ".")
    .WithTerminal(options =>
    {
        options.Columns = 200;
        options.Rows = 50;
    });
```

Validation:

- `dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.WithTerminalTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (23 passed)

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
