### PR TITLE
Fix Delve server API compatibility

### DIFF
--- a/src/Aspire.Hosting.Go/DelveServerOptions.cs
+++ b/src/Aspire.Hosting.Go/DelveServerOptions.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Go;
+
+/// <summary>
+/// Configures the headless Delve debug server used for remote debugging of a Go application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server listens on the loopback interface. By default, it accepts a single debugger client
+/// and relies on Delve's default same-user connection policy.
+/// </para>
+/// <para>
+/// Set <see cref="AcceptMultiClient"/> only when the server must remain available after a debugger
+/// disconnects or when multiple debugger clients need to attach.
+/// </para>
+/// </remarks>
+/// <example>
+/// Configure a Delve server that continues the application immediately and accepts multiple debugger clients:
+/// <code lang="csharp">
+/// builder.AddGoApp("api", "../go-api")
+///        .WithDelveServer(new DelveServerOptions
+///        {
+///            AcceptMultiClient = true,
+///            ContinueOnStart = true
+///        });
+/// </code>
+/// </example>
+[AspireDto]
+public sealed class DelveServerOptions
+{
+    /// <summary>
+    /// Gets the TCP port on which Delve listens. The default is <c>2345</c>.
+    /// </summary>
+    public int Port { get; init; } = 2345;
+
+    /// <summary>
+    /// Gets a value indicating whether Delve accepts multiple debugger clients.
+    /// The default is <see langword="false"/>.
+    /// </summary>
+    public bool AcceptMultiClient { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Delve allows connections only from the same operating system user.
+    /// When <see langword="null"/>, Delve's default same-user policy is used.
+    /// </summary>
+    public bool? OnlySameUser { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Delve continues the application immediately after startup.
+    /// The default is <see langword="false"/>.
+    /// </summary>
+    public bool ContinueOnStart { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Delve server logging is enabled.
+    /// The default is <see langword="false"/>.
+    /// </summary>
+    public bool Log { get; init; }
+
+    /// <summary>
+    /// Gets the Delve logging components enabled when <see cref="Log"/> is <see langword="true"/>.
+    /// When <see langword="null"/> or empty, Delve uses its default logging components.
+    /// </summary>
+    public string? LogOutput { get; init; }
+}

--- a/src/Aspire.Hosting.Go/GoDelveServerAnnotation.cs
+++ b/src/Aspire.Hosting.Go/GoDelveServerAnnotation.cs
@@ -11,16 +11,16 @@ namespace Aspire.Hosting.Go;
 /// </summary>
 internal sealed class GoDelveServerAnnotation(
     int port,
-    bool acceptMulticlient,
+    bool acceptMultiClient,
     bool? onlySameUser,
     bool continueOnStart,
     bool log,
-    string logOutput) : IResourceAnnotation
+    string? logOutput) : IResourceAnnotation
 {
     public int Port { get; } = port;
-    public bool AcceptMulticlient { get; } = acceptMulticlient;
+    public bool AcceptMultiClient { get; } = acceptMultiClient;
     public bool? OnlySameUser { get; } = onlySameUser;
     public bool ContinueOnStart { get; } = continueOnStart;
     public bool Log { get; } = log;
-    public string LogOutput { get; } = logOutput;
+    public string? LogOutput { get; } = logOutput;
 }

--- a/src/Aspire.Hosting.Go/GoHostingExtensions.cs
+++ b/src/Aspire.Hosting.Go/GoHostingExtensions.cs
@@ -692,7 +692,7 @@ public static class GoHostingExtensions
     /// </summary>
     /// <typeparam name="T">The type of the Go application resource.</typeparam>
     /// <param name="builder">The resource builder for the Go application.</param>
-    /// <param name="options">The options that configure the Delve server.</param>
+    /// <param name="options">The options that configure the Delve server. When <see langword="null"/>, the default options are used.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
@@ -715,11 +715,11 @@ public static class GoHostingExtensions
     [AspireExport]
     public static IResourceBuilder<T> WithDelveServer<T>(
         this IResourceBuilder<T> builder,
-        DelveServerOptions options)
+        DelveServerOptions? options = null)
         where T : GoAppResource
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(options);
+        options ??= new DelveServerOptions();
 
         // WithDelveServer changes the resource into a headless Delve process that IDEs attach to
         // manually. Leaving the VS Code launch annotation in place would make DCP hand execution to

--- a/src/Aspire.Hosting.Go/GoHostingExtensions.cs
+++ b/src/Aspire.Hosting.Go/GoHostingExtensions.cs
@@ -51,7 +51,7 @@ public static class GoHostingExtensions
     /// Use <see cref="WithModTidy{T}"/>, <see cref="WithModVendor{T}"/>, or <see cref="WithModDownload{T}"/>
     /// to manage module dependencies before startup, and <see cref="WithVetTool{T}"/> to run static analysis.
     /// Use <see cref="WithAppArgs{T}"/> to pass runtime program arguments, and
-    /// <see cref="WithDelveServer{T}"/> to enable remote debugging via a headless Delve server.
+    /// <see cref="WithDelveServer{T}(IResourceBuilder{T}, DelveServerOptions)"/> to enable remote debugging via a headless Delve server.
     /// </para>
     /// </remarks>
     /// <example>
@@ -108,7 +108,7 @@ public static class GoHostingExtensions
                     ctx.Args.Add("--headless=true");
                     ctx.Args.Add($"--listen=127.0.0.1:{delveAnnotation!.Port}");
                     ctx.Args.Add("--api-version=2");
-                    if (delveAnnotation.AcceptMulticlient)
+                    if (delveAnnotation.AcceptMultiClient)
                     {
                         ctx.Args.Add("--accept-multiclient");
                     }
@@ -619,21 +619,14 @@ public static class GoHostingExtensions
     }
 
     /// <summary>
-    /// Starts a headless Delve debug server so that any DAP-compatible client can attach remotely.
-    /// The application is launched as
-    /// <c>dlv --headless=true --listen=127.0.0.1:&lt;port&gt; --api-version=2 --accept-multiclient debug .</c>
-    /// instead of <c>go run .</c>. Delve must be available on the PATH.
+    /// Starts a headless Delve debug server so that a DAP-compatible client can attach remotely.
+    /// The application is launched with <c>dlv debug</c> instead of <c>go run</c>.
+    /// Delve must be available on the PATH.
     /// </summary>
     /// <typeparam name="T">The type of the Go application resource.</typeparam>
     /// <param name="builder">The resource builder for the Go application.</param>
     /// <param name="port">The TCP port Delve listens on. Defaults to <c>2345</c>.</param>
-    /// <param name="acceptMulticlient">Whether Delve accepts multiple debugger clients with <c>--accept-multiclient</c>. Defaults to <see langword="true"/>.</param>
-    /// <param name="onlySameUser">Whether Delve allows connections only from the same operating system user. When <see langword="null"/>, the <c>--only-same-user</c> flag is not passed.</param>
-    /// <param name="continueOnStart">Whether Delve passes <c>--continue</c> to continue the debuggee immediately after startup. Defaults to <see langword="false"/>.</param>
-    /// <param name="log">Whether Delve debug server logging is enabled with <c>--log</c>. Defaults to <see langword="false"/>.</param>
-    /// <param name="logOutput">The Delve logging components passed with <c>--log-output</c> when <paramref name="log"/> is <see langword="true"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
-    /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
     /// <para>
     /// Delve is the only Go debugger; both GoLand and VS Code use it under the hood, just in
@@ -664,18 +657,46 @@ public static class GoHostingExtensions
     ///        .WithDelveServer(port: 2345);
     /// </code>
     /// </example>
+    [AspireExportIgnore(Reason = "This compatibility overload is C#-only. Polyglot AppHosts use the DelveServerOptions overload.")]
+    public static IResourceBuilder<T> WithDelveServer<T>(this IResourceBuilder<T> builder, int port = 2345)
+        where T : GoAppResource
+        => builder.WithDelveServer(new DelveServerOptions { Port = port });
+
+    /// <summary>
+    /// Starts a configurable headless Delve debug server so that DAP-compatible clients can attach remotely.
+    /// The application is launched with <c>dlv debug</c> instead of <c>go run</c>.
+    /// Delve must be available on the PATH.
+    /// </summary>
+    /// <typeparam name="T">The type of the Go application resource.</typeparam>
+    /// <param name="builder">The resource builder for the Go application.</param>
+    /// <param name="options">The options that configure the Delve server.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// The server listens on <c>127.0.0.1</c> and accepts a single debugger client by default.
+    /// Set <see cref="DelveServerOptions.AcceptMultiClient"/> to <see langword="true"/> only when
+    /// multiple clients or reconnections are required.
+    /// </remarks>
+    /// <example>
+    /// <code lang="csharp">
+    /// builder.AddGoApp("api", "../go-api")
+    ///        .WithDelveServer(new DelveServerOptions
+    ///        {
+    ///            Port = 2345,
+    ///            ContinueOnStart = true,
+    ///            Log = true,
+    ///            LogOutput = "rpc,dap,debugger"
+    ///        });
+    /// </code>
+    /// </example>
     [AspireExport]
     public static IResourceBuilder<T> WithDelveServer<T>(
         this IResourceBuilder<T> builder,
-        int port = 2345,
-        bool acceptMulticlient = true,
-        bool? onlySameUser = null,
-        bool continueOnStart = false,
-        bool log = false,
-        string logOutput = "")
+        DelveServerOptions options)
         where T : GoAppResource
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
 
         // WithDelveServer changes the resource into a headless Delve process that IDEs attach to
         // manually. Leaving the VS Code launch annotation in place would make DCP hand execution to
@@ -692,7 +713,15 @@ public static class GoHostingExtensions
             .WithAnnotation(
                 new ExecutableAnnotation { Command = "dlv", WorkingDirectory = builder.Resource.WorkingDirectory },
                 ResourceAnnotationMutationBehavior.Replace)
-            .WithAnnotation(new GoDelveServerAnnotation(port, acceptMulticlient, onlySameUser, continueOnStart, log, logOutput), ResourceAnnotationMutationBehavior.Replace)
+            .WithAnnotation(
+                new GoDelveServerAnnotation(
+                    options.Port,
+                    options.AcceptMultiClient,
+                    options.OnlySameUser,
+                    options.ContinueOnStart,
+                    options.Log,
+                    options.LogOutput),
+                ResourceAnnotationMutationBehavior.Replace)
             .WithRequiredCommand("dlv", "https://github.com/go-delve/delve");
     }
 

--- a/src/Aspire.Hosting.Go/GoHostingExtensions.cs
+++ b/src/Aspire.Hosting.Go/GoHostingExtensions.cs
@@ -625,7 +625,6 @@ public static class GoHostingExtensions
     /// </summary>
     /// <typeparam name="T">The type of the Go application resource.</typeparam>
     /// <param name="builder">The resource builder for the Go application.</param>
-    /// <param name="port">The TCP port Delve listens on. Defaults to <c>2345</c>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
     /// <remarks>
     /// <para>
@@ -654,10 +653,34 @@ public static class GoHostingExtensions
     /// <example>
     /// <code lang="csharp">
     /// builder.AddGoApp("api", "../go-api")
-    ///        .WithDelveServer(port: 2345);
+    ///        .WithDelveServer();
     /// </code>
     /// </example>
-    [AspireExportIgnore(Reason = "This compatibility overload is C#-only. Polyglot AppHosts use the DelveServerOptions overload.")]
+    [AspireExportIgnore(Reason = "This C# convenience overload uses default options. Polyglot AppHosts use the DelveServerOptions overload.")]
+    public static IResourceBuilder<T> WithDelveServer<T>(this IResourceBuilder<T> builder)
+        where T : GoAppResource
+        => builder.WithDelveServer(new DelveServerOptions());
+
+    /// <summary>
+    /// Starts a headless Delve debug server on the specified port.
+    /// </summary>
+    /// <typeparam name="T">The type of the Go application resource.</typeparam>
+    /// <param name="builder">The resource builder for the Go application.</param>
+    /// <param name="port">The TCP port Delve listens on. Defaults to <c>2345</c>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// This overload is retained for binary compatibility. Use <see cref="WithDelveServer{T}(IResourceBuilder{T})"/>
+    /// for the default port or <see cref="WithDelveServer{T}(IResourceBuilder{T}, DelveServerOptions)"/>
+    /// to configure the port and other Delve server options.
+    /// </remarks>
+    /// <example>
+    /// <code lang="csharp">
+    /// builder.AddGoApp("api", "../go-api")
+    ///        .WithDelveServer(new DelveServerOptions { Port = 3456 });
+    /// </code>
+    /// </example>
+    [Obsolete("Use WithDelveServer() or WithDelveServer(DelveServerOptions) instead.")]
+    [AspireExportIgnore(Reason = "This obsolete compatibility overload is C#-only. Polyglot AppHosts use the DelveServerOptions overload.")]
     public static IResourceBuilder<T> WithDelveServer<T>(this IResourceBuilder<T> builder, int port = 2345)
         where T : GoAppResource
         => builder.WithDelveServer(new DelveServerOptions { Port = port });

--- a/src/Aspire.Hosting.Go/README.md
+++ b/src/Aspire.Hosting.Go/README.md
@@ -90,7 +90,7 @@ application is replaced by a headless Delve server:
 
 ```csharp
 builder.AddGoApp("api", "../go-api")
-    .WithDelveServer(port: 2345)
+    .WithDelveServer()
     .WithHttpEndpoint(port: 8080);
 ```
 

--- a/src/Aspire.Hosting.Go/README.md
+++ b/src/Aspire.Hosting.Go/README.md
@@ -96,22 +96,46 @@ builder.AddGoApp("api", "../go-api")
 
 This launches:
 ```sh
-dlv --headless=true --listen=127.0.0.1:2345 --api-version=2 --accept-multiclient debug .
+dlv --headless=true --listen=127.0.0.1:2345 --api-version=2 debug .
 ```
 
-`WithDelveServer` passes `--accept-multiclient` by default so the Delve server remains available
-after a debugger detaches. Set `acceptMulticlient: false` if you need Delve to exit when the first
-debugger disconnects. To customize Delve server flags, use named arguments:
+The default accepts one debugger client. To keep the server available after a debugger disconnects
+or allow multiple debugger clients, opt in with `AcceptMultiClient`. Configure additional Delve
+server flags with `DelveServerOptions`:
 
 ```csharp
 builder.AddGoApp("api", "../go-api")
-    .WithDelveServer(
-        continueOnStart: true,
-        log: true,
-        logOutput: "rpc,dap,debugger");
+    .WithDelveServer(new DelveServerOptions
+    {
+        AcceptMultiClient = true,
+        ContinueOnStart = true,
+        Log = true,
+        LogOutput = "rpc,dap,debugger"
+    });
 ```
 
-Set `continueOnStart: true` when you want the Go application to run immediately under Delve and
+For a TypeScript AppHost, pass the same options as an object:
+
+```typescript
+const api = await builder.addGoApp("api", "../go-api");
+await api.withDelveServer({
+    acceptMultiClient: true,
+    continueOnStart: true,
+    log: true,
+    logOutput: "rpc,dap,debugger",
+});
+```
+
+| Option | Default | Delve behavior |
+|---|---|---|
+| `Port` | `2345` | Sets the loopback listener port. |
+| `AcceptMultiClient` | `false` | Passes `--accept-multiclient` when enabled. |
+| `OnlySameUser` | `null` | Passes `--only-same-user=true` or `--only-same-user=false` when set. |
+| `ContinueOnStart` | `false` | Passes `--continue` when enabled. |
+| `Log` | `false` | Passes `--log` when enabled. |
+| `LogOutput` | `null` | Passes `--log-output=<components>` when logging is enabled and components are specified. |
+
+Set `ContinueOnStart` to `true` when you want the Go application to run immediately under Delve and
 attach a debugger later.
 
 If an IDE fails to attach, enable Delve logging first and inspect the resource logs. Some IDE and
@@ -121,13 +145,15 @@ can disable that check:
 
 ```csharp
 builder.AddGoApp("api", "../go-api")
-    .WithDelveServer(
-        onlySameUser: false,
-        log: true,
-        logOutput: "rpc,dap,debugger");
+    .WithDelveServer(new DelveServerOptions
+    {
+        OnlySameUser = false,
+        Log = true,
+        LogOutput = "rpc,dap,debugger"
+    });
 ```
 
-`onlySameUser: false` maps to `--only-same-user=false`. Use it only when needed; the Delve listener
+`OnlySameUser = false` maps to `--only-same-user=false`. Use it only when needed; the Delve listener
 remains bound to `127.0.0.1`.
 
 **GoLand** — create a **Go Remote** run/debug configuration (**Edit | Run Configurations**):

--- a/tests/Aspire.Hosting.Go.Tests/AddGoAppTests.cs
+++ b/tests/Aspire.Hosting.Go.Tests/AddGoAppTests.cs
@@ -351,7 +351,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "."
               ]
@@ -361,12 +360,12 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task VerifyManifest_WithDelveServer_DisableAcceptMulticlient()
+    public async Task VerifyManifest_WithDelveServer_EnableAcceptMultiClient()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(acceptMulticlient: false);
+            .WithDelveServer(new DelveServerOptions { AcceptMultiClient = true });
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -379,6 +378,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
+                "--accept-multiclient",
                 "debug",
                 "."
               ]
@@ -393,7 +393,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(onlySameUser: false);
+            .WithDelveServer(new DelveServerOptions { OnlySameUser = false });
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -406,7 +406,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "--only-same-user=false",
                 "debug",
                 "."
@@ -422,7 +421,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(continueOnStart: true);
+            .WithDelveServer(new DelveServerOptions { ContinueOnStart = true });
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -435,7 +434,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "--continue",
                 "."
@@ -451,7 +449,11 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(log: true, logOutput: "rpc,dap,debugger");
+            .WithDelveServer(new DelveServerOptions
+            {
+                Log = true,
+                LogOutput = "rpc,dap,debugger"
+            });
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -464,7 +466,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "--log",
                 "--log-output=rpc,dap,debugger",
                 "debug",
@@ -476,14 +477,25 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void WithDelveServer_RemovesVSCodeDebuggingAnnotation()
+    public async Task WithDelveServer_UsesDelveCommandWhenGoLaunchConfigurationIsSupported()
     {
-        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["go"]
+        };
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(runSessionInfo);
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
             .WithDelveServer(port: 2345);
+        var application = builder.Build();
 
-        Assert.DoesNotContain(app.Resource.Annotations, annotation => annotation is SupportsDebuggingAnnotation);
+        var commandArguments = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        Assert.Equal("dlv", app.Resource.Command);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "."], commandArguments);
     }
 
     // ---- VS Code debugging --------------------------------------------------
@@ -616,7 +628,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "--build-flags=-tags=\u0027netgo\u0027 -ldflags=\u0027-s -w\u0027",
                 "."
@@ -647,7 +658,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "--build-flags=-race",
                 "."
@@ -678,7 +688,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "--build-flags=-gcflags=\u0027all=-N -l\u0027",
                 "."
@@ -710,7 +719,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 ".",
                 "--",

--- a/tests/Aspire.Hosting.Go.Tests/AddGoAppTests.cs
+++ b/tests/Aspire.Hosting.Go.Tests/AddGoAppTests.cs
@@ -338,7 +338,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -489,7 +489,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
         var application = builder.Build();
 
         var commandArguments = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
@@ -615,7 +615,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         var app = builder.AddGoApp("api", AppContext.BaseDirectory,
                 buildTags: ["netgo"],
                 ldFlags: "-s -w")
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -645,7 +645,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory, raceDetector: true)
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -675,7 +675,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory, gcFlags: "all=-N -l")
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -706,7 +706,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
             .WithAppArgs("--port", "9090")
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 

--- a/tests/Aspire.Hosting.Go.Tests/GoPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Go.Tests/GoPublicApiTests.cs
@@ -141,7 +141,7 @@ public class GoPublicApiTests
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
-        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "--accept-multiclient", "debug", "./cmd/server"], args);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "./cmd/server"], args);
     }
 
     [Fact]
@@ -426,6 +426,28 @@ public class GoPublicApiTests
     }
 
     [Fact]
+    public void WithDelveServerShouldThrowWhenOptionsIsNull()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddGoApp("api", builder.AppHostDirectory);
+
+        var action = () => app.WithDelveServer(options: null!);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void DelveServerOptionsHaveSafeDefaults()
+    {
+        var options = new DelveServerOptions();
+
+        Assert.Equal(
+            (Port: 2345, AcceptMultiClient: false, OnlySameUser: (bool?)null, ContinueOnStart: false, Log: false, LogOutput: (string?)null),
+            (options.Port, options.AcceptMultiClient, options.OnlySameUser, options.ContinueOnStart, options.Log, options.LogOutput));
+    }
+
+    [Fact]
     public void WithDelveServerSwitchesCommandToDlv()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
@@ -444,7 +466,40 @@ public class GoPublicApiTests
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
-        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "--accept-multiclient", "debug", "."], args);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "."], args);
+    }
+
+    [Fact]
+    public async Task WithDelveServerOptionsProduceCorrectArgs()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddGoApp("api", builder.AppHostDirectory)
+            .WithDelveServer(new DelveServerOptions
+            {
+                Port = 3456,
+                AcceptMultiClient = true,
+                OnlySameUser = false,
+                ContinueOnStart = true,
+                Log = true,
+                LogOutput = "rpc,dap,debugger"
+            });
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
+
+        Assert.Equal(
+            [
+                "--headless=true",
+                "--listen=127.0.0.1:3456",
+                "--api-version=2",
+                "--accept-multiclient",
+                "--only-same-user=false",
+                "--log",
+                "--log-output=rpc,dap,debugger",
+                "debug",
+                "--continue",
+                "."
+            ],
+            args);
     }
 
     [Fact]
@@ -459,7 +514,7 @@ public class GoPublicApiTests
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
         // All user-influenced values are shell-quoted so the Delve parser keeps them as single tokens.
-        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "--accept-multiclient", "debug", "--build-flags=-tags='netgo' -ldflags='-s -w'", "."], args);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "--build-flags=-tags='netgo' -ldflags='-s -w'", "."], args);
     }
 
     [Fact]
@@ -472,6 +527,6 @@ public class GoPublicApiTests
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
-        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "--accept-multiclient", "debug", ".", "--", "--config", "dev.yaml"], args);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", ".", "--", "--config", "dev.yaml"], args);
     }
 }

--- a/tests/Aspire.Hosting.Go.Tests/GoPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Go.Tests/GoPublicApiTests.cs
@@ -137,7 +137,7 @@ public class GoPublicApiTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var app = builder.AddGoApp("api", builder.AppHostDirectory, packagePath: "./cmd/server")
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
@@ -452,7 +452,7 @@ public class GoPublicApiTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var app = builder.AddGoApp("api", builder.AppHostDirectory)
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         Assert.Equal("dlv", app.Resource.Command);
     }
@@ -462,11 +462,25 @@ public class GoPublicApiTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var app = builder.AddGoApp("api", builder.AppHostDirectory)
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
         Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "."], args);
+    }
+
+    [Fact]
+    public async Task ObsoleteWithDelveServerPortOverloadPreservesBehavior()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+#pragma warning disable CS0618 // The obsolete overload must remain callable for source and binary compatibility.
+        var app = builder.AddGoApp("api", builder.AppHostDirectory)
+            .WithDelveServer(port: 3456);
+#pragma warning restore CS0618
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
+
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:3456", "--api-version=2", "debug", "."], args);
     }
 
     [Fact]
@@ -509,7 +523,7 @@ public class GoPublicApiTests
         var app = builder.AddGoApp("api", builder.AppHostDirectory,
                             buildTags: ["netgo"],
                             ldFlags: "-s -w")
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
@@ -523,7 +537,7 @@ public class GoPublicApiTests
         using var builder = TestDistributedApplicationBuilder.Create();
         var app = builder.AddGoApp("api", builder.AppHostDirectory)
                          .WithAppArgs("--config", "dev.yaml")
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 

--- a/tests/Aspire.Hosting.Go.Tests/GoPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Go.Tests/GoPublicApiTests.cs
@@ -426,15 +426,15 @@ public class GoPublicApiTests
     }
 
     [Fact]
-    public void WithDelveServerShouldThrowWhenOptionsIsNull()
+    public async Task WithDelveServerNullOptionsUseDefaults()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
-        var app = builder.AddGoApp("api", builder.AppHostDirectory);
+        var app = builder.AddGoApp("api", builder.AppHostDirectory)
+            .WithDelveServer(options: null);
 
-        var action = () => app.WithDelveServer(options: null!);
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal("options", exception.ParamName);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "."], args);
     }
 
     [Fact]

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Go/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Go/Go/apphost.go
@@ -45,7 +45,7 @@ func main() {
 
 	// Go app with headless Delve server for remote debugging (GoLand / VS Code attach)
 	debugService := builder.AddGoApp("debug-service", "../go-debug-service").
-		WithDelveServer(&aspire.WithDelveServerOptions{
+		WithDelveServer(&aspire.DelveServerOptions{
 			Port: aspire.Float64Ptr(2345),
 		})
 	if err = debugService.Err(); err != nil {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Go/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Go/Java/AppHost.java
@@ -26,8 +26,14 @@ void main() throws Exception {
             .withAppArgs(new String[] { "--config", "prod.yaml" });
 
         // Go app with headless Delve server for remote debugging (GoLand / VS Code attach)
+        var delveServerOptions = new DelveServerOptions();
+        // Java DTOs serialize unset fields as null, so specify every non-nullable default.
+        delveServerOptions.setPort(2345.0);
+        delveServerOptions.setAcceptMultiClient(false);
+        delveServerOptions.setContinueOnStart(false);
+        delveServerOptions.setLog(false);
         var debugService = builder.addGoApp("debug-service", "../go-debug-service")
-            .withDelveServer();
+            .withDelveServer(delveServerOptions);
 
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Go/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Go/Python/apphost.py
@@ -26,6 +26,6 @@ with create_builder() as builder:
 
     # Go app with headless Delve server for remote debugging
     debug_service = builder.add_go_app("debug-service", "../go-debug-service")
-    debug_service.with_delve_server()
+    debug_service.with_delve_server({"Port": 2345})
 
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Go/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Go/TypeScript/apphost.mts
@@ -26,6 +26,6 @@ await managed.withAppArgs(['--config', 'prod.yaml']);
 
 // Go app with headless Delve server for remote debugging (GoLand / VS Code attach)
 const debugService = await builder.addGoApp('debug-service', '../go-debug-service');
-await debugService.withDelveServer({ port: 2345 });
+await debugService.withDelveServer();
 
 await builder.build().run();


### PR DESCRIPTION
## Description

This follows up on #17846 to preserve binary compatibility while correcting the API shape of the preview-versioned `Aspire.Hosting.Go` integration.

The shipped `WithDelveServer<T>(builder, int port = 2345)` method remains as an obsolete binary compatibility shim and preserves its original single-client behavior. Supported C# callers now use `WithDelveServer()` for defaults or `WithDelveServer(DelveServerOptions)` for expanded configuration. The ATS-friendly DTO uses the corrected `AcceptMultiClient` casing and defaults multi-client support to `false`.

Only the DTO-based overload is exported to generated SDKs, avoiding overload collisions. The Go integration README and Go, Java, Python, and TypeScript polyglot fixtures reflect the generated API shape. Targeted tests assert the complete default, obsolete-port, and all-options Delve argument sequences.

### User-facing usage

C# AppHost:

```csharp
builder.AddGoApp("api", "../go-api")
    .WithDelveServer();

builder.AddGoApp("worker", "../go-worker")
    .WithDelveServer(new DelveServerOptions
    {
        AcceptMultiClient = true,
        ContinueOnStart = true,
        Log = true,
        LogOutput = "rpc,dap,debugger"
    });
```

TypeScript AppHost:

```typescript
const api = await builder.addGoApp("api", "../go-api");
await api.withDelveServer({
    acceptMultiClient: true,
    continueOnStart: true,
    log: true,
    logOutput: "rpc,dap,debugger",
});
```

Validation:

- `dotnet build src/Aspire.Hosting.Go/Aspire.Hosting.Go.csproj --no-restore`
- `dotnet test --project tests/Aspire.Hosting.Go.Tests/Aspire.Hosting.Go.Tests.csproj --no-launch-profile -- --filter-method "*DelveServer*" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (20 passed)
- `aspire sdk dump --format ci src/Aspire.Hosting.Go/Aspire.Hosting.Go.csproj`
- Generated SDK compilation for the Go, Java, Python, and TypeScript `Aspire.Hosting.Go` polyglot AppHosts

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No