### PR TITLE
Improve handling of object change notifications during local run

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -319,15 +319,12 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     // a completed flush would stall all resource watches. A later changed terminal notification
                     // can retry point-in-time FailedToStart reads and incomplete attempts because they are not
                     // recorded as complete. The marker is cleared below if the resource is restarted.
+                    var logsAvailable = HasLogsAvailable(resource);
                     var isTerminal = status.State is not null && KnownResourceStates.TerminalStates.Contains(status.State);
-                    var terminalLogsHandledForActiveSubscribers = false;
                     if (isTerminal)
                     {
-                        terminalLogsHandledForActiveSubscribers =
-                            HasLogsAvailable(resource) &&
-                            _loggerService.HasActiveSubscribers(resource.Metadata.Name);
-
-                        if (terminalLogsHandledForActiveSubscribers &&
+                        if (logsAvailable &&
+                            _loggerService.HasActiveSubscribers(resource.Metadata.Name) &&
                             !_allLogsFlushed.ContainsKey(resource.Metadata.Name))
                         {
                             var completed = await FlushCurrentLogsAsync(resource, status, _shutdownToken).ConfigureAwait(false);
@@ -344,15 +341,15 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
                     await _executorEvents.PublishAsync(new OnResourceChangedContext(_shutdownToken, resourceType, appModelResource, resource.Metadata.Name, status, s => snapshotFactory(resource, s))).ConfigureAwait(false);
 
-                    if (HasLogsAvailable(resource))
+                    if (logsAvailable)
                     {
-                        // Avoid opening a second follow stream when terminal handling already served the active
-                        // subscribers. A replacement still needs its own stream after its old registration was reset.
-                        // If no subscriber was active during the check above, keep this notification startable so a
-                        // concurrent subscriber notification cannot fall between the terminal check and this write.
+                        // Avoid opening a second follow stream only after a terminal follow flush completed. Timed-out
+                        // flushes and point-in-time FailedToStart reads leave the normal stream startable so an existing
+                        // subscriber can receive later logs without another subscriber change or resource notification.
+                        // A replacement still needs its own stream after its old registration was reset.
                         var shouldStartStream =
                             resourceChange == ResourceChangeResult.Replaced ||
-                            !terminalLogsHandledForActiveSubscribers;
+                            !_allLogsFlushed.ContainsKey(resource.Metadata.Name);
                         _logInformationChannel.Writer.TryWrite(new(resource.Metadata.Name, LogsAvailable: true, HasSubscribers: null, ShouldStartStream: shouldStartStream));
                     }
                 }

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -68,6 +68,9 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         return _logStreams.TryGetValue(resourceName, out var logStream) ? logStream.Task : null;
     }
 
+    // Internal for testing.
+    internal Func<string?, ValueTask>? BeforeLogBatchDeliveryAsync { get; set; }
+
     public DcpResourceWatcher(
         ILogger logger,
         IKubernetesService kubernetesService,
@@ -173,10 +176,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     }
                     else
                     {
-                        if (_logStreams.TryRemove(entry.ResourceName, out var logStream))
-                        {
-                            logStream.Cancel();
-                        }
+                        CancelLogStream(entry.ResourceName);
                     }
                 }
 
@@ -389,10 +389,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
     private void ResetResourceLogState(string resourceName)
     {
-        if (_logStreams.TryRemove(resourceName, out var logStream))
-        {
-            logStream.Cancel();
-        }
+        CancelLogStream(resourceName);
 
         lock (_pendingFollowLogDeduplicationsLock)
         {
@@ -400,6 +397,18 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         }
 
         _allLogsFlushed.TryRemove(resourceName, out _);
+    }
+
+    private void CancelLogStream(string resourceName)
+    {
+        if (_logStreams.TryGetValue(resourceName, out var logStream))
+        {
+            // Keep this registration until cancellation has synchronized with any synchronous batch
+            // delivery. Otherwise another stream can claim the same name while the old stream is
+            // still publishing a batch that ResourceLogSource yielded before cancellation.
+            logStream.Cancel();
+            _logStreams.TryRemove(new(resourceName, logStream));
+        }
     }
 
     private async Task<bool> FlushCurrentLogsAsync<T>(T resource, ResourceStatus status, CancellationToken cancellationToken)
@@ -614,8 +623,16 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     await foreach (var batch in enumerable.WithCancellation(cancellationToken).ConfigureAwait(false))
                     {
                         var logEntries = CreateLogEntries(batch).ToList();
-                        logEntries = DeduplicateFollowBatch(resourceName, logStream, logEntries);
-                        _loggerService.AddLogEntries(resourceName, logEntries, inMemorySource: false, skipExisting: false);
+                        if (BeforeLogBatchDeliveryAsync is { } beforeLogBatchDeliveryAsync)
+                        {
+                            await beforeLogBatchDeliveryAsync(logStream.ResourceUid).ConfigureAwait(false);
+                        }
+
+                        logStream.TryDeliver(() =>
+                        {
+                            logEntries = DeduplicateFollowBatch(resourceName, logStream, logEntries);
+                            _loggerService.AddLogEntries(resourceName, logEntries, inMemorySource: false, skipExisting: false);
+                        });
                     }
                 }
                 catch (OperationCanceledException)
@@ -984,6 +1001,22 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
         // Access is guarded by the owning DcpResourceWatcher's pending-deduplication lock.
         public PendingFollowLogDeduplication? PendingDeduplication { get; set; }
+
+        public bool TryDeliver(Action deliver)
+        {
+            lock (_lock)
+            {
+                if (_disposed || _cancellation.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                // Cancellation takes this same lock, so reset cannot free the resource-name slot
+                // until a delivery that already started has finished publishing synchronously.
+                deliver();
+                return true;
+            }
+        }
 
         public void Cancel()
         {

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -37,8 +37,9 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     private readonly DcpResourceState _resourceState;
     private readonly ResourceSnapshotBuilder _snapshotBuilder;
 
-    private readonly ConcurrentDictionary<string, (CancellationTokenSource Cancellation, Task Task)> _logStreams = new();
-    private readonly ConcurrentDictionary<string, PendingFollowLogDeduplication> _pendingFollowLogDeduplications = new();
+    private readonly ConcurrentDictionary<string, LogStreamState> _logStreams = new();
+    private readonly Dictionary<string, PendingFollowLogDeduplication> _pendingFollowLogDeduplications = [];
+    private readonly object _pendingFollowLogDeduplicationsLock = new();
 
     // Last identity and resource version seen for each DCP object, keyed by (object kind, object name).
     // The stable key avoids retaining stale entries when a delete is missed, while the UID distinguishes
@@ -60,6 +61,18 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     internal ResiliencePipeline WatchResourceRetryPipeline { get; set; }
 
     internal ResourceSnapshotBuilder SnapshotBuilder => _snapshotBuilder;
+
+    // Internal for testing.
+    internal Task? GetLogStreamTask(string resourceName)
+    {
+        return _logStreams.TryGetValue(resourceName, out var logStream) ? logStream.Task : null;
+    }
+
+    // Internal for testing.
+    internal bool IsLogStreamDisposed(string resourceName)
+    {
+        return _logStreams.TryGetValue(resourceName, out var logStream) && logStream.IsDisposed;
+    }
 
     public DcpResourceWatcher(
         ILogger logger,
@@ -165,7 +178,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     {
                         if (_logStreams.TryRemove(entry.ResourceName, out var logStream))
                         {
-                            logStream.Cancellation.Cancel();
+                            logStream.Cancel();
                         }
                     }
                 }
@@ -222,10 +235,10 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             tasks.Add(resourceTask);
         }
 
-        foreach (var (_, (cancellation, logTask)) in _logStreams)
+        foreach (var (_, logStream) in _logStreams)
         {
-            cancellation.Cancel();
-            tasks.Add(logTask);
+            logStream.Cancel();
+            tasks.Add(logStream.Task);
         }
 
         try
@@ -369,10 +382,14 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     {
         if (_logStreams.TryRemove(resourceName, out var logStream))
         {
-            logStream.Cancellation.Cancel();
+            logStream.Cancel();
         }
 
-        _pendingFollowLogDeduplications.TryRemove(resourceName, out _);
+        lock (_pendingFollowLogDeduplicationsLock)
+        {
+            _pendingFollowLogDeduplications.Remove(resourceName);
+        }
+
         _allLogsFlushed.TryRemove(resourceName, out _);
     }
 
@@ -565,8 +582,10 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         // creating multiple log streams.
         _logStreams.GetOrAdd(resource.Metadata.Name, resourceName =>
         {
-            var cancellation = new CancellationTokenSource();
             var resourceUid = resource.Metadata.Uid;
+            var logStream = new LogStreamState(resourceUid);
+            var cancellationToken = logStream.CancellationToken;
+            ObservePendingFollowLogDeduplication(resourceName, logStream);
 
             var task = Task.Run(async () =>
             {
@@ -577,10 +596,10 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                         _logger.LogDebug("Starting log streaming for {ResourceName}.", resourceName);
                     }
 
-                    await foreach (var batch in enumerable.WithCancellation(cancellation.Token).ConfigureAwait(false))
+                    await foreach (var batch in enumerable.WithCancellation(cancellationToken).ConfigureAwait(false))
                     {
                         var logEntries = CreateLogEntries(batch).ToList();
-                        logEntries = DeduplicateFollowBatch(resourceName, resourceUid, logEntries);
+                        logEntries = DeduplicateFollowBatch(resourceName, logStream, logEntries);
                         _loggerService.AddLogEntries(resourceName, logEntries, inMemorySource: false, skipExisting: false);
                     }
                 }
@@ -600,16 +619,19 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                 }
                 finally
                 {
-                    if (_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) &&
-                        HasSameResourceIdentity(pendingDeduplication.ResourceUid, resourceUid))
+                    try
                     {
-                        RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
+                        RemovePendingFollowLogDeduplication(resourceName, logStream);
+                    }
+                    finally
+                    {
+                        logStream.Dispose();
                     }
                 }
-            },
-            cancellation.Token);
+            });
 
-            return (cancellation, task);
+            logStream.SetTask(task);
+            return logStream;
         });
     }
 
@@ -617,10 +639,13 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     {
         if (flushedLogEntries.Count == 0)
         {
-            if (_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) &&
-                HasSameResourceIdentity(pendingDeduplication.ResourceUid, resourceUid))
+            lock (_pendingFollowLogDeduplicationsLock)
             {
-                RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
+                if (_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) &&
+                    HasSameResourceIdentity(pendingDeduplication.ResourceUid, resourceUid))
+                {
+                    RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
+                }
             }
 
             return;
@@ -648,58 +673,100 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             }
         }
 
-        _pendingFollowLogDeduplications[resourceName] = new(resourceUid, counts, latestTimestamp, remainingCount);
+        var newPendingDeduplication = new PendingFollowLogDeduplication(resourceUid, counts, latestTimestamp, remainingCount);
+        lock (_pendingFollowLogDeduplicationsLock)
+        {
+            _pendingFollowLogDeduplications[resourceName] = newPendingDeduplication;
+            if (_logStreams.TryGetValue(resourceName, out var logStream) &&
+                HasSameResourceIdentity(logStream.ResourceUid, resourceUid))
+            {
+                logStream.PendingDeduplication = newPendingDeduplication;
+            }
+        }
     }
 
-    private List<LogEntry> DeduplicateFollowBatch(string resourceName, string? resourceUid, List<LogEntry> logEntries)
+    private void ObservePendingFollowLogDeduplication(string resourceName, LogStreamState logStream)
     {
-        if (!_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) ||
-            !HasSameResourceIdentity(pendingDeduplication.ResourceUid, resourceUid))
+        lock (_pendingFollowLogDeduplicationsLock)
         {
-            return logEntries;
-        }
-
-        List<LogEntry>? addedEntries = null;
-        foreach (var logEntry in logEntries)
-        {
-            // Consume at most one pending occurrence per matching entry. If a flushed snapshot
-            // contained the same line twice, the follow stream must replay it twice before both
-            // copies are treated as overlap.
-            var key = LogEntryKey.Create(logEntry);
-            if (pendingDeduplication.Counts.TryGetValue(key, out var count) && count > 0)
+            if (_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) &&
+                HasSameResourceIdentity(pendingDeduplication.ResourceUid, logStream.ResourceUid))
             {
-                pendingDeduplication.Counts[key] = count - 1;
-                pendingDeduplication.RemainingCount--;
-                continue;
+                logStream.PendingDeduplication = pendingDeduplication;
+            }
+        }
+    }
+
+    private List<LogEntry> DeduplicateFollowBatch(string resourceName, LogStreamState logStream, List<LogEntry> logEntries)
+    {
+        lock (_pendingFollowLogDeduplicationsLock)
+        {
+            if (!_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) ||
+                !HasSameResourceIdentity(pendingDeduplication.ResourceUid, logStream.ResourceUid))
+            {
+                return logEntries;
             }
 
-            addedEntries ??= [];
-            addedEntries.Add(logEntry);
-        }
+            logStream.PendingDeduplication = pendingDeduplication;
 
-        // Terminal-state snapshots can overlap with the follow stream, but only around the flush.
-        // Deduplicate against the flushed snapshot itself instead of rebuilding the full backlog
-        // for every follow batch for the lifetime of a chatty resource. DCP log timestamps are
-        // monotonic enough for this boundary: once the follow stream yields a newer timestamp, it
-        // has moved past the overlap window. Timestamp-less entries cannot establish that boundary,
-        // so drop the pending state after the first such batch to avoid suppressing future repeated
-        // messages that happen to have the same content.
-        if (pendingDeduplication.LatestTimestamp is null ||
-            pendingDeduplication.RemainingCount == 0 ||
-            logEntries.Any(entry => entry.Timestamp is null || entry.Timestamp > pendingDeduplication.LatestTimestamp.Value))
+            List<LogEntry>? addedEntries = null;
+            foreach (var logEntry in logEntries)
+            {
+                // Consume at most one pending occurrence per matching entry. If a flushed snapshot
+                // contained the same line twice, the follow stream must replay it twice before both
+                // copies are treated as overlap.
+                var key = LogEntryKey.Create(logEntry);
+                if (pendingDeduplication.Counts.TryGetValue(key, out var count) && count > 0)
+                {
+                    pendingDeduplication.Counts[key] = count - 1;
+                    pendingDeduplication.RemainingCount--;
+                    continue;
+                }
+
+                addedEntries ??= [];
+                addedEntries.Add(logEntry);
+            }
+
+            // Terminal-state snapshots can overlap with the follow stream, but only around the flush.
+            // Deduplicate against the flushed snapshot itself instead of rebuilding the full backlog
+            // for every follow batch for the lifetime of a chatty resource. DCP log timestamps are
+            // monotonic enough for this boundary: once the follow stream yields a newer timestamp, it
+            // has moved past the overlap window. Timestamp-less entries cannot establish that boundary,
+            // so drop the pending state after the first such batch to avoid suppressing future repeated
+            // messages that happen to have the same content.
+            if (pendingDeduplication.LatestTimestamp is null ||
+                pendingDeduplication.RemainingCount == 0 ||
+                logEntries.Any(entry => entry.Timestamp is null || entry.Timestamp > pendingDeduplication.LatestTimestamp.Value))
+            {
+                RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
+            }
+
+            return addedEntries ?? [];
+        }
+    }
+
+    private void RemovePendingFollowLogDeduplication(string resourceName, LogStreamState logStream)
+    {
+        lock (_pendingFollowLogDeduplicationsLock)
         {
-            RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
+            if (logStream.PendingDeduplication is { } pendingDeduplication)
+            {
+                RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
+            }
         }
-
-        return addedEntries ?? [];
     }
 
     private void RemovePendingFollowLogDeduplication(string resourceName, PendingFollowLogDeduplication pendingDeduplication)
     {
-        // Remove only the state observed by this stream. A canceled stream from a previous object
+        Debug.Assert(Monitor.IsEntered(_pendingFollowLogDeduplicationsLock));
+
+        // Remove only the exact state observed by this stream. A canceled stream from a previous object
         // incarnation can finish after its replacement has already installed new deduplication state.
-        ((ICollection<KeyValuePair<string, PendingFollowLogDeduplication>>)_pendingFollowLogDeduplications)
-            .Remove(new(resourceName, pendingDeduplication));
+        if (_pendingFollowLogDeduplications.TryGetValue(resourceName, out var currentDeduplication) &&
+            ReferenceEquals(currentDeduplication, pendingDeduplication))
+        {
+            _pendingFollowLogDeduplications.Remove(resourceName);
+        }
     }
 
     private async Task ProcessEndpointChange(WatchEventType watchEventType, Endpoint endpoint)
@@ -861,6 +928,71 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         Updated,
         Replaced,
         Deleted
+    }
+
+    private sealed class LogStreamState(string? resourceUid) : IDisposable
+    {
+        private readonly object _lock = new();
+        private readonly CancellationTokenSource _cancellation = new();
+        private bool _disposed;
+
+        public CancellationToken CancellationToken
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    ObjectDisposedException.ThrowIf(_disposed, this);
+                    return _cancellation.Token;
+                }
+            }
+        }
+
+        public Task Task { get; private set; } = Task.CompletedTask;
+
+        public string? ResourceUid { get; } = resourceUid;
+
+        // Access is guarded by the owning DcpResourceWatcher's pending-deduplication lock.
+        public PendingFollowLogDeduplication? PendingDeduplication { get; set; }
+
+        public bool IsDisposed
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _disposed;
+                }
+            }
+        }
+
+        public void SetTask(Task task)
+        {
+            Task = task;
+        }
+
+        public void Cancel()
+        {
+            lock (_lock)
+            {
+                if (!_disposed)
+                {
+                    _cancellation.Cancel();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (!_disposed)
+                {
+                    _cancellation.Dispose();
+                    _disposed = true;
+                }
+            }
+        }
     }
 
     private sealed class PendingFollowLogDeduplication(

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -53,7 +53,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     private readonly ConcurrentDictionary<string, bool> _allLogsFlushed = new();
     private Task? _resourceWatchTask;
 
-    private readonly record struct LogInformationEntry(string ResourceName, bool? LogsAvailable, bool? HasSubscribers);
+    private readonly record struct LogInformationEntry(string ResourceName, bool? LogsAvailable, bool? HasSubscribers, bool ShouldStartStream);
     private readonly Channel<LogInformationEntry> _logInformationChannel = Channel.CreateUnbounded<LogInformationEntry>(
         new UnboundedChannelOptions { SingleReader = true });
 
@@ -66,12 +66,6 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     internal Task? GetLogStreamTask(string resourceName)
     {
         return _logStreams.TryGetValue(resourceName, out var logStream) ? logStream.Task : null;
-    }
-
-    // Internal for testing.
-    internal bool IsLogStreamDisposed(string resourceName)
-    {
-        return _logStreams.TryGetValue(resourceName, out var logStream) && logStream.IsDisposed;
     }
 
     public DcpResourceWatcher(
@@ -130,7 +124,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         {
             await foreach (var subscribers in _loggerService.WatchAnySubscribersAsync(cancellationToken).ConfigureAwait(false))
             {
-                _logInformationChannel.Writer.TryWrite(new(subscribers.Name, LogsAvailable: null, subscribers.AnySubscribers));
+                _logInformationChannel.Writer.TryWrite(new(subscribers.Name, LogsAvailable: null, subscribers.AnySubscribers, ShouldStartStream: true));
             }
         });
 
@@ -161,17 +155,20 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                 {
                     if (hasSubscribers)
                     {
-                        if (_resourceState.ContainersMap.TryGetValue(entry.ResourceName, out var container))
+                        if (entry.ShouldStartStream)
                         {
-                            StartLogStream(container);
-                        }
-                        else if (_resourceState.ExecutablesMap.TryGetValue(entry.ResourceName, out var executable))
-                        {
-                            StartLogStream(executable);
-                        }
-                        else if (_resourceState.ContainerExecsMap.TryGetValue(entry.ResourceName, out var containerExec))
-                        {
-                            StartLogStream(containerExec);
+                            if (_resourceState.ContainersMap.TryGetValue(entry.ResourceName, out var container))
+                            {
+                                StartLogStream(container);
+                            }
+                            else if (_resourceState.ExecutablesMap.TryGetValue(entry.ResourceName, out var executable))
+                            {
+                                StartLogStream(executable);
+                            }
+                            else if (_resourceState.ContainerExecsMap.TryGetValue(entry.ResourceName, out var containerExec))
+                            {
+                                StartLogStream(containerExec);
+                            }
                         }
                     }
                     else
@@ -322,10 +319,15 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     // a completed flush would stall all resource watches. A later changed terminal notification
                     // can retry point-in-time FailedToStart reads and incomplete attempts because they are not
                     // recorded as complete. The marker is cleared below if the resource is restarted.
-                    if (status.State is not null && KnownResourceStates.TerminalStates.Contains(status.State))
+                    var isTerminal = status.State is not null && KnownResourceStates.TerminalStates.Contains(status.State);
+                    var terminalLogsHandledForActiveSubscribers = false;
+                    if (isTerminal)
                     {
-                        if (HasLogsAvailable(resource) &&
-                            _loggerService.HasActiveSubscribers(resource.Metadata.Name) &&
+                        terminalLogsHandledForActiveSubscribers =
+                            HasLogsAvailable(resource) &&
+                            _loggerService.HasActiveSubscribers(resource.Metadata.Name);
+
+                        if (terminalLogsHandledForActiveSubscribers &&
                             !_allLogsFlushed.ContainsKey(resource.Metadata.Name))
                         {
                             var completed = await FlushCurrentLogsAsync(resource, status, _shutdownToken).ConfigureAwait(false);
@@ -344,7 +346,14 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
                     if (HasLogsAvailable(resource))
                     {
-                        _logInformationChannel.Writer.TryWrite(new(resource.Metadata.Name, LogsAvailable: true, HasSubscribers: null));
+                        // Avoid opening a second follow stream when terminal handling already served the active
+                        // subscribers. A replacement still needs its own stream after its old registration was reset.
+                        // If no subscriber was active during the check above, keep this notification startable so a
+                        // concurrent subscriber notification cannot fall between the terminal check and this write.
+                        var shouldStartStream =
+                            resourceChange == ResourceChangeResult.Replaced ||
+                            !terminalLogsHandledForActiveSubscribers;
+                        _logInformationChannel.Writer.TryWrite(new(resource.Metadata.Name, LogsAvailable: true, HasSubscribers: null, ShouldStartStream: shouldStartStream));
                     }
                 }
             }
@@ -578,16 +587,22 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             return;
         }
 
-        // This does not run concurrently for the same resource so we can safely use GetOrAdd without
-        // creating multiple log streams.
-        _logStreams.GetOrAdd(resource.Metadata.Name, resourceName =>
+        var resourceName = resource.Metadata.Name;
+        var logStream = new LogStreamState(resource.Metadata.Uid);
+        var cancellationToken = logStream.CancellationToken;
+
+        // Register before starting the worker so an immediately completing stream can remove itself.
+        if (!_logStreams.TryAdd(resourceName, logStream))
         {
-            var resourceUid = resource.Metadata.Uid;
-            var logStream = new LogStreamState(resourceUid);
-            var cancellationToken = logStream.CancellationToken;
+            logStream.Dispose();
+            return;
+        }
+
+        try
+        {
             ObservePendingFollowLogDeduplication(resourceName, logStream);
 
-            var task = Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 try
                 {
@@ -621,7 +636,18 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                 {
                     try
                     {
-                        RemovePendingFollowLogDeduplication(resourceName, logStream);
+                        try
+                        {
+                            RemovePendingFollowLogDeduplication(resourceName, logStream);
+                        }
+                        finally
+                        {
+                            // Remove only this registration. A canceled stream can finish after a
+                            // replacement stream has registered under the same resource name.
+                            // LogStreamState intentionally retains reference equality so this
+                            // KeyValuePair overload performs an atomic identity-based removal.
+                            _logStreams.TryRemove(new(resourceName, logStream));
+                        }
                     }
                     finally
                     {
@@ -629,10 +655,13 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     }
                 }
             });
-
-            logStream.SetTask(task);
-            return logStream;
-        });
+        }
+        catch
+        {
+            _logStreams.TryRemove(new(resourceName, logStream));
+            logStream.Dispose();
+            throw;
+        }
     }
 
     private void SetPendingFollowLogDeduplication(string resourceName, string? resourceUid, IReadOnlyList<LogEntry> flushedLogEntries)
@@ -934,6 +963,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     {
         private readonly object _lock = new();
         private readonly CancellationTokenSource _cancellation = new();
+        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private bool _disposed;
 
         public CancellationToken CancellationToken
@@ -948,28 +978,12 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             }
         }
 
-        public Task Task { get; private set; } = Task.CompletedTask;
+        public Task Task => _completion.Task;
 
         public string? ResourceUid { get; } = resourceUid;
 
         // Access is guarded by the owning DcpResourceWatcher's pending-deduplication lock.
         public PendingFollowLogDeduplication? PendingDeduplication { get; set; }
-
-        public bool IsDisposed
-        {
-            get
-            {
-                lock (_lock)
-                {
-                    return _disposed;
-                }
-            }
-        }
-
-        public void SetTask(Task task)
-        {
-            Task = task;
-        }
 
         public void Cancel()
         {
@@ -984,13 +998,20 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
         public void Dispose()
         {
-            lock (_lock)
+            try
             {
-                if (!_disposed)
+                lock (_lock)
                 {
-                    _cancellation.Dispose();
-                    _disposed = true;
+                    if (!_disposed)
+                    {
+                        _cancellation.Dispose();
+                        _disposed = true;
+                    }
                 }
+            }
+            finally
+            {
+                _completion.TrySetResult();
             }
         }
     }

--- a/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
+++ b/src/Aspire.Hosting/Dcp/DcpResourceWatcher.cs
@@ -40,14 +40,15 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
     private readonly ConcurrentDictionary<string, (CancellationTokenSource Cancellation, Task Task)> _logStreams = new();
     private readonly ConcurrentDictionary<string, PendingFollowLogDeduplication> _pendingFollowLogDeduplications = new();
 
-    // Last resource version seen for each DCP object, keyed by (object kind, object name). Used to
-    // recognize and drop watch replays. See ProcessResourceChange.
-    private readonly ConcurrentDictionary<(string Kind, string Name), string?> _resourceVersions = new();
+    // Last identity and resource version seen for each DCP object, keyed by (object kind, object name).
+    // The stable key avoids retaining stale entries when a delete is missed, while the UID distinguishes
+    // a recreated object from an unchanged watch replay. See ProcessResourceChange.
+    private readonly ConcurrentDictionary<(string Kind, string Name), ObservedResource> _observedResources = new();
 
-    // Holds names of resources that reached terminal state and logs have already been flushed for them. 
+    // Holds names of resources that reached terminal state and logs have already been flushed for them.
     // Prevents re-reading DCP's log store every time an already-terminal resource is reported again.
-    // Point-in-time FailedToStart reads and incomplete attempts are intentionally not recorded so a later terminal
-    // notification can retry them.
+    // Point-in-time FailedToStart reads and incomplete attempts are intentionally not recorded so a later changed
+    // terminal notification can retry them. Unchanged watch replays are suppressed before reaching this path.
     private readonly ConcurrentDictionary<string, bool> _allLogsFlushed = new();
     private Task? _resourceWatchTask;
 
@@ -249,8 +250,14 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
     private async Task ProcessResourceChange<T>(WatchEventType watchEventType, T resource, ConcurrentDictionary<string, T> resourceByName, string resourceKind, Func<T, CustomResourceSnapshot, CustomResourceSnapshot> snapshotFactory) where T : CustomResource, IKubernetesStaticMetadata
     {
-        if (ProcessResourceChange(resourceByName, watchEventType, resource))
+        var resourceChange = ProcessResourceChange(resourceByName, watchEventType, resource);
+        if (resourceChange != ResourceChangeResult.Ignored)
         {
+            if (resourceChange is ResourceChangeResult.Deleted or ResourceChangeResult.Replaced)
+            {
+                ResetResourceLogState(resource.Metadata.Name);
+            }
+
             UpdateAssociatedServicesMap();
 
             var changeType = watchEventType switch
@@ -268,15 +275,6 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             {
                 if (changeType == ResourceSnapshotChangeType.Delete)
                 {
-                    // Stop the log stream for the resource
-                    if (_logStreams.TryRemove(resource.Metadata.Name, out var logStream))
-                    {
-                        logStream.Cancellation.Cancel();
-                    }
-
-                    _pendingFollowLogDeduplications.TryRemove(resource.Metadata.Name, out _);
-                    _allLogsFlushed.TryRemove(resource.Metadata.Name, out _);
-
                     // TODO: Handle resource deletion
                     if (_logger.IsEnabled(LogLevel.Trace))
                     {
@@ -303,13 +301,14 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     //
                     // Only do this when a subscriber is active. Without subscribers there is no caller
                     // depending on the ordering, and GetAllAsync can still query DCP's external log
-                    // store later without this extra read on every terminal transition.
+                    // store later without this extra read on every terminal transition. If a subscriber
+                    // attaches later, the subscriber information path starts the normal DCP follow stream.
                     //
                     // A successfully completed follow stream needs to run only once per terminal period.
                     // The flush is awaited while holding the watcher's single output semaphore, so repeating
-                    // a completed flush would stall all resource watches. Point-in-time FailedToStart reads
-                    // and incomplete attempts remain retryable because they cannot guarantee all logs were read.
-                    // The marker is cleared below if the resource is restarted.
+                    // a completed flush would stall all resource watches. A later changed terminal notification
+                    // can retry point-in-time FailedToStart reads and incomplete attempts because they are not
+                    // recorded as complete. The marker is cleared below if the resource is restarted.
                     if (status.State is not null && KnownResourceStates.TerminalStates.Contains(status.State))
                     {
                         if (HasLogsAvailable(resource) &&
@@ -366,6 +365,17 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         }
     }
 
+    private void ResetResourceLogState(string resourceName)
+    {
+        if (_logStreams.TryRemove(resourceName, out var logStream))
+        {
+            logStream.Cancellation.Cancel();
+        }
+
+        _pendingFollowLogDeduplications.TryRemove(resourceName, out _);
+        _allLogsFlushed.TryRemove(resourceName, out _);
+    }
+
     private async Task<bool> FlushCurrentLogsAsync<T>(T resource, ResourceStatus status, CancellationToken cancellationToken)
         where T : CustomResource, IKubernetesStaticMetadata
     {
@@ -390,8 +400,8 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             //
             // FailedToStart is different: the process never starts, so there may be no completing
             // process log stream to follow. Use a current snapshot there to avoid blocking terminal
-            // state publication indefinitely. A later resource notification retries the snapshot
-            // because, unlike a completed follow stream, it cannot prove all logs were drained.
+            // state publication indefinitely. A later changed terminal notification retries the
+            // snapshot because, unlike a completed follow stream, it cannot prove all logs were drained.
             var logSource = new ResourceLogSource<T>(_logger, _kubernetesService, resource, follow: follow);
 
             // Treat the flush as best-effort: logs collected before the timeout are still forwarded
@@ -426,7 +436,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         // These logs came from DCP's external log store, not in-process ILogger. Do not store
         // them as in-memory entries; otherwise GetAllAsync would replay them before querying
         // the same DCP log source again.
-        SetPendingFollowLogDeduplication(resource.Metadata.Name, logEntries);
+        SetPendingFollowLogDeduplication(resource.Metadata.Name, resource.Metadata.Uid, logEntries);
         _loggerService.AddLogEntries(resource.Metadata.Name, logEntries, inMemorySource: false, skipExisting: true);
 
         // Only normal completion of a follow stream proves DCP has no more logs to deliver.
@@ -556,6 +566,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         _logStreams.GetOrAdd(resource.Metadata.Name, resourceName =>
         {
             var cancellation = new CancellationTokenSource();
+            var resourceUid = resource.Metadata.Uid;
 
             var task = Task.Run(async () =>
             {
@@ -569,7 +580,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                     await foreach (var batch in enumerable.WithCancellation(cancellation.Token).ConfigureAwait(false))
                     {
                         var logEntries = CreateLogEntries(batch).ToList();
-                        logEntries = DeduplicateFollowBatch(resourceName, logEntries);
+                        logEntries = DeduplicateFollowBatch(resourceName, resourceUid, logEntries);
                         _loggerService.AddLogEntries(resourceName, logEntries, inMemorySource: false, skipExisting: false);
                     }
                 }
@@ -589,7 +600,11 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                 }
                 finally
                 {
-                    _pendingFollowLogDeduplications.TryRemove(resourceName, out _);
+                    if (_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) &&
+                        HasSameResourceIdentity(pendingDeduplication.ResourceUid, resourceUid))
+                    {
+                        RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
+                    }
                 }
             },
             cancellation.Token);
@@ -598,11 +613,16 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         });
     }
 
-    private void SetPendingFollowLogDeduplication(string resourceName, IReadOnlyList<LogEntry> flushedLogEntries)
+    private void SetPendingFollowLogDeduplication(string resourceName, string? resourceUid, IReadOnlyList<LogEntry> flushedLogEntries)
     {
         if (flushedLogEntries.Count == 0)
         {
-            _pendingFollowLogDeduplications.TryRemove(resourceName, out _);
+            if (_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) &&
+                HasSameResourceIdentity(pendingDeduplication.ResourceUid, resourceUid))
+            {
+                RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
+            }
+
             return;
         }
 
@@ -628,12 +648,13 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             }
         }
 
-        _pendingFollowLogDeduplications[resourceName] = new(counts, latestTimestamp, remainingCount);
+        _pendingFollowLogDeduplications[resourceName] = new(resourceUid, counts, latestTimestamp, remainingCount);
     }
 
-    private List<LogEntry> DeduplicateFollowBatch(string resourceName, List<LogEntry> logEntries)
+    private List<LogEntry> DeduplicateFollowBatch(string resourceName, string? resourceUid, List<LogEntry> logEntries)
     {
-        if (!_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication))
+        if (!_pendingFollowLogDeduplications.TryGetValue(resourceName, out var pendingDeduplication) ||
+            !HasSameResourceIdentity(pendingDeduplication.ResourceUid, resourceUid))
         {
             return logEntries;
         }
@@ -667,15 +688,23 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
             pendingDeduplication.RemainingCount == 0 ||
             logEntries.Any(entry => entry.Timestamp is null || entry.Timestamp > pendingDeduplication.LatestTimestamp.Value))
         {
-            _pendingFollowLogDeduplications.TryRemove(resourceName, out _);
+            RemovePendingFollowLogDeduplication(resourceName, pendingDeduplication);
         }
 
         return addedEntries ?? [];
     }
 
+    private void RemovePendingFollowLogDeduplication(string resourceName, PendingFollowLogDeduplication pendingDeduplication)
+    {
+        // Remove only the state observed by this stream. A canceled stream from a previous object
+        // incarnation can finish after its replacement has already installed new deduplication state.
+        ((ICollection<KeyValuePair<string, PendingFollowLogDeduplication>>)_pendingFollowLogDeduplications)
+            .Remove(new(resourceName, pendingDeduplication));
+    }
+
     private async Task ProcessEndpointChange(WatchEventType watchEventType, Endpoint endpoint)
     {
-        if (!ProcessResourceChange(_resourceState.EndpointsMap, watchEventType, endpoint))
+        if (ProcessResourceChange(_resourceState.EndpointsMap, watchEventType, endpoint) == ResourceChangeResult.Ignored)
         {
             return;
         }
@@ -693,7 +722,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
 
     private async Task ProcessServiceChange(WatchEventType watchEventType, Service service)
     {
-        if (!ProcessResourceChange(_resourceState.ServicesMap, watchEventType, service))
+        if (ProcessResourceChange(_resourceState.ServicesMap, watchEventType, service) == ResourceChangeResult.Ignored)
         {
             return;
         }
@@ -747,7 +776,7 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
         }
     }
 
-    private bool ProcessResourceChange<T>(ConcurrentDictionary<string, T> map, WatchEventType watchEventType, T resource)
+    private ResourceChangeResult ProcessResourceChange<T>(ConcurrentDictionary<string, T> map, WatchEventType watchEventType, T resource)
             where T : CustomResource, IKubernetesStaticMetadata
     {
         var resourceKey = (T.ObjectKind, resource.Metadata.Name);
@@ -769,48 +798,79 @@ internal sealed class DcpResourceWatcher : IConsoleLogsService, IAsyncDisposable
                 // whenever the stored object changes and leaves it alone otherwise, so a replay of an
                 // unchanged object carries the version we have already seen.
                 // https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions
+                //
+                // A delete can occur while the watch is disconnected, so the replacement Added event
+                // can arrive without a preceding Deleted event. Kubernetes UIDs identify object
+                // incarnations and let that replacement through even if its opaque resource version
+                // happens to equal the value recorded for the previous object.
+                // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                var resourceUid = resource.Metadata.Uid;
                 var resourceVersion = resource.Metadata.ResourceVersion;
+                var hasPreviousObservation = _observedResources.TryGetValue(resourceKey, out var previousObservation);
+                var isSameResource = !hasPreviousObservation || HasSameResourceIdentity(previousObservation.Uid, resourceUid);
 
                 // The value is opaque, so it is only compared for equality; ordering is explicitly not defined. 
                 // An empty value means the server did not supply one, which is treated as "cannot tell", 
                 // so the event is processed rather than risk suppressing a real change.
-                if (!string.IsNullOrEmpty(resourceVersion) &&
-                    _resourceVersions.TryGetValue(resourceKey, out var previousResourceVersion) &&
-                    string.Equals(previousResourceVersion, resourceVersion, StringComparison.Ordinal))
+                if (isSameResource &&
+                    !string.IsNullOrEmpty(resourceVersion) &&
+                    string.Equals(previousObservation.ResourceVersion, resourceVersion, StringComparison.Ordinal))
                 {
                     if (_logger.IsEnabled(LogLevel.Trace))
                     {
                         _logger.LogTrace("Ignoring {ResourceKind} resource {ResourceName} reported by the DCP watch because its resource version {ResourceVersion} is unchanged.", T.ObjectKind, resource.Metadata.Name, resourceVersion);
                     }
 
-                    return false;
+                    return ResourceChangeResult.Ignored;
                 }
+
+                var isReplacement = hasPreviousObservation &&
+                    !string.IsNullOrEmpty(previousObservation.Uid) &&
+                    !string.IsNullOrEmpty(resourceUid) &&
+                    !isSameResource;
 
                 // Added is treated like Modified rather than using TryAdd. A watch restart replays
                 // existing objects as Added, and if such an object changed while the watch was down,
                 // keeping the stale instance would leave the map disagreeing with both the version
                 // recorded here and the snapshot published to subscribers.
-                _resourceVersions[resourceKey] = resourceVersion;
+                _observedResources[resourceKey] = new(resourceUid, resourceVersion);
                 map[resource.Metadata.Name] = resource;
-                break;
+                return isReplacement ? ResourceChangeResult.Replaced : ResourceChangeResult.Updated;
 
             case WatchEventType.Deleted:
-                _resourceVersions.TryRemove(resourceKey, out _);
+                _observedResources.TryRemove(resourceKey, out _);
                 map.Remove(resource.Metadata.Name, out _);
-                break;
+                return ResourceChangeResult.Deleted;
 
             default:
-                return false;
+                return ResourceChangeResult.Ignored;
         }
+    }
 
-        return true;
+    private static bool HasSameResourceIdentity(string? previousUid, string? resourceUid)
+    {
+        return string.Equals(previousUid, resourceUid, StringComparison.Ordinal) ||
+            (string.IsNullOrEmpty(previousUid) && string.IsNullOrEmpty(resourceUid));
+    }
+
+    private readonly record struct ObservedResource(string? Uid, string? ResourceVersion);
+
+    private enum ResourceChangeResult
+    {
+        Ignored,
+        Updated,
+        Replaced,
+        Deleted
     }
 
     private sealed class PendingFollowLogDeduplication(
+        string? resourceUid,
         Dictionary<LogEntryKey, int> counts,
         DateTime? latestTimestamp,
         int remainingCount)
     {
+        public string? ResourceUid { get; } = resourceUid;
+
         public Dictionary<LogEntryKey, int> Counts { get; } = counts;
 
         public DateTime? LatestTimestamp { get; } = latestTimestamp;

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1461,6 +1461,82 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceLogging_LateSubscriberReceivesFailedToStartLogsWithoutWatchReplay()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        const string failedToStartLogMessage = "failure discovered after the terminal notification";
+        var followStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (obj is Container { Status.State: ContainerState.FailedToStart } &&
+                logStreamType == Logs.StreamTypeStdErr &&
+                follow == true)
+            {
+                followStreamStarted.TrySetResult();
+                return new MemoryStream(Encoding.UTF8.GetBytes(
+                    "2024-08-19T06:10:33.473275911Z " + failedToStartLogMessage + Environment.NewLine));
+            }
+
+            return new MemoryStream();
+        });
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resourceLoggerService = new ResourceLoggerService();
+        var terminalNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        string? dcpResourceName = null;
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.DcpResourceName == dcpResourceName &&
+                context.Status.State == ContainerState.FailedToStart)
+            {
+                terminalNotification.TrySetResult();
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            kubernetesService: kubernetesService,
+            resourceLoggerService: resourceLoggerService,
+            events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        dcpResourceName = container.Metadata.Name;
+
+        container.Status = new ContainerStatus { State = ContainerState.FailedToStart };
+        kubernetesService.PushResourceModified(container);
+
+        await terminalNotification.Task.DefaultTimeout();
+        Assert.False(followStreamStarted.Task.IsCompleted, "A terminal log stream should not start without a subscriber.");
+
+        var logLines = new ConcurrentQueue<LogLine>();
+        using var subscription = resourceLoggerService.Subscribe(dcpResourceName, batch =>
+        {
+            foreach (var logLine in batch)
+            {
+                logLines.Enqueue(logLine);
+            }
+        });
+
+        await followStreamStarted.Task.DefaultTimeout();
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => logLines.Any(line => line.Content.Contains(failedToStartLogMessage, StringComparison.Ordinal)),
+            "The subscriber-driven follow stream should deliver logs without a watch replay.");
+
+        Assert.Single(logLines, line => line.Content.Contains(failedToStartLogMessage, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ResourceLogging_TerminalStateFollowsLogsBeforeNotification()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
@@ -1798,6 +1874,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         await appExecutor.RunApplicationAsync().DefaultTimeout();
 
         var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        container.Metadata.Uid = "database-instance";
 
         container.Status = new ContainerStatus { State = ContainerState.Running };
         kubernetesService.PushResourceModified(container);
@@ -1806,8 +1883,8 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             () => observedStates.Contains(ContainerState.Running),
             "The state change to Running should be reported.");
 
-        // Re-delivering the resource without a new resource version means nothing was stored, so it
-        // does not describe a change no matter which event type carries it.
+        // Re-delivering the same resource UID without a new resource version means nothing was stored,
+        // so it does not describe a change no matter which event type carries it.
         kubernetesService.PushResourceUnchanged(container);
         kubernetesService.PushResourceUnchanged(container, k8s.WatchEventType.Added);
 
@@ -1874,6 +1951,93 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             "The recreated resource should be reported even when its resource version was seen before deletion.");
 
         AssertStatesReportedAfter(observedStates, ContainerState.Running, ContainerState.Exited);
+    }
+
+    [Fact]
+    public async Task ResourceWatch_RecreatedResourceAfterMissedDeleteIsProcessedAndResetsLogState()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        var normalStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var terminalFollowStreamOpens = 0;
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (obj is Container { Status.State: ContainerState.Running } &&
+                logStreamType == Logs.StreamTypeSystem &&
+                follow == true)
+            {
+                normalStreamStarted.TrySetResult();
+            }
+
+            if (obj is Container { Status.State: ContainerState.Exited } &&
+                logStreamType == Logs.StreamTypeSystem &&
+                follow == true)
+            {
+                Interlocked.Increment(ref terminalFollowStreamOpens);
+            }
+
+            return new MemoryStream();
+        });
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resourceLoggerService = new ResourceLoggerService();
+        var flushesAtNotification = new ConcurrentQueue<int>();
+        string? dcpResourceName = null;
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.DcpResourceName == dcpResourceName &&
+                context.Status.State == ContainerState.Exited)
+            {
+                flushesAtNotification.Enqueue(Volatile.Read(ref terminalFollowStreamOpens));
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            kubernetesService: kubernetesService,
+            resourceLoggerService: resourceLoggerService,
+            events: events);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        dcpResourceName = container.Metadata.Name;
+        container.Metadata.Uid = "database-instance-1";
+
+        using var subscription = resourceLoggerService.Subscribe(dcpResourceName, _ => { });
+
+        container.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(container);
+        await normalStreamStarted.Task.DefaultTimeout();
+
+        container.Status = new ContainerStatus { State = ContainerState.Exited };
+        kubernetesService.PushResourceModified(container);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => !flushesAtNotification.IsEmpty,
+            "The first resource incarnation should report its terminal state.");
+
+        // Simulate a delete and recreation that happened while the watch was disconnected. The fresh
+        // list-and-watch reports only Added for the new UID, and resourceVersion is opaque enough that
+        // it can equal the value last observed for the previous object.
+        container.Metadata.Uid = "database-instance-2";
+        container.Status = new ContainerStatus { State = ContainerState.Exited, ExitCode = 1 };
+        kubernetesService.PushResourceUnchanged(container, k8s.WatchEventType.Added);
+
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => flushesAtNotification.Count >= 2,
+            "The replacement resource should be processed even though no delete event was observed.");
+
+        Assert.Equal([1, 2], flushesAtNotification.ToArray());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1791,7 +1791,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ResourceLogging_CompletedFollowStreamIsDisposedAndCanRestart()
+    public async Task ResourceLogging_CompletedFollowStreamIsRemovedAndCanRestartWithExistingSubscriber()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
         {
@@ -1800,21 +1800,24 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         builder.AddContainer("database", "image");
 
+        const string restartedLogMessage = "log after restart";
+        var restartedLogLine = "2024-08-19T06:10:33.473275911Z " + restartedLogMessage + Environment.NewLine;
         var firstFollowStream = new GatedReadStream();
         var secondFollowStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var systemFollowStreamCount = 0;
+        var stdoutFollowStreamCount = 0;
         var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
         {
             if (obj is Container { Status.State: ContainerState.Running } &&
-                logStreamType == Logs.StreamTypeSystem &&
+                logStreamType == Logs.StreamTypeStdOut &&
                 follow == true)
             {
-                if (Interlocked.Increment(ref systemFollowStreamCount) == 1)
+                if (Interlocked.Increment(ref stdoutFollowStreamCount) == 1)
                 {
                     return firstFollowStream;
                 }
 
                 secondFollowStreamStarted.TrySetResult();
+                return new MemoryStream(Encoding.UTF8.GetBytes(restartedLogLine));
             }
 
             return new MemoryStream();
@@ -1822,6 +1825,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
         var resourceLoggerService = new ResourceLoggerService();
+        var logLines = new ConcurrentQueue<LogLine>();
         var appExecutor = CreateAppExecutor(
             distributedAppModel,
             kubernetesService: kubernetesService,
@@ -1829,7 +1833,13 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         await appExecutor.RunApplicationAsync().DefaultTimeout();
 
         var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
-        IDisposable? firstSubscription = resourceLoggerService.Subscribe(container.Metadata.Name, _ => { });
+        using var subscription = resourceLoggerService.Subscribe(container.Metadata.Name, batch =>
+        {
+            foreach (var logLine in batch)
+            {
+                logLines.Enqueue(logLine);
+            }
+        });
 
         try
         {
@@ -1845,20 +1855,20 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
             firstFollowStream.Release();
             await firstLogStreamTask.DefaultTimeout();
-            Assert.True(appExecutor.ResourceWatcher.IsLogStreamDisposed(container.Metadata.Name));
+            Assert.Null(appExecutor.ResourceWatcher.GetLogStreamTask(container.Metadata.Name));
 
-            firstSubscription.Dispose();
-            firstSubscription = null;
-
-            using var secondSubscription = resourceLoggerService.Subscribe(container.Metadata.Name, _ => { });
+            kubernetesService.PushResourceModified(container);
             await secondFollowStreamStarted.Task.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => logLines.Any(line => line.Content.Contains(restartedLogMessage, StringComparison.Ordinal)),
+                "The follow stream started after the restart should deliver logs to the existing subscriber.");
 
-            Assert.Equal(2, Volatile.Read(ref systemFollowStreamCount));
+            Assert.Equal(2, Volatile.Read(ref stdoutFollowStreamCount));
+            Assert.Single(logLines, line => line.Content.Contains(restartedLogMessage, StringComparison.Ordinal));
         }
         finally
         {
             firstFollowStream.TryRelease();
-            firstSubscription?.Dispose();
         }
     }
 
@@ -1996,6 +2006,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             previousFollowStream.Release();
             logger.Release();
             await previousLogStreamTask.DefaultTimeout();
+            Assert.Same(currentLogStreamTask, appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName));
 
             currentFollowStream.Release(secondTerminalLogLine);
             await currentLogStreamTask.DefaultTimeout();

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -2205,15 +2205,18 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         builder.AddContainer("database", "image");
 
+        const string previousLateLogMessage = "late log from previous resource";
         const string replacementLogMessage = "replacement terminal log";
+        var previousLateLogLine = "2024-08-19T06:10:32.473275911Z " + previousLateLogMessage + Environment.NewLine;
         var replacementLogLine = "2024-08-19T06:10:33.473275911Z " + replacementLogMessage + Environment.NewLine;
         var previousFollowStream = new GatedReadStream();
         var replacementFollowStream = new GatedReadStream();
+        var previousBatchReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePreviousBatch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var replacementFollowStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var replacementStdErrFollowStreams = 0;
         string? previousResourceUid = null;
         string? replacementResourceUid = null;
-        var logger = new GatedLogger<DcpExecutor>("was cancelled.");
 
         var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
         {
@@ -2266,8 +2269,15 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             distributedAppModel,
             kubernetesService: kubernetesService,
             resourceLoggerService: resourceLoggerService,
-            events: events,
-            logger: logger);
+            events: events);
+        appExecutor.ResourceWatcher.BeforeLogBatchDeliveryAsync = async resourceUid =>
+        {
+            if (resourceUid == previousResourceUid)
+            {
+                previousBatchReady.TrySetResult();
+                await releasePreviousBatch.Task.ConfigureAwait(false);
+            }
+        };
         await appExecutor.RunApplicationAsync().DefaultTimeout();
 
         var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
@@ -2301,6 +2311,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
                 () => Volatile.Read(ref terminalNotifications) >= 1,
                 "The first resource incarnation should report its terminal state.");
 
+            // Pause after the old stream has yielded a batch to DcpResourceWatcher. Cancellation can stop
+            // future reads, but it cannot revoke a batch that the outer await-foreach loop already received.
+            previousFollowStream.Release(previousLateLogLine);
+            await previousBatchReady.Task.DefaultTimeout();
+
             // Simulate a delete and recreation that happened while the watch was disconnected. The fresh
             // list-and-watch reports only Added for the new UID, and resourceVersion is opaque enough that
             // it can equal the value last observed for the previous object.
@@ -2309,7 +2324,6 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             container.Status = new ContainerStatus { State = ContainerState.Exited, ExitCode = 1 };
             kubernetesService.PushResourceUnchanged(container, k8s.WatchEventType.Added);
 
-            await logger.Blocked.DefaultTimeout();
             await AsyncTestHelpers.AssertIsTrueRetryAsync(
                 () => Volatile.Read(ref terminalNotifications) >= 2,
                 "The replacement resource should be processed even though no delete event was observed.");
@@ -2319,24 +2333,27 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
                 "The replacement resource should start a new log stream.");
             var replacementLogStreamTask = appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName);
             Assert.NotNull(replacementLogStreamTask);
-
             Assert.Single(logLines, line => line.Content.Contains(replacementLogMessage, StringComparison.Ordinal));
 
-            // Let the canceled stream finish only after the replacement flush has installed its pending
-            // deduplication state. Its cleanup must not remove state owned by the replacement UID.
-            previousFollowStream.Release();
-            logger.Release();
+            // Let the old batch continue only after the replacement stream has installed its pending
+            // deduplication state. It must neither publish under the replacement's name nor remove that state.
+            releasePreviousBatch.TrySetResult();
             await previousLogStreamTask.DefaultTimeout();
 
             replacementFollowStream.Release(replacementLogLine);
             await replacementLogStreamTask.DefaultTimeout();
 
             Assert.Equal(2, Volatile.Read(ref replacementStdErrFollowStreams));
-            Assert.Single(logLines, line => line.Content.Contains(replacementLogMessage, StringComparison.Ordinal));
+            Assert.Collection(
+                logLines.Where(line =>
+                    line.Content.Contains(previousLateLogMessage, StringComparison.Ordinal) ||
+                    line.Content.Contains(replacementLogMessage, StringComparison.Ordinal)),
+                line => Assert.Contains(replacementLogMessage, line.Content, StringComparison.Ordinal));
         }
         finally
         {
-            logger.Release();
+            appExecutor.ResourceWatcher.BeforeLogBatchDeliveryAsync = null;
+            releasePreviousBatch.TrySetResult();
             previousFollowStream.TryRelease();
             replacementFollowStream.TryRelease();
         }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1537,6 +1537,88 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceLogging_ActiveSubscriberReceivesFailedToStartLogsAfterSnapshot()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        const string failedToStartLogMessage = "failure discovered after the point-in-time snapshot";
+        var runningFollowStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failedToStartSnapshotStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failedToStartFollowStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failedToStartFollowStreamCount = 0;
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (obj is Container { Status.State: ContainerState.Running } &&
+                logStreamType == Logs.StreamTypeSystem &&
+                follow == true)
+            {
+                runningFollowStreamStarted.TrySetResult();
+            }
+
+            if (obj is Container { Status.State: ContainerState.FailedToStart } &&
+                logStreamType == Logs.StreamTypeStdErr)
+            {
+                if (follow == false)
+                {
+                    failedToStartSnapshotStarted.TrySetResult();
+                }
+                else if (follow == true)
+                {
+                    Interlocked.Increment(ref failedToStartFollowStreamCount);
+                    failedToStartFollowStreamStarted.TrySetResult();
+                    return new MemoryStream(Encoding.UTF8.GetBytes(
+                        "2024-08-19T06:10:33.473275911Z " + failedToStartLogMessage + Environment.NewLine));
+                }
+            }
+
+            return new MemoryStream();
+        });
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resourceLoggerService = new ResourceLoggerService();
+        var logLines = new ConcurrentQueue<LogLine>();
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            kubernetesService: kubernetesService,
+            resourceLoggerService: resourceLoggerService);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        using var subscription = resourceLoggerService.Subscribe(container.Metadata.Name, batch =>
+        {
+            foreach (var logLine in batch)
+            {
+                logLines.Enqueue(logLine);
+            }
+        });
+
+        container.Status = new ContainerStatus { State = ContainerState.Running };
+        kubernetesService.PushResourceModified(container);
+
+        await runningFollowStreamStarted.Task.DefaultTimeout();
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => appExecutor.ResourceWatcher.GetLogStreamTask(container.Metadata.Name) is null,
+            "The initial follow stream should complete before the terminal transition.");
+
+        container.Status = new ContainerStatus { State = ContainerState.FailedToStart };
+        kubernetesService.PushResourceModified(container);
+
+        await failedToStartSnapshotStarted.Task.DefaultTimeout();
+        await failedToStartFollowStreamStarted.Task.DefaultTimeout();
+        await AsyncTestHelpers.AssertIsTrueRetryAsync(
+            () => logLines.Any(line => line.Content.Contains(failedToStartLogMessage, StringComparison.Ordinal)),
+            "The normal follow stream should deliver logs after the point-in-time snapshot.");
+
+        Assert.Equal(1, Volatile.Read(ref failedToStartFollowStreamCount));
+        Assert.Single(logLines, line => line.Content.Contains(failedToStartLogMessage, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ResourceLogging_TerminalStateFollowsLogsBeforeNotification()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
@@ -1624,7 +1706,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         string? blockingDcpResourceName = null;
         var normalStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var blockingFlushAttempts = 0;
+        var blockingTerminalFollowStreamCount = 0;
         var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
         {
             if (obj.Metadata.Name == blockingDcpResourceName &&
@@ -1641,7 +1723,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
                 logStreamType == Logs.StreamTypeStdErr &&
                 follow == true)
             {
-                if (Interlocked.Increment(ref blockingFlushAttempts) == 1)
+                if (Interlocked.Increment(ref blockingTerminalFollowStreamCount) == 1)
                 {
                     return new Pipe().Reader.AsStream();
                 }
@@ -1705,7 +1787,96 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             "The terminal state change after a timed-out flush should be reported.");
 
         Assert.Equal(2, Volatile.Read(ref blockingTerminalNotifications));
-        Assert.Equal(2, Volatile.Read(ref blockingFlushAttempts));
+        // The first terminal event opens the timed-out flush and its recovery stream. The changed
+        // terminal event then retries the flush because the first one was not recorded as complete.
+        Assert.Equal(3, Volatile.Read(ref blockingTerminalFollowStreamCount));
+    }
+
+    [Fact]
+    public async Task ResourceLogging_ActiveSubscriberContinuesAfterTerminalFlushTimeout()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        const string terminalLogMessage = "log delivered after terminal flush timeout";
+        var timedOutFlushPipe = new Pipe();
+        var runningFollowStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var terminalFollowStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var terminalStdErrFollowStreamCount = 0;
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (obj is Container { Status.State: ContainerState.Running } &&
+                logStreamType == Logs.StreamTypeSystem &&
+                follow == true)
+            {
+                runningFollowStreamStarted.TrySetResult();
+            }
+
+            if (obj is Container { Status.State: ContainerState.Exited } &&
+                logStreamType == Logs.StreamTypeStdErr &&
+                follow == true)
+            {
+                if (Interlocked.Increment(ref terminalStdErrFollowStreamCount) == 1)
+                {
+                    return timedOutFlushPipe.Reader.AsStream();
+                }
+
+                terminalFollowStreamStarted.TrySetResult();
+                return new MemoryStream(Encoding.UTF8.GetBytes(
+                    "2024-08-19T06:10:33.473275911Z " + terminalLogMessage + Environment.NewLine));
+            }
+
+            return new MemoryStream();
+        });
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resourceLoggerService = new ResourceLoggerService();
+        var logLines = new ConcurrentQueue<LogLine>();
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            kubernetesService: kubernetesService,
+            resourceLoggerService: resourceLoggerService);
+        appExecutor.ResourceWatcher.TerminalLogFlushTimeout = TimeSpan.FromMilliseconds(100);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        using var subscription = resourceLoggerService.Subscribe(container.Metadata.Name, batch =>
+        {
+            foreach (var logLine in batch)
+            {
+                logLines.Enqueue(logLine);
+            }
+        });
+
+        try
+        {
+            container.Status = new ContainerStatus { State = ContainerState.Running };
+            kubernetesService.PushResourceModified(container);
+
+            await runningFollowStreamStarted.Task.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => appExecutor.ResourceWatcher.GetLogStreamTask(container.Metadata.Name) is null,
+                "The initial follow stream should complete before the terminal transition.");
+
+            container.Status = new ContainerStatus { State = ContainerState.Exited };
+            kubernetesService.PushResourceModified(container);
+
+            await terminalFollowStreamStarted.Task.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => logLines.Any(line => line.Content.Contains(terminalLogMessage, StringComparison.Ordinal)),
+                "The normal follow stream should deliver logs after the terminal flush times out.");
+
+            Assert.Equal(2, Volatile.Read(ref terminalStdErrFollowStreamCount));
+            Assert.Single(logLines, line => line.Content.Contains(terminalLogMessage, StringComparison.Ordinal));
+        }
+        finally
+        {
+            timedOutFlushPipe.Writer.Complete();
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1791,6 +1791,237 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResourceLogging_CompletedFollowStreamIsDisposedAndCanRestart()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        var firstFollowStream = new GatedReadStream();
+        var secondFollowStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var systemFollowStreamCount = 0;
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (obj is Container { Status.State: ContainerState.Running } &&
+                logStreamType == Logs.StreamTypeSystem &&
+                follow == true)
+            {
+                if (Interlocked.Increment(ref systemFollowStreamCount) == 1)
+                {
+                    return firstFollowStream;
+                }
+
+                secondFollowStreamStarted.TrySetResult();
+            }
+
+            return new MemoryStream();
+        });
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resourceLoggerService = new ResourceLoggerService();
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            kubernetesService: kubernetesService,
+            resourceLoggerService: resourceLoggerService);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        IDisposable? firstSubscription = resourceLoggerService.Subscribe(container.Metadata.Name, _ => { });
+
+        try
+        {
+            container.Status = new ContainerStatus { State = ContainerState.Running };
+            kubernetesService.PushResourceModified(container);
+
+            await firstFollowStream.ReadStarted.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => appExecutor.ResourceWatcher.GetLogStreamTask(container.Metadata.Name) is not null,
+                "The first subscription should start a log stream.");
+            var firstLogStreamTask = appExecutor.ResourceWatcher.GetLogStreamTask(container.Metadata.Name);
+            Assert.NotNull(firstLogStreamTask);
+
+            firstFollowStream.Release();
+            await firstLogStreamTask.DefaultTimeout();
+            Assert.True(appExecutor.ResourceWatcher.IsLogStreamDisposed(container.Metadata.Name));
+
+            firstSubscription.Dispose();
+            firstSubscription = null;
+
+            using var secondSubscription = resourceLoggerService.Subscribe(container.Metadata.Name, _ => { });
+            await secondFollowStreamStarted.Task.DefaultTimeout();
+
+            Assert.Equal(2, Volatile.Read(ref systemFollowStreamCount));
+        }
+        finally
+        {
+            firstFollowStream.TryRelease();
+            firstSubscription?.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ResourceLogging_OverlappingSameUidStreamCannotClearNewDeduplicationState()
+    {
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            AssemblyName = typeof(DistributedApplicationTests).Assembly.FullName
+        });
+
+        builder.AddContainer("database", "image");
+
+        const string firstTerminalLogMessage = "first terminal period";
+        const string secondTerminalLogMessage = "second terminal period";
+        var firstTerminalLogLine = "2024-08-19T06:10:33.473275911Z " + firstTerminalLogMessage + Environment.NewLine;
+        var secondTerminalLogLine = "2024-08-19T06:10:34.473275911Z " + secondTerminalLogMessage + Environment.NewLine;
+        var previousFollowStream = new GatedReadStream();
+        var currentFollowStream = new GatedReadStream();
+        var logger = new GatedLogger<DcpExecutor>("was cancelled.");
+        var runningFollowStreams = 0;
+        var terminalFlushes = 0;
+
+        var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
+        {
+            if (obj is Container container &&
+                logStreamType == Logs.StreamTypeStdErr &&
+                follow == true)
+            {
+                if (container.Status?.State == ContainerState.Running)
+                {
+                    return Interlocked.Increment(ref runningFollowStreams) == 1
+                        ? previousFollowStream
+                        : currentFollowStream;
+                }
+
+                if (container.Status?.State == ContainerState.Exited)
+                {
+                    return new MemoryStream(Encoding.UTF8.GetBytes(
+                        Interlocked.Increment(ref terminalFlushes) == 1
+                            ? firstTerminalLogLine
+                            : secondTerminalLogLine));
+                }
+            }
+
+            return new MemoryStream();
+        });
+
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var resourceLoggerService = new ResourceLoggerService();
+        var logLines = new ConcurrentQueue<LogLine>();
+        var runningNotifications = 0;
+        var terminalNotifications = 0;
+        string? dcpResourceName = null;
+
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceChangedContext>(context =>
+        {
+            if (context.DcpResourceName == dcpResourceName)
+            {
+                if (context.Status.State == ContainerState.Running)
+                {
+                    Interlocked.Increment(ref runningNotifications);
+                }
+                else if (context.Status.State == ContainerState.Exited)
+                {
+                    Interlocked.Increment(ref terminalNotifications);
+                }
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            kubernetesService: kubernetesService,
+            resourceLoggerService: resourceLoggerService,
+            events: events,
+            logger: logger);
+        await appExecutor.RunApplicationAsync().DefaultTimeout();
+
+        var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
+        dcpResourceName = container.Metadata.Name;
+        Assert.False(string.IsNullOrEmpty(container.Metadata.Uid));
+
+        IDisposable? firstSubscription = resourceLoggerService.Subscribe(dcpResourceName, AddLogLines);
+        IDisposable? secondSubscription = null;
+
+        try
+        {
+            container.Status = new ContainerStatus { State = ContainerState.Running };
+            kubernetesService.PushResourceModified(container);
+            await previousFollowStream.ReadStarted.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName) is not null,
+                "The first terminal period should have an active follow stream.");
+            var previousLogStreamTask = appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName);
+            Assert.NotNull(previousLogStreamTask);
+
+            container.Status = new ContainerStatus { State = ContainerState.Exited };
+            kubernetesService.PushResourceModified(container);
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => Volatile.Read(ref terminalNotifications) >= 1,
+                "The first terminal period should be reported.");
+            Assert.Single(logLines, line => line.Content.Contains(firstTerminalLogMessage, StringComparison.Ordinal));
+
+            container.Status = new ContainerStatus { State = ContainerState.Running };
+            kubernetesService.PushResourceModified(container);
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => Volatile.Read(ref runningNotifications) >= 2,
+                "The restarted resource should be reported as running.");
+
+            firstSubscription.Dispose();
+            firstSubscription = null;
+            await logger.Blocked.DefaultTimeout();
+
+            secondSubscription = resourceLoggerService.Subscribe(dcpResourceName, AddLogLines);
+            await currentFollowStream.ReadStarted.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName) is { } task && task != previousLogStreamTask,
+                "The second subscription should start a new follow stream.");
+            var currentLogStreamTask = appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName);
+            Assert.NotNull(currentLogStreamTask);
+
+            container.Status = new ContainerStatus { State = ContainerState.Exited, ExitCode = 1 };
+            kubernetesService.PushResourceModified(container);
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => Volatile.Read(ref terminalNotifications) >= 2,
+                "The second terminal period should be reported.");
+            Assert.Single(logLines, line => line.Content.Contains(secondTerminalLogMessage, StringComparison.Ordinal));
+
+            // The canceled stream owns the first terminal period's deduplication state. Finishing it
+            // now must not clear the newer state installed for the same UID's second terminal period.
+            previousFollowStream.Release();
+            logger.Release();
+            await previousLogStreamTask.DefaultTimeout();
+
+            currentFollowStream.Release(secondTerminalLogLine);
+            await currentLogStreamTask.DefaultTimeout();
+
+            Assert.Equal(2, Volatile.Read(ref terminalFlushes));
+            Assert.Single(logLines, line => line.Content.Contains(secondTerminalLogMessage, StringComparison.Ordinal));
+        }
+        finally
+        {
+            logger.Release();
+            previousFollowStream.TryRelease();
+            currentFollowStream.TryRelease();
+            firstSubscription?.Dispose();
+            secondSubscription?.Dispose();
+        }
+
+        void AddLogLines(IReadOnlyList<LogLine> batch)
+        {
+            foreach (var logLine in batch)
+            {
+                logLines.Enqueue(logLine);
+            }
+        }
+    }
+
+    [Fact]
     public async Task ResourceWatch_ResourceWithoutResourceVersionIsAlwaysProcessed()
     {
         var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
@@ -1874,7 +2105,6 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         await appExecutor.RunApplicationAsync().DefaultTimeout();
 
         var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
-        container.Metadata.Uid = "database-instance";
 
         container.Status = new ContainerStatus { State = ContainerState.Running };
         kubernetesService.PushResourceModified(container);
@@ -1943,6 +2173,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         // observed for the previous object with the same kind and name. The Deleted event must clear
         // that version before the recreated object is delivered as Added.
         kubernetesService.PushResourceDeleted(container);
+        container.Metadata.Uid = "database-instance-2";
         container.Status = new ContainerStatus { State = ContainerState.Exited };
         kubernetesService.PushResourceUnchanged(container, k8s.WatchEventType.Added);
 
@@ -1963,22 +2194,39 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         builder.AddContainer("database", "image");
 
-        var normalStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var terminalFollowStreamOpens = 0;
+        const string replacementLogMessage = "replacement terminal log";
+        var replacementLogLine = "2024-08-19T06:10:33.473275911Z " + replacementLogMessage + Environment.NewLine;
+        var previousFollowStream = new GatedReadStream();
+        var replacementFollowStream = new GatedReadStream();
+        var replacementFollowStreamStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var replacementStdErrFollowStreams = 0;
+        string? previousResourceUid = null;
+        string? replacementResourceUid = null;
+        var logger = new GatedLogger<DcpExecutor>("was cancelled.");
+
         var kubernetesService = new TestKubernetesService(startStreamWithFollow: (obj, logStreamType, follow) =>
         {
-            if (obj is Container { Status.State: ContainerState.Running } &&
-                logStreamType == Logs.StreamTypeSystem &&
+            if (obj is Container container &&
+                logStreamType == Logs.StreamTypeStdErr &&
                 follow == true)
             {
-                normalStreamStarted.TrySetResult();
-            }
+                if (container.Metadata.Uid == previousResourceUid &&
+                    container.Status?.State == ContainerState.Running)
+                {
+                    return previousFollowStream;
+                }
 
-            if (obj is Container { Status.State: ContainerState.Exited } &&
-                logStreamType == Logs.StreamTypeSystem &&
-                follow == true)
-            {
-                Interlocked.Increment(ref terminalFollowStreamOpens);
+                if (container.Metadata.Uid == replacementResourceUid &&
+                    container.Status?.State == ContainerState.Exited)
+                {
+                    if (Interlocked.Increment(ref replacementStdErrFollowStreams) == 1)
+                    {
+                        return new MemoryStream(Encoding.UTF8.GetBytes(replacementLogLine));
+                    }
+
+                    replacementFollowStreamStarted.TrySetResult();
+                    return replacementFollowStream;
+                }
             }
 
             return new MemoryStream();
@@ -1987,7 +2235,8 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
         var resourceLoggerService = new ResourceLoggerService();
-        var flushesAtNotification = new ConcurrentQueue<int>();
+        var logLines = new ConcurrentQueue<LogLine>();
+        var terminalNotifications = 0;
         string? dcpResourceName = null;
 
         var events = new DcpExecutorEvents();
@@ -1996,7 +2245,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             if (context.DcpResourceName == dcpResourceName &&
                 context.Status.State == ContainerState.Exited)
             {
-                flushesAtNotification.Enqueue(Volatile.Read(ref terminalFollowStreamOpens));
+                Interlocked.Increment(ref terminalNotifications);
             }
 
             return Task.CompletedTask;
@@ -2006,38 +2255,80 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             distributedAppModel,
             kubernetesService: kubernetesService,
             resourceLoggerService: resourceLoggerService,
-            events: events);
+            events: events,
+            logger: logger);
         await appExecutor.RunApplicationAsync().DefaultTimeout();
 
         var container = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
         dcpResourceName = container.Metadata.Name;
-        container.Metadata.Uid = "database-instance-1";
+        previousResourceUid = container.Metadata.Uid;
+        Assert.False(string.IsNullOrEmpty(previousResourceUid));
 
-        using var subscription = resourceLoggerService.Subscribe(dcpResourceName, _ => { });
+        using var subscription = resourceLoggerService.Subscribe(dcpResourceName, batch =>
+        {
+            foreach (var logLine in batch)
+            {
+                logLines.Enqueue(logLine);
+            }
+        });
 
-        container.Status = new ContainerStatus { State = ContainerState.Running };
-        kubernetesService.PushResourceModified(container);
-        await normalStreamStarted.Task.DefaultTimeout();
+        try
+        {
+            container.Status = new ContainerStatus { State = ContainerState.Running };
+            kubernetesService.PushResourceModified(container);
+            await previousFollowStream.ReadStarted.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName) is not null,
+                "The first resource incarnation should have an active log stream.");
+            var previousLogStreamTask = appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName);
+            Assert.NotNull(previousLogStreamTask);
 
-        container.Status = new ContainerStatus { State = ContainerState.Exited };
-        kubernetesService.PushResourceModified(container);
+            container.Status = new ContainerStatus { State = ContainerState.Exited };
+            kubernetesService.PushResourceModified(container);
 
-        await AsyncTestHelpers.AssertIsTrueRetryAsync(
-            () => !flushesAtNotification.IsEmpty,
-            "The first resource incarnation should report its terminal state.");
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => Volatile.Read(ref terminalNotifications) >= 1,
+                "The first resource incarnation should report its terminal state.");
 
-        // Simulate a delete and recreation that happened while the watch was disconnected. The fresh
-        // list-and-watch reports only Added for the new UID, and resourceVersion is opaque enough that
-        // it can equal the value last observed for the previous object.
-        container.Metadata.Uid = "database-instance-2";
-        container.Status = new ContainerStatus { State = ContainerState.Exited, ExitCode = 1 };
-        kubernetesService.PushResourceUnchanged(container, k8s.WatchEventType.Added);
+            // Simulate a delete and recreation that happened while the watch was disconnected. The fresh
+            // list-and-watch reports only Added for the new UID, and resourceVersion is opaque enough that
+            // it can equal the value last observed for the previous object.
+            replacementResourceUid = "database-instance-2";
+            container.Metadata.Uid = replacementResourceUid;
+            container.Status = new ContainerStatus { State = ContainerState.Exited, ExitCode = 1 };
+            kubernetesService.PushResourceUnchanged(container, k8s.WatchEventType.Added);
 
-        await AsyncTestHelpers.AssertIsTrueRetryAsync(
-            () => flushesAtNotification.Count >= 2,
-            "The replacement resource should be processed even though no delete event was observed.");
+            await logger.Blocked.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => Volatile.Read(ref terminalNotifications) >= 2,
+                "The replacement resource should be processed even though no delete event was observed.");
+            await replacementFollowStreamStarted.Task.DefaultTimeout();
+            await AsyncTestHelpers.AssertIsTrueRetryAsync(
+                () => appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName) is { } task && task != previousLogStreamTask,
+                "The replacement resource should start a new log stream.");
+            var replacementLogStreamTask = appExecutor.ResourceWatcher.GetLogStreamTask(dcpResourceName);
+            Assert.NotNull(replacementLogStreamTask);
 
-        Assert.Equal([1, 2], flushesAtNotification.ToArray());
+            Assert.Single(logLines, line => line.Content.Contains(replacementLogMessage, StringComparison.Ordinal));
+
+            // Let the canceled stream finish only after the replacement flush has installed its pending
+            // deduplication state. Its cleanup must not remove state owned by the replacement UID.
+            previousFollowStream.Release();
+            logger.Release();
+            await previousLogStreamTask.DefaultTimeout();
+
+            replacementFollowStream.Release(replacementLogLine);
+            await replacementLogStreamTask.DefaultTimeout();
+
+            Assert.Equal(2, Volatile.Read(ref replacementStdErrFollowStreams));
+            Assert.Single(logLines, line => line.Content.Contains(replacementLogMessage, StringComparison.Ordinal));
+        }
+        finally
+        {
+            logger.Release();
+            previousFollowStream.TryRelease();
+            replacementFollowStream.TryRelease();
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/GatedLogger.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/GatedLogger.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Tests.Dcp;
+
+internal sealed class GatedLogger<T>(string messageFragment) : ILogger<T>
+{
+    private readonly TaskCompletionSource _blocked = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _blockCount;
+
+    public Task Blocked => _blocked.Task;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (formatter(state, exception).Contains(messageFragment, StringComparison.Ordinal) &&
+            Interlocked.CompareExchange(ref _blockCount, 1, 0) == 0)
+        {
+            _blocked.TrySetResult();
+            _release.Task.GetAwaiter().GetResult();
+        }
+    }
+
+    public void Release()
+    {
+        _release.TrySetResult();
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dcp/GatedReadStream.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/GatedReadStream.cs
@@ -8,13 +8,10 @@ namespace Aspire.Hosting.Tests.Dcp;
 internal sealed class GatedReadStream : Stream
 {
     private readonly TaskCompletionSource _readStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private readonly TaskCompletionSource _disposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource<ReadOnlyMemory<byte>> _content = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _offset;
 
     public Task ReadStarted => _readStarted.Task;
-
-    public Task Disposed => _disposed.Task;
 
     public override bool CanRead => true;
 
@@ -88,15 +85,5 @@ internal sealed class GatedReadStream : Stream
     public override void Write(byte[] buffer, int offset, int count)
     {
         throw new NotSupportedException();
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _disposed.TrySetResult();
-        }
-
-        base.Dispose(disposing);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/GatedReadStream.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/GatedReadStream.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Aspire.Hosting.Tests.Dcp;
+
+internal sealed class GatedReadStream : Stream
+{
+    private readonly TaskCompletionSource _readStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _disposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<ReadOnlyMemory<byte>> _content = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _offset;
+
+    public Task ReadStarted => _readStarted.Task;
+
+    public Task Disposed => _disposed.Task;
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public void Release(string content = "")
+    {
+        if (!TryRelease(content))
+        {
+            throw new InvalidOperationException("The stream has already been released.");
+        }
+    }
+
+    public bool TryRelease(string content = "")
+    {
+        return _content.TrySetResult(Encoding.UTF8.GetBytes(content));
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        _readStarted.TrySetResult();
+
+        // The test controls completion explicitly so it can reproduce a DCP stream that finishes after
+        // its cancellation request and after a replacement stream has installed new deduplication state.
+        var content = await _content.Task.ConfigureAwait(false);
+        if (_offset == content.Length)
+        {
+            return 0;
+        }
+
+        var count = Math.Min(buffer.Length, content.Length - _offset);
+        content.Span.Slice(_offset, count).CopyTo(buffer.Span);
+        _offset += count;
+        return count;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _disposed.TrySetResult();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -29,6 +29,7 @@ internal sealed class TestKubernetesService : IKubernetesService
     private readonly Func<CustomResource, string, bool?, Stream> _startStream;
     private readonly bool _ignoreDeletes;
     private int _nextPort = StartOfAutoPortRange;
+    private int _nextResourceUid;
     private int _nextResourceVersion;
 
     public TestKubernetesService(
@@ -101,6 +102,7 @@ internal sealed class TestKubernetesService : IKubernetesService
         lock (CreatedResources)
         {
             var modifiedResources = AllocateProxylessContainerServicePorts(res);
+            StampResourceUid(res);
             StampResourceVersion(res);
             CreatedResources.Enqueue(res);
             foreach (var c in _watchChannels)
@@ -184,6 +186,18 @@ internal sealed class TestKubernetesService : IKubernetesService
                     c.Writer.TryWrite((WatchEventType.Added, Copy(res)));
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Assigns a stable identity to a newly stored resource, the way an API server does when it
+    /// accepts a create request.
+    /// </summary>
+    private void StampResourceUid(CustomResource resource)
+    {
+        if (string.IsNullOrEmpty(resource.Metadata.Uid))
+        {
+            resource.Metadata.Uid = $"test-resource-{Interlocked.Increment(ref _nextResourceUid)}";
         }
     }
 


### PR DESCRIPTION
## Description

This is a follow-up to the [post-merge review discussion](https://github.com/microsoft/aspire/pull/18952#discussion_r3730676032) on #18952.

During a local run, a DCP watch can reconnect after an object was deleted and recreated without observing the `Deleted` event. The previous replay deduplication keyed observations by object kind, name, and resource version, so a replacement object could be suppressed if its opaque resource version happened to equal the previous object's version. Per-resource log state could also remain associated with the old object incarnation.

This change tracks each observation's Kubernetes UID with its resource version, treats a changed UID as a replacement, and clears stale log-stream and terminal-flush state before processing the replacement. Unchanged watch replays remain suppressed. The terminal-log comments now describe the exact retry behavior, and regression tests verify both replacement handling and late-subscriber log delivery.

### User-facing behavior

Local runs now recognize recreated DCP objects even when deletion happened while the watch was disconnected. Late console-log subscribers continue to receive terminal-resource logs through the normal subscriber-driven follow stream, without relying on periodic watch replays.

Validation:

```text
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.DcpExecutorTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
209 passed, 1 platform-specific test skipped
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
