### PR TITLE
Restore hosted agent ATS compatibility

### DIFF
--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -111,14 +111,42 @@ public static class HostedAgentResourceBuilderExtensions
         return AsHostedAgent(builder, project: null, configure);
     }
 
-    // The internal AsHostedAgentForExport overload below is the polyglot-exported version of AsHostedAgent.
-    // The CLR method name differs from AsHostedAgent to avoid C# overload ambiguity with the Action-based
-    // overload, but the ATS capability name must stay "asHostedAgent" for compatibility.
-    // .NET callers should keep using the Action<HostedAgentConfiguration> overload when they need the
-    // full HostedAgentConfiguration surface (tools, content filters, additional protocol versions, etc.).
+    // The internal adapters below keep ATS compatibility without adding CLR overloads that would be
+    // ambiguous with the public Action-based overloads. The original asHostedAgent capability retains
+    // its Responses/2.0.0 defaults, while asHostedAgentWithProtocol exposes explicit protocol selection.
+    // .NET callers should keep using the public overloads when they need the full HostedAgentConfiguration
+    // surface (tools, content filters, additional protocol versions, etc.).
 
     /// <summary>
-    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry, targeting the specified Foundry project.
+    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry using the Responses protocol version 2.0.0.
+    /// </summary>
+    /// <typeparam name="T">The type of resource being configured.</typeparam>
+    /// <param name="builder">The resource builder for the compute resource.</param>
+    /// <param name="project">The Microsoft Foundry project the hosted agent is deployed into.</param>
+    /// <param name="options">Optional hosted agent deployment options. Options apply in publish mode.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="project"/> is <see langword="null"/>.</exception>
+    [AspireExport("asHostedAgent", MethodName = "asHostedAgent")]
+    internal static IResourceBuilder<T> AsHostedAgentForExport<T>(
+        this IResourceBuilder<T> builder,
+        IResourceBuilder<AzureCognitiveServicesProjectResource> project,
+        HostedAgentOptions? options = null)
+        where T : IResourceWithEndpoints, IResourceWithEnvironment, IComputeResource
+    {
+        ArgumentNullException.ThrowIfNull(project);
+
+        Action<HostedAgentConfiguration>? configure = options is null ? null : options.ApplyTo;
+        return ConfigureAsHostedAgent(
+            builder,
+            project,
+            HostedAgentProtocol.Responses,
+            AzureHostedAgentResource.DefaultResponsesProtocolVersion,
+            configure);
+    }
+
+    /// <summary>
+    /// Configures the resource to run and publish as a hosted agent in Microsoft Foundry using an explicit protocol and version.
     /// </summary>
     /// <typeparam name="T">The type of resource being configured.</typeparam>
     /// <param name="builder">The resource builder for the compute resource.</param>
@@ -129,8 +157,8 @@ public static class HostedAgentResourceBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="project"/> is <see langword="null"/>.</exception>
-    [AspireExport("asHostedAgent", MethodName = "asHostedAgent")]
-    internal static IResourceBuilder<T> AsHostedAgentForExport<T>(
+    [AspireExport("asHostedAgentWithProtocol")]
+    internal static IResourceBuilder<T> AsHostedAgentWithProtocolForExport<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureCognitiveServicesProjectResource> project,
         HostedAgentProtocol protocol,
@@ -141,7 +169,7 @@ public static class HostedAgentResourceBuilderExtensions
         ArgumentNullException.ThrowIfNull(project);
 
         Action<HostedAgentConfiguration>? configure = options is null ? null : options.ApplyTo;
-        return ConfigureAsHostedAgent(builder, project: project, protocol, protocolVersion, configure: configure);
+        return ConfigureAsHostedAgent(builder, project, protocol, protocolVersion, configure);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
+++ b/src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentBuilderExtension.cs
@@ -77,10 +77,12 @@ public static class HostedAgentResourceBuilderExtensions
     /// <param name="configure">A callback to configure hosted agent deployment options.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <remarks>
-    /// This C# convenience overload is not exported to polyglot app hosts. Polyglot hosts must declare the
-    /// hosted agent protocol and protocol version explicitly. The configuration callback is applied in publish mode.
+    /// This C# convenience overload defaults to the Responses protocol version 2.0.0, mirroring the exported
+    /// <c>asHostedAgent</c> entry point used by polyglot app hosts. Polyglot hosts that need a different protocol
+    /// or version should use the exported <c>asHostedAgentWithProtocol</c> entry point instead. The configuration
+    /// callback is applied in publish mode.
     /// </remarks>
-    [AspireExportIgnore(Reason = "C# convenience overload; polyglot hosts must pass protocol and version explicitly.")]
+    [AspireExportIgnore(Reason = "Action callback shape is awkward for polyglot hosts; the defaulted asHostedAgent export covers this case.")]
     public static IResourceBuilder<T> AsHostedAgent<T>(
         this IResourceBuilder<T> builder,
         IResourceBuilder<AzureCognitiveServicesProjectResource>? project,

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -451,7 +451,7 @@ public class HostedAgentExtensionTests
         };
 
         builder.AddPythonApp("agent", "./app.py", "main:app")
-            .AsHostedAgentForExport(project, HostedAgentProtocol.Invocations, "1.0.0", options);
+            .AsHostedAgentWithProtocolForExport(project, HostedAgentProtocol.Invocations, "1.0.0", options);
 
         builder.Build();
 
@@ -571,7 +571,7 @@ public class HostedAgentExtensionTests
             .AddProject("my-project");
 
         builder.AddPythonApp("agent", "./app.py", "main:app")
-            .AsHostedAgentForExport(project, HostedAgentProtocol.Responses, "2.0.0", options: null);
+            .AsHostedAgentWithProtocolForExport(project, HostedAgentProtocol.Responses, "2.0.0", options: null);
 
         builder.Build();
 
@@ -590,7 +590,7 @@ public class HostedAgentExtensionTests
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var app = builder.AddPythonApp("agent", "./app.py", "main:app");
 
-        Assert.Throws<ArgumentNullException>(() => app.AsHostedAgentForExport(project: null!, HostedAgentProtocol.Responses, "2.0.0"));
+        Assert.Throws<ArgumentNullException>(() => app.AsHostedAgentForExport(project: null!));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
+++ b/tests/Aspire.Hosting.Foundry.Tests/HostedAgentExtensionTests.cs
@@ -471,6 +471,42 @@ public class HostedAgentExtensionTests
     }
 
     [Fact]
+    public void AsHostedAgentForExport_WithOptions_UsesDefaultResponsesProtocolAndAppliesOptions()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var project = builder.AddFoundry("account")
+            .AddProject("my-project");
+
+        var options = new HostedAgentOptions
+        {
+            Description = "test description",
+            Cpu = 1m,
+            Memory = 2m,
+            Metadata = { ["scenario"] = "unit-test" },
+            EnvironmentVariables = { ["MY_VAR"] = "my-value" }
+        };
+
+        builder.AddPythonApp("agent", "./app.py", "main:app")
+            .AsHostedAgentForExport(project, options);
+
+        builder.Build();
+
+        var hostedAgent = Assert.Single(builder.Resources.OfType<AzureHostedAgentResource>());
+
+        var configuration = new HostedAgentConfiguration("test-image");
+        hostedAgent.Configure!(configuration);
+
+        Assert.Equal("test description", configuration.Description);
+        Assert.Equal(1m, configuration.Cpu);
+        Assert.Equal(2m, configuration.Memory);
+        Assert.Equal("unit-test", configuration.Metadata["scenario"]);
+        Assert.Equal("my-value", configuration.EnvironmentVariables["MY_VAR"]);
+        var protocol = Assert.Single(configuration.ProtocolVersions);
+        Assert.Equal(ProjectsAgentProtocol.Responses, protocol.Protocol);
+        Assert.Equal(AzureHostedAgentResource.DefaultResponsesProtocolVersion, protocol.Version);
+    }
+
+    [Fact]
     public void AsHostedAgent_WithConfigureCallback_EnsuresSelectedProtocolRemainsInConfiguration()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
@@ -145,6 +145,9 @@ server.listen(port, '127.0.0.1');
 			"-e",
 			hostedAgentScript,
 		})
+	// Both hosted agents run as plain host processes (not containers), so they must not share the
+	// default 8088 target port or the second process fails to bind with EADDRINUSE.
+	hostedAgentWithProtocol.WithHttpEndpoint(&aspire.WithHttpEndpointOptions{TargetPort: aspire.Float64Ptr(8089)})
 	hostedAgentWithProtocol.AsHostedAgentWithProtocol(project, aspire.HostedAgentProtocolInvocations, "1.0.0", nil)
 
 	_ = builder.AddContainer("api", "nginx")

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Go/apphost.go
@@ -92,13 +92,7 @@ func main() {
 	})
 	project.AddModelDeployment("project-model", model)
 
-	hostedAgent := builder.AddExecutable(
-		"hosted-agent",
-		"node",
-		".",
-		[]string{
-			"-e",
-			`
+	hostedAgentScript := `
 const http = require('node:http');
 const port = Number(process.env.DEFAULT_AD_PORT ?? '8088');
 const server = http.createServer((req, res) => {
@@ -112,14 +106,26 @@ const server = http.createServer((req, res) => {
     res.end(JSON.stringify({ output: 'hello from validation app host' }));
     return;
   }
+  if (req.url === '/invocations') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ response: 'hello from validation app host' }));
+    return;
+  }
   res.writeHead(404);
   res.end();
 });
 server.listen(port, '127.0.0.1');
-`,
+`
+	hostedAgent := builder.AddExecutable(
+		"hosted-agent",
+		"node",
+		".",
+		[]string{
+			"-e",
+			hostedAgentScript,
 		})
 
-	hostedAgent.AsHostedAgent(project, aspire.HostedAgentProtocolResponses, "2.0.0", &aspire.HostedAgentOptions{
+	hostedAgent.AsHostedAgent(project, &aspire.HostedAgentOptions{
 		Description: "Validation hosted agent",
 		Cpu:         aspire.Float64Ptr(1),
 		Memory:      aspire.Float64Ptr(2),
@@ -130,6 +136,16 @@ server.listen(port, '127.0.0.1');
 			"VALIDATION_MODE": "true",
 		},
 	})
+
+	hostedAgentWithProtocol := builder.AddExecutable(
+		"hosted-agent-with-protocol",
+		"node",
+		".",
+		[]string{
+			"-e",
+			hostedAgentScript,
+		})
+	hostedAgentWithProtocol.AsHostedAgentWithProtocol(project, aspire.HostedAgentProtocolInvocations, "1.0.0", nil)
 
 	_ = builder.AddContainer("api", "nginx")
 	_ = []aspire.FoundryRole{

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
@@ -129,6 +129,9 @@ server.listen(port, '127.0.0.1');
                 "-e",
                 hostedAgentScript
             });
+        // Both hosted agents run as plain host processes (not containers), so they must not share the
+        // default 8088 target port or the second process fails to bind with EADDRINUSE.
+        hostedAgentWithProtocol.withHttpEndpoint(new WithHttpEndpointOptions().targetPort(8089.0));
         hostedAgentWithProtocol.asHostedAgentWithProtocol(project, HostedAgentProtocol.INVOCATIONS, "1.0.0");
 
         var api = builder.addContainer("api", "nginx");

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Java/AppHost.java
@@ -80,13 +80,7 @@ void main() throws Exception {
         var builderProject = builderProjectFoundry.addProject("builder-project");
         var _builderProjectModel = builderProject.addModelDeployment("builder-project-model", "Phi-4-mini", new AddModelDeploymentOptions().modelVersion("1").format("Microsoft"));
         var _projectModel = project.addModelDeployment("project-model", FoundryModels.Microsoft.Phi4);
-        var hostedAgent = builder.addExecutable(
-            "hosted-agent",
-            "node",
-            ".",
-            new String[] {
-                "-e",
-                """
+        var hostedAgentScript = """
 const http = require('node:http');
 const port = Number(process.env.DEFAULT_AD_PORT ?? '8088');
 const server = http.createServer((req, res) => {
@@ -100,11 +94,23 @@ const server = http.createServer((req, res) => {
     res.end(JSON.stringify({ output: 'hello from validation app host' }));
     return;
   }
+  if (req.url === '/invocations') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ response: 'hello from validation app host' }));
+    return;
+  }
   res.writeHead(404);
   res.end();
 });
 server.listen(port, '127.0.0.1');
-"""
+""";
+        var hostedAgent = builder.addExecutable(
+            "hosted-agent",
+            "node",
+            ".",
+            new String[] {
+                "-e",
+                hostedAgentScript
             });
 
         var hostedAgentOptions = new HostedAgentOptions();
@@ -113,7 +119,17 @@ server.listen(port, '127.0.0.1');
         hostedAgentOptions.setMemory(2.0);
         hostedAgentOptions.setMetadata(Map.of("scenario", "validation"));
         hostedAgentOptions.setEnvironmentVariables(Map.of("VALIDATION_MODE", "true"));
-        hostedAgent.asHostedAgent(project, HostedAgentProtocol.RESPONSES, "2.0.0", hostedAgentOptions);
+        hostedAgent.asHostedAgent(project, hostedAgentOptions);
+
+        var hostedAgentWithProtocol = builder.addExecutable(
+            "hosted-agent-with-protocol",
+            "node",
+            ".",
+            new String[] {
+                "-e",
+                hostedAgentScript
+            });
+        hostedAgentWithProtocol.asHostedAgentWithProtocol(project, HostedAgentProtocol.INVOCATIONS, "1.0.0");
 
         var api = builder.addContainer("api", "nginx");
         foundry.withContainerRegistryRoleAssignments(registry, new AzureContainerRegistryRole[] {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Python/apphost.py
@@ -1,4 +1,4 @@
-from aspire_app import create_builder
+from aspire_app import HostedAgentProtocol, create_builder
 
 
 with create_builder() as builder:
@@ -96,13 +96,7 @@ with create_builder() as builder:
         model_version="1",
         format="Microsoft")
     _project_model = project.add_model_deployment("project-model", model)
-    hosted_agent = builder.add_executable(
-        "hosted-agent",
-        "node",
-        ".",
-        [
-            "-e",
-            """
+    hosted_agent_script = """
 const http = require('node:http');
 const port = Number(process.env.DEFAULT_AD_PORT ?? '8088');
 const server = http.createServer((req, res) => {
@@ -116,14 +110,33 @@ const server = http.createServer((req, res) => {
     res.end(JSON.stringify({ output: 'hello from validation app host' }));
     return;
   }
+  if (req.url === '/invocations') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ response: 'hello from validation app host' }));
+    return;
+  }
   res.writeHead(404);
   res.end();
 });
 server.listen(port, '127.0.0.1');
 """
-        ])
+    hosted_agent = builder.add_executable(
+        "hosted-agent",
+        "node",
+        ".",
+        ["-e", hosted_agent_script])
 
     hosted_agent.as_hosted_agent(project=project)
+
+    hosted_agent_with_protocol = builder.add_executable(
+        "hosted-agent-with-protocol",
+        "node",
+        ".",
+        ["-e", hosted_agent_script])
+    hosted_agent_with_protocol.as_hosted_agent_with_protocol(
+        project,
+        HostedAgentProtocol.INVOCATIONS,
+        "1.0.0")
 
     api = builder.add_container("api", "nginx")
     foundry.with_container_registry_role_assignments(registry)

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/Python/apphost.py
@@ -133,6 +133,9 @@ server.listen(port, '127.0.0.1');
         "node",
         ".",
         ["-e", hosted_agent_script])
+    # Both hosted agents run as plain host processes (not containers), so they must not share the
+    # default 8088 target port or the second process fails to bind with EADDRINUSE.
+    hosted_agent_with_protocol.with_http_endpoint(target_port=8089)
     hosted_agent_with_protocol.as_hosted_agent_with_protocol(
         project,
         HostedAgentProtocol.INVOCATIONS,

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
@@ -126,6 +126,9 @@ const hostedAgentWithProtocol = await builder.addExecutable(
     'node',
     '.',
     ['-e', hostedAgentScript]);
+// Both hosted agents run as plain host processes (not containers), so they must not share the
+// default 8088 target port or the second process fails to bind with EADDRINUSE.
+await hostedAgentWithProtocol.withHttpEndpoint({ targetPort: 8089 });
 await hostedAgentWithProtocol.asHostedAgentWithProtocol(project, HostedAgentProtocol.Invocations, '1.0.0');
 
 const api = await builder.addContainer('api', 'nginx');

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Foundry/TypeScript/apphost.mts
@@ -83,13 +83,7 @@ const builderProjectFoundry = await builder.addFoundry('builder-project-foundry'
 const builderProject = await builderProjectFoundry.addProject('builder-project');
 const _builderProjectModel = await builderProject.addModelDeployment('builder-project-model', 'Phi-4-mini', { modelVersion: '1', format: 'Microsoft' });
 const _projectModel = await project.addModelDeployment('project-model', FoundryModels.Microsoft.Phi4);
-const hostedAgent = await builder.addExecutable(
-    'hosted-agent',
-    'node',
-    '.',
-    [
-        '-e',
-        `
+const hostedAgentScript = `
 const http = require('node:http');
 const port = Number(process.env.DEFAULT_AD_PORT ?? '8088');
 const server = http.createServer((req, res) => {
@@ -112,16 +106,27 @@ const server = http.createServer((req, res) => {
   res.end();
 });
 server.listen(port, '127.0.0.1');
-`
-    ]);
+`;
+const hostedAgent = await builder.addExecutable(
+    'hosted-agent',
+    'node',
+    '.',
+    ['-e', hostedAgentScript]);
 
-await hostedAgent.asHostedAgent(project, HostedAgentProtocol.Invocations, '1.0.0', {
+await hostedAgent.asHostedAgent(project, {
     description: 'Validation hosted agent',
     cpu: 1,
     memory: 2,
     metadata: { scenario: 'validation' },
     environmentVariables: { VALIDATION_MODE: 'true' }
 });
+
+const hostedAgentWithProtocol = await builder.addExecutable(
+    'hosted-agent-with-protocol',
+    'node',
+    '.',
+    ['-e', hostedAgentScript]);
+await hostedAgentWithProtocol.asHostedAgentWithProtocol(project, HostedAgentProtocol.Invocations, '1.0.0');
 
 const api = await builder.addContainer('api', 'nginx');
 await foundry.withContainerRegistryRoleAssignments(registry, [AzureContainerRegistryRole.AcrPull]);


### PR DESCRIPTION
## Description

Restores the shipped polyglot `asHostedAgent(project, options?)` capability so existing AppHosts continue to use the Responses protocol version 2.0.0 defaults. The explicit protocol form is now exposed as the additive `asHostedAgentWithProtocol` capability instead of replacing the existing signature.

The two ATS adapters use distinct internal CLR names and capability IDs, preserving the existing public C# overloads without introducing overload ambiguity. TypeScript, Python, Go, and Java validation AppHosts exercise both generated methods.

Related reviews:
- https://github.com/microsoft/aspire/pull/17846#discussion_r3708195048
- https://github.com/microsoft/aspire/pull/18339

### User-facing usage

C# callers continue to use the existing overloads:

```csharp
agent.AsHostedAgent(project, HostedAgentProtocol.Invocations, "1.0.0");
```

Polyglot callers can retain the existing defaulted form or opt into explicit protocol selection:

```typescript
await agent.asHostedAgent(project, options);
await agent.asHostedAgentWithProtocol(
    project,
    HostedAgentProtocol.Invocations,
    "1.0.0",
    options);
```

Validation:
- Built `Aspire.Hosting.Foundry` with integration analyzers enabled.
- Passed all 117 `Aspire.Hosting.Foundry.Tests`.
- Generated and compiled the Foundry validation AppHosts for TypeScript, Python, Go, and Java.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
