### PR TITLE
Fix Kubernetes persistent volume ATS export names

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeExtensions.cs
@@ -91,7 +91,7 @@ public static class KubernetesPersistentVolumeExtensions
     /// <param name="storageClassName">A parameter resource builder for the storage
     /// class name.</param>
     /// <returns>The same builder for chaining.</returns>
-    [AspireExport("withPvStorageClassParam")]
+    [AspireExport("withStorageClassParam")]
     public static IResourceBuilder<KubernetesPersistentVolumeResource> WithStorageClass(
         this IResourceBuilder<KubernetesPersistentVolumeResource> builder,
         IResourceBuilder<ParameterResource> storageClassName)
@@ -132,7 +132,7 @@ public static class KubernetesPersistentVolumeExtensions
     /// <param name="capacity">A parameter resource builder for the capacity quantity
     /// string.</param>
     /// <returns>The same builder for chaining.</returns>
-    [AspireExport("withPvCapacityParam")]
+    [AspireExport("withCapacityParam")]
     public static IResourceBuilder<KubernetesPersistentVolumeResource> WithCapacity(
         this IResourceBuilder<KubernetesPersistentVolumeResource> builder,
         IResourceBuilder<ParameterResource> capacity)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeResource.cs
@@ -61,6 +61,7 @@ namespace Aspire.Hosting.Kubernetes;
 /// </code>
 /// </example>
 [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExport]
 public sealed class KubernetesPersistentVolumeResource(
     string name,
     KubernetesEnvironmentResource environment) : Resource(name), IResourceWithParent<KubernetesEnvironmentResource>

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go
@@ -17,6 +17,8 @@ func main() {
 	helmChartName := builder.AddParameter("helm-chart-name")
 	helmChartVersion := builder.AddParameter("helm-chart-version")
 	helmChartDescription := builder.AddParameter("helm-chart-description")
+	persistentVolumeStorageClass := builder.AddParameter("persistent-volume-storage-class")
+	persistentVolumeCapacity := builder.AddParameter("persistent-volume-capacity")
 
 	kubernetes := builder.AddKubernetesEnvironment("kube")
 	kubernetes.WithHelm(&aspire.WithHelmOptions{
@@ -60,6 +62,14 @@ func main() {
 	ingress := kubernetes.AddIngress("public-ingress")
 	ingress.WithHostname("ingress.example.com")
 	ingress.WithTls("ingress-tls")
+
+	persistentVolume := kubernetes.AddPersistentVolume("data")
+	persistentVolume.WithStorageClass("fast-storage")
+	persistentVolume.WithCapacity("5Gi")
+
+	parameterizedPersistentVolume := kubernetes.AddPersistentVolume("parameterized-data")
+	parameterizedPersistentVolume.WithStorageClassParam(persistentVolumeStorageClass)
+	parameterizedPersistentVolume.WithCapacityParam(persistentVolumeCapacity)
 
 	serviceContainer := builder.AddContainer("kube-service", "redis:alpine")
 	serviceContainer.WithComputeEnvironment(kubernetes)

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go
@@ -66,6 +66,7 @@ func main() {
 	persistentVolume := kubernetes.AddPersistentVolume("data")
 	persistentVolume.WithStorageClass("fast-storage")
 	persistentVolume.WithCapacity("5Gi")
+	_, _ = persistentVolume.GetResourceName()
 
 	parameterizedPersistentVolume := kubernetes.AddPersistentVolume("parameterized-data")
 	parameterizedPersistentVolume.WithStorageClassParam(persistentVolumeStorageClass)

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
@@ -7,6 +7,8 @@ void main() throws Exception {
         var helmChartName = builder.addParameter("helm-chart-name");
         var helmChartVersion = builder.addParameter("helm-chart-version");
         var helmChartDescription = builder.addParameter("helm-chart-description");
+        var persistentVolumeStorageClass = builder.addParameter("persistent-volume-storage-class");
+        var persistentVolumeCapacity = builder.addParameter("persistent-volume-capacity");
         var kubernetes = builder.addKubernetesEnvironment("kube");
         kubernetes.withHelm((helm) -> {
             helm.withNamespace("validation-namespace");
@@ -42,6 +44,12 @@ void main() throws Exception {
         var ingress = kubernetes.addIngress("public-ingress");
         ingress.withHostname("ingress.example.com");
         ingress.withTls("ingress-tls");
+        var persistentVolume = kubernetes.addPersistentVolume("data");
+        persistentVolume.withStorageClass("fast-storage");
+        persistentVolume.withCapacity("5Gi");
+        var parameterizedPersistentVolume = kubernetes.addPersistentVolume("parameterized-data");
+        parameterizedPersistentVolume.withStorageClassParam(persistentVolumeStorageClass);
+        parameterizedPersistentVolume.withCapacityParam(persistentVolumeCapacity);
         var serviceContainer = builder.addContainer("kube-service", "redis:alpine");
         serviceContainer.withComputeEnvironment(kubernetes);
         serviceContainer.publishAsKubernetesService((service) -> {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
@@ -47,6 +47,7 @@ void main() throws Exception {
         var persistentVolume = kubernetes.addPersistentVolume("data");
         persistentVolume.withStorageClass("fast-storage");
         persistentVolume.withCapacity("5Gi");
+        var _persistentVolumeResourceName = persistentVolume.getResourceName();
         var parameterizedPersistentVolume = kubernetes.addPersistentVolume("parameterized-data");
         parameterizedPersistentVolume.withStorageClassParam(persistentVolumeStorageClass);
         parameterizedPersistentVolume.withCapacityParam(persistentVolumeCapacity);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
@@ -39,6 +39,7 @@ with create_builder() as builder:
     persistent_volume = kubernetes.add_persistent_volume("data")
     persistent_volume.with_storage_class("fast-storage")
     persistent_volume.with_capacity("5Gi")
+    _persistent_volume_resource_name = persistent_volume.get_resource_name()
     parameterized_persistent_volume = kubernetes.add_persistent_volume("parameterized-data")
     parameterized_persistent_volume.with_storage_class_param(persistent_volume_storage_class)
     parameterized_persistent_volume.with_capacity_param(persistent_volume_capacity)

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
@@ -10,6 +10,8 @@ with create_builder() as builder:
     helm_chart_name = builder.add_parameter("helm-chart-name")
     helm_chart_version = builder.add_parameter("helm-chart-version")
     helm_chart_description = builder.add_parameter("helm-chart-description")
+    persistent_volume_storage_class = builder.add_parameter("persistent-volume-storage-class")
+    persistent_volume_capacity = builder.add_parameter("persistent-volume-capacity")
     kubernetes = builder.add_kubernetes_environment("resource")
 
     def configure_helm(helm):
@@ -34,6 +36,12 @@ with create_builder() as builder:
     ingress = kubernetes.add_ingress("public-ingress")
     ingress.with_hostname("ingress.example.com")
     ingress.with_tls("ingress-tls")
+    persistent_volume = kubernetes.add_persistent_volume("data")
+    persistent_volume.with_storage_class("fast-storage")
+    persistent_volume.with_capacity("5Gi")
+    parameterized_persistent_volume = kubernetes.add_persistent_volume("parameterized-data")
+    parameterized_persistent_volume.with_storage_class_param(persistent_volume_storage_class)
+    parameterized_persistent_volume.with_capacity_param(persistent_volume_capacity)
     service_container = builder.add_container("resource", "image")
     service_container.with_compute_environment(kubernetes)
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.mts
@@ -7,6 +7,8 @@ const helmReleaseName = await builder.addParameter('helm-release-name');
 const helmChartName = await builder.addParameter('helm-chart-name');
 const helmChartVersion = await builder.addParameter('helm-chart-version');
 const helmChartDescription = await builder.addParameter('helm-chart-description');
+const persistentVolumeStorageClass = await builder.addParameter('persistent-volume-storage-class');
+const persistentVolumeCapacity = await builder.addParameter('persistent-volume-capacity');
 
 const kubernetes = await builder.addKubernetesEnvironment('kube');
 
@@ -55,6 +57,14 @@ await gateway.withTls('gateway-tls');
 const ingress = await kubernetes.addIngress('public-ingress');
 await ingress.withHostname('ingress.example.com');
 await ingress.withTls('ingress-tls');
+
+const persistentVolume = await kubernetes.addPersistentVolume('data');
+await persistentVolume.withStorageClass('fast-storage');
+await persistentVolume.withCapacity('5Gi');
+
+const parameterizedPersistentVolume = await kubernetes.addPersistentVolume('parameterized-data');
+await parameterizedPersistentVolume.withStorageClassParam(persistentVolumeStorageClass);
+await parameterizedPersistentVolume.withCapacityParam(persistentVolumeCapacity);
 
 // === cert-manager ===
 // Validates the typed cert-manager API surface generated for TypeScript:

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.mts
@@ -61,6 +61,7 @@ await ingress.withTls('ingress-tls');
 const persistentVolume = await kubernetes.addPersistentVolume('data');
 await persistentVolume.withStorageClass('fast-storage');
 await persistentVolume.withCapacity('5Gi');
+const _persistentVolumeResourceName: string = await persistentVolume.getResourceName();
 
 const parameterizedPersistentVolume = await kubernetes.addPersistentVolume('parameterized-data');
 await parameterizedPersistentVolume.withStorageClassParam(persistentVolumeStorageClass);


### PR DESCRIPTION
## Description

Parameterized Kubernetes persistent-volume configuration should be discoverable beside its literal counterpart in generated AppHost SDKs. This changes the ATS export names from `withPvStorageClassParam` and `withPvCapacityParam` to the parallel `withStorageClassParam` and `withCapacityParam` names.

`KubernetesPersistentVolumeResource` is now explicitly exported to ATS, matching the established pattern for Kubernetes Gateway, Ingress, NodePool, HelmChart, and cert-manager resources. The Kubernetes polyglot AppHosts exercise the resource-level API plus both literal and parameterized persistent-volume configuration in TypeScript, Python, Go, and Java.

### User-facing usage

C# AppHost:

```csharp
var storageClass = builder.AddParameter("persistent-volume-storage-class");
var capacity = builder.AddParameter("persistent-volume-capacity");

var volume = kubernetes.AddPersistentVolume("data")
    .WithStorageClass(storageClass)
    .WithCapacity(capacity);
```

TypeScript AppHost:

```typescript
const volume = await kubernetes.addPersistentVolume('data');
await volume.withStorageClassParam(storageClass);
await volume.withCapacityParam(capacity);
const resourceName = await volume.getResourceName();
```

Validation included building `Aspire.Hosting.Kubernetes`, regenerating each affected polyglot SDK with the repository CLI, and compiling the TypeScript, Python, Go, and Java Kubernetes AppHosts.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No