### PR TITLE
Remove Publish-Build-Assets variable group from release/9.0-efnpgsql

### DIFF
--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -19,7 +19,6 @@ variables:
       value: real
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -17,7 +17,6 @@ variables:
       value: True
     - name: _SignType
       value: real
-    # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `eng/pipelines/common-variables.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131