### PR TITLE
Fix metrics chart 24-hour time format

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
@@ -73,7 +73,12 @@ public partial class PlotlyChart : ChartBase
         if (!tickUpdate)
         {
             // The chart mostly shows numbers but some localization is needed for displaying time ticks.
-            var is24Hour = DateTimeFormatInfo.CurrentInfo.LongTimePattern.StartsWith("H", StringComparison.Ordinal);
+            var is24Hour = TimeProvider.ResolvedTimeFormat switch
+            {
+                TimeFormat.TwentyFourHour => true,
+                TimeFormat.TwelveHour => false,
+                _ => DateTimeFormatInfo.CurrentInfo.LongTimePattern.StartsWith("H", StringComparison.Ordinal)
+            };
             // Plotly uses d3-time-format https://d3js.org/d3-time-format
             var time = is24Hour ? "%H:%M:%S" : "%-I:%M:%S %p";
             var userLocale = new PlotlyUserLocale

--- a/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
@@ -73,12 +73,7 @@ public partial class PlotlyChart : ChartBase
         if (!tickUpdate)
         {
             // The chart mostly shows numbers but some localization is needed for displaying time ticks.
-            var is24Hour = TimeProvider.ResolvedTimeFormat switch
-            {
-                TimeFormat.TwentyFourHour => true,
-                TimeFormat.TwelveHour => false,
-                _ => DateTimeFormatInfo.CurrentInfo.LongTimePattern.StartsWith("H", StringComparison.Ordinal)
-            };
+            var is24Hour = BrowserTimeProvider.Is24HourFormat(TimeProvider.ResolvedTimeFormat);
             // Plotly uses d3-time-format https://d3js.org/d3-time-format
             var time = is24Hour ? "%H:%M:%S" : "%-I:%M:%S %p";
             var userLocale = new PlotlyUserLocale

--- a/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
+++ b/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Dashboard.Utils;
 
 namespace Aspire.Dashboard.Model;
@@ -63,5 +64,18 @@ public class BrowserTimeProvider : TimeProvider, ITimeFormatProvider
     public void SetConfiguredTimeFormat(TimeFormat timeFormat)
     {
         ConfiguredTimeFormat = timeFormat;
+    }
+
+    /// <summary>
+    /// Determines whether the specified time format uses a 24-hour clock.
+    /// </summary>
+    internal static bool Is24HourFormat(TimeFormat timeFormat)
+    {
+        return timeFormat switch
+        {
+            TimeFormat.TwentyFourHour => true,
+            TimeFormat.TwelveHour => false,
+            _ => DateTimeFormatInfo.CurrentInfo.LongTimePattern.StartsWith('H')
+        };
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -48,6 +48,7 @@ public class PlotlyChartTests : DashboardTestContext
     }
 
     [Theory]
+    [InlineData(TimeFormat.System, "12:59:57 AM", "%-I:%M:%S %p")]
     [InlineData(TimeFormat.TwelveHour, "12:59:57 AM", "%-I:%M:%S %p")]
     [InlineData(TimeFormat.TwentyFourHour, "0:59:57", "%H:%M:%S")]
     public async Task Render_HasInstrument_InitializeChartInvocation(TimeFormat timeFormat, string expectedTooltipTime, string expectedPlotlyTimeFormat)

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -7,6 +7,7 @@ using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Aspire.Dashboard.Utils;
 using Bunit;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Metrics.V1;
@@ -46,11 +47,14 @@ public class PlotlyChartTests : DashboardTestContext
             });
     }
 
-    [Fact]
-    public async Task Render_HasInstrument_InitializeChartInvocation()
+    [Theory]
+    [InlineData(TimeFormat.TwelveHour, "12:59:57 AM", "%-I:%M:%S %p")]
+    [InlineData(TimeFormat.TwentyFourHour, "0:59:57", "%H:%M:%S")]
+    public async Task Render_HasInstrument_InitializeChartInvocation(TimeFormat timeFormat, string expectedTooltipTime, string expectedPlotlyTimeFormat)
     {
         // Arrange
-        FluentUISetupHelpers.AddCommonDashboardServices(this);
+        var timeProvider = new TestTimeProvider { ConfiguredTimeFormat = timeFormat };
+        FluentUISetupHelpers.AddCommonDashboardServices(this, browserTimeProvider: timeProvider);
         MetricsSetupHelpers.SetupPlotlyChart(this);
 
         var options = new TelemetryLimitOptions();
@@ -105,8 +109,9 @@ public class PlotlyChartTests : DashboardTestContext
                 Assert.Collection((IEnumerable<PlotlyTrace>)i.Arguments[1]!, trace =>
                 {
                     Assert.Equal("Unit-&lt;b&gt;Bold&lt;/b&gt;", trace.Name);
-                    Assert.Equal("<b>Name-&lt;b&gt;Bold&lt;/b&gt;</b><br />Unit-&lt;b&gt;Bold&lt;/b&gt;: 1<br />Time: 12:59:57 AM", trace.Tooltips[0], ignoreWhiteSpaceDifferences: true);
+                    Assert.Equal($"<b>Name-&lt;b&gt;Bold&lt;/b&gt;</b><br />Unit-&lt;b&gt;Bold&lt;/b&gt;: 1<br />Time: {expectedTooltipTime}", trace.Tooltips[0], ignoreWhiteSpaceDifferences: true);
                 });
+                Assert.Equal(expectedPlotlyTimeFormat, Assert.IsType<PlotlyUserLocale>(i.Arguments[5]).Time);
             });
     }
 }


### PR DESCRIPTION
## Description

The metrics chart ignored the dashboard's configured time format and derived its axis tick format from the server culture. As a result, selecting the 24-hour preference could leave chart ticks in 12-hour format.

The chart now uses the resolved browser time provider preference when selecting the Plotly locale time pattern, while retaining the culture-based fallback for the system setting. Component tests cover explicit 12-hour and 24-hour preferences and verify that chart ticks and tooltips use consistent formats.

### User-facing usage

Set the dashboard **Time format** preference to **24-hour**. Metrics chart axis labels now use 24-hour time alongside the rest of the dashboard.

Validation: `PlotlyChartTests` passed (3 tests).

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No