### PR TITLE
Validate TerminalOptions columns and rows are positive

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
@@ -100,14 +100,8 @@ public sealed class TerminalOptions
     private int _rows = 30;
 
     /// <summary>
-    /// Gets or sets the initial number of columns for the terminal. Defaults to 120.
+    /// Gets or sets the initial number of columns for the terminal. The value must be greater than zero. Defaults to 120.
     /// </summary>
-    /// <remarks>
-    /// Must be greater than zero. Aspire.TerminalHost rejects a PTY width below 1
-    /// (see its <c>--columns</c> validator), so validating here surfaces the error at
-    /// the <see cref="TerminalResourceBuilderExtensions.WithTerminal{T}(IResourceBuilder{T}, Action{TerminalOptions}?)"/>
-    /// call site instead of as a hidden terminal-host startup failure.
-    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when set to zero or a negative value.</exception>
     public int Columns
     {
@@ -120,14 +114,8 @@ public sealed class TerminalOptions
     }
 
     /// <summary>
-    /// Gets or sets the initial number of rows for the terminal. Defaults to 30.
+    /// Gets or sets the initial number of rows for the terminal. The value must be greater than zero. Defaults to 30.
     /// </summary>
-    /// <remarks>
-    /// Must be greater than zero. Aspire.TerminalHost rejects a PTY height below 1
-    /// (see its <c>--rows</c> validator), so validating here surfaces the error at
-    /// the <see cref="TerminalResourceBuilderExtensions.WithTerminal{T}(IResourceBuilder{T}, Action{TerminalOptions}?)"/>
-    /// call site instead of as a hidden terminal-host startup failure.
-    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when set to zero or a negative value.</exception>
     public int Rows
     {

--- a/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/TerminalAnnotation.cs
@@ -96,15 +96,48 @@ internal sealed class TerminalAnnotation : IResourceAnnotation
 [Experimental("ASPIRETERMINAL001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public sealed class TerminalOptions
 {
+    private int _columns = 120;
+    private int _rows = 30;
+
     /// <summary>
     /// Gets or sets the initial number of columns for the terminal. Defaults to 120.
     /// </summary>
-    public int Columns { get; set; } = 120;
+    /// <remarks>
+    /// Must be greater than zero. Aspire.TerminalHost rejects a PTY width below 1
+    /// (see its <c>--columns</c> validator), so validating here surfaces the error at
+    /// the <see cref="TerminalResourceBuilderExtensions.WithTerminal{T}(IResourceBuilder{T}, Action{TerminalOptions}?)"/>
+    /// call site instead of as a hidden terminal-host startup failure.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when set to zero or a negative value.</exception>
+    public int Columns
+    {
+        get => _columns;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+            _columns = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the initial number of rows for the terminal. Defaults to 30.
     /// </summary>
-    public int Rows { get; set; } = 30;
+    /// <remarks>
+    /// Must be greater than zero. Aspire.TerminalHost rejects a PTY height below 1
+    /// (see its <c>--rows</c> validator), so validating here surfaces the error at
+    /// the <see cref="TerminalResourceBuilderExtensions.WithTerminal{T}(IResourceBuilder{T}, Action{TerminalOptions}?)"/>
+    /// call site instead of as a hidden terminal-host startup failure.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when set to zero or a negative value.</exception>
+    public int Rows
+    {
+        get => _rows;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+            _rows = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the shell to use for the terminal session.

--- a/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithTerminalTests.cs
@@ -80,6 +80,53 @@ public class WithTerminalTests
         Assert.Equal("/bin/bash", annotation.Options.Shell);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void WithTerminalRejectsNonPositiveColumns(int columns)
+    {
+        // Aspire.TerminalHost rejects a PTY width below 1, so an invalid Columns value must
+        // fail at the WithTerminal() call site rather than as a hidden terminal-host startup
+        // failure that can block the parent resource.
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddExecutable("myapp", "myapp", ".");
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => resource.WithTerminal(options => options.Columns = columns));
+        Assert.Equal("value", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void WithTerminalRejectsNonPositiveRows(int rows)
+    {
+        // Aspire.TerminalHost rejects a PTY height below 1, so an invalid Rows value must
+        // fail at the WithTerminal() call site rather than as a hidden terminal-host startup
+        // failure that can block the parent resource.
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddExecutable("myapp", "myapp", ".");
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => resource.WithTerminal(options => options.Rows = rows));
+        Assert.Equal("value", ex.ParamName);
+    }
+
+    [Fact]
+    public void TerminalOptionsRejectNonPositiveDimensions()
+    {
+        var options = new TerminalOptions();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Columns = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.Rows = -5);
+
+        // A valid assignment still succeeds, and the boundary value 1 is accepted.
+        options.Columns = 1;
+        options.Rows = 1;
+        Assert.Equal(1, options.Columns);
+        Assert.Equal(1, options.Rows);
+    }
+
     [Fact]
     public async Task WithTerminalCreatesPerReplicaHiddenTerminalHostResources()
     {


### PR DESCRIPTION
## Description

`WithTerminal()` lets you attach an interactive terminal to a resource and optionally set the initial PTY size via `TerminalOptions.Columns` / `TerminalOptions.Rows`. Previously those properties accepted **zero or negative** values during AppHost model construction, but `Aspire.TerminalHost` rejects any dimension below `1` (its `--columns` / `--rows` validators). The mismatch turned a bad value into a hidden terminal-host startup failure that could block the parent resource, with no clear indication of what went wrong.

Now an invalid width/height fails fast at the `WithTerminal()` call site with a clear `ArgumentOutOfRangeException`, instead of surfacing later as an opaque host failure.

### User-facing usage

Valid usage is unchanged:

```csharp
builder.AddExecutable("myapp", "myapp", ".")
       .WithTerminal(options =>
       {
           options.Columns = 200;
           options.Rows = 50;
       });
```

Invalid dimensions now throw immediately at configuration time:

```csharp
builder.AddExecutable("myapp", "myapp", ".")
       .WithTerminal(options => options.Columns = 0); // throws ArgumentOutOfRangeException
```

The boundary value `1` is still accepted (matches TerminalHost's `>= 1` rule). The polyglot `withTerminal` dispatcher uses the built-in defaults (120×30), which remain valid, so polyglot AppHosts are unaffected.

### Implementation

`TerminalOptions.Columns` and `Rows` validate in their setters with `ArgumentOutOfRangeException.ThrowIfNegativeOrZero`, matching the existing `ProcessCommandOptions.MaxOutputLineCount` convention. No generated `api/*.cs` files were modified (this is an experimental API and did not add new surface). Regression tests were added in `WithTerminalTests` covering zero/negative columns and rows and the accepted boundary value; they fail before the fix and pass after.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
