### PR TITLE
Make hidden annotation exit codes read-only

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/HiddenAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HiddenAnnotation.cs
@@ -36,5 +36,5 @@ public sealed class HiddenAnnotation(HiddenBehavior behavior) : IResourceAnnotat
     /// <summary>
     /// Gets the exit codes that are treated as successful completion when <see cref="Behavior"/> is <see cref="HiddenBehavior.OnCompletion"/>.
     /// </summary>
-    public List<int> SuccessfulExitCodes { get; init; } = [0];
+    public IReadOnlyList<int> SuccessfulExitCodes { get; init; } = [0];
 }


### PR DESCRIPTION
## Description

`HiddenAnnotation.SuccessfulExitCodes` should expose successful process exit codes without allowing callers to mutate the collection directly. This changes the property type from `List<int>` to `IReadOnlyList<int>` while preserving init-only configuration and the default exit code of `0`.

Existing `WithHiddenOnCompletion` behavior remains unchanged. The targeted hosting tests pass.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No