### PR TITLE
Cover single-file AppHost re-search fallback and make the no-AppHost error generic

### DIFF
--- a/src/Aspire.Cli/Projects/ProjectLocator.cs
+++ b/src/Aspire.Cli/Projects/ProjectLocator.cs
@@ -1235,7 +1235,7 @@ internal static class ProjectLocatorErrorHelper
             ProjectLocatorFailureReason.MultipleProjectFilesFound
                 => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedMultipleAppHostsFound),
             ProjectLocatorFailureReason.NoProjectFileFound
-                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedNoCsprojFound),
+                => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.ProjectOptionNotSpecifiedNoAppHostsFound),
             ProjectLocatorFailureReason.AppHostsMayNotBeBuildable
                 => (CliExitCodes.FailedToFindProject, InteractionServiceStrings.UnbuildableAppHostsDetected),
             _ => (CliExitCodes.FailedToFindProject, string.Format(CultureInfo.CurrentCulture, InteractionServiceStrings.UnexpectedErrorOccurred, ex.Message))

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.Designer.cs
@@ -367,11 +367,11 @@ namespace Aspire.Cli.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The project argument was not specified and no *.csproj files were detected..
+        ///   Looks up a localized string similar to The --apphost option was not specified and no AppHost project files were detected..
         /// </summary>
-        public static string ProjectOptionNotSpecifiedNoCsprojFound {
+        public static string ProjectOptionNotSpecifiedNoAppHostsFound {
             get {
-                return ResourceManager.GetString("ProjectOptionNotSpecifiedNoCsprojFound", resourceCulture);
+                return ResourceManager.GetString("ProjectOptionNotSpecifiedNoAppHostsFound", resourceCulture);
             }
         }
 

--- a/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
+++ b/src/Aspire.Cli/Resources/InteractionServiceStrings.resx
@@ -197,8 +197,8 @@
   <data name="ProjectOptionNotSpecifiedMultipleAppHostsFound" xml:space="preserve">
     <value>The --apphost option was not specified and multiple AppHost project files were detected.</value>
   </data>
-  <data name="ProjectOptionNotSpecifiedNoCsprojFound" xml:space="preserve">
-    <value>The project argument was not specified and no AppHost project files were detected.</value>
+  <data name="ProjectOptionNotSpecifiedNoAppHostsFound" xml:space="preserve">
+    <value>The --apphost option was not specified and no AppHost project files were detected.</value>
   </data>
   <data name="ProjectCouldNotBeBuilt" xml:space="preserve">
     <value>The project could not be built.</value>

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.cs.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">Nebyl zadán parametr --apphost a bylo zjištěno více souborů projektu hostitele aplikací.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">Nebyl zadán argument projektu a nebyly zjištěny žádné soubory projektů hostitele aplikace.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.de.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">Die Option „--apphost“ wurde nicht angegeben, und es wurden mehrere App-Hostprojektdateien erkannt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">Das Projektargument wurde nicht angegeben, und es wurden keine App-Hostprojektdateien erkannt.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.es.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">No se especificó la opción --apphost y se detectaron varios archivos de proyecto de host de aplicación.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">No se especificó el argumento del proyecto y no se detectaron archivos de proyecto de host de aplicaciones.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.fr.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">L’option --apphost n’a pas été spécifiée et plusieurs fichiers de projet d’hôte d’application ont été détectés.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">L'argument de projet n'a pas été spécifié et aucun fichier de projet hôte d'application n'a été détecté.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.it.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">L'opzione --apphost non è stata specificata e sono stati rilevati più file di progetto host delle app.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">L'argomento del progetto non è stato specificato e non sono stati rilevati file del progetto host dell'app.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ja.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">--apphost オプションが指定されておらず、アプリ ホスティング プロセスのプロジェクト ファイルが複数検出されました。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">プロジェクト引数が指定されておらず、アプリ ホスト プロジェクト ファイルが検出されませんでした。</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ko.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">--apphost 옵션이 지정되지 않았고 앱 호스트 프로젝트 파일이 여러 개 검색되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">프로젝트 인수가 지정되지 않았고 앱 호스트 프로젝트 파일이 감지되지 않았습니다.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pl.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">Nie określono opcji --apphost i wykryto wiele plików projektu hosta aplikacji.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">Nie określono argumentu projektu i nie wykryto plików projektu hosta aplikacji.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.pt-BR.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">A opção --apphost não foi especificada e vários arquivos de projeto de host do aplicativo foram detectados.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">O argumento do projeto não foi especificado e nenhum arquivo de projeto do host do aplicativo foi detectado.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.ru.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">Параметр --apphost не указан, и обнаружено несколько файлов проекта app host.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">Аргумент проекта не указан. Не найдены файлы проекта узла приложений.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.tr.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">--apphost seçeneği belirtilmedi ve birden fazla uygulama ana işlemi projesi dosyası algılandı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">Proje bağımsız değişkeni belirtilmedi ve uygulama ana işlemi projesinin dosyaları tespit edilemedi.</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hans.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">未指定 --apphost 选项，并且检测到多个应用主机项目文件。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">未指定项目参数，并且未检测到应用主机项目文件。</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/InteractionServiceStrings.zh-Hant.xlf
@@ -157,9 +157,9 @@
         <target state="needs-review-translation">未指定 --apphost 選項，且偵測到多個應用程式主機專案檔案。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectOptionNotSpecifiedNoCsprojFound">
-        <source>The project argument was not specified and no AppHost project files were detected.</source>
-        <target state="needs-review-translation">未指定專案引數，且未偵測到任何主控處理程序專案檔案。</target>
+      <trans-unit id="ProjectOptionNotSpecifiedNoAppHostsFound">
+        <source>The --apphost option was not specified and no AppHost project files were detected.</source>
+        <target state="new">The --apphost option was not specified and no AppHost project files were detected.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectOptionSpecifiedDirectoryContainsMultipleAppHosts">

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -29,6 +29,24 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
             workingDirectory);
     }
 
+    // A single-file AppHost is recognized by the `#:sdk Aspire.AppHost.Sdk` file-based app
+    // directive rather than by a project file, so discovery tests need a file that carries it.
+    // See https://learn.microsoft.com/dotnet/core/sdk/file-based-programs for the directive format.
+    private static async Task<FileInfo> CreateSingleFileAppHostAsync(DirectoryInfo directory)
+    {
+        var appHostFile = new FileInfo(Path.Combine(directory.FullName, "apphost.cs"));
+        await File.WriteAllTextAsync(
+            appHostFile.FullName,
+            """
+            #:sdk Aspire.AppHost.Sdk
+            using Aspire.Hosting;
+            var builder = DistributedApplication.CreateBuilder(args);
+            builder.Build().Run();
+            """);
+
+        return appHostFile;
+    }
+
     [Fact]
     public async Task UseOrFindAppHostProjectFileThrowsIfExplicitProjectFileDoesNotExist()
     {
@@ -228,20 +246,11 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     // existed. The legacy settings file is exercised here (rather than aspire.config.json) because
     // that is the shape reported in the issue.
     [Fact]
-    public async Task UseOrFindAppHostProjectFileFallsBackToSingleFileAppHostWhenLegacySettingsPathIsMissing()
+    public async Task UseOrFindAppHostProjectFileFallsBackToSingleFileAppHostWhenLegacySettingsFileSpecifiesMissingAppHostPath()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
 
-        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("SingleFile");
-        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "apphost.cs"));
-        await File.WriteAllTextAsync(
-            appHostFile.FullName,
-            """
-            #:sdk Aspire.AppHost.Sdk
-            using Aspire.Hosting;
-            var builder = DistributedApplication.CreateBuilder(args);
-            builder.Build().Run();
-            """);
+        var appHostFile = await CreateSingleFileAppHostAsync(workspace.WorkspaceRoot.CreateSubdirectory("SingleFile"));
 
         // "../apphost.cs" is the exact relative path from the issue report: it resolves to the
         // workspace root, where no apphost.cs exists.
@@ -263,20 +272,11 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     // Companion to the legacy-settings regression test above, covering the modern
     // aspire.config.json shape that replaced .aspire/settings.json.
     [Fact]
-    public async Task UseOrFindAppHostProjectFileFallsBackToSingleFileAppHostWhenConfigFilePathIsMissing()
+    public async Task UseOrFindAppHostProjectFileFallsBackToSingleFileAppHostWhenConfigFileSpecifiesMissingAppHostPath()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
 
-        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("SingleFile");
-        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "apphost.cs"));
-        await File.WriteAllTextAsync(
-            appHostFile.FullName,
-            """
-            #:sdk Aspire.AppHost.Sdk
-            using Aspire.Hosting;
-            var builder = DistributedApplication.CreateBuilder(args);
-            builder.Build().Run();
-            """);
+        var appHostFile = await CreateSingleFileAppHostAsync(workspace.WorkspaceRoot.CreateSubdirectory("SingleFile"));
 
         var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
         await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -35,14 +35,19 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
     private static async Task<FileInfo> CreateSingleFileAppHostAsync(DirectoryInfo directory)
     {
         var appHostFile = new FileInfo(Path.Combine(directory.FullName, "apphost.cs"));
-        await File.WriteAllTextAsync(
-            appHostFile.FullName,
-            """
+        var contents = """
             #:sdk Aspire.AppHost.Sdk
             using Aspire.Hosting;
             var builder = DistributedApplication.CreateBuilder(args);
             builder.Build().Run();
-            """);
+            """;
+
+        Assert.Equal("#:sdk Aspire.AppHost.Sdk", new StringReader(contents).ReadLine());
+        Assert.StartsWith("#:sdk Aspire.AppHost.Sdk", contents, StringComparison.Ordinal);
+
+        await File.WriteAllTextAsync(
+            appHostFile.FullName,
+            contents);
 
         return appHostFile;
     }

--- a/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProjectLocatorTests.cs
@@ -221,6 +221,92 @@ public class ProjectLocatorTests(ITestOutputHelper outputHelper)
         Assert.Equal(realAppHostProjectFile.FullName, foundAppHost?.FullName);
     }
 
+    // Regression test for https://github.com/microsoft/aspire/issues/12660. Single-file AppHost
+    // support introduced a locator path where a stale `.aspire/settings.json` entry pointing at a
+    // missing `apphost.cs` short-circuited discovery instead of falling back to a recursive scan,
+    // so the CLI reported "no AppHost project files were detected" even though a valid AppHost
+    // existed. The legacy settings file is exercised here (rather than aspire.config.json) because
+    // that is the shape reported in the issue.
+    [Fact]
+    public async Task UseOrFindAppHostProjectFileFallsBackToSingleFileAppHostWhenLegacySettingsPathIsMissing()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("SingleFile");
+        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "apphost.cs"));
+        await File.WriteAllTextAsync(
+            appHostFile.FullName,
+            """
+            #:sdk Aspire.AppHost.Sdk
+            using Aspire.Hosting;
+            var builder = DistributedApplication.CreateBuilder(args);
+            builder.Build().Run();
+            """);
+
+        // "../apphost.cs" is the exact relative path from the issue report: it resolves to the
+        // workspace root, where no apphost.cs exists.
+        var workspaceSettingsDirectory = workspace.CreateDirectory(".aspire");
+        var aspireSettingsFile = new FileInfo(Path.Combine(workspaceSettingsDirectory.FullName, "settings.json"));
+        await File.WriteAllTextAsync(aspireSettingsFile.FullName, JsonSerializer.Serialize(new
+        {
+            appHostPath = "../apphost.cs"
+        }));
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocatorWithSingleFileEnabled(executionContext);
+
+        var foundAppHost = await projectLocator.UseOrFindAppHostProjectFileAsync(null, createSettingsFile: false).DefaultTimeout();
+
+        Assert.Equal(appHostFile.FullName, foundAppHost?.FullName);
+    }
+
+    // Companion to the legacy-settings regression test above, covering the modern
+    // aspire.config.json shape that replaced .aspire/settings.json.
+    [Fact]
+    public async Task UseOrFindAppHostProjectFileFallsBackToSingleFileAppHostWhenConfigFilePathIsMissing()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var appHostDirectory = workspace.WorkspaceRoot.CreateSubdirectory("SingleFile");
+        var appHostFile = new FileInfo(Path.Combine(appHostDirectory.FullName, "apphost.cs"));
+        await File.WriteAllTextAsync(
+            appHostFile.FullName,
+            """
+            #:sdk Aspire.AppHost.Sdk
+            using Aspire.Hosting;
+            var builder = DistributedApplication.CreateBuilder(args);
+            builder.Build().Run();
+            """);
+
+        var configPath = Path.Combine(workspace.WorkspaceRoot.FullName, AspireConfigFile.FileName);
+        await File.WriteAllTextAsync(configPath, JsonSerializer.Serialize(new
+        {
+            appHost = new { path = "./apphost.cs" }
+        }));
+
+        var executionContext = CreateExecutionContext(workspace.WorkspaceRoot);
+        var projectLocator = CreateProjectLocatorWithSingleFileEnabled(executionContext);
+
+        var foundAppHost = await projectLocator.UseOrFindAppHostProjectFileAsync(null, createSettingsFile: false).DefaultTimeout();
+
+        Assert.Equal(appHostFile.FullName, foundAppHost?.FullName);
+    }
+
+    // When the stale configured path is the only lead and nothing else is discoverable, the CLI
+    // must still fail. The user-facing message must not name a .NET-specific artifact because
+    // AppHosts can be single-file C#, TypeScript, or Python — see
+    // https://github.com/microsoft/aspire/issues/12660.
+    [Fact]
+    public void NoProjectFileFoundMapsToAppHostAgnosticErrorMessage()
+    {
+        var exception = new ProjectLocatorException(ErrorStrings.NoProjectFileFound, ProjectLocatorFailureReason.NoProjectFileFound);
+
+        var (exitCode, errorMessage) = ProjectLocatorErrorHelper.GetExitCodeAndMessage(exception);
+
+        Assert.Equal(CliExitCodes.FailedToFindProject, exitCode);
+        Assert.Equal(InteractionServiceStrings.ProjectOptionNotSpecifiedNoAppHostsFound, errorMessage);
+    }
+
     [Fact]
     public async Task UseOrFindAppHostProjectFileUsesValidSettingsWithoutScanning()
     {


### PR DESCRIPTION
## Description

When a configured AppHost path goes stale, `aspire` should warn and then re-search the workspace rather than giving up. #12660 reported that single-file AppHost support broke this: a `.aspire/settings.json` pointing at a missing `apphost.cs` caused the CLI to bail out with `The project argument was not specified and no *.csproj files were detected.` even when a perfectly good AppHost was sitting in the tree.

I re-ran the reported scenario against current `main` and **the re-search fallback itself works today** — a stale path is warned about, discovery continues, and the AppHost is found (verified for legacy `.aspire/settings.json`, modern `aspire.config.json`, single-file `apphost.cs`, and `.csproj` shapes). What was missing was a test guarding the single-file path, and the error message still carried stale wording.

This PR closes the remaining gaps:

1. **Regression coverage for the single-file case.** `ProjectLocatorTests` already covered re-search for `.csproj` AppHosts (`UseOrFindAppHostProjectFileFallsBackWhenSettingsFileSpecifiesNonexistentAppHost`), but nothing covered `apphost.cs` — which is exactly the shape that regressed. Two new tests pin the behavior for both the legacy `.aspire/settings.json` (using the literal `../apphost.cs` path from the issue) and the modern `aspire.config.json` config shapes.

2. **A genuinely AppHost-agnostic error message.** #12661 removed `*.csproj` from the message but left `The project argument was not specified`. There is no "project argument" — the option is `--apphost`, and the sibling multiple-AppHosts message already says so. The resource is renamed `ProjectOptionNotSpecifiedNoCsprojFound` → `ProjectOptionNotSpecifiedNoAppHostsFound` and reworded to match, with a test covering the failure-reason → message mapping.

### User-facing usage

When no AppHost can be found, the message now names the real option and no longer implies .NET-only projects:

```text
❌ The --apphost option was not specified and no AppHost project files were detected.
```

Before:

```text
❌ The project argument was not specified and no AppHost project files were detected.
```

The re-search behavior, confirmed with a CLI built from this branch (stale `.aspire/settings.json` → `../apphost.cs`, real AppHost at `sub/apphost.cs`):

```text
⚠️ AppHost file was specified in '<scratch>/.aspire/settings.json' but it does not exist at '<scratch>/apphost.cs'.
┌──────────────────┬──────────┬───────────┐
│ Path             │ Language │ Status    │
├──────────────────┼──────────┼───────────┤
│ sub/apphost.cs   │ csharp   │ buildable │
└──────────────────┴──────────┴───────────┘
```

### Validation

- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj` — 4820 tests, 0 failures.
- **Mutation-checked the new regression tests**: temporarily changed the two "configured AppHost path is missing" branches in `ProjectLocator` to throw instead of returning `null` (simulating the original regression). Both new fallback tests failed as expected, then passed again once reverted — so they genuinely guard the fallback rather than passing vacuously.
- Manually reproduced the issue scenario end-to-end with a CLI built from this branch across legacy settings, modern config, single-file, and `.csproj` AppHost shapes.

Note the message change is CLI text only — no rendering, layout, or interaction changes.

Fixes #12660

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
