### PR TITLE
Preserve Azure Bicep scope API compatibility

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -281,7 +281,10 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
         if (Scope is not null)
         {
             context.Writer.WriteStartObject("scope");
-            WriteScopeValue(context, "resourceGroup", Scope.ResourceGroup);
+            if (Scope.HasResourceGroup)
+            {
+                WriteScopeValue(context, "resourceGroup", Scope.ResourceGroup);
+            }
             WriteScopeValue(context, "subscription", Scope.Subscription);
             if (Scope.IsTenantScope)
             {

--- a/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
@@ -8,6 +8,8 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 public sealed class AzureBicepResourceScope
 {
+    private readonly object? _resourceGroup;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureBicepResourceScope"/> class with a resource group scope.
     /// </summary>
@@ -16,7 +18,7 @@ public sealed class AzureBicepResourceScope
     {
         ArgumentNullException.ThrowIfNull(resourceGroup);
 
-        ResourceGroup = resourceGroup;
+        _resourceGroup = resourceGroup;
     }
 
     /// <summary>
@@ -31,11 +33,26 @@ public sealed class AzureBicepResourceScope
         Subscription = subscription;
     }
 
-    private AzureBicepResourceScope(object? resourceGroup, object? subscription, bool isTenantScope)
+    private AzureBicepResourceScope(ScopeKind scopeKind)
     {
-        ResourceGroup = resourceGroup;
+        if (scopeKind is not ScopeKind.Tenant)
+        {
+            throw new ArgumentOutOfRangeException(nameof(scopeKind));
+        }
+
+        IsTenantScope = true;
+    }
+
+    private AzureBicepResourceScope(ScopeKind scopeKind, object subscription)
+    {
+        if (scopeKind is not ScopeKind.Subscription)
+        {
+            throw new ArgumentOutOfRangeException(nameof(scopeKind));
+        }
+
+        ArgumentNullException.ThrowIfNull(subscription);
+
         Subscription = subscription;
-        IsTenantScope = isTenantScope;
     }
 
     /// <summary>
@@ -47,7 +64,7 @@ public sealed class AzureBicepResourceScope
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
-        return new AzureBicepResourceScope(resourceGroup: null, subscription, isTenantScope: false);
+        return new AzureBicepResourceScope(ScopeKind.Subscription, subscription);
     }
 
     /// <summary>
@@ -56,13 +73,14 @@ public sealed class AzureBicepResourceScope
     /// <returns>A new <see cref="AzureBicepResourceScope"/> scoped to the current tenant.</returns>
     public static AzureBicepResourceScope ForTenant()
     {
-        return new AzureBicepResourceScope(resourceGroup: null, subscription: null, isTenantScope: true);
+        return new AzureBicepResourceScope(ScopeKind.Tenant);
     }
 
     /// <summary>
     /// Represents the resource group to encode in the scope.
     /// </summary>
-    public object? ResourceGroup { get; }
+    /// <exception cref="InvalidOperationException">The scope does not target a resource group.</exception>
+    public object ResourceGroup => _resourceGroup ?? throw new InvalidOperationException("The Azure Bicep resource scope does not target a resource group.");
 
     /// <summary>
     /// Represents the subscription to encode in the scope.
@@ -73,6 +91,8 @@ public sealed class AzureBicepResourceScope
     /// Gets a value indicating whether the scope targets the current tenant.
     /// </summary>
     public bool IsTenantScope { get; }
+
+    internal bool HasResourceGroup => _resourceGroup is not null;
 
     internal static AzureBicepResourceScope? FromExistingResourceAnnotation(ExistingAzureResourceAnnotation annotation)
     {
@@ -90,5 +110,11 @@ public sealed class AzureBicepResourceScope
             (null, { } subscription) => ForSubscription(subscription),
             _ => null
         };
+    }
+
+    private enum ScopeKind
+    {
+        Subscription,
+        Tenant
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
@@ -198,7 +198,8 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
     private static bool ScopeEquals(AzureBicepResourceScope expected, AzureBicepResourceScope? actual)
     {
         return actual is not null &&
-            ScopeValueEquals(expected.ResourceGroup, actual.ResourceGroup) &&
+            expected.HasResourceGroup == actual.HasResourceGroup &&
+            (!expected.HasResourceGroup || ScopeValueEquals(expected.ResourceGroup, actual.ResourceGroup)) &&
             ScopeValueEquals(expected.Subscription, actual.Subscription) &&
             expected.IsTenantScope == actual.IsTenantScope;
     }
@@ -220,7 +221,7 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
             return new FunctionCallExpression(new IdentifierExpression("tenant"));
         }
 
-        if (scope.ResourceGroup is not null && scope.Subscription is not null)
+        if (scope.HasResourceGroup && scope.Subscription is not null)
         {
             return (scope.Subscription, scope.ResourceGroup) switch
             {
@@ -232,7 +233,7 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
             };
         }
 
-        if (scope.ResourceGroup is not null)
+        if (scope.HasResourceGroup)
         {
             return scope.ResourceGroup switch
             {

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -181,7 +181,10 @@ public sealed class AzurePublishingContext(
 
             if (resource.Scope is { } scope)
             {
-                await VisitAsync(scope.ResourceGroup, MapParameterAsync, cancellationToken).ConfigureAwait(false);
+                if (scope.HasResourceGroup)
+                {
+                    await VisitAsync(scope.ResourceGroup, MapParameterAsync, cancellationToken).ConfigureAwait(false);
+                }
                 await VisitAsync(scope.Subscription, MapParameterAsync, cancellationToken).ConfigureAwait(false);
             }
 
@@ -263,27 +266,29 @@ public sealed class AzurePublishingContext(
                 return new IdentifierExpression(rg.BicepIdentifier);
             }
 
-            if (resource.Scope.IsTenantScope)
+            var scope = resource.Scope;
+
+            if (scope.IsTenantScope)
             {
                 return new FunctionCallExpression(new IdentifierExpression("tenant"));
             }
 
-            if (resource.Scope.ResourceGroup is not null && resource.Scope.Subscription is not null)
+            if (scope.HasResourceGroup && scope.Subscription is not null)
             {
                 return new FunctionCallExpression(
                     new IdentifierExpression("resourceGroup"),
-                    ResolveValue(Eval(resource.Scope.Subscription)).Compile(),
-                    ResolveValue(Eval(resource.Scope.ResourceGroup)).Compile());
+                    ResolveValue(Eval(scope.Subscription)).Compile(),
+                    ResolveValue(Eval(scope.ResourceGroup)).Compile());
             }
 
-            if (resource.Scope.ResourceGroup is not null)
+            if (scope.HasResourceGroup)
             {
-                return new FunctionCallExpression(new IdentifierExpression("resourceGroup"), ResolveValue(Eval(resource.Scope.ResourceGroup)).Compile());
+                return new FunctionCallExpression(new IdentifierExpression("resourceGroup"), ResolveValue(Eval(scope.ResourceGroup)).Compile());
             }
 
-            if (resource.Scope.Subscription is not null)
+            if (scope.Subscription is not null)
             {
-                return new FunctionCallExpression(new IdentifierExpression("subscription"), ResolveValue(Eval(resource.Scope.Subscription)).Compile());
+                return new FunctionCallExpression(new IdentifierExpression("subscription"), ResolveValue(Eval(scope.Subscription)).Compile());
             }
 
             throw new InvalidOperationException("The Azure Bicep resource scope must specify a resource group, subscription, or tenant scope.");

--- a/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
@@ -86,7 +86,10 @@ internal static class BicepUtilities
             return;
         }
 
-        await SetScopeValueAsync(scope, "resourceGroup", targetScope.ResourceGroup, cancellationToken).ConfigureAwait(false);
+        if (targetScope.HasResourceGroup)
+        {
+            await SetScopeValueAsync(scope, "resourceGroup", targetScope.ResourceGroup, cancellationToken).ConfigureAwait(false);
+        }
         await SetScopeValueAsync(scope, "subscription", targetScope.Subscription, cancellationToken).ConfigureAwait(false);
         if (targetScope.IsTenantScope)
         {

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -511,7 +511,7 @@ internal sealed class BicepProvisioner(
         var targetScope = BicepUtilities.GetExistingResourceScope(resource);
         var isTenantScoped = targetScope?.IsTenantScope == true;
         var isSubscriptionScoped = !isTenantScoped &&
-            targetScope is { Subscription: not null, ResourceGroup: null };
+            targetScope is { Subscription: not null, HasResourceGroup: false };
 
         if (targetScope?.Subscription is { } existingSubscription)
         {
@@ -519,8 +519,9 @@ internal sealed class BicepProvisioner(
             subscription = await context.ArmClient.GetSubscriptionAsync(existingSubscriptionId, cancellationToken).ConfigureAwait(false);
         }
 
-        if (targetScope?.ResourceGroup is { } existingResourceGroup)
+        if (targetScope?.HasResourceGroup == true)
         {
+            var existingResourceGroup = targetScope.ResourceGroup;
             var existingResourceGroupName = await ResolveScopeValueAsync(existingResourceGroup, cancellationToken).ConfigureAwait(false);
             var response = await subscription.GetResourceGroups().GetAsync(existingResourceGroupName, cancellationToken).ConfigureAwait(false);
             resourceGroup = response.Value;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureBicepResourceScopeTests
+{
+    [Fact]
+    public void ResourceGroupReturnsConstructorValue()
+    {
+        var scope = new AzureBicepResourceScope("test-rg");
+
+        Assert.Equal("test-rg", scope.ResourceGroup);
+    }
+
+    [Fact]
+    public void ResourceGroupThrowsForSubscriptionScope()
+    {
+        var scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => scope.ResourceGroup);
+
+        Assert.Equal("The Azure Bicep resource scope does not target a resource group.", exception.Message);
+    }
+
+    [Fact]
+    public void ResourceGroupThrowsForTenantScope()
+    {
+        var scope = AzureBicepResourceScope.ForTenant();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => scope.ResourceGroup);
+
+        Assert.Equal("The Azure Bicep resource scope does not target a resource group.", exception.Message);
+    }
+}


### PR DESCRIPTION
## Description

#17988 made `AzureBicepResourceScope.ResourceGroup` nullable to represent subscription- and tenant-scoped deployments, which breaks the existing public API contract. This restores the shipped non-nullable `object ResourceGroup` property while keeping the new scope scenarios working.

Subscription and tenant scopes now model resource-group absence internally with `HasResourceGroup`. Internal publishing and provisioning paths check that state before accessing `ResourceGroup`, whose public getter throws when the selected scope does not target a resource group. Focused tests cover resource-group, subscription, and tenant behavior.

Validated with the targeted Azure hosting scope tests and a Release build of `Aspire.Hosting.Azure`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No