### PR TITLE
Render aspire doctor output from issue template as code block by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -60,6 +60,7 @@ body:
       label: Aspire doctor output
       description: |
         Run `aspire doctor` and paste output here
+      render: plain
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
## Description

The CLI installations block from `aspire doctor` gets rendered rather poorly.  Tell the issue template to render the `aspire doctor` output as a code block by default, rather than try and treat it as markdown which can have unexpected results.  

- `Aspire CLI Installations` gest rendered as a markdown header due to the `=====` line below,
- Installations table looks weird when rendered without a fixed width font / or if word wrap is introduced

<img width="811" height="415" alt="image" src="https://github.com/user-attachments/assets/e397bd30-3883-4701-abe4-ad17e90402df" />

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
