### PR TITLE
Improve Aspire Team App refresh and issue UX

### DIFF
--- a/.github/extensions/aspire-team-app/README.md
+++ b/.github/extensions/aspire-team-app/README.md
@@ -49,13 +49,20 @@ card shows are driven by its lane and its signal pills:
 
 - **Review mode** — buckets every open PR across your watched repos into lanes:
   Needs your review, Ready to merge, CI failing, Unresolved feedback, and Your PRs.
-- **Issues mode** — Assigned to you, Your issues, Needs triage, Recently active.
+- **Issues mode** — Assigned to you, Your issues, Needs triage, Recently active,
+  with linked pull requests shown directly on issue cards and opened in in-app
+  browser tabs.
 - **Ship mode** — PRs in the current release milestone grouped into Ready to ship,
   In progress, and Blocked.
 - **Signal pills** — Draft, CI failing, Merge conflicts, Changes requested,
   N unresolved, Approved, Ready to merge, Needs review, Quick win, Stalled.
 - **Notifications** — review requested, your PR ready to merge, changes requested,
   CI failing, with per-category preferences. Live updates over SSE.
+- **Stable background refresh** — GitHub data is assembled into a complete snapshot
+  while the current board remains visible, then applied in one update. The compact
+  **Auto** toolbar switch can pause automatic UI updates; when paused, an **Apply
+  update** pill appears only after changed data is ready. The refresh button tooltip
+  counts down to the next background data check.
 - **Multiple GitHub accounts** — every detected credential (gh CLI, environment,
   Copilot) appears on the Accounts screen. Activate any number of them and their
   results **interleave across every tab**, de-duplicated by PR/issue URL. Each
@@ -72,14 +79,14 @@ card shows are driven by its lane and its signal pills:
 | File | Responsibility |
 | --- | --- |
 | `extension.mjs` | Wiring: `joinSession` + `createCanvas`, agent-facing actions. |
-| `server.mjs` | Per-instance loopback HTTP server, JSON API, SSE refresh, multi-account interleave. |
+| `server.mjs` | Per-instance loopback HTTP server, complete-snapshot cache, background polling, SSE refresh, multi-account interleave. |
 | `accounts.mjs` | Credential discovery, per-account repo-access probing, host/enterprise detection. |
 | `github.mjs` | GraphQL queries, lane bucketing, signals, avatars, cross-account merge. |
 | `model.mjs` | Attention buckets, focus queue, core-team / community classification. |
 | `constants.mjs` | Configuration: core-team members, release milestone, personal picks. |
 | `render.mjs` | Iframe HTML / CSS / client JS, styled with Copilot theme tokens. |
 | `agent.mjs` | Card-action prompt/log builders (Test, Review, Resolve conflicts, Address review, Evaluate CI failures, Discuss review, Address feedback) with untrusted-PR hardening. |
-| `state.mjs` | Durable per-account preferences (watched repos, active flag, notifications). |
+| `state.mjs` | Durable preferences (watched repos, active accounts, notifications, refresh behavior). |
 
 The canvas reads each account's token from `GH_TOKEN` / `GITHUB_TOKEN`, the
 per-account Copilot credentials, or `gh auth token`, and queries the matching

--- a/.github/extensions/aspire-team-app/extension.mjs
+++ b/.github/extensions/aspire-team-app/extension.mjs
@@ -7,8 +7,8 @@
 // github.mjs; durable preferences in state.mjs.
 
 import { joinSession, createCanvas, CanvasError } from "@github/copilot-sdk/extension";
-import { startInstance, stopInstance, forceRefresh, getDashboard, rescanAccounts, toggleAccount, setReposFor, setAgentSend } from "./server.mjs";
-import { loadPrefs, savePrefs } from "./state.mjs";
+import { startInstance, stopInstance, forceRefresh, getDashboard, rescanAccounts, toggleAccount, setReposFor, setAgentSend, setBrowserOpen } from "./server.mjs";
+import { updatePrefs } from "./state.mjs";
 import { accountId } from "./accounts.mjs";
 
 function resolveAccountId(ref) {
@@ -54,9 +54,7 @@ const session = await joinSession({
             if (!["review", "issues", "ship"].includes(mode)) {
               throw new CanvasError("invalid_mode", "mode must be review, issues, or ship");
             }
-            const prefs = await loadPrefs();
-            prefs.mode = mode;
-            await savePrefs(prefs);
+            await updatePrefs((prefs) => { prefs.mode = mode; });
             const { dashboard } = await forceRefresh();
             return { mode: dashboard.mode, counts: dashboard.counts ?? null };
           },
@@ -208,4 +206,19 @@ setAgentSend(async ({ prompt, log }) => {
   } finally {
     sendsInFlight--;
   }
+});
+
+setBrowserOpen(async (pr) => {
+  const instanceId = `aspire-team-app-pr-${pr.repository}-${pr.number}`
+    .replace(/[^a-zA-Z0-9._-]/g, "-")
+    .slice(0, 128);
+  return session.rpc.canvas.open({
+    canvasId: "browser",
+    instanceId,
+    input: {
+      url: pr.url,
+      title: `${pr.repository} #${pr.number}`,
+      placement: { surface: "panel", focus: true },
+    },
+  });
 });

--- a/.github/extensions/aspire-team-app/github.mjs
+++ b/.github/extensions/aspire-team-app/github.mjs
@@ -128,6 +128,9 @@ query($owner:String!, $name:String!, $after:String) {
         milestone { title }
         labels(first:15) { nodes { name } }
         assignees(first:10) { nodes { login } }
+        closedByPullRequestsReferences(first:5, includeClosedPrs:true) {
+          nodes { number title url state repository { nameWithOwner } }
+        }
       }
     }
   }
@@ -344,6 +347,15 @@ function normalizePr(repo, node, viewers, repoPrivate = false) {
 function normalizeIssue(repo, node, viewers) {
   const labels = (node.labels?.nodes ?? []).map((l) => l.name);
   const assignees = (node.assignees?.nodes ?? []).map((a) => a.login);
+  const linkedPullRequests = (node.closedByPullRequestsReferences?.nodes ?? [])
+    .filter((pr) => pr.state !== "CLOSED")
+    .map((pr) => ({
+      repository: pr.repository?.nameWithOwner ?? repo,
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      state: pr.state,
+    }));
   const author = node.author?.login ?? "ghost";
   return {
     repository: repo,
@@ -361,6 +373,7 @@ function normalizeIssue(repo, node, viewers) {
     milestone: node.milestone?.title ?? null,
     labels,
     assignees,
+    linkedPullRequests,
     isMine: viewers.has(author.toLowerCase()),
     assignedToMe: assignees.some((a) => viewers.has(a.toLowerCase())),
   };
@@ -643,7 +656,7 @@ export function capFocusKeepingDebt(cards, limit) {
 // Top-level loader
 // ---------------------------------------------------------------------------
 
-export async function loadDashboard({ accounts, mode, release, prefs, dismissed, showDrafts = false, reviewLimit = REVIEW_LIMIT, onProgress, onPartial }) {
+export async function loadDashboard({ accounts, mode, release, prefs, dismissed, showDrafts = false, reviewLimit = REVIEW_LIMIT, onProgress }) {
   const usable = (accounts ?? []).filter((a) => a && a.token && a.login);
   if (usable.length === 0) {
     return { authenticated: false, message: "No active GitHub account. Enable an account in the Accounts tab so the canvas can read your review queue." };
@@ -667,26 +680,15 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
   const okRepos = new Set();  // hostRepoKey(host, repo) that succeeded under at least one account
   const errorsRaw = [];       // { repo, host, message }
 
-  // Streaming progress + incremental snapshots. Each (account, repo) fetch reports when it
-  // settles so the caller can drive a deterministic progress bar (onProgress) and receive
-  // partial dashboards as data arrives (onPartial). Partials are throttled so a burst of
-  // fast repos doesn't reshape on every single completion.
+  // Each (account, repo) fetch reports when it settles so the caller can drive a deterministic
+  // progress bar. Dashboard state is intentionally produced only after every job completes:
+  // replacing an already-populated board with partial snapshots makes cards disappear and
+  // reappear as slower repositories finish.
   let total = 0;
   let done = 0;
-  let lastPartialAt = 0;
-  const PARTIAL_MIN_MS = 250;
-  const maybePartial = (force) => {
-    if (typeof onPartial !== "function") return;
-    const now = Date.now();
-    if (!force && now - lastPartialAt < PARTIAL_MIN_MS) return;
-    lastPartialAt = now;
-    // A failed partial push must never abort the underlying load.
-    try { onPartial(snapshot()); } catch { /* ignore */ }
-  };
   const reportDone = () => {
     done++;
     if (typeof onProgress === "function") onProgress({ done, total, phase: "fetch" });
-    maybePartial(false);
   };
 
   // Fetch each (account, repo) pair with that account's own token.
@@ -738,8 +740,6 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
   total = jobs.length;
 
   // Reshape the accumulated PRs/issues into the dashboard shape the renderer consumes.
-  // A hoisted function declaration so the streaming callbacks above can snapshot partial
-  // results as repos arrive; also called once more below for the final, complete result.
   function snapshot() {
     const allPrs = [...prById.values()].sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
     const allIssues = [...issueById.values()].sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
@@ -857,8 +857,7 @@ export async function loadDashboard({ accounts, mode, release, prefs, dismissed,
   }
 
   await Promise.all(jobs);
-  // Final, authoritative progress tick so a deterministic bar can complete even if the
-  // last throttled partial was skipped.
+  // Final, authoritative progress tick so the deterministic bar completes with the snapshot.
   if (typeof onProgress === "function") onProgress({ done: total, total, phase: "done" });
   return snapshot();
 }

--- a/.github/extensions/aspire-team-app/github.test.mjs
+++ b/.github/extensions/aspire-team-app/github.test.mjs
@@ -68,9 +68,28 @@ test("loadDashboard paginates open issues for each watched repo", async () => {
     const body = JSON.parse(options.body);
     seenAfter.push(body.variables.after ?? null);
     if (body.query.includes("issues")) {
+      assert.match(body.query, /closedByPullRequestsReferences\(first:5, includeClosedPrs:true\)/);
       return jsonResponse({ data: { repository: { issues: page(
         body.variables.after,
-        issueNode(1, "2026-07-01T10:00:00Z"),
+        issueNode(1, "2026-07-01T10:00:00Z", [{
+          number: 10,
+          title: "Fix issue 1",
+          url: "https://github.com/microsoft/aspire/pull/10",
+          state: "OPEN",
+          repository: { nameWithOwner: "microsoft/aspire" },
+        }, {
+          number: 11,
+          title: "Merged fix for issue 1",
+          url: "https://github.com/microsoft/aspire/pull/11",
+          state: "MERGED",
+          repository: { nameWithOwner: "microsoft/aspire" },
+        }, {
+          number: 12,
+          title: "Abandoned fix for issue 1",
+          url: "https://github.com/microsoft/aspire/pull/12",
+          state: "CLOSED",
+          repository: { nameWithOwner: "microsoft/aspire" },
+        }]),
         issueNode(2, "2026-07-01T11:00:00Z"),
       ) } } });
     }
@@ -88,9 +107,23 @@ test("loadDashboard paginates open issues for each watched repo", async () => {
   assert.deepEqual(seenAfter, [null, "cursor-1"]);
   assert.equal(dashboard.counts.issues, 2);
   assert.deepEqual(dashboard.lanes.flatMap((lane) => lane.items.map((item) => item.issue.number)).sort((a, b) => a - b), [1, 2]);
+  const issue = dashboard.lanes.flatMap((lane) => lane.items).find((item) => item.issue.number === 1).issue;
+  assert.deepEqual(issue.linkedPullRequests, [{
+    repository: "microsoft/aspire",
+    number: 10,
+    title: "Fix issue 1",
+    url: "https://github.com/microsoft/aspire/pull/10",
+    state: "OPEN",
+  }, {
+    repository: "microsoft/aspire",
+    number: 11,
+    title: "Merged fix for issue 1",
+    url: "https://github.com/microsoft/aspire/pull/11",
+    state: "MERGED",
+  }]);
 });
 
-test("loadDashboard reports fetch progress and streams a partial snapshot", async () => {
+test("loadDashboard reports fetch progress and returns one complete snapshot", async () => {
   globalThis.fetch = async (_url, options = {}) => {
     const body = JSON.parse(options.body);
     return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: {
@@ -100,7 +133,6 @@ test("loadDashboard reports fetch progress and streams a partial snapshot", asyn
   };
 
   const progress = [];
-  const partials = [];
   const dashboard = await loadDashboard({
     accounts: [{ token: "token", login: "octo", repos: ["microsoft/aspire", "microsoft/aspire.dev"] }],
     mode: "ship",
@@ -109,7 +141,6 @@ test("loadDashboard reports fetch progress and streams a partial snapshot", asyn
     dismissed: [],
     showDrafts: true,
     onProgress: (p) => progress.push(p),
-    onPartial: (snap) => partials.push(snap),
   });
 
   // Two (account, repo) jobs → total of 2, ending with an authoritative done tick.
@@ -117,9 +148,6 @@ test("loadDashboard reports fetch progress and streams a partial snapshot", asyn
   assert.equal(progress.at(-1).done, 2);
   assert.equal(progress.at(-1).phase, "done");
   assert.ok(progress.some((p) => p.phase === "fetch"), "expected at least one fetch-phase tick");
-  // The first partial is never throttled (lastPartialAt starts at 0), so we always get one.
-  assert.ok(partials.length >= 1, "expected at least one partial snapshot");
-  assert.equal(partials[0].authenticated, true);
   assert.equal(dashboard.counts.total, 1);
 });
 
@@ -192,7 +220,7 @@ function prNode(number, updatedAt) {
   };
 }
 
-function issueNode(number, updatedAt) {
+function issueNode(number, updatedAt, linkedPullRequests = []) {
   return {
     number,
     title: `Issue ${number}`,
@@ -203,6 +231,7 @@ function issueNode(number, updatedAt) {
     milestone: null,
     labels: { nodes: [] },
     assignees: { nodes: [] },
+    closedByPullRequestsReferences: { nodes: linkedPullRequests },
   };
 }
 

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -51,22 +51,28 @@ export const HTML = `<!doctype html>
 export const STYLES = `
 :root {
   color-scheme: light dark;
-  /* Primer primitive first, then the canvas host's older vars, then a hex floor.
-     https://primer.style/foundations/primitives/color */
-  --bg: var(--bgColor-default, var(--background-color-default, #ffffff));
+  --fallback-bg: #ffffff;
+  --fallback-fg: #1f2328;
+  --fallback-muted: #656d76;
+  --fallback-border: #d0d7de;
+  --fallback-focus: #0969da;
+
+  /* The canvas runtime normally mirrors these documented semantic tokens for the active host
+     theme. The fallbacks cover standalone rendering and hosts that omit the theme payload. */
+  --bg: var(--background-color-default, var(--fallback-bg));
   --surface: color-mix(in srgb, var(--bg), var(--fg) 5%);
   --surface-2: color-mix(in srgb, var(--bg), var(--fg) 7%);
   --surface-3: color-mix(in srgb, var(--bg), var(--fg) 10%);
   --card: color-mix(in srgb, var(--bg), var(--fg) 4%);
   --card-hover: color-mix(in srgb, var(--bg), var(--fg) 8%);
   --head-hover: color-mix(in srgb, var(--fg) 8%, transparent);
-  --fg: var(--fgColor-default, var(--text-color-default, #1f2328));
-  --muted: var(--fgColor-muted, var(--text-color-muted, #656d76));
-  --border: var(--borderColor-default, var(--border-color-default, #d0d7de));
+  --fg: var(--text-color-default, var(--fallback-fg));
+  --muted: var(--text-color-muted, var(--fallback-muted));
+  --border: var(--border-color-default, var(--fallback-border));
   --border-soft: color-mix(in srgb, var(--border), transparent 35%);
   --border-strong: color-mix(in srgb, var(--border), var(--fg) 22%);
-  --focus: var(--focus-outlineColor, var(--color-focus-outline, #0969da));
-  --white: var(--fgColor-onEmphasis, var(--color-white, #fff));
+  --focus: var(--color-focus-outline, var(--fallback-focus));
+  --white: var(--color-white, #ffffff);
 
   /* Brand purple - reserved for the brand mark, PR identity, and the loading accent.
      Maps to Primer's "done" (purple) role. */
@@ -99,8 +105,34 @@ export const STYLES = `
   --radius: 6px;
 }
 
-:root[data-color-mode="light"], body[data-color-mode="light"] { color-scheme: light; }
-:root[data-color-mode="dark"], body[data-color-mode="dark"] { color-scheme: dark; }
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fallback-bg: #0d1117;
+    --fallback-fg: #f0f6fc;
+    --fallback-muted: #8c959f;
+    --fallback-border: #30363d;
+    --fallback-focus: #58a6ff;
+  }
+}
+
+:root[data-color-mode="light"] {
+  color-scheme: light;
+  --fallback-bg: #ffffff;
+  --fallback-fg: #1f2328;
+  --fallback-muted: #656d76;
+  --fallback-border: #d0d7de;
+  --fallback-focus: #0969da;
+}
+body[data-color-mode="light"] { color-scheme: light; }
+:root[data-color-mode="dark"] {
+  color-scheme: dark;
+  --fallback-bg: #0d1117;
+  --fallback-fg: #f0f6fc;
+  --fallback-muted: #8c959f;
+  --fallback-border: #30363d;
+  --fallback-focus: #58a6ff;
+}
+body[data-color-mode="dark"] { color-scheme: dark; }
 
 * { box-sizing: border-box; }
 html, body { margin: 0; height: 100%; }

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -157,6 +157,29 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 .tab.active { color: var(--fg); background: var(--surface-3); box-shadow: inset 0 0 0 1px var(--border); }
 .spacer { flex: 1; }
 .tb-actions { display: inline-flex; align-items: center; gap: 6px; }
+.refresh-pref {
+  height: 30px; display: inline-flex; align-items: center; gap: 6px;
+  border: 1px solid var(--border); border-radius: 999px; background: var(--surface);
+  color: var(--muted); padding: 0 10px; font-size: 11.5px; font-weight: 600;
+  transition: color .15s, border-color .15s, background .15s, opacity .15s;
+}
+.refresh-pref:hover { color: var(--fg); border-color: var(--border-strong); background: var(--surface-2); }
+.refresh-pref[disabled] { cursor: default; opacity: .65; }
+.refresh-pref .status-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--muted); transition: background .15s, box-shadow .15s; }
+.refresh-pref.active { color: var(--fg); background: var(--surface-3); border-color: var(--border-strong); }
+.refresh-pref.active .status-dot { background: var(--success); box-shadow: 0 0 0 3px color-mix(in srgb, var(--success) 16%, transparent); }
+.update-ready {
+  height: 30px; display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, var(--border));
+  border-radius: 999px; padding: 0 11px; background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+  color: var(--accent-strong); font-size: 11.5px; font-weight: 650;
+  transition: border-color .15s, background .15s, opacity .15s;
+}
+.update-ready:hover { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 16%, var(--surface)); }
+.update-ready[hidden] { display: none; }
+.update-ready[disabled] { cursor: wait; opacity: .7; }
+.update-ready .update-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); }
+.update-ready.busy .update-dot { background: transparent; border: 1.5px solid var(--accent); border-right-color: transparent; animation: spin .8s linear infinite; }
 
 .backbtn {
   display: inline-flex; align-items: center; gap: 6px; margin-left: 4px;
@@ -175,6 +198,16 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 .iconbtn:hover { color: var(--fg); border-color: var(--border-strong); background: var(--surface-2); }
 .iconbtn.active { color: var(--fg); border-color: var(--border-strong); background: var(--surface-3); box-shadow: inset 0 0 0 1px var(--border-soft); }
 .iconbtn.spin svg { animation: spin 1s linear infinite; }
+.live-tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute; top: calc(100% + 8px); right: 0; z-index: 80;
+  width: max-content; max-width: min(360px, calc(100vw - 24px)); padding: 6px 9px;
+  border: 1px solid var(--border); border-radius: 6px; background: var(--surface-3);
+  color: var(--fg); box-shadow: var(--shadow-floating); font-size: 11.5px; font-weight: 500;
+  line-height: 1.35; white-space: nowrap; pointer-events: none;
+  opacity: 0; transform: translateY(-2px); transition: opacity .12s ease, transform .12s ease;
+}
+.live-tooltip:hover::after, .live-tooltip:focus-visible::after { opacity: 1; transform: none; }
 .badge {
   position: absolute; top: -6px; right: -6px; min-width: 16px; height: 16px; padding: 0 4px;
   border-radius: 999px; background: var(--danger); color: var(--white); font-size: 10px; font-weight: 700;
@@ -387,6 +420,16 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
 .reason { color: var(--muted); font-size: 12px; }
 .pills { display: flex; flex-wrap: wrap; gap: 5px; }
 .pills:empty { display: none; }
+.linked-pr {
+  display: flex; flex-direction: row; align-items: flex-start; gap: 7px; min-width: 0; padding: 2px 0;
+  border-radius: 5px; color: var(--fg); font-size: 11.5px; font-weight: 600; line-height: 1.35;
+}
+.linked-pr:hover .linked-pr-title { color: var(--blue); text-decoration: underline; text-underline-offset: 2px; }
+.linked-pr-icon { display: inline-flex; flex: none; margin-top: 1px; color: var(--muted); }
+.linked-pr-icon.open { color: var(--success); }
+.linked-pr-icon.merged { color: var(--purple); }
+.linked-pr-icon svg { width: 14px; height: 14px; }
+.linked-pr-title { min-width: 0; overflow-wrap: anywhere; }
 .pill {
   --pill-tone: var(--muted);
   display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 500; line-height: 1;
@@ -698,6 +741,9 @@ button.brand:focus-visible { outline: 2px solid var(--focus); outline-offset: 1p
   .brand-text { display: none; }
   .tabs { margin-left: 0; }
   .tab { padding: 5px 11px; }
+  .refresh-pref { width: 30px; padding: 0; justify-content: center; }
+  .refresh-pref .refresh-label { display: none; }
+  .update-ready .update-detail { display: none; }
   .acct-chip { max-width: 150px; }
   .acct-chip .name { max-width: 70px; }
   .page { padding: 14px; }
@@ -740,16 +786,40 @@ let loadError = null;
 // settings, etc.) is stashed here and applied when they return to the queue, so a
 // background refresh never clobbers an in-progress edit.
 let pendingState = null;
+// Completed background snapshots wait here when automatic application is disabled. The SSE event
+// carries metadata only; clicking Apply reads the already-computed complete snapshot from the server.
+let updateAvailable = null;
+let applyingUpdate = false;
+let savingAutoApply = false;
+let nextPollAt = null;
+let pollCountdownTimer = null;
 // Monotonic revision of the snapshot currently applied. fetchedAt is a wall-clock display
-// timestamp and is unsafe as a stream key: a partial and the final can share a millisecond,
-// and snapshots can arrive out of order. The server stamps a strictly increasing seq on
-// every partial/final; we apply only strictly-newer ones. -1 so the first real snapshot (0+)
-// always applies.
+// timestamp and is unsafe as a stream key because overlapping requests can settle out of order.
+// The server stamps a strictly increasing seq whenever semantic content changes; we apply only
+// strictly-newer snapshots. -1 lets the first real snapshot (0+) always apply.
 let lastAppliedSeq = -1;
 // Record the revision of whatever snapshot was just assigned to state. Call at every point
 // that adopts a server snapshot so later SSE pushes are ordered against it.
 function adoptAppliedRev() {
   if (state && typeof state.seq === "number") lastAppliedSeq = state.seq;
+}
+function adoptState(payload) {
+  state = payload.dashboard;
+  prefs = payload.prefs;
+  loadError = null;
+  adoptAppliedRev();
+  const appliedSeq = state && state.seq;
+  if (!updateAvailable || typeof appliedSeq !== "number" || appliedSeq >= updateAvailable.seq) {
+    updateAvailable = null;
+  }
+}
+function autoApplyEnabled() {
+  return !prefs || prefs.autoApplyUpdates !== false;
+}
+function refreshTooltip() {
+  if (typeof nextPollAt !== "number") return "Refresh now";
+  const seconds = Math.max(0, Math.ceil((nextPollAt - Date.now()) / 1000));
+  return "Refresh now (data will auto-update in " + seconds + "s)";
 }
 const expanded = new Set(); // account ids whose detail (sources + repos) is expanded
 const collapsedLanes = new Set(); // lane ids the user collapsed (survives re-render + SSE)
@@ -866,6 +936,7 @@ async function load() {
   // that newer valid state. Suppress the failure when a newer revision was applied after this
   // request started (the withRefresh catch gates the same class of race with its refreshGen id).
   const startSeq = lastAppliedSeq;
+  let changed = false;
   try {
     const res = await fetch("api/state");
     const data = await readJson(res);
@@ -875,31 +946,23 @@ async function load() {
     // state/lastAppliedSeq backward. Mirrors the withRefresh/applyPushedState gate.
     const seq = data.dashboard && data.dashboard.seq;
     if (typeof seq !== "number" || seq > lastAppliedSeq) {
-      state = data.dashboard; prefs = data.prefs; loadError = null;
-      adoptAppliedRev();
+      adoptState(data);
+      changed = true;
     }
   } catch (e) {
     // Only publish this failure if no newer revision was applied while the GET was pending. A late
     // failure from a superseded request must not clobber the newer valid state (or its banner).
     if (lastAppliedSeq === startSeq) {
       loadError = String((e && e.message) || e);
+      changed = true;
     }
   }
-  render();
-}
-
-// Handle the SSE 'refresh' nudge. Every mutation streams the fresh dashboard over the 'state' event
-// (which applyPushedState stashes into pendingState while off the queue) and then fires this legacy
-// 'refresh'. Re-pulling here unconditionally would call load() -> render() even while a form-bearing
-// view (Accounts/Settings/Filters) is open, discarding the user's uncommitted text. Mirror
-// applyPushedState's guard and only act on the nudge while the queue is showing; the paired 'state'
-// push already stashed the latest snapshot, which goView() applies on return to the queue.
-function onSseRefresh() {
-  if (view === "queue") { load(); }
+  if (changed) render(); else updateRefreshControls();
 }
 
 async function withRefresh(fn) {
   const myGen = ++refreshGen;
+  let changed = false;
   refreshInFlight++;
   refreshing = true; setLoading(true); beginProgress();
   try {
@@ -911,8 +974,8 @@ async function withRefresh(fn) {
       // (which would show stale data and corrupt later seq gates). Mirrors applyPushedState's gate.
       const seq = data.dashboard.seq;
       if (typeof seq !== "number" || seq > lastAppliedSeq) {
-        state = data.dashboard; prefs = data.prefs; loadError = null;
-        adoptAppliedRev();
+        adoptState(data);
+        changed = true;
       }
     }
   } catch (e) {
@@ -921,6 +984,7 @@ async function withRefresh(fn) {
     // path is seq-gated for the same reason, but rejections carry no seq, so gate on refreshGen.
     if (myGen === refreshGen) {
       loadError = String((e && e.message) || e);
+      changed = true;
     }
   } finally {
     refreshInFlight--;
@@ -932,13 +996,41 @@ async function withRefresh(fn) {
     // (SSE disconnected, or this refresh joined a background compute started with
     // progress:false, which emits no progress events).
     if (refreshInFlight === 0) { refreshing = false; endProgress(); }
-    render();
+    if (changed) render(); else updateRefreshControls();
   }
 }
 
 function setLoading(on) {
   const rb = document.getElementById("refresh-btn");
   if (rb) rb.classList.toggle("spin", on);
+}
+
+function updateRefreshControls() {
+  const rb = document.getElementById("refresh-btn");
+  if (rb) {
+    rb.classList.toggle("spin", refreshing);
+    const tooltip = refreshTooltip();
+    rb.dataset.tooltip = tooltip;
+    rb.setAttribute("aria-label", tooltip);
+  }
+
+  const auto = document.getElementById("auto-apply-btn");
+  const enabled = autoApplyEnabled();
+  if (auto) {
+    auto.classList.toggle("active", enabled);
+    auto.setAttribute("aria-checked", enabled ? "true" : "false");
+    auto.title = enabled
+      ? "Background updates apply automatically"
+      : "Background updates wait until you apply them";
+    auto.disabled = savingAutoApply;
+  }
+
+  const apply = document.getElementById("apply-update-btn");
+  if (apply) {
+    apply.hidden = !updateAvailable || enabled;
+    apply.disabled = applyingUpdate;
+    apply.classList.toggle("busy", applyingUpdate);
+  }
 }
 
 /* ---- deterministic progress bar ----
@@ -992,9 +1084,8 @@ function applyPushedState(payload) {
   if (view !== "queue") { pendingState = payload; return; }
   const seq = payload.dashboard.seq;
   if (typeof seq === "number" && seq <= lastAppliedSeq) {
-    // Stale or duplicate: an older/out-of-order partial, or the final we already applied via
-    // the triggering request's response. Reject outright — do not overwrite the newer state
-    // we already show (a duplicate carries identical content, a stale one carries older data).
+    // Stale or duplicate: the request response may have already applied this snapshot, or an older
+    // overlapping request settled late. Never overwrite the newer state already on screen.
     return;
   }
   applyState(payload);
@@ -1002,8 +1093,7 @@ function applyPushedState(payload) {
 function applyState(payload) {
   const scroller = document.scrollingElement;
   const top = scroller ? scroller.scrollTop : 0;
-  state = payload.dashboard; prefs = payload.prefs; loadError = null;
-  adoptAppliedRev();
+  adoptState(payload);
   render();
   if (top && scroller) scroller.scrollTop = top;
 }
@@ -1011,6 +1101,103 @@ function applyState(payload) {
 async function postJSON(path, body) {
   const res = await fetch(path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body || {}) });
   return readJson(res);
+}
+
+function onUpdateAvailable(payload) {
+  if (!payload || typeof payload.seq !== "number" || payload.seq <= lastAppliedSeq) return;
+  if (!updateAvailable || payload.seq > updateAvailable.seq) updateAvailable = payload;
+  updateRefreshControls();
+}
+
+function onPreferences(nextPrefs) {
+  if (!nextPrefs || typeof nextPrefs !== "object") return;
+  const wasEnabled = autoApplyEnabled();
+  prefs = nextPrefs;
+  updateRefreshControls();
+  if (!wasEnabled && autoApplyEnabled() && updateAvailable) {
+    applyAvailableUpdate();
+  }
+}
+
+function onSnapshot(payload) {
+  onPollSchedule(payload);
+  if (!payload || typeof payload.seq !== "number" || payload.seq <= lastAppliedSeq) return;
+  if (payload.prefs && typeof payload.prefs === "object") prefs = payload.prefs;
+  // Initial load already reads the complete cache. On reconnect, replay either applies the missed
+  // state automatically or restores the pending-update affordance without touching the board.
+  if (!state) return;
+  if (autoApplyEnabled()) load(); else onUpdateAvailable(payload);
+}
+
+function onPollSchedule(payload) {
+  const value = Number(payload && payload.nextPollAt);
+  if (!Number.isFinite(value) || value <= 0) return;
+  nextPollAt = value;
+  if (!pollCountdownTimer) {
+    pollCountdownTimer = setInterval(updateRefreshControls, 1000);
+  }
+  updateRefreshControls();
+}
+
+async function applyAvailableUpdate() {
+  if (!updateAvailable || applyingUpdate) return;
+  applyingUpdate = true;
+  updateRefreshControls();
+  try {
+    const res = await fetch("api/state");
+    const data = await readJson(res);
+    const seq = data.dashboard && data.dashboard.seq;
+    if (view !== "queue") {
+      pendingState = data;
+      prefs = data.prefs;
+      updateAvailable = null;
+    } else if (typeof seq !== "number" || seq > lastAppliedSeq) {
+      applyState(data);
+    } else {
+      prefs = data.prefs;
+      updateAvailable = null;
+    }
+  } catch (e) {
+    loadError = String((e && e.message) || e);
+    if (view === "queue") render();
+  } finally {
+    applyingUpdate = false;
+    updateRefreshControls();
+  }
+}
+
+async function toggleAutoApply() {
+  if (savingAutoApply) return;
+  const previous = autoApplyEnabled();
+  const enabled = !previous;
+  prefs = { ...(prefs || {}), autoApplyUpdates: enabled };
+  savingAutoApply = true;
+  updateRefreshControls();
+  try {
+    const data = await postJSON("api/auto-apply", { enabled });
+    if (data && data.prefs) prefs = data.prefs;
+    if (enabled && updateAvailable) await applyAvailableUpdate();
+  } catch (e) {
+    prefs = { ...(prefs || {}), autoApplyUpdates: previous };
+    loadError = String((e && e.message) || e);
+    render();
+  } finally {
+    savingAutoApply = false;
+    updateRefreshControls();
+  }
+}
+
+async function openLinkedPr(link) {
+  if (!link || link.classList.contains("busy")) return;
+  link.classList.add("busy");
+  try {
+    await postJSON("api/open-pr", { url: link.href });
+  } catch (e) {
+    loadError = String((e && e.message) || e);
+    render();
+  } finally {
+    link.classList.remove("busy");
+  }
 }
 
 const refresh = () => withRefresh(() => postJSON("api/refresh"));
@@ -1188,7 +1375,7 @@ function persistAccountRepos(id, previousRepos) {
     // orders saves for this account against each other, not against those lastAppliedSeq-keyed paths.
     if (data && data.dashboard) {
       const dseq = data.dashboard.seq;
-      if (typeof dseq !== "number" || dseq > lastAppliedSeq) { state = data.dashboard; prefs = data.prefs; adoptAppliedRev(); }
+      if (typeof dseq !== "number" || dseq > lastAppliedSeq) adoptState(data);
     }
     repoErr(id, "");
     return data;
@@ -1226,12 +1413,11 @@ async function rescanAccounts() {
     const data = await readJson(res);
     // Gate on seq like every other response path: if a newer refresh/SSE snapshot applied while this
     // rescan was in flight, adopting it would roll state (and lastAppliedSeq) backward. When it is the
-    // newest, adoptAppliedRev() also advances the revision so a delayed lower-seq SSE partial from an
-    // earlier recompute can't be accepted after this /api/accounts response and roll the queue back.
+    // newest, adoptState() also advances the revision so a delayed lower-seq response cannot roll
+    // the queue back.
     const dseq = data.dashboard && data.dashboard.seq;
     if (typeof dseq !== "number" || dseq > lastAppliedSeq) {
-      state = data.dashboard; prefs = data.prefs; loadError = null;
-      adoptAppliedRev();
+      adoptState(data);
     }
   } catch (e) {
     loadError = String((e && e.message) || e);
@@ -1261,8 +1447,7 @@ function goView(next, forward) {
     // already show, mirroring applyPushedState's gate. (No seq → legacy payload, apply as before.)
     const seq = payload.dashboard && payload.dashboard.seq;
     if (typeof seq !== "number" || seq > lastAppliedSeq) {
-      state = payload.dashboard; prefs = payload.prefs;
-      adoptAppliedRev();
+      adoptState(payload);
     }
   }
   render(forward === undefined ? undefined : forward);
@@ -1290,9 +1475,8 @@ function cardActionBtn(pr, a) {
   // If a click's POST is still in flight when this card re-renders (e.g. from a streamed
   // 'state' event), keep the replacement split disabled so it can't re-queue the same action.
   const inflight = inflightActions.has(actionKey(a.kind, pr.url || "", pr.repository || "", pr.number));
-  // While a forced refresh is finalizing, cards can be visible from a streamed partial before the
-  // final snapshot (which action resolution trusts) arrives. Grey out actions during that window
-  // and show a spinner so users get immediate feedback instead of a transient "no longer in view".
+  // While a forced refresh is finalizing, keep actions disabled so a click cannot race a user-driven
+  // mode/account change whose replacement snapshot has not committed yet.
   const finalizing = refreshing && !inflight;
   const busyCls = (inflight || finalizing) ? " busy" : "";
   const spinCls = finalizing ? " spin" : "";
@@ -1515,7 +1699,7 @@ function prCard(item, actions) {
 
 function issueCard(item) {
   const is = item.issue;
-  return '<a class="card" href="' + esc(is.url) + '" target="_blank" rel="noreferrer">' +
+  const main = '<a class="card-main" href="' + esc(is.url) + '" target="_blank" rel="noopener noreferrer">' +
     '<div class="card-top"><div class="card-title">' + esc(is.title) + "</div></div>" +
     '<div class="card-sub">' +
       avatarTag(is.authorAvatarUrl, is.author, "avatar", 36) +
@@ -1524,6 +1708,20 @@ function issueCard(item) {
     "</div>" +
     ((item.signals && item.signals.length) ? '<div class="pills">' + item.signals.map(pill).join("") + "</div>" : "") +
   "</a>";
+  const linkedPullRequests = (is.linkedPullRequests || []).filter((pr) => pr.state !== "CLOSED");
+  const linked = linkedPullRequests.length
+    ? linkedPullRequests.map((pr) => {
+        const state = pr.state === "MERGED" ? "merged" : (pr.state === "OPEN" ? "open" : "unknown");
+        const stateLabel = state === "merged" ? "Merged" : (state === "open" ? "Open" : "Linked");
+        const stateIcon = state === "merged" ? ICONS.merge : ICONS.pr;
+        return (
+        '<a class="card-main linked-pr" href="' + esc(pr.url) + '" target="_blank" rel="noopener noreferrer" title="' + stateLabel + " pull request " +
+          esc(shortRepo(pr.repository)) + " #" + pr.number + '" aria-label="' + stateLabel + " pull request: " + esc(pr.title) + '">' +
+          '<span class="linked-pr-icon ' + state + '">' + stateIcon + '</span><span class="linked-pr-title">' + esc(pr.title) + "</span></a>"
+        );
+      }).join("")
+    : "";
+  return '<div class="card">' + main + linked + "</div>";
 }
 
 function laneIcon(lane) {
@@ -1768,13 +1966,23 @@ function accountChip() {
 
 function topbarHtml() {
   const notifCount = (state && state.notifications || []).length;
+  const autoApply = autoApplyEnabled();
+  const showUpdate = !!updateAvailable && !autoApply;
   const left = view === "queue"
     ? tabs()
     : '<button class="backbtn" id="back-btn">' + ICONS.back + "Back</button>";
   const right =
     (state ? accountChip() : "") +
     '<div class="tb-actions">' +
-    '<button class="iconbtn ' + (refreshing ? "spin" : "") + '" id="refresh-btn" title="Refresh">' + ICONS.refresh + "</button>" +
+    '<button class="iconbtn live-tooltip ' + (refreshing ? "spin" : "") + '" id="refresh-btn" aria-label="' + refreshTooltip() +
+      '" data-tooltip="' + refreshTooltip() + '">' + ICONS.refresh + "</button>" +
+    '<button class="update-ready ' + (applyingUpdate ? "busy" : "") + '" id="apply-update-btn" type="button" ' +
+      (showUpdate ? "" : "hidden ") + (applyingUpdate ? "disabled " : "") +
+      'title="Apply the latest completed background update"><span class="update-dot"></span>Apply<span class="update-detail"> update</span></button>' +
+    '<button class="refresh-pref ' + (autoApply ? "active" : "") + '" id="auto-apply-btn" type="button" role="switch" aria-checked="' +
+      (autoApply ? "true" : "false") + '" title="' +
+      (autoApply ? "Background updates apply automatically" : "Background updates wait until you apply them") +
+      '"><span class="status-dot"></span><span class="refresh-label">Auto</span></button>' +
     '<button class="iconbtn ' + (view === "filters" ? "active" : "") + '" id="filters-btn" title="What\u2019s filtered">' + ICONS.funnel + "</button>" +
     '<button class="iconbtn ' + (view === "notifications" ? "active" : "") + '" id="bell-btn" title="Notifications">' + ICONS.bell +
       (notifCount ? '<span class="badge">' + notifCount + "</span>" : "") + "</button>" +
@@ -2087,6 +2295,7 @@ function render(forward) {
     if (bx) bx.addEventListener("click", function () { loadError = null; render(); });
   }
   wire();
+  updateRefreshControls();
   layoutGrids();
 }
 
@@ -2325,6 +2534,14 @@ function wireRepoEditor(id) {
 function wire() {
   document.querySelectorAll(".tab").forEach((b) => b.addEventListener("click", () => setMode(b.dataset.mode)));
   const rb = document.getElementById("refresh-btn"); if (rb) rb.addEventListener("click", refresh);
+  const applyUpdate = document.getElementById("apply-update-btn"); if (applyUpdate) applyUpdate.addEventListener("click", applyAvailableUpdate);
+  const autoApply = document.getElementById("auto-apply-btn"); if (autoApply) autoApply.addEventListener("click", toggleAutoApply);
+  document.querySelectorAll(".linked-pr").forEach((link) =>
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      openLinkedPr(link);
+    }));
   const back = document.getElementById("back-btn"); if (back) back.addEventListener("click", () => goView("queue", false));
   const bell = document.getElementById("bell-btn"); if (bell) bell.addEventListener("click", () => goView(view === "notifications" ? "queue" : "notifications"));
   const gear = document.getElementById("gear-btn"); if (gear) gear.addEventListener("click", () => goView(view === "settings" ? "queue" : "settings"));
@@ -2477,11 +2694,9 @@ function wireAccounts() {
   });
 }
 
-// Live updates over Server-Sent Events. 'progress' drives the deterministic top bar as
-// repos are fetched; 'state' streams partial and final dashboards (applied straight into
-// the UI, guarded against clobbering an active edit); 'refresh' is a legacy nudge kept for
-// back-compat that re-pulls /api/state, guarded (via onSseRefresh) to the queue view so it
-// can't rebuild an open form and discard uncommitted text.
+// Live updates over Server-Sent Events. Progress drives the deterministic top bar. State events
+// contain complete dashboards and apply atomically; when auto-apply is disabled, update-available
+// changes only the toolbar until the user chooses to swap to the completed snapshot.
 try {
   const es = new EventSource("events");
   es.addEventListener("progress", (e) => {
@@ -2490,7 +2705,18 @@ try {
   es.addEventListener("state", (e) => {
     try { applyPushedState(JSON.parse(e.data)); } catch {}
   });
-  es.addEventListener("refresh", onSseRefresh);
+  es.addEventListener("update-available", (e) => {
+    try { onUpdateAvailable(JSON.parse(e.data)); } catch {}
+  });
+  es.addEventListener("preferences", (e) => {
+    try { onPreferences(JSON.parse(e.data)); } catch {}
+  });
+  es.addEventListener("snapshot", (e) => {
+    try { onSnapshot(JSON.parse(e.data)); } catch {}
+  });
+  es.addEventListener("poll-schedule", (e) => {
+    try { onPollSchedule(JSON.parse(e.data)); } catch {}
+  });
 } catch {}
 
 load();

--- a/.github/extensions/aspire-team-app/render.test.mjs
+++ b/.github/extensions/aspire-team-app/render.test.mjs
@@ -19,6 +19,10 @@ test("renderer theme styles follow canvas tokens with accessible light fallbacks
   assert.doesNotMatch(STYLES, /animation: paintfill/);
   assert.doesNotMatch(STYLES, /box-shadow: 0 0 8px/);
   assert.doesNotMatch(STYLES, /var\(--n-/);
+  assert.match(STYLES, /\.refresh-pref\.active \{/);
+  assert.match(STYLES, /\.update-ready\[hidden\] \{ display: none; \}/);
+  assert.match(STYLES, /\.live-tooltip::after \{[\s\S]*?content: attr\(data-tooltip\)/);
+  assert.match(STYLES, /\.live-tooltip:hover::after, \.live-tooltip:focus-visible::after/);
 });
 
 test("render keeps the current dashboard visible and surfaces later load errors", () => {
@@ -587,34 +591,180 @@ test("setProgress doesn't fade the bar from a terminal SSE tick while another re
   assert.equal(loadbar.style.width, "0");
 });
 
-test("onSseRefresh only re-pulls state while the queue is showing, so an off-queue nudge can't clobber an open form", async () => {
-  // Every mutation streams the fresh dashboard over the 'state' event (stashed off-queue by
-  // applyPushedState) and then fires the legacy 'refresh' nudge. Acting on that nudge off the queue
-  // would call load() -> render() and rebuild an open Accounts/Settings/Filters form, discarding the
-  // user's uncommitted text. fetch hands back a strictly-increasing seq so each real load applies.
-  let seq = 0;
-  const fetchSeq = async () => {
-    seq += 1;
-    return jsonResponse({ dashboard: { seq, marker: "s" + seq, authenticated: false, accounts: [], message: "" }, prefs: {} });
+test("an available background update leaves the board unchanged until it is applied", async () => {
+  let stateReads = 0;
+  const next = {
+    dashboard: { seq: 8, marker: "complete", authenticated: false, accounts: [], message: "" },
+    prefs: { autoApplyUpdates: false },
   };
-  const flush = () => new Promise((r) => setTimeout(r, 0));
-  const { api } = createRendererHarness({ fetch: fetchSeq });
-  await flush();
-  assert.equal(api.getState().marker, "s1", "module-init load applies the first snapshot");
+  const { api } = createRendererHarness({
+    fetch: async (url) => {
+      if (String(url) !== "api/state") return new Promise(() => {});
+      stateReads++;
+      return stateReads === 1 ? new Promise(() => {}) : jsonResponse(next);
+    },
+  });
+  api.setState({ seq: 4, marker: "visible", authenticated: false, accounts: [], message: "" });
+  api.setPrefs({ autoApplyUpdates: false });
+  api.onUpdateAvailable({ seq: 8, fetchedAt: "2026-08-06T00:00:00Z" });
 
-  // Off the queue (a form view): the nudge is a no-op, so fetch isn't called and state is untouched.
-  api.setView("accounts");
-  api.onSseRefresh();
-  await flush();
-  assert.equal(seq, 1, "an off-queue refresh nudge must not re-pull /api/state");
-  assert.equal(api.getState().marker, "s1");
+  assert.equal(api.getState().marker, "visible");
+  assert.equal(api.getUpdateAvailable().seq, 8);
 
-  // On the queue: the nudge re-pulls /api/state and applies the newer snapshot.
-  api.setView("queue");
-  api.onSseRefresh();
-  await flush();
-  assert.equal(seq, 2, "a queue refresh nudge re-pulls /api/state");
-  assert.equal(api.getState().marker, "s2");
+  await api.applyAvailableUpdate();
+
+  assert.equal(api.getState().marker, "complete");
+  assert.equal(api.getAppliedSeq(), 8);
+  assert.equal(api.getUpdateAvailable(), null);
+});
+
+test("the toolbar Auto switch persists without refreshing the board", async () => {
+  let posted;
+  const { api } = createRendererHarness({
+    fetch: async (url, options) => {
+      if (String(url) === "api/auto-apply") {
+        posted = JSON.parse(options.body);
+        return jsonResponse({ prefs: { autoApplyUpdates: false } });
+      }
+      return new Promise(() => {});
+    },
+  });
+  api.setState({ seq: 3, marker: "visible", authenticated: false, accounts: [], message: "" });
+  api.setPrefs({ autoApplyUpdates: true });
+
+  await api.toggleAutoApply();
+
+  assert.deepEqual(posted, { enabled: false });
+  assert.equal(api.autoApplyEnabled(), false);
+  assert.equal(api.getState().marker, "visible");
+});
+
+test("enabling Auto applies an update that was already waiting", async () => {
+  let stateReads = 0;
+  const { api } = createRendererHarness({
+    fetch: async (url) => {
+      if (String(url) === "api/auto-apply") {
+        return jsonResponse({ prefs: { autoApplyUpdates: true } });
+      }
+      if (String(url) === "api/state") {
+        stateReads++;
+        if (stateReads === 1) return new Promise(() => {});
+        return jsonResponse({
+          dashboard: { seq: 9, marker: "applied", authenticated: false, accounts: [], message: "" },
+          prefs: { autoApplyUpdates: true },
+        });
+      }
+      return new Promise(() => {});
+    },
+  });
+  api.setState({ seq: 5, marker: "visible", authenticated: false, accounts: [], message: "" });
+  api.setPrefs({ autoApplyUpdates: false });
+  api.onUpdateAvailable({ seq: 9 });
+
+  await api.toggleAutoApply();
+
+  assert.equal(api.autoApplyEnabled(), true);
+  assert.equal(api.getState().marker, "applied");
+  assert.equal(api.getUpdateAvailable(), null);
+});
+
+test("snapshot replay restores the pending indicator without replacing the board when Auto is off", () => {
+  const { api } = createRendererHarness({ fetch: () => new Promise(() => {}) });
+  api.setState({ seq: 5, marker: "visible", authenticated: false, accounts: [], message: "" });
+  api.setPrefs({ autoApplyUpdates: true });
+
+  api.onSnapshot({ seq: 9, prefs: { autoApplyUpdates: false } });
+
+  assert.equal(api.getState().marker, "visible");
+  assert.equal(api.autoApplyEnabled(), false);
+  assert.equal(api.getUpdateAvailable().seq, 9);
+});
+
+test("refresh tooltip counts down to the server's next background poll", () => {
+  const attributes = {};
+  const refreshButton = {
+    dataset: {},
+    classList: classList(),
+    setAttribute(name, value) { attributes[name] = value; },
+  };
+  let intervalMs;
+  const { api } = createRendererHarness({
+    elements: { "refresh-btn": refreshButton },
+    setInterval(_handler, milliseconds) { intervalMs = milliseconds; return 1; },
+  });
+
+  api.onPollSchedule({ nextPollAt: Date.now() + 34_000 });
+
+  assert.match(refreshButton.dataset.tooltip, /^Refresh now \(data will auto-update in 3[34]s\)$/);
+  assert.equal(attributes["aria-label"], refreshButton.dataset.tooltip);
+  assert.equal(intervalMs, 1000);
+});
+
+test("issueCard renders linked pull requests as separate safe new-tab links below the pills", () => {
+  const { api } = createRendererHarness();
+  const html = api.issueCard({
+    issue: {
+      repository: "microsoft/aspire",
+      number: 42,
+      title: "Issue title",
+      url: "https://github.com/microsoft/aspire/issues/42",
+      author: "octo",
+      authorAvatarUrl: null,
+      linkedPullRequests: [{
+        repository: "microsoft/aspire",
+        number: 99,
+        title: "Cover single-file AppHost re-search fallback",
+        url: "https://github.com/microsoft/aspire/pull/99",
+        state: "OPEN",
+      }, {
+        repository: "microsoft/aspire",
+        number: 100,
+        title: "Merged implementation",
+        url: "https://github.com/microsoft/aspire/pull/100",
+        state: "MERGED",
+      }, {
+        repository: "microsoft/aspire",
+        number: 101,
+        title: "Closed implementation",
+        url: "https://github.com/microsoft/aspire/pull/101",
+        state: "CLOSED",
+      }],
+    },
+    signals: [{ label: "Regression", tone: "danger" }],
+  });
+
+  assert.match(html, /class="card-main" href="https:\/\/github\.com\/microsoft\/aspire\/issues\/42" target="_blank" rel="noopener noreferrer"/);
+  assert.match(html, /class="card-main linked-pr" href="https:\/\/github\.com\/microsoft\/aspire\/pull\/99" target="_blank" rel="noopener noreferrer"/);
+  assert.match(html, /aria-label="Open pull request: Cover single-file AppHost re-search fallback"[\s\S]*linked-pr-icon open/);
+  assert.match(html, /href="https:\/\/github\.com\/microsoft\/aspire\/pull\/100"[\s\S]*aria-label="Merged pull request: Merged implementation"[\s\S]*linked-pr-icon merged/);
+  assert.doesNotMatch(html, /pull\/101|Closed implementation/);
+  assert.doesNotMatch(html, /class="linked-prs"/);
+  assert.ok(html.indexOf('class="pills"') < html.indexOf('class="card-main linked-pr"'));
+});
+
+test("openLinkedPr routes the canonical link through the in-app browser endpoint", async () => {
+  let request;
+  const { api } = createRendererHarness({
+    fetch: async (url, options) => {
+      if (String(url) === "api/open-pr") {
+        request = { url: String(url), body: JSON.parse(options.body) };
+        return jsonResponse({ ok: true, instanceId: "aspire-team-app-pr-microsoft-aspire-99" });
+      }
+      return new Promise(() => {});
+    },
+  });
+  const link = {
+    href: "https://github.com/microsoft/aspire/pull/99",
+    classList: classList(),
+  };
+
+  await api.openLinkedPr(link);
+
+  assert.deepEqual(request, {
+    url: "api/open-pr",
+    body: { url: "https://github.com/microsoft/aspire/pull/99" },
+  });
+  assert.equal(link.classList.contains("busy"), false);
 });
 
 test("signalActions detects review debt from the serialized flag when the pill is truncated", () => {
@@ -657,7 +807,11 @@ function createRendererHarness(overrides = {}) {
     classList: classList(),
   };
   const document = {
-    getElementById(id) { return id === "app" ? app : (id === "loadbar" ? (overrides.loadbar ?? null) : null); },
+    getElementById(id) {
+      if (id === "app") return app;
+      if (id === "loadbar") return overrides.loadbar ?? null;
+      return overrides.elements?.[id] ?? null;
+    },
     querySelector: overrides.querySelector ?? (() => null),
     querySelectorAll: () => [],
     addEventListener() {},
@@ -672,10 +826,12 @@ function createRendererHarness(overrides = {}) {
     fetch: overrides.fetch ?? (async () => jsonResponse({ dashboard: null, prefs: null })),
     setTimeout: overrides.setTimeout ?? ((handler) => { handler(); return 1; }),
     clearTimeout: overrides.clearTimeout ?? (() => {}),
+    setInterval: overrides.setInterval ?? (() => 1),
+    clearInterval: overrides.clearInterval ?? (() => {}),
     console,
   };
 
-  vm.runInNewContext(`${APP_JS}\n;globalThis.__test = {\n  render,\n  withRefresh,\n  load,\n  rescanAccounts,\n  onCardAction,\n  onSseRefresh,\n  deleteRepo,\n  persistAccountRepos,\n  draftReposByAcct,\n  editingByAcct,\n  forYouCardActions,\n  focusCardActions,\n  laneCardActions,\n  signalActions,\n  mergeActions,\n  queuePanel,\n  cardActionBtn,\n  actionKey,\n  inflightActions,\n  setProgress,\n  setState(value) { state = value; },\n  getState() { return state; },\n  getAppliedSeq() { return lastAppliedSeq; },\n  setPrefs(value) { prefs = value; },\n  setView(value) { view = value; },\n  setRefreshing(value) { refreshing = !!value; },\n  setRefreshInFlight(value) { refreshInFlight = value; },\n  setLoadError(value) { loadError = value; },\n  getLoadError() { return loadError; },\n};`, sandbox);
+  vm.runInNewContext(`${APP_JS}\n;globalThis.__test = {\n  render,\n  withRefresh,\n  load,\n  rescanAccounts,\n  onCardAction,\n  onUpdateAvailable,\n  onPreferences,\n  onSnapshot,\n  onPollSchedule,\n  applyAvailableUpdate,\n  toggleAutoApply,\n  autoApplyEnabled,\n  openLinkedPr,\n  deleteRepo,\n  persistAccountRepos,\n  draftReposByAcct,\n  editingByAcct,\n  forYouCardActions,\n  focusCardActions,\n  laneCardActions,\n  signalActions,\n  mergeActions,\n  queuePanel,\n  cardActionBtn,\n  issueCard,\n  actionKey,\n  inflightActions,\n  setProgress,\n  setState(value) { state = value; },\n  getState() { return state; },\n  getAppliedSeq() { return lastAppliedSeq; },\n  getUpdateAvailable() { return updateAvailable; },\n  setPrefs(value) { prefs = value; },\n  setView(value) { view = value; },\n  setRefreshing(value) { refreshing = !!value; },\n  setRefreshInFlight(value) { refreshInFlight = value; },\n  setLoadError(value) { loadError = value; },\n  getLoadError() { return loadError; },\n};`, sandbox);
 
   return { app, api: sandbox.__test };
 }

--- a/.github/extensions/aspire-team-app/render.test.mjs
+++ b/.github/extensions/aspire-team-app/render.test.mjs
@@ -4,9 +4,16 @@ import test from "node:test";
 
 import { APP_JS, STYLES } from "./render.mjs";
 
-test("renderer theme styles follow canvas tokens with accessible light fallbacks", () => {
-  assert.match(STYLES, /--bg: var\(--bgColor-default, var\(--background-color-default, #ffffff\)\)/);
-  assert.match(STYLES, /--fg: var\(--fgColor-default, var\(--text-color-default, #1f2328\)\)/);
+test("renderer follows canvas theme tokens and falls back to the system color scheme", () => {
+  assert.match(STYLES, /--bg: var\(--background-color-default, var\(--fallback-bg\)\)/);
+  assert.match(STYLES, /--fg: var\(--text-color-default, var\(--fallback-fg\)\)/);
+  assert.match(STYLES, /--muted: var\(--text-color-muted, var\(--fallback-muted\)\)/);
+  assert.match(STYLES, /--border: var\(--border-color-default, var\(--fallback-border\)\)/);
+  assert.match(STYLES, /--focus: var\(--color-focus-outline, var\(--fallback-focus\)\)/);
+  assert.match(STYLES, /--white: var\(--color-white, #ffffff\)/);
+  assert.match(STYLES, /@media \(prefers-color-scheme: dark\) \{[\s\S]*?--fallback-bg: #0d1117/);
+  assert.match(STYLES, /:root\[data-color-mode="light"\] \{[\s\S]*?--fallback-bg: #ffffff/);
+  assert.match(STYLES, /:root\[data-color-mode="dark"\] \{[\s\S]*?--fallback-bg: #0d1117/);
   assert.match(STYLES, /--surface: color-mix\(in srgb, var\(--bg\), var\(--fg\) 5%\)/);
   assert.match(STYLES, /data-color-mode="light".*color-scheme: light/);
   assert.match(STYLES, /data-color-mode="dark".*color-scheme: dark/);

--- a/.github/extensions/aspire-team-app/server.mjs
+++ b/.github/extensions/aspire-team-app/server.mjs
@@ -14,7 +14,7 @@ import { resolveAccounts } from "./accounts.mjs";
 import { buildAgentActionPrompt, buildAgentActionLog, resolveActionTarget, toActionPrNumber } from "./agent.mjs";
 import {
   loadPrefs,
-  savePrefs,
+  updatePrefs,
   parseRepos,
   accountConfig,
   setAccountRepos,
@@ -29,21 +29,19 @@ const sseClients = new Set();
 // iframes), but shutdown must be per-instance: closing one canvas must not end another
 // still-open canvas's stream. A WeakMap avoids leaking entries once a response is GC'd.
 const clientInstance = new WeakMap();
-let cache = null;    // { dashboard, prefs, at } — freshest snapshot; may be a partial mid-stream
-// The last COMPLETE dashboard, used ONLY to resolve card-action PRs (resolveActionPr/findCachedPr).
-// During SSE streaming `cache` is transiently overwritten with partials (see computeDashboard's
-// onPartial) that omit PRs whose repos haven't finished loading this compute. A stale-but-still-
-// visible card clicked in that window would miss in the partial, and a miss is now rejected
-// (resolveActionPr returns null, so the action route answers 400 rather than trusting the client's
-// descriptor). Resolving actions against the last complete snapshot keeps every watched PR findable
-// for the whole refresh, so a still-visible card isn't spuriously rejected mid-stream.
+// The snapshot each iframe is currently expected to display. Background candidates do not advance
+// this map when Auto is off, so card actions continue resolving against the cards the user can see.
+const displayedSnapshots = new Map();
+// The cache contains only complete dashboards. A refresh builds privately and swaps this reference
+// after every watched repository settles, so open canvases and card actions keep using the previous
+// complete snapshot for the entire load.
+let cache = null;    // { dashboard, prefs, at }
 let resolveSnapshot = null;
 let inflight = null;
 let bgTimer = null;
-// Monotonic snapshot revision stamped on every dashboard we cache/broadcast (partial and
-// final, across every compute). The client applies snapshots strictly in seq order so a
-// wall-clock fetchedAt collision can't drop the final snapshot and an out-of-order partial
-// can't overwrite a newer one. Never reset — it only ever increments for the process.
+let nextPollAt = null;
+// Monotonic semantic revision. It advances only when dashboard content changes, so a no-op poll
+// cannot manufacture an update on reconnect merely because fetchedAt changed.
 let stateSeq = 0;
 // Logger captured from the most recent startInstance so background (non-request) work —
 // the poller and stale-while-revalidate refreshes — has somewhere to report failures.
@@ -62,12 +60,17 @@ const POLL_INTERVAL = 90 * 1000;
 // sub-sessions or does interactive work. Null until wired, so a click that races
 // startup fails cleanly instead of throwing an undefined-call.
 let agentSend = null;
+let browserOpen = null;
 
 // Called from extension.mjs. The injected fn receives { prompt, log } and returns
 // { messageId, queued } — queued is true when the agent was already mid-turn, so the
 // prompt waits behind the current task rather than starting immediately.
 export function setAgentSend(fn) {
   agentSend = typeof fn === "function" ? fn : null;
+}
+
+export function setBrowserOpen(fn) {
+  browserOpen = typeof fn === "function" ? fn : null;
 }
 
 // Account resolution probes every candidate credential against its account's
@@ -98,7 +101,12 @@ async function resolveAuth(prefs, { reprobe = false } = {}) {
     if (best) {
       best.active = true;
       setAccountActive(prefs, best.id, true);
-      await savePrefs(prefs);
+      const saved = await updatePrefs((latest) => {
+        if (activeIds(latest).length === 0 && Object.keys(latest.accounts || {}).length === 0) {
+          setAccountActive(latest, best.id, true);
+        }
+      });
+      Object.assign(prefs, saved);
     }
   }
 
@@ -121,13 +129,33 @@ function decorateDashboard(dashboard, auth, active, prefs) {
   dashboard.dismissedCount = (prefs.dismissedNotifications || []).length;
 }
 
-// Compute a fresh dashboard. When at least one iframe is connected we stream results:
-// `progress` ticks drive the deterministic client bar, and throttled `partial` snapshots
-// let cards fill in as each repo's PRs arrive, ending with a final authoritative `state`
-// push. Background polls pass progress:false so the bar doesn't flash every cycle while
-// the silent partial/final state pushes still refresh the UI.
-async function computeDashboard({ progress = true } = {}) {
+function dashboardContent(dashboard) {
+  if (!dashboard) return null;
+  const { seq: _seq, fetchedAt: _fetchedAt, ...content } = dashboard;
+  return JSON.stringify(content);
+}
+
+export function dashboardChanged(previous, next) {
+  return dashboardContent(previous) !== dashboardContent(next);
+}
+
+function dashboardInputKey(prefs) {
+  return JSON.stringify({
+    mode: prefs.mode,
+    release: prefs.release,
+    showDrafts: prefs.showDrafts,
+    notifications: prefs.notifications,
+    dismissedNotifications: prefs.dismissedNotifications,
+    accounts: prefs.accounts,
+  });
+}
+
+// Compute a complete dashboard privately. Progress events can update the top bar, but dashboard
+// state is published only once all repositories finish. Background checks either atomically apply
+// the completed snapshot or announce that one is ready, depending on the persisted user preference.
+async function computeDashboard({ progress = true, background = false } = {}) {
   const stream = sseClients.size > 0;
+  const previous = cache?.dashboard ?? null;
   const prefs = await loadPrefs();
   const auth = await resolveAuth(prefs);
   const active = auth.accounts.filter((a) => a.active && a.status !== "failed");
@@ -158,36 +186,31 @@ async function computeDashboard({ progress = true } = {}) {
       dismissed: prefs.dismissedNotifications,
       showDrafts: prefs.showDrafts,
       onProgress: stream && progress ? broadcastProgress : undefined,
-      onPartial: stream
-        ? (partial) => {
-            decorateDashboard(partial, auth, active, prefs);
-            // Stamp a strictly increasing revision so the client can order/ignore snapshots.
-            partial.seq = ++stateSeq;
-            // Publish the partial as the current cache so a canvas opening mid-load gets
-            // the freshest data-so-far, and push it to already-open iframes. Deliberately does
-            // NOT touch resolveSnapshot: a partial omits not-yet-loaded PRs, so using it to
-            // resolve a card action could strip a watched PR's host (see resolveSnapshot above).
-            cache = { dashboard: partial, prefs, at: Date.now() };
-            broadcastState(partial, prefs);
-          }
-        : undefined,
     });
     decorateDashboard(dashboard, auth, active, prefs);
   }
-  // Stamp the final (or unauthenticated) snapshot after any partials so it always carries the
-  // highest seq of this compute; the POST response returns this same cached object.
-  dashboard.seq = ++stateSeq;
-  cache = { dashboard, prefs, at: Date.now() };
-  // Only a COMPLETE compute advances the action-resolution snapshot; partials (above) never do,
-  // so mid-stream cache churn can't drop a watched PR's host and misroute its card action.
+  // A preference mutation can finish while GitHub requests are in flight. Auto is a publish choice,
+  // so use its latest committed value. If an input that shaped the dashboard changed, discard this
+  // stale candidate when a prior complete cache exists; the forced mutation compute queued behind it
+  // will publish the correctly-shaped replacement.
+  const latestPrefs = await loadPrefs();
+  if (cache && dashboardInputKey(prefs) !== dashboardInputKey(latestPrefs)) return cache;
+
+  const changed = dashboardChanged(previous, dashboard);
+  dashboard.seq = !previous || changed ? ++stateSeq : previous.seq;
+  cache = { dashboard, prefs: latestPrefs, at: Date.now() };
   resolveSnapshot = dashboard;
-  // Re-check the live SSE client set here instead of reusing the `stream` snapshot captured at the
-  // top of this compute. The browser constructs its EventSource and immediately GETs /api/state, and
-  // a stale-cache revalidation can begin before that stream registers — so `stream` may be false even
-  // though a client connects during this compute's GitHub fetch. Gating the final broadcast on the
-  // stale snapshot would suppress it for that just-connected client, leaving the canvas stale until
-  // the ~90s poll. The live set is authoritative at completion time.
-  if (sseClients.size > 0) { broadcastState(dashboard, prefs); }
+
+  // Re-check the live client set at completion: an iframe can connect after the compute begins.
+  // Explicit operations always publish. Silent polls publish only when data changed, and honor the
+  // user's choice to review a completed update before applying it.
+  if (sseClients.size > 0 && (!background || changed)) {
+    if (!background || latestPrefs.autoApplyUpdates) {
+      broadcastState(dashboard, latestPrefs);
+    } else {
+      broadcastUpdateAvailable(dashboard);
+    }
+  }
   return cache;
 }
 
@@ -217,9 +240,9 @@ function startCompute(opts, force = false) {
 // credential/GitHub failure; without a handler that rejection would surface as an
 // unhandledRejection and could terminate the extension host instead of merely leaving the
 // stale cache in place. Swallow + log it so the next tick (poller or TTL) can retry safely.
-function backgroundRefresh(opts) {
+function backgroundRefresh() {
   Promise.resolve()
-    .then(() => startCompute(opts))
+    .then(() => refreshInBackground())
     .catch((e) => {
       // bgLog wraps the async session logger (session.log). If the session has disconnected the
       // log call itself can reject, and returning that rejected promise from this handler would
@@ -238,7 +261,7 @@ async function getDashboard(force = false) {
     // canvas is instant, and kick a silent background refresh once it's aged past the TTL.
     // progress:false so this passive revalidation doesn't flash the top bar — only the very
     // first load and explicit user refreshes drive it. New data still streams via `state`.
-    if (Date.now() - (cache.at || 0) > STATE_TTL) backgroundRefresh({ progress: false });
+    if (Date.now() - (cache.at || 0) > STATE_TTL) backgroundRefresh();
     return cache;
   }
   return startCompute(undefined, force);
@@ -249,28 +272,42 @@ async function getDashboard(force = false) {
 // count so it never keeps the process alive or works when nobody is watching.
 function ensurePoller() {
   if (bgTimer) return;
+  nextPollAt = Date.now() + POLL_INTERVAL;
   bgTimer = setInterval(() => {
+    nextPollAt = Date.now() + POLL_INTERVAL;
+    writeSse("poll-schedule", JSON.stringify({ nextPollAt }));
     if (sseClients.size === 0) return;
     // Route through backgroundRefresh so a rejected poll can't become an unhandled rejection
     // on the timer path (which has no caller to await it) and crash the extension.
-    backgroundRefresh({ progress: false });
+    backgroundRefresh();
   }, POLL_INTERVAL);
   if (typeof bgTimer.unref === "function") bgTimer.unref();
 }
 
 function writeSse(event, data) {
   for (const res of sseClients) {
-    try {
-      res.write(`event: ${event}\ndata: ${data}\n\n`);
-    } catch {
+    if (!writeSseResponse(res, event, data)) {
       sseClients.delete(res);
     }
+  }
+}
+
+function writeSseResponse(res, event, data) {
+  try {
+    res.write(`event: ${event}\ndata: ${data}\n\n`);
+    return true;
+  } catch {
+    return false;
   }
 }
 
 // SSE data lines must be single-line; JSON.stringify escapes any newlines inside strings,
 // so the whole dashboard/prefs payload is safe to emit as one `data:` line.
 function broadcastState(dashboard, prefs) {
+  for (const res of sseClients) {
+    const instanceId = clientInstance.get(res);
+    if (instanceId) displayedSnapshots.set(instanceId, dashboard);
+  }
   writeSse("state", JSON.stringify({ dashboard, prefs }));
 }
 
@@ -278,11 +315,16 @@ function broadcastProgress(p) {
   writeSse("progress", JSON.stringify(p));
 }
 
-// Legacy nudge kept for resilience: tells clients to re-pull /api/state. The streaming
-// `state` push above is the primary path; this is a harmless fallback for any client that
-// only listens for `refresh`.
-function broadcastRefresh() {
-  writeSse("refresh", "1");
+function broadcastUpdateAvailable(dashboard) {
+  writeSse("update-available", JSON.stringify({
+    seq: dashboard.seq,
+    fetchedAt: dashboard.fetchedAt ?? null,
+    counts: dashboard.counts ?? null,
+  }));
+}
+
+function broadcastPreferences(prefs) {
+  writeSse("preferences", JSON.stringify(prefs));
 }
 
 // Resolve a client-supplied card-action PR descriptor against the server's own cached
@@ -295,11 +337,11 @@ function broadcastRefresh() {
 // back to the client's owner/repo/number would let a tampered or stale descriptor retarget a
 // tool-enabled action at an arbitrary github.com PR, and would misroute a GHES/EMU card to the
 // same-slug repo on dotcom — exactly the cache trust boundary this resolution exists to enforce.
-function resolveActionPr(pr) {
+function resolveActionPr(pr, instanceId) {
   const repository = String(pr?.repository ?? "").trim();
   const number = toActionPrNumber(pr?.number);
   const canonical = Number.isInteger(number)
-    ? findCachedPr(repository, number, pr?.url)
+    ? findCachedPr(repository, number, pr?.url, instanceId)
     : undefined;
   if (canonical) {
     return { repository: canonical.repository, number: canonical.number, url: canonical.url, title: canonical.title, author: canonical.author };
@@ -329,15 +371,13 @@ function hostOf(url) {
 // (undefined) rather than silently targeting whichever host the scan reached first.
 //
 // We match PR records ONLY. Normalized PRs carry a `review` object (normalizePr in github.mjs);
-// issues and PRs' linkedIssues share repository/number/url but have no `review`. Without that
-// discriminator a tampered descriptor could resolve a cached ISSUE, and since an issue url is
-// /issues/N (never /pull/N) safePrUrl would fail its host/path check and fall back to rewriting
-// it as a github.com /pull/N target — retargeting a tool-enabled action at an unrelated PR.
-function findCachedPr(repository, number, urlHint) {
-  // Resolve against the last COMPLETE dashboard, not `cache`, which can hold a partial mid-stream
-  // that omits not-yet-loaded PRs (see resolveSnapshot). Fall back to `cache` only before the first
-  // complete compute, when there are no prior host-qualified cards to misroute anyway.
-  const dashboard = resolveSnapshot ?? cache?.dashboard;
+// issues, PRs' linkedIssues, and issues' linkedPullRequests share repository/number/url but have no
+// `review`. Without that discriminator a tampered descriptor could resolve one of those nested
+// records and retarget a tool-enabled action at a PR that is not a visible actionable card.
+function findCachedPr(repository, number, urlHint, instanceId) {
+  // Refreshes keep the previous complete snapshot available until the replacement is complete, so
+  // card actions remain resolvable throughout an in-flight load.
+  const dashboard = displayedSnapshots.get(instanceId) ?? resolveSnapshot ?? cache?.dashboard;
   if (!dashboard || !repository) return undefined;
   const target = `${repository}#${number}`.toLowerCase();
   const byUrl = new Map();
@@ -371,6 +411,37 @@ function findCachedPr(repository, number, urlHint) {
   const wantHost = hostOf(urlHint);
   const onHost = wantHost ? matches.filter((m) => hostOf(m.url) === wantHost) : [];
   return onHost.length === 1 ? onHost[0] : undefined;
+}
+
+// Linked-PR URLs are client-supplied when clicked. Resolve them against the snapshot this canvas is
+// displaying before asking the host to open a browser canvas, so a modified DOM/request cannot turn
+// the loopback route into an arbitrary in-app URL opener.
+function findCachedLinkedPullRequest(url, instanceId) {
+  const dashboard = displayedSnapshots.get(instanceId) ?? resolveSnapshot ?? cache?.dashboard;
+  if (!dashboard || typeof url !== "string") return undefined;
+  let match;
+  const visit = (node) => {
+    if (match || !node || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      for (const value of node) visit(value);
+      return;
+    }
+    if (!node.review && (node.state === "OPEN" || node.state === "MERGED")
+      && typeof node.repository === "string" && Number.isInteger(node.number)
+      && typeof node.title === "string" && node.url === url) {
+      match = {
+        repository: node.repository,
+        number: node.number,
+        title: node.title,
+        url: node.url,
+        state: node.state,
+      };
+      return;
+    }
+    for (const value of Object.values(node)) visit(value);
+  };
+  visit(dashboard);
+  return match;
 }
 
 function send(res, status, body, type = "application/json") {
@@ -492,43 +563,55 @@ async function handle(req, res, log, instanceId) {
       return send(res, 200, APP_JS, "text/javascript");
     }
     if (req.method === "GET" && path === "/api/state") {
-      return send(res, 200, await getDashboard(false));
+      const next = await getDashboard(false);
+      displayedSnapshots.set(instanceId, next.dashboard);
+      return send(res, 200, next);
     }
     if (req.method === "POST" && path === "/api/refresh") {
-      return send(res, 200, await getDashboard(true));
+      const next = await getDashboard(true);
+      displayedSnapshots.set(instanceId, next.dashboard);
+      return send(res, 200, next);
+    }
+    if (req.method === "POST" && path === "/api/auto-apply") {
+      const { enabled } = await readBody(req);
+      if (typeof enabled !== "boolean") {
+        return send(res, 400, { error: "enabled must be a boolean" });
+      }
+      const prefs = await updatePrefs((latest) => { latest.autoApplyUpdates = enabled; });
+      if (cache) cache = { ...cache, prefs };
+      broadcastPreferences(prefs);
+      return send(res, 200, { prefs });
     }
     if (req.method === "POST" && path === "/api/mode") {
       const { mode } = await readBody(req);
-      const prefs = await loadPrefs();
-      if (["review", "issues", "ship"].includes(mode)) prefs.mode = mode;
-      await savePrefs(prefs);
+      await updatePrefs((prefs) => {
+        if (["review", "issues", "ship"].includes(mode)) prefs.mode = mode;
+      });
       const next = await getDashboard(true);
-      broadcastRefresh();
+      displayedSnapshots.set(instanceId, next.dashboard);
       return send(res, 200, next);
     }
     if (req.method === "POST" && path === "/api/prefs") {
       // Release milestone + notification preferences + draft visibility. Watched
       // repos are configured per account via /api/account/repos.
       const body = await readBody(req);
-      const prefs = await loadPrefs();
-      if (typeof body.release === "string" && body.release.trim()) prefs.release = body.release.trim();
-      if (typeof body.showDrafts === "boolean") prefs.showDrafts = body.showDrafts;
-      if (body.notifications) prefs.notifications = { ...prefs.notifications, ...body.notifications };
-      await savePrefs(prefs);
+      await updatePrefs((prefs) => {
+        if (typeof body.release === "string" && body.release.trim()) prefs.release = body.release.trim();
+        if (typeof body.showDrafts === "boolean") prefs.showDrafts = body.showDrafts;
+        if (body.notifications) prefs.notifications = { ...prefs.notifications, ...body.notifications };
+      });
       const next = await getDashboard(true);
-      broadcastRefresh();
+      displayedSnapshots.set(instanceId, next.dashboard);
       return send(res, 200, next);
     }
     if (req.method === "POST" && path === "/api/account/toggle") {
       const { id, active } = await readBody(req);
       if (typeof id === "string" && id) {
-        const prefs = await loadPrefs();
-        setAccountActive(prefs, id, !!active);
-        await savePrefs(prefs);
+        await updatePrefs((prefs) => { setAccountActive(prefs, id, !!active); });
         invalidateAuth();
       }
       const next = await getDashboard(true);
-      broadcastRefresh();
+      displayedSnapshots.set(instanceId, next.dashboard);
       return send(res, 200, next);
     }
     if (req.method === "POST" && path === "/api/account/repos") {
@@ -537,15 +620,14 @@ async function handle(req, res, log, instanceId) {
       // clobber its local draft. The dashboard cache is still recomputed.
       const { id, repos } = await readBody(req);
       if (typeof id === "string" && id) {
-        const prefs = await loadPrefs();
         // Pass an empty fallback so a cleared submission resets to the account's own
         // default (public vs EMU) inside setAccountRepos, rather than parseRepos
         // pre-filling the public default here.
-        setAccountRepos(prefs, id, parseRepos(repos, []));
-        await savePrefs(prefs);
+        await updatePrefs((prefs) => { setAccountRepos(prefs, id, parseRepos(repos, [])); });
         invalidateAuth();
       }
       const next = await getDashboard(true);
+      displayedSnapshots.set(instanceId, next.dashboard);
       return send(res, 200, next);
     }
     if (req.method === "POST" && path === "/api/agent/action") {
@@ -565,7 +647,7 @@ async function handle(req, res, log, instanceId) {
       // that doesn't resolve to a unique cached PR is rejected outright: we never reconstruct a
       // target from the client's owner/repo/number, so a tampered or aged-out card can't retarget
       // a tool-enabled action at an arbitrary github.com PR (or a same-slug dotcom repo).
-      const resolvedPr = resolveActionPr(pr);
+      const resolvedPr = resolveActionPr(pr, instanceId);
       if (!resolvedPr) {
         return send(res, 400, { error: "This pull request is no longer in view. Refresh and try again." });
       }
@@ -586,37 +668,45 @@ async function handle(req, res, log, instanceId) {
       const effectiveTarget = resolveActionTarget(resolvedPr, target);
       return send(res, 200, { ok: true, kind, target: effectiveTarget, messageId, queued });
     }
+    if (req.method === "POST" && path === "/api/open-pr") {
+      if (!browserOpen) {
+        return send(res, 503, { error: "The in-app browser is not ready yet. Try again in a moment." });
+      }
+      const { url } = await readBody(req);
+      const pr = findCachedLinkedPullRequest(url, instanceId);
+      if (!pr) {
+        return send(res, 400, { error: "This pull request is no longer linked to a visible issue. Refresh and try again." });
+      }
+      const opened = await browserOpen(pr);
+      return send(res, 200, { ok: true, instanceId: opened?.instanceId ?? null });
+    }
     if (req.method === "POST" && path === "/api/notifications/dismiss") {
       const { id } = await readBody(req);
       if (typeof id === "string" && id) {
-        const prefs = await loadPrefs();
-        if (!prefs.dismissedNotifications.includes(id)) {
-          prefs.dismissedNotifications.push(id);
-          await savePrefs(prefs);
-        }
+        await updatePrefs((prefs) => {
+          if (!prefs.dismissedNotifications.includes(id)) prefs.dismissedNotifications.push(id);
+        });
       }
       const next = await getDashboard(true);
-      broadcastRefresh();
+      displayedSnapshots.set(instanceId, next.dashboard);
       return send(res, 200, next);
     }
     if (req.method === "POST" && path === "/api/notifications/dismiss-all") {
-      const prefs = await loadPrefs();
       const current = await getDashboard(false);
       const ids = (current.dashboard.notifications || []).map((n) => n.id).filter(Boolean);
-      const set = new Set(prefs.dismissedNotifications);
-      for (const id of ids) set.add(id);
-      prefs.dismissedNotifications = [...set];
-      await savePrefs(prefs);
+      await updatePrefs((prefs) => {
+        const set = new Set(prefs.dismissedNotifications);
+        for (const id of ids) set.add(id);
+        prefs.dismissedNotifications = [...set];
+      });
       const next = await getDashboard(true);
-      broadcastRefresh();
+      displayedSnapshots.set(instanceId, next.dashboard);
       return send(res, 200, next);
     }
     if (req.method === "POST" && path === "/api/notifications/restore") {
-      const prefs = await loadPrefs();
-      prefs.dismissedNotifications = [];
-      await savePrefs(prefs);
+      await updatePrefs((prefs) => { prefs.dismissedNotifications = []; });
       const next = await getDashboard(true);
-      broadcastRefresh();
+      displayedSnapshots.set(instanceId, next.dashboard);
       return send(res, 200, next);
     }
     if (req.method === "GET" && path === "/api/accounts") {
@@ -624,7 +714,7 @@ async function handle(req, res, log, instanceId) {
       const prefs = await loadPrefs();
       const auth = await resolveAuth(prefs, { reprobe: true });
       const next = await getDashboard(true);
-      broadcastRefresh();
+      displayedSnapshots.set(instanceId, next.dashboard);
       return send(res, 200, { accounts: auth.accounts, ...next });
     }
     if (req.method === "GET" && path === "/events") {
@@ -637,9 +727,18 @@ async function handle(req, res, log, instanceId) {
       sseClients.add(res);
       // Remember which instance owns this stream so stopInstance ends only its own clients.
       clientInstance.set(res, instanceId);
-      // A canvas is now watching — make sure the background monitor is running so its
-      // queue keeps refreshing without a manual reload.
+      // Start the shared cadence before replaying metadata so this client gets an exact deadline even
+      // when it is the first canvas to connect after the extension process starts.
       ensurePoller();
+      writeSseResponse(res, "poll-schedule", JSON.stringify({ nextPollAt }));
+      if (cache) {
+        writeSseResponse(res, "snapshot", JSON.stringify({
+          seq: cache.dashboard.seq,
+          fetchedAt: cache.dashboard.fetchedAt ?? null,
+          prefs: cache.prefs,
+          nextPollAt,
+        }));
+      }
       req.on("close", () => { sseClients.delete(res); clientInstance.delete(res); });
       return;
     }
@@ -674,6 +773,7 @@ export async function stopInstance(instanceId) {
   const entry = servers.get(instanceId);
   if (!entry) return;
   servers.delete(instanceId);
+  displayedSnapshots.delete(instanceId);
   // SSE responses are long-lived, so server.close() would hang forever waiting for them
   // to drain. End the open event streams first, then force any lingering sockets closed so
   // shutdown completes promptly (e.g. when the canvas iframe is still connected). sseClients
@@ -693,39 +793,32 @@ export async function stopInstance(instanceId) {
 }
 
 export async function forceRefresh() {
-  const next = await getDashboard(true);
-  broadcastRefresh();
-  return next;
+  return getDashboard(true);
+}
+
+export async function refreshInBackground() {
+  return startCompute({ progress: false, background: true });
 }
 
 export async function rescanAccounts() {
   const prefs = await loadPrefs();
   const auth = await resolveAuth(prefs, { reprobe: true });
   const next = await getDashboard(true);
-  broadcastRefresh();
   return { accounts: auth.accounts, activeAccounts: next.dashboard.activeAccounts ?? [], dashboard: next.dashboard };
 }
 
 export async function toggleAccount(id, active) {
-  const prefs = await loadPrefs();
-  setAccountActive(prefs, id, !!active);
-  await savePrefs(prefs);
+  await updatePrefs((prefs) => { setAccountActive(prefs, id, !!active); });
   invalidateAuth();
-  const next = await getDashboard(true);
-  broadcastRefresh();
-  return next;
+  return getDashboard(true);
 }
 
 export async function setReposFor(id, repos) {
-  const prefs = await loadPrefs();
   // Empty fallback: a cleared list resets to the account's own default in
   // setAccountRepos (public vs EMU) instead of parseRepos forcing the public one.
-  setAccountRepos(prefs, id, parseRepos(repos, []));
-  await savePrefs(prefs);
+  await updatePrefs((prefs) => { setAccountRepos(prefs, id, parseRepos(repos, [])); });
   invalidateAuth();
-  const next = await getDashboard(true);
-  broadcastRefresh();
-  return next;
+  return getDashboard(true);
 }
 
 export { getDashboard };

--- a/.github/extensions/aspire-team-app/server.test.mjs
+++ b/.github/extensions/aspire-team-app/server.test.mjs
@@ -47,6 +47,45 @@ test("mutating POST rejects cross-site loopback requests before saving preferenc
   await assert.rejects(readFile(preferencesPath, "utf8"), { code: "ENOENT" });
 });
 
+test("auto-apply preference is persisted without recomputing the dashboard", async (t) => {
+  await resetTestHome({
+    accounts: { "acct:octo": { repos: ["microsoft/aspire"], active: true } },
+  });
+  process.env.GH_TOKEN = "test-token";
+  delete process.env.GITHUB_TOKEN;
+  process.env.PATH = "";
+  globalThis.fetch = makeGitHubMock();
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const server = await import(`./server.mjs?test=auto-apply-${Date.now()}`);
+  const entry = await server.startInstance("auto-apply-test", () => {});
+  t.after(() => server.stopInstance("auto-apply-test"));
+
+  const seeded = await (await fetch(new URL("api/state", entry.url))).json();
+  const response = await fetch(new URL("api/auto-apply", entry.url), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ enabled: false }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).prefs.autoApplyUpdates, false);
+  assert.equal(JSON.parse(await readFile(preferencesPath, "utf8")).autoApplyUpdates, false);
+  const cached = await (await fetch(new URL("api/state", entry.url))).json();
+  assert.equal(cached.prefs.autoApplyUpdates, false, "the in-memory cache must not restore the old preference");
+  assert.equal(cached.dashboard.seq, seeded.dashboard.seq, "changing the toolbar preference must not recompute GitHub data");
+});
+
+test("dashboard change detection ignores refresh metadata but detects semantic changes", async () => {
+  const { dashboardChanged } = await import(`./server.mjs?test=dashboard-change-${Date.now()}`);
+  const previous = { seq: 1, fetchedAt: "2026-08-06T00:00:00Z", counts: { prs: 2 }, lanes: [{ id: "ready" }] };
+  const refreshed = { seq: 2, fetchedAt: "2026-08-06T00:01:00Z", counts: { prs: 2 }, lanes: [{ id: "ready" }] };
+  const changed = { ...refreshed, counts: { prs: 3 } };
+
+  assert.equal(dashboardChanged(previous, refreshed), false);
+  assert.equal(dashboardChanged(previous, changed), true);
+});
+
 test("isAllowedPostRequest pins the Host header to this server's loopback origin (blocks DNS rebinding)", async () => {
   const server = await import(`./server.mjs?test=host-${Date.now()}`);
   const { isAllowedPostRequest } = server;
@@ -358,6 +397,80 @@ test("a cached linked ISSUE sharing repository#number is not resolvable as a PR"
   assert.equal(received, null);
 });
 
+test("linked PR route opens the cached pull request in the in-app browser canvas", async (t) => {
+  await resetTestHome({
+    mode: "issues",
+    accounts: { "acct:octo": { repos: ["microsoft/aspire"], active: true } },
+  });
+  process.env.GH_TOKEN = "test-token";
+  delete process.env.GITHUB_TOKEN;
+  process.env.PATH = "";
+
+  const base = makeGitHubMock();
+  globalThis.fetch = async (url, options = {}) => {
+    const requestUrl = String(url);
+    if (requestUrl.startsWith("http://127.0.0.1:")) return originalFetch(url, options);
+    const query = options.body ? JSON.parse(options.body).query ?? "" : "";
+    if (query.includes("issues(states:OPEN")) {
+      return jsonResponse({ data: { repository: { issues: {
+        nodes: [{
+          number: 42,
+          title: "Issue with a fix",
+          url: "https://github.com/microsoft/aspire/issues/42",
+          createdAt: "2026-07-01T09:00:00Z",
+          updatedAt: "2026-07-01T10:00:00Z",
+          author: { __typename: "User", login: "octo", avatarUrl: null },
+          milestone: null,
+          labels: { nodes: [] },
+          assignees: { nodes: [] },
+          closedByPullRequestsReferences: { nodes: [{
+            repository: { nameWithOwner: "microsoft/aspire" },
+            number: 99,
+            title: "Fix issue 42",
+            url: "https://github.com/microsoft/aspire/pull/99",
+            state: "OPEN",
+          }] },
+        }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      } } } });
+    }
+    return base(url, options);
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const server = await import(`./server.mjs?test=open-linked-pr-${Date.now()}`);
+  const entry = await server.startInstance("open-linked-pr-test", () => {});
+  t.after(() => {
+    server.setBrowserOpen(null);
+    return server.stopInstance("open-linked-pr-test");
+  });
+  await (await fetch(new URL("api/state", entry.url))).json();
+
+  const early = await postOpenPr(entry.url, "https://github.com/microsoft/aspire/pull/99");
+  assert.equal(early.status, 503);
+
+  let received = null;
+  server.setBrowserOpen(async (pr) => {
+    received = pr;
+    return { instanceId: "aspire-team-app-pr-microsoft-aspire-99" };
+  });
+  const opened = await postOpenPr(entry.url, "https://github.com/microsoft/aspire/pull/99");
+  assert.equal(opened.status, 200);
+  assert.deepEqual(received, {
+    repository: "microsoft/aspire",
+    number: 99,
+    title: "Fix issue 42",
+    url: "https://github.com/microsoft/aspire/pull/99",
+    state: "OPEN",
+  });
+  assert.equal((await opened.json()).instanceId, "aspire-team-app-pr-microsoft-aspire-99");
+
+  received = null;
+  const tampered = await postOpenPr(entry.url, "https://evil.example/microsoft/aspire/pull/99");
+  assert.equal(tampered.status, 400);
+  assert.equal(received, null);
+});
+
 test("api/state serves cache instantly on the second call (stale-while-revalidate)", async (t) => {
   await resetTestHome({
     accounts: { "acct:octo": { repos: ["microsoft/aspire"], active: true } },
@@ -441,6 +554,154 @@ test("api/state streams progress and a state snapshot to connected SSE clients",
   // the final or lets an out-of-order partial overwrite it).
   assert.equal(typeof payload.dashboard.seq, "number", "expected a numeric seq on the streamed snapshot");
 });
+
+test("a reconnecting event stream receives the latest snapshot metadata", async (t) => {
+  await resetTestHome({
+    autoApplyUpdates: false,
+    accounts: { "acct:octo": { repos: ["microsoft/aspire"], active: true } },
+  });
+  process.env.GH_TOKEN = "test-token";
+  delete process.env.GITHUB_TOKEN;
+  process.env.PATH = "";
+
+  globalThis.fetch = makeGitHubMock();
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const server = await import(`./server.mjs?test=snapshot-replay-${Date.now()}`);
+  const entry = await server.startInstance("snapshot-replay-test", () => {});
+  t.after(() => server.stopInstance("snapshot-replay-test"));
+
+  const seeded = await (await fetch(new URL("api/state", entry.url))).json();
+  await server.refreshInBackground();
+  const unchanged = await (await fetch(new URL("api/state", entry.url))).json();
+  assert.equal(unchanged.dashboard.seq, seeded.dashboard.seq, "a no-op poll must not advance the semantic revision");
+  const ac = new AbortController();
+  t.after(() => ac.abort());
+  const events = await fetch(new URL("events", entry.url), { signal: ac.signal });
+  const records = await readSseUntil(events.body.getReader(), "snapshot");
+  const snapshot = parseSseData(records.find((r) => r.startsWith("event: snapshot")));
+
+  assert.equal(snapshot.seq, seeded.dashboard.seq);
+  assert.equal(snapshot.prefs.autoApplyUpdates, false);
+  assert.ok(records.some((r) => r.startsWith("event: poll-schedule")));
+  assert.ok(snapshot.nextPollAt > Date.now());
+  assert.ok(snapshot.nextPollAt <= Date.now() + 90_000);
+});
+
+for (const scenario of [
+  { autoApplyUpdates: true, event: "state" },
+  { autoApplyUpdates: false, event: "update-available" },
+]) {
+  test(`changed background data emits ${scenario.event} when auto-apply is ${scenario.autoApplyUpdates}`, async (t) => {
+    await resetTestHome({
+      autoApplyUpdates: scenario.autoApplyUpdates,
+      accounts: { "acct:octo": { repos: ["microsoft/aspire"], active: true } },
+    });
+    process.env.GH_TOKEN = "test-token";
+    delete process.env.GITHUB_TOKEN;
+    process.env.PATH = "";
+
+    let nodes = [];
+    globalThis.fetch = makeGitHubMock(() => nodes);
+    t.after(() => { globalThis.fetch = originalFetch; });
+
+    const server = await import(`./server.mjs?test=background-${scenario.event}-${Date.now()}`);
+    const entry = await server.startInstance(`background-${scenario.event}-test`, () => {});
+    t.after(() => server.stopInstance(`background-${scenario.event}-test`));
+
+    // Seed the complete cache before opening the event stream; the background pass below adds a PR.
+    const initial = await (await fetch(new URL("api/state", entry.url))).json();
+    assert.equal(initial.dashboard.counts.prs, 0);
+
+    const ac = new AbortController();
+    t.after(() => ac.abort());
+    const evRes = await fetch(new URL("events", entry.url), { signal: ac.signal });
+    const reader = evRes.body.getReader();
+    const recordsPromise = readSseUntil(reader, scenario.event);
+
+    nodes = [makePrNode()];
+    await server.refreshInBackground();
+
+    const records = await Promise.race([
+      recordsPromise,
+      new Promise((_, reject) => setTimeout(() => reject(new Error(`timed out waiting for ${scenario.event}`)), 5000)),
+    ]);
+    assert.ok(records.some((r) => r.startsWith(`event: ${scenario.event}`)));
+    const otherEvent = scenario.event === "state" ? "update-available" : "state";
+    assert.equal(records.some((r) => r.startsWith(`event: ${otherEvent}`)), false);
+
+    const latest = await (await fetch(new URL("api/state", entry.url))).json();
+    assert.equal(latest.dashboard.counts.prs, 1, "the complete server cache advances in both UI modes");
+  });
+}
+
+for (const scenario of [
+  { initial: true, toggled: false, event: "update-available" },
+  { initial: false, toggled: true, event: "state" },
+]) {
+  test(`an in-flight poll honors Auto changing from ${scenario.initial} to ${scenario.toggled}`, async (t) => {
+    await resetTestHome({
+      autoApplyUpdates: scenario.initial,
+      accounts: { "acct:octo": { repos: ["microsoft/aspire"], active: true } },
+    });
+    process.env.GH_TOKEN = "test-token";
+    delete process.env.GITHUB_TOKEN;
+    process.env.PATH = "";
+
+    let nodes = [];
+    let gateArmed = false;
+    let releaseFetch;
+    let signalFetchStarted;
+    const fetchGate = new Promise((resolve) => { releaseFetch = resolve; });
+    const fetchStarted = new Promise((resolve) => { signalFetchStarted = resolve; });
+    const base = makeGitHubMock(() => nodes);
+    globalThis.fetch = async (url, options = {}) => {
+      const requestUrl = String(url);
+      const query = options.body ? JSON.parse(options.body).query ?? "" : "";
+      if (gateArmed && !requestUrl.startsWith("http://127.0.0.1:") && query.includes("pullRequests")) {
+        signalFetchStarted();
+        await fetchGate;
+      }
+      return base(url, options);
+    };
+    t.after(() => {
+      releaseFetch();
+      globalThis.fetch = originalFetch;
+    });
+
+    const server = await import(`./server.mjs?test=auto-race-${scenario.initial}-${Date.now()}`);
+    const instanceId = `auto-race-${scenario.initial}-test`;
+    const entry = await server.startInstance(instanceId, () => {});
+    t.after(() => server.stopInstance(instanceId));
+    await (await fetch(new URL("api/state", entry.url))).json();
+
+    const ac = new AbortController();
+    t.after(() => ac.abort());
+    const events = await fetch(new URL("events", entry.url), { signal: ac.signal });
+    const recordsPromise = readSseUntil(events.body.getReader(), scenario.event);
+
+    nodes = [makePrNode()];
+    gateArmed = true;
+    const refresh = server.refreshInBackground();
+    await fetchStarted;
+    const toggle = await fetch(new URL("api/auto-apply", entry.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ enabled: scenario.toggled }),
+    });
+    assert.equal(toggle.status, 200);
+    releaseFetch();
+    await refresh;
+
+    const records = await Promise.race([
+      recordsPromise,
+      new Promise((_, reject) => setTimeout(() => reject(new Error(`timed out waiting for ${scenario.event}`)), 5000)),
+    ]);
+    assert.ok(records.some((r) => r.startsWith(`event: ${scenario.event}`)));
+    const otherEvent = scenario.event === "state" ? "update-available" : "state";
+    assert.equal(records.some((r) => r.startsWith(`event: ${otherEvent}`)), false);
+  });
+}
 
 test("computeDashboard streams the final snapshot to an SSE client that connects mid-compute", async (t) => {
   await resetTestHome({
@@ -587,15 +848,7 @@ test("stopInstance ends its own live SSE stream promptly and leaves other instan
   );
 });
 
-test("a card action resolves against the last complete snapshot, not a mid-stream partial (no host misroute)", async (t) => {
-  // Regression for the streaming-cache host-confusion bug: while a refresh streams partials, `cache`
-  // is transiently overwritten with a snapshot that omits repos still loading. A GHES/EMU card that
-  // is still visible in that window would miss in the partial, and resolveActionPr would drop its
-  // host so agent.mjs safePrUrl reconstructs a github.com URL — misrouting the action to a same-slug
-  // repo on dotcom (target flips new-session -> current-session only when the URL is off-dotcom). The
-  // fix resolves actions against the last COMPLETE dashboard, so the enterprise host survives the
-  // whole refresh. One account watches two repos; the enterprise PR's repo is gated on the second
-  // compute so a partial without it lands in `cache` before we click.
+test("an in-flight refresh keeps the last complete snapshot and does not stream partial state", async (t) => {
   await resetTestHome({
     accounts: { "acct:octo": { repos: ["microsoft/fast", "microsoft/xrepo"], active: true } },
   });
@@ -629,13 +882,15 @@ test("a card action resolves against the last complete snapshot, not a mid-strea
     closingIssuesReferences: { nodes: [] },
   };
 
-  // xrepo's PR fetch is gated only on the SECOND compute so the first completes with the PR present
-  // (seeding the resolution snapshot), then the second stalls after emitting a partial without it.
+  // xrepo's PR fetch is gated only on the second compute so the first complete snapshot contains the
+  // enterprise PR. The replacement compute then stalls while that snapshot remains authoritative.
   let gateArmed = false;
   let releaseXrepo;
   let signalPartialWindow;
+  let signalFastDone;
   const xrepoGate = new Promise((resolve) => { releaseXrepo = resolve; });
   const partialWindow = new Promise((resolve) => { signalPartialWindow = resolve; });
+  const fastDone = new Promise((resolve) => { signalFastDone = resolve; });
   // Always release the gated fetch on teardown so an assertion failure mid-test can't leave the
   // second compute stalled (which would surface as post-test async activity).
   t.after(() => releaseXrepo());
@@ -659,7 +914,7 @@ test("a card action resolves against the last complete snapshot, not a mid-strea
         if (gateArmed) { signalPartialWindow(); await xrepoGate; }
         return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: { nodes: [xrepoPr] } } } });
       }
-      // microsoft/fast: no PRs, returns immediately so its completion fires the partial.
+      if (gateArmed) signalFastDone();
       return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: { nodes: [] } } } });
     }
     throw new Error(`Unexpected fetch: ${requestUrl} ${query}`);
@@ -676,19 +931,21 @@ test("a card action resolves against the last complete snapshot, not a mid-strea
   let received = null;
   server.setAgentSend(async (payload) => { received = payload; return { messageId: "m-1", queued: true }; });
 
-  // First compute (no SSE client -> no partials): completes with the enterprise PR present, so the
-  // action-resolution snapshot now carries its host-qualified URL.
+  // The first compute completes with the enterprise PR present.
   const first = await fetch(new URL("api/state", entry.url));
   await first.json();
 
-  // Arm the gate and connect an SSE client so the next compute streams a partial we can await.
+  // Arm the gate and connect an SSE client before starting the replacement compute.
   gateArmed = true;
   const ac = new AbortController();
   t.after(() => ac.abort());
   const evRes = await fetch(new URL("events", entry.url), { signal: ac.signal });
   const reader = evRes.body.getReader();
   const decoder = new TextDecoder();
-  const sawPartialState = (async () => {
+  const records = [];
+  let signalState;
+  const stateSeen = new Promise((resolve) => { signalState = resolve; });
+  const readStates = (async () => {
     let buf = "";
     while (true) {
       const { value, done } = await reader.read();
@@ -698,35 +955,83 @@ test("a card action resolves against the last complete snapshot, not a mid-strea
       while ((idx = buf.indexOf("\n\n")) !== -1) {
         const record = buf.slice(0, idx);
         buf = buf.slice(idx + 2);
-        if (record.startsWith("event: state")) return;
+        records.push(record);
+        if (record.startsWith("event: state")) signalState();
       }
     }
-  })();
+  })().catch((e) => { if (e.name !== "AbortError") throw e; });
 
-  // Trigger the second compute; don't await — it stalls in xrepo's gated fetch after fast's
-  // completion has already published a partial (without the enterprise PR) as the current cache.
+  // The second compute stalls in xrepo after the fast repository has completed. No state event may
+  // be emitted in this window because the candidate dashboard is incomplete.
   const refreshPromise = fetch(new URL("api/refresh", entry.url), { method: "POST" });
-  await partialWindow;   // xrepo fetch reached and is now blocked
-  await sawPartialState; // the partial (without xrepo's PR) has been broadcast + cached
+  await Promise.all([partialWindow, fastDone]);
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.equal(records.some((r) => r.startsWith("event: state")), false);
 
-  // Click the still-visible enterprise card while `cache` holds the partial that omits it.
+  // The still-visible enterprise card resolves against the previous complete snapshot.
   const acted = await postAction(entry.url, { kind: "test", target: "new-session", pr: {
     repository: "microsoft/xrepo", number: 5, url: ghesUrl, title: "Enterprise PR", author: "octo",
   } });
   assert.equal(acted.status, 200);
   const actedBody = await acted.json();
 
-  // Invariant: action resolution reads the last COMPLETE snapshot, not the mid-stream partial, so
-  // the enterprise PR is found there with its host-qualified URL — the prompt targets the GHES URL
-  // and new-session degrades to current-session. If resolution instead read the partial (which
-  // omits the not-yet-loaded enterprise PR), the miss would reconstruct a github.com URL and leave
-  // the action new-session, misrouting it to the same-slug dotcom repo.
   assert.equal(actedBody.target, "current-session");
   assert.match(received.prompt, /ghe\.example\.com:8443\/microsoft\/xrepo\/pull\/5/);
   assert.doesNotMatch(received.prompt, /github\.com\/microsoft\/xrepo/);
 
   releaseXrepo();
   await refreshPromise;
+  await Promise.race([
+    stateSeen,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("final state was not broadcast")), 5000)),
+  ]);
+  assert.equal(records.filter((r) => r.startsWith("event: state")).length, 1);
+  ac.abort();
+  await readStates;
+});
+
+test("card actions resolve against the snapshot displayed by that canvas when an update is waiting", async (t) => {
+  await resetTestHome({
+    autoApplyUpdates: false,
+    accounts: { "acct:octo": { repos: ["microsoft/aspire"], active: true } },
+  });
+  process.env.GH_TOKEN = "test-token";
+  delete process.env.GITHUB_TOKEN;
+  process.env.PATH = "";
+
+  let nodes = [makePrNode()];
+  globalThis.fetch = makeGitHubMock(() => nodes);
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const server = await import(`./server.mjs?test=displayed-snapshot-${Date.now()}`);
+  const entry = await server.startInstance("displayed-snapshot-test", () => {});
+  t.after(() => {
+    server.setAgentSend(null);
+    return server.stopInstance("displayed-snapshot-test");
+  });
+  server.setAgentSend(async () => ({ messageId: "m-1", queued: false }));
+
+  await (await fetch(new URL("api/state", entry.url))).json();
+  nodes = [];
+  await server.refreshInBackground();
+
+  const descriptor = {
+    kind: "review",
+    target: "new-session",
+    pr: {
+      repository: "microsoft/aspire",
+      number: 1,
+      url: "https://github.com/microsoft/aspire/pull/1",
+      title: "Seed PR",
+      author: "octo",
+    },
+  };
+  assert.equal((await postAction(entry.url, descriptor)).status, 200, "the still-visible card remains actionable");
+
+  // GET /api/state is the Apply operation: after this canvas adopts the latest complete snapshot,
+  // the removed PR is no longer trusted as visible.
+  await (await fetch(new URL("api/state", entry.url))).json();
+  assert.equal((await postAction(entry.url, descriptor)).status, 400);
 });
 
 // Minimal GitHub GraphQL mock: scope probe, viewer, repo existence probe, and a pull-request
@@ -751,10 +1056,34 @@ function makeGitHubMock(prNodes = []) {
       return jsonResponse({ data: { r0: { nameWithOwner: "microsoft/aspire" } } });
     }
     if (query.includes("pullRequests")) {
-      return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: { nodes: prNodes } } } });
+      const nodes = typeof prNodes === "function" ? prNodes() : prNodes;
+      return jsonResponse({ data: { repository: { isPrivate: false, pullRequests: { nodes } } } });
     }
     throw new Error(`Unexpected fetch: ${requestUrl} ${query}`);
   };
+}
+
+async function readSseUntil(reader, eventName) {
+  const decoder = new TextDecoder();
+  const records = [];
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) return records;
+    buffer += decoder.decode(value, { stream: true });
+    let index;
+    while ((index = buffer.indexOf("\n\n")) !== -1) {
+      const record = buffer.slice(0, index);
+      buffer = buffer.slice(index + 2);
+      records.push(record);
+      if (record.startsWith(`event: ${eventName}`)) return records;
+    }
+  }
+}
+
+function parseSseData(record) {
+  const line = record.split("\n").find((value) => value.startsWith("data: "));
+  return JSON.parse(line.slice(6));
 }
 
 // A complete GraphQL PR node with sensible defaults, overridable per field. reshapeDashboard reads
@@ -793,6 +1122,14 @@ async function postAction(baseUrl, payload) {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(payload),
+  });
+}
+
+async function postOpenPr(baseUrl, url) {
+  return fetch(new URL("api/open-pr", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ url }),
   });
 }
 

--- a/.github/extensions/aspire-team-app/state.mjs
+++ b/.github/extensions/aspire-team-app/state.mjs
@@ -17,6 +17,7 @@ import { isEmuAccountId } from "./accounts.mjs";
 const COPILOT_HOME = process.env.COPILOT_HOME || join(homedir(), ".copilot");
 const ARTIFACT_DIR = join(COPILOT_HOME, "extensions", "aspire-team-app", "artifacts");
 const PREFS_FILE = join(ARTIFACT_DIR, "preferences.json");
+let prefsUpdate = Promise.resolve();
 
 export const DEFAULT_NOTIFICATIONS = {
   reviewRequested: true,
@@ -29,6 +30,7 @@ export const DEFAULT_PREFS = {
   mode: "review",
   release: CURRENT_RELEASE,
   showDrafts: false,
+  autoApplyUpdates: true,
   dismissedNotifications: [],
   notifications: { ...DEFAULT_NOTIFICATIONS },
   // Per-account configuration keyed by account id ("acct:<host>/<login>"):
@@ -57,6 +59,7 @@ function migrate(parsed) {
     ...DEFAULT_PREFS,
     ...parsed,
     showDrafts: !!parsed.showDrafts,
+    autoApplyUpdates: parsed.autoApplyUpdates !== false,
     notifications: { ...DEFAULT_NOTIFICATIONS, ...(parsed.notifications ?? {}) },
     dismissedNotifications: Array.isArray(parsed.dismissedNotifications) ? parsed.dismissedNotifications : [],
     accounts: normalizeAccounts(parsed.accounts),
@@ -89,6 +92,20 @@ export async function savePrefs(prefs) {
   await mkdir(ARTIFACT_DIR, { recursive: true });
   await writeFile(PREFS_FILE, JSON.stringify(prefs, null, 2) + "\n", "utf8");
   return prefs;
+}
+
+// Every canvas instance shares this preference file. Serialize read-modify-write operations so
+// simultaneous toolbar, settings, and account changes cannot overwrite one another with stale copies.
+export function updatePrefs(mutator) {
+  const run = prefsUpdate
+    .catch(() => {})
+    .then(async () => {
+      const prefs = await loadPrefs();
+      await mutator(prefs);
+      return savePrefs(prefs);
+    });
+  prefsUpdate = run;
+  return run;
 }
 
 // ---------------------------------------------------------------------------

--- a/.github/extensions/aspire-team-app/state.test.mjs
+++ b/.github/extensions/aspire-team-app/state.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { accountConfig, setAccountActive, setAccountRepos } from "./state.mjs";
+import { accountConfig, DEFAULT_PREFS, setAccountActive, setAccountRepos } from "./state.mjs";
 import { DEFAULT_REPOS, DEFAULT_EMU_REPOS } from "./github.mjs";
+
+test("background updates apply automatically by default", () => {
+  assert.equal(DEFAULT_PREFS.autoApplyUpdates, true);
+});
 
 test("accountConfig defaults unconfigured EMU accounts to the first-party repos", () => {
   const emu = accountConfig({ accounts: {} }, "acct:github.com/dapine_microsoft");


### PR DESCRIPTION
## Description

The Aspire Team App previously replaced its visible board with incomplete per-repository snapshots during background refreshes. Cards disappeared and reappeared for several seconds, making the review and issue boards difficult to browse.

This change keeps the last complete snapshot visible while GitHub data refreshes in the background, then publishes one atomic update. It also adds:

- A compact **Auto** toolbar switch that controls whether completed background updates are applied immediately.
- An **Apply update** indicator when Auto is disabled and changed data is ready.
- A live refresh tooltip that counts down to the server's next background poll.
- Semantic snapshot revisions so no-op polls do not rebuild the UI or create false update notifications.
- Reconnect replay, serialized preference writes, and per-canvas displayed snapshots.
- Linked pull requests on issue cards, including green open and purple merged states; closed PRs are omitted.
- In-app PR navigation through the built-in browser canvas instead of the operating system browser.

Linked-PR browser requests are resolved against the server-owned snapshot displayed by that canvas before the runtime browser canvas is opened. This preserves the existing loopback trust boundary and prevents a modified client request from opening an arbitrary URL.

### User-facing usage

- Leave **Auto** enabled to apply completed background refreshes atomically.
- Disable **Auto** to keep the current board unchanged until **Apply update** is selected.
- Hover or focus **Refresh** to see when the next background data check starts; selecting it always refreshes and applies changed data immediately.
- On the Issues tab, select a linked PR row to open that PR in an in-app browser tab.

### Screenshots / Recordings

> **This PR includes UI changes.** Please add screenshots or screen recordings so reviewers can evaluate the visual changes without running locally.
>
> - For before/after comparisons, place them side-by-side or label them clearly.
> - For interactive changes (animations, transitions, new flows), prefer a short screen recording (GIF or video).
> - If you cannot capture visuals now, note what scenario to test and mark this section as TODO.

<img width="140" height="48" alt="image" src="https://github.com/user-attachments/assets/411bda19-fc5c-4324-8fed-d06ca53d66c6" />

<img width="135" height="59" alt="image" src="https://github.com/user-attachments/assets/8b1d7e50-f2ec-45b1-badd-53dc4231ef3b" />

<img width="163" height="57" alt="image" src="https://github.com/user-attachments/assets/91d95770-ae69-4d18-a045-d1a54f42f163" />

<img width="320" height="92" alt="image" src="https://github.com/user-attachments/assets/474afcff-d1f9-4e88-9dbe-59c272b0320f" />

<img width="445" height="352" alt="image" src="https://github.com/user-attachments/assets/db1ae3cb-7c04-4569-bf62-4c9683c4c7ed" />

<img width="557" height="107" alt="image" src="https://github.com/user-attachments/assets/46d41733-e436-4665-ad51-aceee2d43604" />

### Validation

- `node --test .github/extensions/aspire-team-app/*.test.mjs` — 105 tests passed.
- Verified a live refresh emits one complete state update while progress continues independently.
- Verified the refresh tooltip updates while displayed.
- Verified live open and merged linked PR states and that closed references are absent.
- Verified PR #18999 opens through the runtime's in-app browser canvas.

### Security considerations

The loopback server accepts a linked-PR URL from the iframe before opening an in-app browser canvas. The request remains protected by the existing loopback Host/Origin checks, and the URL must exactly match an open or merged PR linked from the complete snapshot currently displayed by that canvas. No client-supplied URL is forwarded directly to the browser canvas.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
