### PR TITLE
Show status while preparing dashboard bundle

### DIFF
--- a/src/Aspire.Cli/Commands/DashboardRunCommand.cs
+++ b/src/Aspire.Cli/Commands/DashboardRunCommand.cs
@@ -21,6 +21,8 @@ namespace Aspire.Cli.Commands;
 /// </summary>
 internal sealed class DashboardRunCommand : BaseCommand
 {
+    private static readonly TimeSpan s_bundleStatusDelay = TimeSpan.FromMilliseconds(200);
+
     internal override HelpGroup HelpGroup => HelpGroup.Monitoring;
 
     protected override bool UpdateNotificationsEnabled => true;
@@ -83,7 +85,7 @@ internal sealed class DashboardRunCommand : BaseCommand
 
     protected override async Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
-        using var layoutLease = await _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "dashboard", cancellationToken).ConfigureAwait(false);
+        using var layoutLease = await EnsureDashboardBundleAsync(cancellationToken).ConfigureAwait(false);
         var layout = layoutLease?.Layout;
         if (layout is null)
         {
@@ -138,6 +140,21 @@ internal sealed class DashboardRunCommand : BaseCommand
         var dashboardInfo = ResolveDashboardInfo(dashboardArgs, unmatchedTokens, _environment, browserToken);
 
         return await ExecuteForegroundAsync(managedPath, dashboardArgs, dashboardInfo, environmentVariables, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<BundleLayoutLease?> EnsureDashboardBundleAsync(CancellationToken cancellationToken)
+    {
+        var layoutTask = _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "dashboard", cancellationToken);
+
+        // Cached bundle acquisition normally completes quickly, so wait briefly before showing a status to avoid flicker during typical usage.
+        if (await Task.WhenAny(layoutTask, Task.Delay(s_bundleStatusDelay, CancellationToken.None)).ConfigureAwait(false) == layoutTask)
+        {
+            return await layoutTask.ConfigureAwait(false);
+        }
+
+        return await InteractionService.ShowStatusAsync(
+            DashboardCommandStrings.EnsuringDashboardBundle,
+            () => layoutTask).ConfigureAwait(false);
     }
 
     private static void AddOptionArgs(ParseResult parseResult, List<string> args, IReadOnlyList<string> unmatchedTokens, IEnvironment environment)

--- a/src/Aspire.Cli/Resources/DashboardCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/DashboardCommandStrings.Designer.cs
@@ -93,6 +93,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string EnsuringDashboardBundle {
+            get {
+                return ResourceManager.GetString("EnsuringDashboardBundle", resourceCulture);
+            }
+        }
+
         public static string DashboardStartTimedOut {
             get {
                 return ResourceManager.GetString("DashboardStartTimedOut", resourceCulture);

--- a/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/DashboardCommandStrings.resx
@@ -141,6 +141,9 @@
   <data name="StartingDashboard" xml:space="preserve">
     <value>Starting dashboard...</value>
   </data>
+  <data name="EnsuringDashboardBundle" xml:space="preserve">
+    <value>Preparing dashboard bits...</value>
+  </data>
   <data name="DashboardStartTimedOut" xml:space="preserve">
     <value>Dashboard did not become ready within the expected time.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.cs.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.de.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.es.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.fr.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.it.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ja.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ko.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pl.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.ru.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.tr.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/DashboardCommandStrings.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="new">Manage the Aspire dashboard (Preview)</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsuringDashboardBundle">
+        <source>Preparing dashboard bits...</source>
+        <target state="new">Preparing dashboard bits...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrontendUrlOptionDescription">
         <source>One or more HTTP endpoints through which the dashboard frontend is served</source>
         <target state="new">One or more HTTP endpoints through which the dashboard frontend is served</target>

--- a/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DashboardRunCommandTests.cs
@@ -148,6 +148,62 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task DashboardRunCommand_BundleAvailableWithinDelay_DoesNotDisplayBundleStatus()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var testInteractionService = new TestInteractionService();
+        var (services, _, _) = CreateServicesWithLayout(workspace, interactionService: testInteractionService);
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Equal([DashboardCommandStrings.StartingDashboard], testInteractionService.ShownStatuses);
+    }
+
+    [Fact]
+    public async Task DashboardRunCommand_BundleUnavailableAfterDelay_DisplaysBundleStatus()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var releaseBundle = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bundleStatusDisplayed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testInteractionService = new TestInteractionService
+        {
+            ShowStatusCallback = status =>
+            {
+                if (status == DashboardCommandStrings.EnsuringDashboardBundle)
+                {
+                    bundleStatusDisplayed.TrySetResult();
+                }
+            }
+        };
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            EnsureExtractedAndAcquireLayoutAsyncCallback = cancellationToken => releaseBundle.Task.WaitAsync(cancellationToken)
+        };
+        var (services, _, _) = CreateServicesWithLayout(workspace, testInteractionService, bundleService);
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("dashboard run");
+
+        var pendingRun = result.InvokeAsync();
+        await bundleStatusDisplayed.Task.DefaultTimeout();
+        releaseBundle.TrySetResult();
+        var exitCode = await pendingRun.DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Equal(
+            [DashboardCommandStrings.EnsuringDashboardBundle, DashboardCommandStrings.StartingDashboard],
+            testInteractionService.ShownStatuses);
+    }
+
+    [Fact]
     public async Task DashboardRunCommand_DefaultOptions_PassesDefaultArgsToProcess()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
@@ -540,7 +596,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
 
     private (IServiceCollection Services, string ManagedPath, TestProcessExecutionFactory ExecutionFactory) CreateServicesWithLayout(
         TemporaryWorkspace workspace,
-        TestInteractionService? interactionService = null)
+        TestInteractionService? interactionService = null,
+        TestBundleService? bundleService = null)
     {
         var layoutDir = Path.Combine(workspace.WorkspaceRoot.FullName, "layout");
         var managedDir = Path.Combine(layoutDir, "managed");
@@ -553,6 +610,8 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
             LayoutPath = layoutDir,
             Components = new LayoutComponents { Managed = "managed" }
         };
+        bundleService ??= new TestBundleService(isBundle: true);
+        bundleService.Layout = layout;
 
         var executionFactory = new TestProcessExecutionFactory
         {
@@ -562,7 +621,7 @@ public class DashboardRunCommandTests(ITestOutputHelper outputHelper)
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
         {
             options.LayoutDiscoveryFactory = _ => new FakeLayoutDiscovery(layout);
-            options.BundleServiceFactory = _ => new TestBundleService(true) { Layout = layout };
+            options.BundleServiceFactory = _ => bundleService;
             options.DotNetCliExecutionFactoryFactory = _ => executionFactory;
             if (interactionService is not null)
             {

--- a/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
+++ b/tests/Aspire.Cli.Tests/Utils/CliTestHelper.cs
@@ -798,16 +798,28 @@ internal sealed class TestBundleService(bool isBundle) : IBundleService
 
     public Func<CancellationToken, Task>? EnsureExtractedAsyncCallback { get; set; }
 
+    public Func<CancellationToken, Task>? EnsureExtractedAndAcquireLayoutAsyncCallback { get; set; }
+
     public Task EnsureExtractedAsync(CancellationToken cancellationToken = default)
         => EnsureExtractedAsyncCallback?.Invoke(cancellationToken) ?? Task.CompletedTask;
 
     public Task<BundleExtractResult> ExtractAsync(string destinationPath, bool force = false, CancellationToken cancellationToken = default)
         => Task.FromResult(isBundle ? BundleExtractResult.AlreadyUpToDate : BundleExtractResult.NoPayload);
 
-    public Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
-        => EnsureExtractedException is not null
-            ? Task.FromException<BundleLayoutLease?>(EnsureExtractedException)
-            : Task.FromResult(Layout is null ? null : new BundleLayoutLease(Layout, lease: null));
+    public async Task<BundleLayoutLease?> EnsureExtractedAndAcquireLayoutAsync(string holderKind, string? commandName = null, CancellationToken cancellationToken = default)
+    {
+        if (EnsureExtractedException is not null)
+        {
+            throw EnsureExtractedException;
+        }
+
+        if (EnsureExtractedAndAcquireLayoutAsyncCallback is not null)
+        {
+            await EnsureExtractedAndAcquireLayoutAsyncCallback(cancellationToken);
+        }
+
+        return Layout is null ? null : new BundleLayoutLease(Layout, lease: null);
+    }
 
     public string? GetDefaultExtractDir(string processPath) => null;
 }


### PR DESCRIPTION
## Description

`aspire dashboard run` could appear idle while the CLI prepared or extracted its bundle. The existing `Starting dashboard...` status is intentionally scoped to launching the dashboard process, so this change adds a separate delayed status for bundle preparation.

Bundle acquisition now gets a 200 ms grace period. Typical cached acquisition remains quiet, while slower acquisition displays `Preparing dashboard bits...` until the bundle is ready.

### User-facing usage

```bash
aspire dashboard run
```

When bundle preparation takes longer than 200 ms, the CLI now shows:

```text
Preparing dashboard bits...
Starting dashboard...
```

### Screenshots / Recordings

> **This PR includes UI changes.** Please add screenshots or screen recordings so reviewers can evaluate the visual changes without running locally.
>
> - For before/after comparisons, place them side-by-side or label them clearly.
> - For interactive changes (animations, transitions, new flows), prefer a short screen recording (GIF or video).
> - If you cannot capture visuals now, note what scenario to test and mark this section as TODO.

TODO: Run `aspire dashboard run` with uncached bundle extraction to capture the delayed preparation status.

Validation:

```text
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.DashboardRunCommand_BundleAvailableWithinDelay_DoesNotDisplayBundleStatus" --filter-method "*.DashboardRunCommand_BundleUnavailableAfterDelay_DisplaysBundleStatus" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No