### PR TITLE
Move Capture paused warning to the start of the items footer

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
@@ -1,12 +1,15 @@
 ﻿@namespace Aspire.Dashboard.Components
 
+@* The pause warning leads the footer so it sits to the left of the result count. Placing it
+   after the count left the warning floating in the middle of an otherwise empty footer, which
+   read as misaligned rather than as part of the footer. *@
 <div class="items-footer">
-    <span class="result-count" aria-live="polite" aria-atomic="true">
-        @((MarkupString)string.Format(TotalItemCount == 1 ? SingularText : PluralText, TotalItemCount))
-    </span>
-
     @if (PauseText is not null)
     {
         <PauseWarning PauseText="@PauseText" />
     }
+
+    <span class="result-count" aria-live="polite" aria-atomic="true">
+        @((MarkupString)string.Format(TotalItemCount == 1 ? SingularText : PluralText, TotalItemCount))
+    </span>
 </div>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -1535,14 +1535,14 @@ fluent-switch.table-switch::part(label) {
     text-align: start !important;
 }
 
+/* The inline start inset lives on the footer itself rather than on .result-count so that
+   whichever item comes first (the pause warning, when capture is paused, otherwise the
+   result count) lines up with the rest of the page content. */
 .items-footer {
     display: flex;
     column-gap: 20px;
     min-height: 46px;
     align-items: center;
-}
-
-.items-footer .result-count {
     padding-left: var(--layout-left-padding);
 }
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/StructuredLogsTests.cs
@@ -250,6 +250,14 @@ public partial class StructuredLogsTests : DashboardTestContext
 
         Assert.True(Services.GetRequiredService<PauseManager>().AreStructuredLogsPaused(out _));
         Assert.Contains("Capture paused", cut.Markup);
+
+        // The warning leads the footer so it sits to the left of "Showing X structured logs"
+        // instead of floating in the middle of the footer.
+        var footer = cut.Find(".items-footer");
+        Assert.Collection(
+            footer.Children,
+            first => Assert.Contains("block-warning", first.ClassList),
+            second => Assert.Contains("result-count", second.ClassList));
     }
 
     private void SetupStructureLogsServices()


### PR DESCRIPTION
## Description

On the Structured logs page the "Capture paused" warning was rendered after the result count in
`TotalItemsFooter`, so it ended up sitting a short distance to the right of "Showing X structured
logs" with an otherwise empty footer stretching away to the right. That reads as a floating,
misaligned banner rather than as part of the footer.

This moves the warning ahead of the result count so it leads the footer, which is the first of the
two placements suggested in the issue. The inline start inset moves from `.result-count` onto
`.items-footer` itself so whichever element comes first still lines up with the rest of the page
content.

The same footer is used by the Traces and Resources pages, so those get the identical treatment when
their capture is paused.

Fixes #19018

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
