### PR TITLE
Fix dashboard accessibility regressions

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/IconCheckbox.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/IconCheckbox.razor.css
@@ -18,11 +18,6 @@
     background: var(--neutral-fill-stealth-active);
 }
 
-.icon-checkbox:focus-visible {
-    outline: 2px solid var(--accent-fill-rest);
-    outline-offset: 2px;
-}
-
 .icon-checkbox[aria-disabled="true"] {
     cursor: not-allowed;
     opacity: var(--disabled-opacity);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -122,7 +122,7 @@
                                        instead of taking their own toolbar band. On mobile they live in the filter drawer. *@
                                     @if (ViewportInformation.IsDesktop)
                                     {
-                                        <div class="resource-tabs-toolbar" role="toolbar" aria-label="@ControlsStringsLoc[nameof(ControlsStrings.PageToolbarLandmark)]">
+                                        <div class="resource-tabs-toolbar" role="group" aria-label="@ControlsStringsLoc[nameof(ControlsStrings.PageToolbarLandmark)]">
                                             @GetDesktopFilterControls()
                                         </div>
                                     }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -84,6 +84,14 @@ fluent-toolbar::part(end) {
     row-gap: calc(var(--design-unit) * 1.5px);
 }
 
+/* Native controls do not consume Fluent design tokens. Give links, form controls, and explicitly
+   tabbable elements the same keyboard-focus treatment as Fluent shadow controls. :where() keeps the
+   rule easy to override for specialized controls, such as the non-interactive dialog title anchor. */
+:where(a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])):focus-visible {
+    outline: calc(var(--focus-stroke-width) * 1px) solid var(--focus-stroke-outer);
+    outline-offset: calc(var(--focus-stroke-width) * 1px);
+}
+
 /* Hide any web components that haven't been */
 :not(:defined),
 .before-upgrade {
@@ -145,14 +153,6 @@ fluent-select:focus-within::part(control),
 fluent-combobox:focus-within::part(control),
 fluent-text-area:focus-within::part(control) {
     outline: 1px solid var(--dash-focus-ring-color);
-}
-
-/* Fluent delegates focus to the shadow-DOM button, where its internal :focus-visible rule draws the
-   outline from these inherited tokens. Override the tokens on the host so the internal rule keeps its
-   keyboard-only behavior while using the dashboard focus treatment. */
-fluent-button {
-    --focus-stroke-width: 1;
-    --focus-stroke-outer: var(--dash-focus-ring-color);
 }
 
 /*
@@ -230,10 +230,16 @@ fluent-combobox {
     --kbd-background-color: var(--neutral-layer-4);
     --dialog-background-color: #ffffff;
     --dialog-border-color: #e5e5e5;
-     /* Focus ring color shared by inputs, checkboxes, dropdowns, buttons, and scroll buttons. Ring width
-         and focus state are control-specific. Defaults to the accent fill (a dark violet on light theme,
-         which reads fine on white); dark theme overrides it to a tamed violet because the dark accent fill
-         (--accent-fill-rest #e5bfff) is a near-white lavender that paints a loud halo on the violet panels. */
+    /* Global focus defaults inherited by Fluent shadow controls. app-theme.js also wires the matching
+       Fluent design tokens to these values so token consumers and CSS consumers stay aligned. Inputs,
+       checkboxes, and dropdowns use the ring color for their explicit part outlines; scroll buttons use
+       it for their native outline. Focus state remains control-specific. */
+    --focus-stroke-width: var(--aspire-focus-stroke-width);
+    --focus-stroke-outer: var(--dash-focus-ring-color);
+    --focus-stroke-inner: var(--dash-focus-ring-color);
+    /* Defaults to the accent fill (a dark violet on light theme, which reads fine on white); dark theme
+       overrides it to a tamed violet because the dark accent fill (--accent-fill-rest #e5bfff) is a
+       near-white lavender that paints a loud halo on violet panels. */
     --dash-focus-ring-color: var(--accent-fill-rest);
     /* Message bar surfaces derive from the shared --aspire-status-* seeds (tokens.css)
        so each intent hue is defined once and every theme mixes its own surface from it.
@@ -357,7 +363,7 @@ fluent-combobox {
     --kbd-background-color: var(--neutral-fill-secondary-rest);
     /* Keep the blue-violet undertone from the generated ramp while setting dialogs one step darker.
        Their nested neutral-layer-1 surfaces then regain the hierarchy visible in light mode. */
-    --dialog-background-color: color-mix(in srgb, var(--neutral-layer-1) 75%, #000000);
+    --dialog-background-color: color-mix(in srgb, var(--neutral-layer-2) 75%, #000000);
     --dialog-border-color: var(--neutral-stroke-rest);
     /* A mid periwinkle-violet keeps the focus ring above the WCAG 1.4.11 3:1 non-text contrast
        minimum on the generated dark surfaces without becoming a near-white halo. */
@@ -1655,8 +1661,6 @@ fluent-switch.table-switch::part(label) {
 }
 
 .scroll-button:focus-visible {
-    outline: 2px solid var(--dash-focus-ring-color);
-    outline-offset: 2px;
     opacity: 1;
     visibility: visible;
 }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -102,11 +102,11 @@ fluent-toolbar::part(end) {
 }
 
 /*
-    Text input focus treatment
-    ==========================
-    Fluent/FAST text inputs draw their focus affordance as an animated accent
-    bar on the host's ::after pseudo-element (not on a ::part, so it cannot be
-    targeted directly from here), e.g.:
+    Fluent control focus treatment
+    ==============================
+    Fluent/FAST text inputs and dropdowns draw their focus affordance as an
+    animated accent bar on the host's ::after pseudo-element (not on a ::part,
+    so it cannot be targeted directly from here), e.g.:
 
         :host(:not([disabled]):focus-within)::after {
             content: "";
@@ -118,18 +118,17 @@ fluent-toolbar::part(end) {
     outline: none), so hiding it outright would regress keyboard accessibility.
     Instead we swap it for a modern, box-consistent focus ring:
 
-      1. --focus-stroke-width is set to 0 on the input hosts. Custom properties
-         inherit through the shadow boundary, so the ::after bar - which sizes
-         itself from that token - collapses to nothing in both the :focus-within
-         and :active states, removing the underline without changing the global
-         focus-stroke width used elsewhere.
-      2. A 2px accent outline (--dash-focus-ring-color) is drawn on the exposed root part
-         (the control part for fluent-text-area) on :focus-within. Fluent delegates focus into
-         its shadow DOM, so the host itself does not match :focus-visible when the inner control
-         has keyboard focus. :focus-within follows that delegated focus reliably. On dark the
-         ring is a tamed mid-violet rather than the near-white --accent-fill-rest, so it stays
-         a calm accent edge while keeping >=3:1 non-text contrast (WCAG 2.4.11). The outline
-         follows the control's corner radius and stays visible in forced-colors mode.
+        1. --focus-stroke-width is set to 0 on the text-input and dropdown hosts. Custom
+            properties inherit through the shadow boundary, so the ::after bar - which sizes
+            itself from that token - collapses to nothing in both the :focus-within and :active
+            states without changing the global focus-stroke width used elsewhere.
+        2. A 1px accent outline (--dash-focus-ring-color) is drawn on each exposed root/control
+            part on :focus-within; the checkbox shares this outline treatment but has no underline
+            to suppress. Fluent delegates focus into shadow DOM, so the host does not reliably
+            match :focus-visible when its inner control has keyboard focus. :focus-within follows
+            delegated keyboard and pointer focus. On dark, the mid-violet ring avoids the near-white
+            --accent-fill-rest while retaining >=3:1 non-text contrast (WCAG 1.4.11). The outline
+            follows the control's corner radius and remains visible in forced-colors mode.
 */
 fluent-text-field,
 fluent-search,
@@ -146,6 +145,14 @@ fluent-select:focus-within::part(control),
 fluent-combobox:focus-within::part(control),
 fluent-text-area:focus-within::part(control) {
     outline: 1px solid var(--dash-focus-ring-color);
+}
+
+/* Fluent delegates focus to the shadow-DOM button, where its internal :focus-visible rule draws the
+   outline from these inherited tokens. Override the tokens on the host so the internal rule keeps its
+   keyboard-only behavior while using the dashboard focus treatment. */
+fluent-button {
+    --focus-stroke-width: 1;
+    --focus-stroke-outer: var(--dash-focus-ring-color);
 }
 
 /*
@@ -178,12 +185,10 @@ fluent-text-area::part(control) {
     resting "underline": their ::part(control) background is the same two-layer image trick
     (linear-gradient(fill, fill), linear-gradient(... bright --neutral-stroke bottom 1px ...)), which
     reads as a heavy bottom-only border and gives the closed dropdown almost no definition against the
-    surface. Give them the same flat fill + uniform 1px border as text fields, and swap the underline
-    focus bar (sized from --focus-stroke-width) for a box-consistent accent outline drawn on
-    :focus-visible only. Using :focus-visible (not :focus-within) means a mouse click on the closed
-    dropdown no longer paints a heavy near-white perimeter ring; the ring is reserved for keyboard
-    navigation, where a visible focus indicator is required. Scoped to ::part(control) so the open
-    listbox popup is untouched. */
+    surface. Give them the same flat fill + uniform 1px border as text fields. Setting
+    --focus-stroke-width to 0 below suppresses their underline focus bar; the shared :focus-within
+    rule above draws the replacement 1px outline on ::part(control), leaving the popup listbox
+    untouched. */
 fluent-select::part(control),
 fluent-combobox::part(control) {
     background: var(--neutral-layer-1) !important;
@@ -193,12 +198,6 @@ fluent-combobox::part(control) {
 fluent-select,
 fluent-combobox {
     --focus-stroke-width: 0;
-}
-
-fluent-select:focus-visible::part(control),
-fluent-combobox:focus-visible::part(control) {
-    outline: 2px solid var(--dash-focus-ring-color);
-    outline-offset: 1px;
 }
 
 :root {
@@ -231,10 +230,10 @@ fluent-combobox:focus-visible::part(control) {
     --kbd-background-color: var(--neutral-layer-4);
     --dialog-background-color: #ffffff;
     --dialog-border-color: #e5e5e5;
-    /* Keyboard focus ring color. Single knob for the 2px :focus-visible outline shared by text inputs,
-       selects/comboboxes and scroll buttons. Defaults to the accent fill (a dark violet on light theme,
-       which reads fine on white); dark theme overrides it to a tamed violet because the dark accent fill
-       (--accent-fill-rest #e5bfff) is a near-white lavender that paints a loud halo on the violet panels. */
+     /* Focus ring color shared by inputs, checkboxes, dropdowns, buttons, and scroll buttons. Ring width
+         and focus state are control-specific. Defaults to the accent fill (a dark violet on light theme,
+         which reads fine on white); dark theme overrides it to a tamed violet because the dark accent fill
+         (--accent-fill-rest #e5bfff) is a near-white lavender that paints a loud halo on the violet panels. */
     --dash-focus-ring-color: var(--accent-fill-rest);
     /* Message bar surfaces derive from the shared --aspire-status-* seeds (tokens.css)
        so each intent hue is defined once and every theme mixes its own surface from it.
@@ -358,9 +357,9 @@ fluent-combobox:focus-visible::part(control) {
     --kbd-background-color: var(--neutral-fill-secondary-rest);
     /* Keep the blue-violet undertone from the generated ramp while setting dialogs one step darker.
        Their nested neutral-layer-1 surfaces then regain the hierarchy visible in light mode. */
-    --dialog-background-color: color-mix(in srgb, var(--neutral-layer-1) 82%, #000000);
+    --dialog-background-color: color-mix(in srgb, var(--neutral-layer-1) 75%, #000000);
     --dialog-border-color: var(--neutral-stroke-rest);
-    /* A mid periwinkle-violet keeps the focus ring above the WCAG 2.4.11 3:1 non-text contrast
+    /* A mid periwinkle-violet keeps the focus ring above the WCAG 1.4.11 3:1 non-text contrast
        minimum on the generated dark surfaces without becoming a near-white halo. */
     --dash-focus-ring-color: #a98eff;
     /* Message bar surfaces derive from the shared --aspire-status-* seeds (tokens.css).
@@ -795,10 +794,6 @@ h1 {
    color declarations regardless of nesting, and `::part(content)` reaches the anchor's shadow text. */
 .fluent-messagebar .fluent-messagebar-message,
 .fluent-messagebar .title {
-    color: var(--messagebar-foreground-color) !important;
-}
-
-.fluent-messagebar .hypertext::part(content) {
     color: var(--messagebar-foreground-color) !important;
 }
 

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -123,14 +123,13 @@ fluent-toolbar::part(end) {
          itself from that token - collapses to nothing in both the :focus-within
          and :active states, removing the underline without changing the global
          focus-stroke width used elsewhere.
-      2. A 2px accent outline (--dash-focus-ring-color) is drawn on ::part(root) on
-         :focus-visible - i.e. keyboard focus only - so a mouse click no longer paints
-         a heavy full-perimeter ring. On dark the ring is a tamed mid-violet rather than
-         the near-white --accent-fill-rest, so it stays a calm accent edge while keeping
-         >=3:1 non-text contrast (WCAG 2.4.11). Text inputs always match :focus-visible
-         while focused, so their ring still shows on click where you want it; non-editable
-         selects only ring on keyboard nav. The outline follows the control's corner radius
-         and stays visible in forced-colors mode.
+      2. A 2px accent outline (--dash-focus-ring-color) is drawn on the exposed root part
+         (the control part for fluent-text-area) on :focus-within. Fluent delegates focus into
+         its shadow DOM, so the host itself does not match :focus-visible when the inner control
+         has keyboard focus. :focus-within follows that delegated focus reliably. On dark the
+         ring is a tamed mid-violet rather than the near-white --accent-fill-rest, so it stays
+         a calm accent edge while keeping >=3:1 non-text contrast (WCAG 2.4.11). The outline
+         follows the control's corner radius and stays visible in forced-colors mode.
 */
 fluent-text-field,
 fluent-search,
@@ -139,10 +138,10 @@ fluent-text-area {
     --focus-stroke-width: 0;
 }
 
-fluent-text-field:focus-visible::part(root),
-fluent-search:focus-visible::part(root),
-fluent-number-field:focus-visible::part(root),
-fluent-text-area:focus-visible::part(root) {
+fluent-text-field:focus-within::part(root),
+fluent-search:focus-within::part(root),
+fluent-number-field:focus-within::part(root),
+fluent-text-area:focus-within::part(control) {
     outline: 2px solid var(--dash-focus-ring-color);
     outline-offset: 1px;
 }
@@ -150,7 +149,8 @@ fluent-text-area:focus-visible::part(root) {
 /*
     Remove the resting "input underline"
     ====================================
-    FAST paints the text input's resting border as a two-layer background-image on ::part(root):
+    FAST paints the text input's resting border as a two-layer background-image on its exposed
+    root part (the control part for fluent-text-area):
     a flat fill layer, plus a vertical gradient whose top/side 1px uses the near-invisible fill color
     but whose bottom 1px is a bright --neutral-stroke, e.g.:
 
@@ -166,7 +166,7 @@ fluent-text-area:focus-visible::part(root) {
 fluent-text-field::part(root),
 fluent-search::part(root),
 fluent-number-field::part(root),
-fluent-text-area::part(root) {
+fluent-text-area::part(control) {
     background: var(--neutral-layer-1) !important;
     border: 1px solid var(--neutral-stroke-rest) !important;
 }
@@ -291,7 +291,7 @@ fluent-combobox:focus-visible::part(control) {
     --hljs-literal: #aa5d00;
     --hljs-attribute: #aa5d00;
     --hljs-string: green;
-    --hljs-section: #007faa;
+    --hljs-section: #00779f;
     --hljs-keyword: #7928a1;
     /* geni visualizer */
     --main-container-background-color: #f7f7f7;
@@ -848,7 +848,7 @@ fluent-dialog td[cell-type=columnheader] fluent-button[appearance=stealth]:not(:
 [data-theme="dark"] fluent-dialog fluent-text-field::part(root),
 [data-theme="dark"] fluent-dialog fluent-search::part(root),
 [data-theme="dark"] fluent-dialog fluent-number-field::part(root),
-[data-theme="dark"] fluent-dialog fluent-text-area::part(root),
+[data-theme="dark"] fluent-dialog fluent-text-area::part(control),
 [data-theme="dark"] fluent-dialog fluent-select::part(control),
 [data-theme="dark"] fluent-dialog fluent-combobox::part(control) {
     background: var(--neutral-layer-2) !important;
@@ -859,17 +859,17 @@ fluent-dialog td[cell-type=columnheader] fluent-button[appearance=stealth]:not(:
    primary action reads as a bright, inviting chip against the dark chrome. FAST's stock dark
    accent recipe is a near-white lavender (looks washed-out/disabled) and the brand-violet + white
    treatment we used before read heavy; a light-purple fill + dark text is the requested look. The fill
-   and label are mixed from the brand seed (--accent-base-color #512bd4) so they track the theme: ~30%
-   over white is a legible light purple and ~85% over black is a deep-violet label that clears AA
-   (~5.5:1) on that fill. Applies to every accent button/anchor - dialogs AND page toolbars.
+   and label are mixed from the brand seed (--accent-base-color #512bd4) so they track the theme. Each
+   interaction state darkens both the fill and label in tandem, preserving at least 4.5:1 text contrast.
+   Applies to every accent button/anchor - dialogs AND page toolbars.
    IMPORTANT: LIGHT theme is intentionally NOT touched here (stays on the stock saturated violet + white
    recipe), per the design ask. --foreground-on-accent is pinned to the dark label so FluentUI's own
    slotted label/icon colour follows it instead of painting white. */
 [data-theme="dark"] fluent-button[appearance='accent'],
 [data-theme="dark"] fluent-anchor[appearance='accent'] {
     --foreground-on-accent-rest: color-mix(in srgb, var(--accent-base-color) 85%, #000000);
-    --foreground-on-accent-hover: color-mix(in srgb, var(--accent-base-color) 85%, #000000);
-    --foreground-on-accent-active: color-mix(in srgb, var(--accent-base-color) 85%, #000000);
+    --foreground-on-accent-hover: color-mix(in srgb, var(--accent-base-color) 80%, #000000);
+    --foreground-on-accent-active: color-mix(in srgb, var(--accent-base-color) 75%, #000000);
 }
 
 [data-theme="dark"] fluent-button[appearance='accent']:not(:hover):not(:active)::part(control),
@@ -881,8 +881,14 @@ fluent-dialog td[cell-type=columnheader] fluent-button[appearance=stealth]:not(:
 
 [data-theme="dark"] fluent-button[appearance='accent']:hover::part(control),
 [data-theme="dark"] fluent-anchor[appearance='accent']:hover::part(control) {
-    background: color-mix(in srgb, var(--accent-base-color) 42%, #ffffff);
-    color: color-mix(in srgb, var(--accent-base-color) 88%, #000000);
+    background: color-mix(in srgb, var(--accent-base-color) 40%, #ffffff);
+    color: color-mix(in srgb, var(--accent-base-color) 80%, #000000);
+}
+
+[data-theme="dark"] fluent-button[appearance='accent']:active::part(control),
+[data-theme="dark"] fluent-anchor[appearance='accent']:active::part(control) {
+    background: color-mix(in srgb, var(--accent-base-color) 45%, #ffffff);
+    color: color-mix(in srgb, var(--accent-base-color) 75%, #000000);
 }
 
 /* Secondary buttons (Cancel / Manage, neutral or default appearance): FAST's neutral fill is nearly the

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -361,9 +361,8 @@ fluent-combobox {
     --reconnection-ui-bg: #D6D6D6;
     --error-counter-badge-foreground-color: #ffffff;
     --kbd-background-color: var(--neutral-fill-secondary-rest);
-    /* Keep the blue-violet undertone from the generated ramp while setting dialogs one step darker.
-       Their nested neutral-layer-1 surfaces then regain the hierarchy visible in light mode. */
-    --dialog-background-color: color-mix(in srgb, var(--neutral-layer-2) 75%, #000000);
+    /* A 10% black mix subtly darkens dialogs while preserving the ramp's blue-violet undertone. */
+    --dialog-background-color: color-mix(in srgb, var(--neutral-layer-2) 90%, #000000);
     --dialog-border-color: var(--neutral-stroke-rest);
     /* A mid periwinkle-violet keeps the focus ring above the WCAG 1.4.11 3:1 non-text contrast
        minimum on the generated dark surfaces without becoming a near-white halo. */

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -141,9 +141,11 @@ fluent-text-area {
 fluent-text-field:focus-within::part(root),
 fluent-search:focus-within::part(root),
 fluent-number-field:focus-within::part(root),
+fluent-checkbox:focus-within::part(control),
+fluent-select:focus-within::part(control),
+fluent-combobox:focus-within::part(control),
 fluent-text-area:focus-within::part(control) {
-    outline: 2px solid var(--dash-focus-ring-color);
-    outline-offset: 1px;
+    outline: 1px solid var(--dash-focus-ring-color);
 }
 
 /*

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -130,8 +130,9 @@ fluent-toolbar::part(end) {
             properties inherit through the shadow boundary, so the ::after bar - which sizes
             itself from that token - collapses to nothing in both the :focus-within and :active
             states without changing the global focus-stroke width used elsewhere.
-        2. A 1px accent outline (--dash-focus-ring-color) is drawn on each exposed root/control
-            part on :focus-within; the checkbox shares this outline treatment but has no underline
+        2. An accent outline (--dash-focus-ring-color) using the global focus stroke width is drawn
+            on each exposed root/control part on :focus-within; the checkbox shares this outline
+            treatment but has no underline
             to suppress. Fluent delegates focus into shadow DOM, so the host does not reliably
             match :focus-visible when its inner control has keyboard focus. :focus-within follows
             delegated keyboard and pointer focus. On dark, the mid-violet ring avoids the near-white
@@ -152,7 +153,7 @@ fluent-checkbox:focus-within::part(control),
 fluent-select:focus-within::part(control),
 fluent-combobox:focus-within::part(control),
 fluent-text-area:focus-within::part(control) {
-    outline: 1px solid var(--dash-focus-ring-color);
+    outline: calc(var(--aspire-focus-stroke-width) * 1px) solid var(--dash-focus-ring-color);
 }
 
 /*

--- a/src/Aspire.Dashboard/wwwroot/css/tokens.css
+++ b/src/Aspire.Dashboard/wwwroot/css/tokens.css
@@ -226,7 +226,8 @@
         matching Fluent DesignTokens in app-theme.js so the whole system can be tuned
         from one place. Fluent consumes these purely as CSS custom properties (there is
         no JS height-number recipe in Fluent Blazor 4.14), so the var() indirection is
-        safe. All default to Fluent 4.14's values, so the default render is unchanged:
+        safe. Most default to Fluent 4.14's values; the focus stroke is intentionally
+        reduced to 1px for the dashboard's quieter focus treatment:
 
           - height-multiplier + density + design-unit set control height:
             (8 + -1) * 4 = 28px (density is set above).
@@ -240,7 +241,7 @@
     --aspire-height-multiplier: 8;
     --aspire-horizontal-spacing-multiplier: 3;
     --aspire-stroke-width: 1;
-    --aspire-focus-stroke-width: 2;
+    --aspire-focus-stroke-width: 1;
     --aspire-disabled-opacity: 0.3;
 
     /*

--- a/src/Aspire.Dashboard/wwwroot/css/tokens.css
+++ b/src/Aspire.Dashboard/wwwroot/css/tokens.css
@@ -226,8 +226,7 @@
         matching Fluent DesignTokens in app-theme.js so the whole system can be tuned
         from one place. Fluent consumes these purely as CSS custom properties (there is
         no JS height-number recipe in Fluent Blazor 4.14), so the var() indirection is
-        safe. Most default to Fluent 4.14's values; the focus stroke is intentionally
-        reduced to 1px for the dashboard's quieter focus treatment:
+        safe. All default to Fluent 4.14's values:
 
           - height-multiplier + density + design-unit set control height:
             (8 + -1) * 4 = 28px (density is set above).
@@ -241,7 +240,7 @@
     --aspire-height-multiplier: 8;
     --aspire-horizontal-spacing-multiplier: 3;
     --aspire-stroke-width: 1;
-    --aspire-focus-stroke-width: 1;
+    --aspire-focus-stroke-width: 2;
     --aspire-disabled-opacity: 0.3;
 
     /*

--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -33,6 +33,8 @@ import {
     designUnit,
     strokeWidth,
     focusStrokeWidth,
+    focusStrokeOuter,
+    focusStrokeInner,
     disabledOpacity,
     PaletteRGB
 } from "/_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js";
@@ -350,6 +352,8 @@ function wireAspireDesignTokens() {
     designUnit.withDefault("var(--aspire-design-unit)");
     strokeWidth.withDefault("var(--aspire-stroke-width)");
     focusStrokeWidth.withDefault("var(--aspire-focus-stroke-width)");
+    focusStrokeOuter.withDefault("var(--dash-focus-ring-color)");
+    focusStrokeInner.withDefault("var(--dash-focus-ring-color)");
     disabledOpacity.withDefault("var(--aspire-disabled-opacity)");
 }
 

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -639,7 +639,23 @@ window.downloadStreamAsFile = async function (fileName, contentStreamReference) 
 
         const rect = container.getBoundingClientRect();
         const overflow = container.scrollHeight - container.clientHeight;
-        let active = rect.width > 0 && rect.height > 0 && overflow > OVERFLOW_THRESHOLD_PX;
+        const PAD = 12;
+        const scrollbarWidth = container.offsetWidth - container.clientWidth;
+        const visibleLeft = Math.max(rect.left, 0);
+        const visibleRight = Math.min(rect.right - scrollbarWidth, window.innerWidth);
+        const visibleTop = Math.max(rect.top, 0);
+        const visibleBottom = Math.min(rect.bottom, window.innerHeight);
+        const visibleWidth = Math.max(0, visibleRight - visibleLeft);
+        const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+        const buttonStyle = getComputedStyle(entry.bottomBtn);
+        const buttonWidth = Number.parseFloat(buttonStyle.width);
+        const buttonHeight = Number.parseFloat(buttonStyle.height);
+        let active =
+            rect.width > 0 &&
+            rect.height > 0 &&
+            visibleWidth >= buttonWidth &&
+            visibleHeight >= buttonHeight + PAD * 2 &&
+            overflow > OVERFLOW_THRESHOLD_PX;
 
         // When a modal dialog is open, only show buttons for containers inside it; otherwise the
         // page's own buttons would float on top of the dialog surface.
@@ -655,15 +671,11 @@ window.downloadStreamAsFile = async function (fileName, contentStreamReference) 
 
         // Center the control horizontally over the region and anchor it near the visible bottom edge.
         // Clamp its span to the viewport and exclude the scrollbar from the horizontal center.
-        const PAD = 12;
-        const scrollbarWidth = container.offsetWidth - container.clientWidth;
-        const visibleTop = Math.max(rect.top, 0);
-        const visibleBottom = Math.min(rect.bottom, window.innerHeight);
         root.style.right = "auto";
         root.style.bottom = "auto";
-        root.style.left = (rect.left + (rect.width - scrollbarWidth) / 2) + "px";
+        root.style.left = (visibleLeft + visibleWidth / 2) + "px";
         root.style.top = (visibleTop + PAD) + "px";
-        root.style.height = Math.max(0, (visibleBottom - visibleTop) - PAD * 2) + "px";
+        root.style.height = (visibleHeight - PAD * 2) + "px";
 
         const atBottom = overflow - container.scrollTop <= EDGE_THRESHOLD_PX;
         entry.bottomBtn.classList.toggle("is-visible", !atBottom);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -294,6 +294,25 @@ public partial class ResourcesTests : DashboardTestContext
         });
     }
 
+    [Fact]
+    public void DesktopFilterControls_AreLabeledGroup()
+    {
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: [], resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(this, viewport, dashboardClient);
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        var filterGroup = cut.Find(".resource-tabs-toolbar");
+        var loc = Services.GetRequiredService<IStringLocalizer<Dashboard.Resources.ControlsStrings>>();
+
+        Assert.Equal("group", filterGroup.GetAttribute("role"));
+        Assert.Equal(loc[nameof(Dashboard.Resources.ControlsStrings.PageToolbarLandmark)].Value, filterGroup.GetAttribute("aria-label"));
+    }
+
     [Theory]
     [InlineData(false, true, "vertical")]
     [InlineData(true, true, "vertical")]

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
@@ -106,6 +106,126 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
         return AssertNoBlockingWcagViolationsAsync(startUrl, theme, s_desktopViewport, openSurfaceAsync: openSurfaceAsync, surfaceLabel: label);
     }
 
+    [Theory]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    [InlineData("Light", "fluent-text-field", "root")]
+    [InlineData("Light", "fluent-search", "root")]
+    [InlineData("Light", "fluent-number-field", "root")]
+    [InlineData("Light", "fluent-text-area", "control")]
+    [InlineData("Dark", "fluent-text-field", "root")]
+    [InlineData("Dark", "fluent-search", "root")]
+    [InlineData("Dark", "fluent-number-field", "root")]
+    [InlineData("Dark", "fluent-text-area", "control")]
+    public async Task FluentDelegatedInput_ShowsVisibleFocusIndicator(string theme, string controlName, string partName)
+    {
+        var baseUrl = DashboardServerFixture.DashboardApp.FrontendSingleEndPointAccessor().GetResolvedAddress();
+
+        await using var context = await PlaywrightFixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+            BaseURL = baseUrl,
+            ViewportSize = s_desktopViewport
+        });
+
+        await context.AddCookiesAsync([new Cookie { Name = "currentTheme", Value = theme, Url = baseUrl }]);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync("/").DefaultTimeout();
+        await page.WaitForSelectorAsync("body:not(.before-upgrade)").DefaultTimeout();
+        await page.WaitForSelectorAsync(
+            $"html[data-theme='{theme.ToLowerInvariant()}']",
+            new PageWaitForSelectorOptions { State = WaitForSelectorState.Attached }).DefaultTimeout();
+        await Assertions.Expect(page.GetByText("frontend", new PageGetByTextOptions { Exact = true }).First).ToBeVisibleAsync();
+        await WaitForComponentsAndFontsAsync(page);
+
+        ILocator control;
+        if (string.Equals(controlName, "fluent-search", StringComparison.Ordinal))
+        {
+            control = page.Locator("fluent-search[name='resources-search']");
+        }
+        else
+        {
+            await page.EvaluateAsync(
+                """
+                async controlName => {
+                    await customElements.whenDefined(controlName);
+                    const control = document.createElement(controlName);
+                    control.id = 'delegated-focus-probe';
+                    control.style.cssText = 'position:fixed;left:-99999px;top:0;';
+                    document.body.appendChild(control);
+                    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+                }
+                """,
+                controlName).DefaultTimeout();
+            control = page.Locator("#delegated-focus-probe");
+        }
+
+        await AssertVisibleFocusIndicatorAsync(control, partName);
+    }
+
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task DarkAccentButtonInteractionStates_MeetWcagAaContrast()
+    {
+        var baseUrl = DashboardServerFixture.DashboardApp.FrontendSingleEndPointAccessor().GetResolvedAddress();
+
+        await using var context = await PlaywrightFixture.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+            BaseURL = baseUrl,
+            ViewportSize = s_desktopViewport
+        });
+
+        await context.AddCookiesAsync([new Cookie { Name = "currentTheme", Value = "Dark", Url = baseUrl }]);
+
+        var page = await context.NewPageAsync();
+        await page.GotoAsync("/").DefaultTimeout();
+        await page.WaitForSelectorAsync("body:not(.before-upgrade)").DefaultTimeout();
+        await page.WaitForSelectorAsync(
+            "html[data-theme='dark']",
+            new PageWaitForSelectorOptions { State = WaitForSelectorState.Attached }).DefaultTimeout();
+        await WaitForComponentsAndFontsAsync(page);
+
+        await page.EvaluateAsync("""
+            async () => {
+                await customElements.whenDefined('fluent-button');
+                const button = document.createElement('fluent-button');
+                button.id = 'accent-contrast-probe';
+                button.setAttribute('appearance', 'accent');
+                button.textContent = 'Primary action';
+                button.style.cssText = 'position:fixed;left:16px;top:16px;z-index:10000;';
+                document.body.appendChild(button);
+                await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+            }
+            """).DefaultTimeout();
+
+        var button = page.Locator("#accent-contrast-probe");
+        var states = new List<(string Name, (int R, int G, int B) Foreground, (int R, int G, int B) Background)>();
+        var rest = await ReadFluentControlColorsAsync(button);
+        states.Add(("rest", rest.Foreground, rest.Background));
+
+        await button.HoverAsync();
+        var hover = await ReadFluentControlColorsAsync(button);
+        states.Add(("hover", hover.Foreground, hover.Background));
+
+        await page.Mouse.DownAsync();
+        var active = await ReadFluentControlColorsAsync(button);
+        states.Add(("active", active.Foreground, active.Background));
+        await page.Mouse.UpAsync();
+
+        var failures = states
+            .Select(state => (state.Name, state.Foreground, state.Background, Ratio: ContrastRatio(state.Foreground, state.Background)))
+            .Where(state => state.Ratio < WcagAaContrastMinimum)
+            .Select(state =>
+                $"  {state.Name}: {state.Ratio:F2}:1 " +
+                $"(text rgb({state.Foreground.R},{state.Foreground.G},{state.Foreground.B}) on background rgb({state.Background.R},{state.Background.G},{state.Background.B}))")
+            .ToList();
+
+        Assert.True(
+            failures.Count == 0,
+            $"Dark accent button state contrast falls below the WCAG AA {WcagAaContrastMinimum:F1}:1 minimum:{Environment.NewLine}{string.Join(Environment.NewLine, failures)}");
+    }
+
     // Maps each dialog surface (the InlineData key) to the page it's opened from, a human-readable
     // label used in failure messages, and the interaction that opens it and waits for it to render.
     // Settings is a right-aligned flyout panel reachable from every page's header; Filter is the
@@ -179,19 +299,23 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
 
         var probeJson = await page.EvaluateAsync<string>(CodeblockColorProbeScript);
         using var probe = JsonDocument.Parse(probeJson);
-        var root = probe.RootElement;
-        var background = ReadRgb(root.GetProperty("bg"));
 
         var failures = new List<string>();
-        foreach (var token in root.GetProperty("tokens").EnumerateArray())
+        foreach (var surface in probe.RootElement.GetProperty("surfaces").EnumerateArray())
         {
-            var foreground = ReadRgb(token);
-            var ratio = ContrastRatio(foreground, background);
-            if (ratio < WcagAaContrastMinimum)
+            var surfaceName = surface.GetProperty("name").GetString();
+            var background = ReadRgb(surface.GetProperty("bg"));
+
+            foreach (var token in surface.GetProperty("tokens").EnumerateArray())
             {
-                failures.Add(
-                    $"  {token.GetProperty("name").GetString()}: {ratio:F2}:1 " +
-                    $"(text rgb({foreground.R},{foreground.G},{foreground.B}) on background rgb({background.R},{background.G},{background.B}))");
+                var foreground = ReadRgb(token);
+                var ratio = ContrastRatio(foreground, background);
+                if (ratio < WcagAaContrastMinimum)
+                {
+                    failures.Add(
+                        $"  {surfaceName} / {token.GetProperty("name").GetString()}: {ratio:F2}:1 " +
+                        $"(text rgb({foreground.R},{foreground.G},{foreground.B}) on background rgb({background.R},{background.G},{background.B}))");
+                }
             }
         }
 
@@ -402,6 +526,95 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
     private static (int R, int G, int B) ReadRgb(JsonElement element)
         => (element.GetProperty("r").GetInt32(), element.GetProperty("g").GetInt32(), element.GetProperty("b").GetInt32());
 
+    private static async Task AssertVisibleFocusIndicatorAsync(ILocator host, string partName)
+    {
+        var focusJson = await host.EvaluateAsync<string>(
+            """
+            (element, partName) => {
+                const focusTarget = element.shadowRoot?.querySelector(
+                    'input, textarea, [role="combobox"], [tabindex]:not([tabindex="-1"])');
+                if (!focusTarget) {
+                    throw new Error(`No delegated focus target found for ${element.localName}.`);
+                }
+
+                focusTarget.focus();
+
+                const part = element.shadowRoot.querySelector(`[part~="${partName}"]`);
+                if (!part) {
+                    const availableParts = [...element.shadowRoot.querySelectorAll('[part]')]
+                        .map(node => node.getAttribute('part'))
+                        .join(', ');
+                    throw new Error(
+                        `No ${partName} part found for ${element.localName}. Available parts: ${availableParts}.`);
+                }
+
+                const style = getComputedStyle(part);
+                return JSON.stringify({
+                    focusWithin: element.matches(':focus-within'),
+                    focusVisible: element.matches(':focus-visible'),
+                    outlineStyle: style.outlineStyle,
+                    outlineWidth: Number.parseFloat(style.outlineWidth),
+                    outlineColor: style.outlineColor
+                });
+            }
+            """,
+            partName);
+
+        using var focus = JsonDocument.Parse(focusJson);
+        var root = focus.RootElement;
+        var outlineStyle = root.GetProperty("outlineStyle").GetString();
+        var outlineWidth = root.GetProperty("outlineWidth").GetDouble();
+        var outlineColor = root.GetProperty("outlineColor").GetString();
+        var hasOpaqueOutline = !string.Equals(outlineColor, "transparent", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(outlineColor, "rgba(0, 0, 0, 0)", StringComparison.OrdinalIgnoreCase);
+
+        Assert.True(root.GetProperty("focusWithin").GetBoolean(), $"Expected {await host.EvaluateAsync<string>("element => element.localName")} to contain delegated focus.");
+        Assert.True(
+            !string.Equals(outlineStyle, "none", StringComparison.Ordinal) && outlineWidth >= 2 && hasOpaqueOutline,
+            $"Expected a visible focus outline on the {partName} part, but got style '{outlineStyle}', width {outlineWidth}px, color {outlineColor}, host :focus-visible={root.GetProperty("focusVisible").GetBoolean()}.");
+    }
+
+    private static async Task<((int R, int G, int B) Foreground, (int R, int G, int B) Background)> ReadFluentControlColorsAsync(ILocator host)
+    {
+        var colorsJson = await host.EvaluateAsync<string>(
+            """
+            element => {
+                function parseRgb(s) {
+                    s = String(s).trim();
+                    let m = s.match(/rgba?\(([^)]+)\)/);
+                    if (m) {
+                        const p = m[1].split(/[ ,\/]+/).filter(Boolean).map(parseFloat);
+                        return [p[0], p[1], p[2]];
+                    }
+                    m = s.match(/color\(srgb\s+([^)]+)\)/);
+                    if (m) {
+                        const p = m[1].split(/[ \/]+/).filter(Boolean).map(parseFloat);
+                        return [Math.round(p[0] * 255), Math.round(p[1] * 255), Math.round(p[2] * 255)];
+                    }
+                    throw new Error('unparseable color: ' + s);
+                }
+
+                const control = element.shadowRoot?.querySelector('[part~="control"]');
+                if (!control) {
+                    throw new Error(`No control part found for ${element.localName}.`);
+                }
+
+                const style = getComputedStyle(control);
+                const foreground = parseRgb(style.color);
+                const background = parseRgb(style.backgroundColor);
+                return JSON.stringify({
+                    fg: { r: foreground[0], g: foreground[1], b: foreground[2] },
+                    bg: { r: background[0], g: background[1], b: background[2] }
+                });
+            }
+            """);
+
+        using var colors = JsonDocument.Parse(colorsJson);
+        var root = colors.RootElement;
+
+        return (ReadRgb(root.GetProperty("fg")), ReadRgb(root.GetProperty("bg")));
+    }
+
     // WCAG 2.x relative luminance and contrast ratio.
     // See https://www.w3.org/TR/WCAG21/#dfn-relative-luminance and #dfn-contrast-ratio.
     private static double ContrastRatio((int R, int G, int B) foreground, (int R, int G, int B) background)
@@ -423,11 +636,11 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
         return (0.2126 * Channel(r)) + (0.7152 * Channel(g)) + (0.0722 * Channel(b));
     }
 
-    // Renders an off-screen text visualizer on the same neutral-layer-1 surface used by dialogs so its
-    // theme-scoped highlight.js colors resolve exactly as they do in the product. The active theme is
+    // Render the two production syntax-highlight surfaces off-screen: Text Visualizer inherits the
+    // dialog surface, while rendered markdown paints its own code-block surface. The active theme is
     // whatever the page booted with (data-theme on <html>). WCAG math is done in C# in the test.
     private const string CodeblockColorProbeScript = """
-        () => {
+        async () => {
             function parseRgb(s) {
                 s = String(s).trim();
                 let m = s.match(/rgba?\(([^)]+)\)/);
@@ -436,31 +649,77 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
                 if (m) { const p = m[1].split(/[ \/]+/).filter(Boolean).map(parseFloat); return [Math.round(p[0] * 255), Math.round(p[1] * 255), Math.round(p[2] * 255)]; }
                 throw new Error('unparseable color: ' + s);
             }
+
             const groups = { default: 'hljs', comment: 'hljs-comment', variable: 'hljs-variable', literal: 'hljs-literal', attribute: 'hljs-attribute', string: 'hljs-string', section: 'hljs-section', keyword: 'hljs-keyword' };
             const theme = document.documentElement.getAttribute('data-theme');
-            const container = document.createElement('div');
-            container.className = 'text-visualizer-container';
-            container.style.cssText = 'position:fixed;left:-99999px;top:0;background:var(--neutral-layer-1);';
+
+            async function readSurface(name, container, getBackgroundElement, line) {
+                document.body.appendChild(container);
+                await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+                const backgroundElement = getBackgroundElement();
+                if (!backgroundElement) {
+                    throw new Error(`No production background element found for ${name}.`);
+                }
+
+                const bg = parseRgb(getComputedStyle(backgroundElement).backgroundColor);
+                const tokens = [];
+
+                for (const tokenName of Object.keys(groups)) {
+                    const cls = groups[tokenName];
+                    let element;
+                    if (cls === 'hljs') {
+                        element = line;
+                    } else {
+                        element = document.createElement('span');
+                        element.className = cls;
+                        element.textContent = 'x';
+                        line.appendChild(element);
+                    }
+
+                    const fg = parseRgb(getComputedStyle(element).color);
+                    tokens.push({ name: tokenName, r: fg[0], g: fg[1], b: fg[2] });
+                }
+
+                container.remove();
+                return { name: name, bg: { r: bg[0], g: bg[1], b: bg[2] }, tokens: tokens };
+            }
+
+            await customElements.whenDefined('fluent-dialog');
+            const dialog = document.createElement('fluent-dialog');
+            dialog.style.cssText = 'position:fixed;left:-99999px;top:0;';
+            const textVisualizer = document.createElement('div');
+            textVisualizer.className = 'text-visualizer-container';
             const overflow = document.createElement('div');
             overflow.className = 'log-overflow';
-            const line = document.createElement('span');
-            line.className = 'log-content highlight-line hljs theme-a11y-' + theme + '-min';
-            line.textContent = 'sample';
-            overflow.appendChild(line);
-            container.appendChild(overflow);
-            document.body.appendChild(container);
-            const bg = parseRgb(getComputedStyle(container).backgroundColor);
-            const tokens = [];
-            for (const name of Object.keys(groups)) {
-                const cls = groups[name];
-                let el;
-                if (cls === 'hljs') { el = line; }
-                else { el = document.createElement('span'); el.className = cls; el.textContent = 'x'; line.appendChild(el); }
-                const fg = parseRgb(getComputedStyle(el).color);
-                tokens.push({ name: name, r: fg[0], g: fg[1], b: fg[2] });
-            }
-            document.body.removeChild(container);
-            return JSON.stringify({ bg: { r: bg[0], g: bg[1], b: bg[2] }, tokens: tokens });
+            const visualizerLine = document.createElement('span');
+            visualizerLine.className = 'log-content highlight-line hljs theme-a11y-' + theme + '-min';
+            visualizerLine.textContent = 'sample';
+            overflow.appendChild(visualizerLine);
+            textVisualizer.appendChild(overflow);
+            dialog.appendChild(textVisualizer);
+
+            const markdown = document.createElement('div');
+            markdown.className = 'markdown-container';
+            markdown.style.cssText = 'position:fixed;left:-99999px;top:0;';
+            const codeBlock = document.createElement('div');
+            codeBlock.className = 'code-block';
+            const markdownCode = document.createElement('code');
+            markdownCode.className = 'hljs theme-a11y-' + theme + '-min';
+            markdownCode.textContent = 'sample';
+            codeBlock.appendChild(markdownCode);
+            markdown.appendChild(codeBlock);
+
+            return JSON.stringify({
+                surfaces: [
+                    await readSurface(
+                        'text visualizer',
+                        dialog,
+                        () => dialog.shadowRoot?.querySelector('[part~="control"]'),
+                        visualizerLine),
+                    await readSurface('rendered markdown', markdown, () => codeBlock, markdownCode)
+                ]
+            });
         }
         """;
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/DashboardInteractionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/DashboardInteractionsTests.cs
@@ -126,6 +126,45 @@ public class DashboardInteractionsTests : PlaywrightTestsBase<DashboardInteracti
         });
     }
 
+    [Fact]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    public async Task ScrollButtons_RemainInactiveWhenRegionHasNoRoomForControl()
+    {
+        await RunTestAsync(async page =>
+        {
+            await GoToResourcesAndWaitAsync(page);
+
+            await page.EvaluateAsync("""
+                () => {
+                    const region = document.createElement('div');
+                    region.className = 'continuous-scroll-overflow';
+                    region.id = 'partially-visible-scroll-region';
+                    region.style.cssText = 'position:fixed;left:0;top:-280px;width:400px;height:300px;overflow:auto;';
+                    const tall = document.createElement('div');
+                    tall.style.height = '2000px';
+                    region.appendChild(tall);
+                    document.body.appendChild(region);
+                }
+                """);
+
+            var buttons = page.Locator(".scroll-buttons");
+            await Assertions.Expect(buttons).ToHaveCountAsync(1);
+            await page.EvaluateAsync("() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))").DefaultTimeout();
+
+            Assert.Equal("scroll-buttons", await buttons.GetAttributeAsync("class"));
+
+            await page.EvaluateAsync("""
+                () => {
+                    document.getElementById('partially-visible-scroll-region').style.top = '0';
+                    window.dispatchEvent(new Event('resize'));
+                }
+                """);
+            await page.EvaluateAsync("() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))").DefaultTimeout();
+
+            Assert.Equal("scroll-buttons is-active", await buttons.GetAttributeAsync("class"));
+        });
+    }
+
     private static async Task GoToResourcesAndWaitAsync(IPage page)
     {
         await page.GotoAsync("/");


### PR DESCRIPTION
## Description

This follows up on [review feedback](https://github.com/microsoft/aspire/pull/18943#pullrequestreview-4858492231) for #18943. Keyboard users now retain a visible focus ring on Fluent text inputs, scroll controls no longer float over a region that is mostly outside the viewport, and the updated code and accent colors meet WCAG AA contrast on the dashboard surfaces where they are rendered.

- Represent the Resources filter controls as a labeled group instead of a toolbar.
- Require enough visible viewport space before activating the fixed scroll controls.
- Use `:focus-within` for shadow-delegated Fluent input focus and target the text area's actual control part.
- Measure syntax colors against the production dialog and rendered-markdown backgrounds.
- Preserve WCAG AA contrast for dark accent buttons in their hover and active states.

The menu-registration feedback from the review no longer applies on current `main` because #18989 removed that mechanism.

### User-facing usage

No configuration is required. The fixes apply automatically while navigating the dashboard with a keyboard, viewing highlighted code, and interacting with Resources page controls.

### Screenshots / Recordings

Captured against a local dashboard with Playwright, same commit in both columns except for `app.css` / `app.js`.

**Keyboard focus ring on Fluent text inputs.** Tabbing into a text input painted no ring at all on `main`, because Fluent delegates focus into its shadow DOM and the host never matches `:focus-visible`. `fluent-text-area` was worse - it exposes no `root` part, so it also missed the well/border treatment entirely.

![Keyboard focus ring before and after](https://github.com/user-attachments/assets/f125278a-a1ec-408c-9c2f-813d4826ccec)

**Scroll control over a mostly clipped region.** With only ~44px of the scroll region inside the viewport, `main` still activated the floating control and pinned it into that sliver.

![Scroll control before and after](https://github.com/user-attachments/assets/34a3c3d6-e67a-4f51-940e-f3f96257cd70)

**Dark accent button hover/active.** Both states sat at 4.27:1 on `main`; they are 4.94:1 (hover) and 4.78:1 (active) now. Ratios are measured from the captured pixels.

![Accent button states before and after](https://github.com/user-attachments/assets/ed8c2b52-8f27-4045-9d44-d34699a65b28)

### Validation

- Added component coverage for the Resources filter semantics.
- Added Playwright regression coverage for delegated focus, partially visible scroll regions, syntax-color surfaces, and accent interaction-state contrast.
- Ran the Dashboard test suite excluding quarantined and outerloop tests.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

