### PR TITLE
Improve AI agents dialog copy

### DIFF
--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -61,12 +61,14 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        ///   Looks up a localized string similar to Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
         ///
         ///- 📦 Resource state, health checks, and relationships
         ///- 🖥️ Console logs
         ///- 📊 Distributed traces
         ///- 🪵 Structured logs
+        ///
+        ///## Getting started
         ///
         ///AI agents access dashboard telemetry through the Aspire CLI. If you haven’t installed it yet, [install the Aspire CLI]({1}).
         ///
@@ -85,7 +87,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        ///   Looks up a localized string similar to Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
         ///
         ///- 📊 Distributed traces
         ///- 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -539,7 +539,7 @@
     <value>AI agents</value>
   </data>
   <data name="AIAgentsDialogStandaloneDescription" xml:space="preserve">
-    <value>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+    <value>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -560,12 +560,14 @@ For more information about using AI agents with the dashboard, including setting
     <comment>{0} is the dashboard URL, {1} is the learn more URL, {2} is the install CLI URL</comment>
   </data>
   <data name="AIAgentsDialogAppHostDescription" xml:space="preserve">
-    <value>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+    <value>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="de" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="es" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="it" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -3,12 +3,14 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Dialogs.resx">
     <body>
       <trans-unit id="AIAgentsDialogAppHostDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -23,12 +25,14 @@ This command configures skill files for your AI agent. The skill files tell the 
 Once connected, agents can start your app, check resource health, fetch logs and traces, and more.
 
 For more information about using AI agents with Aspire, such as setting up skills, see [AI coding agents]({0}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📦 Resource state, health checks, and relationships
 - 🖥️ Console logs
 - 📊 Distributed traces
 - 🪵 Structured logs
+
+## Getting started
 
 AI agents access dashboard telemetry through the Aspire CLI. If you haven't installed it yet, [install the Aspire CLI]({1}).
 
@@ -46,7 +50,7 @@ For more information about using AI agents with Aspire, such as setting up skill
         <note>{0} is the learn more URL, {1} is the install CLI URL</note>
       </trans-unit>
       <trans-unit id="AIAgentsDialogStandaloneDescription">
-        <source>Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <source>Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans
@@ -64,7 +68,7 @@ aspire otel logs --dashboard-url {0}
 This is one example of how AI agents can access telemetry for your app. See [`aspire otel`](https://aspire.dev/reference/cli/commands/aspire-otel/) and [`aspire export`](https://aspire.dev/reference/cli/commands/aspire-export/).
 
 For more information about using AI agents with the dashboard, including setting up skills, see [Standalone dashboard and AI coding agents]({1}).</source>
-        <target state="new">Aspire makes agentic development more powerful. It gives AI coding agents deep observability into your app using the information visible in the dashboard. Agents can use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
+        <target state="new">Aspire gives AI coding agents deep observability into your app using the same information visible in the dashboard. Agents use telemetry to diagnose issues faster and verify fixes with confidence. 🚀
 
 - 📊 Distributed traces
 - 🔗 Trace spans


### PR DESCRIPTION
## Description

Clarifies the AI agents dialog copy to emphasize that coding agents use the same information visible in the dashboard. The AppHost dialog now separates CLI setup under a **Getting started** heading so the next action is easier to scan.

### User-facing usage

The AI agents dialog presents the updated introduction in both standalone and AppHost modes. In AppHost mode, Aspire CLI setup appears under a **Getting started** section.

Validation: `dotnet build /t:UpdateXlf src/Aspire.Dashboard/Aspire.Dashboard.csproj`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `&lt;remarks /&gt;` and `&lt;code /&gt;` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
