### PR TITLE
Re-enable VS Code extension E2E tests in CI

### DIFF
--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -253,6 +253,9 @@ jobs:
             archivePattern: aspire-cli-linux-x64*.tar.gz
             cliBinary: aspire
             useXvfb: true
+            # Keep the shard visible in CI, but leave the Functions fixture disabled until
+            # the hosted Linux startup timeout is root-caused.
+            disabledIssue: 'https://github.com/microsoft/aspire/issues/19151'
             installAzureFunctions: true
     defaults:
       run:
@@ -359,8 +362,13 @@ jobs:
             Start-Sleep -Seconds $delay
           }
 
+      - name: Note skipped Azure Functions E2E shard
+        if: ${{ matrix.disabledIssue }}
+        run: |
+          Write-Host "::notice title=Azure Functions E2E shard skipped::${{ matrix.shardName }} is disabled pending ${{ matrix.disabledIssue }}."
+
       - name: Install Azure Functions E2E prerequisites
-        if: ${{ matrix.installAzureFunctions }}
+        if: ${{ matrix.installAzureFunctions && !matrix.disabledIssue }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -489,6 +489,7 @@ jobs:
           }
 
       - name: Run extension E2E tests
+        if: ${{ !matrix.disabledIssue }}
         working-directory: extension
         env:
           ASPIRE_EXTENSION_E2E_VSIX: ${{ github.workspace }}/extension/out/aspire-extension.vsix

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -708,12 +708,7 @@ jobs:
 
   extension_e2e_tests:
     name: Run VS Code extension E2E tests
-    # Temporarily disabled: the VS Code extension E2E shards are flaky and currently failing in CI
-    # (intermittent teardown AggregateError, see https://github.com/microsoft/aspire/issues/18098),
-    # so they block unrelated PRs. Keep the job defined (it stays in the aggregate gate's needs) but
-    # force it to skip until the flakiness is fixed. Re-enable by removing the `false &&` guard below.
-    # Tracked by https://github.com/microsoft/aspire/issues/18412.
-    if: ${{ false && needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
+    if: ${{ needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
     uses: ./.github/workflows/extension-e2e-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux, build_cli_archive_windows, extension_tests_win, extension_bootstrap_linux]
 
@@ -831,10 +826,8 @@ jobs:
         #   bucket actually had work. Before selective CI these were always populated on a full run.
         # - cli_starter_validation_windows: this job only runs for pull requests and is expected to
         #   be skipped for other workflow events.
-        # - extension_e2e_tests: temporarily disabled (always skipped) because the E2E shards are
-        #   flaky/failing; see https://github.com/microsoft/aspire/issues/18412. While
-        #   disabled, a 'skipped' result must NOT fail this gate, so the run_extension_e2e skip checks
-        #   were removed below. Restore them when re-enabling the job.
+        # - extension_e2e_tests: this job only runs when the PR/push changes the VS Code extension,
+        #   Aspire CLI, or the extension E2E workflow wiring.
         # - polyglot_validation: this job runs for pull requests and main branch builds; it is
         #   expected to be skipped for other workflow events.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
@@ -844,6 +837,8 @@ jobs:
                contains(needs.*.result, 'cancelled') ||
                (github.event_name == 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
+                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
+                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.cli_starter_validation_windows.result == 'skipped' && (needs.setup_for_tests.outputs.run_cli_starter == 'true')) ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
@@ -868,6 +863,8 @@ jobs:
                  (needs.polyglot_validation.result == 'skipped' && (needs.setup_for_tests.outputs.run_polyglot == 'true')))) ||
                (github.event_name != 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
+                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
+                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
                  needs.build_cli_archive_macos_x64.result == 'skipped' ||

--- a/extension/src/test-e2e/appHostTree.e2e.test.ts
+++ b/extension/src/test-e2e/appHostTree.e2e.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { findRunningAppHost, getCommandInvocationCount, getResources, getTerminalCommandCount, getTreeAppHostLabel, isSamePath, waitForCommandOutcome, waitForDashboardUrl, waitForExtensionState, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForResource, waitForRunningAppHost, waitForTerminalCommand, waitForWorkspaceAppHost } from './helpers/assertions';
-import { assertClipboardMatchesLastExpectationForE2E, captureWorkspaceAppHostPathClipboardExpectationForE2E, executeE2eControlCommand, getCliWrapperInvocationCount, getCliWrapperInvocations, restoreClipboardSnapshotForE2E, restoreE2eCliPathForE2E, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setE2eCliPathForE2E, setTerminalCommandExecutionSuppressedForE2E, snapshotClipboardForE2E, stopAppHostIfRunning, stopPrimaryAppHostIfRunning, touchPrimaryAppHostProject, writeDelayedPsCliWrapper, writeStreamingDiscoveryCliWrapper, writeTrackedDelayedPsCliWrapper, writeTrackedStreamingDiscoveryCliWrapper } from './helpers/fixtures';
+import { assertClipboardMatchesLastExpectationForE2E, captureWorkspaceAppHostPathClipboardExpectationForE2E, executeE2eControlCommand, getCliWrapperInvocationCount, getCliWrapperInvocations, restoreClipboardSnapshotForE2E, restoreE2eCliPathForE2E, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setE2eCliPathForE2E, setTerminalCommandExecutionSuppressedForE2E, snapshotClipboardForE2E, stopAppHostIfRunning, stopPrimaryAppHostIfRunning, touchPrimaryAppHostProject, writeDelayedPsCliWrapper, writeGatedStreamingDiscoveryCliWrapper, writeStreamingDiscoveryCliWrapper, writeTrackedDelayedPsCliWrapper, writeTrackedStreamingDiscoveryCliWrapper } from './helpers/fixtures';
 import { getPrimaryAppHostProjectPath } from './helpers/paths';
 import { cancelActiveInput, clickTreeItem, executeCommandFromPalette, openAspireView, waitForChildTreeItem, waitForNotificationMessage, waitForTreeItem, waitForWorkbenchText } from './helpers/vscode';
 
@@ -186,37 +186,45 @@ suite('Aspire AppHost tree E2E', function () {
         await waitForCommandOutcome('aspire-vscode.runAppHost', 'success');
         await waitForRunningAppHost();
 
-        // Keep workspace discovery pending long enough for the fresh aspire ps snapshot to
-        // independently restore the running AppHost to the tree.
-        await setE2eCliPathForE2E(writeStreamingDiscoveryCliWrapper(5_000, 5_000));
+        // The loading welcome text is transient. Gate both ps and ls so the test
+        // observes loading before any runtime snapshot can restore the running AppHost.
+        const discoveryGate = writeGatedStreamingDiscoveryCliWrapper();
+        await setE2eCliPathForE2E(discoveryGate.cliPath);
         const invocationCountBefore = getCommandInvocationCount('aspire-vscode.refreshAppHosts');
-        await executeE2eControlCommand({ name: 'refreshAppHosts' }, { waitFor: 'started' });
+        try {
+            await executeE2eControlCommand({ name: 'refreshAppHosts' }, { waitFor: 'started' });
 
-        await waitForWorkspaceRediscoveryLoading('workspace AppHost refresh loading state before running AppHost refresh');
+            await waitForWorkspaceRediscoveryLoading('workspace AppHost refresh loading state before running AppHost refresh');
 
-        const runningBeforeDiscovery = await waitForExtensionState(
-            file => !file.state.isRepositoryLoading
-                && file.state.isWorkspaceAppHostDiscoveryComplete === false
-                && file.state.workspaceAppHostCandidatePaths.length === 0
-                && findRunningAppHost(file.state) !== undefined,
-            'running AppHost to clear loading before workspace discovery produces a candidate',
-            30000);
-        assert.ok(findRunningAppHost(runningBeforeDiscovery.state));
+            discoveryGate.releasePsSnapshot();
+            const runningBeforeDiscovery = await waitForExtensionState(
+                file => !file.state.isRepositoryLoading
+                    && file.state.isWorkspaceAppHostDiscoveryComplete === false
+                    && file.state.workspaceAppHostCandidatePaths.length === 0
+                    && findRunningAppHost(file.state) !== undefined,
+                'running AppHost to clear loading before workspace discovery produces a candidate',
+                30000);
+            assert.ok(findRunningAppHost(runningBeforeDiscovery.state));
 
-        section = await openAspireView();
-        const runningItem = await waitForTreeItem(section, appHostLabel);
-        assert.strictEqual(await runningItem.getLabel(), appHostLabel);
+            section = await openAspireView();
+            const runningItem = await waitForTreeItem(section, appHostLabel);
+            assert.strictEqual(await runningItem.getLabel(), appHostLabel);
 
-        const candidateAfterRunning = await waitForExtensionState(
-            file => file.state.isWorkspaceAppHostDiscoveryComplete === false
-                && file.state.workspaceAppHostCandidatePaths.some(candidatePath => isSamePath(candidatePath, getPrimaryAppHostProjectPath()))
-                && findRunningAppHost(file.state) !== undefined,
-            'streamed workspace AppHost candidate after the running AppHost is restored',
-            30000);
-        assert.strictEqual(candidateAfterRunning.state.isRepositoryLoading, false);
+            discoveryGate.releaseLsCandidate();
+            const candidateAfterRunning = await waitForExtensionState(
+                file => file.state.isWorkspaceAppHostDiscoveryComplete === false
+                    && file.state.workspaceAppHostCandidatePaths.some(candidatePath => isSamePath(candidatePath, getPrimaryAppHostProjectPath()))
+                    && findRunningAppHost(file.state) !== undefined,
+                'streamed workspace AppHost candidate after the running AppHost is restored',
+                30000);
+            assert.strictEqual(candidateAfterRunning.state.isRepositoryLoading, false);
 
-        await waitForCommandOutcome('aspire-vscode.refreshAppHosts', 'success', 30000, invocationCountBefore);
-        await waitForRepositoryIdle();
+            await waitForCommandOutcome('aspire-vscode.refreshAppHosts', 'success', 30000, invocationCountBefore);
+            await waitForRepositoryIdle();
+        } finally {
+            discoveryGate.releasePsSnapshot();
+            discoveryGate.releaseLsCandidate();
+        }
     });
 
     test('clicking the Path tree item copies the AppHost path and shows a confirmation notification', async () => {

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -242,6 +242,33 @@ export function writeStreamingDiscoveryCliWrapper(delayMs = 5_000, initialDelayM
     });
 }
 
+export function writeGatedStreamingDiscoveryCliWrapper(): { cliPath: string; releasePsSnapshot: () => void; releaseLsCandidate: () => void } {
+    const gateDirectory = path.join(getWorkspaceRoot(), '.e2e-cli-wrappers', 'gated-streaming-discovery');
+    const psSnapshotReleaseFilePath = path.join(gateDirectory, 'release-ps-snapshot');
+    const lsCandidateReleaseFilePath = path.join(gateDirectory, 'release-ls-candidate');
+    removePath(gateDirectory, { recursive: true, force: true });
+    fs.mkdirSync(gateDirectory, { recursive: true });
+
+    const cliPath = writeCliWrapper('aspire-gated-streaming-discovery', {
+        configInfoJson: createConfigInfo([lsJsonStreamCapability]),
+        streamedLsCandidate: {
+            path: getPrimaryAppHostProjectPath(),
+            language: 'csharp',
+            status: 'buildable',
+            selected: true,
+        },
+        streamedLsDelayMs: 5_000,
+        streamedLsReleaseFilePath: lsCandidateReleaseFilePath,
+        psSnapshotReleaseFilePath,
+    });
+
+    return {
+        cliPath,
+        releasePsSnapshot: () => writeFileWithRetry(psSnapshotReleaseFilePath, ''),
+        releaseLsCandidate: () => writeFileWithRetry(lsCandidateReleaseFilePath, ''),
+    };
+}
+
 export function writeTrackedStreamingDiscoveryCliWrapper(delayMs = 4_000, initialDelayMs = 500): { cliPath: string; invocationLogPath: string } {
     const invocationLogPath = path.join(getWorkspaceRoot(), '.e2e-cli-wrappers', 'streaming-discovery-invocations.log');
     removePath(invocationLogPath, { force: true });
@@ -736,9 +763,11 @@ function writeCliWrapper(
         streamedLsCandidate?: unknown;
         streamedLsDelayMs?: number;
         streamedLsInitialDelayMs?: number;
+        streamedLsReleaseFilePath?: string;
         streamedLsInvocationLogPath?: string;
         invocationLogPath?: string;
         psSnapshotDelayMs?: number;
+        psSnapshotReleaseFilePath?: string;
     },
 ): string {
     const wrapperDirectory = path.join(getWorkspaceRoot(), '.e2e-cli-wrappers');
@@ -747,9 +776,21 @@ function writeCliWrapper(
     const scriptPath = path.join(wrapperDirectory, `${name}.js`);
     fs.writeFileSync(scriptPath, `#!/usr/bin/env node
 const { spawnSync } = require('child_process');
+const fs = require('fs');
 const realCli = ${JSON.stringify(getCliPath())};
 const args = process.argv.slice(2);
-${options.invocationLogPath === undefined ? '' : `require('fs').appendFileSync(${JSON.stringify(options.invocationLogPath)}, JSON.stringify(args) + '\\n');`}
+${options.invocationLogPath === undefined ? '' : `fs.appendFileSync(${JSON.stringify(options.invocationLogPath)}, JSON.stringify(args) + '\\n');`}
+
+function waitForReleaseFile(filePath, description) {
+  const deadline = Date.now() + 120000;
+  while (!fs.existsSync(filePath)) {
+    if (Date.now() >= deadline) {
+      console.error(\`Timed out waiting for \${description} release file: \${filePath}\`);
+      process.exit(124);
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+  }
+}
 
 if (args.includes('--include-disabled-commands')) {
   console.error('simulated old CLI does not support --include-disabled-commands');
@@ -767,20 +808,24 @@ ${options.configInfoJson === undefined
 ${options.streamedLsCandidate === undefined
         ? ''
         : `if (args[0] === 'ls') {
-${options.streamedLsInvocationLogPath === undefined ? '' : `  require('fs').appendFileSync(${JSON.stringify(options.streamedLsInvocationLogPath)}, 'ls\\n');`}
+${options.streamedLsInvocationLogPath === undefined ? '' : `  fs.appendFileSync(${JSON.stringify(options.streamedLsInvocationLogPath)}, 'ls\\n');`}
   if (!args.includes('--format') || args[args.indexOf('--format') + 1] !== 'json' || !args.includes('--stream')) {
     console.error('Expected AppHost discovery to use ls --format json --stream.');
     process.exit(126);
   }
 
+${options.streamedLsReleaseFilePath === undefined ? '' : `  waitForReleaseFile(${JSON.stringify(options.streamedLsReleaseFilePath)}, 'streamed ls candidate');`}
   setTimeout(() => {
     console.log(${JSON.stringify(JSON.stringify(options.streamedLsCandidate))});
     setTimeout(() => process.exit(0), ${options.streamedLsDelayMs ?? 5_000});
   }, ${options.streamedLsInitialDelayMs ?? 0});
 }
 else {`}
-if (args[0] === 'ps' && !args.includes('--follow')) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${options.psSnapshotDelayMs ?? 0});
+if (args[0] === 'ps') {
+${options.psSnapshotReleaseFilePath === undefined ? '' : `  waitForReleaseFile(${JSON.stringify(options.psSnapshotReleaseFilePath)}, 'ps snapshot');`}
+  if (!args.includes('--follow')) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${options.psSnapshotDelayMs ?? 0});
+  }
 }
 
 const result = spawnSync(realCli, args, {

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -496,6 +496,20 @@ suite('E2E launch profile', () => {
         assert.ok(!debugDashboard.includes("file => file.state.stoppingPaths.some(stoppingPath => isSamePath(stoppingPath, appHostPath))"));
     });
 
+    test('gates slow AppHost discovery before asserting transient loading UI', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..');
+        const fixtures = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'fixtures.ts'), 'utf8');
+        const appHostTree = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'appHostTree.e2e.test.ts'), 'utf8');
+
+        assert.ok(fixtures.includes('writeGatedStreamingDiscoveryCliWrapper'));
+        assert.ok(fixtures.includes('function waitForReleaseFile'));
+        assert.ok(appHostTree.includes('writeGatedStreamingDiscoveryCliWrapper'));
+        assert.ok(appHostTree.includes('discoveryGate.releasePsSnapshot();'));
+        assert.ok(appHostTree.includes('discoveryGate.releaseLsCandidate();'));
+        assert.ok(appHostTree.indexOf('await waitForWorkspaceRediscoveryLoading') < appHostTree.indexOf('discoveryGate.releasePsSnapshot();'));
+        assert.ok(appHostTree.indexOf('discoveryGate.releasePsSnapshot();') < appHostTree.indexOf('discoveryGate.releaseLsCandidate();'));
+    });
+
     test('patches ExTester launch arguments without replacement-token expansion', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const runner = fs.readFileSync(path.join(extensionRoot, 'scripts', 'run-e2e.js'), 'utf8');

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -231,9 +231,14 @@ suite('E2E launch profile', () => {
         const workflow = fs.readFileSync(path.join(extensionRoot, '..', '.github', 'workflows', 'extension-e2e-tests.yml'), 'utf8');
         const resourceGroupsInstallIndex = runner.indexOf("displayName: 'Azure Resource Groups'");
         const functionsInstallIndex = runner.indexOf("displayName: 'Azure Functions'");
+        const skipNoticeIndex = workflow.indexOf('Note skipped Azure Functions E2E shard');
+        const runStepIndex = workflow.indexOf('- name: Run extension E2E tests');
+        const uploadStepIndex = workflow.indexOf('- name: Upload E2E diagnostics');
+        const runStep = workflow.slice(runStepIndex, uploadStepIndex);
 
         assert.ok(workflow.includes('shardName: azure-functions'));
         assert.ok(workflow.includes('installAzureFunctions: true'));
+        assert.ok(workflow.includes("disabledIssue: 'https://github.com/microsoft/aspire/issues/19151'"));
         assert.ok(workflow.includes("core_tools_version='4.12.1'"));
         assert.ok(workflow.includes('faf8fb8d50b5293df338bec70594b12f45730e9fe251805298859b2238cf627e'));
         assert.ok(workflow.includes('vscode-azureresourcegroups/0.12.7/vspackage'));
@@ -245,6 +250,9 @@ suite('E2E launch profile', () => {
         assert.ok(functionsInstallIndex > resourceGroupsInstallIndex);
         assert.ok(runner.includes("path: resolveRequiredVsixPath('ASPIRE_EXTENSION_E2E_AZURE_RESOURCE_GROUPS_VSIX')"));
         assert.ok(runner.includes("path: resolveRequiredVsixPath('ASPIRE_EXTENSION_E2E_AZURE_FUNCTIONS_VSIX')"));
+        assert.ok(skipNoticeIndex >= 0);
+        assert.ok(runStepIndex > skipNoticeIndex);
+        assert.ok(runStep.includes('if: ${{ !matrix.disabledIssue }}'));
     });
 
     test('keeps Linux E2E recordings for successful runs by default', () => {

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -19,6 +19,18 @@ function stripComments(source: string): string {
     return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 }
 
+function getTestBlock(source: string, testName: string): string {
+    const testStart = source.indexOf(`test('${testName}'`);
+    assert.ok(testStart >= 0, `Expected to find test '${testName}'.`);
+
+    const nextTestStart = source.indexOf('\n    test(', testStart + 1);
+    const suiteEnd = source.indexOf('\n});', testStart + 1);
+    const testEnd = nextTestStart >= 0 && nextTestStart < suiteEnd ? nextTestStart : suiteEnd;
+    assert.ok(testEnd > testStart, `Expected to find the end of test '${testName}'.`);
+
+    return source.slice(testStart, testEnd);
+}
+
 suite('E2E launch profile', () => {
     test('creates nothing in the per-run root that a later module-scope throw could strand', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
@@ -500,14 +512,15 @@ suite('E2E launch profile', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const fixtures = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'fixtures.ts'), 'utf8');
         const appHostTree = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'appHostTree.e2e.test.ts'), 'utf8');
+        const runningBeforeDiscoveryTest = getTestBlock(appHostTree, 'running AppHosts appear before slow discovery results');
 
         assert.ok(fixtures.includes('writeGatedStreamingDiscoveryCliWrapper'));
         assert.ok(fixtures.includes('function waitForReleaseFile'));
         assert.ok(appHostTree.includes('writeGatedStreamingDiscoveryCliWrapper'));
         assert.ok(appHostTree.includes('discoveryGate.releasePsSnapshot();'));
         assert.ok(appHostTree.includes('discoveryGate.releaseLsCandidate();'));
-        assert.ok(appHostTree.indexOf('await waitForWorkspaceRediscoveryLoading') < appHostTree.indexOf('discoveryGate.releasePsSnapshot();'));
-        assert.ok(appHostTree.indexOf('discoveryGate.releasePsSnapshot();') < appHostTree.indexOf('discoveryGate.releaseLsCandidate();'));
+        assert.ok(runningBeforeDiscoveryTest.indexOf('await waitForWorkspaceRediscoveryLoading') < runningBeforeDiscoveryTest.indexOf('discoveryGate.releasePsSnapshot();'));
+        assert.ok(runningBeforeDiscoveryTest.indexOf('discoveryGate.releasePsSnapshot();') < runningBeforeDiscoveryTest.indexOf('discoveryGate.releaseLsCandidate();'));
     });
 
     test('patches ExTester launch arguments without replacement-token expansion', () => {

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -519,8 +519,17 @@ suite('E2E launch profile', () => {
         assert.ok(appHostTree.includes('writeGatedStreamingDiscoveryCliWrapper'));
         assert.ok(appHostTree.includes('discoveryGate.releasePsSnapshot();'));
         assert.ok(appHostTree.includes('discoveryGate.releaseLsCandidate();'));
-        assert.ok(runningBeforeDiscoveryTest.indexOf('await waitForWorkspaceRediscoveryLoading') < runningBeforeDiscoveryTest.indexOf('discoveryGate.releasePsSnapshot();'));
-        assert.ok(runningBeforeDiscoveryTest.indexOf('discoveryGate.releasePsSnapshot();') < runningBeforeDiscoveryTest.indexOf('discoveryGate.releaseLsCandidate();'));
+
+        const cleanupIndex = runningBeforeDiscoveryTest.indexOf('finally {');
+        assert.ok(cleanupIndex >= 0, 'Expected the E2E to keep cleanup releases in a finally block.');
+        const testBeforeCleanup = runningBeforeDiscoveryTest.slice(0, cleanupIndex);
+        const loadingIndex = testBeforeCleanup.indexOf('await waitForWorkspaceRediscoveryLoading');
+        const releasePsIndex = testBeforeCleanup.indexOf('discoveryGate.releasePsSnapshot();');
+        const releaseLsIndex = testBeforeCleanup.indexOf('discoveryGate.releaseLsCandidate();');
+
+        assert.ok(loadingIndex >= 0, 'The E2E must wait for the transient loading UI before releasing the running AppHost snapshot.');
+        assert.ok(releasePsIndex > loadingIndex, 'The running AppHost snapshot must be released after the loading UI has been observed.');
+        assert.ok(releaseLsIndex > releasePsIndex, 'The slow workspace candidate must be released after the running AppHost snapshot.');
     });
 
     test('patches ExTester launch arguments without replacement-token expansion', () => {

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using YamlDotNet.RepresentationModel;
+
+namespace Infrastructure.Tests.Pipelines;
+
+/// <summary>
+/// Guards the shard-disable contract in <c>.github/workflows/extension-e2e-tests.yml</c>.
+///
+/// A shard row is disabled by adding <c>disabledIssue</c> to its matrix entry, which keeps the job
+/// visible in the checks list while the underlying fixture is broken. That only works if every step
+/// the disabled shard cannot survive is guarded by the same condition: guarding the prerequisite
+/// installation alone leaves the suite itself running against missing prerequisites, so the shard
+/// fails anyway (or worse, passes without running anything and hides the disable).
+/// </summary>
+public sealed class ExtensionE2eWorkflowTests
+{
+    private const string WorkflowRelativePath = ".github/workflows/extension-e2e-tests.yml";
+    private const string DisabledGuard = "!matrix.disabledIssue";
+
+    [Fact]
+    public void DisabledShardRowsSkipEveryShardOnlyStep()
+    {
+        var job = LoadExtensionE2eJob();
+
+        var disabledRows = MatrixIncludeRows(job)
+            .Where(row => row.Children.ContainsKey(new YamlScalarNode("disabledIssue")))
+            .ToList();
+        Assert.NotEmpty(disabledRows);
+
+        var steps = ((YamlSequenceNode)job.Children[new YamlScalarNode("steps")]).Cast<YamlMappingNode>().ToList();
+
+        // The suite itself. Without the guard the disabled shard still runs the E2E tests, which is
+        // exactly what `disabledIssue` is supposed to prevent.
+        var runSuiteSteps = steps.Where(step => Scalar(step, "run")?.Contains("run-e2e.js", StringComparison.Ordinal) == true).ToList();
+        Assert.NotEmpty(runSuiteSteps);
+        foreach (var step in runSuiteSteps)
+        {
+            var condition = Scalar(step, "if");
+            Assert.True(
+                condition?.Contains(DisabledGuard, StringComparison.Ordinal) == true,
+                $"Step '{Scalar(step, "name")}' runs the E2E suite but is not guarded by '{DisabledGuard}' (if: {condition ?? "<none>"}).");
+        }
+
+        // Shard-specific setup. Any step conditioned on a matrix capability flag belongs to one
+        // shard only, so a disabled row must skip it too - otherwise the row keeps paying for (and
+        // can keep failing on) setup for a suite that never runs.
+        var shardSetupSteps = steps
+            .Where(step => Scalar(step, "if") is { } condition
+                && condition.Contains("matrix.installAzureFunctions", StringComparison.Ordinal))
+            .ToList();
+        Assert.NotEmpty(shardSetupSteps);
+        foreach (var step in shardSetupSteps)
+        {
+            var condition = Scalar(step, "if")!;
+            Assert.True(
+                condition.Contains(DisabledGuard, StringComparison.Ordinal),
+                $"Step '{Scalar(step, "name")}' is shard-specific setup but is not guarded by '{DisabledGuard}' (if: {condition}).");
+        }
+    }
+
+    [Fact]
+    public void DisabledShardRowsAnnounceWhyTheyAreSkipped()
+    {
+        var job = LoadExtensionE2eJob();
+        var steps = ((YamlSequenceNode)job.Children[new YamlScalarNode("steps")]).Cast<YamlMappingNode>();
+
+        // A green shard that ran nothing is indistinguishable from a green shard that passed unless
+        // the job says so, so the disable has to be visible in the run itself.
+        var noticeStep = steps.FirstOrDefault(step =>
+            Scalar(step, "if")?.Contains("matrix.disabledIssue", StringComparison.Ordinal) == true
+            && Scalar(step, "if")?.Contains(DisabledGuard, StringComparison.Ordinal) != true);
+
+        Assert.NotNull(noticeStep);
+        Assert.Contains("matrix.disabledIssue", Scalar(noticeStep, "run"), StringComparison.Ordinal);
+    }
+
+    private static YamlMappingNode LoadExtensionE2eJob()
+    {
+        var yaml = new YamlStream();
+        using var reader = new StringReader(File.ReadAllText(Path.Combine(RepoRoot.Path, WorkflowRelativePath)));
+        yaml.Load(reader);
+
+        var root = (YamlMappingNode)yaml.Documents[0].RootNode;
+        var jobs = (YamlMappingNode)root.Children[new YamlScalarNode("jobs")];
+
+        return (YamlMappingNode)jobs.Children[new YamlScalarNode("extension_e2e")];
+    }
+
+    private static IEnumerable<YamlMappingNode> MatrixIncludeRows(YamlMappingNode job)
+    {
+        var strategy = (YamlMappingNode)job.Children[new YamlScalarNode("strategy")];
+        var matrix = (YamlMappingNode)strategy.Children[new YamlScalarNode("matrix")];
+
+        return ((YamlSequenceNode)matrix.Children[new YamlScalarNode("include")]).Cast<YamlMappingNode>();
+    }
+
+    private static string? Scalar(YamlMappingNode node, string key)
+        => node.Children.TryGetValue(new YamlScalarNode(key), out var value) && value is YamlScalarNode scalar
+            ? scalar.Value
+            : null;
+}


### PR DESCRIPTION
Re-enables the VS Code extension E2E workflow by removing the `false &&` guard and restoring the aggregate-gate skip checks.

## Probe result

Run 31202231991 exercised the E2E matrix after the guard was removed. `Verify ExTester internal feed availability` passed.

Passed on both Linux and Windows in that run: `apphost-tree`, `command-palette`, `debug-dashboard`, `debug-startup-timeout`, `discovery-configuration`, `edge-cases`, `package-surface`, `settings-files`, `tree-actions`, and `zero-to-running`. `debug-dashboard` passing on both platforms removes the main known reason the job had been disabled.

A later run exposed a race in `apphost-tree`: the test waited for the transient `Searching for AppHosts...` welcome after discovery could already finish. This PR now gates the simulated `ps` and streaming `ls` CLI calls so the loading state is observed deterministically before releasing the running AppHost snapshot and then the workspace candidate.

The only deterministic E2E shard failure from the original probe was `azure-functions` on Linux: it timed out after 300000ms waiting for `e2e-functions` to reach `Running` with `Last error: <none>`. The job log shows Azure Functions Core Tools 4.12.1 was installed and `func --version` succeeded, so this was not a missing Core Tools install. The workflow currently has no Windows `azure-functions` shard.

## Follow-up

The `azure-functions` shard remains visible in the reusable workflow, but the Functions fixture is disabled pending https://github.com/microsoft/aspire/issues/19151. The other VS Code extension E2E shards are re-enabled.

Validation after the AppHost race fix: run 31212569613 passed both `apphost-tree` jobs (`Linux` and `Windows`) and reported no VS Code extension E2E failures.
## Review follow-up

Re-checked the guard and fixed it to slice the intended `running AppHosts appear before slow discovery results` test block before comparing the wait/release ordering. The earlier unrelated `waitForWorkspaceRediscoveryLoading` occurrence can no longer make the guard pass.

Validation from `extension/`:

```
corepack yarn compile-tests   passed
corepack yarn compile         webpack succeeded with existing optional/ws warnings
corepack yarn lint            passed
./node_modules/.bin/mocha out/test/e2eLaunchProfile.test.js --ui tdd --grep "gates slow AppHost discovery"
  1 passing
```

Mutation check: moving the intended wait after `discoveryGate.releasePsSnapshot()` made the fixed guard fail on the wait-before-release assertion.

Pushed commit: `b74dc620c7df64fb67177c6f5f57590cc4da73f5`.

## Review convergence follow-up

Latest Copilot pass found that `disabledIssue` skipped Azure Functions prerequisites but not the actual E2E execution step. The `Run extension E2E tests` step now has the same `!matrix.disabledIssue` guard, so disabled shards stay visible in the matrix without running the spec.

Validation:

```
corepack yarn --silent compile-tests                         passed
corepack yarn --silent compile                               webpack succeeded with existing optional/ws warnings
corepack yarn --silent unit-test --grep "E2E launch profile"
  50 passing
```

Mutation check: removing the `Run extension E2E tests` condition made `pins the real Azure Functions toolchain for the offline E2E shard` fail on `assert.ok(runStep.includes('if: ${{ !matrix.disabledIssue }}'))`. Restored fix reran green.

Pushed commit: `0d41da0bf69bd957cc94c659dd74c9dc13395ccb`.
