### PR TITLE
Enable CLI bundle in C# AppHost templates

### DIFF
--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -289,6 +289,7 @@ internal sealed class InitCommand : BaseCommand
         var aspireVersion = _executionContext.IdentitySdkVersion;
         var appHostContent = $$"""
             #:sdk Aspire.AppHost.Sdk@{{aspireVersion}}
+            #:property AspireUseCliBundle=true
 
             var builder = DistributedApplication.CreateBuilder(args);
 

--- a/src/Aspire.Cli/Templating/Templates/empty-apphost/apphost.cs
+++ b/src/Aspire.Cli/Templating/Templates/empty-apphost/apphost.cs
@@ -1,4 +1,5 @@
 #:sdk Aspire.AppHost.Sdk@{{aspireVersion}}
+#:property AspireUseCliBundle=true
 
 var builder = DistributedApplication.CreateBuilder(args);
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/apphost.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost-singlefile/apphost.cs
@@ -1,4 +1,5 @@
 #:sdk Aspire.AppHost.Sdk@!!REPLACE_WITH_LATEST_VERSION!!
+#:property AspireUseCliBundle=true
 
 var builder = DistributedApplication.CreateBuilder(args);
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/Aspire.AppHost1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/Aspire.AppHost1.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AspireUseCliBundle>true</AspireUseCliBundle>
     <UserSecretsId>98048c9c-bf28-46ba-a98e-63767ee5e3a8</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.AppHost/AspireApplication.1.AppHost.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.AppHost/AspireApplication.1.AppHost.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AspireUseCliBundle>true</AspireUseCliBundle>
     <UserSecretsId>98048c9c-bf28-46ba-a98e-63767ee5e3a8</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AspireUseCliBundle>true</AspireUseCliBundle>
     <UserSecretsId>98048c9c-bf28-46ba-a98e-63767ee5e3a8</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-ts-cs-starter/Aspire-StarterApplication.1.AppHost/Aspire-StarterApplication.1.AppHost.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AspireUseCliBundle>true</AspireUseCliBundle>
     <UserSecretsId>98048c9c-bf28-46ba-a98e-63767ee5e3a8</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/BundleSmokeTests.cs
@@ -73,15 +73,7 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
 
         var appHostProject = File.ReadAllText(appHostProjectPath);
         Assert.Contains("<Nullable>enable</Nullable>", appHostProject);
-        Assert.DoesNotContain("AspireUseCliBundle", appHostProject);
-        appHostProject = appHostProject.Replace(
-            "<Nullable>enable</Nullable>",
-            """
-            <Nullable>enable</Nullable>
-                <AspireUseCliBundle>true</AspireUseCliBundle>
-            """,
-            StringComparison.Ordinal);
-        File.WriteAllText(appHostProjectPath, appHostProject);
+        Assert.Contains("<AspireUseCliBundle>true</AspireUseCliBundle>", appHostProject);
 
         File.WriteAllText(
             appHostSourcePath,
@@ -238,11 +230,7 @@ public sealed class BundleSmokeTests(ITestOutputHelper output)
         var sdkDirective = File.ReadLines(appHostSourcePath).First();
         Assert.StartsWith("#:sdk Aspire.AppHost.Sdk@", sdkDirective);
         Assert.Contains("var builder = DistributedApplication.CreateBuilder(args);", appHostSource);
-        Assert.DoesNotContain("AspireUseCliBundle", appHostSource);
-        appHostSource = appHostSource.Replace(
-            sdkDirective,
-            $"{sdkDirective}{Environment.NewLine}#:property AspireUseCliBundle=true",
-            StringComparison.Ordinal);
+        Assert.Contains("#:property AspireUseCliBundle=true", appHostSource);
 
         File.WriteAllText(
             appHostSourcePath,

--- a/tests/Aspire.Cli.EndToEnd.Tests/SingleFileAppHostInitDotnetRunTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SingleFileAppHostInitDotnetRunTests.cs
@@ -69,7 +69,7 @@ public sealed class SingleFileAppHostInitDotnetRunTests(ITestOutputHelper output
 
         Assert.True(File.Exists(appHostCs), $"Expected apphost.cs to exist at: {appHostCs}");
         Assert.True(File.Exists(aspireConfigJson), $"Expected aspire.config.json to exist at: {aspireConfigJson}");
-        Assert.DoesNotContain("AspireUseCliBundle", File.ReadAllText(appHostCs));
+        Assert.Contains("#:property AspireUseCliBundle=true", File.ReadAllText(appHostCs));
         Assert.True(
             File.Exists(appHostRunJson),
             $"Expected apphost.run.json to exist at: {appHostRunJson}. "

--- a/tests/Aspire.Cli.EndToEnd.Tests/SingleFileAppHostInitDotnetRunTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/SingleFileAppHostInitDotnetRunTests.cs
@@ -91,12 +91,12 @@ public sealed class SingleFileAppHostInitDotnetRunTests(ITestOutputHelper output
         Assert.False(string.IsNullOrWhiteSpace(httpsEnv["ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL"]?.GetValue<string>()));
         Assert.False(string.IsNullOrWhiteSpace(httpsEnv["ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL"]?.GetValue<string>()));
 
-        // The generated AppHost uses the default direct launch path, so wait for the
-        // structured startup message emitted by DistributedApplication.
+        // The generated AppHost opts into the CLI bundle, so `dotnet run` delegates to the
+        // CLI and displays its startup message instead of the direct AppHost log message.
         await auto.TypeAsync("dotnet run apphost.cs");
         await auto.EnterAsync();
         await auto.WaitUntilTextAsync(
-            "Distributed application started. Press Ctrl+C to shut down.",
+            "Press CTRL+C to stop the AppHost and exit.",
             timeout: TimeSpan.FromMinutes(1));
 
         // Stop the running AppHost with Ctrl+C and wait for the shell prompt.

--- a/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/InitCommandTests.cs
@@ -659,6 +659,7 @@ public class InitCommandTests(ITestOutputHelper outputHelper)
         var firstLine = appHostContent.Split('\n')[0].TrimEnd('\r');
         Assert.StartsWith("#:sdk Aspire.AppHost.Sdk@", firstLine, StringComparison.Ordinal);
         Assert.NotEqual("#:sdk Aspire.AppHost.Sdk@", firstLine);
+        Assert.Contains("#:property AspireUseCliBundle=true", appHostContent);
     }
 
     [Fact]

--- a/tests/Shared/TemplatesTesting/AspireProject.cs
+++ b/tests/Shared/TemplatesTesting/AspireProject.cs
@@ -177,7 +177,7 @@ public partial class AspireProject : IAsyncDisposable
         AppExited = new();
         AppHostProcess = new Process();
 
-        var processArguments = $"run {(noBuild ? "--no-build" : "")}";
+        var processArguments = $"run {(noBuild ? "--no-build" : "")} {_buildEnv.DefaultBuildArgs}";
         processArguments += extraArgs is not null ? " " + string.Join(" ", extraArgs) : "";
         AppHostProcess.StartInfo = new ProcessStartInfo(_buildEnv.DotNet, processArguments)
         {

--- a/tests/Shared/TemplatesTesting/BuildEnvironment.cs
+++ b/tests/Shared/TemplatesTesting/BuildEnvironment.cs
@@ -160,7 +160,11 @@ public class BuildEnvironment
         }
 
         sdkForTemplatePath = Path.GetFullPath(sdkForTemplatePath);
-        DefaultBuildArgs = string.Empty;
+        // The generated AppHost project opts into the CLI bundle, so an environment variable
+        // cannot disable it: project properties override properties imported from the environment.
+        // Template tests use repo-built DCP and dashboard packages instead of an installed bundle,
+        // so pass the opt-out as a global MSBuild property that the project cannot override.
+        DefaultBuildArgs = "/p:AspireUseCliBundle=false";
         NuGetPackagesPath = UsesCustomDotNet ? Path.Combine(AppContext.BaseDirectory, $"nuget-cache-{Guid.NewGuid()}") : null;
         EnvVars = new Dictionary<string, string>();
         if (UsesCustomDotNet)

--- a/tests/Shared/TemplatesTesting/DotNetNewCommand.cs
+++ b/tests/Shared/TemplatesTesting/DotNetNewCommand.cs
@@ -26,5 +26,7 @@ public class DotNetNewCommand : DotNetCommand
     }
 
     protected override string GetFullArgs(params string[] args)
-        => $"new {base.GetFullArgs(args)} --debug:custom-hive \"{_customHive}\"";
+        // DefaultBuildArgs contains MSBuild properties for build, test, and run commands.
+        // `dotnet new` treats those arguments as template options, so do not append them here.
+        => $"new {string.Join(" ", args)} --debug:custom-hive \"{_customHive}\"";
 }


### PR DESCRIPTION
## Description

New C# AppHosts should use the Aspire CLI bundle by default so they do not emit the opt-in warning and can use features provided by the bundled dashboard and DCP packages.

This updates all C# AppHost project templates, single-file AppHost templates, and the `aspire init` single-file skeleton to enable `AspireUseCliBundle`. The bundle smoke tests now verify that generated projects opt in without modifying the generated files.

### User-facing usage

Generated AppHost projects now include:

```xml
<AspireUseCliBundle>true</AspireUseCliBundle>
```

Generated single-file AppHosts now include:

```csharp
#:property AspireUseCliBundle=true
```

### Validation

- `dotnet test --project tests\Aspire.Cli.Tests\Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-method "*.InitCommand_WhenNoSolutionExists_SingleFileSkeletonPinsSdkVersion" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`
- `dotnet build src\Aspire.ProjectTemplates\Aspire.ProjectTemplates.csproj --no-restore`
- `dotnet build tests\Aspire.Cli.EndToEnd.Tests\Aspire.Cli.EndToEnd.Tests.csproj --no-restore`

Fixes #19074

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
