### PR TITLE
Remove misleading TerminalOptions.Shell no-op

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
@@ -107,15 +107,6 @@ public sealed class TerminalOptions
     public int Rows { get; set; } = 30;
 
     /// <summary>
-    /// Gets or sets the shell to use for the terminal session.
-    /// </summary>
-    /// <remarks>
-    /// When <c>null</c>, the default shell for the resource is used.
-    /// For containers, this is typically <c>/bin/sh</c>. For executables, the process itself serves as the terminal program.
-    /// </remarks>
-    public string? Shell { get; set; }
-
-    /// <summary>
     /// Gets or sets a value indicating whether the per-replica terminal host resources
     /// (named <c>{parent}-terminalhost-{index}</c>) should appear in the resource list.
     /// </summary>

--- a/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
@@ -114,9 +114,8 @@ public static class TerminalResourceBuilderExtensions
     /// Polyglot dispatcher for <see cref="WithTerminal{T}(IResourceBuilder{T}, Action{TerminalOptions}?)"/>.
     /// Exposed to non-C# AppHosts via ATS as <c>withTerminal</c> — they cannot pass a
     /// C# <see cref="Action{T}"/>, so this overload simply applies the defaults from
-    /// <see cref="TerminalOptions"/> (120×30, default shell). Polyglot AppHosts that need
-    /// to customise columns/rows/shell can fall back to per-resource environment variables
-    /// or wait for a future overload that accepts a DTO.
+    /// <see cref="TerminalOptions"/> (120×30). Polyglot AppHosts that need to customise
+    /// the terminal dimensions can wait for a future overload that accepts a DTO.
     /// </summary>
     /// <ats-summary>Adds an interactive terminal session to a resource using the default terminal options.</ats-summary>
     [AspireExport("withTerminal")]

--- a/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/TerminalResourceBuilderExtensions.cs
@@ -427,12 +427,6 @@ public static class TerminalResourceBuilderExtensions
             context.Args.Add("--rows");
             context.Args.Add(options.Rows.ToString(CultureInfo.InvariantCulture));
 
-            if (!string.IsNullOrEmpty(options.Shell))
-            {
-                context.Args.Add("--shell");
-                context.Args.Add(options.Shell);
-            }
-
             return Task.CompletedTask;
         }));
     }

--- a/src/Aspire.TerminalHost/TerminalHostApp.cs
+++ b/src/Aspire.TerminalHost/TerminalHostApp.cs
@@ -99,18 +99,9 @@ public sealed class TerminalHostApp : IAsyncDisposable
     /// </summary>
     public async Task<int> RunAsync(CancellationToken cancellationToken)
     {
-        if (_args.Shell is { } shell)
-        {
-            _logger.LogInformation(
-                "Aspire terminal host starting: shell hint='{Shell}', size={Cols}x{Rows}, producer='{Producer}', consumer='{Consumer}'.",
-                shell, _args.Columns, _args.Rows, _args.ProducerUdsPath, _args.ConsumerUdsPath);
-        }
-        else
-        {
-            _logger.LogInformation(
-                "Aspire terminal host starting: size={Cols}x{Rows}, producer='{Producer}', consumer='{Consumer}'.",
-                _args.Columns, _args.Rows, _args.ProducerUdsPath, _args.ConsumerUdsPath);
-        }
+        _logger.LogInformation(
+            "Aspire terminal host starting: size={Cols}x{Rows}, producer='{Producer}', consumer='{Consumer}'.",
+            _args.Columns, _args.Rows, _args.ProducerUdsPath, _args.ConsumerUdsPath);
 
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken, _shutdownCts.Token);

--- a/src/Aspire.TerminalHost/TerminalHostArgs.cs
+++ b/src/Aspire.TerminalHost/TerminalHostArgs.cs
@@ -41,6 +41,7 @@ internal sealed class TerminalHostArgs
     ///   <item><c>--control-uds PATH</c> (required) — path the host LISTENS on; AppHost dials for status/shutdown RPC.</item>
     ///   <item><c>--columns N</c> (optional, default 120)</item>
     ///   <item><c>--rows N</c> (optional, default 30)</item>
+    ///   <item><c>--shell NAME</c> (optional, accepted for compatibility and ignored)</item>
     /// </list>
     /// Every option is single-valued and may only be specified once; duplicates throw
     /// <see cref="TerminalHostArgsException"/>. We use <c>System.CommandLine</c> so the
@@ -62,6 +63,11 @@ internal sealed class TerminalHostArgs
             "Initial PTY width in columns (default 120).", defaultValue: 120);
         var rowsOption = SingleValueOption<int>("--rows", required: false,
             "Initial PTY height in rows (default 30).", defaultValue: 30);
+        // Older Aspire.Hosting packages can run with a newer CLI-provided terminal host
+        // and still emit --shell. Accept the argument so that mixed-version AppHosts start,
+        // but ignore it because DCP launches the resource process that owns the PTY.
+        var shellOption = SingleValueOption<string?>("--shell", required: false,
+            "Legacy shell hint accepted for compatibility and ignored.");
 
         // Cols / rows must be positive. System.CommandLine has no built-in range validator
         // for ints, so attach one explicitly. Skip when the value couldn't be converted at
@@ -98,6 +104,7 @@ internal sealed class TerminalHostArgs
             controlOption,
             columnsOption,
             rowsOption,
+            shellOption,
         };
         // The terminal host argv comes from DCP only; treat unknown flags as a hard error
         // so we don't silently accept garbage and start with the wrong configuration.
@@ -167,4 +174,3 @@ internal sealed class TerminalHostArgs
 /// Thrown when the terminal host receives malformed command-line arguments.
 /// </summary>
 internal sealed class TerminalHostArgsException(string message) : Exception(message);
-

--- a/src/Aspire.TerminalHost/TerminalHostArgs.cs
+++ b/src/Aspire.TerminalHost/TerminalHostArgs.cs
@@ -34,12 +34,6 @@ internal sealed class TerminalHostArgs
     public int Rows { get; init; } = 30;
 
     /// <summary>
-    /// Optional shell name. Informational only (the host does not spawn a PTY itself —
-    /// that is DCP's responsibility); included so the host can log it on startup.
-    /// </summary>
-    public string? Shell { get; init; }
-
-    /// <summary>
     /// Parses command-line arguments. The argument shape is:
     /// <list type="bullet">
     ///   <item><c>--producer-uds PATH</c> (required) — path the host LISTENS on; DCP dials.</item>
@@ -47,7 +41,6 @@ internal sealed class TerminalHostArgs
     ///   <item><c>--control-uds PATH</c> (required) — path the host LISTENS on; AppHost dials for status/shutdown RPC.</item>
     ///   <item><c>--columns N</c> (optional, default 120)</item>
     ///   <item><c>--rows N</c> (optional, default 30)</item>
-    ///   <item><c>--shell NAME</c> (optional, informational)</item>
     /// </list>
     /// Every option is single-valued and may only be specified once; duplicates throw
     /// <see cref="TerminalHostArgsException"/>. We use <c>System.CommandLine</c> so the
@@ -69,8 +62,6 @@ internal sealed class TerminalHostArgs
             "Initial PTY width in columns (default 120).", defaultValue: 120);
         var rowsOption = SingleValueOption<int>("--rows", required: false,
             "Initial PTY height in rows (default 30).", defaultValue: 30);
-        var shellOption = SingleValueOption<string?>("--shell", required: false,
-            "Informational shell name, logged on startup.");
 
         // Cols / rows must be positive. System.CommandLine has no built-in range validator
         // for ints, so attach one explicitly. Skip when the value couldn't be converted at
@@ -107,7 +98,6 @@ internal sealed class TerminalHostArgs
             controlOption,
             columnsOption,
             rowsOption,
-            shellOption,
         };
         // The terminal host argv comes from DCP only; treat unknown flags as a hard error
         // so we don't silently accept garbage and start with the wrong configuration.
@@ -135,7 +125,6 @@ internal sealed class TerminalHostArgs
             ControlUdsPath = parseResult.GetValue(controlOption)!,
             Columns = parseResult.GetValue(columnsOption),
             Rows = parseResult.GetValue(rowsOption),
-            Shell = parseResult.GetValue(shellOption),
         };
     }
 
@@ -160,7 +149,7 @@ internal sealed class TerminalHostArgs
 
         // System.CommandLine accepts repeated occurrences of single-valued options and
         // silently keeps the last value (last-write-wins). For this host every flag
-        // identifies a per-replica resource (UDS path, dimensions, shell), so a duplicate
+        // identifies a per-replica resource (UDS path, dimensions), so a duplicate
         // is unambiguously a misuse by the caller - reject it uniformly across all flags.
         option.Validators.Add(r =>
         {

--- a/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
@@ -502,10 +502,8 @@ public class WithTerminalTests
             Assert.Contains("200", args);
             Assert.Contains("--rows", args);
             Assert.Contains("50", args);
-            // The terminal host never selected the shell: DCP allocates the PTY for the
-            // resource's own process (there is no shell field on the DCP TerminalSpec), so
-            // no shell flag is forwarded. Guards against re-introducing the misleading
-            // TerminalOptions.Shell no-op that only forwarded --shell to the host.
+            // DCP allocates the PTY for the resource's own process, and its TerminalSpec
+            // has no shell field. The terminal host therefore receives no shell argument.
             Assert.DoesNotContain("--shell", args);
         }
     }

--- a/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
@@ -41,7 +41,6 @@ public class WithTerminalTests
         Assert.NotNull(annotation);
         Assert.Equal(120, annotation.Options.Columns);
         Assert.Equal(30, annotation.Options.Rows);
-        Assert.Null(annotation.Options.Shell);
 
         // Until BeforeStartEvent fires the per-replica hosts are not yet materialized:
         // TerminalHosts is empty and IsInitialized is false. This deferral is what
@@ -70,14 +69,12 @@ public class WithTerminalTests
         {
             options.Columns = 200;
             options.Rows = 50;
-            options.Shell = "/bin/bash";
         });
 
         var annotation = resource.Resource.Annotations.OfType<TerminalAnnotation>().SingleOrDefault();
         Assert.NotNull(annotation);
         Assert.Equal(200, annotation.Options.Columns);
         Assert.Equal(50, annotation.Options.Rows);
-        Assert.Equal("/bin/bash", annotation.Options.Shell);
     }
 
     [Fact]
@@ -480,7 +477,6 @@ public class WithTerminalTests
         {
             options.Columns = 200;
             options.Rows = 50;
-            options.Shell = "/bin/bash";
         });
 
         await PublishBeforeStartAsync(builder);
@@ -506,8 +502,11 @@ public class WithTerminalTests
             Assert.Contains("200", args);
             Assert.Contains("--rows", args);
             Assert.Contains("50", args);
-            Assert.Contains("--shell", args);
-            Assert.Contains("/bin/bash", args);
+            // The terminal host never selected the shell: DCP allocates the PTY for the
+            // resource's own process (there is no shell field on the DCP TerminalSpec), so
+            // no shell flag is forwarded. Guards against re-introducing the misleading
+            // TerminalOptions.Shell no-op that only forwarded --shell to the host.
+            Assert.DoesNotContain("--shell", args);
         }
     }
 

--- a/tests/Aspire.TerminalHost.Tests/TerminalHostArgsTests.cs
+++ b/tests/Aspire.TerminalHost.Tests/TerminalHostArgsTests.cs
@@ -37,6 +37,21 @@ public class TerminalHostArgsTests
     }
 
     [Fact]
+    public void ParseAcceptsIgnoredShellForCompatibility()
+    {
+        var args = TerminalHostArgs.Parse([
+            "--producer-uds", "/tmp/p.sock",
+            "--consumer-uds", "/tmp/c.sock",
+            "--control-uds", "/tmp/ctrl.sock",
+            "--shell", "/bin/bash",
+        ]);
+
+        Assert.Equal("/tmp/p.sock", args.ProducerUdsPath);
+        Assert.Equal("/tmp/c.sock", args.ConsumerUdsPath);
+        Assert.Equal("/tmp/ctrl.sock", args.ControlUdsPath);
+    }
+
+    [Fact]
     public void ParseMissingProducerUdsThrows()
     {
         var ex = Assert.Throws<TerminalHostArgsException>(() => TerminalHostArgs.Parse([

--- a/tests/Aspire.TerminalHost.Tests/TerminalHostArgsTests.cs
+++ b/tests/Aspire.TerminalHost.Tests/TerminalHostArgsTests.cs
@@ -19,11 +19,10 @@ public class TerminalHostArgsTests
         Assert.Equal("/tmp/ctrl.sock", args.ControlUdsPath);
         Assert.Equal(120, args.Columns);
         Assert.Equal(30, args.Rows);
-        Assert.Null(args.Shell);
     }
 
     [Fact]
-    public void ParseAcceptsOptionalDimensionsAndShell()
+    public void ParseAcceptsOptionalDimensions()
     {
         var args = TerminalHostArgs.Parse([
             "--producer-uds", "/tmp/p.sock",
@@ -31,12 +30,10 @@ public class TerminalHostArgsTests
             "--control-uds", "/tmp/ctrl.sock",
             "--columns", "200",
             "--rows", "50",
-            "--shell", "/bin/bash",
         ]);
 
         Assert.Equal(200, args.Columns);
         Assert.Equal(50, args.Rows);
-        Assert.Equal("/bin/bash", args.Shell);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`TerminalOptions.Shell` (part of the experimental `WithTerminal()` feature) publicly claimed to select the shell for a terminal session, but setting it never changed anything.

Under the hood, when a resource opts into `WithTerminal()`, DCP allocates a pseudo-terminal for the resource's **own** process — the executable itself, or the container's process — and bridges that PTY to the Aspire terminal host. The DCP `TerminalSpec` (which mirrors `api/v1/terminal_types.go` in microsoft/dcp) only carries `udsPath`, `socketMode`, `cols`, and `rows`; there is no shell field, and DCP does not spawn a separate shell. The `options.Shell` value was only forwarded to `Aspire.TerminalHost` as an informational `--shell` argument that the host otherwise ignored. So the resource is always the terminal program, and shell selection is fundamentally incompatible with the design.

Because `WithTerminal()` is experimental (`ASPIRETERMINAL001`), this PR corrects the API contract by removing the misleading no-op rather than preserving it:

- Removed `TerminalOptions.Shell`.
- Removed the `--shell` argv emission on the AppHost side (`ConfigureTerminalHostAnnotations`).
- Removed the `Shell` property from `TerminalHostArgs` and the shell-hint logging branch in `TerminalHostApp`.
- Retained `--shell` as an accepted-but-ignored TerminalHost parser argument so newer CLI bundles remain compatible with older Aspire.Hosting packages that still emit it.
- Updated the polyglot overload documentation to describe the supported dimension defaults without implying shell selection.

No DCP schema change is needed, and no generated `api/*.cs` files were edited. Actual DCP `TerminalSpec` behavior — `cols`/`rows`/`socketMode`/`udsPath` — is unchanged and continues to work.

### Breaking changes

This removes the experimental `TerminalOptions.Shell` property. AppHosts that set it must remove that assignment; it never affected the launched executable or container process.

### Validation

- `WithTerminalTests` (23 passed)
- Executable and container DCP terminal-spec tests (2 passed)
- `TerminalHostArgsTests` (13 passed)
- Dogfood executable and container PTY attach scenarios passed against PR head

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
