### PR TITLE
Update DevTunnelOptions.cs

### DIFF
--- a/src/Aspire.Hosting.DevTunnels/DevTunnelOptions.cs
+++ b/src/Aspire.Hosting.DevTunnels/DevTunnelOptions.cs
@@ -36,14 +36,14 @@ public sealed class DevTunnelOptions
         Region switch
         {
             DevTunnelRegion.WestEurope => "euw",
-            DevTunnelRegion.UkSouth => "uks1",
+            DevTunnelRegion.UKSouth => "uks1",
             DevTunnelRegion.NorthEurope => "eun1",
             DevTunnelRegion.EastUs => "use",
             DevTunnelRegion.EastUs2 => "use2",
             DevTunnelRegion.WestUs2 => "usw2",
             DevTunnelRegion.WestUs3 => "usw3",
             DevTunnelRegion.CentralIndia => "inc1",
-            DevTunnelRegion.SouthEastAsia => "asse",
+            DevTunnelRegion.SoutheastAsia => "asse",
             DevTunnelRegion.BrazilSouth => "brs",
             DevTunnelRegion.AustraliaCentral => "auc1",
             DevTunnelRegion.AustraliaEast => "aue",
@@ -86,7 +86,7 @@ public sealed class DevTunnelPortOptions
 /// <summary>
 /// Region options for dev tunnel creation.
 /// </summary>
-public enum DevTunnelRegion : byte
+public enum DevTunnelRegion
 {
     /// <summary>
     /// West Europe region.
@@ -96,7 +96,7 @@ public enum DevTunnelRegion : byte
     /// <summary>
     /// UK South region.
     /// </summary>
-    UkSouth,
+    UKSouth,
 
     /// <summary>
     /// North Europe region.
@@ -131,7 +131,7 @@ public enum DevTunnelRegion : byte
     /// <summary>
     /// Southeast Asia region.
     /// </summary>
-    SouthEastAsia,
+    SoutheastAsia,
 
     /// <summary>
     /// Brazil South region.


### PR DESCRIPTION
## Description

Recreates #19051 by @kola-tm, which was merged into `update-api-diffs` instead of `main`.

This aligns the public `DevTunnelRegion` API with .NET naming conventions by renaming `UkSouth` to `UKSouth` and `SouthEastAsia` to `SoutheastAsia`, and removes the explicit `byte` underlying type. The service-region mappings remain unchanged.

### User-facing usage

Consumers can select the corrected region names:

```csharp
options.Region = DevTunnelRegion.UKSouth;
options.Region = DevTunnelRegion.SoutheastAsia;
```

Validation: `dotnet test --project tests/Aspire.Hosting.DevTunnels.Tests/Aspire.Hosting.DevTunnels.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (37 passed).

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
