### PR TITLE
Disable default timeout for HTTP commands

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/HttpCommandOptions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HttpCommandOptions.cs
@@ -49,6 +49,10 @@ public class HttpCommandOptions : CommandOptions
     /// <summary>
     /// Gets or sets the name of the HTTP client to use when creating it via <see cref="IHttpClientFactory.CreateClient(string)"/>.
     /// </summary>
+    /// <remarks>
+    /// When this property is <see langword="null"/>, the default <see cref="HttpClient"/> is used and its <see cref="HttpClient.Timeout"/>
+    /// is set to <see cref="Timeout.InfiniteTimeSpan"/>. Specify a named client to preserve its configured timeout.
+    /// </remarks>
     public string? HttpClientName { get; set; }
 
     /// <summary>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3547,8 +3547,9 @@ public static class ResourceBuilderExtensions
     /// </para>
     /// <para>
     /// Specifying <see cref="HttpCommandOptions.HttpClientName"/> will use that named <see cref="HttpClient"/> when sending the request. This allows you to configure the <see cref="HttpClient"/>
-    /// instance with a specific handler or other options using <see cref="HttpClientFactoryServiceCollectionExtensions.AddHttpClient(IServiceCollection, string)"/>.
-    /// If <see cref="HttpCommandOptions.HttpClientName"/> is not specified, the default <see cref="HttpClient"/> will be used.
+    /// instance with a specific handler, timeout, or other options using <see cref="HttpClientFactoryServiceCollectionExtensions.AddHttpClient(IServiceCollection, string)"/>.
+    /// If <see cref="HttpCommandOptions.HttpClientName"/> is not specified, the default <see cref="HttpClient"/> will be used and its
+    /// <see cref="HttpClient.Timeout"/> will be set to <see cref="Timeout.InfiniteTimeSpan"/>. Specify a named client to preserve its configured timeout.
     /// </para>
     /// <para>
     /// The <see cref="HttpCommandOptions.PrepareRequest"/> callback will be invoked to configure the request before it is sent. This can be used to add headers or a request payload
@@ -3640,8 +3641,9 @@ public static class ResourceBuilderExtensions
     /// </para>
     /// <para>
     /// Specifying a <see cref="HttpCommandOptions.HttpClientName"/> will use that named <see cref="HttpClient"/> when sending the request. This allows you to configure the <see cref="HttpClient"/>
-    /// instance with a specific handler or other options using <see cref="HttpClientFactoryServiceCollectionExtensions.AddHttpClient(IServiceCollection, string)"/>.
-    /// If no <see cref="HttpCommandOptions.HttpClientName"/> is specified, the default <see cref="HttpClient"/> will be used.
+    /// instance with a specific handler, timeout, or other options using <see cref="HttpClientFactoryServiceCollectionExtensions.AddHttpClient(IServiceCollection, string)"/>.
+    /// If <see cref="HttpCommandOptions.HttpClientName"/> is not specified, the default <see cref="HttpClient"/> will be used and its
+    /// <see cref="HttpClient.Timeout"/> will be set to <see cref="Timeout.InfiniteTimeSpan"/>. Specify a named client to preserve its configured timeout.
     /// </para>
     /// <para>
     /// The <see cref="HttpCommandOptions.PrepareRequest"/> callback will be invoked to configure the request before it is sent. This can be used to add headers or a request payload
@@ -3715,7 +3717,8 @@ public static class ResourceBuilderExtensions
                 if (commandOptions.HttpClientName is null)
                 {
                     // HTTP commands are user-cancelable and may legitimately run longer than HttpClient's 100-second default.
-                    // Named clients retain their configured timeout.
+                    // The unnamed default client therefore has no timeout. A named client selects custom configuration,
+                    // including its configured timeout.
                     httpClient.Timeout = Timeout.InfiniteTimeSpan;
                 }
                 var request = new HttpRequestMessage(commandOptions.Method, uri);

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -3712,6 +3712,12 @@ public static class ResourceBuilderExtensions
                 }
                 var uri = new UriBuilder(endpoint.Url) { Path = path }.Uri;
                 var httpClient = context.Services.GetRequiredService<IHttpClientFactory>().CreateClient(commandOptions.HttpClientName ?? Options.DefaultName);
+                if (commandOptions.HttpClientName is null)
+                {
+                    // HTTP commands are user-cancelable and may legitimately run longer than HttpClient's 100-second default.
+                    // Named clients retain their configured timeout.
+                    httpClient.Timeout = Timeout.InfiniteTimeSpan;
+                }
                 var request = new HttpRequestMessage(commandOptions.Method, uri);
                 if (commandOptions.PrepareRequest is not null)
                 {

--- a/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithHttpCommandTests.cs
@@ -9,6 +9,7 @@ using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Tests;
 
@@ -115,6 +116,36 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
 
         var httpClientFactory = app.Services.GetService<IHttpClientFactory>();
         Assert.NotNull(httpClientFactory);
+    }
+
+    [Fact]
+    public async Task WithHttpCommand_WithoutNamedHttpClient_HasNoTimeout()
+    {
+        using var builder = CreateTestDistributedApplicationBuilder();
+        var fakeHandler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        builder.Services.AddHttpClient(Options.DefaultName)
+            .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromSeconds(100))
+            .ConfigurePrimaryHttpMessageHandler(() => fakeHandler);
+
+        TimeSpan? timeout = null;
+        var service = CreateResourceWithAllocatedEndpoint(builder, "service");
+        service.WithHttpCommand("/some-path", "Do The Thing", commandName: "mycommand", commandOptions: new()
+        {
+            PrepareRequest = context =>
+            {
+                timeout = context.HttpClient.Timeout;
+                return Task.CompletedTask;
+            }
+        });
+
+        using var app = builder.Build();
+        await app.StartAsync().DefaultTimeout();
+        await MoveResourceToRunningStateAsync(app, service.Resource);
+
+        var result = await app.ResourceCommands.ExecuteCommandAsync(service.Resource, "mycommand").DefaultTimeout();
+
+        Assert.True(result.Success);
+        Assert.Equal(Timeout.InfiniteTimeSpan, timeout);
     }
 
     [Fact]
@@ -468,11 +499,21 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
         // Arrange
         using var builder = CreateTestDistributedApplicationBuilder();
         var fakeHandler = new FakeHttpMessageHandler(HttpStatusCode.OK);
-        builder.Services.AddHttpClient("commandclient")
+        var configuredTimeout = TimeSpan.FromMinutes(5);
+        builder.Services.AddHttpClient("commandclient", client => client.Timeout = configuredTimeout)
             .ConfigurePrimaryHttpMessageHandler(() => fakeHandler);
 
+        TimeSpan? timeout = null;
         var service = CreateResourceWithAllocatedEndpoint(builder, "service");
-        service.WithHttpCommand("/get-only", "Do The Thing", commandName: "mycommand", commandOptions: new() { HttpClientName = "commandclient" });
+        service.WithHttpCommand("/get-only", "Do The Thing", commandName: "mycommand", commandOptions: new()
+        {
+            HttpClientName = "commandclient",
+            PrepareRequest = context =>
+            {
+                timeout = context.HttpClient.Timeout;
+                return Task.CompletedTask;
+            }
+        });
 
         // Act
         using var app = builder.Build();
@@ -484,6 +525,7 @@ public class WithHttpCommandTests(ITestOutputHelper testOutputHelper)
 
         // Assert
         Assert.True(fakeHandler.Called);
+        Assert.Equal(configuredTimeout, timeout);
     }
 
     private sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, string? responseBody = null, string? mediaType = null) : HttpMessageHandler


### PR DESCRIPTION
## Description

HTTP resource commands that run for more than 100 seconds currently fail with the default `HttpClient.Timeout`, even though command execution already supports explicit cancellation from the dashboard.

This change removes the implicit timeout for HTTP commands that do not specify `HttpCommandOptions.HttpClientName`. Those commands now run until they complete or the command cancellation token is canceled. Named HTTP clients continue to honor their configured timeout.

### User-facing usage

Long-running HTTP commands no longer require a named client solely to exceed 100 seconds:

```csharp
resource.WithHttpCommand("/long-running-operation", "Run long operation");
```

Applications that need a finite timeout can continue to configure a named client and set `HttpCommandOptions.HttpClientName`.

Validation:

```text
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.WithHttpCommandTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Passed: 41, Failed: 0
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
