### PR TITLE
Stabilize Azure deployment test infrastructure

### DIFF
--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -593,7 +593,13 @@ jobs:
           mkdir -p "$(dirname "$diagnostics")"
           {
             echo "=== Azure account ==="
-            az account show --query "{subscriptionId:id, tenantId:tenantId, user:user.name}" -o json
+            az account show --query "{subscriptionId:id, tenantId:tenantId, state:state, user:user.name}" -o json
+
+            echo "=== Azure subscription policies ==="
+            subscription_id=$(az account show --query id -o tsv)
+            az rest --method get \
+             --uri "https://management.azure.com/subscriptions/${subscription_id}?api-version=2022-12-01" \
+             --query "{state:state, subscriptionPolicies:subscriptionPolicies}" -o json
 
             echo "=== Required provider states ==="
             for provider in \
@@ -615,6 +621,16 @@ jobs:
 
             echo "=== Standard_D2as_v5 restrictions in West US 3 ==="
             az vm list-skus --location westus3 --size Standard_D2as_v5 --all \
+             --query "[?name=='Standard_D2as_v5'].{name:name, locations:locations, restrictions:restrictions}" \
+             -o json
+
+            echo "=== East US comparison compute usage ==="
+            az vm list-usage --location eastus \
+             --query "[?name.value=='standardDASv5Family' || name.value=='cores'].{name:name.value, localizedName:name.localizedValue, currentValue:currentValue, limit:limit}" \
+             -o json
+
+            echo "=== Standard_D2as_v5 restrictions in East US ==="
+            az vm list-skus --location eastus --size Standard_D2as_v5 --all \
              --query "[?name=='Standard_D2as_v5'].{name:name, locations:locations, restrictions:restrictions}" \
              -o json
 
@@ -643,15 +659,16 @@ jobs:
 
             try_aks_create() {
               local variant="$1"
-              shift
+              local location="$2"
+              shift 2
               local cluster_name="diag-${variant}-${GITHUB_RUN_ATTEMPT}"
 
-              echo "--- az aks create variant: $variant ---"
+              echo "--- az aks create variant: $variant ($location) ---"
               set +e
               az aks create \
                --resource-group "$diagnostic_resource_group" \
                --name "$cluster_name" \
-               --location westus3 \
+               --location "$location" \
                --node-count 1 \
                --node-vm-size Standard_D2as_v5 \
                --enable-managed-identity \
@@ -666,19 +683,21 @@ jobs:
             }
 
             accepted_variant=""
-            if try_aks_create "free"; then
+            if try_aks_create "free" westus3; then
               accepted_variant="free"
-            elif try_aks_create "standard" --tier standard; then
+            elif try_aks_create "standard" westus3 --tier standard; then
               accepted_variant="standard"
             else
               default_kubernetes_version=$(az aks get-versions --location westus3 \
                --query "values[?isDefault].version | [0]" -o tsv)
 
               if [ -n "$default_kubernetes_version" ] &&
-                 try_aks_create "version" --tier standard --kubernetes-version "$default_kubernetes_version"; then
+                 try_aks_create "version" westus3 --tier standard --kubernetes-version "$default_kubernetes_version"; then
                 accepted_variant="explicit Kubernetes version"
-              elif try_aks_create "azurecni" --tier standard --network-plugin azure; then
+              elif try_aks_create "azurecni" westus3 --tier standard --network-plugin azure; then
                 accepted_variant="Azure CNI"
+              elif try_aks_create "eastus" eastus --tier standard; then
+                accepted_variant="East US"
               fi
             fi
 
@@ -696,7 +715,6 @@ jobs:
                  awk '!/preview/ { print; exit }')
               fi
 
-              subscription_id=$(az account show --query id -o tsv)
               rest_cluster_name="diag-rest-${GITHUB_RUN_ATTEMPT}"
               request_body="$RUNNER_TEMP/aks-managed-cluster-request.json"
               cat > "$request_body" <<JSON

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -257,6 +257,7 @@ jobs:
             Microsoft.Compute
             Microsoft.ContainerInstance
             Microsoft.OperationalInsights
+            Microsoft.OperationsManagement
             Microsoft.Insights
             Microsoft.App
             Microsoft.ContainerRegistry

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -293,7 +293,9 @@ jobs:
             local registered p
             registered="$(cat)"
             for p in "${providers[@]}"; do
-              grep -qxF "$p" <<<"$registered" || echo "$p"
+              # Azure canonicalizes some namespaces with different casing (for example,
+              # microsoft.insights), but provider namespace matching is case-insensitive.
+              grep -qxiF "$p" <<<"$registered" || echo "$p"
             done
           }
 

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -427,9 +427,9 @@ jobs:
             # re-submitting it via the `||` fallback. A request that is not granted in time surfaces
             # later as a normal QuotaExceeded error in the test that needs it.
             if timeout 30 az quota create --resource-name "$name" --scope "$scope" \
-                 --limit-object value="$desired" "${rt_args[@]}" --no-wait --only-show-errors >/dev/null 2>&1 \
+                 --limit-object value="$desired" "${rt_args[@]}" --no-wait --only-show-errors \
                || timeout 30 az quota update --resource-name "$name" --scope "$scope" \
-                 --limit-object value="$desired" "${rt_args[@]}" --no-wait --only-show-errors >/dev/null 2>&1; then
+                 --limit-object value="$desired" "${rt_args[@]}" --no-wait --only-show-errors; then
               echo "  Request submitted for $provider/$name in $location (asynchronous; may await manual approval)."
             else
               echo "⚠ Quota request for $provider/$name in $location was not accepted (may need manual approval); continuing."

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -355,7 +355,7 @@ jobs:
       # QuotaExceeded error in the test that needs it.
       #
       # Scope: this self-heals only the quotas configured in QUOTA_TARGETS (currently westus3
-      # Container Apps public IPs plus AKS node-pool compute vCPUs and managed-cluster count).
+      # public IPs plus AKS node-pool compute vCPUs and managed-cluster count).
       # Azure enforces both the StandardDASv5Family quota and Total Regional vCPUs independently,
       # so a node pool needs headroom in each. Other quotas the suite depends on, such as westus3
       # App Service, remain documented manual quota requests (see the E2E README's quota section).
@@ -371,7 +371,7 @@ jobs:
           #   resourceType - optional; compute vCPU quotas need it (dedicated | lowPriority), omit otherwise
           # Add a line to cover a new provider, region, resource, or higher limit.
           QUOTA_TARGETS: |
-            Microsoft.App westus3 ManagedEnvironmentPublicIPCount 150
+            Microsoft.Network westus3 PublicIPAddresses 150
             Microsoft.Compute westus3 StandardDASv5Family 200 dedicated
             Microsoft.Compute westus3 cores 200 dedicated
             Microsoft.ContainerService westus3 ManagedClusters 20

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -353,13 +353,12 @@ jobs:
       # QuotaExceeded error in the test that needs it.
       #
       # Scope: this self-heals only the quotas configured in QUOTA_TARGETS (currently the westus3
-      # AKS node-pool compute vCPUs — both the StandardDASv5Family quota and the Total Regional vCPUs
-      # quota, which Azure enforces independently, so a node pool needs headroom in each). Other
-      # quotas the suite depends on are NOT covered here — westus3 Container Apps / App Service and
-      # the AKS managed-cluster count
-      # (Microsoft.ContainerService is not exposed through the Microsoft.Quota API used here) remain
-      # documented manual quota requests (see the E2E README's quota section). Requests are submitted
-      # asynchronously (--no-wait, below), so extending QUOTA_TARGETS does not lengthen this step.
+      # AKS node-pool compute vCPUs and managed-cluster count). Azure enforces both the
+      # StandardDASv5Family quota and Total Regional vCPUs independently, so a node pool needs
+      # headroom in each. Other quotas the suite depends on, such as westus3 Container Apps and
+      # App Service, remain documented manual quota requests (see the E2E README's quota section).
+      # Requests are submitted asynchronously (--no-wait, below), so extending QUOTA_TARGETS does
+      # not lengthen this step.
       - name: Ensure Azure quotas
         env:
           # Quotas to ensure, one per line: "provider location resourceName desiredLimit [resourceType]".
@@ -372,6 +371,7 @@ jobs:
           QUOTA_TARGETS: |
             Microsoft.Compute westus3 StandardDASv5Family 200 dedicated
             Microsoft.Compute westus3 cores 200 dedicated
+            Microsoft.ContainerService westus3 ManagedClusters 20
         run: |
           sub="$ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION"
 
@@ -432,22 +432,6 @@ jobs:
               echo "⚠ Quota request for $provider/$name in $location was not accepted (may need manual approval); continuing."
             fi
           done <<< "$QUOTA_TARGETS"
-
-          # AKS managed-cluster count has its own regional quota scope. Print it so a
-          # zero/default entitlement is visible before deployments collapse it into the
-          # generic AKS BadRequest response.
-          echo "AKS managed-cluster quota in westus3:"
-          az quota list \
-             --scope "/subscriptions/$sub/providers/Microsoft.ContainerService/locations/westus3" \
-             --only-show-errors -o json ||
-             echo "⚠ Could not read Microsoft.ContainerService quota in westus3."
-
-          echo "AKS-specific Standard_D2as_v5 availability in westus3:"
-          az rest --method get \
-             --uri "https://management.azure.com/subscriptions/$sub/providers/Microsoft.ContainerService/locations/westus3/vmSkus?api-version=2026-05-02-preview" \
-             --query "value[?name=='Standard_D2as_v5'].{name:name, family:family, locations:locations, restrictions:restrictions}" \
-             -o json ||
-             echo "⚠ Could not read AKS VM SKU availability in westus3."
 
   # Run each test class in parallel
   deploy-test:
@@ -592,191 +576,6 @@ jobs:
             --ignore-exit-code 8 \
             ${{ matrix.extraTestArgs }} \
             || echo "test_failed=true" >> $GITHUB_OUTPUT
-
-      - name: Collect AKS subscription diagnostics
-        if: ${{ always() && inputs.test_filter == 'AksStarterDeploymentTests' }}
-        run: |
-          diagnostics="${{ github.workspace }}/testresults/aks-subscription-diagnostics.txt"
-          mkdir -p "$(dirname "$diagnostics")"
-          {
-            echo "=== Azure account ==="
-            az account show --query "{subscriptionId:id, tenantId:tenantId, state:state, user:user.name}" -o json
-
-            echo "=== Azure subscription policies ==="
-            subscription_id=$(az account show --query id -o tsv)
-            az rest --method get \
-             --uri "https://management.azure.com/subscriptions/${subscription_id}?api-version=2022-12-01" \
-             --query "{state:state, subscriptionPolicies:subscriptionPolicies}" -o json
-
-            echo "=== Required provider states ==="
-            for provider in \
-             Microsoft.ContainerService \
-             Microsoft.Compute \
-             Microsoft.Network \
-             Microsoft.ManagedIdentity \
-             Microsoft.OperationsManagement \
-             Microsoft.OperationalInsights \
-             Microsoft.Insights; do
-             az provider show --namespace "$provider" \
-               --query "{namespace:namespace, registrationState:registrationState}" -o json
-            done
-
-            echo "=== West US 3 compute usage ==="
-            az vm list-usage --location westus3 \
-             --query "[?name.value=='standardDASv5Family' || name.value=='cores'].{name:name.value, localizedName:name.localizedValue, currentValue:currentValue, limit:limit}" \
-             -o json
-
-            echo "=== Standard_D2as_v5 restrictions in West US 3 ==="
-            az vm list-skus --location westus3 --size Standard_D2as_v5 --all \
-             --query "[?name=='Standard_D2as_v5'].{name:name, locations:locations, restrictions:restrictions}" \
-             -o json
-
-            echo "=== East US comparison compute usage ==="
-            az vm list-usage --location eastus \
-             --query "[?name.value=='standardDASv5Family' || name.value=='cores'].{name:name.value, localizedName:name.localizedValue, currentValue:currentValue, limit:limit}" \
-             -o json
-
-            echo "=== Standard_D2as_v5 restrictions in East US ==="
-            az vm list-skus --location eastus --size Standard_D2as_v5 --all \
-             --query "[?name=='Standard_D2as_v5'].{name:name, locations:locations, restrictions:restrictions}" \
-             -o json
-
-            echo "=== Existing AKS clusters ==="
-            az aks list \
-             --query "[].{name:name, resourceGroup:resourceGroup, location:location, provisioningState:provisioningState, sku:sku}" \
-             -o json
-
-            echo "=== Supported AKS versions in West US 3 ==="
-            az aks get-versions --location westus3 \
-             --query "values[].{version:version, isDefault:isDefault}" -o json
-
-            echo "=== Supported Microsoft.ContainerService managedClusters API versions ==="
-            managed_cluster_api_versions=$(az provider show --namespace Microsoft.ContainerService \
-             --query "resourceTypes[?resourceType=='managedClusters'].apiVersions[]" -o tsv)
-            printf '%s\n' "$managed_cluster_api_versions"
-
-            echo "=== Isolated AKS request-shape diagnostics ==="
-            diagnostic_resource_group="e2e-aksdiag-${GITHUB_RUN_ID}"
-            az group create --name "$diagnostic_resource_group" --location westus3 --output none
-
-            cleanup_diagnostic_resource_group() {
-              az group delete --name "$diagnostic_resource_group" --yes --no-wait --output none || true
-            }
-            trap cleanup_diagnostic_resource_group EXIT
-
-            try_aks_create() {
-              local variant="$1"
-              local location="$2"
-              shift 2
-              local cluster_name="diag-${variant}-${GITHUB_RUN_ATTEMPT}"
-
-              echo "--- az aks create variant: $variant ($location) ---"
-              set +e
-              az aks create \
-               --resource-group "$diagnostic_resource_group" \
-               --name "$cluster_name" \
-               --location "$location" \
-               --node-count 1 \
-               --node-vm-size Standard_D2as_v5 \
-               --enable-managed-identity \
-               --no-ssh-key \
-               --no-wait \
-               --only-show-errors \
-               "$@"
-              local exit_code=$?
-              set -e
-              echo "Exit code: $exit_code"
-              return "$exit_code"
-            }
-
-            accepted_variant=""
-            if try_aks_create "free" westus3; then
-              accepted_variant="free"
-            elif try_aks_create "standard" westus3 --tier standard; then
-              accepted_variant="standard"
-            else
-              default_kubernetes_version=$(az aks get-versions --location westus3 \
-               --query "values[?isDefault].version | [0]" -o tsv)
-
-              if [ -n "$default_kubernetes_version" ] &&
-                 try_aks_create "version" westus3 --tier standard --kubernetes-version "$default_kubernetes_version"; then
-                accepted_variant="explicit Kubernetes version"
-              elif try_aks_create "azurecni" westus3 --tier standard --network-plugin azure; then
-                accepted_variant="Azure CNI"
-              elif try_aks_create "eastus" eastus --tier standard; then
-                accepted_variant="East US"
-              fi
-            fi
-
-            if [ -n "$accepted_variant" ]; then
-              echo "Accepted AKS CLI variant: $accepted_variant"
-            else
-              echo "--- Minimal managedClusters PUT using an older stable API ---"
-              stable_api_version=$(printf '%s\n' "$managed_cluster_api_versions" |
-               tr '\t' '\n' |
-               awk '/^2025-[0-9][0-9]-[0-9][0-9]$/ { print; exit }')
-
-              if [ -z "$stable_api_version" ]; then
-                stable_api_version=$(printf '%s\n' "$managed_cluster_api_versions" |
-                 tr '\t' '\n' |
-                 awk '!/preview/ { print; exit }')
-              fi
-
-              rest_cluster_name="diag-rest-${GITHUB_RUN_ATTEMPT}"
-              request_body="$RUNNER_TEMP/aks-managed-cluster-request.json"
-              cat > "$request_body" <<JSON
-          {
-            "location": "westus3",
-            "identity": {
-              "type": "SystemAssigned"
-            },
-            "sku": {
-              "name": "Base",
-              "tier": "Standard"
-            },
-            "properties": {
-              "dnsPrefix": "$rest_cluster_name",
-              "enableRBAC": true,
-              "servicePrincipalProfile": {
-                "clientId": "msi"
-              },
-              "agentPoolProfiles": [
-                {
-                  "name": "systempool",
-                  "count": 1,
-                  "vmSize": "Standard_D2as_v5",
-                  "osType": "Linux",
-                  "mode": "System",
-                  "type": "VirtualMachineScaleSets"
-                }
-              ],
-              "networkProfile": {
-                "networkPlugin": "kubenet",
-                "loadBalancerSku": "standard",
-                "outboundType": "loadBalancer"
-              }
-            }
-          }
-          JSON
-
-              set +e
-              az rest --method put --debug \
-               --uri "https://management.azure.com/subscriptions/${subscription_id}/resourceGroups/${diagnostic_resource_group}/providers/Microsoft.ContainerService/managedClusters/${rest_cluster_name}?api-version=${stable_api_version}" \
-               --headers "Content-Type=application/json" \
-               --body "@$request_body"
-              rest_exit_code=$?
-              set -e
-              echo "API version: $stable_api_version"
-              echo "Exit code: $rest_exit_code"
-            fi
-
-            echo "=== Recent failed Microsoft.ContainerService activity ==="
-            sleep 60
-            az monitor activity-log list --offset 3h --status Failed \
-             --namespace Microsoft.ContainerService --max-events 100 \
-             --query "[].{time:eventTimestamp, operation:operationName.localizedValue, resourceGroup:resourceGroupName, resourceId:resourceId, status:status.localizedValue, subStatus:subStatus.localizedValue, correlationId:correlationId, statusMessage:properties.statusMessage}" \
-             -o json
-          } 2>&1 | tee "$diagnostics"
 
       - name: Collect Aspire CLI logs
         if: always()

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -371,7 +371,7 @@ jobs:
           #   resourceType - optional; compute vCPU quotas need it (dedicated | lowPriority), omit otherwise
           # Add a line to cover a new provider, region, resource, or higher limit.
           QUOTA_TARGETS: |
-            Microsoft.Network westus3 PublicIPAddresses 150
+            Microsoft.Network westus3 publicIPAddresses 150
             Microsoft.Compute westus3 StandardDASv5Family 200 dedicated
             Microsoft.Compute westus3 cores 200 dedicated
             Microsoft.ContainerService westus3 ManagedClusters 20

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -433,6 +433,13 @@ jobs:
             fi
           done <<< "$QUOTA_TARGETS"
 
+          # The AKS managed-cluster count is exposed by the AKS RP rather than Microsoft.Quota.
+          # Print the effective regional limit so a zero/default entitlement is visible before
+          # deployments collapse it into the generic AKS BadRequest response.
+          echo "AKS resource usage in westus3:"
+          az aks list-usage --location westus3 -o json ||
+             echo "⚠ Could not read Microsoft.ContainerService usage in westus3."
+
   # Run each test class in parallel
   deploy-test:
     name: Deploy (${{ matrix.shortname }})
@@ -613,6 +620,10 @@ jobs:
             az aks list \
              --query "[].{name:name, resourceGroup:resourceGroup, location:location, provisioningState:provisioningState, sku:sku}" \
              -o json
+
+            echo "=== AKS resource usage in West US 3 ==="
+            az aks list-usage --location westus3 -o json ||
+              echo "Could not read Microsoft.ContainerService usage in westus3."
 
             echo "=== Supported AKS versions in West US 3 ==="
             az aks get-versions --location westus3 \

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -354,10 +354,10 @@ jobs:
       # not guaranteed to be granted synchronously, so a still-short quota surfaces its own
       # QuotaExceeded error in the test that needs it.
       #
-      # Scope: this self-heals only the quotas configured in QUOTA_TARGETS (currently westus3
-      # public IPs plus AKS node-pool compute vCPUs and managed-cluster count).
-      # Azure enforces both the StandardDASv5Family quota and Total Regional vCPUs independently,
-      # so a node pool needs headroom in each. Other quotas the suite depends on, such as westus3
+      # Scope: this self-heals only the quotas configured in QUOTA_TARGETS (currently the westus3
+      # AKS node-pool compute vCPUs and managed-cluster count). Azure enforces both the
+      # StandardDASv5Family quota and Total Regional vCPUs independently, so a node pool needs
+      # headroom in each. Other quotas the suite depends on, such as westus3 Container Apps and
       # App Service, remain documented manual quota requests (see the E2E README's quota section).
       # Requests are submitted asynchronously (--no-wait, below), so extending QUOTA_TARGETS does
       # not lengthen this step.
@@ -371,7 +371,6 @@ jobs:
           #   resourceType - optional; compute vCPU quotas need it (dedicated | lowPriority), omit otherwise
           # Add a line to cover a new provider, region, resource, or higher limit.
           QUOTA_TARGETS: |
-            Microsoft.Network westus3 publicIPAddresses 150
             Microsoft.Compute westus3 StandardDASv5Family 200 dedicated
             Microsoft.Compute westus3 cores 200 dedicated
             Microsoft.ContainerService westus3 ManagedClusters 20

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -442,6 +442,13 @@ jobs:
              --only-show-errors -o json ||
              echo "⚠ Could not read Microsoft.ContainerService quota in westus3."
 
+          echo "AKS-specific Standard_D2as_v5 availability in westus3:"
+          az rest --method get \
+             --uri "https://management.azure.com/subscriptions/$sub/providers/Microsoft.ContainerService/locations/westus3/vmSkus?api-version=2026-05-02-preview" \
+             --query "value[?name=='Standard_D2as_v5'].{name:name, family:family, locations:locations, restrictions:restrictions}" \
+             -o json ||
+             echo "⚠ Could not read AKS VM SKU availability in westus3."
+
   # Run each test class in parallel
   deploy-test:
     name: Deploy (${{ matrix.shortname }})

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -576,6 +576,51 @@ jobs:
             ${{ matrix.extraTestArgs }} \
             || echo "test_failed=true" >> $GITHUB_OUTPUT
 
+      - name: Collect AKS subscription diagnostics
+        if: ${{ always() && inputs.test_filter == 'AksStarterDeploymentTests' }}
+        run: |
+          diagnostics="${{ github.workspace }}/testresults/aks-subscription-diagnostics.txt"
+          mkdir -p "$(dirname "$diagnostics")"
+          {
+            echo "=== Azure account ==="
+            az account show --query "{subscriptionId:id, tenantId:tenantId, user:user.name}" -o json
+
+            echo "=== Required provider states ==="
+            for provider in \
+             Microsoft.ContainerService \
+             Microsoft.Compute \
+             Microsoft.Network \
+             Microsoft.ManagedIdentity \
+             Microsoft.OperationsManagement \
+             Microsoft.OperationalInsights \
+             Microsoft.Insights; do
+             az provider show --namespace "$provider" \
+               --query "{namespace:namespace, registrationState:registrationState}" -o json
+            done
+
+            echo "=== West US 3 compute usage ==="
+            az vm list-usage --location westus3 \
+             --query "[?name.value=='standardDASv5Family' || name.value=='cores'].{name:name.value, localizedName:name.localizedValue, currentValue:currentValue, limit:limit}" \
+             -o json
+
+            echo "=== Standard_D2as_v5 restrictions in West US 3 ==="
+            az vm list-skus --location westus3 --size Standard_D2as_v5 --all \
+             --query "[?name=='Standard_D2as_v5'].{name:name, locations:locations, restrictions:restrictions}" \
+             -o json
+
+            echo "=== Existing AKS clusters ==="
+            az aks list \
+             --query "[].{name:name, resourceGroup:resourceGroup, location:location, provisioningState:provisioningState, sku:sku}" \
+             -o json
+
+            echo "=== Recent failed Microsoft.ContainerService activity ==="
+            sleep 60
+            az monitor activity-log list --offset 3h --status Failed \
+             --namespace Microsoft.ContainerService --max-events 100 \
+             --query "[].{time:eventTimestamp, operation:operationName.localizedValue, resourceGroup:resourceGroupName, resourceId:resourceId, status:status.localizedValue, subStatus:subStatus.localizedValue, correlationId:correlationId, statusMessage:properties.statusMessage}" \
+             -o json
+          } 2>&1 | tee "$diagnostics"
+
       - name: Collect Aspire CLI logs
         if: always()
         run: |

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -433,12 +433,14 @@ jobs:
             fi
           done <<< "$QUOTA_TARGETS"
 
-          # The AKS managed-cluster count is exposed by the AKS RP rather than Microsoft.Quota.
-          # Print the effective regional limit so a zero/default entitlement is visible before
-          # deployments collapse it into the generic AKS BadRequest response.
-          echo "AKS resource usage in westus3:"
-          az aks list-usage --location westus3 -o json ||
-             echo "⚠ Could not read Microsoft.ContainerService usage in westus3."
+          # AKS managed-cluster count has its own regional quota scope. Print it so a
+          # zero/default entitlement is visible before deployments collapse it into the
+          # generic AKS BadRequest response.
+          echo "AKS managed-cluster quota in westus3:"
+          az quota list \
+             --scope "/subscriptions/$sub/providers/Microsoft.ContainerService/locations/westus3" \
+             --only-show-errors -o json ||
+             echo "⚠ Could not read Microsoft.ContainerService quota in westus3."
 
   # Run each test class in parallel
   deploy-test:
@@ -620,10 +622,6 @@ jobs:
             az aks list \
              --query "[].{name:name, resourceGroup:resourceGroup, location:location, provisioningState:provisioningState, sku:sku}" \
              -o json
-
-            echo "=== AKS resource usage in West US 3 ==="
-            az aks list-usage --location westus3 -o json ||
-              echo "Could not read Microsoft.ContainerService usage in westus3."
 
             echo "=== Supported AKS versions in West US 3 ==="
             az aks get-versions --location westus3 \

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -354,10 +354,10 @@ jobs:
       # not guaranteed to be granted synchronously, so a still-short quota surfaces its own
       # QuotaExceeded error in the test that needs it.
       #
-      # Scope: this self-heals only the quotas configured in QUOTA_TARGETS (currently the westus3
-      # AKS node-pool compute vCPUs and managed-cluster count). Azure enforces both the
-      # StandardDASv5Family quota and Total Regional vCPUs independently, so a node pool needs
-      # headroom in each. Other quotas the suite depends on, such as westus3 Container Apps and
+      # Scope: this self-heals only the quotas configured in QUOTA_TARGETS (currently westus3
+      # Container Apps public IPs plus AKS node-pool compute vCPUs and managed-cluster count).
+      # Azure enforces both the StandardDASv5Family quota and Total Regional vCPUs independently,
+      # so a node pool needs headroom in each. Other quotas the suite depends on, such as westus3
       # App Service, remain documented manual quota requests (see the E2E README's quota section).
       # Requests are submitted asynchronously (--no-wait, below), so extending QUOTA_TARGETS does
       # not lengthen this step.
@@ -371,6 +371,7 @@ jobs:
           #   resourceType - optional; compute vCPU quotas need it (dedicated | lowPriority), omit otherwise
           # Add a line to cover a new provider, region, resource, or higher limit.
           QUOTA_TARGETS: |
+            Microsoft.App westus3 ManagedEnvironmentPublicIPCount 150
             Microsoft.Compute westus3 StandardDASv5Family 200 dedicated
             Microsoft.Compute westus3 cores 200 dedicated
             Microsoft.ContainerService westus3 ManagedClusters 20

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -614,6 +614,128 @@ jobs:
              --query "[].{name:name, resourceGroup:resourceGroup, location:location, provisioningState:provisioningState, sku:sku}" \
              -o json
 
+            echo "=== Supported AKS versions in West US 3 ==="
+            az aks get-versions --location westus3 \
+             --query "values[].{version:version, isDefault:isDefault}" -o json
+
+            echo "=== Supported Microsoft.ContainerService managedClusters API versions ==="
+            managed_cluster_api_versions=$(az provider show --namespace Microsoft.ContainerService \
+             --query "resourceTypes[?resourceType=='managedClusters'].apiVersions[]" -o tsv)
+            printf '%s\n' "$managed_cluster_api_versions"
+
+            echo "=== Isolated AKS request-shape diagnostics ==="
+            diagnostic_resource_group="e2e-aksdiag-${GITHUB_RUN_ID}"
+            az group create --name "$diagnostic_resource_group" --location westus3 --output none
+
+            cleanup_diagnostic_resource_group() {
+              az group delete --name "$diagnostic_resource_group" --yes --no-wait --output none || true
+            }
+            trap cleanup_diagnostic_resource_group EXIT
+
+            try_aks_create() {
+              local variant="$1"
+              shift
+              local cluster_name="diag-${variant}-${GITHUB_RUN_ATTEMPT}"
+
+              echo "--- az aks create variant: $variant ---"
+              set +e
+              az aks create \
+               --resource-group "$diagnostic_resource_group" \
+               --name "$cluster_name" \
+               --location westus3 \
+               --node-count 1 \
+               --node-vm-size Standard_D2as_v5 \
+               --enable-managed-identity \
+               --no-ssh-key \
+               --no-wait \
+               --only-show-errors \
+               "$@"
+              local exit_code=$?
+              set -e
+              echo "Exit code: $exit_code"
+              return "$exit_code"
+            }
+
+            accepted_variant=""
+            if try_aks_create "free"; then
+              accepted_variant="free"
+            elif try_aks_create "standard" --tier standard; then
+              accepted_variant="standard"
+            else
+              default_kubernetes_version=$(az aks get-versions --location westus3 \
+               --query "values[?isDefault].version | [0]" -o tsv)
+
+              if [ -n "$default_kubernetes_version" ] &&
+                 try_aks_create "version" --tier standard --kubernetes-version "$default_kubernetes_version"; then
+                accepted_variant="explicit Kubernetes version"
+              elif try_aks_create "azurecni" --tier standard --network-plugin azure; then
+                accepted_variant="Azure CNI"
+              fi
+            fi
+
+            if [ -n "$accepted_variant" ]; then
+              echo "Accepted AKS CLI variant: $accepted_variant"
+            else
+              echo "--- Minimal managedClusters PUT using an older stable API ---"
+              stable_api_version=$(printf '%s\n' "$managed_cluster_api_versions" |
+               tr '\t' '\n' |
+               awk '/^2025-[0-9][0-9]-[0-9][0-9]$/ { print; exit }')
+
+              if [ -z "$stable_api_version" ]; then
+                stable_api_version=$(printf '%s\n' "$managed_cluster_api_versions" |
+                 tr '\t' '\n' |
+                 awk '!/preview/ { print; exit }')
+              fi
+
+              subscription_id=$(az account show --query id -o tsv)
+              rest_cluster_name="diag-rest-${GITHUB_RUN_ATTEMPT}"
+              request_body="$RUNNER_TEMP/aks-managed-cluster-request.json"
+              cat > "$request_body" <<JSON
+          {
+            "location": "westus3",
+            "identity": {
+              "type": "SystemAssigned"
+            },
+            "sku": {
+              "name": "Base",
+              "tier": "Standard"
+            },
+            "properties": {
+              "dnsPrefix": "$rest_cluster_name",
+              "enableRBAC": true,
+              "servicePrincipalProfile": {
+                "clientId": "msi"
+              },
+              "agentPoolProfiles": [
+                {
+                  "name": "systempool",
+                  "count": 1,
+                  "vmSize": "Standard_D2as_v5",
+                  "osType": "Linux",
+                  "mode": "System",
+                  "type": "VirtualMachineScaleSets"
+                }
+              ],
+              "networkProfile": {
+                "networkPlugin": "kubenet",
+                "loadBalancerSku": "standard",
+                "outboundType": "loadBalancer"
+              }
+            }
+          }
+          JSON
+
+              set +e
+              az rest --method put --debug \
+               --uri "https://management.azure.com/subscriptions/${subscription_id}/resourceGroups/${diagnostic_resource_group}/providers/Microsoft.ContainerService/managedClusters/${rest_cluster_name}?api-version=${stable_api_version}" \
+               --headers "Content-Type=application/json" \
+               --body "@$request_body"
+              rest_exit_code=$?
+              set -e
+              echo "API version: $stable_api_version"
+              echo "Exit code: $rest_exit_code"
+            fi
+
             echo "=== Recent failed Microsoft.ContainerService activity ==="
             sleep 60
             az monitor activity-log list --offset 3h --status Failed \

--- a/.github/workflows/deployment-tests.yml
+++ b/.github/workflows/deployment-tests.yml
@@ -252,7 +252,7 @@ jobs:
             Microsoft.Quota
             Microsoft.ManagedIdentity
             # AKS node pools are Microsoft.Compute VMSS, and reading/requesting the compute vCPU
-            # quota (StandardDSv5Family, in QUOTA_TARGETS below) needs this provider registered on a
+            # quota (StandardDASv5Family, in QUOTA_TARGETS below) needs this provider registered on a
             # fresh subscription; without it the quota self-heal step silently skips that target.
             Microsoft.Compute
             Microsoft.ContainerInstance
@@ -342,20 +342,20 @@ jobs:
 
       # Ensure the target subscription has enough quota for the resources listed in QUOTA_TARGETS
       # below. Like provider registration above, this is per-subscription setup rather than a test
-      # concern: a fresh subscription starts with low quotas, so tests fail with QuotaExceeded
-      # (observed: a fresh subscription reports 0 dedicated vCPUs for the target compute family in
-      # centralus). For each requested quota, read the current limit via the provider-agnostic
+      # concern: a fresh subscription can have little or no dedicated vCPU quota for the target
+      # compute family, so tests fail with QuotaExceeded. For each requested quota, read the current
+      # limit via the provider-agnostic
       # Microsoft.Quota service and only when it is below the desired value submit an increase
       # request. Best-effort and never fails the job: quota requests can route to manual review
       # (self-service auto-approves only small increases; larger asks need a support ticket) and are
       # not guaranteed to be granted synchronously, so a still-short quota surfaces its own
       # QuotaExceeded error in the test that needs it.
       #
-      # Scope: this self-heals only the quotas configured in QUOTA_TARGETS (currently the centralus
-      # AKS node-pool compute vCPUs — both the StandardDSv5Family quota and the Total Regional vCPUs
+      # Scope: this self-heals only the quotas configured in QUOTA_TARGETS (currently the westus3
+      # AKS node-pool compute vCPUs — both the StandardDASv5Family quota and the Total Regional vCPUs
       # quota, which Azure enforces independently, so a node pool needs headroom in each). Other
-      # quotas the suite depends on are NOT covered here — westus3 Container Apps / App Service,
-      # australiaeast DASv4 (AksBlazorRedis), and the AKS managed-cluster count
+      # quotas the suite depends on are NOT covered here — westus3 Container Apps / App Service and
+      # the AKS managed-cluster count
       # (Microsoft.ContainerService is not exposed through the Microsoft.Quota API used here) remain
       # documented manual quota requests (see the E2E README's quota section). Requests are submitted
       # asynchronously (--no-wait, below), so extending QUOTA_TARGETS does not lengthen this step.
@@ -364,13 +364,13 @@ jobs:
           # Quotas to ensure, one per line: "provider location resourceName desiredLimit [resourceType]".
           #   provider     - resource provider that owns the quota (e.g. Microsoft.Compute, Microsoft.Network)
           #   location     - region the quota applies to; match the Azure__Location the tests deploy into
-          #   resourceName - the quota's resource name (e.g. StandardDSv5Family, cores)
+          #   resourceName - the quota's resource name (e.g. StandardDASv5Family, cores)
           #   desiredLimit - both the minimum we accept and the value we request
           #   resourceType - optional; compute vCPU quotas need it (dedicated | lowPriority), omit otherwise
           # Add a line to cover a new provider, region, resource, or higher limit.
           QUOTA_TARGETS: |
-            Microsoft.Compute centralus StandardDSv5Family 200 dedicated
-            Microsoft.Compute centralus cores 200 dedicated
+            Microsoft.Compute westus3 StandardDASv5Family 200 dedicated
+            Microsoft.Compute westus3 cores 200 dedicated
         run: |
           sub="$ASPIRE_DEPLOYMENT_TEST_SUBSCRIPTION"
 
@@ -380,7 +380,7 @@ jobs:
 
           # Read the current effective limit for a quota (works across providers). Shape of
           # 'az quota show':
-          #   { "name": "standardDSv5Family",
+          #   { "name": "standardDASv5Family",
           #     "properties": { "limit": { "value": 100 }, "unit": "Count", ... } }
           read_limit() {
             az quota show --resource-name "$2" --scope "$1" \

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 var cache = builder.AddRedis("cache");
 
 var api = builder.AddNodeApp("api", "./api", "src/index.ts")
-    .WithReference(cache)
-    .WaitFor(cache)
-    .WithHttpEndpoint(env: "PORT")
-    .WithExternalHttpEndpoints();
+        .WithReference(cache)
+        .WaitFor(cache)
+        .WithHttpEndpoint(env: "PORT")
+        .WithExternalHttpEndpoints();
 
 builder.AddViteApp("frontend", "./frontend")
     .WithReference(api)

--- a/docs/specs/aks-support.md
+++ b/docs/specs/aks-support.md
@@ -720,4 +720,4 @@ service CIDR `10.0.0.0/16`).
 - 31 AKS unit tests passing (extensions + infrastructure)
 - 88 K8s base tests passing
 - `playground/AksDemo/` validated end-to-end against a live AKS cluster (multi-Gateway, AGC, cert-manager TLS)
-- `tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentGatewayDeploymentTests` — automated deployment test that provisions an AKS environment with AGC + Gateway, deploys an API, and verifies an HTTP 200 from `<gateway-fqdn>/weatherforecast`. Passes against live Azure (`centralus`, `Standard_D2s_v5`).
+- `tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentGatewayDeploymentTests` — automated deployment test that provisions an AKS environment with AGC + Gateway, deploys an API, and verifies an HTTP 200 from `<gateway-fqdn>/weatherforecast`. Targets `westus3` with `Standard_D2as_v5` nodes.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaManagedRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaManagedRedisDeploymentTests.cs
@@ -18,6 +18,7 @@ public sealed class AcaManagedRedisDeploymentTests(ITestOutputHelper output)
     private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
 
     [Fact]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/19174")]
     public async Task DeployStarterWithManagedRedisToAzureContainerApps()
     {
         using var cts = new CancellationTokenSource(s_testTimeout);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AcaManagedRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AcaManagedRedisDeploymentTests.cs
@@ -159,11 +159,12 @@ builder.Build().Run();
             await auto.RunCommandAsync($"cd {AspireCliShellCommandHelpers.QuoteBashArg($"{projectName}.AppHost")}", counter);
 
             // Step 11: Set environment variables for deployment
-            // Use eastus for Azure Managed Redis availability zone support.
+            // Use eastus2 for Azure Managed Redis availability zone support. East US returned
+            // InsufficientCapacity for the Balanced B0 SKU during deployment test runs.
             // Unset the job-level Azure__Location=westus3 the CI workflow injects first: on Linux it coexists
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
             await auto.RunCommandAsync(
-                $"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=eastus AZURE__RESOURCEGROUP={AspireCliShellCommandHelpers.QuoteBashArg(resourceGroupName)}",
+                $"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=eastus2 AZURE__RESOURCEGROUP={AspireCliShellCommandHelpers.QuoteBashArg(resourceGroupName)}",
                 counter);
 
             // Step 12: Deploy to Azure Container Apps

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerDeploymentTests.cs
@@ -126,8 +126,8 @@ var albSubnet = vnet.AddSubnet("alb-public", "10.100.4.0/24");
 
 var aks = builder.AddAzureKubernetesEnvironment("aks")
     .WithSubnet(aksSubnet)
-    .WithSystemNodePool("Standard_D2s_v5");
-aks.AddNodePool("workload", "Standard_D2s_v5", minCount: 1, maxCount: 3);
+    .WithSystemNodePool("Standard_D2as_v5");
+aks.AddNodePool("workload", "Standard_D2as_v5", minCount: 1, maxCount: 3);
 
 var publicLb = aks.AddLoadBalancer("public", albSubnet);
 
@@ -184,7 +184,7 @@ builder.Build().Run();
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
             await auto.TypeAsync(
                 $"unset ASPIRE_PLAYGROUND && unset Azure__Location && " +
-                $"export AZURE__LOCATION=centralus && " +
+                $"export AZURE__LOCATION=westus3 && " +
                 $"export AZURE__RESOURCEGROUP={resourceGroupName} && " +
                 $"export Parameters__acmeemail={acmeEmail}");
             await auto.EnterAsync();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentCertManagerTypeScriptDeploymentTests.cs
@@ -148,8 +148,8 @@ const albSubnet = await vnet.addSubnet("alb-public", "10.100.4.0/24");
 
 const aks = await builder.addAzureKubernetesEnvironment("aks");
 await aks.withSubnet(aksSubnet);
-await aks.withSystemNodePool({ vmSize: "Standard_D2s_v5" });
-await aks.addNodePool("workload", { vmSize: "Standard_D2s_v5", minCount: 1, maxCount: 3 });
+await aks.withSystemNodePool({ vmSize: "Standard_D2as_v5" });
+await aks.addNodePool("workload", { vmSize: "Standard_D2as_v5", minCount: 1, maxCount: 3 });
 
 const publicLb = await aks.addLoadBalancer("public", albSubnet);
 
@@ -198,7 +198,7 @@ await builder.build().run();
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
             await auto.TypeAsync(
                 $"unset ASPIRE_PLAYGROUND && unset Azure__Location && " +
-                $"export AZURE__LOCATION=centralus && " +
+                $"export AZURE__LOCATION=westus3 && " +
                 $"export AZURE__RESOURCEGROUP={resourceGroupName} && " +
                 $"export Parameters__acmeemail={acmeEmail}");
             await auto.EnterAsync();

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentGatewayDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksAzureKubernetesEnvironmentGatewayDeploymentTests.cs
@@ -114,7 +114,7 @@ public sealed class AksAzureKubernetesEnvironmentGatewayDeploymentTests(ITestOut
             var content = File.ReadAllText(appHostFilePath);
 
             // Inject the AGC ingress profile + ApplicationLoadBalancer + Gateway/HTTPRoute pieces
-            // before builder.Build().Run();. Use Standard_D2s_v5 to match the other AKS deployment
+            // before builder.Build().Run();. Use Standard_D2as_v5 to match the other AKS deployment
             // tests' SKU/region quota story.
             const string buildRunPattern = "builder.Build().Run();";
             const string replacement = """
@@ -128,8 +128,8 @@ var albSubnet = vnet.AddSubnet("alb-public", "10.100.4.0/24");
 
 var aks = builder.AddAzureKubernetesEnvironment("aks")
     .WithSubnet(aksSubnet)
-    .WithSystemNodePool("Standard_D2s_v5");
-aks.AddNodePool("workload", "Standard_D2s_v5", minCount: 1, maxCount: 3);
+    .WithSystemNodePool("Standard_D2as_v5");
+aks.AddNodePool("workload", "Standard_D2as_v5", minCount: 1, maxCount: 3);
 
 // AddLoadBalancer creates the AGC ApplicationLoadBalancer CR, delegates the frontend subnet
 // to Microsoft.ServiceNetworking, and ensures the AGC managed identity gets
@@ -180,13 +180,13 @@ builder.Build().Run();
 
             // Step 8: Set environment variables for deployment.
             // - Unset ASPIRE_PLAYGROUND to avoid conflicts.
-            // - Set Azure location to centralus (where we have Standard_D2s_v5 capacity, matching
+            // - Set Azure location to westus3 (where we have Standard_D2as_v5 capacity, matching
             //   the rest of the AKS deployment tests).
             // - Set AZURE__RESOURCEGROUP to use our unique resource group name so the finally
             //   block can clean it up.
             // Unset the job-level Azure__Location=westus3 the CI workflow injects: on Linux it coexists
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
-            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=centralus && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksBlazorRedisDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksBlazorRedisDeploymentTests.cs
@@ -104,13 +104,13 @@ public sealed class AksBlazorRedisDeploymentTests(ITestOutputHelper output)
             var content = File.ReadAllText(appHostFilePath);
 
             // Insert the Azure Kubernetes Environment before builder.Build().Run();
-            // Use DASv4 VM SKUs for both system and user pools.
+            // Use DASv5 VM SKUs for both system and user pools.
             var buildRunPattern = "builder.Build().Run();";
             var replacement = """
-// Add Azure Kubernetes Environment for deployment with DASv4 SKUs
+// Add Azure Kubernetes Environment for deployment with DASv5 SKUs
 var aks = builder.AddAzureKubernetesEnvironment("aks")
-    .WithSystemNodePool("Standard_D2as_v4");
-aks.AddNodePool("workload", "Standard_D2as_v4", 1, 3);
+    .WithSystemNodePool("Standard_D2as_v5");
+aks.AddNodePool("workload", "Standard_D2as_v5", 1, 3);
 
 builder.Build().Run();
 """;
@@ -130,9 +130,9 @@ builder.Build().Run();
             // - Unset ASPIRE_PLAYGROUND to avoid conflicts
             // - Unset the job-level Azure__Location=westus3 the CI workflow injects: on Linux it coexists
             //   with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead
-            // - Set Azure location to Australia East (DASv4 SKU availability)
+            // - Set Azure location to West US 3 (DASv5 SKU availability)
             // - Set AZURE__RESOURCEGROUP to use our unique resource group name
-            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=australiaeast && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksMultipleNodePoolsDeploymentTests.cs
@@ -115,9 +115,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 // AKS environment with multiple node pools
 var aks = builder.AddAzureKubernetesEnvironment("aks")
-    .WithSystemNodePool("Standard_D2s_v5", minCount: 1, maxCount: 2);
+    .WithSystemNodePool("Standard_D2as_v5", minCount: 1, maxCount: 2);
 
-var workerPool = aks.AddNodePool("workers", "Standard_D2s_v5", 1, 3);
+var workerPool = aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3);
 """);
 
             // Pin apiservice to the worker node pool
@@ -138,7 +138,7 @@ var workerPool = aks.AddNodePool("workers", "Standard_D2s_v5", 1, 3);
             // Step 8: Set environment variables for deployment
             // Unset the job-level Azure__Location=westus3 the CI workflow injects: on Linux it coexists
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
-            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=centralus && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -94,7 +94,7 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
 
             // Step 3: Create resource group
             output.WriteLine("Step 3: Creating resource group...");
-            await auto.TypeAsync($"az group create --name {resourceGroupName} --location centralus --output table");
+            await auto.TypeAsync($"az group create --name {resourceGroupName} --location westus3 --output table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
@@ -113,13 +113,13 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
             // Step 5: Create AKS cluster with ACR attached
-            // Using minimal configuration: 1 node, Standard_D2s_v5 (widely available with quota)
+            // Using minimal configuration: 1 node, Standard_D2as_v5 (widely available with quota)
             output.WriteLine("Step 5: Creating AKS cluster (this may take 10-15 minutes)...");
             await auto.TypeAsync($"az aks create " +
                   $"--resource-group {resourceGroupName} " +
                   $"--name {clusterName} " +
                   $"--node-count 1 " +
-                  $"--node-vm-size Standard_D2s_v5 " +
+                  $"--node-vm-size Standard_D2as_v5 " +
                   $"--generate-ssh-keys " +
                   $"--attach-acr {acrName} " +
                   $"--enable-managed-identity " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -123,8 +123,7 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
                   $"--generate-ssh-keys " +
                   $"--attach-acr {acrName} " +
                   $"--enable-managed-identity " +
-                  $"--output table " +
-                  $"--debug");
+                  $"--output table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(20));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterDeploymentTests.cs
@@ -123,7 +123,8 @@ public sealed class AksStarterDeploymentTests(ITestOutputHelper output)
                   $"--generate-ssh-keys " +
                   $"--attach-acr {acrName} " +
                   $"--enable-managed-identity " +
-                  $"--output table");
+                  $"--output table " +
+                  $"--debug");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(20));
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisHelmDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksStarterWithRedisHelmDeploymentTests.cs
@@ -96,7 +96,7 @@ public sealed class AksStarterWithRedisHelmDeploymentTests(ITestOutputHelper out
 
             // Step 3: Create resource group
             output.WriteLine("Step 3: Creating resource group...");
-            await auto.TypeAsync($"az group create --name {resourceGroupName} --location centralus --output table");
+            await auto.TypeAsync($"az group create --name {resourceGroupName} --location westus3 --output table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
@@ -120,7 +120,7 @@ public sealed class AksStarterWithRedisHelmDeploymentTests(ITestOutputHelper out
                   $"--resource-group {resourceGroupName} " +
                   $"--name {clusterName} " +
                   $"--node-count 1 " +
-                  $"--node-vm-size Standard_D2s_v5 " +
+                  $"--node-vm-size Standard_D2as_v5 " +
                   $"--generate-ssh-keys " +
                   $"--attach-acr {acrName} " +
                   $"--enable-managed-identity " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetInfraDeploymentTests.cs
@@ -106,10 +106,10 @@ var workerSubnet = vnet.AddSubnet("worker-subnet", "10.1.4.0/22");
 
 // AKS environment with VNet integration and per-pool subnets
 var aks = builder.AddAzureKubernetesEnvironment("aks")
-    .WithSystemNodePool("Standard_D2s_v5")
+    .WithSystemNodePool("Standard_D2as_v5")
     .WithSubnet(systemSubnet);
 
-aks.AddNodePool("workers", "Standard_D2s_v5", 1, 3)
+aks.AddNodePool("workers", "Standard_D2as_v5", 1, 3)
     .WithSubnet(workerSubnet);
 
 #pragma warning restore ASPIREAZURE003
@@ -127,7 +127,7 @@ builder.Build().Run();
             // Step 7: Set environment variables for deployment
             // Unset the job-level Azure__Location=westus3 the CI workflow injects: on Linux it coexists
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
-            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=centralus && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksVnetWithAzureResourcesDeploymentTests.cs
@@ -144,10 +144,10 @@ var peSubnet = vnet.AddSubnet("pe-subnet", "10.1.4.0/24");
 
 // AKS environment with VNet integration
 var aks = builder.AddAzureKubernetesEnvironment("aks")
-    .WithSystemNodePool("Standard_D2s_v5")
+    .WithSystemNodePool("Standard_D2as_v5")
     .WithSubnet(aksSubnet);
 
-var workerPool = aks.AddNodePool("workload", "Standard_D2s_v5", 1, 3);
+var workerPool = aks.AddNodePool("workload", "Standard_D2as_v5", 1, 3);
 
 // Azure resources with Private Endpoint
 var vault = builder.AddAzureKeyVault("vault");
@@ -226,7 +226,7 @@ app.Run();
             output.WriteLine("Step 10: Setting environment variables...");
             // Unset the job-level Azure__Location=westus3 the CI workflow injects: on Linux it coexists
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
-            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=centralus && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksWithAzureResourcesDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksWithAzureResourcesDeploymentTests.cs
@@ -135,10 +135,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 #pragma warning disable ASPIREAZURE003
 
-// AKS environment with DSv5 SKUs
+// AKS environment with DASv5 SKUs
 var aks = builder.AddAzureKubernetesEnvironment("aks")
-    .WithSystemNodePool("Standard_D2s_v5");
-aks.AddNodePool("workload", "Standard_D2s_v5", 1, 3);
+    .WithSystemNodePool("Standard_D2as_v5");
+aks.AddNodePool("workload", "Standard_D2as_v5", 1, 3);
 
 // Azure resources co-deployed alongside AKS
 var vault = builder.AddAzureKeyVault("vault");
@@ -214,7 +214,7 @@ app.Run();
             // Step 10: Set environment variables for deployment
             // Unset the job-level Azure__Location=westus3 the CI workflow injects: on Linux it coexists
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
-            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=centralus && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AksWithHelmChartDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AksWithHelmChartDeploymentTests.cs
@@ -115,11 +115,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 #pragma warning disable ASPIREAZURE003
 
 // AKS environment provisioned by Aspire (Azure Kubernetes Service).
-// Pin both the system and workload pools to a Standard_D2s_v5 SKU; the default pool SKUs
-// routinely hit vCPU quota, so we standardize on StandardDSv5Family, where we hold quota.
+// Pin both the system and workload pools to a Standard_D2as_v5 SKU; the default pool SKUs
+// routinely hit vCPU quota, so we standardize on StandardDASv5Family, where we hold quota.
 var aks = builder.AddAzureKubernetesEnvironment("aks")
-    .WithSystemNodePool("Standard_D2s_v5");
-aks.AddNodePool("workload", "Standard_D2s_v5", 1, 3);
+    .WithSystemNodePool("Standard_D2as_v5");
+aks.AddNodePool("workload", "Standard_D2as_v5", 1, 3);
 
 // Install podinfo as an external Helm chart and opt in to destroy-time uninstall.
 aks.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1")
@@ -145,7 +145,7 @@ aks.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1"
             // Step 8: Set env vars for deployment
             // Unset the job-level Azure__Location=westus3 the CI workflow injects: on Linux it coexists
             // with AZURE__LOCATION (case-sensitive env) and .NET config may bind the inherited westus3 instead.
-            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=centralus && export AZURE__RESOURCEGROUP={resourceGroupName}");
+            await auto.TypeAsync($"unset ASPIRE_PLAYGROUND && unset Azure__Location && export AZURE__LOCATION=westus3 && export AZURE__RESOURCEGROUP={resourceGroupName}");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter);
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/AzureResourceScopeDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/AzureResourceScopeDeploymentTests.cs
@@ -15,6 +15,7 @@ public sealed class AzureResourceScopeDeploymentTests(ITestOutputHelper output)
     private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(40);
 
     [Fact]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/19173")]
     public async Task DeployExistingServiceBusWithResourceGroupAndSubscriptionScope()
     {
         using var cts = new CancellationTokenSource(s_testTimeout);

--- a/tests/Aspire.Deployment.EndToEnd.Tests/FrontDoorDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/FrontDoorDeploymentTests.cs
@@ -151,17 +151,17 @@ builder.Build().Run();
             await auto.WaitUntilTextAsync(ConsoleActivityLoggerStrings.PipelineSucceeded, timeout: TimeSpan.FromMinutes(30));
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
-            // Step 10: Verify endpoints (skip Front Door endpoint checks — DNS propagation takes 5-15 minutes)
-            output.WriteLine("Step 10: Verifying deployed endpoints...");
+            // Front Door provisioning is covered by the successful deployment above. Do not query it
+            // through `az afd` here: recent Azure CLI versions dynamically install the `cdn` extension,
+            // which can block this interactive terminal waiting for installation confirmation. Front Door
+            // HTTP checks are also intentionally skipped because DNS propagation can take 5-15 minutes.
+            output.WriteLine("Step 10: Verifying deployed ACA endpoints...");
             await auto.TypeAsync($"RG_NAME=\"{resourceGroupName}\" && " +
                   "echo \"Resource group: $RG_NAME\" && " +
                   "if ! az group show -n \"$RG_NAME\" &>/dev/null; then echo \"❌ Resource group not found\"; exit 1; fi && " +
                   // Check ACA endpoints (exclude internal endpoints)
                   "urls=$(az containerapp list -g \"$RG_NAME\" --query \"[].properties.configuration.ingress.fqdn\" -o tsv 2>/dev/null | grep -v '\\.internal\\.') && " +
                   "if [ -z \"$urls\" ]; then echo \"❌ No external container app endpoints found\"; exit 1; fi && " +
-                  // Check Front Door endpoints
-                  "fdurls=$(az afd endpoint list -g \"$RG_NAME\" --profile-name $(az afd profile list -g \"$RG_NAME\" --query \"[0].name\" -o tsv 2>/dev/null) --query \"[].hostName\" -o tsv 2>/dev/null) && " +
-                  "echo \"Front Door endpoints: $fdurls\" && " +
                   "failed=0 && " +
                   // Share a single deadline across every endpoint (see the rationale comment below the
                   // command) so the whole loop stays bounded no matter how many endpoints are returned.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesGatewayTlsDeploymentTests.cs
@@ -114,7 +114,7 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
 
             // Create resource group
             output.WriteLine("Step 3: Creating resource group...");
-            await auto.TypeAsync($"az group create --name {resourceGroupName} --location centralus --output table");
+            await auto.TypeAsync($"az group create --name {resourceGroupName} --location westus3 --output table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
@@ -136,9 +136,9 @@ public sealed class KubernetesGatewayTlsDeploymentTests(ITestOutputHelper output
                 $"az aks create " +
                 $"--resource-group {resourceGroupName} " +
                 $"--name {clusterName} " +
-                $"--location centralus " +
+                $"--location westus3 " +
                 $"--node-count 1 " +
-                $"--node-vm-size Standard_D2s_v5 " +
+                $"--node-vm-size Standard_D2as_v5 " +
                 $"--network-plugin azure " +
                 $"--generate-ssh-keys " +
                 $"--attach-acr {acrName} " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesHelmChartDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/KubernetesHelmChartDeploymentTests.cs
@@ -93,7 +93,7 @@ public sealed class KubernetesHelmChartDeploymentTests(ITestOutputHelper output)
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
 
             output.WriteLine("Step 3: Creating resource group...");
-            await auto.TypeAsync($"az group create --name {resourceGroupName} --location centralus --output table");
+            await auto.TypeAsync($"az group create --name {resourceGroupName} --location westus3 --output table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
@@ -112,7 +112,7 @@ public sealed class KubernetesHelmChartDeploymentTests(ITestOutputHelper output)
                 $"--resource-group {resourceGroupName} " +
                 $"--name {clusterName} " +
                 $"--node-count 1 " +
-                $"--node-vm-size Standard_D2s_v5 " +
+                $"--node-vm-size Standard_D2as_v5 " +
                 $"--generate-ssh-keys " +
                 $"--attach-acr {acrName} " +
                 $"--enable-managed-identity " +

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -15,7 +15,7 @@ The deployment tests require an Azure subscription with sufficient quota for the
 | Resource | Quota Required | Current Setting | Notes |
 |----------|---------------|-----------------|-------|
 | Managed Environments | 150+ | 150 | Each test run creates a new environment. High quota allows concurrent runs and handles cleanup delays. |
-| Standard Public IP Addresses (`Microsoft.Network`) | 150+ | 20 | Public Container Apps environments consume this regional quota. The workflow requests 150 in `westus3`. |
+| Standard Public IP Addresses (`Microsoft.Network`) | 150+ | 20 | Public Container Apps environments consume this regional quota. Request manually in `westus3`; Microsoft.Quota exposes the limit but rejects CLI create/update requests. |
 | Container App Instances | Default | - | Standard quota is typically sufficient |
 
 ### App Service

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -15,7 +15,7 @@ The deployment tests require an Azure subscription with sufficient quota for the
 | Resource | Quota Required | Current Setting | Notes |
 |----------|---------------|-----------------|-------|
 | Managed Environments | 150+ | 150 | Each test run creates a new environment. High quota allows concurrent runs and handles cleanup delays. |
-| Managed Environment Public IPs | 150+ | 150 | Public Container Apps environments consume this regional quota. Self-healed by the workflow in `westus3`. |
+| Standard Public IP Addresses (`Microsoft.Network`) | 150+ | 150 | Public Container Apps environments consume this regional quota. Self-healed by the workflow in `westus3`. |
 | Container App Instances | Default | - | Standard quota is typically sufficient |
 
 ### App Service
@@ -68,7 +68,7 @@ To request quota increases:
 
 Common quota increase requests:
 - **Container Apps Managed Environments**: Request 150+ in westus3
-- **Container Apps Managed Environment Public IPs**: Request 150+ in westus3
+- **Standard Public IP Addresses**: Request 150+ in westus3
 - **App Service PremiumV3 vCPUs**: Request 10+ in westus3
 - **AKS `StandardDASv5Family` vCPUs**: Request 200 (dedicated) in westus3
 - **AKS Managed Clusters**: Request 20 in westus3

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -8,14 +8,14 @@ These tests use the [Hex1b](https://github.com/hex1b/hex1b) terminal automation 
 
 ## Azure Subscription Quota Requirements
 
-The deployment tests require an Azure subscription with sufficient quota for the resources being deployed. Most scenarios, including the AKS (Azure Kubernetes Service) scenarios, deploy to `westus3`; a resource-specific test uses `eastus`. Ensure the quotas below are available in the region noted for each section.
+The deployment tests require an Azure subscription with sufficient quota for the resources being deployed. Most scenarios, including the AKS (Azure Kubernetes Service) scenarios, deploy to `westus3`; a resource-specific test uses `eastus2`. Ensure the quotas below are available in the region noted for each section.
 
 ### Container Apps
 
 | Resource | Quota Required | Current Setting | Notes |
 |----------|---------------|-----------------|-------|
 | Managed Environments | 150+ | 150 | Each test run creates a new environment. High quota allows concurrent runs and handles cleanup delays. |
-| Standard Public IP Addresses (`Microsoft.Network`) | 150+ | 20 | Public Container Apps environments consume this regional quota. Request manually in `westus3`; Microsoft.Quota exposes the limit but rejects CLI create/update requests. |
+| Standard Public IP Addresses (`Microsoft.Network`) | 150+ | 50 | Public Container Apps environments consume this regional quota. Request manually in `westus3`; Microsoft.Quota exposes the limit but rejects CLI create/update requests. |
 | Container App Instances | Default | - | Standard quota is typically sufficient |
 
 ### App Service
@@ -37,7 +37,7 @@ The AKS scenarios deploy to `westus3`, where the subscription holds `Standard_D2
 
 One test intentionally uses another region for a resource-specific requirement:
 
-- `AcaManagedRedisDeploymentTests` → `eastus` (Azure Managed Redis availability-zone support).
+- `AcaManagedRedisDeploymentTests` → `eastus2` (Azure Managed Redis availability-zone support).
 
 ### Container Registry
 

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -15,6 +15,7 @@ The deployment tests require an Azure subscription with sufficient quota for the
 | Resource | Quota Required | Current Setting | Notes |
 |----------|---------------|-----------------|-------|
 | Managed Environments | 150+ | 150 | Each test run creates a new environment. High quota allows concurrent runs and handles cleanup delays. |
+| Managed Environment Public IPs | 150+ | 150 | Public Container Apps environments consume this regional quota. Self-healed by the workflow in `westus3`. |
 | Container App Instances | Default | - | Standard quota is typically sufficient |
 
 ### App Service
@@ -67,6 +68,7 @@ To request quota increases:
 
 Common quota increase requests:
 - **Container Apps Managed Environments**: Request 150+ in westus3
+- **Container Apps Managed Environment Public IPs**: Request 150+ in westus3
 - **App Service PremiumV3 vCPUs**: Request 10+ in westus3
 - **AKS `StandardDASv5Family` vCPUs**: Request 200 (dedicated) in westus3
 - **AKS Managed Clusters**: Request 20 in westus3

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -15,7 +15,7 @@ The deployment tests require an Azure subscription with sufficient quota for the
 | Resource | Quota Required | Current Setting | Notes |
 |----------|---------------|-----------------|-------|
 | Managed Environments | 150+ | 150 | Each test run creates a new environment. High quota allows concurrent runs and handles cleanup delays. |
-| Standard Public IP Addresses (`Microsoft.Network`) | 150+ | 150 | Public Container Apps environments consume this regional quota. Self-healed by the workflow in `westus3`. |
+| Standard Public IP Addresses (`Microsoft.Network`) | 150+ | 20 | Public Container Apps environments consume this regional quota. The workflow requests 150 in `westus3`. |
 | Container App Instances | Default | - | Standard quota is typically sufficient |
 
 ### App Service

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -8,7 +8,7 @@ These tests use the [Hex1b](https://github.com/hex1b/hex1b) terminal automation 
 
 ## Azure Subscription Quota Requirements
 
-The deployment tests require an Azure subscription with sufficient quota for the resources being deployed. Most scenarios deploy to `westus3`, but the AKS (Azure Kubernetes Service) scenarios deploy to `centralus`, and a couple of resource-specific tests use other regions (`australiaeast`, `eastus`). Ensure the quotas below are available in the region noted for each section.
+The deployment tests require an Azure subscription with sufficient quota for the resources being deployed. Most scenarios, including the AKS (Azure Kubernetes Service) scenarios, deploy to `westus3`; a resource-specific test uses `eastus`. Ensure the quotas below are available in the region noted for each section.
 
 ### Container Apps
 
@@ -26,17 +26,16 @@ The deployment tests require an Azure subscription with sufficient quota for the
 
 ### AKS / Kubernetes node pools
 
-The AKS scenarios deploy to `centralus`, where the subscription holds `Standard_D2s_v5` (DSv5) capacity. The CI workflow's quota self-healing (`QUOTA_TARGETS` in `.github/workflows/deployment-tests.yml`) requests the compute vCPU quotas automatically; the managed-cluster count is not exposed by the Microsoft.Quota API and must be raised manually if the default is ever insufficient:
+The AKS scenarios deploy to `westus3`, where the subscription holds `Standard_D2as_v5` (DASv5) capacity. The CI workflow's quota self-healing (`QUOTA_TARGETS` in `.github/workflows/deployment-tests.yml`) requests the compute vCPU quotas automatically; the managed-cluster count is not exposed by the Microsoft.Quota API and must be raised manually if the default is ever insufficient:
 
 | Resource | Region | Quota Required | Notes |
 |----------|--------|----------------|-------|
-| `StandardDSv5Family` vCPUs (`Microsoft.Compute`) | `centralus` | 200 (dedicated) | System and workload node pools use `Standard_D2s_v5`. Self-healed by the workflow. |
-| Total Regional vCPUs (`Microsoft.Compute`, `cores`) | `centralus` | 200 (dedicated) | Azure enforces this regional total independently of the family quota, so node pools need headroom in both. Self-healed by the workflow. |
-| Managed Clusters (`Microsoft.ContainerService`) | `centralus` | 20 | Each AKS test creates a cluster; headroom covers concurrent runs and cleanup lag. Not exposed by the Microsoft.Quota API — request via the Azure Portal/support if the default is insufficient. |
+| `StandardDASv5Family` vCPUs (`Microsoft.Compute`) | `westus3` | 200 (dedicated) | System and workload node pools use `Standard_D2as_v5`. Self-healed by the workflow. |
+| Total Regional vCPUs (`Microsoft.Compute`, `cores`) | `westus3` | 200 (dedicated) | Azure enforces this regional total independently of the family quota, so node pools need headroom in both. Self-healed by the workflow. |
+| Managed Clusters (`Microsoft.ContainerService`) | `westus3` | 20 | Each AKS test creates a cluster; headroom covers concurrent runs and cleanup lag. Not exposed by the Microsoft.Quota API — request via the Azure Portal/support if the default is insufficient. |
 
-A few tests intentionally use other regions for capacity or feature reasons:
+One test intentionally uses another region for a resource-specific requirement:
 
-- `AksBlazorRedisDeploymentTests` → `australiaeast` (`Standard_D2as_v4` / DASv4 family).
 - `AcaManagedRedisDeploymentTests` → `eastus` (Azure Managed Redis availability-zone support).
 
 ### Container Registry
@@ -69,8 +68,8 @@ To request quota increases:
 Common quota increase requests:
 - **Container Apps Managed Environments**: Request 150+ in westus3
 - **App Service PremiumV3 vCPUs**: Request 10+ in westus3
-- **AKS `StandardDSv5Family` vCPUs**: Request 200 (dedicated) in centralus
-- **AKS Managed Clusters**: Request 20 in centralus
+- **AKS `StandardDASv5Family` vCPUs**: Request 200 (dedicated) in westus3
+- **AKS Managed Clusters**: Request 20 in westus3
 
 ## Prerequisites
 
@@ -354,6 +353,6 @@ The test Azure tenant/subscription rotates approximately every 90 days per polic
 3. Grant Owner role on subscription (constrained - cannot create other Owner identities)
 4. Update GitHub secrets: `AZURE_DEPLOYMENT_TEST_CLIENT_ID`, `AZURE_DEPLOYMENT_TEST_TENANT_ID`
 5. Update GitHub variable: `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID`
-6. Ensure regional quotas per [Azure Subscription Quota Requirements](#azure-subscription-quota-requirements): Container Apps and App Service in `westus3`, and AKS in `centralus` (`StandardDSv5Family` vCPUs, Total Regional vCPUs, and managed clusters). The CI workflow self-heals the compute vCPU quotas (family and regional total); the managed-cluster count is not covered by the Microsoft.Quota API, so a new subscription may still need a manual portal/support request.
+6. Ensure regional quotas per [Azure Subscription Quota Requirements](#azure-subscription-quota-requirements): Container Apps, App Service, and AKS in `westus3` (`StandardDASv5Family` vCPUs, Total Regional vCPUs, and managed clusters). The CI workflow self-heals the compute vCPU quotas (family and regional total); the managed-cluster count is not covered by the Microsoft.Quota API, so a new subscription may still need a manual portal/support request.
 
 See [Deployment Testing Documentation](../../docs/deployment-testing.md) for detailed rotation procedures.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/README.md
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/README.md
@@ -26,13 +26,13 @@ The deployment tests require an Azure subscription with sufficient quota for the
 
 ### AKS / Kubernetes node pools
 
-The AKS scenarios deploy to `westus3`, where the subscription holds `Standard_D2as_v5` (DASv5) capacity. The CI workflow's quota self-healing (`QUOTA_TARGETS` in `.github/workflows/deployment-tests.yml`) requests the compute vCPU quotas automatically; the managed-cluster count is not exposed by the Microsoft.Quota API and must be raised manually if the default is ever insufficient:
+The AKS scenarios deploy to `westus3`, where the subscription holds `Standard_D2as_v5` (DASv5) capacity. The CI workflow's quota self-healing (`QUOTA_TARGETS` in `.github/workflows/deployment-tests.yml`) requests the compute vCPU and managed-cluster quotas automatically:
 
 | Resource | Region | Quota Required | Notes |
 |----------|--------|----------------|-------|
 | `StandardDASv5Family` vCPUs (`Microsoft.Compute`) | `westus3` | 200 (dedicated) | System and workload node pools use `Standard_D2as_v5`. Self-healed by the workflow. |
 | Total Regional vCPUs (`Microsoft.Compute`, `cores`) | `westus3` | 200 (dedicated) | Azure enforces this regional total independently of the family quota, so node pools need headroom in both. Self-healed by the workflow. |
-| Managed Clusters (`Microsoft.ContainerService`) | `westus3` | 20 | Each AKS test creates a cluster; headroom covers concurrent runs and cleanup lag. Not exposed by the Microsoft.Quota API — request via the Azure Portal/support if the default is insufficient. |
+| Managed Clusters (`Microsoft.ContainerService`) | `westus3` | 20 | Each AKS test creates a cluster; headroom covers concurrent runs and cleanup lag. Self-healed by the workflow. |
 
 One test intentionally uses another region for a resource-specific requirement:
 
@@ -353,6 +353,6 @@ The test Azure tenant/subscription rotates approximately every 90 days per polic
 3. Grant Owner role on subscription (constrained - cannot create other Owner identities)
 4. Update GitHub secrets: `AZURE_DEPLOYMENT_TEST_CLIENT_ID`, `AZURE_DEPLOYMENT_TEST_TENANT_ID`
 5. Update GitHub variable: `AZURE_DEPLOYMENT_TEST_SUBSCRIPTION_ID`
-6. Ensure regional quotas per [Azure Subscription Quota Requirements](#azure-subscription-quota-requirements): Container Apps, App Service, and AKS in `westus3` (`StandardDASv5Family` vCPUs, Total Regional vCPUs, and managed clusters). The CI workflow self-heals the compute vCPU quotas (family and regional total); the managed-cluster count is not covered by the Microsoft.Quota API, so a new subscription may still need a manual portal/support request.
+6. Ensure regional quotas per [Azure Subscription Quota Requirements](#azure-subscription-quota-requirements): Container Apps, App Service, and AKS in `westus3` (`StandardDASv5Family` vCPUs, Total Regional vCPUs, and managed clusters). The CI workflow self-heals all three AKS quotas.
 
 See [Deployment Testing Documentation](../../docs/deployment-testing.md) for detailed rotation procedures.

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -212,7 +212,7 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(5));
 
             output.WriteLine("Step 3: Creating resource group...");
-            await auto.TypeAsync($"az group create --name {resourceGroupName} --location centralus --output table");
+            await auto.TypeAsync($"az group create --name {resourceGroupName} --location westus3 --output table");
             await auto.EnterAsync();
             await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromSeconds(60));
 
@@ -235,7 +235,7 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
                   $"--resource-group {resourceGroupName} " +
                   $"--name {clusterName} " +
                   $"--node-count 1 " +
-                  $"--node-vm-size Standard_D2s_v5 " +
+                  $"--node-vm-size Standard_D2as_v5 " +
                   // The test never SSHes into the nodes, so configure no SSH key at all. This avoids
                   // `--generate-ssh-keys`, which would write ~/.ssh/id_rsa[.pub] on a local run and
                   // mutate the developer's SSH state (the test isolates kube/rad/docker config in

--- a/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
+++ b/tests/Aspire.Deployment.EndToEnd.Tests/RadiusStarterDeploymentTests.cs
@@ -30,6 +30,7 @@ public sealed class RadiusStarterDeploymentTests(ITestOutputHelper output)
     private static readonly TimeSpan s_testTimeout = TimeSpan.FromMinutes(55);
 
     [Fact]
+    [ActiveIssue("https://github.com/microsoft/aspire/issues/19172")]
     public async Task DeployStarterTemplateToRadiusOnAks()
     {
         using var cts = new CancellationTokenSource(s_testTimeout);


### PR DESCRIPTION
## Description

Stabilizes the Azure deployment E2E matrix after exercising the subscription's current quota and regional capacity limits:

- Moves all AKS-backed scenarios to `Standard_D2as_v5` in `westus3`.
- Registers `Microsoft.OperationsManagement` and makes provider checks case-insensitive.
- Self-heals the `StandardDASv5Family`, Total Regional vCPU, and Managed Clusters quotas before the matrix runs.
- Documents the manually managed Standard Public IP quota and its current limit of 50 in `westus3`.
- Removes an unused `az afd` lookup that could block on the Azure CLI CDN extension prompt after Front Door provisioning succeeded.
- Moves the Azure Managed Redis scenario from `eastus` to `eastus2` after the Balanced B0 SKU returned `InsufficientCapacity` in East US.
- Temporarily disables three unrelated failures with issue-linked `ActiveIssue` attributes:
  - #19172 — Radius deployment succeeds, but the Redis-backed diagnostics endpoint returns HTTP 500.
  - #19173 — Azure CLI 2.88.0/Python 3.14 deadlocks while importing `requests.structures` during Service Bus setup.
  - #19174 — Azure Managed Redis provisioning is flaky because regional Balanced B0 capacity is intermittently unavailable.

The earlier AKS service-side `BadRequest` blocker is resolved. The disabled tests should be re-enabled when their linked issues are fixed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No