### PR TITLE
Add experimental Azure VMSS compute environment

### DIFF
--- a/Aspire.slnx
+++ b/Aspire.slnx
@@ -93,6 +93,7 @@
     <Project Path="src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.AppService/Aspire.Hosting.Azure.AppService.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj" />
+    <Project Path="src/Aspire.Hosting.Azure.Compute/Aspire.Hosting.Azure.Compute.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.ContainerRegistry/Aspire.Hosting.Azure.ContainerRegistry.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj" />
     <Project Path="src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj" />

--- a/src/Aspire.Hosting.Azure.Compute/Aspire.Hosting.Azure.Compute.csproj
+++ b/src/Aspire.Hosting.Azure.Compute/Aspire.Hosting.Azure.Compute.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <PackageTags>aspire integration hosting azure compute virtual-machine-scale-set vmss cloud</PackageTags>
+    <Description>Azure Virtual Machine Scale Set compute environment resource types for Aspire.</Description>
+    <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>
+    <EnablePackageValidation>false</EnablePackageValidation>
+    <NoWarn>$(NoWarn);AZPROVISION001;ASPIREAZURE003;ASPIREAZURE004;ASPIRECOMPUTE002</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aspire.Hosting.Azure.Network\Aspire.Hosting.Azure.Network.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting.Dotnet\Aspire.Hosting.Dotnet.csproj" />
+    <PackageReference Include="Azure.Storage.Blobs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="AzureVirtualMachineScaleSetFoundation.bicep" />
+    <EmbeddedResource Include="AzureVirtualMachineScaleSetEnvironment.bicep" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironment.bicep
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironment.bicep
@@ -1,0 +1,170 @@
+@description('The location for the resources to be deployed.')
+param location string = resourceGroup().location
+
+param resourceName string
+param vmSku string
+param capacity string
+param imagePublisher string
+param imageOffer string
+param imageSku string
+param imageVersion string
+param subnetId string
+@secure()
+param vmApplicationPackageUri string
+param vmApplicationVersion string
+param adminSshPublicKey string
+param workloadIdentityName string
+param galleryName string
+param galleryApplicationName string
+param adminUsername string = 'azureuser'
+param tags object = {}
+
+var suffix = uniqueString(resourceGroup().id)
+
+resource workloadIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = {
+  name: workloadIdentityName
+}
+
+resource gallery 'Microsoft.Compute/galleries@2025-03-03' existing = {
+  name: galleryName
+}
+
+resource galleryApplication 'Microsoft.Compute/galleries/applications@2025-03-03' existing = {
+  parent: gallery
+  name: galleryApplicationName
+}
+
+resource galleryApplicationVersion 'Microsoft.Compute/galleries/applications/versions@2025-03-03' = {
+  parent: galleryApplication
+  name: vmApplicationVersion
+  location: location
+  properties: {
+    publishingProfile: {
+      source: {
+        mediaLink: vmApplicationPackageUri
+      }
+      manageActions: {
+        install: 'staging="$(mktemp -d)" && trap \'rm -rf "$staging"\' EXIT && tar -xzf aspire-application.tar.gz --no-same-owner -C "$staging" && bash "$staging/install.sh"'
+        update: 'staging="$(mktemp -d)" && trap \'rm -rf "$staging"\' EXIT && tar -xzf aspire-application.tar.gz --no-same-owner -C "$staging" && bash "$staging/update.sh"'
+        remove: 'if [ -f /opt/aspire/${resourceName}/remove.sh ]; then bash /opt/aspire/${resourceName}/remove.sh || exit $?; fi; rm -rf /opt/aspire/${resourceName}'
+      }
+      settings: {
+        packageFileName: 'aspire-application.tar.gz'
+      }
+      targetRegions: [
+        {
+          name: location
+          regionalReplicaCount: 1
+          storageAccountType: 'Standard_LRS'
+        }
+      ]
+      replicaCount: 1
+      excludeFromLatest: false
+    }
+    safetyProfile: {
+      allowDeletionOfReplicatedLocations: false
+    }
+  }
+}
+
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2025-04-01' = {
+  name: take('${resourceName}-${suffix}', 64)
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${workloadIdentity.id}': {}
+    }
+  }
+  sku: {
+    name: vmSku
+    tier: 'Standard'
+    capacity: int(capacity)
+  }
+  properties: {
+    // Uniform orchestration applies VMSS model updates according to upgradePolicy. Flexible
+    // orchestration requires an explicit per-instance update that this preview does not perform.
+    // See https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes.
+    orchestrationMode: 'Uniform'
+    platformFaultDomainCount: 1
+    singlePlacementGroup: false
+    zoneBalance: false
+    upgradePolicy: {
+      // Rolling upgrades require an application health contract, which this preview does not expose yet.
+      // Automatic mode ensures a newly pinned VM Application version reaches existing instances.
+      mode: 'Automatic'
+    }
+    virtualMachineProfile: {
+      osProfile: {
+        computerNamePrefix: 'aspire'
+        adminUsername: adminUsername
+        linuxConfiguration: {
+          disablePasswordAuthentication: true
+          provisionVMAgent: true
+          ssh: {
+            publicKeys: [
+              {
+                path: '/home/${adminUsername}/.ssh/authorized_keys'
+                keyData: adminSshPublicKey
+              }
+            ]
+          }
+        }
+      }
+      storageProfile: {
+        imageReference: {
+          publisher: imagePublisher
+          offer: imageOffer
+          sku: imageSku
+          version: imageVersion
+        }
+        osDisk: {
+          createOption: 'FromImage'
+          caching: 'ReadWrite'
+          managedDisk: {
+            storageAccountType: 'Standard_LRS'
+          }
+          deleteOption: 'Delete'
+        }
+      }
+      networkProfile: {
+        networkApiVersion: '2020-11-01'
+        networkInterfaceConfigurations: [
+          {
+            name: 'primary'
+            properties: {
+              primary: true
+              deleteOption: 'Delete'
+              ipConfigurations: [
+                {
+                  name: 'primary'
+                  properties: {
+                    primary: true
+                    subnet: {
+                      id: subnetId
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+      applicationProfile: {
+        galleryApplications: [
+          {
+            packageReferenceId: galleryApplicationVersion.id
+            treatFailureAsDeploymentFailure: true
+            enableAutomaticUpgrade: false
+            order: 1
+          }
+        ]
+      }
+    }
+  }
+  tags: tags
+}
+
+output vmssId string = vmss.id
+output workloadIdentityClientId string = workloadIdentity.properties.clientId
+output galleryApplicationVersionId string = galleryApplicationVersion.id

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironment.bicep
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironment.bicep
@@ -127,7 +127,6 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2025-04-01' = {
         }
       }
       networkProfile: {
-        networkApiVersion: '2020-11-01'
         networkInterfaceConfigurations: [
           {
             name: 'primary'

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironment.bicep
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironment.bicep
@@ -124,7 +124,6 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2025-04-01' = {
           managedDisk: {
             storageAccountType: 'Standard_LRS'
           }
-          deleteOption: 'Delete'
         }
       }
       networkProfile: {
@@ -134,7 +133,6 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2025-04-01' = {
             name: 'primary'
             properties: {
               primary: true
-              deleteOption: 'Delete'
               ipConfigurations: [
                 {
                   name: 'primary'

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironmentExtensions.cs
@@ -1,0 +1,320 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Provides extension methods for adding Azure Virtual Machine Scale Set compute environments.
+/// </summary>
+[Experimental("ASPIREAZURE004", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public static class AzureVirtualMachineScaleSetEnvironmentExtensions
+{
+    private static readonly string[] s_azureBlobEndpointSuffixes =
+    [
+        "blob.core.windows.net",
+        "blob.core.usgovcloudapi.net",
+        "blob.core.chinacloudapi.cn",
+        "blob.core.cloudapi.de"
+    ];
+
+    /// <summary>
+    /// Adds an Azure Virtual Machine Scale Set compute environment to the application model.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <returns>The Azure Virtual Machine Scale Set compute environment resource builder.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty or contains only whitespace.</exception>
+    [AspireExport]
+    public static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> AddAzureVirtualMachineScaleSetEnvironment(
+        this IDistributedApplicationBuilder builder,
+        string name)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        builder.AddAzureProvisioning();
+        builder.Services.Configure<AzureProvisioningOptions>(options => options.SupportsTargetedRoleAssignments = true);
+
+        var workloadIdentity = builder.AddAzureUserAssignedIdentity(CreateChildResourceName(name, "identity"));
+        var foundation = new AzureVirtualMachineScaleSetFoundationResource(
+            CreateChildResourceName(name, "foundation"),
+            name);
+        if (builder.ExecutionContext.IsPublishMode)
+        {
+            builder.AddResource(foundation);
+        }
+
+        var resource = new AzureVirtualMachineScaleSetEnvironmentResource(name, foundation)
+        {
+            WorkloadIdentity = workloadIdentity.Resource
+        };
+
+        var resourceBuilder = builder.ExecutionContext.IsPublishMode
+            ? builder.AddResource(resource)
+            : builder.CreateResourceBuilder(resource);
+
+        return resourceBuilder.WithAnnotation(new AzureComputeEnvironmentIdentityAnnotation(workloadIdentity.Resource));
+    }
+
+    /// <summary>
+    /// Configures the Linux platform image used by the virtual machine instances.
+    /// </summary>
+    /// <param name="builder">The Azure Virtual Machine Scale Set compute environment resource builder.</param>
+    /// <param name="publisher">The image publisher.</param>
+    /// <param name="offer">The image offer.</param>
+    /// <param name="sku">The image SKU.</param>
+    /// <param name="version">The image version.</param>
+    /// <returns>The Azure Virtual Machine Scale Set compute environment resource builder.</returns>
+    /// <remarks>
+    /// This experimental integration publishes the application for <c>linux-x64</c>. The selected
+    /// platform image and virtual machine SKU must therefore provide a compatible Linux x64 environment.
+    /// </remarks>
+    [AspireExport]
+    public static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> WithPlatformImage(
+        this IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> builder,
+        string publisher,
+        string offer,
+        string sku,
+        string version)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(publisher);
+        ArgumentException.ThrowIfNullOrWhiteSpace(offer);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sku);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        builder.Resource.ImagePublisher = publisher;
+        builder.Resource.ImageOffer = offer;
+        builder.Resource.ImageSku = sku;
+        builder.Resource.ImageVersion = version;
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the Azure virtual machine SKU used by the scale set.
+    /// </summary>
+    /// <param name="builder">The Azure Virtual Machine Scale Set compute environment resource builder.</param>
+    /// <param name="sku">The Azure virtual machine SKU.</param>
+    /// <returns>The Azure Virtual Machine Scale Set compute environment resource builder.</returns>
+    /// <remarks>
+    /// This experimental integration publishes the application for <c>linux-x64</c>. Arm-based
+    /// virtual machine SKUs are not supported.
+    /// </remarks>
+    [AspireExport]
+    public static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> WithVmSku(
+        this IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> builder,
+        string sku)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sku);
+
+        builder.Resource.VmSku = sku;
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the fixed number of virtual machine instances in the scale set.
+    /// </summary>
+    /// <param name="builder">The Azure Virtual Machine Scale Set compute environment resource builder.</param>
+    /// <param name="capacity">The number of virtual machine instances.</param>
+    /// <returns>The Azure Virtual Machine Scale Set compute environment resource builder.</returns>
+    [AspireExport]
+    public static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> WithCapacity(
+        this IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> builder,
+        int capacity)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+
+        builder.Resource.Capacity = capacity;
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Attaches the virtual machine scale set network interfaces to an Azure subnet.
+    /// </summary>
+    /// <param name="builder">The Azure Virtual Machine Scale Set compute environment resource builder.</param>
+    /// <param name="subnet">The Azure subnet resource builder.</param>
+    /// <returns>The Azure Virtual Machine Scale Set compute environment resource builder.</returns>
+    [AspireExport]
+    public static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> WithSubnet(
+        this IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> builder,
+        IResourceBuilder<AzureSubnetResource> subnet)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(subnet);
+
+        builder.Resource.Subnet = subnet.Resource;
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the Azure VM Application package used by the scale set.
+    /// </summary>
+    /// <param name="builder">The Azure Virtual Machine Scale Set compute environment resource builder.</param>
+    /// <param name="packageUri">The HTTPS URI of the VM Application package in Azure Blob Storage.</param>
+    /// <param name="version">The immutable three-part numeric VM Application version.</param>
+    /// <returns>The Azure Virtual Machine Scale Set compute environment resource builder.</returns>
+    /// <remarks>
+    /// The package must be a gzip-compressed tar archive containing <c>install.sh</c> and <c>update.sh</c>
+    /// at its root. A root-level <c>remove.sh</c> script is optional. The package must be accessible to Azure
+    /// Compute Gallery without credentials. Query strings are rejected so credentials cannot be written into
+    /// the generated deployment template.
+    /// </remarks>
+    [AspireExport("withVmApplicationPackageUri", MethodName = "withVmApplicationPackageUri")]
+    public static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> WithVmApplicationPackage(
+        this IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> builder,
+        Uri packageUri,
+        string version)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(packageUri);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        if (!packageUri.IsAbsoluteUri)
+        {
+            throw new ArgumentException("The VM Application package URI must be absolute.", nameof(packageUri));
+        }
+
+        if (packageUri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new ArgumentException("The VM Application package URI must use HTTPS.", nameof(packageUri));
+        }
+
+        if (!string.IsNullOrEmpty(packageUri.UserInfo))
+        {
+            throw new ArgumentException("The VM Application package URI cannot contain user information.", nameof(packageUri));
+        }
+
+        if (!string.IsNullOrEmpty(packageUri.Query))
+        {
+            throw new ArgumentException("The VM Application package URI cannot contain a query string.", nameof(packageUri));
+        }
+
+        if (!string.IsNullOrEmpty(packageUri.Fragment))
+        {
+            throw new ArgumentException("The VM Application package URI cannot contain a fragment.", nameof(packageUri));
+        }
+
+        if (!IsAzureBlobUri(packageUri))
+        {
+            throw new ArgumentException("The VM Application package URI must identify a blob in Azure Storage.", nameof(packageUri));
+        }
+
+        if (!IsValidGalleryApplicationVersion(version))
+        {
+            throw new ArgumentException("The VM Application version must contain exactly three non-negative numeric parts.", nameof(version));
+        }
+
+        builder.Resource.ApplicationPackageUri = packageUri.AbsoluteUri;
+        builder.Resource.ApplicationVersion = version;
+        builder.Resource.UsesGeneratedApplicationPackage = false;
+        builder.Resource.Foundation.ProvisionPackageStorage = false;
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the Azure VM Application package using a secret URI parameter.
+    /// </summary>
+    /// <param name="builder">The Azure Virtual Machine Scale Set compute environment resource builder.</param>
+    /// <param name="packageUri">A secret parameter containing the HTTPS Azure Blob Storage URI, including a SAS query string when required.</param>
+    /// <param name="version">The immutable three-part numeric VM Application version.</param>
+    /// <returns>The Azure Virtual Machine Scale Set compute environment resource builder.</returns>
+    /// <remarks>
+    /// The package must be a gzip-compressed tar archive containing <c>install.sh</c> and <c>update.sh</c>
+    /// at its root. A root-level <c>remove.sh</c> script is optional. Use this overload for private blobs accessed
+    /// through a SAS URI. The parameter remains secret in the Aspire manifest and generated Bicep.
+    /// </remarks>
+    [AspireExport("withVmApplicationPackageParameter", MethodName = "withVmApplicationPackageParameter")]
+    public static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> WithVmApplicationPackage(
+        this IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> builder,
+        IResourceBuilder<ParameterResource> packageUri,
+        string version)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(packageUri);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        if (!packageUri.Resource.Secret)
+        {
+            throw new ArgumentException("The VM Application package URI parameter must be secret.", nameof(packageUri));
+        }
+
+        if (!IsValidGalleryApplicationVersion(version))
+        {
+            throw new ArgumentException("The VM Application version must contain exactly three non-negative numeric parts.", nameof(version));
+        }
+
+        builder.WithParameter("vmApplicationPackageUri", packageUri);
+        builder.Resource.ApplicationPackageUri = packageUri.Resource;
+        builder.Resource.ApplicationVersion = version;
+        builder.Resource.UsesGeneratedApplicationPackage = false;
+        builder.Resource.Foundation.ProvisionPackageStorage = false;
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the SSH public key used to provision the Linux administrator account.
+    /// </summary>
+    /// <param name="builder">The Azure Virtual Machine Scale Set compute environment resource builder.</param>
+    /// <param name="publicKey">The SSH public key.</param>
+    /// <returns>The Azure Virtual Machine Scale Set compute environment resource builder.</returns>
+    /// <remarks>No inbound SSH access is provisioned by this integration.</remarks>
+    [AspireExport]
+    public static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> WithAdminSshPublicKey(
+        this IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> builder,
+        string publicKey)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(publicKey);
+
+        builder.Resource.AdminSshPublicKey = publicKey;
+
+        return builder;
+    }
+
+    private static bool IsValidGalleryApplicationVersion(string version)
+    {
+        var parts = version.Split('.');
+
+        return parts.Length == 3 && parts.All(static part => uint.TryParse(part, out _));
+    }
+
+    private static bool IsAzureBlobUri(Uri uri)
+    {
+        var host = uri.DnsSafeHost;
+        var hasBlobEndpoint = s_azureBlobEndpointSuffixes.Any(suffix =>
+        {
+            if (!host.EndsWith($".{suffix}", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var accountName = host[..^(suffix.Length + 1)];
+            return accountName.Length is >= 3 and <= 24 &&
+                accountName.All(static character => character is >= 'a' and <= 'z' or >= '0' and <= '9');
+        });
+        var pathParts = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        return hasBlobEndpoint && pathParts.Length >= 2;
+    }
+
+    private static string CreateChildResourceName(string parentName, string suffix)
+    {
+        var maximumParentLength = 64 - suffix.Length - 1;
+        var prefix = parentName[..Math.Min(parentName.Length, maximumParentLength)].TrimEnd('-');
+        return $"{prefix}-{suffix}";
+    }
+}

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironmentResource.cs
@@ -314,8 +314,10 @@ public sealed class AzureVirtualMachineScaleSetEnvironmentResource : AzureBicepR
             },
             Metadata = new Dictionary<string, string>
             {
-                ["aspire-fingerprint"] = fingerprint,
-                ["aspire-version"] = applicationVersion
+                // Azure Blob metadata names must be valid C# identifiers.
+                // See https://learn.microsoft.com/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#metadata-key-and-value-names.
+                ["aspire_fingerprint"] = fingerprint,
+                ["aspire_version"] = applicationVersion
             }
         };
     }

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironmentResource.cs
@@ -1,0 +1,317 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREFILESYSTEM001
+#pragma warning disable ASPIREPIPELINES001
+#pragma warning disable ASPIREPIPELINES003
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dotnet;
+using Aspire.Hosting.Pipelines;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Represents an Azure Virtual Machine Scale Set compute environment.
+/// </summary>
+/// <remarks>
+/// This resource is an experimental capability proof that publishes one .NET project as a
+/// self-contained <c>linux-x64</c> application and deploys it through Azure VM Applications.
+/// </remarks>
+[Experimental("ASPIREAZURE004", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+public sealed class AzureVirtualMachineScaleSetEnvironmentResource : AzureBicepResource, IAzureComputeEnvironmentResource
+{
+    private const string BuildPackageStepTag = "build-vm-application-package";
+    private const string UploadPackageStepTag = "upload-vm-application-package";
+
+#pragma warning disable ASPIRECOMPUTE002
+    bool IComputeEnvironmentResource.AllowsImplicitBinding => false;
+
+    int IComputeEnvironmentResource.MinimumResourceCount => 1;
+
+    int? IComputeEnvironmentResource.MaximumResourceCount => 1;
+
+    bool IComputeEnvironmentResource.SupportsResource(IComputeResource resource) => resource is DotnetProjectResource;
+
+    bool IComputeEnvironmentResource.UsesContainerImages(IComputeResource resource) => false;
+#pragma warning restore ASPIRECOMPUTE002
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureVirtualMachineScaleSetEnvironmentResource"/> class.
+    /// </summary>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="foundation">The Azure resources used to stage and distribute the VM Application package.</param>
+    internal AzureVirtualMachineScaleSetEnvironmentResource(
+        string name,
+        AzureVirtualMachineScaleSetFoundationResource foundation)
+        : base(name, templateResourceName: "Aspire.Hosting.Azure.Compute.AzureVirtualMachineScaleSetEnvironment.bicep")
+    {
+        Foundation = foundation;
+        ApplicationPackageUri = foundation.PackageUri;
+
+        Annotations.Add(new PipelineStepAnnotation(_ =>
+        {
+            if (!UsesGeneratedApplicationPackage)
+            {
+                return [];
+            }
+
+            var buildPackageStep = new PipelineStep
+            {
+                Name = $"build-{name}-vm-application-package",
+                Description = $"Publishes and packages the .NET project bound to {name}.",
+                Action = BuildApplicationPackageAsync,
+                Tags = [WellKnownPipelineTags.BuildCompute, BuildPackageStepTag],
+                DependsOnSteps = [WellKnownPipelineSteps.DeployPrereq],
+                Resource = this
+            };
+            var uploadPackageStep = new PipelineStep
+            {
+                Name = $"upload-{name}-vm-application-package",
+                Description = $"Uploads the VM Application package for {name}.",
+                Action = UploadApplicationPackageAsync,
+                Tags = [UploadPackageStepTag],
+                Resource = this
+            };
+
+            return [buildPackageStep, uploadPackageStep];
+        }));
+
+        Annotations.Add(new PipelineConfigurationAnnotation(context =>
+        {
+            var project = context.Model.Resources
+                .OfType<DotnetProjectResource>()
+                .SingleOrDefault(resource => ReferenceEquals(resource.GetComputeEnvironment(), this));
+            if (project is null)
+            {
+                return;
+            }
+
+            var rolloutProvisionSteps = context.GetSteps(this, WellKnownPipelineTags.ProvisionInfrastructure);
+            var prerequisiteResources = project.Annotations
+                .OfType<DeploymentPrerequisitesAnnotation>()
+                .SelectMany(annotation => annotation.Resources)
+                .Distinct()
+                .ToArray();
+            foreach (var prerequisite in prerequisiteResources)
+            {
+                References.Add(prerequisite);
+                rolloutProvisionSteps.DependsOn(
+                    context.GetSteps(prerequisite, WellKnownPipelineTags.ProvisionInfrastructure));
+            }
+
+            if (!UsesGeneratedApplicationPackage)
+            {
+                return;
+            }
+
+            var buildPackageSteps = context.GetSteps(this, BuildPackageStepTag);
+            var uploadPackageSteps = context.GetSteps(this, UploadPackageStepTag);
+            var foundationProvisionSteps = context.GetSteps(Foundation, WellKnownPipelineTags.ProvisionInfrastructure);
+            var workloadIdentity = WorkloadIdentity ??
+                throw new InvalidOperationException(
+                    $"The Azure Virtual Machine Scale Set compute environment '{Name}' requires a workload identity.");
+            var identityProvisionSteps = context.GetSteps(workloadIdentity, WellKnownPipelineTags.ProvisionInfrastructure);
+
+            buildPackageSteps.DependsOn(identityProvisionSteps);
+            foreach (var prerequisite in prerequisiteResources)
+            {
+                buildPackageSteps.DependsOn(
+                    context.GetSteps(prerequisite, WellKnownPipelineTags.ProvisionInfrastructure));
+            }
+            uploadPackageSteps.DependsOn(buildPackageSteps);
+            uploadPackageSteps.DependsOn(foundationProvisionSteps);
+            rolloutProvisionSteps.DependsOn(uploadPackageSteps);
+        }));
+    }
+
+    internal AzureVirtualMachineScaleSetFoundationResource Foundation { get; }
+
+    internal string VmSku { get; set; } = "Standard_D2s_v6";
+
+    internal int Capacity { get; set; } = 2;
+
+    internal string ImagePublisher { get; set; } = "Canonical";
+
+    internal string ImageOffer { get; set; } = "ubuntu-24_04-lts";
+
+    internal string ImageSku { get; set; } = "server";
+
+    internal string ImageVersion { get; set; } = "latest";
+
+    internal AzureSubnetResource? Subnet { get; set; }
+
+    internal object? ApplicationPackageUri { get; set; }
+
+    internal bool UsesGeneratedApplicationPackage { get; set; } = true;
+
+    internal string ApplicationVersion { get; set; } = "1.0.0";
+
+    internal string AdminSshPublicKey { get; set; } = string.Empty;
+
+    internal AzureUserAssignedIdentityResource? WorkloadIdentity { get; set; }
+
+    internal string? GeneratedApplicationPackagePath { get; private set; }
+
+    internal string? GeneratedApplicationPackageFingerprint { get; private set; }
+
+    /// <inheritdoc/>
+    public override BicepTemplateFile GetBicepTemplateFile(string? directory = null, bool deleteTemporaryFileOnDispose = true)
+    {
+        EnsureTemplateParameters();
+
+        return base.GetBicepTemplateFile(directory, deleteTemporaryFileOnDispose);
+    }
+
+    /// <inheritdoc/>
+    public override string GetBicepTemplateString()
+    {
+        EnsureTemplateParameters();
+
+        return base.GetBicepTemplateString();
+    }
+
+    /// <inheritdoc/>
+    public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference)
+        => throw new NotSupportedException("Ingress for Azure Virtual Machine Scale Set compute environments is not implemented yet.");
+
+    private void EnsureTemplateParameters()
+    {
+        if (Subnet is null)
+        {
+            throw new InvalidOperationException($"The Azure Virtual Machine Scale Set compute environment '{Name}' requires an Azure subnet.");
+        }
+
+        if (ApplicationPackageUri is null)
+        {
+            throw new InvalidOperationException($"The Azure Virtual Machine Scale Set compute environment '{Name}' requires a VM Application package.");
+        }
+
+        if (string.IsNullOrWhiteSpace(AdminSshPublicKey))
+        {
+            throw new InvalidOperationException($"The Azure Virtual Machine Scale Set compute environment '{Name}' requires an administrator SSH public key.");
+        }
+
+        if (WorkloadIdentity is null)
+        {
+            throw new InvalidOperationException($"The Azure Virtual Machine Scale Set compute environment '{Name}' requires a workload identity.");
+        }
+
+        Parameters["resourceName"] = Name;
+        Parameters["vmSku"] = VmSku;
+        Parameters["capacity"] = Capacity.ToString(CultureInfo.InvariantCulture);
+        Parameters["imagePublisher"] = ImagePublisher;
+        Parameters["imageOffer"] = ImageOffer;
+        Parameters["imageSku"] = ImageSku;
+        Parameters["imageVersion"] = ImageVersion;
+        Parameters["subnetId"] = Subnet.Id;
+        Parameters["vmApplicationPackageUri"] = ApplicationPackageUri;
+        Parameters["vmApplicationVersion"] = ApplicationVersion;
+        Parameters["adminSshPublicKey"] = AdminSshPublicKey;
+        Parameters["workloadIdentityName"] = WorkloadIdentity.NameOutputReference;
+        Parameters["galleryName"] = Foundation.GalleryName;
+        Parameters["galleryApplicationName"] = Foundation.GalleryApplicationName;
+    }
+
+    private async Task BuildApplicationPackageAsync(PipelineStepContext context)
+    {
+        var project = context.Model.Resources
+            .OfType<DotnetProjectResource>()
+            .SingleOrDefault(resource => ReferenceEquals(resource.GetComputeEnvironment(), this))
+            ?? throw new InvalidOperationException(
+                $"The Azure Virtual Machine Scale Set compute environment '{Name}' requires exactly one bound .NET project.");
+
+        var workloadIdentity = WorkloadIdentity ??
+            throw new InvalidOperationException(
+                $"The Azure Virtual Machine Scale Set compute environment '{Name}' requires a workload identity.");
+        var package = await VirtualMachineScaleSetApplicationPackageBuilder.BuildAsync(
+            project,
+            this,
+            context.ExecutionContext,
+            workloadIdentity.ClientId,
+            context.Services.GetRequiredService<IFileSystemService>(),
+            context.Services.GetRequiredService<IAspireStore>(),
+            context.Logger,
+            context.CancellationToken).ConfigureAwait(false);
+
+        GeneratedApplicationPackagePath = package.Path;
+        GeneratedApplicationPackageFingerprint = package.Fingerprint;
+        ApplicationVersion = package.Version;
+        Parameters["vmApplicationVersion"] = package.Version;
+
+        context.Summary.Add($"{Name} package", $"{Path.GetFileName(package.Path)} ({package.Fingerprint[..12]})");
+    }
+
+    private async Task UploadApplicationPackageAsync(PipelineStepContext context)
+    {
+        if (GeneratedApplicationPackagePath is not { } packagePath ||
+            GeneratedApplicationPackageFingerprint is not { } fingerprint)
+        {
+            throw new InvalidOperationException(
+                $"The VM Application package for compute environment '{Name}' has not been built.");
+        }
+
+        var packageUriValue = await Foundation.PackageUri.GetValueAsync(context.CancellationToken).ConfigureAwait(false);
+        if (!Uri.TryCreate(packageUriValue, UriKind.Absolute, out var packageUri))
+        {
+            throw new InvalidOperationException(
+                $"The package Storage foundation for compute environment '{Name}' did not produce a valid package URI.");
+        }
+
+        var credential = context.Services.GetRequiredService<ITokenCredentialProvider>().TokenCredential;
+        var timeProvider = context.Services.GetRequiredService<TimeProvider>();
+        var blobClient = new BlobClient(packageUri, credential);
+        var uploadOptions = new BlobUploadOptions
+        {
+            HttpHeaders = new BlobHttpHeaders
+            {
+                ContentType = "application/gzip"
+            },
+            Metadata =
+            {
+                ["aspire-fingerprint"] = fingerprint,
+                ["aspire-version"] = ApplicationVersion
+            }
+        };
+
+        const int maximumAttempts = 10;
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                using var packageStream = File.OpenRead(packagePath);
+                await blobClient.UploadAsync(
+                    packageStream,
+                    uploadOptions,
+                    context.CancellationToken).ConfigureAwait(false);
+                break;
+            }
+            catch (RequestFailedException exception) when (
+                exception.Status is 403 or 404 &&
+                attempt < maximumAttempts &&
+                !context.CancellationToken.IsCancellationRequested)
+            {
+                // Azure Storage data-plane RBAC and container visibility can lag ARM completion.
+                var backoffSeconds = Math.Min(2 << (attempt - 1), 30);
+                var jitterMilliseconds = Random.Shared.Next(0, 2_001);
+                var delay = TimeSpan.FromSeconds(backoffSeconds) + TimeSpan.FromMilliseconds(jitterMilliseconds);
+                context.Logger.LogDebug(
+                    "Waiting {Delay} for package Storage access for compute environment {ComputeEnvironment} (attempt {Attempt}/{MaximumAttempts}).",
+                    delay,
+                    Name,
+                    attempt,
+                    maximumAttempts);
+                await Task.Delay(delay, timeProvider, context.CancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        context.Summary.Add($"{Name} package upload", packageUri.GetLeftPart(UriPartial.Path));
+    }
+}

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetEnvironmentResource.cs
@@ -268,18 +268,7 @@ public sealed class AzureVirtualMachineScaleSetEnvironmentResource : AzureBicepR
         var credential = context.Services.GetRequiredService<ITokenCredentialProvider>().TokenCredential;
         var timeProvider = context.Services.GetRequiredService<TimeProvider>();
         var blobClient = new BlobClient(packageUri, credential);
-        var uploadOptions = new BlobUploadOptions
-        {
-            HttpHeaders = new BlobHttpHeaders
-            {
-                ContentType = "application/gzip"
-            },
-            Metadata =
-            {
-                ["aspire-fingerprint"] = fingerprint,
-                ["aspire-version"] = ApplicationVersion
-            }
-        };
+        var uploadOptions = CreatePackageUploadOptions(fingerprint, ApplicationVersion);
 
         const int maximumAttempts = 10;
         for (var attempt = 1; ; attempt++)
@@ -313,5 +302,21 @@ public sealed class AzureVirtualMachineScaleSetEnvironmentResource : AzureBicepR
         }
 
         context.Summary.Add($"{Name} package upload", packageUri.GetLeftPart(UriPartial.Path));
+    }
+
+    internal static BlobUploadOptions CreatePackageUploadOptions(string fingerprint, string applicationVersion)
+    {
+        return new BlobUploadOptions
+        {
+            HttpHeaders = new BlobHttpHeaders
+            {
+                ContentType = "application/gzip"
+            },
+            Metadata = new Dictionary<string, string>
+            {
+                ["aspire-fingerprint"] = fingerprint,
+                ["aspire-version"] = applicationVersion
+            }
+        };
     }
 }

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetFoundation.bicep
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetFoundation.bicep
@@ -1,0 +1,95 @@
+@description('The location for the resources to be deployed.')
+param location string = resourceGroup().location
+
+param resourceName string
+param userPrincipalId string
+param provisionPackageStorage bool
+param tags object = {}
+
+var suffix = uniqueString(resourceGroup().id)
+var storageBlobDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+
+resource galleryIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('${resourceName}-gallery-${suffix}', 128)
+  location: location
+  tags: tags
+}
+
+resource gallery 'Microsoft.Compute/galleries@2025-03-03' = {
+  name: take(replace('${resourceName}${suffix}', '-', ''), 80)
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${galleryIdentity.id}': {}
+    }
+  }
+  properties: {
+    description: 'Compute gallery for the ${resourceName} Aspire compute environment.'
+  }
+  tags: tags
+}
+
+resource galleryApplication 'Microsoft.Compute/galleries/applications@2025-03-03' = {
+  parent: gallery
+  name: 'aspire-application'
+  location: location
+  properties: {
+    description: 'Application deployed by the ${resourceName} Aspire compute environment.'
+    supportedOSType: 'Linux'
+  }
+}
+
+resource packageStorage 'Microsoft.Storage/storageAccounts@2024-01-01' = if (provisionPackageStorage) {
+  name: 'aspire${uniqueString(resourceGroup().id, resourceName)}'
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+    defaultToOAuthAuthentication: true
+    minimumTlsVersion: 'TLS1_2'
+    publicNetworkAccess: 'Enabled'
+    supportsHttpsTrafficOnly: true
+  }
+  tags: tags
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = if (provisionPackageStorage) {
+  parent: packageStorage
+  name: 'default'
+}
+
+resource packageContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2024-01-01' = if (provisionPackageStorage) {
+  parent: blobService
+  name: 'vm-applications'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource deployerPackageContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (provisionPackageStorage) {
+  name: guid(packageStorage.id, userPrincipalId, storageBlobDataContributorRoleId)
+  scope: packageStorage
+  properties: {
+    principalId: userPrincipalId
+    roleDefinitionId: storageBlobDataContributorRoleId
+  }
+}
+
+resource galleryPackageReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (provisionPackageStorage) {
+  name: guid(packageStorage.id, galleryIdentity.id, storageBlobDataContributorRoleId)
+  scope: packageStorage
+  properties: {
+    principalId: galleryIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageBlobDataContributorRoleId
+  }
+}
+
+output packageUri string = provisionPackageStorage ? '${packageStorage!.properties.primaryEndpoints.blob}${packageContainer!.name}/aspire-application.tar.gz' : ''
+output galleryName string = gallery.name
+output galleryApplicationName string = galleryApplication.name

--- a/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetFoundationResource.cs
+++ b/src/Aspire.Hosting.Azure.Compute/AzureVirtualMachineScaleSetFoundationResource.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure;
+
+internal sealed class AzureVirtualMachineScaleSetFoundationResource : AzureBicepResource
+{
+    public AzureVirtualMachineScaleSetFoundationResource(string name, string environmentName)
+        : base(name, templateResourceName: "Aspire.Hosting.Azure.Compute.AzureVirtualMachineScaleSetFoundation.bicep")
+    {
+        Parameters["resourceName"] = environmentName;
+        Parameters["provisionPackageStorage"] = true;
+        Parameters[KnownParameters.UserPrincipalId] = null;
+
+        PackageUri = new BicepOutputReference("packageUri", this);
+        GalleryName = new BicepOutputReference("galleryName", this);
+        GalleryApplicationName = new BicepOutputReference("galleryApplicationName", this);
+    }
+
+    internal BicepOutputReference PackageUri { get; }
+
+    internal BicepOutputReference GalleryName { get; }
+
+    internal BicepOutputReference GalleryApplicationName { get; }
+
+    internal bool ProvisionPackageStorage
+    {
+        set => Parameters["provisionPackageStorage"] = value;
+    }
+}

--- a/src/Aspire.Hosting.Azure.Compute/VirtualMachineScaleSetApplicationPackageBuilder.cs
+++ b/src/Aspire.Hosting.Azure.Compute/VirtualMachineScaleSetApplicationPackageBuilder.cs
@@ -1,0 +1,639 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREFILESYSTEM001
+#pragma warning disable ASPIREDOTNETPROJECT001
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.IO.Hashing;
+using System.Text;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dotnet;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Azure;
+
+internal static class VirtualMachineScaleSetApplicationPackageBuilder
+{
+    private const long MaximumPackageSizeInBytes = 2L * 1024 * 1024 * 1024;
+    private const string TargetRuntimeIdentifier = "linux-x64";
+    private static readonly DateTimeOffset s_archiveTimestamp = DateTimeOffset.UnixEpoch;
+    private const UnixFileMode DirectoryMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+    private const UnixFileMode ExecutableFileMode = DirectoryMode;
+    private const UnixFileMode RegularFileMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite |
+        UnixFileMode.GroupRead |
+        UnixFileMode.OtherRead;
+
+    internal static async Task<VirtualMachineScaleSetApplicationPackage> BuildAsync(
+        DotnetProjectResource project,
+        AzureVirtualMachineScaleSetEnvironmentResource environment,
+        DistributedApplicationExecutionContext executionContext,
+        IValueProvider workloadIdentityClientId,
+        IFileSystemService fileSystem,
+        IAspireStore store,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(workloadIdentityClientId);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        using var stagingDirectory = fileSystem.TempDirectory.CreateTempSubdirectory("aspire-vmss");
+        using var archiveFile = fileSystem.TempDirectory.CreateTempFile("aspire-application.tar.gz");
+        var publishDirectory = Path.Combine(stagingDirectory.Path, "app");
+        Directory.CreateDirectory(publishDirectory);
+
+        var projectPath = project.Annotations.OfType<IProjectMetadata>().Single().ProjectPath;
+        await PublishProjectAsync(projectPath, publishDirectory, logger, cancellationToken).ConfigureAwait(false);
+
+        var configuration = await ResolveConfigurationAsync(
+            project,
+            executionContext,
+            workloadIdentityClientId,
+            logger,
+            cancellationToken).ConfigureAwait(false);
+        var entryPoint = FindEntryPoint(publishDirectory, project.Name);
+        await WriteManagementFilesAsync(
+            stagingDirectory.Path,
+            environment.Name,
+            project.Name,
+            entryPoint,
+            configuration.EnvironmentVariables,
+            configuration.Arguments,
+            cancellationToken).ConfigureAwait(false);
+        await CreateArchiveAsync(stagingDirectory.Path, archiveFile.Path, entryPoint, cancellationToken).ConfigureAwait(false);
+        ValidatePackageSize(new FileInfo(archiveFile.Path).Length, project.Name);
+
+        var fingerprint = await ComputeFingerprintAsync(archiveFile.Path, cancellationToken).ConfigureAwait(false);
+        using var archiveStream = File.OpenRead(archiveFile.Path);
+        var storedPath = store.GetFileNameWithContent($"{environment.Name}-vm-application.tgz", archiveStream);
+
+        return new VirtualMachineScaleSetApplicationPackage(
+            storedPath,
+            fingerprint.Hex,
+            CreateGalleryApplicationVersion(fingerprint.Value));
+    }
+
+    internal static void ValidatePackageSize(long packageSizeInBytes, string projectName)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(packageSizeInBytes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectName);
+
+        // Azure VM Applications accept individual packages up to 2 GiB.
+        // See https://learn.microsoft.com/azure/virtual-machines/vm-applications#failure-resiliency-and-high-scale-performance.
+        if (packageSizeInBytes > MaximumPackageSizeInBytes)
+        {
+            throw new DistributedApplicationException(
+                $"The VM Application package for project '{projectName}' is {packageSizeInBytes} bytes, " +
+                $"which exceeds the Azure VM Applications limit of {MaximumPackageSizeInBytes} bytes.");
+        }
+    }
+
+    internal static async Task CreateArchiveAsync(
+        string stagingDirectory,
+        string archivePath,
+        string entryPoint,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stagingDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(archivePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryPoint);
+
+        using var archiveStream = File.Create(archivePath);
+        using var gzipStream = new GZipStream(archiveStream, CompressionLevel.SmallestSize, leaveOpen: false);
+        using var tarWriter = new TarWriter(gzipStream, TarEntryFormat.Ustar, leaveOpen: false);
+
+        var enumerationOptions = new EnumerationOptions
+        {
+            AttributesToSkip = 0,
+            RecurseSubdirectories = true,
+            ReturnSpecialDirectories = false
+        };
+
+        var directories = Directory.EnumerateDirectories(stagingDirectory, "*", enumerationOptions)
+            .Select(path => NormalizeArchivePath(stagingDirectory, path) + "/")
+            .Order(StringComparer.Ordinal);
+        foreach (var directory in directories)
+        {
+            var entry = new UstarTarEntry(TarEntryType.Directory, directory)
+            {
+                Gid = 0,
+                GroupName = string.Empty,
+                Mode = DirectoryMode,
+                ModificationTime = s_archiveTimestamp,
+                Uid = 0,
+                UserName = string.Empty
+            };
+            await tarWriter.WriteEntryAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+
+        var files = Directory.EnumerateFiles(stagingDirectory, "*", enumerationOptions)
+            .Select(path => (FullPath: path, ArchivePath: NormalizeArchivePath(stagingDirectory, path)))
+            .OrderBy(item => item.ArchivePath, StringComparer.Ordinal);
+        foreach (var file in files)
+        {
+            using var dataStream = File.OpenRead(file.FullPath);
+            var isExecutable =
+                file.ArchivePath is "install.sh" or "update.sh" or "remove.sh" ||
+                string.Equals(file.ArchivePath, $"app/{entryPoint}", StringComparison.Ordinal) ||
+                HasExecutableFileHeader(dataStream);
+            var entry = new UstarTarEntry(TarEntryType.RegularFile, file.ArchivePath)
+            {
+                DataStream = dataStream,
+                Gid = 0,
+                GroupName = string.Empty,
+                Mode = isExecutable ? ExecutableFileMode : RegularFileMode,
+                ModificationTime = s_archiveTimestamp,
+                Uid = 0,
+                UserName = string.Empty
+            };
+            await tarWriter.WriteEntryAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    internal static async Task WriteManagementFilesAsync(
+        string stagingDirectory,
+        string environmentName,
+        string projectName,
+        string entryPoint,
+        IReadOnlyDictionary<string, string> environmentVariables,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stagingDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(environmentName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryPoint);
+        ArgumentNullException.ThrowIfNull(environmentVariables);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var serviceName = $"aspire-{environmentName}.service";
+        var environmentFileName = $"aspire-{environmentName}.env";
+        var deploymentDirectory = $"/opt/aspire/{environmentName}";
+        var execStart = new StringBuilder(EscapeSystemdExecArgument($"{deploymentDirectory}/app/{entryPoint}"));
+        foreach (var argument in arguments)
+        {
+            execStart.Append(' ').Append(EscapeSystemdExecArgument(argument));
+        }
+
+        var unit = $$"""
+            [Unit]
+            Description=Aspire project {{projectName}}
+            Wants=network-online.target
+            After=network-online.target
+
+            [Service]
+            Type=simple
+            User=aspire-app
+            Group=aspire-app
+            WorkingDirectory={{deploymentDirectory}}/app
+            ExecStart={{execStart}}
+            EnvironmentFile=/etc/aspire/{{environmentName}}.env
+            Restart=always
+            RestartSec=5
+            NoNewPrivileges=true
+            PrivateTmp=true
+            ProtectHome=true
+            ProtectSystem=full
+
+            [Install]
+            WantedBy=multi-user.target
+
+            """;
+        var install = $$"""
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            source_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+            deployment_dir="{{deploymentDirectory}}"
+            service_name="{{serviceName}}"
+            service_user="aspire-app"
+
+            systemctl stop "$service_name" 2>/dev/null || true
+            if ! getent group "$service_user" >/dev/null; then
+                groupadd --system "$service_user"
+            fi
+            if ! id -u "$service_user" >/dev/null 2>&1; then
+                useradd --system --gid "$service_user" --home-dir "$deployment_dir" --no-create-home --shell /usr/sbin/nologin "$service_user"
+            fi
+            install -d -o root -g root -m 0755 "$deployment_dir"
+            install -d -o root -g root -m 0755 /etc/aspire
+            rm -rf "$deployment_dir/app"
+            cp -a "$source_dir/app" "$deployment_dir/app"
+            install -m 0755 "$source_dir/remove.sh" "$deployment_dir/remove.sh"
+            install -o root -g root -m 0600 "$source_dir/{{environmentFileName}}" "/etc/aspire/{{environmentName}}.env"
+            install -m 0644 "$source_dir/{{serviceName}}" "/etc/systemd/system/$service_name"
+            systemctl daemon-reload
+            systemctl enable "$service_name"
+            systemctl restart "$service_name"
+
+            """;
+        var update = """
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            source_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+            exec "$source_dir/install.sh"
+
+            """;
+        var remove = $$"""
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            service_name="{{serviceName}}"
+            systemctl disable --now "$service_name" 2>/dev/null || true
+            rm -f "/etc/systemd/system/$service_name"
+            rm -f "/etc/aspire/{{environmentName}}.env"
+            systemctl daemon-reload
+
+            """;
+        var environmentFile = new StringBuilder();
+        foreach (var (name, value) in environmentVariables.OrderBy(static item => item.Key, StringComparer.Ordinal))
+        {
+            environmentFile
+                .Append(name)
+                .Append("=\"")
+                .Append(EscapeSystemdEnvironmentValue(value))
+                .AppendLine("\"");
+        }
+
+        await Task.WhenAll(
+            File.WriteAllTextAsync(Path.Combine(stagingDirectory, serviceName), unit, new UTF8Encoding(false), cancellationToken),
+            File.WriteAllTextAsync(Path.Combine(stagingDirectory, environmentFileName), environmentFile.ToString(), new UTF8Encoding(false), cancellationToken),
+            File.WriteAllTextAsync(Path.Combine(stagingDirectory, "install.sh"), install, new UTF8Encoding(false), cancellationToken),
+            File.WriteAllTextAsync(Path.Combine(stagingDirectory, "update.sh"), update, new UTF8Encoding(false), cancellationToken),
+            File.WriteAllTextAsync(Path.Combine(stagingDirectory, "remove.sh"), remove, new UTF8Encoding(false), cancellationToken)).ConfigureAwait(false);
+    }
+
+    internal static async Task<VirtualMachineScaleSetWorkloadConfiguration> ResolveConfigurationAsync(
+        DotnetProjectResource project,
+        DistributedApplicationExecutionContext executionContext,
+        IValueProvider workloadIdentityClientId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(workloadIdentityClientId);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var environmentVariables = new Dictionary<string, object>(StringComparer.Ordinal);
+        if (project.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var environmentCallbacks))
+        {
+            var callbackContext = new EnvironmentCallbackContext(
+                executionContext,
+                project,
+                environmentVariables,
+                cancellationToken)
+            {
+                Logger = logger
+            };
+            foreach (var callback in environmentCallbacks)
+            {
+                await callback.Callback(callbackContext).ConfigureAwait(false);
+            }
+        }
+
+        var arguments = new List<object>();
+        if (project.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argumentCallbacks))
+        {
+            var callbackContext = new CommandLineArgsCallbackContext(arguments, project, cancellationToken)
+            {
+                ExecutionContext = executionContext,
+                Logger = logger
+            };
+            foreach (var callback in argumentCallbacks)
+            {
+                await callback.Callback(callbackContext).ConfigureAwait(false);
+            }
+        }
+
+        RemoveDotnetRunScaffolding(arguments);
+
+        var resolvedEnvironment = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (name, value) in environmentVariables)
+        {
+            if (!IsValidEnvironmentVariableName(name))
+            {
+                throw new DistributedApplicationException(
+                    $"Environment variable '{name}' on project '{project.Name}' is not a valid Linux environment variable name.");
+            }
+
+            ThrowIfSecret(value, $"environment variable '{name}'", project.Name);
+            if (await ResolveValueAsync(value, project, executionContext, cancellationToken).ConfigureAwait(false) is { } resolvedValue)
+            {
+                resolvedEnvironment[name] = resolvedValue;
+            }
+        }
+
+        var identityClientId = await workloadIdentityClientId.GetValueAsync(
+            new ValueProviderContext
+            {
+                Caller = project,
+                ExecutionContext = executionContext
+            },
+            cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(identityClientId))
+        {
+            throw new DistributedApplicationException(
+                $"The workload identity client ID for project '{project.Name}' could not be resolved.");
+        }
+
+        resolvedEnvironment.TryAdd("DOTNET_ENVIRONMENT", "Production");
+        resolvedEnvironment["AZURE_CLIENT_ID"] = identityClientId;
+        resolvedEnvironment["AZURE_TOKEN_CREDENTIALS"] = "ManagedIdentityCredential";
+
+        var resolvedArguments = new List<string>(arguments.Count);
+        foreach (var argument in arguments)
+        {
+            ThrowIfSecret(argument, "command-line argument", project.Name);
+            if (await ResolveValueAsync(argument, project, executionContext, cancellationToken).ConfigureAwait(false) is { } resolvedArgument)
+            {
+                resolvedArguments.Add(resolvedArgument);
+            }
+        }
+
+        return new VirtualMachineScaleSetWorkloadConfiguration(resolvedEnvironment, resolvedArguments);
+    }
+
+    private static void RemoveDotnetRunScaffolding(List<object> arguments)
+    {
+        // AddDotnetProject emits launcher arguments in this shape:
+        //   run --project <path> [--configuration <configuration>] --no-launch-profile <application arguments>
+        // The VM Application starts the published executable directly, so only arguments after the
+        // dotnet-run prefix belong on the generated systemd ExecStart command.
+        if (arguments.Count < 4 ||
+            arguments[0] is not string { } verb ||
+            !string.Equals(verb, "run", StringComparison.Ordinal) ||
+            arguments[1] is not string projectOption ||
+            projectOption is not ("--project" or "--file"))
+        {
+            return;
+        }
+
+        var launchProfileOptionIndex = arguments.FindIndex(
+            argument => argument is string value && string.Equals(value, "--no-launch-profile", StringComparison.Ordinal));
+        if (launchProfileOptionIndex >= 0)
+        {
+            arguments.RemoveRange(0, launchProfileOptionIndex + 1);
+        }
+    }
+
+    private static async Task PublishProjectAsync(
+        string projectPath,
+        string outputDirectory,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            WorkingDirectory = Path.GetDirectoryName(projectPath),
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("publish");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("--configuration");
+        startInfo.ArgumentList.Add("Release");
+        startInfo.ArgumentList.Add("--runtime");
+        startInfo.ArgumentList.Add(TargetRuntimeIdentifier);
+        startInfo.ArgumentList.Add("--self-contained");
+        startInfo.ArgumentList.Add("--output");
+        startInfo.ArgumentList.Add(outputDirectory);
+        startInfo.ArgumentList.Add("--nologo");
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start 'dotnet publish' for project '{projectPath}'.");
+
+        // Read both streams concurrently so a full redirected pipe cannot block the publish process.
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            throw;
+        }
+
+        var standardOutput = await standardOutputTask.ConfigureAwait(false);
+        var standardError = await standardErrorTask.ConfigureAwait(false);
+        logger.LogDebug("dotnet publish output for {ProjectPath}:{NewLine}{StandardOutput}", projectPath, Environment.NewLine, standardOutput);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"'dotnet publish' failed for project '{projectPath}' with exit code {process.ExitCode}:{Environment.NewLine}{LimitOutput(standardError)}");
+        }
+    }
+
+    private static string FindEntryPoint(string publishDirectory, string projectName)
+    {
+        var runtimeConfigFiles = Directory.GetFiles(
+            publishDirectory,
+            "*.runtimeconfig.json",
+            SearchOption.TopDirectoryOnly);
+        if (runtimeConfigFiles.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Published project '{projectName}' produced {runtimeConfigFiles.Length} runtime configuration files; exactly one is required.");
+        }
+
+        const string runtimeConfigSuffix = ".runtimeconfig.json";
+        var runtimeConfigName = Path.GetFileName(runtimeConfigFiles[0]);
+        var entryPoint = runtimeConfigName[..^runtimeConfigSuffix.Length];
+        if (!File.Exists(Path.Combine(publishDirectory, entryPoint)))
+        {
+            throw new InvalidOperationException(
+                $"The self-contained Linux executable '{entryPoint}' was not found in the publish output for project '{projectName}'.");
+        }
+
+        return entryPoint;
+    }
+
+    private static async Task<(string Hex, ulong Value)> ComputeFingerprintAsync(
+        string filePath,
+        CancellationToken cancellationToken)
+    {
+        var hash = new XxHash3();
+        using var stream = File.OpenRead(filePath);
+        var buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
+        {
+            int bytesRead;
+            while ((bytesRead = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+            {
+                hash.Append(buffer.AsSpan(0, bytesRead));
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        var bytes = hash.GetCurrentHash();
+        return (Convert.ToHexString(bytes).ToLowerInvariant(), BinaryPrimitives.ReadUInt64BigEndian(bytes));
+    }
+
+    private static string CreateGalleryApplicationVersion(ulong fingerprint)
+    {
+        var minor = (fingerprint >> 31) & int.MaxValue;
+        var patch = fingerprint & int.MaxValue;
+        return $"1.{minor}.{patch}";
+    }
+
+    private static string NormalizeArchivePath(string root, string path)
+        => Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/');
+
+    private static bool HasExecutableFileHeader(Stream stream)
+    {
+        Span<byte> header = stackalloc byte[4];
+        var bytesRead = stream.Read(header);
+        stream.Position = 0;
+
+        return bytesRead >= 2 && header[0] == (byte)'#' && header[1] == (byte)'!' ||
+            bytesRead == header.Length &&
+            header.SequenceEqual((ReadOnlySpan<byte>)[0x7f, (byte)'E', (byte)'L', (byte)'F']);
+    }
+
+    private static async ValueTask<string?> ResolveValueAsync(
+        object? value,
+        IResource caller,
+        DistributedApplicationExecutionContext executionContext,
+        CancellationToken cancellationToken)
+    {
+        var valueProvider = value switch
+        {
+            IValueProvider provider => provider,
+            IResourceBuilder<IResource> builder when builder.Resource is IValueProvider provider => provider,
+            _ => null
+        };
+        if (valueProvider is not null)
+        {
+            return await valueProvider.GetValueAsync(
+                new ValueProviderContext
+                {
+                    Caller = caller,
+                    ExecutionContext = executionContext
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return value switch
+        {
+            string text => text,
+            null => null,
+            _ => value.ToString()
+        };
+    }
+
+    private static void ThrowIfSecret(object? value, string configurationDescription, string projectName)
+    {
+        if (ContainsSecret(value, []))
+        {
+            throw new DistributedApplicationException(
+                $"The {configurationDescription} on project '{projectName}' contains a secret. " +
+                "Azure Virtual Machine Scale Set compute environments do not support materializing secrets into VM Application packages.");
+        }
+    }
+
+    private static bool ContainsSecret(object? value, HashSet<object> visited)
+    {
+        if (value is null || !visited.Add(value))
+        {
+            return false;
+        }
+
+        if (value is ParameterResource { Secret: true } or IAzureKeyVaultSecretReference)
+        {
+            return true;
+        }
+
+#pragma warning disable CS0618
+        if (value is BicepSecretOutputReference)
+        {
+            return true;
+        }
+#pragma warning restore CS0618
+
+        if (value is IResourceBuilder<IResource> builder)
+        {
+            return ContainsSecret(builder.Resource, visited);
+        }
+
+        return value is IValueWithReferences valueWithReferences &&
+            valueWithReferences.References.Any(reference => ContainsSecret(reference, visited));
+    }
+
+    private static bool IsValidEnvironmentVariableName(string name)
+    {
+        if (name.Length == 0 || name[0] is not ('_' or >= 'A' and <= 'Z' or >= 'a' and <= 'z'))
+        {
+            return false;
+        }
+
+        foreach (var character in name.AsSpan(1))
+        {
+            if (character is not ('_' or >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string EscapeSystemdExecArgument(string value)
+        => $"\"{value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal)
+            .Replace("%", "%%", StringComparison.Ordinal)}\"";
+
+    private static string EscapeSystemdEnvironmentValue(string value)
+        => value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
+
+    private static string LimitOutput(string output)
+    {
+        const int maximumLength = 4_000;
+        var trimmed = output.Trim();
+        return trimmed.Length <= maximumLength ? trimmed : trimmed[^maximumLength..];
+    }
+}
+
+internal sealed record VirtualMachineScaleSetApplicationPackage(
+    string Path,
+    string Fingerprint,
+    string Version);
+
+internal sealed record VirtualMachineScaleSetWorkloadConfiguration(
+    IReadOnlyDictionary<string, string> EnvironmentVariables,
+    IReadOnlyList<string> Arguments);

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Compute" />
     <InternalsVisibleTo Include="Aspire.Hosting.Azure.ContainerRegistry" />
     <InternalsVisibleTo Include="Aspire.Hosting.Foundry" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure/AzureComputeEnvironmentIdentityAnnotation.cs
+++ b/src/Aspire.Hosting.Azure/AzureComputeEnvironmentIdentityAnnotation.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+internal sealed class AzureComputeEnvironmentIdentityAnnotation(AzureUserAssignedIdentityResource identityResource) : IResourceAnnotation
+{
+    public AzureUserAssignedIdentityResource IdentityResource { get; } = identityResource;
+}

--- a/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourcePreparer.cs
@@ -203,16 +203,63 @@ internal sealed class AzureResourcePreparer(
             // - if in PublishMode
             //   - if a compute resource has RoleAssignmentAnnotations, use them
             //   - if the resource doesn't, copy the DefaultRoleAssignments to RoleAssignmentAnnotations to apply the defaults
+#pragma warning disable ASPIRECOMPUTE002
             var resourceSnapshot = appModel.GetComputeResources()
+                .Concat(appModel.Resources
+                    .OfType<IComputeResource>()
+                    .Where(r => !r.IsExcludedFromPublish() &&
+                        !r.IsContainer() &&
+                        !r.IsEmulator() &&
+                        r.GetComputeEnvironment() is IAzureComputeEnvironmentResource environment &&
+                        environment.SupportsResource(r)))
                 .Concat(appModel.Resources
                     .OfType<AzureUserAssignedIdentityResource>()
                     .Where(r => !r.IsExcludedFromPublish()))
+                .Distinct()
                 .ToArray(); // avoid modifying the collection while iterating
+#pragma warning restore ASPIRECOMPUTE002
             foreach (var resource in resourceSnapshot)
             {
+                if (executionContext.IsPublishMode &&
+                    resource.GetComputeEnvironment() is IAzureComputeEnvironmentResource environment &&
+                    environment.TryGetLastAnnotation<AzureComputeEnvironmentIdentityAnnotation>(out var environmentIdentity))
+                {
+                    if (resource.TryGetLastAnnotation<AppIdentityAnnotation>(out var existingAppIdentity))
+                    {
+                        if (existingAppIdentity.IdentityResource != environmentIdentity.IdentityResource)
+                        {
+                            var existingIdentityName = (existingAppIdentity.IdentityResource as IResource)?.Name ??
+                                existingAppIdentity.IdentityResource.GetType().Name;
+                            var environmentIdentityName = (environmentIdentity.IdentityResource as IResource)?.Name ??
+                                environmentIdentity.IdentityResource.GetType().Name;
+                            throw new DistributedApplicationException(
+                                $"Compute resource '{resource.Name}' uses identity '{existingIdentityName}', " +
+                                $"but compute environment '{environment.Name}' requires identity '{environmentIdentityName}'.");
+                        }
+                    }
+                    else
+                    {
+                        resource.Annotations.Add(new AppIdentityAnnotation(environmentIdentity.IdentityResource));
+                    }
+                }
+
                 var prerequisiteResources = new HashSet<AzureBicepResource>();
                 var directDependencies = await resource.GetResourceDependenciesAsync(executionContext, ResourceDependencyDiscoveryMode.DirectOnly, cancellationToken).ConfigureAwait(false);
                 var azureReferences = new HashSet<IAzureResource>(directDependencies.OfType<IAzureResource>());
+
+                if (executionContext.IsPublishMode &&
+                    resource is IComputeResource computeResource &&
+                    resource.GetComputeEnvironment() is IAzureComputeEnvironmentResource computeEnvironment)
+                {
+#pragma warning disable ASPIRECOMPUTE002
+                    if (!computeEnvironment.UsesContainerImages(computeResource))
+                    {
+                        // Direct-deploy publishers resolve Azure outputs before packaging rather than
+                        // passing output expressions into a container deployment template.
+                        prerequisiteResources.UnionWith(azureReferences.OfType<AzureBicepResource>());
+                    }
+#pragma warning restore ASPIRECOMPUTE002
+                }
 
                 var azureReferencesWithRoleAssignments =
                     (resource.TryGetAnnotationsOfType<RoleAssignmentAnnotation>(out var annotations)

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -1406,6 +1406,11 @@ internal sealed class BicepProvisioner(
             resource.Parameters[AzureBicepResource.KnownParameters.PrincipalType] = "User";
         }
 
+        if (resource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.UserPrincipalId, out var userPrincipalId) && userPrincipalId is null)
+        {
+            resource.Parameters[AzureBicepResource.KnownParameters.UserPrincipalId] = context.Principal.Id;
+        }
+
         if (!resource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.Location, out var location) || location is null)
         {
             resource.Parameters[AzureBicepResource.KnownParameters.Location] = context.Location.Name;

--- a/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IComputeEnvironmentResource.cs
@@ -12,6 +12,55 @@ namespace Aspire.Hosting.ApplicationModel;
 public interface IComputeEnvironmentResource : IResource
 {
     /// <summary>
+    /// Gets a value indicating whether this environment can be selected automatically when it is the only compute environment in the application model.
+    /// </summary>
+    /// <remarks>
+    /// Environments that require workloads to opt in explicitly should return <see langword="false"/>.
+    /// </remarks>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    bool AllowsImplicitBinding => true;
+
+    /// <summary>
+    /// Gets the minimum number of compute resources that must be bound to this environment.
+    /// </summary>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    int MinimumResourceCount => 0;
+
+    /// <summary>
+    /// Gets the maximum number of compute resources that can be bound to this environment, or <see langword="null"/> when no maximum applies.
+    /// </summary>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    int? MaximumResourceCount => null;
+
+    /// <summary>
+    /// Determines whether the specified compute resource can be bound to this environment.
+    /// </summary>
+    /// <param name="resource">The compute resource to evaluate.</param>
+    /// <returns><see langword="true"/> when the resource is supported; otherwise, <see langword="false"/>.</returns>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    bool SupportsResource(IComputeResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether the specified compute resource should be built as a container image for this environment.
+    /// </summary>
+    /// <param name="resource">The compute resource to evaluate.</param>
+    /// <returns><see langword="true"/> when the resource requires a container image; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Compute environments that deploy projects or executables without containers can return <see langword="false"/>
+    /// and provide their own build pipeline steps.
+    /// </remarks>
+    [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+    bool UsesContainerImages(IComputeResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        return true;
+    }
+
+    /// <summary>
     /// Gets a <see cref="ReferenceExpression"/> representing the host address or host name for the specified <see cref="EndpointReference"/>.
     /// </summary>
     /// <param name="endpointReference">The endpoint reference for which to retrieve the host address or host name.</param>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -955,6 +955,17 @@ public static class ResourceExtensions
             return false;
         }
 
+        if (resource is IComputeResource computeResource &&
+            resource.GetComputeEnvironment() is { } computeEnvironment)
+        {
+#pragma warning disable ASPIRECOMPUTE002
+            if (!computeEnvironment.UsesContainerImages(computeResource))
+            {
+                return false;
+            }
+#pragma warning restore ASPIRECOMPUTE002
+        }
+
         return resource is ProjectResource || resource.TryGetLastAnnotation<DockerfileBuildAnnotation>(out _);
     }
 

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -717,16 +717,18 @@ public class DistributedApplication : IHost, IAsyncDisposable
     }
 
     /// <summary>
-    /// When the model contains exactly one compute environment, applies a
+    /// When the model contains exactly one compute environment that allows implicit binding, applies a
     /// <see cref="ComputeEnvironmentAnnotation"/> pointing to that environment to every
     /// <see cref="IComputeResource"/> that doesn't already have one.
     /// </summary>
     /// <remarks>
     /// This implements the "single compute environment is the default" convention: when only one
-    /// compute environment is present (e.g., a single <c>AzureContainerAppEnvironmentResource</c>),
+    /// compatible compute environment is present (e.g., a single <c>AzureContainerAppEnvironmentResource</c>),
     /// developers don't need to call <c>WithComputeEnvironment(...)</c> on every compute resource —
     /// the unique environment is auto-assigned here. Resources that have been explicitly bound to a
-    /// compute environment (via <c>WithComputeEnvironment</c> or otherwise) are left untouched.
+    /// compute environment (via <c>WithComputeEnvironment</c> or otherwise) are left untouched. Environments
+    /// that return <see langword="false"/> from <see cref="IComputeEnvironmentResource.AllowsImplicitBinding"/>
+    /// require every targeted workload to opt in explicitly.
     ///
     /// When zero or more than one compute environment is present we deliberately do nothing.
     /// - With zero compute environments there is no default to apply.
@@ -741,10 +743,19 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// </remarks>
     private static void EnsureComputeEnvironmentAnnotationsApplied(DistributedApplicationModel appModel)
     {
-        var computeEnvironments = appModel.Resources.OfType<IComputeEnvironmentResource>().ToList();
+        var computeEnvironments = appModel.Resources
+            .OfType<IComputeEnvironmentResource>()
+            .Where(static environment =>
+            {
+#pragma warning disable ASPIRECOMPUTE002
+                return environment.AllowsImplicitBinding;
+#pragma warning restore ASPIRECOMPUTE002
+            })
+            .ToList();
         if (computeEnvironments.Count == 1)
         {
             var environment = computeEnvironments[0];
+
             foreach (var computeResource in appModel.Resources.OfType<IComputeResource>())
             {
                 // Skip resources that already have an explicit compute environment binding so we

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -353,7 +353,7 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
             Description = "Validates compute resource bindings before startup.",
             Action = static context =>
             {
-                ValidateComputeEnvironmentBindings(context.Model);
+                ValidateComputeEnvironmentBindings(context.Model, context.ExecutionContext);
                 return Task.CompletedTask;
             },
             RequiredBySteps = [WellKnownPipelineSteps.BeforeStart],
@@ -381,21 +381,66 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
         });
     }
 
-    private static void ValidateComputeEnvironmentBindings(DistributedApplicationModel model)
+    private static void ValidateComputeEnvironmentBindings(
+        DistributedApplicationModel model,
+        DistributedApplicationExecutionContext executionContext)
     {
-        // With multiple compute environments there is no unambiguous default. Surface a clear
-        // error for any compute resource that hasn't been explicitly bound, rather than letting
-        // the environments' steps silently skip it (which would result in the resource
-        // never being deployed).
+        var computeResources = model.Resources
+            .OfType<IComputeResource>()
+            .Where(resource => !executionContext.IsPublishMode || !resource.IsExcludedFromPublish())
+            .ToList();
+        var computeEnvironments = model.Resources
+            .OfType<IComputeEnvironmentResource>()
+            .Where(environment => !executionContext.IsPublishMode || !environment.IsExcludedFromPublish())
+            .ToList();
 
-        var computeEnvironments = model.Resources.OfType<IComputeEnvironmentResource>().ToList();
-        if (computeEnvironments.Count <= 1)
+        foreach (var environment in computeEnvironments)
         {
-            return;
+#pragma warning disable ASPIRECOMPUTE002
+            var minimumResourceCount = environment.MinimumResourceCount;
+            var maximumResourceCount = environment.MaximumResourceCount;
+#pragma warning restore ASPIRECOMPUTE002
+
+            if (minimumResourceCount < 0 ||
+                maximumResourceCount is < 0 ||
+                maximumResourceCount < minimumResourceCount)
+            {
+                throw new DistributedApplicationException(
+                    $"Compute environment '{environment.Name}' has an invalid resource count policy. " +
+                    $"The minimum count must be non-negative and cannot exceed the maximum count.");
+            }
+
+            var boundResources = computeResources
+                .Where(resource => ReferenceEquals(resource.GetComputeEnvironment(), environment))
+                .ToList();
+            var boundResourceCount = boundResources.Count;
+            if (boundResourceCount < minimumResourceCount)
+            {
+                throw new DistributedApplicationException(
+                    $"Compute environment '{environment.Name}' requires at least {minimumResourceCount} bound compute resource(s), but {boundResourceCount} were found. " +
+                    $"Bind a resource by calling 'WithComputeEnvironment' on its resource builder.");
+            }
+
+            if (maximumResourceCount is int maximum && boundResourceCount > maximum)
+            {
+                throw new DistributedApplicationException(
+                    $"Compute environment '{environment.Name}' supports at most {maximum} bound compute resource(s), but {boundResourceCount} were found.");
+            }
+
+#pragma warning disable ASPIRECOMPUTE002
+            var unsupportedResources = boundResources.Where(resource => !environment.SupportsResource(resource)).ToList();
+#pragma warning restore ASPIRECOMPUTE002
+            if (unsupportedResources.Count > 0)
+            {
+                var unsupportedResourceNames = string.Join(
+                    "', '",
+                    unsupportedResources.Select(resource => $"{resource.Name} ({resource.GetType().Name})"));
+                throw new DistributedApplicationException(
+                    $"Compute environment '{environment.Name}' does not support compute resource(s) '{unsupportedResourceNames}'.");
+            }
         }
 
-        var unboundResources = model.Resources
-            .OfType<IComputeResource>()
+        var unboundResources = computeResources
             .Where(resource => resource.GetComputeEnvironment() is null)
             .ToList();
 
@@ -404,10 +449,47 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
             return;
         }
 
+        var implicitBindingEnvironments = computeEnvironments
+            .Where(static environment =>
+            {
+#pragma warning disable ASPIRECOMPUTE002
+                return environment.AllowsImplicitBinding;
+#pragma warning restore ASPIRECOMPUTE002
+            })
+            .ToList();
+
+        if (implicitBindingEnvironments.Count == 1)
+        {
+            return;
+        }
+
+        if (implicitBindingEnvironments.Count == 0)
+        {
+            if (computeEnvironments.Count == 1)
+            {
+                var unboundResourceNames = string.Join("', '", unboundResources.Select(resource => resource.Name));
+                throw new DistributedApplicationException(
+                    $"Compute environment '{computeEnvironments[0].Name}' does not allow implicit binding, but compute resource(s) '{unboundResourceNames}' are not bound to an environment. " +
+                    $"Bind each resource by calling 'WithComputeEnvironment' on its resource builder.");
+            }
+
+            if (computeEnvironments.Count > 1)
+            {
+                var unboundResourceNames = string.Join("', '", unboundResources.Select(resource => resource.Name));
+                var explicitOnlyEnvironmentNames = string.Join("', '", computeEnvironments.Select(environment => environment.Name));
+                throw new DistributedApplicationException(
+                    $"Compute resource(s) '{unboundResourceNames}' are not assigned to a compute environment, and none of the compute environments ('{explicitOnlyEnvironmentNames}') allow implicit binding. " +
+                    $"Bind each resource by calling 'WithComputeEnvironment' on its resource builder.");
+            }
+
+            return;
+        }
+
+        // With multiple implicit-binding compute environments there is no unambiguous default.
         var resourceNames = string.Join("', '", unboundResources.Select(resource => resource.Name));
-        var environmentNames = string.Join("', '", computeEnvironments.Select(environment => environment.Name));
+        var environmentNames = string.Join("', '", implicitBindingEnvironments.Select(environment => environment.Name));
         throw new InvalidOperationException(
-            $"Compute resource(s) '{resourceNames}' are not assigned to a compute environment, but the model contains multiple compute environments ('{environmentNames}'). " +
+            $"Compute resource(s) '{resourceNames}' are not assigned to a compute environment, but the model contains multiple implicit-binding compute environments ('{environmentNames}'). " +
             $"Specify which environment each resource should target by calling 'WithComputeEnvironment' on the resource builder.");
     }
 

--- a/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Tests/Aspire.Hosting.Azure.Tests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppContainers\Aspire.Hosting.Azure.AppContainers.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ApplicationInsights\Aspire.Hosting.Azure.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.CognitiveServices\Aspire.Hosting.Azure.CognitiveServices.csproj" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Compute\Aspire.Hosting.Azure.Compute.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ContainerRegistry\Aspire.Hosting.Azure.ContainerRegistry.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.CosmosDB\Aspire.Hosting.Azure.CosmosDB.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.EventHubs\Aspire.Hosting.Azure.EventHubs.csproj" />

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -147,6 +147,30 @@ public class AzureBicepProvisionerTests
     }
 
     [Fact]
+    public async Task GetOrCreateResourceAsync_InPublishMode_PopulatesUserPrincipalId()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.Services.AddSingleton<IDeploymentStateManager>(new MockDeploymentStateManager());
+        using var services = builder.Services.BuildServiceProvider();
+
+        var resource = new AzureBicepResource("storage-roles", templateString: """
+            param userPrincipalId string
+            output id string = userPrincipalId
+            """);
+        resource.Parameters[AzureBicepResource.KnownParameters.UserPrincipalId] = null;
+
+        var principalId = Guid.Parse("00000000-0000-0000-0000-000000000042");
+        var context = ProvisioningTestHelpers.CreateTestProvisioningContext(
+            principal: new UserPrincipal(principalId, "test@example.com"),
+            executionContext: new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish));
+
+        var provisioner = CreateProvisioner(services);
+        await provisioner.GetOrCreateResourceAsync(resource, context, CancellationToken.None);
+
+        Assert.Equal(principalId, resource.Parameters[AzureBicepResource.KnownParameters.UserPrincipalId]);
+    }
+
+    [Fact]
     public async Task GetOrCreateResourceAsync_WithSubscriptionScope_UsesSubscriptionDeploymentCollection()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureVirtualMachineScaleSetEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureVirtualMachineScaleSetEnvironmentTests.cs
@@ -462,6 +462,18 @@ public class AzureVirtualMachineScaleSetEnvironmentTests
     }
 
     [Fact]
+    public void PackageUploadOptionsContainPackageMetadata()
+    {
+        var options = AzureVirtualMachineScaleSetEnvironmentResource.CreatePackageUploadOptions(
+            "0123456789abcdef",
+            "1.2.3");
+
+        Assert.Equal("application/gzip", options.HttpHeaders.ContentType);
+        Assert.Equal("0123456789abcdef", options.Metadata["aspire-fingerprint"]);
+        Assert.Equal("1.2.3", options.Metadata["aspire-version"]);
+    }
+
+    [Fact]
     public async Task RejectsWorkloadIdentityThatDiffersFromEnvironmentIdentity()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureVirtualMachineScaleSetEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureVirtualMachineScaleSetEnvironmentTests.cs
@@ -1,0 +1,552 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREAZURE003, ASPIREAZURE004
+#pragma warning disable ASPIREDOTNETPROJECT001
+#pragma warning disable ASPIREFILESYSTEM001
+#pragma warning disable ASPIREPIPELINES001
+
+using System.Formats.Tar;
+using System.IO.Compression;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureVirtualMachineScaleSetEnvironmentTests
+{
+    [Fact]
+    public async Task GeneratesVmssGalleryApplicationInfrastructure()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var virtualNetwork = builder.AddAzureVirtualNetwork("network");
+        var subnet = virtualNetwork.AddSubnet("compute-subnet", "10.0.0.0/24");
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute")
+            .WithPlatformImage("Canonical", "ubuntu-24_04-lts", "server", "latest")
+            .WithVmSku("Standard_D2s_v5")
+            .WithCapacity(2)
+            .WithSubnet(subnet)
+            .WithAdminSshPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCapabilityProof")
+            .WithVmApplicationPackage(new Uri("https://account.blob.core.windows.net/applications/app-001.tar.gz"), "1.2.3");
+
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(environment.Resource, skipPreparer: true);
+
+        Assert.IsType<string>(environment.Resource.Parameters["capacity"]);
+        Assert.Equal("2", environment.Resource.Parameters["capacity"]);
+        await Verify(manifest.ToString(), "json")
+            .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Fact]
+    public async Task GeneratesPrivatePackageStorageAndGalleryFoundation()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+
+        var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(
+            environment.Resource.Foundation,
+            skipPreparer: true);
+
+        await Verify(manifest.ToString(), "json")
+            .AppendContentAsFile(bicep, "bicep");
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("1.0")]
+    [InlineData("1.0.0.0")]
+    [InlineData("1.0.latest")]
+    [InlineData("-1.0.0")]
+    public void RejectsInvalidVmApplicationVersion(string version)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            environment.WithVmApplicationPackage(new Uri("https://account.blob.core.windows.net/applications/app.tar.gz"), version));
+
+        Assert.Equal("version", exception.ParamName);
+    }
+
+    [Fact]
+    public void RejectsPackageUriWithQueryString()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            environment.WithVmApplicationPackage(new Uri("https://account.blob.core.windows.net/applications/app.tar.gz?sig=secret"), "1.2.3"));
+
+        Assert.Equal("packageUri", exception.ParamName);
+        Assert.StartsWith("The VM Application package URI cannot contain a query string.", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(
+        "http://account.blob.core.windows.net/applications/app.tar.gz",
+        "The VM Application package URI must use HTTPS.")]
+    [InlineData(
+        "https://user:password@account.blob.core.windows.net/applications/app.tar.gz",
+        "The VM Application package URI cannot contain user information.")]
+    [InlineData(
+        "https://account.blob.core.windows.net/applications/app.tar.gz#fragment",
+        "The VM Application package URI cannot contain a fragment.")]
+    [InlineData(
+        "https://storage.example.test/applications/app.tar.gz",
+        "The VM Application package URI must identify a blob in Azure Storage.")]
+    [InlineData(
+        "https://invalid.account.blob.core.windows.net/applications/app.tar.gz",
+        "The VM Application package URI must identify a blob in Azure Storage.")]
+    [InlineData(
+        "https://account.blob.core.windows.net/applications",
+        "The VM Application package URI must identify a blob in Azure Storage.")]
+    public void RejectsInvalidPackageUri(string packageUri, string expectedMessage)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            environment.WithVmApplicationPackage(new Uri(packageUri), "1.2.3"));
+
+        Assert.Equal("packageUri", exception.ParamName);
+        Assert.StartsWith(expectedMessage, exception.Message);
+    }
+
+    [Theory]
+    [InlineData("https://account.blob.core.windows.net/applications/app.tar.gz")]
+    [InlineData("https://account.blob.core.usgovcloudapi.net/applications/app.tar.gz")]
+    [InlineData("https://account.blob.core.chinacloudapi.cn/applications/app.tar.gz")]
+    [InlineData("https://account.blob.core.cloudapi.de/applications/app.tar.gz")]
+    public void AcceptsAzureBlobPackageUris(string packageUri)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+
+        environment.WithVmApplicationPackage(new Uri(packageUri), "1.2.3");
+
+        Assert.Equal(packageUri, environment.Resource.ApplicationPackageUri);
+        Assert.Equal(false, environment.Resource.Foundation.Parameters["provisionPackageStorage"]);
+    }
+
+    [Fact]
+    public void AcceptsSecretPackageUriParameter()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var packageUri = builder.AddParameter("package-uri", secret: true);
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+
+        environment.WithVmApplicationPackage(packageUri, "1.2.3");
+
+        Assert.Same(packageUri.Resource, environment.Resource.ApplicationPackageUri);
+        Assert.Same(packageUri.Resource, environment.Resource.Parameters["vmApplicationPackageUri"]);
+        Assert.Equal(false, environment.Resource.Foundation.Parameters["provisionPackageStorage"]);
+    }
+
+    [Fact]
+    public void RejectsNonSecretPackageUriParameter()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var packageUri = builder.AddParameter("package-uri");
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            environment.WithVmApplicationPackage(packageUri, "1.2.3"));
+
+        Assert.Equal("packageUri", exception.ParamName);
+        Assert.StartsWith("The VM Application package URI parameter must be secret.", exception.Message);
+    }
+
+    [Fact]
+    public void RequiresSubnet()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => environment.Resource.GetBicepTemplateFile());
+
+        Assert.Equal("The Azure Virtual Machine Scale Set compute environment 'compute' requires an Azure subnet.", exception.Message);
+    }
+
+    [Fact]
+    public void UsesGeneratedVmApplicationPackageByDefault()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var subnet = builder.AddAzureVirtualNetwork("network").AddSubnet("compute-subnet", "10.0.0.0/24");
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute")
+            .WithSubnet(subnet)
+            .WithAdminSshPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCapabilityProof");
+
+        _ = environment.Resource.GetBicepTemplateString();
+
+        Assert.True(environment.Resource.UsesGeneratedApplicationPackage);
+        Assert.Equal("Standard_D2s_v6", environment.Resource.VmSku);
+        Assert.Same(environment.Resource.Foundation.PackageUri, environment.Resource.ApplicationPackageUri);
+        Assert.Same(environment.Resource.Foundation.PackageUri, environment.Resource.Parameters["vmApplicationPackageUri"]);
+    }
+
+    [Fact]
+    public void RequiresAdminSshPublicKey()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var subnet = builder.AddAzureVirtualNetwork("network").AddSubnet("compute-subnet", "10.0.0.0/24");
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute")
+            .WithSubnet(subnet)
+            .WithVmApplicationPackage(new Uri("https://account.blob.core.windows.net/applications/app.tar.gz"), "1.2.3");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => environment.Resource.GetBicepTemplateFile());
+
+        Assert.Equal("The Azure Virtual Machine Scale Set compute environment 'compute' requires an administrator SSH public key.", exception.Message);
+    }
+
+    [Fact]
+    public async Task AcceptsOneExplicitlyBoundDotnetProject()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var environment = AddConfiguredEnvironment(builder);
+        var blobs = builder.AddAzureStorage("storage").AddBlobs("blobs");
+        var app = builder.AddDotnetProject("app", "app.csproj", options => options.ExcludeLaunchProfile = true)
+            .WithReference(blobs)
+            .WithComputeEnvironment(environment);
+
+        using var application = builder.Build();
+
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(application, default);
+
+        Assert.Same(environment.Resource, app.Resource.GetComputeEnvironment());
+        Assert.True(app.Resource.TryGetLastAnnotation<AppIdentityAnnotation>(out var appIdentity));
+        var identity = Assert.IsType<AzureUserAssignedIdentityResource>(appIdentity.IdentityResource);
+        Assert.Equal("compute-identity", identity.Name);
+
+        var model = application.Services.GetRequiredService<DistributedApplicationModel>();
+        var roleAssignments = Assert.Single(
+            model.Resources.OfType<AzureRoleAssignmentResource>(),
+            resource => ReferenceEquals(resource.OwnerResource, app.Resource));
+        Assert.Same(identity, roleAssignments.IdentityResource);
+    }
+
+    [Fact]
+    public void BoundDotnetProjectDoesNotRequireAContainerImage()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+        var app = builder.AddDotnetProject("app", "app.csproj", options => options.ExcludeLaunchProfile = true)
+            .WithComputeEnvironment(environment);
+
+        Assert.False(app.Resource.RequiresImageBuild());
+        Assert.False(app.Resource.RequiresImageBuildAndPush());
+    }
+
+    [Fact]
+    public async Task GeneratedPackagePipelineOrdersBuildFoundationUploadAndRollout()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var environment = AddGeneratedPackageEnvironment(builder);
+        var prerequisite = builder.AddAzureStorage("storage");
+        builder.AddDotnetProject("app", "app.csproj", options => options.ExcludeLaunchProfile = true)
+            .WithAnnotation(new DeploymentPrerequisitesAnnotation(new HashSet<AzureBicepResource> { prerequisite.Resource }))
+            .WithComputeEnvironment(environment);
+
+        IReadOnlyList<PipelineStep>? resolvedSteps = null;
+        environment.WithAnnotation(new PipelineConfigurationAnnotation(context =>
+        {
+            resolvedSteps = context.Steps;
+        }));
+        builder.Services.Configure<PipelineOptions>(options => options.Step = WellKnownPipelineSteps.ValidateComputeEnvironments);
+
+        using var application = builder.Build();
+        await ExecutePipelineAsync(application);
+
+        Assert.NotNull(resolvedSteps);
+        var buildPackage = Assert.Single(
+            resolvedSteps,
+            step => step.Name == "build-compute-vm-application-package");
+        var uploadPackage = Assert.Single(
+            resolvedSteps,
+            step => step.Name == "upload-compute-vm-application-package");
+        var foundationProvision = Assert.Single(
+            resolvedSteps,
+            step => step.Name == "provision-compute-foundation");
+        var prerequisiteProvision = Assert.Single(
+            resolvedSteps,
+            step => step.Name == "provision-storage");
+        var rolloutProvision = Assert.Single(
+            resolvedSteps,
+            step => step.Name == "provision-compute");
+
+        Assert.Contains(WellKnownPipelineSteps.DeployPrereq, buildPackage.DependsOnSteps);
+        Assert.Contains(prerequisiteProvision.Name, buildPackage.DependsOnSteps);
+        Assert.Contains(buildPackage.Name, uploadPackage.DependsOnSteps);
+        Assert.Contains(foundationProvision.Name, uploadPackage.DependsOnSteps);
+        Assert.Contains(uploadPackage.Name, rolloutProvision.DependsOnSteps);
+        Assert.Contains(prerequisiteProvision.Name, rolloutProvision.DependsOnSteps);
+    }
+
+    [Fact]
+    public async Task GeneratedVmApplicationArchiveIsDeterministic()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        using var application = builder.Build();
+        var tempFileSystem = application.Services.GetRequiredService<IFileSystemService>().TempDirectory;
+        using var stagingDirectory = tempFileSystem.CreateTempSubdirectory("vmss-package");
+        using var firstArchive = tempFileSystem.CreateTempFile("first.tar.gz");
+        using var secondArchive = tempFileSystem.CreateTempFile("second.tar.gz");
+        var appDirectory = Directory.CreateDirectory(Path.Combine(stagingDirectory.Path, "app"));
+        await File.WriteAllTextAsync(Path.Combine(appDirectory.FullName, "testapp"), "fake executable");
+        await File.WriteAllTextAsync(Path.Combine(appDirectory.FullName, "testapp.runtimeconfig.json"), "{}");
+        await VirtualMachineScaleSetApplicationPackageBuilder.WriteManagementFilesAsync(
+            stagingDirectory.Path,
+            "compute",
+            "app",
+            "testapp",
+            new Dictionary<string, string>
+            {
+                ["AZURE_CLIENT_ID"] = "00000000-0000-0000-0000-000000000001",
+                ["AZURE_TOKEN_CREDENTIALS"] = "ManagedIdentityCredential",
+                ["DOTNET_ENVIRONMENT"] = "Production",
+                ["GREETING"] = "hello \"vm\"\nsecond line"
+            },
+            ["--mode", "value with spaces", "100%"],
+            CancellationToken.None);
+        await File.WriteAllBytesAsync(
+            Path.Combine(appDirectory.FullName, "helper"),
+            [0x7f, (byte)'E', (byte)'L', (byte)'F']);
+
+        await VirtualMachineScaleSetApplicationPackageBuilder.CreateArchiveAsync(
+            stagingDirectory.Path,
+            firstArchive.Path,
+            "testapp",
+            CancellationToken.None);
+        await VirtualMachineScaleSetApplicationPackageBuilder.CreateArchiveAsync(
+            stagingDirectory.Path,
+            secondArchive.Path,
+            "testapp",
+            CancellationToken.None);
+
+        Assert.Equal(await File.ReadAllBytesAsync(firstArchive.Path), await File.ReadAllBytesAsync(secondArchive.Path));
+
+        using var archiveStream = File.OpenRead(firstArchive.Path);
+        using var gzipStream = new GZipStream(archiveStream, CompressionMode.Decompress);
+        using var tarReader = new TarReader(gzipStream);
+        var entries = new List<(string Name, UnixFileMode Mode, string? Content)>();
+        while (await tarReader.GetNextEntryAsync() is { } entry)
+        {
+            string? content = null;
+            if (entry.DataStream is not null)
+            {
+                using var reader = new StreamReader(
+                    entry.DataStream,
+                    System.Text.Encoding.UTF8,
+                    detectEncodingFromByteOrderMarks: true,
+                    bufferSize: 1024,
+                    leaveOpen: true);
+                content = await reader.ReadToEndAsync();
+            }
+
+            entries.Add((entry.Name, entry.Mode, content));
+        }
+
+        Assert.Collection(
+            entries,
+            entry => Assert.Equal(("app/", UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute), (entry.Name, entry.Mode)),
+            entry => Assert.Equal("app/helper", entry.Name),
+            entry => Assert.Equal("app/testapp", entry.Name),
+            entry => Assert.Equal("app/testapp.runtimeconfig.json", entry.Name),
+            entry => Assert.Equal("aspire-compute.env", entry.Name),
+            entry => Assert.Equal("aspire-compute.service", entry.Name),
+            entry => Assert.Equal("install.sh", entry.Name),
+            entry => Assert.Equal("remove.sh", entry.Name),
+            entry => Assert.Equal("update.sh", entry.Name));
+        var serviceUnit = entries.Single(entry => entry.Name == "aspire-compute.service").Content;
+        Assert.Contains(
+            "ExecStart=\"/opt/aspire/compute/app/testapp\" \"--mode\" \"value with spaces\" \"100%%\"",
+            serviceUnit);
+        Assert.Contains("User=aspire-app", serviceUnit);
+        Assert.Contains("EnvironmentFile=/etc/aspire/compute.env", serviceUnit);
+        Assert.Equal(
+            """
+            AZURE_CLIENT_ID="00000000-0000-0000-0000-000000000001"
+            AZURE_TOKEN_CREDENTIALS="ManagedIdentityCredential"
+            DOTNET_ENVIRONMENT="Production"
+            GREETING="hello \"vm\"\nsecond line"
+
+            """,
+            entries.Single(entry => entry.Name == "aspire-compute.env").Content);
+        Assert.Equal(
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
+            entries.Single(entry => entry.Name == "install.sh").Mode);
+        Assert.Equal(
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
+            entries.Single(entry => entry.Name == "app/helper").Mode);
+    }
+
+    [Fact]
+    public async Task ResolvesProjectEnvironmentArgumentsAndWorkloadIdentity()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var app = builder.AddDotnetProject("app", "app.csproj", options => options.ExcludeLaunchProfile = true)
+            .WithEnvironment("GREETING", "hello")
+            .WithArgs("--mode", "worker");
+        var identityClientId = new ParameterResource(
+            "identity-client-id",
+            _ => "00000000-0000-0000-0000-000000000001");
+
+        var configuration = await VirtualMachineScaleSetApplicationPackageBuilder.ResolveConfigurationAsync(
+            app.Resource,
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
+            identityClientId,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        Assert.Equal(
+            new Dictionary<string, string>
+            {
+                ["OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY"] = "in_memory",
+                ["GREETING"] = "hello",
+                ["DOTNET_ENVIRONMENT"] = "Production",
+                ["AZURE_CLIENT_ID"] = "00000000-0000-0000-0000-000000000001",
+                ["AZURE_TOKEN_CREDENTIALS"] = "ManagedIdentityCredential"
+            },
+            configuration.EnvironmentVariables);
+        Assert.Equal(["--mode", "worker"], configuration.Arguments);
+    }
+
+    [Fact]
+    public async Task RejectsSecretsInGeneratedProjectConfiguration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var secret = builder.AddParameter("secret", secret: true);
+        var app = builder.AddDotnetProject("app", "app.csproj", options => options.ExcludeLaunchProfile = true)
+            .WithEnvironment("APP_SECRET", secret);
+        var identityClientId = new ParameterResource(
+            "identity-client-id",
+            _ => "00000000-0000-0000-0000-000000000001");
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(() =>
+            VirtualMachineScaleSetApplicationPackageBuilder.ResolveConfigurationAsync(
+                app.Resource,
+                new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
+                identityClientId,
+                NullLogger.Instance,
+                CancellationToken.None));
+
+        Assert.Equal(
+            "The environment variable 'APP_SECRET' on project 'app' contains a secret. " +
+            "Azure Virtual Machine Scale Set compute environments do not support materializing secrets into VM Application packages.",
+            exception.Message);
+    }
+
+    [Fact]
+    public void RejectsVmApplicationPackagesLargerThanAzureLimit()
+    {
+        const long maximumPackageSize = 2L * 1024 * 1024 * 1024;
+
+        VirtualMachineScaleSetApplicationPackageBuilder.ValidatePackageSize(maximumPackageSize, "app");
+        var exception = Assert.Throws<DistributedApplicationException>(() =>
+            VirtualMachineScaleSetApplicationPackageBuilder.ValidatePackageSize(maximumPackageSize + 1, "app"));
+
+        Assert.Equal(
+            "The VM Application package for project 'app' is 2147483649 bytes, " +
+            "which exceeds the Azure VM Applications limit of 2147483648 bytes.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task RejectsWorkloadIdentityThatDiffersFromEnvironmentIdentity()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var environment = AddConfiguredEnvironment(builder);
+        var otherIdentity = builder.AddAzureUserAssignedIdentity("other-identity");
+        builder.AddDotnetProject("app", "app.csproj", options => options.ExcludeLaunchProfile = true)
+            .WithAzureUserAssignedIdentity(otherIdentity)
+            .WithComputeEnvironment(environment);
+
+        using var application = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => AzureManifestUtils.ExecuteBeforeStartHooksAsync(application, default));
+
+        Assert.Equal(
+            "Compute resource 'app' uses identity 'other-identity', but compute environment 'compute' requires identity 'compute-identity'.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task RunModeDoesNotMaterializeOrValidateVmssInfrastructure()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var environment = builder.AddAzureVirtualMachineScaleSetEnvironment("compute");
+        var project = builder.AddDotnetProject("app", "app.csproj", options => options.ExcludeLaunchProfile = true)
+            .WithComputeEnvironment(environment);
+
+        using var application = builder.Build();
+
+        await AzureManifestUtils.ExecuteBeforeStartHooksAsync(application, default);
+
+        var model = application.Services.GetRequiredService<DistributedApplicationModel>();
+        Assert.False(model.Resources.Contains(environment.Resource));
+        Assert.Same(environment.Resource, project.Resource.GetComputeEnvironment());
+        Assert.False(project.Resource.TryGetLastAnnotation<AppIdentityAnnotation>(out _));
+    }
+
+    [Fact]
+    public async Task RejectsBoundContainerResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var environment = AddConfiguredEnvironment(builder);
+        builder.AddContainer("app", "example/app")
+            .WithComputeEnvironment(environment);
+
+        using var application = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => AzureManifestUtils.ExecuteBeforeStartHooksAsync(application, default));
+
+        Assert.Equal(
+            "Compute environment 'compute' does not support compute resource(s) 'app (ContainerResource)'.",
+            exception.Message);
+    }
+
+    private static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> AddConfiguredEnvironment(
+        IDistributedApplicationBuilder builder)
+    {
+        var subnet = builder.AddAzureVirtualNetwork("network").AddSubnet("compute-subnet", "10.0.0.0/24");
+
+        return builder.AddAzureVirtualMachineScaleSetEnvironment("compute")
+            .WithSubnet(subnet)
+            .WithAdminSshPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCapabilityProof")
+            .WithVmApplicationPackage(new Uri("https://account.blob.core.windows.net/applications/app.tar.gz"), "1.2.3");
+    }
+
+    private static IResourceBuilder<AzureVirtualMachineScaleSetEnvironmentResource> AddGeneratedPackageEnvironment(
+        IDistributedApplicationBuilder builder)
+    {
+        var subnet = builder.AddAzureVirtualNetwork("network").AddSubnet("compute-subnet", "10.0.0.0/24");
+
+        return builder.AddAzureVirtualMachineScaleSetEnvironment("compute")
+            .WithSubnet(subnet)
+            .WithAdminSshPublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCapabilityProof");
+    }
+
+    private static Task ExecutePipelineAsync(DistributedApplication application)
+    {
+        var context = new PipelineContext(
+            application.Services.GetRequiredService<DistributedApplicationModel>(),
+            application.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            application.Services,
+            application.Services.GetRequiredService<ILogger<AzureVirtualMachineScaleSetEnvironmentTests>>(),
+            CancellationToken.None);
+
+        return application.Services.GetRequiredService<IDistributedApplicationPipeline>().ExecuteAsync(context);
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureVirtualMachineScaleSetEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureVirtualMachineScaleSetEnvironmentTests.cs
@@ -469,8 +469,9 @@ public class AzureVirtualMachineScaleSetEnvironmentTests
             "1.2.3");
 
         Assert.Equal("application/gzip", options.HttpHeaders.ContentType);
-        Assert.Equal("0123456789abcdef", options.Metadata["aspire-fingerprint"]);
-        Assert.Equal("1.2.3", options.Metadata["aspire-version"]);
+        Assert.Equal("0123456789abcdef", options.Metadata["aspire_fingerprint"]);
+        Assert.Equal("1.2.3", options.Metadata["aspire_version"]);
+        Assert.All(options.Metadata.Keys, key => Assert.Matches("^[A-Za-z_][A-Za-z0-9_]*$", key));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesPrivatePackageStorageAndGalleryFoundation.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesPrivatePackageStorageAndGalleryFoundation.verified.bicep
@@ -1,0 +1,95 @@
+﻿@description('The location for the resources to be deployed.')
+param location string = resourceGroup().location
+
+param resourceName string
+param userPrincipalId string
+param provisionPackageStorage bool
+param tags object = {}
+
+var suffix = uniqueString(resourceGroup().id)
+var storageBlobDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
+
+resource galleryIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
+  name: take('${resourceName}-gallery-${suffix}', 128)
+  location: location
+  tags: tags
+}
+
+resource gallery 'Microsoft.Compute/galleries@2025-03-03' = {
+  name: take(replace('${resourceName}${suffix}', '-', ''), 80)
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${galleryIdentity.id}': {}
+    }
+  }
+  properties: {
+    description: 'Compute gallery for the ${resourceName} Aspire compute environment.'
+  }
+  tags: tags
+}
+
+resource galleryApplication 'Microsoft.Compute/galleries/applications@2025-03-03' = {
+  parent: gallery
+  name: 'aspire-application'
+  location: location
+  properties: {
+    description: 'Application deployed by the ${resourceName} Aspire compute environment.'
+    supportedOSType: 'Linux'
+  }
+}
+
+resource packageStorage 'Microsoft.Storage/storageAccounts@2024-01-01' = if (provisionPackageStorage) {
+  name: 'aspire${uniqueString(resourceGroup().id, resourceName)}'
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+    defaultToOAuthAuthentication: true
+    minimumTlsVersion: 'TLS1_2'
+    publicNetworkAccess: 'Enabled'
+    supportsHttpsTrafficOnly: true
+  }
+  tags: tags
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = if (provisionPackageStorage) {
+  parent: packageStorage
+  name: 'default'
+}
+
+resource packageContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2024-01-01' = if (provisionPackageStorage) {
+  parent: blobService
+  name: 'vm-applications'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource deployerPackageContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (provisionPackageStorage) {
+  name: guid(packageStorage.id, userPrincipalId, storageBlobDataContributorRoleId)
+  scope: packageStorage
+  properties: {
+    principalId: userPrincipalId
+    roleDefinitionId: storageBlobDataContributorRoleId
+  }
+}
+
+resource galleryPackageReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (provisionPackageStorage) {
+  name: guid(packageStorage.id, galleryIdentity.id, storageBlobDataContributorRoleId)
+  scope: packageStorage
+  properties: {
+    principalId: galleryIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageBlobDataContributorRoleId
+  }
+}
+
+output packageUri string = provisionPackageStorage ? '${packageStorage!.properties.primaryEndpoints.blob}${packageContainer!.name}/aspire-application.tar.gz' : ''
+output galleryName string = gallery.name
+output galleryApplicationName string = galleryApplication.name

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesPrivatePackageStorageAndGalleryFoundation.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesPrivatePackageStorageAndGalleryFoundation.verified.json
@@ -1,0 +1,9 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "aspire.hosting.azure.compute.azurevirtualmachinescalesetfoundation.bicep",
+  "params": {
+    "resourceName": "compute",
+    "provisionPackageStorage": "True",
+    "userPrincipalId": ""
+  }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesVmssGalleryApplicationInfrastructure.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesVmssGalleryApplicationInfrastructure.verified.bicep
@@ -1,0 +1,170 @@
+﻿@description('The location for the resources to be deployed.')
+param location string = resourceGroup().location
+
+param resourceName string
+param vmSku string
+param capacity string
+param imagePublisher string
+param imageOffer string
+param imageSku string
+param imageVersion string
+param subnetId string
+@secure()
+param vmApplicationPackageUri string
+param vmApplicationVersion string
+param adminSshPublicKey string
+param workloadIdentityName string
+param galleryName string
+param galleryApplicationName string
+param adminUsername string = 'azureuser'
+param tags object = {}
+
+var suffix = uniqueString(resourceGroup().id)
+
+resource workloadIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = {
+  name: workloadIdentityName
+}
+
+resource gallery 'Microsoft.Compute/galleries@2025-03-03' existing = {
+  name: galleryName
+}
+
+resource galleryApplication 'Microsoft.Compute/galleries/applications@2025-03-03' existing = {
+  parent: gallery
+  name: galleryApplicationName
+}
+
+resource galleryApplicationVersion 'Microsoft.Compute/galleries/applications/versions@2025-03-03' = {
+  parent: galleryApplication
+  name: vmApplicationVersion
+  location: location
+  properties: {
+    publishingProfile: {
+      source: {
+        mediaLink: vmApplicationPackageUri
+      }
+      manageActions: {
+        install: 'staging="$(mktemp -d)" && trap \'rm -rf "$staging"\' EXIT && tar -xzf aspire-application.tar.gz --no-same-owner -C "$staging" && bash "$staging/install.sh"'
+        update: 'staging="$(mktemp -d)" && trap \'rm -rf "$staging"\' EXIT && tar -xzf aspire-application.tar.gz --no-same-owner -C "$staging" && bash "$staging/update.sh"'
+        remove: 'if [ -f /opt/aspire/${resourceName}/remove.sh ]; then bash /opt/aspire/${resourceName}/remove.sh || exit $?; fi; rm -rf /opt/aspire/${resourceName}'
+      }
+      settings: {
+        packageFileName: 'aspire-application.tar.gz'
+      }
+      targetRegions: [
+        {
+          name: location
+          regionalReplicaCount: 1
+          storageAccountType: 'Standard_LRS'
+        }
+      ]
+      replicaCount: 1
+      excludeFromLatest: false
+    }
+    safetyProfile: {
+      allowDeletionOfReplicatedLocations: false
+    }
+  }
+}
+
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2025-04-01' = {
+  name: take('${resourceName}-${suffix}', 64)
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${workloadIdentity.id}': {}
+    }
+  }
+  sku: {
+    name: vmSku
+    tier: 'Standard'
+    capacity: int(capacity)
+  }
+  properties: {
+    // Uniform orchestration applies VMSS model updates according to upgradePolicy. Flexible
+    // orchestration requires an explicit per-instance update that this preview does not perform.
+    // See https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes.
+    orchestrationMode: 'Uniform'
+    platformFaultDomainCount: 1
+    singlePlacementGroup: false
+    zoneBalance: false
+    upgradePolicy: {
+      // Rolling upgrades require an application health contract, which this preview does not expose yet.
+      // Automatic mode ensures a newly pinned VM Application version reaches existing instances.
+      mode: 'Automatic'
+    }
+    virtualMachineProfile: {
+      osProfile: {
+        computerNamePrefix: 'aspire'
+        adminUsername: adminUsername
+        linuxConfiguration: {
+          disablePasswordAuthentication: true
+          provisionVMAgent: true
+          ssh: {
+            publicKeys: [
+              {
+                path: '/home/${adminUsername}/.ssh/authorized_keys'
+                keyData: adminSshPublicKey
+              }
+            ]
+          }
+        }
+      }
+      storageProfile: {
+        imageReference: {
+          publisher: imagePublisher
+          offer: imageOffer
+          sku: imageSku
+          version: imageVersion
+        }
+        osDisk: {
+          createOption: 'FromImage'
+          caching: 'ReadWrite'
+          managedDisk: {
+            storageAccountType: 'Standard_LRS'
+          }
+          deleteOption: 'Delete'
+        }
+      }
+      networkProfile: {
+        networkApiVersion: '2020-11-01'
+        networkInterfaceConfigurations: [
+          {
+            name: 'primary'
+            properties: {
+              primary: true
+              deleteOption: 'Delete'
+              ipConfigurations: [
+                {
+                  name: 'primary'
+                  properties: {
+                    primary: true
+                    subnet: {
+                      id: subnetId
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+      applicationProfile: {
+        galleryApplications: [
+          {
+            packageReferenceId: galleryApplicationVersion.id
+            treatFailureAsDeploymentFailure: true
+            enableAutomaticUpgrade: false
+            order: 1
+          }
+        ]
+      }
+    }
+  }
+  tags: tags
+}
+
+output vmssId string = vmss.id
+output workloadIdentityClientId string = workloadIdentity.properties.clientId
+output galleryApplicationVersionId string = galleryApplicationVersion.id

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesVmssGalleryApplicationInfrastructure.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesVmssGalleryApplicationInfrastructure.verified.bicep
@@ -127,7 +127,6 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2025-04-01' = {
         }
       }
       networkProfile: {
-        networkApiVersion: '2020-11-01'
         networkInterfaceConfigurations: [
           {
             name: 'primary'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesVmssGalleryApplicationInfrastructure.verified.bicep
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesVmssGalleryApplicationInfrastructure.verified.bicep
@@ -124,7 +124,6 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2025-04-01' = {
           managedDisk: {
             storageAccountType: 'Standard_LRS'
           }
-          deleteOption: 'Delete'
         }
       }
       networkProfile: {
@@ -134,7 +133,6 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2025-04-01' = {
             name: 'primary'
             properties: {
               primary: true
-              deleteOption: 'Delete'
               ipConfigurations: [
                 {
                   name: 'primary'

--- a/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesVmssGalleryApplicationInfrastructure.verified.json
+++ b/tests/Aspire.Hosting.Azure.Tests/Snapshots/AzureVirtualMachineScaleSetEnvironmentTests.GeneratesVmssGalleryApplicationInfrastructure.verified.json
@@ -1,0 +1,20 @@
+﻿{
+  "type": "azure.bicep.v0",
+  "path": "aspire.hosting.azure.compute.azurevirtualmachinescalesetenvironment.bicep",
+  "params": {
+    "resourceName": "compute",
+    "vmSku": "Standard_D2s_v5",
+    "capacity": "2",
+    "imagePublisher": "Canonical",
+    "imageOffer": "ubuntu-24_04-lts",
+    "imageSku": "server",
+    "imageVersion": "latest",
+    "subnetId": "{network.outputs.compute_subnet_Id}",
+    "vmApplicationPackageUri": "https://account.blob.core.windows.net/applications/app-001.tar.gz",
+    "vmApplicationVersion": "1.2.3",
+    "adminSshPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCapabilityProof",
+    "workloadIdentityName": "{compute-identity.outputs.name}",
+    "galleryName": "{compute-foundation.outputs.galleryName}",
+    "galleryApplicationName": "{compute-foundation.outputs.galleryApplicationName}"
+  }
+}

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
@@ -60,6 +60,158 @@ public class ComputeEnvironmentValidationTests
         Assert.Same(env.Resource, api.Resource.GetComputeEnvironment());
     }
 
+    [Fact]
+    public async Task ExplicitOnlyEnvironment_DoesNotDisableAnotherEnvironmentsImplicitBinding()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var defaultEnvironment = builder.AddResource(new TestComputeEnvironmentResource("default"));
+        var explicitEnvironment = builder.AddResource(new TestComputeEnvironmentResource(
+            "explicit",
+            allowsImplicitBinding: false));
+        var explicitlyBoundResource = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironment(explicitEnvironment);
+        var implicitlyBoundResource = builder.AddResource(new TestComputeResource("worker"));
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        Assert.Same(explicitEnvironment.Resource, explicitlyBoundResource.Resource.GetComputeEnvironment());
+        Assert.Same(defaultEnvironment.Resource, implicitlyBoundResource.Resource.GetComputeEnvironment());
+    }
+
+    [Fact]
+    public async Task ExplicitOnlyComputeEnvironment_RejectsUnboundResources()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env = builder.AddResource(new TestComputeEnvironmentResource("env1", allowsImplicitBinding: false));
+        var api = builder.AddResource(new TestComputeResource("api"))
+            .WithComputeEnvironment(env);
+        var worker = builder.AddResource(new TestComputeResource("worker"));
+
+        using var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => app.ExecuteBeforeStartHooksAsync(default)).DefaultTimeout();
+
+        Assert.Same(env.Resource, api.Resource.GetComputeEnvironment());
+        Assert.Null(worker.Resource.GetComputeEnvironment());
+        Assert.Equal(
+            "Compute environment 'env1' does not allow implicit binding, but compute resource(s) 'worker' are not bound to an environment. " +
+            "Bind each resource by calling 'WithComputeEnvironment' on its resource builder.",
+            ex.Message);
+    }
+
+    [Fact]
+    public async Task ExplicitOnlyComputeEnvironment_IgnoresPublishExcludedUnboundResources()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        var env = builder.AddResource(new TestComputeEnvironmentResource(
+            "env",
+            allowsImplicitBinding: false,
+            minimumResourceCount: 1,
+            maximumResourceCount: 1));
+        builder.AddResource(new TestComputeResource("api")).WithComputeEnvironment(env);
+        builder.AddResource(new TestComputeResource("worker")).ExcludeFromManifest();
+
+        using var app = builder.Build();
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+    }
+
+    [Fact]
+    public async Task ComputeEnvironment_WithTooFewBoundResources_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddResource(new TestComputeEnvironmentResource(
+            "env",
+            allowsImplicitBinding: false,
+            minimumResourceCount: 1,
+            maximumResourceCount: 1));
+
+        using var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => app.ExecuteBeforeStartHooksAsync(default)).DefaultTimeout();
+
+        Assert.Equal(
+            "Compute environment 'env' requires at least 1 bound compute resource(s), but 0 were found. " +
+            "Bind a resource by calling 'WithComputeEnvironment' on its resource builder.",
+            ex.Message);
+    }
+
+    [Fact]
+    public async Task ComputeEnvironment_WithTooManyBoundResources_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env = builder.AddResource(new TestComputeEnvironmentResource(
+            "env",
+            allowsImplicitBinding: false,
+            minimumResourceCount: 1,
+            maximumResourceCount: 1));
+        builder.AddResource(new TestComputeResource("api")).WithComputeEnvironment(env);
+        builder.AddResource(new TestComputeResource("worker")).WithComputeEnvironment(env);
+
+        using var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => app.ExecuteBeforeStartHooksAsync(default)).DefaultTimeout();
+
+        Assert.Equal(
+            "Compute environment 'env' supports at most 1 bound compute resource(s), but 2 were found.",
+            ex.Message);
+    }
+
+    [Fact]
+    public async Task ComputeEnvironment_WithUnsupportedBoundResource_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env = builder.AddResource(new TestComputeEnvironmentResource(
+            "env",
+            allowsImplicitBinding: false,
+            supportsResource: _ => false));
+        builder.AddResource(new TestComputeResource("api")).WithComputeEnvironment(env);
+
+        using var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => app.ExecuteBeforeStartHooksAsync(default)).DefaultTimeout();
+
+        Assert.Equal(
+            "Compute environment 'env' does not support compute resource(s) 'api (TestComputeResource)'.",
+            ex.Message);
+    }
+
+    [Theory]
+    [InlineData(-1, null)]
+    [InlineData(0, -1)]
+    [InlineData(2, 1)]
+    public async Task ComputeEnvironment_WithInvalidResourceCountPolicy_Throws(int minimumResourceCount, int? maximumResourceCount)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.AddResource(new TestComputeEnvironmentResource(
+            "env",
+            minimumResourceCount: minimumResourceCount,
+            maximumResourceCount: maximumResourceCount));
+
+        using var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => app.ExecuteBeforeStartHooksAsync(default)).DefaultTimeout();
+
+        Assert.Equal(
+            "Compute environment 'env' has an invalid resource count policy. " +
+            "The minimum count must be non-negative and cannot exceed the maximum count.",
+            ex.Message);
+    }
+
     [Theory]
     [InlineData(EndpointProperty.Url, "http://api.example.com:8080")]
     [InlineData(EndpointProperty.Host, "api.example.com")]
@@ -103,9 +255,22 @@ public class ComputeEnvironmentValidationTests
         return new EndpointReference(resource, endpoint);
     }
 
-    private sealed class TestComputeEnvironmentResource(string name) : Resource(name), IComputeEnvironmentResource
+    private sealed class TestComputeEnvironmentResource(
+        string name,
+        bool allowsImplicitBinding = true,
+        int minimumResourceCount = 0,
+        int? maximumResourceCount = null,
+        Func<IComputeResource, bool>? supportsResource = null) : Resource(name), IComputeEnvironmentResource
     {
 #pragma warning disable ASPIRECOMPUTE002
+        public bool AllowsImplicitBinding => allowsImplicitBinding;
+
+        public int MinimumResourceCount => minimumResourceCount;
+
+        public int? MaximumResourceCount => maximumResourceCount;
+
+        public bool SupportsResource(IComputeResource resource) => supportsResource?.Invoke(resource) ?? true;
+
         public ReferenceExpression GetHostAddressExpression(EndpointReference endpointReference) =>
             ReferenceExpression.Create($"{endpointReference.Resource.Name}.example.com");
 #pragma warning restore ASPIRECOMPUTE002


### PR DESCRIPTION
## Description

This draft explores deploying an Aspire .NET project directly to an Azure Virtual Machine Scale Set without first containerizing the application. It adds an experimental `Aspire.Hosting.Azure.Compute` integration that publishes one explicitly bound .NET project as a self-contained `linux-x64` application, packages it as an Azure VM Application, and deploys it to a VMSS.

The deployment path provisions private Blob staging, a Compute Gallery application/version, a workload managed identity, targeted RBAC, subnet-attached VMSS instances, and a hardened `systemd` service. VMSS model updates use Uniform orchestration with automatic upgrades so a newly pinned VM Application version reaches existing instances.

This is intentionally a capability proof. It supports one .NET project per VMSS environment, Linux x64 images, fixed capacity, and no ingress. Endpoint-bearing workloads, secret-backed application configuration, health-gated rollout/repair, autoscale, and broader executable/image support remain follow-up work.

### User-facing usage

```csharp
var subnet = builder.AddAzureVirtualNetwork("network")
    .AddSubnet("compute-subnet", "10.0.0.0/24");

var vmss = builder.AddAzureVirtualMachineScaleSetEnvironment("compute")
    .WithPlatformImage("Canonical", "ubuntu-24_04-lts", "server", "latest")
    .WithVmSku("Standard_D2s_v6")
    .WithCapacity(2)
    .WithSubnet(subnet)
    .WithAdminSshPublicKey("<ssh-public-key>");

builder.AddDotnetProject(
        "worker",
        "../Worker/Worker.csproj",
        options => options.ExcludeLaunchProfile = true)
    .WithComputeEnvironment(vmss);
```

After this PR's CI build completes, install its CLI and matching package hive with:

```bash
./eng/scripts/get-aspire-cli-pr.sh <PR_NUMBER>
```

### Security considerations

The VM Application executes generated installation scripts as root to install root-owned application files, a `0600` environment file, and a `systemd` unit. The workload itself runs as a dedicated unprivileged `aspire-app` account with systemd hardening. Package staging uses Microsoft Entra authentication with shared-key access disabled, generated archives use deterministic paths and modes, and secret-backed environment variables or command-line arguments are rejected. This draft has not yet had a dedicated security review.

### Validation

- Full repository build with native AOT skipped.
- VMSS infrastructure, packaging, identity, pipeline-ordering, validation, and Bicep provisioner tests.
- Compute-environment binding and container-image policy tests.
- Both Bicep templates compiled with the Azure CLI.
- A representative project published as a self-contained `linux-x64` executable and confirmed as an x86-64 ELF binary.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
