### PR TITLE
Export Dotnet Blazor gateway APIs to polyglot AppHosts

### DIFF
--- a/.github/workflows/polyglot-validation/test-python-playground.sh
+++ b/.github/workflows/polyglot-validation/test-python-playground.sh
@@ -2,7 +2,7 @@
 # Polyglot SDK Validation - Python validation AppHosts
 # Iterates all Python validation AppHosts under tests/PolyglotAppHosts/*/Python,
 # runs 'aspire restore --apphost' to regenerate the per-integration .aspire/modules/ SDK, and
-# compiles each AppHost with the generated Python modules to verify syntax.
+# verifies syntax plus any fixture-owned generated SDK API assertions.
 set -euo pipefail
 
 echo "=== Python Validation AppHost Codegen Validation ==="
@@ -50,6 +50,58 @@ echo ""
 
 FAILED=()
 PASSED=()
+CHANNEL_SETTINGS_PATH=""
+CHANNEL_SETTINGS_BACKUP=""
+
+restore_channel_settings() {
+    if [ -z "$CHANNEL_SETTINGS_PATH" ]; then
+        return
+    fi
+
+    if [ -n "$CHANNEL_SETTINGS_BACKUP" ]; then
+        cp "$CHANNEL_SETTINGS_BACKUP" "$CHANNEL_SETTINGS_PATH"
+        rm -f "$CHANNEL_SETTINGS_BACKUP"
+    else
+        rm -f "$CHANNEL_SETTINGS_PATH"
+    fi
+
+    CHANNEL_SETTINGS_PATH=""
+    CHANNEL_SETTINGS_BACKUP=""
+}
+
+pin_validation_channel() {
+    if [ -z "${ASPIRE_CLI_CHANNEL:-}" ]; then
+        return
+    fi
+
+    local settings_path="$PWD/.aspire/settings.json"
+    local settings_backup=""
+    mkdir -p "$(dirname "$settings_path")"
+
+    if [ -f "$settings_path" ]; then
+        settings_backup="$(mktemp)"
+        cp "$settings_path" "$settings_backup"
+    fi
+
+    CHANNEL_SETTINGS_PATH="$settings_path"
+    CHANNEL_SETTINGS_BACKUP="$settings_backup"
+
+    # Validation jobs install the current build into a local hive. Pin the requested
+    # project channel so package restore uses that exact hive instead of accepting a
+    # newer package version from an ambient daily feed.
+    python3 - "$settings_path" "$ASPIRE_CLI_CHANNEL" <<'INNERPY'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+settings = json.loads(settings_path.read_text(encoding='utf-8')) if settings_path.exists() else {}
+settings['channel'] = sys.argv[2]
+settings_path.write_text(json.dumps(settings, indent=2) + '\n', encoding='utf-8')
+INNERPY
+}
+
+trap restore_channel_settings EXIT
 
 for app_dir in "${APP_DIRS[@]}"; do
     integration_name="$(basename "$(dirname "$app_dir")")"
@@ -59,12 +111,14 @@ for app_dir in "${APP_DIRS[@]}"; do
     echo "----------------------------------------"
 
     cd "$app_dir"
+    pin_validation_channel
 
     echo "  -> aspire restore --apphost apphost.py..."
     if ! aspire restore --non-interactive --apphost apphost.py 2>&1; then
         echo "  ERROR: aspire restore failed for $integration_name"
         FAILED+=("$integration_name (aspire restore)")
         echo ""
+        restore_channel_settings
         continue
     fi
 
@@ -72,6 +126,7 @@ for app_dir in "${APP_DIRS[@]}"; do
         echo "  ERROR: generated .aspire/modules/aspire_app.py missing for $integration_name"
         FAILED+=("$integration_name (missing .aspire/modules/aspire_app.py)")
         echo ""
+        restore_channel_settings
         continue
     fi
 
@@ -80,6 +135,9 @@ for app_dir in "${APP_DIRS[@]}"; do
 from pathlib import Path
 
 files = [Path('apphost.py')]
+validator = Path('validate_generated_sdk.py')
+if validator.exists():
+    files.append(validator)
 files.extend(sorted(Path('.aspire/modules').rglob('*.py')))
 for file in files:
     compile(file.read_text(encoding='utf-8'), str(file), 'exec')
@@ -88,9 +146,22 @@ INNERPY
         echo "  ERROR: python compilation failed for $integration_name"
         FAILED+=("$integration_name (python compile)")
         echo ""
+        restore_channel_settings
         continue
     fi
 
+    if [ -f "validate_generated_sdk.py" ]; then
+        echo "  -> generated SDK API validation..."
+        if ! PYTHONPATH=".aspire/modules" python3 validate_generated_sdk.py; then
+            echo "  ERROR: generated SDK API validation failed for $integration_name"
+            FAILED+=("$integration_name (generated SDK API validation)")
+            echo ""
+            restore_channel_settings
+            continue
+        fi
+    fi
+
+    restore_channel_settings
     echo "  OK: $integration_name passed"
     PASSED+=("$integration_name")
     echo ""

--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -237,12 +237,15 @@ working through the same generalized helpers unchanged.
   `CreatePublishCompanion`, `ForwardEndpointReference`) over a shared constraint so both gateway resource
   types share one implementation. The new variant supports **run mode**; **publish fails fast** because
   `DotnetProjectResource` is not an `IContainerFilesDestinationResource` (the WASM static-asset merge needs it).
-  This lifts once container execution lands for `DotnetProjectResource`.
+  This lifts once container execution lands for `DotnetProjectResource`. The built-in gateway scripts are packed
+  both as `buildTransitive` assets for C# AppHosts and beside the package assembly for polyglot AppHosts, which
+  load integration assemblies directly without running the package's MSBuild targets.
 - Polyglot SDKs: the `addDotnetProject` export is **additive** in `Aspire.Hosting.Dotnet`; core
   `addCSharpApp` is unchanged. The Blazor variant exports `addDotnetProjectBlazorGateway` and exports the
   `DotnetProjectResource` overload with the distinct `withDotnetProjectBlazorClientApp` capability ID while
-  retaining `withBlazorClientApp` as the generated method name on that resource type. `api/*`,
-  `*.Capabilities.txt`, and `*.ats.txt` remain generated artifacts and are not hand-edited.
+  retaining `withBlazorClientApp` as the generated method name on that resource type. Generated APIs compile in
+  TypeScript, Go, Java, and Python; a package-backed TypeScript run verifies the gateway serves an attached Blazor
+  client. `api/*`, `*.Capabilities.txt`, and `*.ats.txt` remain generated artifacts and are not hand-edited.
 
 ---
 
@@ -262,12 +265,12 @@ regenerate polyglot SDKs/api (additive).
 
 **Verify:** builds clean; a service added via `AddDotnetProject` runs
 (no debug) from a C# app host **and** a TS app host with endpoints/env/service discovery; the existing Blazor
-gateway is unchanged, the new variant works in run mode, and the generated Blazor APIs compile from
-TypeScript, Go, Java, and Python AppHosts. *Depends on: none.*
+gateway is unchanged, the new variant serves an attached client from a package-backed TS app host, and the
+generated Blazor APIs compile from TypeScript, Go, Java, and Python AppHosts. *Depends on: none.*
 
 **Status: ✅ Complete** — initial implementation commit `435f5d08`, PR
-[#18442](https://github.com/microsoft/aspire/pull/18442); polyglot exports and validation added in follow-up PR
-[#19026](https://github.com/microsoft/aspire/pull/19026).
+[#18442](https://github.com/microsoft/aspire/pull/18442); polyglot exports, direct package-load assets, and
+validation added in follow-up PR [#19026](https://github.com/microsoft/aspire/pull/19026).
 
 ### Session 1b — `AddDotnetProject` playground sample (early dogfood harness)
 Add a **committed** `playground/` sample (name TBD, e.g. `ProjectV2AppHost`) that models services via
@@ -434,8 +437,9 @@ callbacks may need to run for build/closure even when a resource isn't "running"
   regeneration picks them up in TypeScript, Go, Java, and Python.
 - **R9 — Blazor gateway variant (Session 1).** The new `DotnetProjectResource`-backed gateway shares one
   generalized helper implementation with the unchanged `ProjectResource` gateway; publish on the new variant
-  fails fast until `DotnetProjectResource` gains container-files support. Its exported run-mode APIs must stay
-  covered by the polyglot validation AppHosts.
+  fails fast until `DotnetProjectResource` gains container-files support. Its scripts are available through both
+  C# `buildTransitive` output and direct polyglot package loading. Keep the generated APIs covered in all four
+  validation AppHosts and the run-mode behavior covered by a package-backed TypeScript test.
 - **O1 — Watch signal shape.** ✅ **Resolved (Session 3):** a `RunConfiguration` object with a
   `bool WatchEnabled` property, exposed read-only as `DistributedApplicationExecutionContext.RunConfiguration`.
   Additional run behaviors are added as further properties rather than as mutually exclusive modes.

--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -265,7 +265,9 @@ regenerate polyglot SDKs/api (additive).
 gateway is unchanged, the new variant works in run mode, and the generated Blazor APIs compile from
 TypeScript, Go, Java, and Python AppHosts. *Depends on: none.*
 
-**Status: ✅ Complete** — commit `435f5d08`, PR [#18442](https://github.com/microsoft/aspire/pull/18442).
+**Status: ✅ Complete** — initial implementation commit `435f5d08`, PR
+[#18442](https://github.com/microsoft/aspire/pull/18442); polyglot exports and validation added in follow-up PR
+[#19026](https://github.com/microsoft/aspire/pull/19026).
 
 ### Session 1b — `AddDotnetProject` playground sample (early dogfood harness)
 Add a **committed** `playground/` sample (name TBD, e.g. `ProjectV2AppHost`) that models services via

--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -238,9 +238,11 @@ working through the same generalized helpers unchanged.
   types share one implementation. The new variant supports **run mode**; **publish fails fast** because
   `DotnetProjectResource` is not an `IContainerFilesDestinationResource` (the WASM static-asset merge needs it).
   This lifts once container execution lands for `DotnetProjectResource`.
-- Polyglot SDKs / `api/*` / `*.Capabilities.txt` / `*.ats.txt`: the `addDotnetProject` export is **additive**
-  (new capability in `Aspire.Hosting.Dotnet`); core `addCSharpApp` is unchanged, so core codegen snapshots
-  are unaffected.
+- Polyglot SDKs: the `addDotnetProject` export is **additive** in `Aspire.Hosting.Dotnet`; core
+  `addCSharpApp` is unchanged. The Blazor variant exports `addDotnetProjectBlazorGateway` and exports the
+  `DotnetProjectResource` overload with the distinct `withDotnetProjectBlazorClientApp` capability ID while
+  retaining `withBlazorClientApp` as the generated method name on that resource type. `api/*`,
+  `*.Capabilities.txt`, and `*.ats.txt` remain generated artifacts and are not hand-edited.
 
 ---
 
@@ -260,7 +262,8 @@ regenerate polyglot SDKs/api (additive).
 
 **Verify:** builds clean; a service added via `AddDotnetProject` runs
 (no debug) from a C# app host **and** a TS app host with endpoints/env/service discovery; the existing Blazor
-gateway is unchanged and the new variant works in run mode. *Depends on: none.*
+gateway is unchanged, the new variant works in run mode, and the generated Blazor APIs compile from
+TypeScript, Go, Java, and Python AppHosts. *Depends on: none.*
 
 **Status: ✅ Complete** — commit `435f5d08`, PR [#18442](https://github.com/microsoft/aspire/pull/18442).
 
@@ -422,11 +425,15 @@ callbacks may need to run for build/closure even when a resource isn't "running"
   (POC was Windows-centric); TS-first verification exercises non-Windows.
 - **R7 — `--watch` vs `DefaultWatchEnabled` vs the old `dotnet watch`.** Reconcile UX/strings so the explicit
   flag, the feature flag, and the host-command behavior don't collide (Sessions 7–8).
-- **R8 — New polyglot capability.** `addDotnetProject` is a new capability in `Aspire.Hosting.Dotnet`
-  (additive; core `addCSharpApp` is unchanged); confirm guest SDK regeneration picks it up.
+- **R8 — New polyglot capabilities.** `addDotnetProject` is a new capability in `Aspire.Hosting.Dotnet`
+  (additive; core `addCSharpApp` is unchanged). The Blazor package also adds
+  `addDotnetProjectBlazorGateway` and `withDotnetProjectBlazorClientApp`; the latter keeps
+  `withBlazorClientApp` as its generated method name on `DotnetProjectResource`. Confirm guest SDK
+  regeneration picks them up in TypeScript, Go, Java, and Python.
 - **R9 — Blazor gateway variant (Session 1).** The new `DotnetProjectResource`-backed gateway shares one
   generalized helper implementation with the unchanged `ProjectResource` gateway; publish on the new variant
-  fails fast until `DotnetProjectResource` gains container-files support.
+  fails fast until `DotnetProjectResource` gains container-files support. Its exported run-mode APIs must stay
+  covered by the polyglot validation AppHosts.
 - **O1 — Watch signal shape.** ✅ **Resolved (Session 3):** a `RunConfiguration` object with a
   `bool WatchEnabled` property, exposed read-only as `DistributedApplicationExecutionContext.RunConfiguration`.
   Additional run behaviors are added as further properties rather than as mutually exclusive modes.

--- a/docs/plans/project-v2-csharpprogram-watch.md
+++ b/docs/plans/project-v2-csharpprogram-watch.md
@@ -238,8 +238,8 @@ working through the same generalized helpers unchanged.
   types share one implementation. The new variant supports **run mode**; **publish fails fast** because
   `DotnetProjectResource` is not an `IContainerFilesDestinationResource` (the WASM static-asset merge needs it).
   This lifts once container execution lands for `DotnetProjectResource`. The built-in gateway scripts are packed
-  both as `buildTransitive` assets for C# AppHosts and beside the package assembly for polyglot AppHosts, which
-  load integration assemblies directly without running the package's MSBuild targets.
+  both as `buildTransitive` assets for C# AppHosts and beside the package assembly for package-backed polyglot
+  AppHosts, which load integration assemblies directly without running the package's MSBuild targets.
 - Polyglot SDKs: the `addDotnetProject` export is **additive** in `Aspire.Hosting.Dotnet`; core
   `addCSharpApp` is unchanged. The Blazor variant exports `addDotnetProjectBlazorGateway` and exports the
   `DotnetProjectResource` overload with the distinct `withDotnetProjectBlazorClientApp` capability ID while

--- a/eng/github-ci/test-trigger-map.yml
+++ b/eng/github-ci/test-trigger-map.yml
@@ -168,6 +168,14 @@ path_rules:
     targets: [job:polyglot]
     reason: polyglot fixtures + workflow; the typesystem/SDK/CLI/codegen production projects are in affected_project_rules
   - paths:
+      - src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
+      - src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+      - src/Aspire.Hosting.Blazor/buildTransitive/**
+      - src/Aspire.Hosting.Blazor/Scripts/**
+      - src/Aspire.Hosting.Blazor/targets/**
+    targets: [test:Aspire.Hosting.Tests, test:Aspire.Cli.EndToEnd.Tests, job:polyglot]
+    reason: Blazor gateway runtime assets must work from both MSBuild output and package-loaded polyglot AppHosts
+  - paths:
       - tests/Aspire.Hosting.CodeGeneration.TypeScript.JsTests/**
       - src/Aspire.Cli/Templating/Templates/ts-starter/**
       - .github/workflows/typescript-sdk-tests.yml

--- a/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
+++ b/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
@@ -41,12 +41,16 @@
   </ItemGroup>
 
   <!-- Scripts are file-based C# apps, not part of this library's compilation.
-       They are packed into the NuGet package and copied to the consumer's output
-       directory via a buildTransitive targets file. -->
+       C# AppHosts copy the buildTransitive assets to their output directory. Polyglot
+       AppHosts load this assembly directly from lib/<tfm>, so the same assets must also
+       be available beside the assembly for GetScriptPath(). -->
   <ItemGroup>
     <Compile Remove="Scripts\**" />
     <None Include="Scripts\Gateway.cs.in" />
-    <Content Include="Scripts\PrefixEndpoints.cs" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="buildTransitive\$(DefaultTargetFramework)\Scripts" />
+    <Content Include="Scripts\PrefixEndpoints.cs"
+             CopyToOutputDirectory="PreserveNewest"
+             Pack="true"
+             PackagePath="buildTransitive\$(DefaultTargetFramework)\Scripts;lib\$(TargetFramework)\Scripts" />
   </ItemGroup>
 
   <!-- Pack the buildTransitive targets file so NuGet consumers get scripts copied to output -->

--- a/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
+++ b/src/Aspire.Hosting.Blazor/Aspire.Hosting.Blazor.csproj
@@ -41,9 +41,9 @@
   </ItemGroup>
 
   <!-- Scripts are file-based C# apps, not part of this library's compilation.
-       C# AppHosts copy the buildTransitive assets to their output directory. Polyglot
-       AppHosts load this assembly directly from lib/<tfm>, so the same assets must also
-       be available beside the assembly for GetScriptPath(). -->
+       C# AppHosts copy the buildTransitive assets to their output directory. Package-backed
+       polyglot AppHosts load this assembly directly from lib/<tfm>, so the same assets must
+       also be available beside the assembly for GetScriptPath(). -->
   <ItemGroup>
     <Compile Remove="Scripts\**" />
     <None Include="Scripts\Gateway.cs.in" />

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -85,6 +85,18 @@ public static class BlazorGatewayExtensions
     /// publish scenarios. This restriction is expected to be lifted once container execution lands for
     /// <see cref="DotnetProjectResource"/>.
     /// </remarks>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The name of the gateway resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for the gateway resource.</returns>
+    /// <exception cref="NotSupportedException">Thrown when the application is being published.</exception>
+    /// <ats-summary>Adds the built-in Blazor gateway as a run-mode .NET resource.</ats-summary>
+    /// <ats-remarks>
+    /// This gateway can be used only when running the AppHost. Publishing it is not supported; use the standard
+    /// Blazor gateway for publish scenarios.
+    /// </ats-remarks>
+    /// <ats-param name="builder">The distributed application builder.</ats-param>
+    /// <ats-param name="name">The name of the gateway resource.</ats-param>
+    /// <ats-returns>The gateway resource builder.</ats-returns>
     [Experimental("ASPIREDOTNETPROJECT001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     [AspireExport]
     public static IResourceBuilder<DotnetProjectResource> AddDotnetProjectBlazorGateway(
@@ -189,6 +201,17 @@ public static class BlazorGatewayExtensions
     /// <param name="apiPrefix">The URL path prefix for API proxy routes. Defaults to <c>"_api"</c>.</param>
     /// <param name="otlpPrefix">The URL path prefix for OTLP proxy routes. Defaults to <c>"_otlp"</c>.</param>
     /// <param name="proxyTelemetry"><see langword="true"/> to expose the OTLP proxy for the client app; otherwise, <see langword="false"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for the gateway resource.</returns>
+    /// <ats-summary>
+    /// Attaches a Blazor WebAssembly app to the gateway. The app's resource name becomes its URL path prefix,
+    /// and its service references are forwarded to the gateway for proxying.
+    /// </ats-summary>
+    /// <ats-param name="gateway">The gateway resource builder.</ats-param>
+    /// <ats-param name="wasmApp">The Blazor WebAssembly app to attach to the gateway.</ats-param>
+    /// <ats-param name="apiPrefix">The URL path prefix for API proxy routes. The default is <c>"_api"</c>.</ats-param>
+    /// <ats-param name="otlpPrefix">The URL path prefix for telemetry proxy routes. The default is <c>"_otlp"</c>.</ats-param>
+    /// <ats-param name="proxyTelemetry"><see langword="true"/> to expose the telemetry proxy for the client app; otherwise, <see langword="false"/>.</ats-param>
+    /// <ats-returns>The gateway resource builder.</ats-returns>
     [Experimental("ASPIREDOTNETPROJECT001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
     [AspireExport("withDotnetProjectBlazorClientApp", MethodName = "withBlazorClientApp")]
     public static IResourceBuilder<DotnetProjectResource> WithBlazorClientApp(
@@ -246,7 +269,7 @@ public static class BlazorGatewayExtensions
     /// transformed (AssetFile prefixed, runtime tree wrapped under prefix), then injected
     /// into the Gateway as environment variables.
     /// </summary>
-    [AspireExportIgnore(Reason = "Blazor gateway APIs are not yet stable for ATS export.")]
+    [AspireExportIgnore(Reason = "Internal open-generic implementation helper; polyglot AppHosts use the exported WithBlazorClientApp methods.")]
     internal static IResourceBuilder<TGateway> WithBlazorApp<TGateway>(
         this IResourceBuilder<TGateway> gateway,
         IResourceBuilder<BlazorWasmAppResource> wasmApp,

--- a/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
+++ b/src/Aspire.Hosting.Blazor/BlazorGatewayExtensions.cs
@@ -86,7 +86,7 @@ public static class BlazorGatewayExtensions
     /// <see cref="DotnetProjectResource"/>.
     /// </remarks>
     [Experimental("ASPIREDOTNETPROJECT001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExportIgnore(Reason = "The DotnetProjectResource-backed Blazor gateway is experimental and not yet stable for ATS export.")]
+    [AspireExport]
     public static IResourceBuilder<DotnetProjectResource> AddDotnetProjectBlazorGateway(
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name)
@@ -190,7 +190,7 @@ public static class BlazorGatewayExtensions
     /// <param name="otlpPrefix">The URL path prefix for OTLP proxy routes. Defaults to <c>"_otlp"</c>.</param>
     /// <param name="proxyTelemetry"><see langword="true"/> to expose the OTLP proxy for the client app; otherwise, <see langword="false"/>.</param>
     [Experimental("ASPIREDOTNETPROJECT001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
-    [AspireExportIgnore(Reason = "The DotnetProjectResource-backed Blazor gateway is experimental and not yet stable for ATS export.")]
+    [AspireExport("withDotnetProjectBlazorClientApp", MethodName = "withBlazorClientApp")]
     public static IResourceBuilder<DotnetProjectResource> WithBlazorClientApp(
         this IResourceBuilder<DotnetProjectResource> gateway,
         IResourceBuilder<BlazorWasmAppResource> wasmApp,

--- a/src/Aspire.Hosting.Blazor/targets/GenerateScripts.targets
+++ b/src/Aspire.Hosting.Blazor/targets/GenerateScripts.targets
@@ -97,7 +97,7 @@ if (!File.Exists(OutputPath) || File.ReadAllText(OutputPath) != content)
     <Content Include="$(_ScriptsOutputDir)Gateway.cs"
              CopyToOutputDirectory="PreserveNewest"
              Pack="true"
-             PackagePath="buildTransitive\$(DefaultTargetFramework)\Scripts"
+             PackagePath="buildTransitive\$(DefaultTargetFramework)\Scripts;lib\$(TargetFramework)\Scripts"
              Link="Scripts\Gateway.cs" />
   </ItemGroup>
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptBlazorGatewayTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptBlazorGatewayTests.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Hex1b.Automation;
+using Xunit;
+
+namespace Aspire.Cli.EndToEnd.Tests;
+
+/// <summary>
+/// End-to-end coverage for Blazor gateway APIs invoked from a TypeScript AppHost.
+/// </summary>
+public sealed class TypeScriptBlazorGatewayTests(ITestOutputHelper output)
+{
+    [Fact]
+    [CaptureWorkspaceOnFailure]
+    public async Task DotnetProjectBlazorGatewayRunsFromTypeScriptAppHost()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+
+        if (strategy.Mode == CliInstallMode.InstallScript && strategy.Quality is null && strategy.Version is null)
+        {
+            Assert.Skip("This test exercises unreleased Blazor polyglot APIs. Build a local Aspire CLI bundle or run in CI so the test uses current PR bits instead of the GA CLI.");
+        }
+
+        using var workspace = TemporaryWorkspace.Create(output);
+        var localChannel = CliE2ETestHelpers.PrepareLocalChannel(
+            repoRoot,
+            strategy,
+            [
+                "Aspire.Hosting.Blazor.",
+                "Aspire.Hosting.CodeGeneration.TypeScript.",
+                "Aspire.Hosting.Dotnet."
+            ]);
+
+        // The gateway is a file-based .NET app, so this scenario needs both Node.js for the
+        // TypeScript AppHost and the .NET SDK for the gateway and Blazor client builds.
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(
+            repoRoot,
+            strategy,
+            output,
+            variant: CliE2ETestHelpers.DockerfileVariant.DotNet,
+            workspace: workspace);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(
+            terminal,
+            workspace,
+            auto,
+            counter,
+            output,
+            TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.RunCommandAsync(
+            "aspire init --language typescript --non-interactive --suppress-agent-init",
+            counter,
+            TimeSpan.FromMinutes(2));
+
+        if (localChannel is not null)
+        {
+            CliE2ETestHelpers.WriteLocalChannelSettings(workspace.WorkspaceRoot.FullName, localChannel.SdkVersion);
+        }
+
+        await auto.TypeAsync("aspire add Aspire.Hosting.Blazor --non-interactive");
+        await auto.EnterAsync();
+        await auto.WaitForAspireAddCompletionAsync(counter, TimeSpan.FromMinutes(2));
+
+        await auto.RunCommandAsync(
+            "dotnet new blazorwasm --name Client --output Client --no-restore",
+            counter,
+            TimeSpan.FromMinutes(2));
+
+        var appHostPath = Path.Combine(workspace.WorkspaceRoot.FullName, "apphost.mts");
+        await File.WriteAllTextAsync(appHostPath, """
+            import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+            const builder = await createBuilder();
+
+            const client = await builder.addBlazorWasmProject('client', './Client/Client.csproj');
+            const gateway = await builder.addDotnetProjectBlazorGateway('gateway');
+            await gateway.withBlazorClientApp(client);
+
+            await builder.build().run();
+            """);
+
+        var verificationScriptPath = Path.Combine(workspace.WorkspaceRoot.FullName, "verify-blazor-gateway.sh");
+        var verificationScript = """
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            cleanup() {
+                aspire stop --non-interactive >/dev/null 2>&1 || true
+            }
+            trap cleanup EXIT
+
+            ASPIRE_CLI_START_TIMEOUT=180 aspire start --non-interactive --format json > aspire-start.json
+            aspire wait gateway --status up --timeout 240
+
+            found=false
+            for i in $(seq 1 20); do
+                aspire describe gateway --format json > gateway.json
+                GATEWAY_URL=$(jq -r '[.resources[0].urls[]? | select(.name == "http" and .isInternal != true) | .url][0] // empty' gateway.json)
+
+                if [ -n "$GATEWAY_URL" ] &&
+                   curl --connect-timeout 2 --max-time 5 -fsS "$GATEWAY_URL/client/" -o client-index.html &&
+                   grep -q '<title>Client</title>' client-index.html &&
+                   grep -q '_framework/blazor.webassembly' client-index.html; then
+                    found=true
+                    break
+                fi
+
+                sleep 2
+            done
+
+            $found
+            """;
+        await File.WriteAllTextAsync(verificationScriptPath, verificationScript.ReplaceLineEndings("\n"));
+
+        try
+        {
+            await auto.RunCommandAsync(
+                "bash verify-blazor-gateway.sh",
+                counter,
+                TimeSpan.FromMinutes(10));
+        }
+        catch
+        {
+            // RunCommandAsync observes the error prompt before throwing but leaves the sequence counter
+            // unchanged. Advance it so TerminalRun can capture diagnostics from the next prompt.
+            counter.Increment();
+            throw;
+        }
+    }
+}

--- a/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptBlazorGatewayTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/TypeScriptBlazorGatewayTests.cs
@@ -102,8 +102,15 @@ public sealed class TypeScriptBlazorGatewayTests(ITestOutputHelper output)
 
             found=false
             for i in $(seq 1 20); do
-                aspire describe gateway --format json > gateway.json
-                GATEWAY_URL=$(jq -r '[.resources[0].urls[]? | select(.name == "http" and .isInternal != true) | .url][0] // empty' gateway.json)
+                if ! aspire describe gateway --format json > gateway.json; then
+                    sleep 2
+                    continue
+                fi
+
+                if ! GATEWAY_URL=$(jq -r '[.resources[0].urls[]? | select(.name == "http" and .isInternal != true) | .url][0] // empty' gateway.json); then
+                    sleep 2
+                    continue
+                fi
 
                 if [ -n "$GATEWAY_URL" ] &&
                    curl --connect-timeout 2 --max-time 5 -fsS "$GATEWAY_URL/client/" -o client-index.html &&
@@ -127,7 +134,7 @@ public sealed class TypeScriptBlazorGatewayTests(ITestOutputHelper output)
                 counter,
                 TimeSpan.FromMinutes(10));
         }
-        catch
+        catch (InvalidOperationException)
         {
             // RunCommandAsync observes the error prompt before throwing but leaves the sequence counter
             // unchanged. Advance it so TerminalRun can capture diagnostics from the next prompt.

--- a/tests/Aspire.Hosting.Blazor.Tests/AddDotnetProjectBlazorGatewayTests.cs
+++ b/tests/Aspire.Hosting.Blazor.Tests/AddDotnetProjectBlazorGatewayTests.cs
@@ -11,22 +11,22 @@ namespace Aspire.Hosting.Blazor.Tests;
 public class AddDotnetProjectBlazorGatewayTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    public void WithBlazorApp_DotnetProjectGateway_AddsGatewayAppsAnnotation()
+    public void AddDotnetProjectBlazorGateway_WithBlazorClientApp_AddsGatewayAppsAnnotation()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
-        // The gateway helpers are generic over the gateway resource type, so a DotnetProjectResource
-        // gateway (created via AddDotnetProject) flows through the same path as an AddBlazorGateway
-        // (ProjectResource) gateway. Build the gateway directly to avoid depending on the Gateway.cs
-        // script content that AddDotnetProjectBlazorGateway resolves at run time. ExcludeLaunchProfile
-        // avoids resolving launchSettings for the placeholder project path.
-        var gateway = builder.AddDotnetProject("gateway", "gateway.csproj", o => o.ExcludeLaunchProfile = true)
-            .WithHttpEndpoint()
-            .WithHttpsEndpoint();
-
+        var gateway = builder.AddDotnetProjectBlazorGateway("gateway");
         var wasmApp = builder.AddBlazorWasmApp("store", "Store/Store.csproj");
 
-        gateway.WithBlazorApp(wasmApp, "store", []);
+        gateway.WithBlazorClientApp(wasmApp);
+
+        Assert.True(gateway.Resource.TryGetLastAnnotation<IProjectMetadata>(out var projectMetadata));
+        Assert.True(File.Exists(projectMetadata.ProjectPath));
+        Assert.Equal("Gateway.cs", Path.GetFileName(projectMetadata.ProjectPath));
+        Assert.Equal("Scripts", Path.GetFileName(Path.GetDirectoryName(projectMetadata.ProjectPath)));
+        Assert.Equal(
+            ["http", "https"],
+            gateway.Resource.Annotations.OfType<EndpointAnnotation>().Select(e => e.Name));
 
         var annotation = gateway.Resource.Annotations.OfType<GatewayAppsAnnotation>().SingleOrDefault();
         Assert.NotNull(annotation);
@@ -42,9 +42,7 @@ public class AddDotnetProjectBlazorGatewayTests(ITestOutputHelper testOutputHelp
         var weatherApi = builder.AddDotnetProject("weatherapi", "weatherapi.csproj", o => o.ExcludeLaunchProfile = true)
             .WithHttpEndpoint();
 
-        var gateway = builder.AddDotnetProject("gateway", "gateway.csproj", o => o.ExcludeLaunchProfile = true)
-            .WithHttpEndpoint()
-            .WithHttpsEndpoint();
+        var gateway = builder.AddDotnetProjectBlazorGateway("gateway");
 
         var wasmApp = builder.AddBlazorWasmApp("store", "Store/Store.csproj")
             .WithReference(weatherApi);

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -1377,6 +1377,52 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void AspireHostingBlazorPackageContainsScriptsForBuildAndDirectLoading()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var packageOutputPath = Path.Combine(workspace.WorkspaceRoot.FullName, "packages");
+        Directory.CreateDirectory(packageOutputPath);
+
+        var packagePath = PackProject(
+            Path.Combine(repoRoot, "src", "Aspire.Hosting.Blazor", "Aspire.Hosting.Blazor.csproj"),
+            packageOutputPath,
+            "Aspire.Hosting.Blazor");
+
+        using var archive = ZipFile.OpenRead(packagePath);
+
+        var assemblyEntry = Assert.Single(
+            archive.Entries,
+            entry => entry.FullName.StartsWith("lib/", StringComparison.Ordinal)
+                && entry.Name == "Aspire.Hosting.Blazor.dll");
+        var targetFramework = assemblyEntry.FullName.Split('/')[1];
+
+        Assert.Contains(
+            archive.Entries,
+            entry => entry.FullName == $"buildTransitive/{targetFramework}/Aspire.Hosting.Blazor.targets");
+
+        foreach (var scriptName in new[] { "Gateway.cs", "PrefixEndpoints.cs" })
+        {
+            var buildTransitiveEntry = Assert.Single(
+                archive.Entries,
+                entry => entry.FullName == $"buildTransitive/{targetFramework}/Scripts/{scriptName}");
+            var directLoadEntry = Assert.Single(
+                archive.Entries,
+                entry => entry.FullName == $"lib/{targetFramework}/Scripts/{scriptName}");
+
+            using var buildTransitiveStream = buildTransitiveEntry.Open();
+            using var directLoadStream = directLoadEntry.Open();
+            using var buildTransitiveContent = new MemoryStream();
+            using var directLoadContent = new MemoryStream();
+            buildTransitiveStream.CopyTo(buildTransitiveContent);
+            directLoadStream.CopyTo(directLoadContent);
+
+            Assert.Equal(buildTransitiveContent.ToArray(), directLoadContent.ToArray());
+        }
+    }
+
+    [Fact]
     public void AspireIntegrationAnalyzerPackageCanBeConsumedFromLocalSource()
     {
         var repoRoot = MSBuildUtils.GetRepoRoot();

--- a/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
+++ b/tests/Infrastructure.Tests/TestTriggerMap/SelectTestsAcceptanceTests.cs
@@ -899,6 +899,23 @@ public sealed class SelectTestsAcceptanceTests(ITestOutputHelper outputHelper) :
         Assert.Contains("job:polyglot", r.Jobs);
     }
 
+    [Fact]
+    public void RealMapBlazorRuntimeAssetChangeRunsPackageAndPolyglotRegressions()
+    {
+        var mapPath = Path.Combine(RepoRoot.Path, "eng", "github-ci", "test-trigger-map.yml");
+        var selector = new TestSelector(mapPath, EnumerateMatrixTestProjects(), LoadProjectDirectories());
+
+        var r = selector.Select(
+            ["src/Aspire.Hosting.Blazor/targets/GenerateScripts.targets"],
+            [],
+            new SelectorOptions());
+
+        Assert.False(r.SelectsAll);
+        Assert.Contains("Aspire.Hosting.Tests", r.TestProjects);
+        Assert.Contains("Aspire.Cli.EndToEnd.Tests", r.TestProjects);
+        Assert.Contains("job:polyglot", r.Jobs);
+    }
+
     // A real src/Aspire.Hosting*/api/<name>.ats.txt baseline for a genuine INTEGRATION (not the
     // codegen engine itself) whose integration also has a tests/PolyglotAppHosts/<name> fixture, so the
     // change exercises the polyglot playground for that integration's exported surface. Computed from the

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/Go/apphost.go
@@ -28,6 +28,10 @@ func main() {
 		WithOtlpExporter(&aspire.WithOtlpExporterOptions{Protocol: &protocol})
 	gateway.WithBlazorClientApp(blazorApp)
 
+	dotnetProjectBlazorApp := builder.AddBlazorWasmProject("dotnet-app", "./src/Client/Client.csproj")
+	dotnetProjectGateway := builder.AddDotnetProjectBlazorGateway("dotnet-gateway")
+	dotnetProjectGateway.WithBlazorClientApp(dotnetProjectBlazorApp)
+
 	app, err := builder.Build()
 	if err != nil {
 		log.Fatalf(aspire.FormatError(err))

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/Java/AppHost.java
@@ -17,5 +17,9 @@ void main() throws Exception {
 
         gateway.withBlazorClientApp(blazorApp);
 
+        var dotnetProjectBlazorApp = builder.addBlazorWasmProject("dotnet-app", "./src/Client/Client.csproj");
+        var dotnetProjectGateway = builder.addDotnetProjectBlazorGateway("dotnet-gateway");
+        dotnetProjectGateway.withBlazorClientApp(dotnetProjectBlazorApp);
+
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/Python/apphost.py
@@ -15,4 +15,8 @@ with create_builder() as builder:
     gateway.with_otlp_exporter(protocol=OtlpProtocol.HTTP_PROTOBUF)
     gateway.with_blazor_client_app(blazor_app)
 
+    dotnet_project_blazor_app = builder.add_blazor_wasm_project("dotnet-app", "./src/Client/Client.csproj")
+    dotnet_project_gateway = builder.add_dotnet_project_blazor_gateway("dotnet-gateway")
+    dotnet_project_gateway.with_blazor_client_app(dotnet_project_blazor_app)
+
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/Python/validate_generated_sdk.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/Python/validate_generated_sdk.py
@@ -1,0 +1,11 @@
+from aspire_app import DistributedApplicationBuilder, DotnetProjectResource
+
+
+required_members = [
+    (DistributedApplicationBuilder, "add_dotnet_project_blazor_gateway"),
+    (DotnetProjectResource, "with_blazor_client_app"),
+]
+
+for owner, member_name in required_members:
+    if not hasattr(owner, member_name):
+        raise AttributeError(f"{owner.__name__}.{member_name} is missing from the generated SDK")

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Blazor/TypeScript/apphost.mts
@@ -16,4 +16,8 @@ const gateway = await builder.addBlazorGateway('gateway')
 
 await gateway.withBlazorClientApp(blazorApp);
 
+const dotnetProjectBlazorApp = await builder.addBlazorWasmProject('dotnet-app', './src/Client/Client.csproj');
+const dotnetProjectGateway = await builder.addDotnetProjectBlazorGateway('dotnet-gateway');
+await dotnetProjectGateway.withBlazorClientApp(dotnetProjectBlazorApp);
+
 await builder.build().run();


### PR DESCRIPTION
## Description

Polyglot AppHosts can now use the `DotnetProjectResource`-backed Blazor gateway APIs introduced for Project V2. These methods were previously marked `[AspireExportIgnore]` even though their parameter and return types are ATS-compatible. This follows Sebastien's feedback in [the API surface review](https://github.com/microsoft/aspire/pull/17846#discussion_r3707963800).

`AddDotnetProjectBlazorGateway` is now exported directly. The `DotnetProjectResource` overload of `WithBlazorClientApp` uses the distinct `withDotnetProjectBlazorClientApp` capability ID to avoid colliding with the existing `ProjectResource` overload, while retaining `withBlazorClientApp` as the generated method name on the new resource handle.

The existing Blazor validation AppHosts now exercise both APIs in TypeScript, Go, Java, and Python. The Project V2 feature plan also records the additive capabilities and the unchanged run-only behavior; publishing this gateway variant still fails fast until `DotnetProjectResource` supports the container-files pipeline.

### User-facing usage

C# AppHost:

```csharp
var client = builder.AddBlazorWasmProject<Projects.Client>("client");

builder.AddDotnetProjectBlazorGateway("gateway")
    .WithBlazorClientApp(client);
```

TypeScript AppHost:

```typescript
const client = await builder.addBlazorWasmProject("client", "../Client/Client.csproj");
const gateway = await builder.addDotnetProjectBlazorGateway("gateway");

await gateway.withBlazorClientApp(client);
```

### Validation

- `Aspire.Hosting.Blazor` builds with zero analyzer warnings or errors.
- `AddDotnetProjectBlazorGatewayTests` passes all 3 tests.
- Regenerated TypeScript, Go, Java, and Python SDK fixtures compile successfully.
- Generated `api/*.cs`, `*.ats.txt`, and `.aspire/modules` files are not included.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
