### PR TITLE
Pin cacheable-request after npm supply-chain compromise

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1087,6 +1087,7 @@
   },
   "resolutions": {
     "braces": "3.0.3",
+    "cacheable-request": "13.0.19",
     "**/@vscode/vsce/minimatch/brace-expansion": "2.1.3",
     "copyfiles/**/minimatch/brace-expansion": "2.1.3",
     "eslint/**/minimatch/brace-expansion": "2.1.3",

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -1801,7 +1801,7 @@ cacheable-lookup@^7.0.0:
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz#3476a8215d046e5a3202a9209dd13fec1f933a27"
   integrity sha1-NHaoIV0EbloyAqkgndE/7B+TOic=
 
-cacheable-request@^13.0.12:
+cacheable-request@13.0.19, cacheable-request@^13.0.12:
   version "13.0.19"
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cacheable-request/-/cacheable-request-13.0.19.tgz#2c8a3b6b4cc37ea6906cc182f5b838e5822b2f97"
   integrity sha1-LIo7a0zDfqaQbMGC9bg45YIrL5c=


### PR DESCRIPTION
## Description

Snyk reported an active npm supply-chain compromise that published `cacheable-request@13.0.20` with a malicious `preinstall` hook. The extension currently resolves the clean `13.0.19` release through `got`, but the dependency range can select a newer 13.x version when the lockfile is regenerated.

This pins `cacheable-request` to `13.0.19` in the extension's Yarn resolutions and records that resolution in `yarn.lock`.

See [Snyk's investigation](https://snyk.io/blog/inside-keyv-npm-compromise-preinstall-malware-trusted-provenance-ide-hooks/).

### Security considerations

The compromised release executes during package installation, before application code runs. The lockfile was regenerated and verified with lifecycle scripts disabled.

The exposure check found:

- 0 malicious resolutions across 91 tracked Aspire lockfiles
- 0 malicious versions or `preinstall` hooks in the installed extension dependency tree
- 0 matching payload hashes in the checked installs, persistence artifacts at Snyk's documented locations, or npm log/cache entries

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] Yes
      - [ ] No
  - [ ] No
