### PR TITLE
Indent UTC timestamps option under Show timestamps in console logs menu

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -192,6 +192,10 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     // Indents a menu item so it reads as a sub-option of the item above it. Defined in app.css.
     internal const string SubOptionMenuItemClass = "sub-option-menu-item";
 
+    // Stable id for the "Show timestamps" menu item so the UTC sub-option can reference it with
+    // aria-describedby. Menu item ids are otherwise generated per render.
+    internal const string ShowTimestampMenuItemId = "console-logs-show-timestamps-menu-item";
+
     // State
     private bool _showHiddenResources;
     private bool _showTimestamp;
@@ -734,6 +738,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
 
             _logsMenuItems.Add(new()
             {
+                Id = ShowTimestampMenuItemId,
                 OnClick = () => ToggleTimestampAsync(showTimestamp: !_showTimestamp, isTimestampUtc: _isTimestampUtc),
                 Text = _showTimestamp ? Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampHide)] : Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShow)],
                 Icon = new Icons.Regular.Size16.CalendarClock()
@@ -743,7 +748,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
             // while timestamps are hidden. It intentionally stays visible rather than being hidden
             // so someone who turns timestamps on doesn't have to reopen the menu to discover it.
             // The indent class makes it read as a sub-option of the timestamp toggle above; without
-            // it the greyed-out checkbox looks like a standalone (or broken) entry.
+            // it the greyed-out checkbox looks like a standalone (or broken) entry. The indent is
+            // only visual, so aria-describedby points at the toggle above to give assistive
+            // technology the same relationship.
             // See https://github.com/microsoft/aspire/issues/19019.
             _logsMenuItems.Add(new()
             {
@@ -751,7 +758,11 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)],
                 Icon = _isTimestampUtc ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked(),
                 IsDisabled = !_showTimestamp,
-                Class = SubOptionMenuItemClass
+                Class = SubOptionMenuItemClass,
+                AdditionalAttributes = new Dictionary<string, object>
+                {
+                    ["aria-describedby"] = ShowTimestampMenuItemId
+                }
             });
 
             _logsMenuItems.Add(new()

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -189,6 +189,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
     private readonly List<MenuButtonItem> _logsMenuItems = new();
     private readonly List<MenuButtonItem> _resourceMenuItems = new();
 
+    // Indents a menu item so it reads as a sub-option of the item above it. Defined in app.css.
+    internal const string SubOptionMenuItemClass = "sub-option-menu-item";
+
     // State
     private bool _showHiddenResources;
     private bool _showTimestamp;
@@ -736,12 +739,19 @@ public sealed partial class ConsoleLogs : ComponentBase, IComponentWithTelemetry
                 Icon = new Icons.Regular.Size16.CalendarClock()
             });
 
+            // UTC only applies to timestamps that are actually rendered, so the item is disabled
+            // while timestamps are hidden. It intentionally stays visible rather than being hidden
+            // so someone who turns timestamps on doesn't have to reopen the menu to discover it.
+            // The indent class makes it read as a sub-option of the timestamp toggle above; without
+            // it the greyed-out checkbox looks like a standalone (or broken) entry.
+            // See https://github.com/microsoft/aspire/issues/19019.
             _logsMenuItems.Add(new()
             {
                 OnClick = () => ToggleTimestampAsync(showTimestamp: _showTimestamp, isTimestampUtc: !_isTimestampUtc),
                 Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)],
                 Icon = _isTimestampUtc ? new Icons.Regular.Size16.CheckboxChecked() : new Icons.Regular.Size16.CheckboxUnchecked(),
-                IsDisabled = !_showTimestamp
+                IsDisabled = !_showTimestamp,
+                Class = SubOptionMenuItemClass
             });
 
             _logsMenuItems.Add(new()

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -2042,6 +2042,15 @@ fluent-tooltip[anchor="dialog_close"] > div {
     max-width: var(--aspire-menu-max-width);
 }
 
+/* Indents a menu item so it reads as a sub-option of the item above it, e.g. the console logs
+   "UTC timestamps" option under "Show timestamps". fluent-menu-item lays its icon and label out
+   in a grid on the host element, so padding on the host shifts both together. The host's own
+   `padding: 0` comes from a :host rule in the component's shadow root, which document styles
+   such as this one override. */
+.aspire-menu-container fluent-menu-item.sub-option-menu-item {
+    padding-inline-start: 16px;
+}
+
 .overflow-fluent-menu-item::part(content) {
     width: 100%;
     text-overflow: ellipsis;

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -904,6 +904,46 @@ public partial class ConsoleLogsTests : DashboardTestContext
         }
     }
 
+    [Fact]
+    public async Task LogsMenu_UtcTimestampsOption_IsIndentedAndFollowsShowTimestamps()
+    {
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var testResource = ModelTestHelpers.CreateResource(resourceName: "test-resource", state: KnownResourceState.Running);
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: _ => consoleLogsChannel,
+            resourceChannelProvider: () => resourceChannel,
+            initialResources: [testResource]);
+
+        SetupConsoleLogsServices(dashboardClient);
+
+        var cut = RenderConsoleLogsPage(CreateViewport(isDesktop: true), resourceName: "test-resource");
+        var instance = cut.Instance;
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource.Id?.InstanceId == testResource.Name);
+
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
+
+        // The UTC option is shown even when it can't be used, so the indent is what tells the user
+        // it belongs to "Show timestamps" rather than being a standalone option.
+        var utcItem = GetUtcTimestampsMenuItem();
+        Assert.True(utcItem.IsDisabled);
+        Assert.Equal(Components.Pages.ConsoleLogs.SubOptionMenuItemClass, utcItem.Class);
+
+        var showTimestampsItem = Assert.Single(
+            instance.LogsMenuItemsForTest,
+            i => i.Text == loc[nameof(Resources.ConsoleLogs.ConsoleLogsTimestampShow)].Value);
+        await cut.InvokeAsync(() => showTimestampsItem.OnClick!());
+
+        utcItem = GetUtcTimestampsMenuItem();
+        Assert.False(utcItem.IsDisabled);
+        Assert.Equal(Components.Pages.ConsoleLogs.SubOptionMenuItemClass, utcItem.Class);
+
+        MenuButtonItem GetUtcTimestampsMenuItem() => Assert.Single(
+            instance.LogsMenuItemsForTest,
+            i => i.Text == loc[nameof(Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)].Value);
+    }
+
     private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null, TestTimeProvider? timeProvider = null)
     {
         FluentUISetupHelpers.SetupFluentDialogProvider(this);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -925,23 +925,38 @@ public partial class ConsoleLogsTests : DashboardTestContext
         var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
 
         // The UTC option is shown even when it can't be used, so the indent is what tells the user
-        // it belongs to "Show timestamps" rather than being a standalone option.
+        // it belongs to "Show timestamps" rather than being a standalone option. The indent is only
+        // visual, so aria-describedby has to carry the same relationship for assistive technology.
         var utcItem = GetUtcTimestampsMenuItem();
         Assert.True(utcItem.IsDisabled);
-        Assert.Equal(Components.Pages.ConsoleLogs.SubOptionMenuItemClass, utcItem.Class);
+        AssertSubOptionOfShowTimestamps(utcItem);
 
         var showTimestampsItem = Assert.Single(
             instance.LogsMenuItemsForTest,
             i => i.Text == loc[nameof(Resources.ConsoleLogs.ConsoleLogsTimestampShow)].Value);
+        Assert.Equal(Components.Pages.ConsoleLogs.ShowTimestampMenuItemId, showTimestampsItem.Id);
         await cut.InvokeAsync(() => showTimestampsItem.OnClick!());
 
         utcItem = GetUtcTimestampsMenuItem();
         Assert.False(utcItem.IsDisabled);
-        Assert.Equal(Components.Pages.ConsoleLogs.SubOptionMenuItemClass, utcItem.Class);
+        AssertSubOptionOfShowTimestamps(utcItem);
+
+        // The toggle keeps its id after its label flips to "Hide timestamps", so the reference stays valid.
+        var hideTimestampsItem = Assert.Single(
+            instance.LogsMenuItemsForTest,
+            i => i.Text == loc[nameof(Resources.ConsoleLogs.ConsoleLogsTimestampHide)].Value);
+        Assert.Equal(Components.Pages.ConsoleLogs.ShowTimestampMenuItemId, hideTimestampsItem.Id);
 
         MenuButtonItem GetUtcTimestampsMenuItem() => Assert.Single(
             instance.LogsMenuItemsForTest,
             i => i.Text == loc[nameof(Resources.ConsoleLogs.ConsoleLogsTimestampShowUtc)].Value);
+
+        static void AssertSubOptionOfShowTimestamps(MenuButtonItem item)
+        {
+            Assert.Equal(Components.Pages.ConsoleLogs.SubOptionMenuItemClass, item.Class);
+            var describedBy = Assert.Contains("aria-describedby", item.AdditionalAttributes!);
+            Assert.Equal(Components.Pages.ConsoleLogs.ShowTimestampMenuItemId, describedBy);
+        }
     }
 
     private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null, TestTimeProvider? timeProvider = null)


### PR DESCRIPTION
## Description

The console logs options menu shows "UTC timestamps" underneath "Show timestamps". It is already
disabled while timestamps are hidden, but nothing indicates the two are related, so the greyed-out
unchecked checkbox reads as a standalone (or broken) menu entry.

Rather than hiding the item, this indents it so it reads as a sub-option of "Show timestamps",
following the discussion on the issue: @adamint noted the item is deliberately kept visible so it
stays discoverable for someone who only opens the menu once, and @afscrome suggested indenting the
label to make the parent/child relationship obvious. The item keeps its existing disabled state
while timestamps are hidden.

The indent is a new `sub-option-menu-item` class applied to the menu item; the padding goes on the
`fluent-menu-item` host, which is a grid, so both the checkbox and the label shift together.

Happy to switch this to hiding the item instead if that is the preference.

Fixes #19019

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
