### PR TITLE
[Azure App Configuration] - Add health check endpoint for app config emulator

### DIFF
--- a/src/Aspire.Hosting.Azure.AppConfiguration/AppConfigurationEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AppConfigurationEmulatorContainerImageTags.cs
@@ -11,6 +11,6 @@ internal static class AppConfigurationEmulatorContainerImageTags
     /// <remarks>azure-app-configuration/app-configuration-emulator</remarks>
     public const string Image = "azure-app-configuration/app-configuration-emulator";
 
-    /// <remarks>1.0.2</remarks>
-    public const string Tag = "1.0.2";
+    /// <remarks>1.2.0</remarks>
+    public const string Tag = "1.2.0";
 }

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -16,6 +16,8 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class AzureAppConfigurationExtensions
 {
+    private const string EmulatorEndpointName = "emulator";
+
     /// <summary>
     /// Adds an Azure App Configuration resource to the application model.
     /// </summary>
@@ -105,7 +107,8 @@ public static class AzureAppConfigurationExtensions
             return builder;
         }
 
-        builder.WithHttpEndpoint(name: "emulator", targetPort: 8483)
+        builder.WithHttpEndpoint(name: EmulatorEndpointName, targetPort: 8483)
+            .WithHttpHealthCheck(endpointName: EmulatorEndpointName, path: "/health")
             .WithAnnotation(new ContainerImageAnnotation
             {
                 Registry = AppConfigurationEmulatorContainerImageTags.Registry,
@@ -165,7 +168,7 @@ public static class AzureAppConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        return builder.WithEndpoint("emulator", endpoint =>
+        return builder.WithEndpoint(EmulatorEndpointName, endpoint =>
         {
             endpoint.Port = port;
         });

--- a/tests/Aspire.Hosting.Azure.Tests/AzureAppConfigurationExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureAppConfigurationExtensionsTests.cs
@@ -128,4 +128,16 @@ public class AzureAppConfigurationExtensionsTests(ITestOutputHelper output)
         await Verify(manifest.ToString(), "json")
              .AppendContentAsFile(bicep, "bicep");
     }
+
+    [Fact]
+    public void RunAsEmulatorRegistersHealthCheck()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var appConfiguration = builder.AddAzureAppConfiguration("appconfig").RunAsEmulator();
+
+        Assert.Contains(
+            appConfiguration.Resource.Annotations,
+            annotation => annotation is HealthCheckAnnotation healthCheck && healthCheck.Key == "appconfig_emulator_/health_200_check");
+    }
 }


### PR DESCRIPTION
## Description

Adds an HTTP health check for Azure App Configuration `RunAsEmulator` using the emulator's `/health` endpoint and updates the image to 1.2.0. This ensures `OnResourceReady` runs only after the emulator is ready to accept requests.

Fixes [#101](https://github.com/Azure/AppConfiguration-Emulator/issues/101)

