### PR TITLE
Lazily initialize dashboard menus

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor
@@ -3,7 +3,15 @@
 @inherits FluentComponentBase
 
 @* aspire-menu-container is added to the div parent of FluentMenu, not the FluentMenu *@
-<FluentMenu Class="aspire-menu-container" @ref="_menu" Anchor="@Anchor" Anchored="@Anchored" Open="@Open" OpenChanged="OnOpenChanged" Style="@Style" VerticalThreshold="@CalculatedVerticalThreshold" HorizontalThreshold="200">
+<FluentMenu Class="aspire-menu-container"
+            @ref="_menu"
+            Anchor="@Anchor"
+            Anchored="@Anchored"
+            Open="@Open"
+            OpenChanged="OnOpenChanged"
+            Style="@Style"
+            VerticalThreshold="@CalculatedVerticalThreshold"
+            HorizontalThreshold="200">
     @foreach (var item in Items)
     {
         @RenderMenuItem(item)

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -58,8 +58,6 @@ public partial class AspireMenu : FluentComponentBase
     // Each menu item is approximately 32px tall, plus 16px padding for the menu container.
     private const int EstimatedItemHeight = 32;
     private const int MenuVerticalPadding = 16;
-    private const int InitializationWaitMilliseconds = 100;
-
     private int CalculatedVerticalThreshold => VerticalThreshold ?? (Items.Count * EstimatedItemHeight + MenuVerticalPadding);
 
     protected override void OnParametersSet()
@@ -75,9 +73,6 @@ public partial class AspireMenu : FluentComponentBase
     {
         if (firstRender && OnRenderComplete.HasDelegate)
         {
-            // FluentMenu writes aria-expanded after its JavaScript modules are initialized.
-            // Wait for that signal before allowing the owner to open the menu.
-            await JS.InvokeVoidAsync("waitForFluentMenuInitialization", Anchor, InitializationWaitMilliseconds);
             await OnRenderComplete.InvokeAsync();
         }
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -58,6 +58,7 @@ public partial class AspireMenu : FluentComponentBase
     // Each menu item is approximately 32px tall, plus 16px padding for the menu container.
     private const int EstimatedItemHeight = 32;
     private const int MenuVerticalPadding = 16;
+    private const int InitializationWaitMilliseconds = 100;
 
     private int CalculatedVerticalThreshold => VerticalThreshold ?? (Items.Count * EstimatedItemHeight + MenuVerticalPadding);
 
@@ -76,7 +77,7 @@ public partial class AspireMenu : FluentComponentBase
         {
             // FluentMenu writes aria-expanded after its JavaScript modules are initialized.
             // Wait for that signal before allowing the owner to open the menu.
-            await JS.InvokeVoidAsync("waitForFluentMenuInitialization", Anchor);
+            await JS.InvokeVoidAsync("waitForFluentMenuInitialization", Anchor, InitializationWaitMilliseconds);
             await OnRenderComplete.InvokeAsync();
         }
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenu.razor.cs
@@ -12,6 +12,8 @@ namespace Aspire.Dashboard.Components;
 public partial class AspireMenu : FluentComponentBase
 {
     private FluentMenu? _menu;
+    private IReadOnlyList<MenuButtonItem>? _renderedItems;
+    private bool _refreshMenuAfterRender;
 
     [Parameter]
     public string? Anchor { get; set; }
@@ -32,6 +34,9 @@ public partial class AspireMenu : FluentComponentBase
     public EventCallback<bool> OpenChanged { get; set; }
 
     [Parameter]
+    public EventCallback OnRenderComplete { get; set; }
+
+    [Parameter]
     public required IReadOnlyList<MenuButtonItem> Items { get; set; }
 
     /// <summary>
@@ -47,18 +52,48 @@ public partial class AspireMenu : FluentComponentBase
     [Inject]
     public required IJSRuntime JS { get; init; }
 
+    [Inject]
+    public required IMenuService MenuService { get; init; }
+
     // Each menu item is approximately 32px tall, plus 16px padding for the menu container.
     private const int EstimatedItemHeight = 32;
     private const int MenuVerticalPadding = 16;
 
     private int CalculatedVerticalThreshold => VerticalThreshold ?? (Items.Count * EstimatedItemHeight + MenuVerticalPadding);
 
+    protected override void OnParametersSet()
+    {
+        if (!ReferenceEquals(_renderedItems, Items))
+        {
+            _renderedItems = Items;
+            _refreshMenuAfterRender = Open;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && OnRenderComplete.HasDelegate)
+        {
+            // FluentMenu writes aria-expanded after its JavaScript modules are initialized.
+            // Wait for that signal before allowing the owner to open the menu.
+            await JS.InvokeVoidAsync("waitForFluentMenuInitialization", Anchor);
+            await OnRenderComplete.InvokeAsync();
+        }
+
+        if (_refreshMenuAfterRender)
+        {
+            _refreshMenuAfterRender = false;
+
+            if (_menu is { Id: { } menuId })
+            {
+                await MenuService.RefreshMenuAsync(menuId, Open);
+            }
+        }
+    }
+
     public async Task CloseAsync()
     {
-        if (_menu is { } menu)
-        {
-            await menu.CloseAsync();
-        }
+        await SetOpenAsync(false);
     }
 
     public async Task OpenAsync(int screenWidth, int screenHeight, int clientX, int clientY)
@@ -120,7 +155,7 @@ public partial class AspireMenu : FluentComponentBase
 
         // Item callbacks can move focus to a dialog or another control, so restore the
         // menu trigger first to avoid stealing focus back after the callback completes.
-        if (item.OnClick is {} onClick)
+        if (item.OnClick is { } onClick)
         {
             await onClick();
         }
@@ -134,6 +169,7 @@ public partial class AspireMenu : FluentComponentBase
     private async Task SetOpenAsync(bool open)
     {
         Open = open;
+        StateHasChanged();
 
         if (OpenChanged.HasDelegate)
         {

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -3,21 +3,12 @@
 @inherits FluentComponentBase
 
 @{
-    // Do not add aria-expanded here. Its presence signals that FluentMenu has finished initializing.
+    // Do not add aria-expanded here. Its presence signals that FluentMenu has finished initializing and so can't be added before then.
+    // We'll have to live with aria-expanded missing before the menu is clicked, and then being set to true while the menu is open.
     var additionalButtonAttributes = new Dictionary<string, object>(AdditionalAttributes ?? ImmutableDictionary<string, object>.Empty)
     {
         { "onkeydown", (KeyboardEventArgs args) => OnKeyDown(args) },
-        // Menu-button ARIA is awkward here because FluentUI's <fluent-button> host is a role-less custom
-        // element whose real interactive element is a native <button part="control"> in its shadow root.
-        // Neither aria-haspopup nor aria-expanded may live on the role-less host: aria-expanded there is an
-        // axe-core aria-allowed-attr violation, and giving the host role="button" would trip
-        // nested-interactive against the inner <button>. So app.js places both on the inner control
-        // (implicit role=button) instead - aria-haspopup="menu" directly, and aria-expanded moved off the
-        // host (where FluentMenu.razor.js stamps it on open/close) onto the inner control - so the trigger
-        // still reports its expanded state to assistive tech while the host stays axe-clean.
-        // The data-* marker lets a single document-level app.js observer find every menu button.
-        // See https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/.
-        { "data-aspire-menu-trigger", "" }
+        { "aria-haspopup", "menu" }
     };
 }
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -3,6 +3,7 @@
 @inherits FluentComponentBase
 
 @{
+    // Do not add aria-expanded here. Its presence signals that FluentMenu has finished initializing.
     var additionalButtonAttributes = new Dictionary<string, object>(AdditionalAttributes ?? ImmutableDictionary<string, object>.Empty)
     {
         { "onkeydown", (KeyboardEventArgs args) => OnKeyDown(args) },
@@ -36,4 +37,8 @@
     }
 </FluentButton>
 
-<AspireMenu Anchor="@MenuButtonId" @bind-Open="@_visible" Items="_items" RestoreFocusOnItemClick="@RestoreFocusOnItemClick" />
+@* Render lazily because FluentMenu is expensive: building menu items and initializing its JavaScript interop add significant overhead when many menu buttons are displayed. *@
+@if (_renderMenu)
+{
+    <AspireMenu Anchor="@MenuButtonId" Open="@_visible" OpenChanged="OnMenuOpenChanged" OnRenderComplete="OnMenuRenderComplete" Items="_items" RestoreFocusOnItemClick="@RestoreFocusOnItemClick" />
+}

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -109,14 +109,6 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
             return;
         }
 
-        RefreshItems();
-
-        if (_disabled)
-        {
-            _renderMenu = false;
-            return;
-        }
-
         if (!_menuRenderComplete)
         {
             // Keep the menu out of the render tree until observation is ready so a parent render
@@ -124,6 +116,8 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
             _jsModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./Components/Controls/AspireMenuButton.razor.js");
             await _jsModule.InvokeVoidAsync("prepareForFluentMenuInitialization", MenuButtonId);
         }
+
+        RefreshItems();
 
         _renderMenu = true;
 

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -13,7 +14,9 @@ namespace Aspire.Dashboard.Components;
 public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
 {
     private static readonly Icon s_defaultIcon = new Icons.Regular.Size24.ChevronDown();
+    private const int InitializationWaitMilliseconds = 100;
 
+    private IJSObjectReference? _jsModule;
     private bool _renderMenu;
     private bool _menuRenderComplete;
     private bool _openWhenMenuRenderCompletes;
@@ -107,27 +110,32 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
         }
 
         RefreshItems();
-        _renderMenu = !_disabled;
 
-        if (_renderMenu)
+        if (_disabled)
         {
-            if (!_menuRenderComplete)
-            {
-                // Start observing before rendering FluentMenu so its first aria-expanded write
-                // cannot happen before the initialization wait is registered.
-                await JS.InvokeVoidAsync("prepareForFluentMenuInitialization", MenuButtonId);
-            }
+            _renderMenu = false;
+            return;
+        }
 
-            // Reopen a retained menu immediately, but defer the first open until FluentMenu has
-            // rendered and initialized its JavaScript modules.
-            if (_menuRenderComplete)
-            {
-                _visible = true;
-            }
-            else
-            {
-                _openWhenMenuRenderCompletes = true;
-            }
+        if (!_menuRenderComplete)
+        {
+            // Keep the menu out of the render tree until observation is ready so a parent render
+            // during the lazy module import can't complete menu rendering before this setup.
+            _jsModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./Components/Controls/AspireMenuButton.razor.js");
+            await _jsModule.InvokeVoidAsync("prepareForFluentMenuInitialization", MenuButtonId);
+        }
+
+        _renderMenu = true;
+
+        // Reopen a retained menu immediately, but defer the first open until FluentMenu has
+        // rendered and initialized its JavaScript modules.
+        if (_menuRenderComplete)
+        {
+            _visible = true;
+        }
+        else
+        {
+            _openWhenMenuRenderCompletes = true;
         }
     }
 
@@ -137,8 +145,11 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
         _disabled = !_items.Any(i => !i.IsDivider);
     }
 
-    private void OnMenuRenderComplete()
+    private async Task OnMenuRenderComplete()
     {
+        // FluentMenu writes aria-expanded after its JavaScript modules are initialized.
+        // Wait for that signal before opening the menu.
+        await _jsModule!.InvokeVoidAsync("waitForFluentMenuInitialization", MenuButtonId, InitializationWaitMilliseconds);
         _menuRenderComplete = true;
 
         if (_openWhenMenuRenderCompletes)
@@ -163,20 +174,25 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (_renderMenu && !_menuRenderComplete)
+        if (_jsModule is { } jsModule)
         {
-            try
+            if (_renderMenu && !_menuRenderComplete)
             {
-                await JS.InvokeVoidAsync("cancelFluentMenuInitialization", MenuButtonId);
+                try
+                {
+                    await jsModule.InvokeVoidAsync("cancelFluentMenuInitialization", MenuButtonId);
+                }
+                catch (JSDisconnectedException)
+                {
+                    // The browser may already be gone when the component is disposed.
+                }
+                catch (OperationCanceledException)
+                {
+                    // The browser may already be gone when the component is disposed.
+                }
             }
-            catch (JSDisconnectedException)
-            {
-                // The browser may already be gone when the component is disposed.
-            }
-            catch (OperationCanceledException)
-            {
-                // The browser may already be gone when the component is disposed.
-            }
+
+            await JSInteropHelpers.SafeDisposeAsync(jsModule);
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -133,8 +133,84 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
 
     private void RefreshItems()
     {
-        _items = ItemsProvider().ToArray();
+        var items = ItemsProvider().ToArray();
+
+        if (HaveSameRenderState(_items, items))
+        {
+            UpdateCallbacks(_items, items);
+        }
+        else
+        {
+            _items = items;
+        }
+
         _disabled = !_items.Any(i => !i.IsDivider);
+    }
+
+    private static bool HaveSameRenderState(IReadOnlyList<MenuButtonItem> currentItems, IReadOnlyList<MenuButtonItem> newItems)
+    {
+        if (currentItems.Count != newItems.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < currentItems.Count; i++)
+        {
+            var currentItem = currentItems[i];
+            var newItem = newItems[i];
+
+            if (currentItem.IsDivider != newItem.IsDivider ||
+                currentItem.Text != newItem.Text ||
+                currentItem.Tooltip != newItem.Tooltip ||
+                !Equals(currentItem.Icon, newItem.Icon) ||
+                currentItem.Role != newItem.Role ||
+                currentItem.Checked != newItem.Checked ||
+                currentItem.IsDisabled != newItem.IsDisabled ||
+                currentItem.Class != newItem.Class ||
+                !HaveSameAttributes(currentItem.AdditionalAttributes, newItem.AdditionalAttributes) ||
+                !HaveSameRenderState(currentItem.NestedMenuItems ?? [], newItem.NestedMenuItems ?? []))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HaveSameAttributes(IReadOnlyDictionary<string, object>? currentAttributes, IReadOnlyDictionary<string, object>? newAttributes)
+    {
+        if (currentAttributes is null || currentAttributes.Count == 0)
+        {
+            return newAttributes is null || newAttributes.Count == 0;
+        }
+
+        if (newAttributes is null || currentAttributes.Count != newAttributes.Count)
+        {
+            return false;
+        }
+
+        foreach (var (name, value) in currentAttributes)
+        {
+            if (!newAttributes.TryGetValue(name, out var newValue) || !Equals(value, newValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void UpdateCallbacks(IReadOnlyList<MenuButtonItem> currentItems, IReadOnlyList<MenuButtonItem> newItems)
+    {
+        for (var i = 0; i < currentItems.Count; i++)
+        {
+            currentItems[i].OnClick = newItems[i].OnClick;
+
+            if (currentItems[i].NestedMenuItems is { } currentNestedItems && newItems[i].NestedMenuItems is { } newNestedItems)
+            {
+                UpdateCallbacks(currentNestedItems, newNestedItems);
+            }
+        }
     }
 
     private void OnMenuRenderComplete()

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -133,84 +133,8 @@ public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
 
     private void RefreshItems()
     {
-        var items = ItemsProvider().ToArray();
-
-        if (HaveSameRenderState(_items, items))
-        {
-            UpdateCallbacks(_items, items);
-        }
-        else
-        {
-            _items = items;
-        }
-
+        _items = ItemsProvider().ToArray();
         _disabled = !_items.Any(i => !i.IsDivider);
-    }
-
-    private static bool HaveSameRenderState(IReadOnlyList<MenuButtonItem> currentItems, IReadOnlyList<MenuButtonItem> newItems)
-    {
-        if (currentItems.Count != newItems.Count)
-        {
-            return false;
-        }
-
-        for (var i = 0; i < currentItems.Count; i++)
-        {
-            var currentItem = currentItems[i];
-            var newItem = newItems[i];
-
-            if (currentItem.IsDivider != newItem.IsDivider ||
-                currentItem.Text != newItem.Text ||
-                currentItem.Tooltip != newItem.Tooltip ||
-                !Equals(currentItem.Icon, newItem.Icon) ||
-                currentItem.Role != newItem.Role ||
-                currentItem.Checked != newItem.Checked ||
-                currentItem.IsDisabled != newItem.IsDisabled ||
-                currentItem.Class != newItem.Class ||
-                !HaveSameAttributes(currentItem.AdditionalAttributes, newItem.AdditionalAttributes) ||
-                !HaveSameRenderState(currentItem.NestedMenuItems ?? [], newItem.NestedMenuItems ?? []))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool HaveSameAttributes(IReadOnlyDictionary<string, object>? currentAttributes, IReadOnlyDictionary<string, object>? newAttributes)
-    {
-        if (currentAttributes is null || currentAttributes.Count == 0)
-        {
-            return newAttributes is null || newAttributes.Count == 0;
-        }
-
-        if (newAttributes is null || currentAttributes.Count != newAttributes.Count)
-        {
-            return false;
-        }
-
-        foreach (var (name, value) in currentAttributes)
-        {
-            if (!newAttributes.TryGetValue(name, out var newValue) || !Equals(value, newValue))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static void UpdateCallbacks(IReadOnlyList<MenuButtonItem> currentItems, IReadOnlyList<MenuButtonItem> newItems)
-    {
-        for (var i = 0; i < currentItems.Count; i++)
-        {
-            currentItems[i].OnClick = newItems[i].OnClick;
-
-            if (currentItems[i].NestedMenuItems is { } currentNestedItems && newItems[i].NestedMenuItems is { } newNestedItems)
-            {
-                UpdateCallbacks(currentNestedItems, newNestedItems);
-            }
-        }
     }
 
     private void OnMenuRenderComplete()

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -5,18 +5,23 @@ using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 using Icons = Microsoft.FluentUI.AspNetCore.Components.Icons;
 
 namespace Aspire.Dashboard.Components;
 
-public partial class AspireMenuButton : FluentComponentBase
+public partial class AspireMenuButton : FluentComponentBase, IAsyncDisposable
 {
     private static readonly Icon s_defaultIcon = new Icons.Regular.Size24.ChevronDown();
 
+    private bool _renderMenu;
+    private bool _menuRenderComplete;
+    private bool _openWhenMenuRenderCompletes;
     private bool _visible;
     private Icon? _icon;
     private MenuButtonItem[] _items = [];
     private bool _disabled;
+    private Func<IList<MenuButtonItem>>? _renderedItemsProvider;
 
     [Parameter]
     public string? Text { get; set; }
@@ -36,8 +41,11 @@ public partial class AspireMenuButton : FluentComponentBase
     [Parameter]
     public string? ButtonClass { get; set; }
 
+    /// <summary>
+    /// Gets or sets the callback that provides menu items when the menu is opened.
+    /// </summary>
     [Parameter]
-    public required IList<MenuButtonItem> Items { get; set; }
+    public required Func<IList<MenuButtonItem>> ItemsProvider { get; set; }
 
     [Parameter]
     public Appearance? ButtonAppearance { get; set; }
@@ -60,29 +68,115 @@ public partial class AspireMenuButton : FluentComponentBase
     [Parameter]
     public bool RestoreFocusOnItemClick { get; set; } = true;
 
+    [Inject]
+    public required IJSRuntime JS { get; init; }
+
     protected override void OnParametersSet()
     {
         _icon = Icon ?? s_defaultIcon;
 
-        if (Items != null && !_items.SequenceEqual(Items))
+        if (!ReferenceEquals(_renderedItemsProvider, ItemsProvider))
         {
-            _items = Items.ToArray();
+            _renderedItemsProvider = ItemsProvider;
+            _disabled = false;
+        }
 
-            // Disabled if there are no actionable items
-            _disabled = !_items.Any(i => !i.IsDivider);
+        if (_visible || _openWhenMenuRenderCompletes)
+        {
+            RefreshItems();
+
+            if (_disabled)
+            {
+                OnMenuOpenChanged(false);
+            }
         }
     }
 
-    private void ToggleMenu()
+    private async Task ToggleMenu()
     {
-        _visible = !_visible;
+        if (_visible)
+        {
+            OnMenuOpenChanged(false);
+            return;
+        }
+
+        if (_renderMenu && !_menuRenderComplete)
+        {
+            _openWhenMenuRenderCompletes = true;
+            return;
+        }
+
+        RefreshItems();
+        _renderMenu = !_disabled;
+
+        if (_renderMenu)
+        {
+            if (!_menuRenderComplete)
+            {
+                // Start observing before rendering FluentMenu so its first aria-expanded write
+                // cannot happen before the initialization wait is registered.
+                await JS.InvokeVoidAsync("prepareForFluentMenuInitialization", MenuButtonId);
+            }
+
+            // Reopen a retained menu immediately, but defer the first open until FluentMenu has
+            // rendered and initialized its JavaScript modules.
+            if (_menuRenderComplete)
+            {
+                _visible = true;
+            }
+            else
+            {
+                _openWhenMenuRenderCompletes = true;
+            }
+        }
+    }
+
+    private void RefreshItems()
+    {
+        _items = ItemsProvider().ToArray();
+        _disabled = !_items.Any(i => !i.IsDivider);
+    }
+
+    private void OnMenuRenderComplete()
+    {
+        _menuRenderComplete = true;
+
+        if (_openWhenMenuRenderCompletes)
+        {
+            OnMenuOpenChanged(true);
+        }
+    }
+
+    private void OnMenuOpenChanged(bool open)
+    {
+        _openWhenMenuRenderCompletes = false;
+        _visible = open;
     }
 
     private void OnKeyDown(KeyboardEventArgs args)
     {
         if (args is not null && args.Key == "Escape")
         {
-            _visible = false;
+            OnMenuOpenChanged(false);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_renderMenu && !_menuRenderComplete)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("cancelFluentMenuInitialization", MenuButtonId);
+            }
+            catch (JSDisconnectedException)
+            {
+                // The browser may already be gone when the component is disposed.
+            }
+            catch (OperationCanceledException)
+            {
+                // The browser may already be gone when the component is disposed.
+            }
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.js
@@ -1,0 +1,58 @@
+const fluentMenuInitializations = new Map();
+
+function completeFluentMenuInitialization(anchorId) {
+    const initialization = fluentMenuInitializations.get(anchorId);
+
+    if (!initialization) {
+        return;
+    }
+
+    if (initialization.timeoutId !== null) {
+        clearTimeout(initialization.timeoutId);
+    }
+    initialization.observer.disconnect();
+    fluentMenuInitializations.delete(anchorId);
+    initialization.resolve();
+}
+
+export function prepareForFluentMenuInitialization(anchorId) {
+    completeFluentMenuInitialization(anchorId);
+
+    const anchor = document.getElementById(anchorId);
+
+    if (!anchor) {
+        return;
+    }
+
+    // Start observing before AspireMenu renders. FluentMenu writes aria-expanded only after its
+    // JavaScript modules are initialized, so its first write is an unambiguous readiness signal.
+    anchor.removeAttribute("aria-expanded");
+    let resolveInitialization;
+    const promise = new Promise(resolve => {
+        resolveInitialization = resolve;
+    });
+    const observer = new MutationObserver(() => completeFluentMenuInitialization(anchorId));
+
+    fluentMenuInitializations.set(anchorId, { promise, observer, resolve: resolveInitialization, timeoutId: null });
+    observer.observe(anchor, { attributes: true, attributeFilter: ["aria-expanded"] });
+}
+
+export function waitForFluentMenuInitialization(anchorId, timeoutMilliseconds) {
+    const initialization = fluentMenuInitializations.get(anchorId);
+
+    if (!initialization) {
+        return Promise.resolve();
+    }
+
+    // FluentMenu normally signals readiness by writing aria-expanded. Bound the wait so a failed
+    // module import or a replaced anchor can't leave the Blazor interop call pending indefinitely.
+    initialization.timeoutId ??= setTimeout(
+        () => completeFluentMenuInitialization(anchorId),
+        timeoutMilliseconds);
+
+    return initialization.promise;
+}
+
+export function cancelFluentMenuInitialization(anchorId) {
+    completeFluentMenuInitialization(anchorId);
+}

--- a/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ClearSignalsButton.razor
@@ -6,7 +6,7 @@
 <AspireMenuButton IconStart="@(new Icons.Regular.Size16.Delete())"
                   Icon="@(new Icons.Regular.Size12.ChevronDown())"
                   IconColor="Color.FillInverse"
-                  Items="@_clearMenuItems"
+                  ItemsProvider="@(() => _clearMenuItems)"
                   ButtonAppearance="Appearance.Neutral"
                   ButtonClass="clear-button"
                   Title="@Loc[nameof(ControlsStrings.ClearSignalsButtonTitle)]" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -36,7 +36,7 @@
     <div class="resource-action-slot">
         <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                           Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
-                          Items="@_menuItems"
+                          ItemsProvider="GetMenuItems"
                           @ref="_menuButton"
                           Title="@ControlLoc[nameof(ControlsStrings.ActionsButtonText)]" />
     </div>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -54,15 +54,23 @@ public partial class ResourceActions : ComponentBase
     public required ViewportInformation ViewportInformation { get; set; }
 
     private readonly List<CommandViewModel> _highlightedCommands = new();
-    private readonly List<MenuButtonItem> _menuItems = new();
 
     protected override void OnParametersSet()
     {
-        _menuItems.Clear();
         _highlightedCommands.Clear();
 
+        // If display is desktop then we display highlighted commands next to the ... button.
+        if (ViewportInformation.IsDesktop)
+        {
+            _highlightedCommands.AddRange(Resource.Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden).Take(MaxHighlightedCount));
+        }
+    }
+
+    private IList<MenuButtonItem> GetMenuItems()
+    {
+        var menuItems = new List<MenuButtonItem>();
         ResourceMenuBuilder.AddMenuItems(
-            _menuItems,
+            menuItems,
             Resource,
             ResourceByName,
             EventCallback.Factory.Create(this, () => OnViewDetails.InvokeAsync(_menuButton?.MenuButtonId)),
@@ -72,10 +80,6 @@ public partial class ResourceActions : ComponentBase
             showConsoleLogsItem: true,
             showUrls: false);
 
-        // If display is desktop then we display highlighted commands next to the ... button.
-        if (ViewportInformation.IsDesktop)
-        {
-            _highlightedCommands.AddRange(Resource.Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden).Take(MaxHighlightedCount));
-        }
+        return menuItems;
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -22,7 +22,7 @@
         <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                           ButtonClass="resource-details-actions"
                           Icon="@(new Icons.Regular.Size20.Options())"
-                          Items="@_resourceActionsMenuItems"
+                          ItemsProvider="@(() => _resourceActionsMenuItems)"
                           Title="@Loc[nameof(Aspire.Dashboard.Resources.Resources.ResourcesChangeViewOptions)]"
                           slot="end" />
     </FluentToolbar>

--- a/src/Aspire.Dashboard/Components/Controls/SpanActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanActions.razor
@@ -2,6 +2,6 @@
 
 <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                   Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
-                  Items="@_menuItems"
+                  ItemsProvider="GetMenuItems"
                   @ref="_menuButton"
                   Title="@ControlsLoc[nameof(Resources.ControlsStrings.ActionsButtonText)]" />

--- a/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
@@ -29,16 +29,15 @@ public partial class SpanActions : ComponentBase
     [Parameter]
     public required SpanWaterfallViewModel SpanViewModel { get; set; }
 
-    private readonly List<MenuButtonItem> _menuItems = new();
-
-    protected override void OnParametersSet()
+    private IList<MenuButtonItem> GetMenuItems()
     {
-        _menuItems.Clear();
-
+        var menuItems = new List<MenuButtonItem>();
         SpanMenuBuilder.AddMenuItems(
-            _menuItems,
+            menuItems,
             SpanViewModel.Span,
             EventCallback.Factory.Create(this, () => OnViewDetails.InvokeAsync(_menuButton?.MenuButtonId)),
             OnLaunchGenAI);
+
+        return menuItems;
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -32,7 +32,7 @@
             <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                               Icon="@(new Icons.Regular.Size20.Options())"
-                              Items="@_spanActionsMenuItems"
+                              ItemsProvider="@(() => _spanActionsMenuItems)"
                               Title="@Loc[nameof(ControlsStrings.ActionsButtonText)]"
                               slot="end" />
         </FluentToolbar>

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor
@@ -2,6 +2,6 @@
 
 <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                   Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
-                  Items="@_menuItems"
+                  ItemsProvider="GetMenuItems"
                   @ref="_menuButton"
                   Title="@ControlsLoc[nameof(Resources.ControlsStrings.ActionsButtonText)]" />

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogActions.razor.cs
@@ -25,15 +25,14 @@ public partial class StructuredLogActions : ComponentBase
     [Parameter]
     public required OtlpLogEntry LogEntry { get; set; }
 
-    private readonly List<MenuButtonItem> _menuItems = new();
-
-    protected override void OnParametersSet()
+    private IList<MenuButtonItem> GetMenuItems()
     {
-        _menuItems.Clear();
-
+        var menuItems = new List<MenuButtonItem>();
         StructuredLogMenuBuilder.AddMenuItems(
-            _menuItems,
+            menuItems,
             LogEntry,
             EventCallback.Factory.Create(this, () => OnViewDetails.InvokeAsync(_menuButton?.MenuButtonId)));
+
+        return menuItems;
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
@@ -22,7 +22,7 @@
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                           Icon="@(new Icons.Regular.Size20.Options())"
-                          Items="@_logActionsMenuItems"
+                          ItemsProvider="@(() => _logActionsMenuItems)"
                           Title="@Loc[nameof(ControlsStrings.ActionsButtonText)]"
                           slot="end" />
     </FluentToolbar>

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor
@@ -2,6 +2,6 @@
 
 <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                   Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
-                  Items="@_menuItems"
+                  ItemsProvider="GetMenuItems"
                   @ref="_menuButton"
                   Title="@ControlsLoc[nameof(Resources.ControlsStrings.ActionsButtonText)]" />

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
@@ -22,12 +22,10 @@ public partial class TraceActions : ComponentBase
     [Parameter]
     public required OtlpTrace Trace { get; set; }
 
-    private readonly List<MenuButtonItem> _menuItems = new();
-
-    protected override void OnParametersSet()
+    private IList<MenuButtonItem> GetMenuItems()
     {
-        _menuItems.Clear();
-
-        TraceMenuBuilder.AddMenuItems(_menuItems, Trace);
+        var menuItems = new List<MenuButtonItem>();
+        TraceMenuBuilder.AddMenuItems(menuItems, Trace);
+        return menuItems;
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -57,7 +57,7 @@
                 {
                     <AspireMenuButton ButtonAppearance="@(ViewportInformation.IsDesktop ? Appearance.Lightweight : Appearance.Neutral)"
                                       Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
-                                      Items="@_resourceMenuItems"
+                                      ItemsProvider="@(() => _resourceMenuItems)"
                                       Title="@ControlsStringsLoc[nameof(ControlsStrings.ResourceActions)]"
                                       Text="@(ViewportInformation.IsDesktop ? null : ControlsStringsLoc[nameof(ControlsStrings.ResourceActions)].Value)"/>
                 }
@@ -87,7 +87,7 @@
                     <AspireMenuButton
                         ButtonAppearance="Appearance.Lightweight"
                         Icon="@(new Icons.Regular.Size20.Options())"
-                        Items="@_logsMenuItems"
+                        ItemsProvider="@(() => _logsMenuItems)"
                         Title="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsSettings)]"
                         slot="end"/>
                 }
@@ -108,7 +108,7 @@
 
                 <AspireMenuButton
                     Icon="@(new Icons.Regular.Size20.Options())"
-                    Items="@_logsMenuItems"
+                    ItemsProvider="@(() => _logsMenuItems)"
                     Text="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsSettings)]"
                     slot="end"/>
             }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -322,7 +322,7 @@
             {
                 <AspireMenuButton ButtonAppearance="Appearance.Stealth"
                                   Icon="@(new Icons.Regular.Size20.Options())"
-                                  Items="@_resourcesMenuItems"
+                                  ItemsProvider="@(() => _resourcesMenuItems)"
                                   RestoreFocusOnItemClick="true"
                                   Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesChangeViewOptions)]"
                                   slot="end" />

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -183,7 +183,7 @@
             {
                 <div slot="end">
                     <FluentCounterBadge HorizontalPosition="70" Count="@(ViewModel.Filters.GetEnabledFilters().Count())" Appearance="Appearance.Accent">
-                        <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                        <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" ItemsProvider="GetFilterMenuItems" />
                     </FluentCounterBadge>
                 </div>
             }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -45,7 +45,7 @@
                     {
                         <div slot="end">
                             <FluentCounterBadge HorizontalPosition="70" Count="@(PageViewModel.Filters.GetEnabledFilters().Count())" Appearance="Appearance.Accent">
-                                <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                                <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" ItemsProvider="GetFilterMenuItems" />
                             </FluentCounterBadge>
                         </div>
                     }
@@ -54,7 +54,7 @@
                     </FluentButton>
                     <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                                       Icon="@(new Icons.Regular.Size20.Options())"
-                                      Items="@_traceActionsMenuItems"
+                                      ItemsProvider="@(() => _traceActionsMenuItems)"
                                       Title="@ControlStringsLoc[nameof(ControlsStrings.ActionsButtonText)]"
                                       Text="@ControlStringsLoc[nameof(ControlsStrings.ActionsButtonText)]"/>
                 }
@@ -378,7 +378,7 @@
                 {
                     <div slot="end">
                         <FluentCounterBadge HorizontalPosition="70" Count="@(PageViewModel.Filters.GetEnabledFilters().Count())" Appearance="Appearance.Accent">
-                            <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                            <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" ItemsProvider="GetFilterMenuItems" />
                         </FluentCounterBadge>
                     </div>
                 }
@@ -391,7 +391,7 @@
 
                 <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                                   Icon="@(new Icons.Regular.Size20.Options())"
-                                  Items="@_traceActionsMenuItems"
+                                  ItemsProvider="@(() => _traceActionsMenuItems)"
                                   Title="@ControlStringsLoc[nameof(ControlsStrings.ActionsButtonText)]" />
             </div>
         </div>;

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -66,7 +66,7 @@
             {
                 <div slot="end">
                     <FluentCounterBadge HorizontalPosition="70" Count="@(TracesViewModel.Filters.GetEnabledFilters().Count())" Appearance="Appearance.Accent">
-                        <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" Items="@GetFilterMenuItems()" />
+                        <AspireMenuButton HideIcon="true" Text="@FilterLoc[nameof(StructuredFiltering.Filters)]" ItemsProvider="GetFilterMenuItems" />
                     </FluentCounterBadge>
                 </div>
             }

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -70,11 +70,7 @@ window.prepareForFluentMenuInitialization = function (anchorId) {
     const promise = new Promise(resolve => {
         resolveInitialization = resolve;
     });
-    const observer = new MutationObserver(() => {
-        if (anchor.hasAttribute("aria-expanded")) {
-            completeFluentMenuInitialization(anchorId);
-        }
-    });
+    const observer = new MutationObserver(() => completeFluentMenuInitialization(anchorId));
 
     fluentMenuInitializations.set(anchorId, { promise, observer, resolve: resolveInitialization, timeoutId: null });
     observer.observe(anchor, { attributes: true, attributeFilter: ["aria-expanded"] });

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -37,65 +37,6 @@ function getFluentMenuItemForTarget(element) {
     return null;
 }
 
-const fluentMenuInitializations = new Map();
-
-function completeFluentMenuInitialization(anchorId) {
-    const initialization = fluentMenuInitializations.get(anchorId);
-
-    if (!initialization) {
-        return;
-    }
-
-    if (initialization.timeoutId !== null) {
-        clearTimeout(initialization.timeoutId);
-    }
-    initialization.observer.disconnect();
-    fluentMenuInitializations.delete(anchorId);
-    initialization.resolve();
-}
-
-window.prepareForFluentMenuInitialization = function (anchorId) {
-    completeFluentMenuInitialization(anchorId);
-
-    const anchor = document.getElementById(anchorId);
-
-    if (!anchor) {
-        return;
-    }
-
-    // Start observing before AspireMenu renders. FluentMenu writes aria-expanded only after its
-    // JavaScript modules are initialized, so its first write is an unambiguous readiness signal.
-    anchor.removeAttribute("aria-expanded");
-    let resolveInitialization;
-    const promise = new Promise(resolve => {
-        resolveInitialization = resolve;
-    });
-    const observer = new MutationObserver(() => completeFluentMenuInitialization(anchorId));
-
-    fluentMenuInitializations.set(anchorId, { promise, observer, resolve: resolveInitialization, timeoutId: null });
-    observer.observe(anchor, { attributes: true, attributeFilter: ["aria-expanded"] });
-};
-
-window.waitForFluentMenuInitialization = function (anchorId, timeoutMilliseconds) {
-    const initialization = fluentMenuInitializations.get(anchorId);
-
-    if (!initialization) {
-        return Promise.resolve();
-    }
-
-    // FluentMenu normally signals readiness by writing aria-expanded. Bound the wait so a failed
-    // module import or a replaced anchor can't leave the Blazor interop call pending indefinitely.
-    initialization.timeoutId ??= setTimeout(
-        () => completeFluentMenuInitialization(anchorId),
-        timeoutMilliseconds);
-
-    return initialization.promise;
-};
-
-window.cancelFluentMenuInitialization = function (anchorId) {
-    completeFluentMenuInitialization(anchorId);
-};
-
 // Register a global click event listener to handle copy/open button clicks.
 // Required because an "onclick" attribute is denied by CSP.
 document.addEventListener("click", function (e) {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -46,6 +46,9 @@ function completeFluentMenuInitialization(anchorId) {
         return;
     }
 
+    if (initialization.timeoutId !== null) {
+        clearTimeout(initialization.timeoutId);
+    }
     initialization.observer.disconnect();
     fluentMenuInitializations.delete(anchorId);
     initialization.resolve();
@@ -73,16 +76,22 @@ window.prepareForFluentMenuInitialization = function (anchorId) {
         }
     });
 
-    fluentMenuInitializations.set(anchorId, { promise, observer, resolve: resolveInitialization });
+    fluentMenuInitializations.set(anchorId, { promise, observer, resolve: resolveInitialization, timeoutId: null });
     observer.observe(anchor, { attributes: true, attributeFilter: ["aria-expanded"] });
 };
 
-window.waitForFluentMenuInitialization = function (anchorId) {
+window.waitForFluentMenuInitialization = function (anchorId, timeoutMilliseconds) {
     const initialization = fluentMenuInitializations.get(anchorId);
 
     if (!initialization) {
         return Promise.resolve();
     }
+
+    // FluentMenu normally signals readiness by writing aria-expanded. Bound the wait so a failed
+    // module import or a replaced anchor can't leave the Blazor interop call pending indefinitely.
+    initialization.timeoutId ??= setTimeout(
+        () => completeFluentMenuInitialization(anchorId),
+        timeoutMilliseconds);
 
     return initialization.promise;
 };
@@ -790,139 +799,6 @@ window.downloadStreamAsFile = async function (fileName, contentStreamReference) 
             }
         }
         return false;
-    }
-
-    if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", start, { once: true });
-    } else {
-        start();
-    }
-})();
-
-// ===== Menu-button ARIA (aria-haspopup + aria-expanded) =====
-// AspireMenuButton renders a <fluent-button> that opens a <fluent-menu>. The ARIA menu-button pattern
-// (https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/) wants aria-haspopup="menu" + aria-expanded on
-// the trigger, but FAST/FluentUI's <fluent-button> host is a role-less custom element whose real control
-// is a native <button part="control"> in its (open) shadow root. Neither attribute may live on the
-// role-less host: aria-expanded there is an axe-core aria-allowed-attr violation, and role="button" on the
-// host would trip nested-interactive against the inner <button>. Both therefore live on the inner control,
-// which has an implicit role=button:
-//  - aria-haspopup is global, so we set it on the inner <button>, where it's valid and FAST leaves it be.
-//  - aria-expanded is what FluentMenu.razor.js stamps onto its anchor (this host) on every open/close, and
-//    FAST reflects the host's aria-expanded onto the inner control. We move that state onto the inner
-//    control and strip the host copy (keeping the host axe-clean), re-pinning the inner control whenever
-//    FAST clears it in response to the host attribute being removed, so the trigger keeps reporting its
-//    expanded/collapsed state to assistive tech.
-// The component just marks each trigger host with data-aspire-menu-trigger; a single document-level
-// observer then covers every menu button, including ones revealed by SPA navigation or opened in dialogs.
-(function initializeMenuButtonAccessibilityFeature() {
-    const TRIGGER_SELECTOR = "fluent-button[data-aspire-menu-trigger]";
-    const registered = new WeakSet();
-
-    function getControl(host) {
-        return host.shadowRoot && host.shadowRoot.querySelector('[part~="control"]');
-    }
-
-    // Reconcile the menu-button ARIA onto the inner native <button>. `expanded` is the state ("true" or
-    // "false") the trigger should report. Returns false until the custom element has upgraded and rendered
-    // its shadow control, so the caller can retry.
-    function applyAria(host, expanded) {
-        const control = getControl(host);
-        if (!control) {
-            return false;
-        }
-        if (control.getAttribute("aria-haspopup") !== "menu") {
-            control.setAttribute("aria-haspopup", "menu");
-        }
-        // Strip the aria-expanded FluentMenu stamps on the role-less host (axe-core aria-allowed-attr) and
-        // pin the desired value onto the inner control instead. The equality guards keep re-pinning (after
-        // FAST clears the inner control) from recursing through the observer indefinitely - setting an
-        // attribute to a new value queues another mutation record, but setting it to its current value is
-        // skipped, so the reconcile settles.
-        if (host.hasAttribute("aria-expanded")) {
-            host.removeAttribute("aria-expanded");
-        }
-        if (control.getAttribute("aria-expanded") !== expanded) {
-            control.setAttribute("aria-expanded", expanded);
-        }
-        return true;
-    }
-
-    function register(host) {
-        if (registered.has(host)) {
-            return;
-        }
-        // The trigger is collapsed until FluentMenu.razor.js reports otherwise via the host's aria-expanded.
-        const state = { expanded: host.getAttribute("aria-expanded") ?? "false" };
-        if (!applyAria(host, state.expanded)) {
-            // The element isn't upgraded yet; retry once its definition is ready (upgrades of already-
-            // parsed elements complete synchronously once the tag is defined).
-            customElements.whenDefined("fluent-button").then(() => register(host));
-            return;
-        }
-        registered.add(host);
-        // A single observer, scoped to aria-expanded on this button, covers both sources of drift so it
-        // stays cheap even on grid pages that render many menu buttons:
-        //  - the host, where FluentMenu.razor.js stamps the authoritative expanded state on open/close, and
-        //  - the inner control, where FAST clears aria-expanded once the host copy is removed.
-        const observer = new MutationObserver(function (mutations) {
-            for (const m of mutations) {
-                // Capture the authoritative state from the host before applyAria strips it below.
-                if (m.target === host && host.hasAttribute("aria-expanded")) {
-                    state.expanded = host.getAttribute("aria-expanded");
-                }
-            }
-            applyAria(host, state.expanded);
-        });
-        observer.observe(host, { attributes: true, attributeFilter: ["aria-expanded"] });
-        const control = getControl(host);
-        if (control) {
-            observer.observe(control, { attributes: true, attributeFilter: ["aria-expanded"] });
-        }
-    }
-
-    function scan() {
-        for (const host of document.querySelectorAll(TRIGGER_SELECTOR)) {
-            register(host);
-        }
-    }
-
-    let scanTimer = null;
-    function scheduleScan() {
-        if (scanTimer !== null) {
-            return;
-        }
-        scanTimer = setTimeout(function () {
-            scanTimer = null;
-            scan();
-        }, 100);
-    }
-
-    function nodeListHasTrigger(nodes) {
-        for (const node of nodes) {
-            if (node.nodeType !== 1) {
-                continue;
-            }
-            if (node.matches?.(TRIGGER_SELECTOR) || node.querySelector?.(TRIGGER_SELECTOR)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    function start() {
-        scan();
-        // Menu buttons are inserted deep in Blazor's render tree (SPA navigation) and inside dialogs
-        // appended at <body>. Only rescan when a batch actually adds a trigger, so streaming-log/grid
-        // churn doesn't cost a document-wide query.
-        new MutationObserver(function (mutations) {
-            for (const m of mutations) {
-                if (nodeListHasTrigger(m.addedNodes)) {
-                    scheduleScan();
-                    return;
-                }
-            }
-        }).observe(document.body, { childList: true, subtree: true });
     }
 
     if (document.readyState === "loading") {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -37,6 +37,60 @@ function getFluentMenuItemForTarget(element) {
     return null;
 }
 
+const fluentMenuInitializations = new Map();
+
+function completeFluentMenuInitialization(anchorId) {
+    const initialization = fluentMenuInitializations.get(anchorId);
+
+    if (!initialization) {
+        return;
+    }
+
+    initialization.observer.disconnect();
+    fluentMenuInitializations.delete(anchorId);
+    initialization.resolve();
+}
+
+window.prepareForFluentMenuInitialization = function (anchorId) {
+    completeFluentMenuInitialization(anchorId);
+
+    const anchor = document.getElementById(anchorId);
+
+    if (!anchor) {
+        return;
+    }
+
+    // Start observing before AspireMenu renders. FluentMenu writes aria-expanded only after its
+    // JavaScript modules are initialized, so its first write is an unambiguous readiness signal.
+    anchor.removeAttribute("aria-expanded");
+    let resolveInitialization;
+    const promise = new Promise(resolve => {
+        resolveInitialization = resolve;
+    });
+    const observer = new MutationObserver(() => {
+        if (anchor.hasAttribute("aria-expanded")) {
+            completeFluentMenuInitialization(anchorId);
+        }
+    });
+
+    fluentMenuInitializations.set(anchorId, { promise, observer, resolve: resolveInitialization });
+    observer.observe(anchor, { attributes: true, attributeFilter: ["aria-expanded"] });
+};
+
+window.waitForFluentMenuInitialization = function (anchorId) {
+    const initialization = fluentMenuInitializations.get(anchorId);
+
+    if (!initialization) {
+        return Promise.resolve();
+    }
+
+    return initialization.promise;
+};
+
+window.cancelFluentMenuInitialization = function (anchorId) {
+    completeFluentMenuInitialization(anchorId);
+};
+
 // Register a global click event listener to handle copy/open button clicks.
 // Required because an "onclick" attribute is denied by CSP.
 document.addEventListener("click", function (e) {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
@@ -134,6 +134,33 @@ public class AspireMenuButtonTests : DashboardTestContext
     }
 
     [Fact]
+    public async Task ItemsProvider_ParameterChangeDuringPendingInitialization_UsesLatestItems()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this, setupAspireMenuButtonModule: false);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        var menuButtonModule = JSInterop.SetupModule("./Components/Controls/AspireMenuButton.razor.js");
+        var preparation = menuButtonModule.SetupVoid("prepareForFluentMenuInitialization", "pending-items-menu-button");
+        menuButtonModule.SetupVoid("waitForFluentMenuInitialization", _ => true).SetVoidResult();
+        var provider = RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<AspireMenuButton>(builder =>
+        {
+            builder.Add(p => p.MenuButtonId, "pending-items-menu-button");
+            builder.Add(p => p.ItemsProvider, () => [new MenuButtonItem { Text = "First item" }]);
+        });
+
+        var clickTask = cut.Find("#pending-items-menu-button").ClickAsync(new());
+        cut.WaitForAssertion(() => Assert.Single(preparation.Invocations));
+
+        cut.SetParametersAndRender(builder => builder.Add(p => p.ItemsProvider, () => [new MenuButtonItem { Text = "Second item" }]));
+        preparation.SetVoidResult();
+        await clickTask;
+
+        provider.WaitForAssertion(() => Assert.Equal("Second item", provider.FindComponent<FluentMenuItem>().Instance.Label));
+    }
+
+    [Fact]
     public async Task DisposeAsync_CancelsPendingMenuInitialization()
     {
         FluentUISetupHelpers.SetupFluentUIComponents(this, setupAspireMenuButtonModule: false);

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
@@ -37,10 +37,14 @@ public class AspireMenuButtonTests : DashboardTestContext
     [Fact]
     public async Task ItemsProvider_AddsMenuWhenButtonIsClicked()
     {
-        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentUIComponents(this, setupAspireMenuButtonModule: false);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
         FluentUISetupHelpers.SetupFluentButton(this);
         FluentUISetupHelpers.SetupFluentMenu(this);
+        var menuButtonModule = JSInterop.SetupModule("./Components/Controls/AspireMenuButton.razor.js");
+        menuButtonModule.SetupVoid("prepareForFluentMenuInitialization", _ => true).SetVoidResult();
+        menuButtonModule.SetupVoid("waitForFluentMenuInitialization", _ => true).SetVoidResult();
+        menuButtonModule.SetupVoid("cancelFluentMenuInitialization", _ => true).SetVoidResult();
 
         var providerInvocationCount = 0;
         var provider = RenderComponent<FluentMenuProvider>();
@@ -57,14 +61,16 @@ public class AspireMenuButtonTests : DashboardTestContext
 
         Assert.Equal(0, providerInvocationCount);
         Assert.Empty(cut.FindComponents<AspireMenu>());
+        Assert.Equal(0, JSInterop.Invocations.Count(invocation => invocation.Identifier == "import" && invocation.Arguments.Contains("./Components/Controls/AspireMenuButton.razor.js")));
 
         cut.Find("#lazy-menu-button").Click();
 
         Assert.Equal(1, providerInvocationCount);
-        var prepareInvocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "prepareForFluentMenuInitialization");
-        var waitInvocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "waitForFluentMenuInitialization");
+        Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "import" && invocation.Arguments.Contains("./Components/Controls/AspireMenuButton.razor.js"));
+        var prepareInvocation = Assert.Single(menuButtonModule.Invocations, invocation => invocation.Identifier == "prepareForFluentMenuInitialization");
+        var waitInvocation = Assert.Single(menuButtonModule.Invocations, invocation => invocation.Identifier == "waitForFluentMenuInitialization");
         Assert.Equal(100, waitInvocation.Arguments[1]);
-        var invocations = JSInterop.Invocations.ToList();
+        var invocations = menuButtonModule.Invocations.ToList();
         Assert.True(invocations.IndexOf(prepareInvocation) < invocations.IndexOf(waitInvocation));
         Assert.Single(cut.FindComponents<AspireMenu>());
         Assert.Single(cut.FindComponents<FluentMenu>());
@@ -130,12 +136,14 @@ public class AspireMenuButtonTests : DashboardTestContext
     [Fact]
     public async Task DisposeAsync_CancelsPendingMenuInitialization()
     {
-        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentUIComponents(this, setupAspireMenuButtonModule: false);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
         FluentUISetupHelpers.SetupFluentButton(this);
         FluentUISetupHelpers.SetupFluentMenu(this);
-        var initialization = JSInterop.SetupVoid("waitForFluentMenuInitialization", "pending-menu-button", 100);
-        JSInterop.SetupVoid("cancelFluentMenuInitialization", "pending-menu-button").SetVoidResult();
+        var menuButtonModule = JSInterop.SetupModule("./Components/Controls/AspireMenuButton.razor.js");
+        menuButtonModule.SetupVoid("prepareForFluentMenuInitialization", "pending-menu-button").SetVoidResult();
+        var initialization = menuButtonModule.SetupVoid("waitForFluentMenuInitialization", "pending-menu-button", 100);
+        menuButtonModule.SetupVoid("cancelFluentMenuInitialization", "pending-menu-button").SetVoidResult();
         var cut = RenderComponent<AspireMenuButton>(builder =>
         {
             builder.Add(p => p.MenuButtonId, "pending-menu-button");
@@ -145,7 +153,7 @@ public class AspireMenuButtonTests : DashboardTestContext
         cut.Find("#pending-menu-button").Click();
         await cut.Instance.DisposeAsync();
 
-        var cancellationInvocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "cancelFluentMenuInitialization");
+        var cancellationInvocation = Assert.Single(menuButtonModule.Invocations, invocation => invocation.Identifier == "cancelFluentMenuInitialization");
         Assert.Equal("pending-menu-button", cancellationInvocation.Arguments[0]);
         initialization.SetVoidResult();
     }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
@@ -128,43 +128,6 @@ public class AspireMenuButtonTests : DashboardTestContext
     }
 
     [Fact]
-    public void ItemsProvider_DoesNotRefreshOpenMenuWhenItemsAreUnchanged()
-    {
-        FluentUISetupHelpers.SetupFluentUIComponents(this);
-        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
-        FluentUISetupHelpers.SetupFluentButton(this);
-        FluentUISetupHelpers.SetupFluentMenu(this);
-
-        var providerInvocationCount = 0;
-        var provider = RenderComponent<FluentMenuProvider>();
-        var cut = RenderComponent<AspireMenuButton>(builder =>
-        {
-            builder.Add(p => p.MenuButtonId, "stable-menu-button");
-            builder.Add(p => p.Text, "View options");
-            builder.Add(p => p.ItemsProvider, () =>
-            {
-                providerInvocationCount++;
-                return [new MenuButtonItem { Text = "Item" }];
-            });
-        });
-
-        cut.Find("#stable-menu-button").Click();
-        provider.WaitForAssertion(() => Assert.Single(provider.FindComponents<FluentMenuItem>()));
-        var initialItemId = provider.FindComponent<FluentMenuItem>().Instance.Id;
-        var menu = cut.FindComponent<AspireMenu>();
-        var initialMenuRenderCount = menu.RenderCount;
-
-        for (var i = 0; i < 5; i++)
-        {
-            cut.SetParametersAndRender(builder => builder.Add(p => p.Text, $"View options {i}"));
-        }
-
-        Assert.Equal(6, providerInvocationCount);
-        Assert.Equal(initialItemId, provider.FindComponent<FluentMenuItem>().Instance.Id);
-        Assert.Equal(initialMenuRenderCount + 5, menu.RenderCount);
-    }
-
-    [Fact]
     public async Task DisposeAsync_CancelsPendingMenuInitialization()
     {
         FluentUISetupHelpers.SetupFluentUIComponents(this);

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.Dashboard.Components.Tests.Controls;
 public class AspireMenuButtonTests : DashboardTestContext
 {
     [Fact]
-    public void Render_OmitsHostAria_AndMarksTriggerForAccessibilityObserver()
+    public void Render_AddsMenuPopupAriaWithoutExpandedState()
     {
         FluentUISetupHelpers.SetupFluentUIComponents(this);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
@@ -30,18 +30,7 @@ public class AspireMenuButtonTests : DashboardTestContext
 
         var button = cut.Find("#view-options-button");
 
-        // Menu-button ARIA is applied by app.js at runtime, not rendered here, so bUnit (which never
-        // executes app.js) asserts the host-element contract the JS observer relies on:
-        //  - The data-* marker is how the single document-level observer in app.js finds every menu
-        //    trigger and then sets aria-haspopup="menu" on the inner shadow-root <button part="control">.
-        Assert.True(button.HasAttribute("data-aspire-menu-trigger"));
-
-        //  - The role-less <fluent-button> host must NOT carry these ARIA attributes: aria-expanded on a
-        //    role-less element is an axe-core aria-allowed-attr violation, and giving the host
-        //    role="button" would trip nested-interactive against its inner <button>. They belong on the
-        //    inner control (verified in a real browser by the Playwright menu-button tests). Asserting
-        //    their absence here guards against regressing back to declarative host ARIA.
-        Assert.False(button.HasAttribute("aria-haspopup"));
+        Assert.Equal("menu", button.GetAttribute("aria-haspopup"));
         Assert.False(button.HasAttribute("aria-expanded"));
     }
 
@@ -74,6 +63,7 @@ public class AspireMenuButtonTests : DashboardTestContext
         Assert.Equal(1, providerInvocationCount);
         var prepareInvocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "prepareForFluentMenuInitialization");
         var waitInvocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "waitForFluentMenuInitialization");
+        Assert.Equal(100, waitInvocation.Arguments[1]);
         var invocations = JSInterop.Invocations.ToList();
         Assert.True(invocations.IndexOf(prepareInvocation) < invocations.IndexOf(waitInvocation));
         Assert.Single(cut.FindComponents<AspireMenu>());
@@ -138,13 +128,50 @@ public class AspireMenuButtonTests : DashboardTestContext
     }
 
     [Fact]
+    public void ItemsProvider_DoesNotRefreshOpenMenuWhenItemsAreUnchanged()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+
+        var providerInvocationCount = 0;
+        var provider = RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<AspireMenuButton>(builder =>
+        {
+            builder.Add(p => p.MenuButtonId, "stable-menu-button");
+            builder.Add(p => p.Text, "View options");
+            builder.Add(p => p.ItemsProvider, () =>
+            {
+                providerInvocationCount++;
+                return [new MenuButtonItem { Text = "Item" }];
+            });
+        });
+
+        cut.Find("#stable-menu-button").Click();
+        provider.WaitForAssertion(() => Assert.Single(provider.FindComponents<FluentMenuItem>()));
+        var initialItemId = provider.FindComponent<FluentMenuItem>().Instance.Id;
+        var menu = cut.FindComponent<AspireMenu>();
+        var initialMenuRenderCount = menu.RenderCount;
+
+        for (var i = 0; i < 5; i++)
+        {
+            cut.SetParametersAndRender(builder => builder.Add(p => p.Text, $"View options {i}"));
+        }
+
+        Assert.Equal(6, providerInvocationCount);
+        Assert.Equal(initialItemId, provider.FindComponent<FluentMenuItem>().Instance.Id);
+        Assert.Equal(initialMenuRenderCount + 5, menu.RenderCount);
+    }
+
+    [Fact]
     public async Task DisposeAsync_CancelsPendingMenuInitialization()
     {
         FluentUISetupHelpers.SetupFluentUIComponents(this);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
         FluentUISetupHelpers.SetupFluentButton(this);
         FluentUISetupHelpers.SetupFluentMenu(this);
-        var initialization = JSInterop.SetupVoid("waitForFluentMenuInitialization", "pending-menu-button");
+        var initialization = JSInterop.SetupVoid("waitForFluentMenuInitialization", "pending-menu-button", 100);
         JSInterop.SetupVoid("cancelFluentMenuInitialization", "pending-menu-button").SetVoidResult();
         var cut = RenderComponent<AspireMenuButton>(builder =>
         {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuButtonTests.cs
@@ -4,6 +4,8 @@
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
 using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 
 namespace Aspire.Dashboard.Components.Tests.Controls;
@@ -18,21 +20,12 @@ public class AspireMenuButtonTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentButton(this);
         FluentUISetupHelpers.SetupFluentMenu(this);
 
-        var cut = Render(builder =>
+        RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<AspireMenuButton>(builder =>
         {
-            builder.OpenComponent<Microsoft.FluentUI.AspNetCore.Components.FluentMenuProvider>(0);
-            builder.CloseComponent();
-            builder.OpenComponent<AspireMenuButton>(1);
-            builder.AddAttribute(2, nameof(AspireMenuButton.MenuButtonId), "view-options-button");
-            builder.AddAttribute(3, nameof(AspireMenuButton.Text), "View options");
-            builder.AddAttribute(4, nameof(AspireMenuButton.Items), new List<MenuButtonItem>
-            {
-                new MenuButtonItem
-                {
-                    Text = "Show hidden resources"
-                }
-            });
-            builder.CloseComponent();
+            builder.Add(p => p.MenuButtonId, "view-options-button");
+            builder.Add(p => p.Text, "View options");
+            builder.Add(p => p.ItemsProvider, () => [new MenuButtonItem { Text = "Show hidden resources" }]);
         });
 
         var button = cut.Find("#view-options-button");
@@ -51,4 +44,120 @@ public class AspireMenuButtonTests : DashboardTestContext
         Assert.False(button.HasAttribute("aria-haspopup"));
         Assert.False(button.HasAttribute("aria-expanded"));
     }
+
+    [Fact]
+    public async Task ItemsProvider_AddsMenuWhenButtonIsClicked()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+
+        var providerInvocationCount = 0;
+        var provider = RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<AspireMenuButton>(builder =>
+        {
+            builder.Add(p => p.MenuButtonId, "lazy-menu-button");
+            builder.Add(p => p.Text, "View options");
+            builder.Add(p => p.ItemsProvider, () =>
+            {
+                providerInvocationCount++;
+                return [new MenuButtonItem { Text = $"Item {providerInvocationCount}" }];
+            });
+        });
+
+        Assert.Equal(0, providerInvocationCount);
+        Assert.Empty(cut.FindComponents<AspireMenu>());
+
+        cut.Find("#lazy-menu-button").Click();
+
+        Assert.Equal(1, providerInvocationCount);
+        var prepareInvocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "prepareForFluentMenuInitialization");
+        var waitInvocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "waitForFluentMenuInitialization");
+        var invocations = JSInterop.Invocations.ToList();
+        Assert.True(invocations.IndexOf(prepareInvocation) < invocations.IndexOf(waitInvocation));
+        Assert.Single(cut.FindComponents<AspireMenu>());
+        Assert.Single(cut.FindComponents<FluentMenu>());
+        cut.WaitForAssertion(() => Assert.True(cut.FindComponent<AspireMenu>().Instance.Open));
+        var menuService = Services.GetRequiredService<IMenuService>();
+        var registeredMenu = menuService.Menus.Single();
+        Assert.True(registeredMenu.OpenChanged.HasDelegate);
+        provider.WaitForAssertion(() =>
+        {
+            Assert.True(registeredMenu.Open);
+            Assert.Single(provider.FindComponents<FluentMenu>());
+        });
+        Assert.True(provider.FindComponent<FluentMenu>().Instance.Open);
+        Assert.Equal("Item 1", provider.FindComponent<FluentMenuItem>().Instance.Label);
+
+        var menu = cut.FindComponent<AspireMenu>().Instance;
+        cut.Find("#lazy-menu-button").Click();
+
+        Assert.Equal(1, providerInvocationCount);
+        Assert.Same(menu, cut.FindComponent<AspireMenu>().Instance);
+        Assert.False(Services.GetRequiredService<IMenuService>().Menus.Single().Open);
+
+        cut.Find("#lazy-menu-button").Click();
+
+        Assert.Equal(2, providerInvocationCount);
+        Assert.Same(menu, cut.FindComponent<AspireMenu>().Instance);
+        Assert.True(registeredMenu.Open);
+        provider.WaitForAssertion(() => Assert.Equal("Item 2", provider.FindComponent<FluentMenuItem>().Instance.Label));
+
+        await cut.InvokeAsync(provider.FindComponent<FluentMenu>().Instance.CloseAsync);
+
+        Assert.False(cut.FindComponent<AspireMenu>().Instance.Open);
+        Assert.False(registeredMenu.Open);
+    }
+
+    [Fact]
+    public void ItemsProvider_RefreshesOpenMenuWhenParametersChange()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+
+        var itemText = "First item";
+        Func<IList<MenuButtonItem>> itemsProvider = () => [new MenuButtonItem { Text = itemText }];
+        var provider = RenderComponent<FluentMenuProvider>();
+        var cut = RenderComponent<AspireMenuButton>(builder =>
+        {
+            builder.Add(p => p.MenuButtonId, "refresh-menu-button");
+            builder.Add(p => p.Text, "View options");
+            builder.Add(p => p.ItemsProvider, itemsProvider);
+        });
+
+        cut.Find("#refresh-menu-button").Click();
+        provider.WaitForAssertion(() => Assert.Equal("First item", provider.FindComponent<FluentMenuItem>().Instance.Label));
+
+        itemText = "Second item";
+        cut.SetParametersAndRender(builder => builder.Add(p => p.Text, "Updated view options"));
+
+        provider.WaitForAssertion(() => Assert.Equal("Second item", provider.FindComponent<FluentMenuItem>().Instance.Label));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CancelsPendingMenuInitialization()
+    {
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+        FluentUISetupHelpers.SetupFluentButton(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        var initialization = JSInterop.SetupVoid("waitForFluentMenuInitialization", "pending-menu-button");
+        JSInterop.SetupVoid("cancelFluentMenuInitialization", "pending-menu-button").SetVoidResult();
+        var cut = RenderComponent<AspireMenuButton>(builder =>
+        {
+            builder.Add(p => p.MenuButtonId, "pending-menu-button");
+            builder.Add(p => p.ItemsProvider, () => [new MenuButtonItem { Text = "Item" }]);
+        });
+
+        cut.Find("#pending-menu-button").Click();
+        await cut.Instance.DisposeAsync();
+
+        var cancellationInvocation = Assert.Single(JSInterop.Invocations, invocation => invocation.Identifier == "cancelFluentMenuInitialization");
+        Assert.Equal("pending-menu-button", cancellationInvocation.Arguments[0]);
+        initialization.SetVoidResult();
+    }
+
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireMenuTests.cs
@@ -5,7 +5,6 @@ using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
 using Bunit;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Xunit;
 
@@ -14,6 +13,27 @@ namespace Aspire.Dashboard.Components.Tests.Controls;
 public class AspireMenuTests : DashboardTestContext
 {
     [Fact]
+    public void UnanchoredAspireMenu_RendersFluentMenu()
+    {
+        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        FluentUISetupHelpers.SetupFluentMenu(this);
+        FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
+
+        var provider = RenderComponent<FluentMenuProvider>();
+        var menuHost = RenderComponent<AspireMenu>(builder =>
+        {
+            builder.Add(p => p.Anchor, "menu-anchor");
+            builder.Add(p => p.Anchored, false);
+            builder.Add(p => p.Items, new[] { new MenuButtonItem { Text = "Item" } });
+        });
+
+        var menu = Assert.Single(menuHost.FindComponents<FluentMenu>()).Instance;
+        Assert.False(menu.Anchored);
+        Assert.Empty(provider.FindComponents<FluentMenu>());
+    }
+
+    [Fact]
     public async Task RemoveAspireMenu_UnregistersFluentMenuFromMenuProvider()
     {
         FluentUISetupHelpers.AddCommonDashboardServices(this);
@@ -21,7 +41,6 @@ public class AspireMenuTests : DashboardTestContext
         FluentUISetupHelpers.SetupFluentMenu(this);
         FluentUISetupHelpers.SetupFluentAnchoredRegion(this);
 
-        var menuService = Services.GetRequiredService<IMenuService>();
         var provider = RenderComponent<FluentMenuProvider>();
         var menuHost = RenderComponent<CascadingValue<bool>>(builder =>
         {
@@ -32,10 +51,9 @@ public class AspireMenuTests : DashboardTestContext
                 menuBuilder.Add(p => p.Items, new[] { new MenuButtonItem { Text = "Item" } });
             });
         });
-        var menu = menuHost.FindComponent<FluentMenu>().Instance;
-        Assert.Contains(menu, menuService.Menus);
+        Assert.Single(menuHost.FindComponents<FluentMenu>());
 
-        await menuHost.InvokeAsync(() => menuService.RefreshMenuAsync(menu.Id!, isOpen: true));
+        await menuHost.InvokeAsync(() => menuHost.FindComponent<AspireMenu>().Instance.OpenAsync(1920, 1080, 10, 10));
 
         provider.WaitForAssertion(() => Assert.Single(provider.FindComponents<FluentMenu>()));
 
@@ -45,7 +63,6 @@ public class AspireMenuTests : DashboardTestContext
             builder.Add(p => p.ChildContent, (RenderFragment)(_ => { }));
         });
 
-        Assert.Empty(menuService.Menus);
         provider.WaitForAssertion(() => Assert.Empty(provider.FindComponents<FluentMenu>()));
     }
 
@@ -77,19 +94,16 @@ public class AspireMenuTests : DashboardTestContext
             }
         };
 
-        var cut = Render(builder =>
+        var provider = RenderComponent<FluentMenuProvider>();
+        var menuButton = RenderComponent<AspireMenuButton>(builder =>
         {
-            builder.OpenComponent<FluentMenuProvider>(0);
-            builder.CloseComponent();
-            builder.OpenComponent<AspireMenuButton>(1);
-            builder.AddAttribute(2, nameof(AspireMenuButton.MenuButtonId), anchor);
-            builder.AddAttribute(3, nameof(AspireMenuButton.Title), "View options");
-            builder.AddAttribute(4, nameof(AspireMenuButton.Items), items);
-            builder.CloseComponent();
+            builder.Add(p => p.MenuButtonId, anchor);
+            builder.Add(p => p.Title, "View options");
+            builder.Add(p => p.ItemsProvider, () => items);
         });
 
-        cut.Find($"#{anchor}").Click();
-        cut.WaitForElement("fluent-menu-item").Click();
+        menuButton.Find($"#{anchor}").Click();
+        provider.WaitForElement("fluent-menu-item").Click();
 
         Assert.True(itemClicked);
         var invocation = Assert.Single(focusElementInvocationHandler.Invocations);
@@ -121,20 +135,17 @@ public class AspireMenuTests : DashboardTestContext
             }
         };
 
-        var cut = Render(builder =>
+        var provider = RenderComponent<FluentMenuProvider>();
+        var menuButton = RenderComponent<AspireMenuButton>(builder =>
         {
-            builder.OpenComponent<FluentMenuProvider>(0);
-            builder.CloseComponent();
-            builder.OpenComponent<AspireMenuButton>(1);
-            builder.AddAttribute(2, nameof(AspireMenuButton.MenuButtonId), anchor);
-            builder.AddAttribute(3, nameof(AspireMenuButton.Title), "View options");
-            builder.AddAttribute(4, nameof(AspireMenuButton.Items), items);
-            builder.AddAttribute(5, nameof(AspireMenuButton.RestoreFocusOnItemClick), false);
-            builder.CloseComponent();
+            builder.Add(p => p.MenuButtonId, anchor);
+            builder.Add(p => p.Title, "View options");
+            builder.Add(p => p.ItemsProvider, () => items);
+            builder.Add(p => p.RestoreFocusOnItemClick, false);
         });
 
-        cut.Find($"#{anchor}").Click();
-        cut.WaitForElement("fluent-menu-item").Click();
+        menuButton.Find($"#{anchor}").Click();
+        provider.WaitForElement("fluent-menu-item").Click();
 
         Assert.True(itemClicked);
         var focusElementInvocations = JSInterop.Invocations
@@ -159,21 +170,18 @@ public class AspireMenuTests : DashboardTestContext
             new() { Text = "Terminal", Role = MenuItemRole.MenuItemCheckbox, Checked = true },
         };
 
-        var cut = Render(builder =>
+        var provider = RenderComponent<FluentMenuProvider>();
+        var menuButton = RenderComponent<AspireMenuButton>(builder =>
         {
-            builder.OpenComponent<FluentMenuProvider>(0);
-            builder.CloseComponent();
-            builder.OpenComponent<AspireMenuButton>(1);
-            builder.AddAttribute(2, nameof(AspireMenuButton.MenuButtonId), anchor);
-            builder.AddAttribute(3, nameof(AspireMenuButton.Title), "View options");
-            builder.AddAttribute(4, nameof(AspireMenuButton.Items), items);
-            builder.CloseComponent();
+            builder.Add(p => p.MenuButtonId, anchor);
+            builder.Add(p => p.Title, "View options");
+            builder.Add(p => p.ItemsProvider, () => items);
         });
 
-        cut.Find($"#{anchor}").Click();
-        cut.WaitForElement("fluent-menu-item");
+        menuButton.Find($"#{anchor}").Click();
+        provider.WaitForElement("fluent-menu-item");
 
-        var menuItems = cut.FindAll("fluent-menu-item");
+        var menuItems = provider.FindAll("fluent-menu-item");
         Assert.Equal(2, menuItems.Count);
 
         // Both options must carry the checkable role so assistive technology announces

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ResourceDetailsTests.cs
@@ -29,6 +29,7 @@ public class ResourceDetailsTests : DashboardTestContext
     {
         // Arrange
         ResourceSetupHelpers.SetupResourceDetails(this);
+        var menuProvider = RenderComponent<FluentMenuProvider>();
 
         var resource1 = ModelTestHelpers.CreateResource(
             "app1",
@@ -64,7 +65,7 @@ public class ResourceDetailsTests : DashboardTestContext
         var actionsButton = cut.Find(".resource-details-actions");
         await actionsButton.ClickAsync(new MouseEventArgs());
 
-        var maskAllSwitch = cut.Find(".mask-all-switch");
+        var maskAllSwitch = menuProvider.WaitForElement(".mask-all-switch");
 
         // HACK. Calling OnClick on the element isn't triggering the event correctly. Instead, call OnClick on the menu item model.
         var item = cut.FindComponents<AspireMenu>().SelectMany(m => m.Instance.Items).Single(s => s.Class == maskAllSwitch.Attributes["class"]!.Value);
@@ -121,6 +122,7 @@ public class ResourceDetailsTests : DashboardTestContext
     {
         // Arrange
         ResourceSetupHelpers.SetupResourceDetails(this);
+        var menuProvider = RenderComponent<FluentMenuProvider>();
 
         var resource1 = ModelTestHelpers.CreateResource(
             "app1",
@@ -156,7 +158,7 @@ public class ResourceDetailsTests : DashboardTestContext
         var actionsButton = cut.Find(".resource-details-actions");
         await actionsButton.ClickAsync(new MouseEventArgs());
 
-        var maskAllSwitch = cut.Find(".mask-all-switch");
+        var maskAllSwitch = menuProvider.WaitForElement(".mask-all-switch");
 
         // HACK. Calling OnClick on the element isn't triggering the event correctly. Instead, call OnClick on the menu item model.
         var item = cut.FindComponents<AspireMenu>().SelectMany(m => m.Instance.Items).Single(s => s.Class == maskAllSwitch.Attributes["class"]!.Value);
@@ -459,8 +461,8 @@ public class ResourceDetailsTests : DashboardTestContext
     [Fact]
     public void Render_NullState_ShowsUnknownStateInResourceDetails()
     {
-        ResourceSetupHelpers.SetupResourceDetails(this);
         Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isEnabled: true));
+        ResourceSetupHelpers.SetupResourceDetails(this);
 
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -25,6 +25,7 @@ namespace Aspire.Dashboard.Components.Tests.Pages;
 public partial class ConsoleLogsTests : DashboardTestContext
 {
     private readonly ITestOutputHelper _testOutputHelper;
+    private IRenderedComponent<FluentMenuProvider>? _menuProvider;
 
     public ConsoleLogsTests(ITestOutputHelper testOutputHelper)
     {
@@ -229,6 +230,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         var settingsMenu = cut.FindComponents<AspireMenu>().Single(m => m.Instance.Items.Any(i => i.Text == Resources.ControlsStrings.ShowHiddenResources));
         var showHiddenMenuItem = settingsMenu.Instance.Items.Single(i => i.Text == Resources.ControlsStrings.ShowHiddenResources);
         Assert.NotNull(showHiddenMenuItem.OnClick);
+        await cut.InvokeAsync(() => settingsMenu.Instance.OpenChanged.InvokeAsync(false));
         await cut.InvokeAsync(showHiddenMenuItem.OnClick);
         cut.Render();
 
@@ -247,9 +249,12 @@ public partial class ConsoleLogsTests : DashboardTestContext
 
         // Act & Assert 3: Click "Hide hidden resources" to hide them again
         // Note: We stay on "All" view to test the hide functionality
+        cut.WaitForAssertion(() => Assert.False(settingsMenu.Instance.Open));
+        settingsMenuButton.Click();
         settingsMenu = cut.FindComponents<AspireMenu>().Single(m => m.Instance.Items.Any(i => i.Text == Resources.ControlsStrings.HideHiddenResources));
         var hideHiddenMenuItem = settingsMenu.Instance.Items.Single(i => i.Text == Resources.ControlsStrings.HideHiddenResources);
         Assert.NotNull(hideHiddenMenuItem.OnClick);
+        await cut.InvokeAsync(() => settingsMenu.Instance.OpenChanged.InvokeAsync(false));
         await cut.InvokeAsync(hideHiddenMenuItem.OnClick);
         cut.Render();
 
@@ -308,7 +313,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         // Assert: The "Show hidden resources" / "Hide hidden resources" menu item should NOT be present
         cut.WaitForAssertion(() =>
         {
-            var menuItems = cut.FindAll("fluent-menu-item");
+            var menuItems = _menuProvider!.FindAll("fluent-menu-item");
             var hiddenResourcesMenuItems = menuItems.Where(item =>
             {
                 var text = item.TextContent;
@@ -582,7 +587,7 @@ public partial class ConsoleLogsTests : DashboardTestContext
         logger.LogInformation("Clear current entries.");
         cut.Find(".clear-button").Click();
 
-        cut.WaitForElement("#clear-menu-all");
+        _menuProvider!.WaitForElement("#clear-menu-all");
         var clearMenu = cut.FindComponents<AspireMenu>().Single(m => m.Instance.Items.Any(i => i.Id == "clear-menu-all"));
         var clearAllMenuItem = clearMenu.Instance.Items.Single(i => i.Id == "clear-menu-all");
         Assert.NotNull(clearAllMenuItem.OnClick);
@@ -926,6 +931,9 @@ public partial class ConsoleLogsTests : DashboardTestContext
         Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient());
         Services.AddScoped<DashboardCommandExecutor>();
         Services.AddSingleton<ConsoleLogsManager>();
+
+        FluentUISetupHelpers.SetupFluentUIComponents(this);
+        _menuProvider = RenderComponent<FluentMenuProvider>();
     }
 
     private IRenderedComponent<Components.Pages.ConsoleLogs> RenderConsoleLogsPage(ViewportInformation viewport, string resourceName)

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -788,7 +788,7 @@ public partial class TraceDetailsTests : DashboardTestContext
 
         // Act - Find the dropdown menu and click Collapse All
         var menuButton = cut.FindComponent<AspireMenuButton>();
-        var collapseAllMenuItem = menuButton.Instance.Items.FirstOrDefault(item => item.Text == "Collapse all"); // Locate by text since ID was removed
+        var collapseAllMenuItem = menuButton.Instance.ItemsProvider().FirstOrDefault(item => item.Text == "Collapse all"); // Locate by text since ID was removed
         Assert.NotNull(collapseAllMenuItem);
         cut.InvokeAsync(() => collapseAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
 
@@ -863,7 +863,7 @@ public partial class TraceDetailsTests : DashboardTestContext
 
         // First click "Collapse All" to collapse everything
         var menuButton = cut.FindComponent<AspireMenuButton>();
-        var collapseAllMenuItem = menuButton.Instance.Items.FirstOrDefault(item => item.Text == "Collapse all"); // Locate by text since ID was removed
+        var collapseAllMenuItem = menuButton.Instance.ItemsProvider().FirstOrDefault(item => item.Text == "Collapse all"); // Locate by text since ID was removed
         Assert.NotNull(collapseAllMenuItem);
         cut.InvokeAsync(() => collapseAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
 
@@ -876,7 +876,7 @@ public partial class TraceDetailsTests : DashboardTestContext
         });
 
         // Act - Click "Expand All"
-        var expandAllMenuItem = menuButton.Instance.Items.FirstOrDefault(item => item.Text == "Expand all"); // Locate by text since ID was removed
+        var expandAllMenuItem = menuButton.Instance.ItemsProvider().FirstOrDefault(item => item.Text == "Expand all"); // Locate by text since ID was removed
         Assert.NotNull(expandAllMenuItem);
         cut.InvokeAsync(() => expandAllMenuItem!.OnClick?.Invoke() ?? Task.CompletedTask);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
@@ -180,11 +180,17 @@ internal static class FluentUISetupHelpers
         context.Services.AddSingleton<IOptions<DashboardOptions>>(Options.Create(new DashboardOptions()));
     }
 
-    public static void SetupFluentUIComponents(TestContext context)
+    public static void SetupFluentUIComponents(TestContext context, bool setupAspireMenuButtonModule = true)
     {
         context.Services.AddFluentUIComponents();
-        context.JSInterop.SetupVoid("prepareForFluentMenuInitialization", _ => true).SetVoidResult();
-        context.JSInterop.SetupVoid("waitForFluentMenuInitialization", _ => true).SetVoidResult();
+
+        if (setupAspireMenuButtonModule)
+        {
+            var menuButtonModule = context.JSInterop.SetupModule("./Components/Controls/AspireMenuButton.razor.js");
+            menuButtonModule.SetupVoid("prepareForFluentMenuInitialization", _ => true).SetVoidResult();
+            menuButtonModule.SetupVoid("waitForFluentMenuInitialization", _ => true).SetVoidResult();
+            menuButtonModule.SetupVoid("cancelFluentMenuInitialization", _ => true).SetVoidResult();
+        }
 
         // Setting a provider ID on menu service is required to simulate <FluentMenuProvider> on the page.
         // This makes FluentMenu render without error.

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/FluentUISetupHelpers.cs
@@ -183,6 +183,8 @@ internal static class FluentUISetupHelpers
     public static void SetupFluentUIComponents(TestContext context)
     {
         context.Services.AddFluentUIComponents();
+        context.JSInterop.SetupVoid("prepareForFluentMenuInitialization", _ => true).SetVoidResult();
+        context.JSInterop.SetupVoid("waitForFluentMenuInitialization", _ => true).SetVoidResult();
 
         // Setting a provider ID on menu service is required to simulate <FluentMenuProvider> on the page.
         // This makes FluentMenu render without error.

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -39,6 +39,8 @@ internal static class ResourceSetupHelpers
 
         context.JSInterop.SetupVoid("scrollToTop", _ => true);
         context.JSInterop.SetupVoid("focusElement", _ => true);
+
+        FluentUISetupHelpers.SetupFluentUIComponents(context);
     }
 
     public static void SetupResourcesPage(TestContext context, ViewportInformation viewport, IDashboardClient? dashboardClient = null, ILocalStorage? localStorage = null)

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AspireMenuButtonFocusTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AspireMenuButtonFocusTests.cs
@@ -32,20 +32,19 @@ public class AspireMenuButtonFocusTests : PlaywrightTestsBase<DashboardServerFix
             // repository, so nothing else legitimately claims focus and the assertion stays meaningful.
             // Focus after a menu closes is a browser-only behavior that bUnit can't observe.
             //
-            // Keep the host for focus restoration, but inspect the native shadow button for ARIA state.
-            var clearButton = page.Locator($"fluent-button[title='{ControlsStrings.ClearSignalsButtonTitle}']").First;
-            var clearButtonControl = clearButton.Locator("button[part~='control']");
-            await Assertions.Expect(clearButtonControl).ToHaveAttributeAsync("aria-haspopup", "menu");
-            await Assertions.Expect(clearButtonControl).ToHaveAttributeAsync("aria-expanded", "false");
+            // Keep the host for focus restoration and inspect the state FluentMenu writes to its anchor.
+            var clearButton = page.Locator($"fluent-button[title='{ControlsStrings.ClearSignalsButtonTitle}'][aria-haspopup='menu']").First;
+            var initialExpandedState = await clearButton.GetAttributeAsync("aria-expanded");
+            Assert.Null(initialExpandedState);
 
             var clearButtonId = await clearButton.GetAttributeAsync("id");
             Assert.False(string.IsNullOrEmpty(clearButtonId));
 
             await clearButton.ClickAsync();
-            await Assertions.Expect(clearButtonControl).ToHaveAttributeAsync("aria-expanded", "true");
+            await Assertions.Expect(clearButton).ToHaveAttributeAsync("aria-expanded", "true");
 
             await page.Locator("fluent-menu-item#clear-menu-all").ClickAsync();
-            await Assertions.Expect(clearButtonControl).ToHaveAttributeAsync("aria-expanded", "false");
+            await Assertions.Expect(clearButton).ToHaveAttributeAsync("aria-expanded", "false");
 
             await AsyncTestHelpers.AssertIsTrueRetryAsync(
                 async () => string.Equals(await page.EvaluateAsync<string?>("() => document.activeElement?.id"), clearButtonId, StringComparison.Ordinal),

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/ResourcesTests.cs
@@ -29,7 +29,8 @@ public class ResourcesTests : PlaywrightTestsBase<ResourcesTests.ResourcesDashbo
             await PlaywrightFixture.GoToHomeAndWaitForDataGridLoad(page).DefaultTimeout();
 
             var viewOptionsButton = page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { Name = Dashboard.Resources.Resources.ResourcesChangeViewOptions, Exact = true });
-            await Assertions.Expect(viewOptionsButton).ToHaveAttributeAsync("aria-expanded", "false");
+            var initialExpandedState = await viewOptionsButton.GetAttributeAsync("aria-expanded");
+            Assert.Null(initialExpandedState);
 
             await viewOptionsButton.ClickAsync();
             await Assertions.Expect(viewOptionsButton).ToHaveAttributeAsync("aria-expanded", "true");


### PR DESCRIPTION
## Description

Pages with resource, log, trace, and span action grids currently render every Fluent menu up front, even when most menus are never opened. This adds avoidable component construction and JavaScript initialization overhead when many menu buttons are displayed.

This change creates menu items through an `ItemsProvider` only when a menu is opened and lazily renders `AspireMenu` on the first click. The initialized menu is retained for subsequent opens. A pre-render JavaScript observer waits for FluentMenu's first `aria-expanded` write before opening, preventing overlapping renders while FluentMenu is still loading its AnchoredRegion module. Open retained menus also refresh their items when virtualized rows receive new data.

Validation:

- Dashboard build succeeded.
- Dashboard tests: 1,513 passed.
- Dashboard component tests: 192 passed.
- `node --check src/Aspire.Dashboard/wwwroot/js/app.js` succeeded.

### User-facing usage

Dashboard action menus continue to open and close normally. On pages with many menu buttons, each menu and its items are initialized only when that button is first used.

### Screenshots / Recordings

TODO: Record opening, closing, and reopening action menus on the Resources and Traces pages with many rows.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
