### PR TITLE
Graduate year-old experimental Aspire APIs

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/AppHost.cs
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/AppHost.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREACADOMAINS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPERSISTENCE001 // Resource lifetime APIs are experimental.
 
 using Aspire.Hosting.Azure;

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
@@ -56,7 +55,6 @@ public static class ContainerAppExtensions
     /// </remarks>
     /// <ats-remarks />
     [AspireExport]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public static void ConfigureCustomDomain(this ContainerApp app, IResourceBuilder<ParameterResource> customDomain, IResourceBuilder<ParameterResource> certificateName)
     {
         ArgumentNullException.ThrowIfNull(app);

--- a/src/Aspire.Hosting/Pipelines/CompletionState.cs
+++ b/src/Aspire.Hosting/Pipelines/CompletionState.cs
@@ -1,14 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting.Pipelines;
 
 /// <summary>
 /// Represents the completion state of a publishing activity (task, step, or top-level operation).
 /// </summary>
-[Experimental("ASPIREPIPELINES001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 public enum CompletionState
 {
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREACADOMAINS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIRECOMPUTE002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREDOCKERFILEBUILDER001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREPIPELINES001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/tests/Aspire.Hosting.Azure.Tests/ContainerRegistryTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ContainerRegistryTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIREACADOMAINS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable CS0618 // Type or member is obsolete
 
 using Aspire.Hosting.ApplicationModel;

--- a/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/PublicApiTests/AppContainersPublicApiTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.AppContainers;
@@ -113,7 +112,6 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenAppIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -128,7 +126,6 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenCustomDomainIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -143,7 +140,6 @@ public class AppContainersPublicApiTests
     }
 
     [Fact]
-    [Experimental("ASPIREACADOMAINS001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     public void ConfigureCustomDomainShouldThrowWhenCertificateNameIsNull()
     {
         using var builder = TestDistributedApplicationBuilder.Create();


### PR DESCRIPTION
## Description

Issue #17175 inventories Aspire APIs that remain experimental. This starts the graduation work with a one-year threshold and stabilizes the qualifying APIs that can be graduated independently without exposing younger experimental dependencies or preserving an unsuitable API shape.

This removes the experimental marker from:

- `ContainerAppExtensions.ConfigureCustomDomain` (`ASPIREACADOMAINS001`)
- `CompletionState` (`ASPIREPIPELINES001`)

Consumers can now use these APIs without suppressing their respective experimental diagnostics. The change also removes stale `ASPIREACADOMAINS001` suppressions and test-level experimental attributes. API signatures, runtime behavior, ATS exports, and generated API baseline files are unchanged.

Other APIs older than one year were reviewed but intentionally deferred: the Cosmos vNext API still has the stale `RunAsPreviewEmulator` name, while the older Azure environment and publishing extension APIs expose younger experimental resource or pipeline types.

### User-facing usage

```csharp
var customDomain = builder.AddParameter("customDomain");
var certificateName = builder.AddParameter("certificateName");

builder.AddProject<Projects.ApiService>("api")
       .PublishAsAzureContainerApp((_, app) =>
       {
           app.ConfigureCustomDomain(customDomain, certificateName);
       });
```

Validation:

```text
dotnet test --project tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-class "*.AzureContainerAppsTests" --filter-class "*.AppContainersPublicApiTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.PublishingActivityReporterTests" --filter-class "*.PublishingExtensionsTests" --filter-class "*.DistributedApplicationPipelineTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
./build.sh --build /p:SkipNativeBuild=true
```

Contributes to #17175

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No