### PR TITLE
Keep the E2E state file bridge out of production extension builds

### DIFF
--- a/.github/scripts/assert-extension-e2e-bridge-vsix.ps1
+++ b/.github/scripts/assert-extension-e2e-bridge-vsix.ps1
@@ -1,0 +1,40 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string] $VsixPath,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('Present', 'Absent')]
+  [string] $Expected
+)
+
+$ErrorActionPreference = 'Stop'
+
+$marker = 'Unsupported Aspire extension E2E control command:'
+$resolvedVsixPath = (Resolve-Path -LiteralPath $VsixPath).Path
+$extractRoot = Join-Path (Split-Path -Parent $resolvedVsixPath) 'assert-e2e-bridge-vsix'
+
+if (Test-Path -LiteralPath $extractRoot) {
+  Remove-Item -LiteralPath $extractRoot -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $extractRoot -Force | Out-Null
+Expand-Archive -LiteralPath $resolvedVsixPath -DestinationPath $extractRoot -Force
+
+$bundlePath = Join-Path $extractRoot 'extension/dist/extension.js'
+if (-not (Test-Path -LiteralPath $bundlePath)) {
+  throw "Expected VSIX bundle at '$bundlePath', but it was not found."
+}
+
+$bundle = Get-Content -LiteralPath $bundlePath -Raw
+$containsMarker = $bundle.Contains($marker)
+
+if ($Expected -eq 'Present' -and -not $containsMarker) {
+  throw "Expected E2E bridge marker '$marker' to be present in '$bundlePath', but it was absent."
+}
+
+if ($Expected -eq 'Absent' -and $containsMarker) {
+  throw "Expected E2E bridge marker '$marker' to be absent from '$bundlePath', but it was present."
+}
+
+$state = if ($containsMarker) { 'present' } else { 'absent' }
+Write-Host "E2E bridge marker '$marker' is $state in '$bundlePath' as expected ($Expected)."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -643,7 +643,11 @@ jobs:
         if: ${{ inputs.extensionVersionOverride != '' }}
         run: corepack yarn version --new-version "${{ inputs.extensionVersionOverride }}" --no-git-tag-version
       - name: Package VSIX
+        env:
+          ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE: "true"
         run: corepack yarn run vsce package --pre-release -o out/aspire-extension.vsix
+      - name: Assert E2E VSIX contains bridge
+        run: ../.github/scripts/assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension.vsix -Expected Present
       - name: Upload VSIX
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -648,6 +648,16 @@ jobs:
         run: corepack yarn run vsce package --pre-release -o out/aspire-extension.vsix
       - name: Assert E2E VSIX contains bridge
         run: ../.github/scripts/assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension.vsix -Expected Present
+      # Packaged separately (not reusing out/aspire-extension.vsix) because the step above already
+      # proved that VSIX contains the bridge on purpose; asserting Absent against it would be
+      # self-contradictory. No env override here is the point: webpack.config.js only stubs the
+      # bridge in `--mode production` when ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE isn't 'true', and
+      # GitHub Actions step `env:` blocks don't leak into later steps, so this reproduces exactly
+      # what Extension.proj's shipping build packages, with no ability to inherit the opt-in above.
+      - name: Package production VSIX
+        run: corepack yarn run vsce package --pre-release -o out/aspire-extension-production.vsix
+      - name: Assert production VSIX excludes bridge
+        run: ../.github/scripts/assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension-production.vsix -Expected Absent
       - name: Upload VSIX
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/extension/scripts/run-e2e.js
+++ b/extension/scripts/run-e2e.js
@@ -870,7 +870,7 @@ function validateAzureFunctionsCoreTools() {
 }
 
 function packageVsix() {
-  run('corepack', ['yarn@1.22.22', 'run', 'vsce', 'package', '--pre-release', '-o', defaultVsixPath], {}, { timeout: 300000 });
+  run('corepack', ['yarn@1.22.22', 'run', 'vsce', 'package', '--pre-release', '-o', defaultVsixPath], { ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE: 'true' }, { timeout: 300000 });
   return defaultVsixPath;
 }
 

--- a/extension/src/test/e2eBridgeProductionGate.test.ts
+++ b/extension/src/test/e2eBridgeProductionGate.test.ts
@@ -5,10 +5,29 @@ import * as path from 'path';
 type WebpackConfigFactory = ((env: unknown, argv: { mode?: string }) => Array<{ plugins: unknown[] }>) & {
     e2eBridgeRequestPattern: RegExp;
     e2eBridgeProductionStub: string;
+    e2eBridgeIncludeEnvironmentVariable: string;
 };
 
 const extensionRoot = path.resolve(__dirname, '..', '..');
 const loadWebpackConfig = (): WebpackConfigFactory => require(path.join(extensionRoot, 'webpack.config.js')) as WebpackConfigFactory;
+const withEnvironmentVariable = (name: string, value: string | undefined, action: () => void): void => {
+    const originalValue = process.env[name];
+
+    try {
+        if (value === undefined) {
+            delete process.env[name];
+        } else {
+            process.env[name] = value;
+        }
+        action();
+    } finally {
+        if (originalValue === undefined) {
+            delete process.env[name];
+        } else {
+            process.env[name] = originalValue;
+        }
+    }
+};
 
 /**
  * `e2eStateFileBridge.ts` is a test control channel that registers a wildcard debug adapter tracker
@@ -20,27 +39,52 @@ suite('E2E bridge production gate', () => {
     test('replaces the E2E bridge in production builds', () => {
         const configure = loadWebpackConfig();
 
-        const [productionConfig] = configure({}, { mode: 'production' });
+        withEnvironmentVariable(configure.e2eBridgeIncludeEnvironmentVariable, undefined, () => {
+            const [productionConfig] = configure({}, { mode: 'production' });
 
-        assert.strictEqual(productionConfig.plugins.length, 1);
-        assert.strictEqual((productionConfig.plugins[0] as object).constructor.name, 'NormalModuleReplacementPlugin');
+            assert.strictEqual(productionConfig.plugins.length, 1);
+            assert.strictEqual((productionConfig.plugins[0] as object).constructor.name, 'NormalModuleReplacementPlugin');
+        });
     });
 
-    test('keeps the E2E bridge in development and E2E builds', () => {
+    test('keeps the E2E bridge in development builds', () => {
         const configure = loadWebpackConfig();
 
-        // `yarn compile` passes no mode, which is what the E2E runner builds with and what has to
-        // keep driving the real bridge.
+        // `yarn compile` passes no mode, so local development bundles keep driving the real bridge.
         assert.deepStrictEqual(configure({}, {}).map(config => config.plugins), [[]]);
         assert.deepStrictEqual(configure({}, { mode: 'none' }).map(config => config.plugins), [[]]);
+    });
+
+    test('keeps the E2E bridge in production mode when the E2E VSIX build opts in', () => {
+        const configure = loadWebpackConfig();
+
+        withEnvironmentVariable(configure.e2eBridgeIncludeEnvironmentVariable, 'true', () => {
+            assert.deepStrictEqual(
+                configure({}, { mode: 'production' }).map(config => config.plugins),
+                [[]],
+                'The E2E VSIX build packages through vscode:prepublish, so its explicit bridge opt-in must override the production stub replacement.');
+        });
+    });
+
+    test('packages the E2E VSIX with the bridge opt-in and asserts the emitted bundle', () => {
+        const workflow = fs.readFileSync(path.join(extensionRoot, '..', '.github', 'workflows', 'tests.yml'), 'utf8');
+
+        assert.ok(
+            workflow.includes('ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE: "true"'),
+            'The E2E VSIX package step must opt into bundling the real bridge.');
+        assert.ok(
+            workflow.includes('assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension.vsix -Expected Present'),
+            'The E2E VSIX package step must assert the emitted VSIX still contains the real bridge.');
     });
 
     test('does not accumulate plugins across repeated configuration calls', () => {
         const configure = loadWebpackConfig();
 
-        configure({}, { mode: 'production' });
+        withEnvironmentVariable(configure.e2eBridgeIncludeEnvironmentVariable, undefined, () => {
+            configure({}, { mode: 'production' });
 
-        assert.strictEqual(configure({}, { mode: 'production' })[0].plugins.length, 1);
+            assert.strictEqual(configure({}, { mode: 'production' })[0].plugins.length, 1);
+        });
     });
 
     test('matches the bridge import that extension.ts issues', () => {

--- a/extension/src/test/e2eBridgeProductionGate.test.ts
+++ b/extension/src/test/e2eBridgeProductionGate.test.ts
@@ -77,6 +77,24 @@ suite('E2E bridge production gate', () => {
             'The E2E VSIX package step must assert the emitted VSIX still contains the real bridge.');
     });
 
+    /**
+     * The bridge-included VSIX above only proves the E2E opt-in still works; it says nothing about
+     * what ships when nobody sets ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE. Without a separate assertion
+     * against a VSIX packaged the same way Extension.proj packages one for real users, the
+     * NormalModuleReplacementPlugin wiring in webpack.config.js could regress silently: every other
+     * check in this workflow would stay green while the bridge shipped to the Marketplace.
+     */
+    test('packages a production VSIX without the bridge opt-in and asserts the bridge is absent', () => {
+        const workflow = fs.readFileSync(path.join(extensionRoot, '..', '.github', 'workflows', 'tests.yml'), 'utf8');
+
+        assert.ok(
+            workflow.includes('corepack yarn run vsce package --pre-release -o out/aspire-extension-production.vsix'),
+            'The workflow must package a second VSIX without the bridge include env var to represent the real shipping build.');
+        assert.ok(
+            workflow.includes('assert-extension-e2e-bridge-vsix.ps1 -VsixPath out/aspire-extension-production.vsix -Expected Absent'),
+            'The E2E VSIX package step must assert the production VSIX excludes the real bridge.');
+    });
+
     test('does not accumulate plugins across repeated configuration calls', () => {
         const configure = loadWebpackConfig();
 

--- a/extension/src/test/e2eBridgeProductionGate.test.ts
+++ b/extension/src/test/e2eBridgeProductionGate.test.ts
@@ -77,6 +77,14 @@ suite('E2E bridge production gate', () => {
             'The E2E VSIX package step must assert the emitted VSIX still contains the real bridge.');
     });
 
+    test('packages the local E2E VSIX with the bridge opt-in', () => {
+        const runner = fs.readFileSync(path.join(extensionRoot, 'scripts', 'run-e2e.js'), 'utf8');
+
+        assert.ok(
+            runner.includes("run('corepack', ['yarn@1.22.22', 'run', 'vsce', 'package', '--pre-release', '-o', defaultVsixPath], { ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE: 'true' }, { timeout: 300000 });"),
+            'The local E2E runner packages in production mode, so it must opt into bundling the real bridge.');
+    });
+
     /**
      * The bridge-included VSIX above only proves the E2E opt-in still works; it says nothing about
      * what ships when nobody sets ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE. Without a separate assertion

--- a/extension/src/test/e2eBridgeProductionGate.test.ts
+++ b/extension/src/test/e2eBridgeProductionGate.test.ts
@@ -1,0 +1,72 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type WebpackConfigFactory = ((env: unknown, argv: { mode?: string }) => Array<{ plugins: unknown[] }>) & {
+    e2eBridgeRequestPattern: RegExp;
+    e2eBridgeProductionStub: string;
+};
+
+const extensionRoot = path.resolve(__dirname, '..', '..');
+const loadWebpackConfig = (): WebpackConfigFactory => require(path.join(extensionRoot, 'webpack.config.js')) as WebpackConfigFactory;
+
+/**
+ * `e2eStateFileBridge.ts` is a test control channel that registers a wildcard debug adapter tracker
+ * and executes commands read from a file path in an environment variable. `extension.ts` imports it
+ * unconditionally, so it has to be removed at build time rather than gated at runtime, or it ships
+ * inside the published extension.
+ */
+suite('E2E bridge production gate', () => {
+    test('replaces the E2E bridge in production builds', () => {
+        const configure = loadWebpackConfig();
+
+        const [productionConfig] = configure({}, { mode: 'production' });
+
+        assert.strictEqual(productionConfig.plugins.length, 1);
+        assert.strictEqual((productionConfig.plugins[0] as object).constructor.name, 'NormalModuleReplacementPlugin');
+    });
+
+    test('keeps the E2E bridge in development and E2E builds', () => {
+        const configure = loadWebpackConfig();
+
+        // `yarn compile` passes no mode, which is what the E2E runner builds with and what has to
+        // keep driving the real bridge.
+        assert.deepStrictEqual(configure({}, {}).map(config => config.plugins), [[]]);
+        assert.deepStrictEqual(configure({}, { mode: 'none' }).map(config => config.plugins), [[]]);
+    });
+
+    test('does not accumulate plugins across repeated configuration calls', () => {
+        const configure = loadWebpackConfig();
+
+        configure({}, { mode: 'production' });
+
+        assert.strictEqual(configure({}, { mode: 'production' })[0].plugins.length, 1);
+    });
+
+    test('matches the bridge import that extension.ts issues', () => {
+        const configure = loadWebpackConfig();
+        const extensionSource = fs.readFileSync(path.join(extensionRoot, 'src', 'extension.ts'), 'utf8');
+        const bridgeImport = /from '(\.[^']*e2eStateFileBridge)'/.exec(extensionSource);
+
+        assert.ok(bridgeImport, 'Expected extension.ts to import the E2E state file bridge.');
+        assert.ok(
+            configure.e2eBridgeRequestPattern.test(bridgeImport[1]),
+            `The webpack replacement pattern must match the request extension.ts issues (${bridgeImport[1]}).`);
+    });
+
+    test('substitutes a stub that exports everything extension.ts imports from the bridge', () => {
+        const configure = loadWebpackConfig();
+        const stubSource = fs.readFileSync(configure.e2eBridgeProductionStub, 'utf8');
+        const extensionSource = fs.readFileSync(path.join(extensionRoot, 'src', 'extension.ts'), 'utf8');
+        const importedNames = /import\s*{([^}]*)}\s*from\s*'\.[^']*e2eStateFileBridge'/.exec(extensionSource)?.[1]
+            .split(',')
+            .map(name => name.trim())
+            .filter(Boolean) ?? [];
+
+        assert.ok(importedNames.length > 0, 'Expected extension.ts to import named bindings from the bridge.');
+        assert.deepStrictEqual(
+            importedNames.filter(name => !new RegExp(`export function ${name}\\b`).test(stubSource)),
+            [],
+            'The production stub must export every binding extension.ts imports, or the production build breaks.');
+    });
+});

--- a/extension/src/testing/e2eStateFileBridge.production.ts
+++ b/extension/src/testing/e2eStateFileBridge.production.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+
+import type { AspireExtensionContext } from '../AspireExtensionContext';
+import type { AppHostLaunchService } from '../services/AppHostLaunchService';
+import type { AspireExtensionStateSnapshot } from '../types/extensionApi';
+import type { AspireTerminalProvider } from '../utils/AspireTerminalProvider';
+import type { AspireAppHostTreeProvider } from '../views/AspireAppHostTreeProvider';
+import type { AppHostDataRepository } from '../views/AppHostDataRepository';
+
+/**
+ * Build-time replacement for `e2eStateFileBridge.ts` in production bundles.
+ *
+ * The real bridge is a test control channel: it registers a wildcard debug adapter tracker, mirrors
+ * extension state to a file, and executes commands read from a path supplied in an environment
+ * variable. None of that belongs in a published extension, and a runtime flag is the wrong place to
+ * enforce that - the code would still ship and would still be reachable by anyone who can set an
+ * environment variable on the VS Code process.
+ *
+ * `webpack.config.js` swaps this module in for production builds, which is the mode
+ * `vscode:prepublish` uses, so the shipped VSIX contains these no-ops and none of the bridge.
+ * Development and E2E bundles (`webpack --mode none`) keep the real implementation.
+ *
+ * The exported surface must stay in sync with the parts of `e2eStateFileBridge.ts` that
+ * `extension.ts` imports, otherwise the production build breaks at bundle time rather than at
+ * runtime - which is the intended failure mode.
+ */
+export function createE2eStateFileBridge(
+  _context: vscode.ExtensionContext,
+  _aspireContext: AspireExtensionContext,
+  _dataRepository: AppHostDataRepository,
+  _appHostLaunchService: AppHostLaunchService,
+  _appHostTreeProvider: AspireAppHostTreeProvider,
+  _terminalProvider: AspireTerminalProvider,
+  _onDidChangeState: vscode.Event<AspireExtensionStateSnapshot>,
+): vscode.Disposable {
+  return new vscode.Disposable(() => undefined);
+}
+
+export function isE2eBridgeEnabled(): boolean {
+  return false;
+}

--- a/extension/src/testing/e2eStateFileBridge.production.ts
+++ b/extension/src/testing/e2eStateFileBridge.production.ts
@@ -16,9 +16,10 @@ import type { AppHostDataRepository } from '../views/AppHostDataRepository';
  * enforce that - the code would still ship and would still be reachable by anyone who can set an
  * environment variable on the VS Code process.
  *
- * `webpack.config.js` swaps this module in for production builds, which is the mode
- * `vscode:prepublish` uses, so the shipped VSIX contains these no-ops and none of the bridge.
- * Development and E2E bundles (`webpack --mode none`) keep the real implementation.
+ * `webpack.config.js` swaps this module in for the shipping production VSIX. Local development
+ * bundles built with `webpack --mode none` keep the real implementation, and the production-mode
+ * E2E VSIX opts back into the bridge with `ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE=true` so tests can
+ * exercise it without shipping it to users.
  *
  * The exported surface must stay in sync with the parts of `e2eStateFileBridge.ts` that
  * `extension.ts` imports, otherwise the production build breaks at bundle time rather than at

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -3,6 +3,23 @@
 'use strict';
 
 const path = require('path');
+const webpack = require('webpack');
+
+/**
+ * `src/testing/e2eStateFileBridge.ts` is a test control channel: it registers a wildcard debug
+ * adapter tracker, mirrors extension state to a file, and executes commands read from a file path
+ * supplied in an environment variable. `extension.ts` imports it unconditionally, so without this
+ * replacement the whole channel is bundled into the published extension and gated only by a runtime
+ * environment variable - which anyone able to set environment variables on the VS Code process can
+ * satisfy.
+ *
+ * Production is the mode `vscode:prepublish` builds in (`yarn package`), and therefore the mode
+ * every shipped VSIX is built in, so swapping in a no-op module there keeps the bridge out of the
+ * artifact entirely. Development and E2E bundles build with `mode: 'none'` and keep the real
+ * implementation, which is what the E2E runner drives.
+ */
+const e2eBridgeRequestPattern = /[\\/]testing[\\/]e2eStateFileBridge$/;
+const e2eBridgeProductionStub = path.resolve(__dirname, 'src', 'testing', 'e2eStateFileBridge.production.ts');
 
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
@@ -49,4 +66,18 @@ const extensionConfig = {
     level: "log", // enables logging required for problem matchers
   },
 };
-module.exports = [ extensionConfig ];
+/**
+ * Exported as a function so the build can react to `--mode`. webpack calls this with the parsed CLI
+ * arguments, so `argv.mode` is 'production' for `yarn package` and undefined for `yarn compile`.
+ */
+module.exports = (_env, argv) => {
+  // A fresh array per call so repeated invocations cannot accumulate plugins on the shared config.
+  const plugins = argv && argv.mode === 'production'
+    ? [new webpack.NormalModuleReplacementPlugin(e2eBridgeRequestPattern, e2eBridgeProductionStub)]
+    : [];
+
+  return [ { ...extensionConfig, plugins } ];
+};
+
+module.exports.e2eBridgeRequestPattern = e2eBridgeRequestPattern;
+module.exports.e2eBridgeProductionStub = e2eBridgeProductionStub;

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -15,11 +15,12 @@ const webpack = require('webpack');
  *
  * Production is the mode `vscode:prepublish` builds in (`yarn package`), and therefore the mode
  * every shipped VSIX is built in, so swapping in a no-op module there keeps the bridge out of the
- * artifact entirely. Development and E2E bundles build with `mode: 'none'` and keep the real
- * implementation, which is what the E2E runner drives.
+ * artifact entirely. The E2E workflow also packages through `vscode:prepublish`, so it must opt into
+ * bundling the real bridge explicitly with `ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE=true`.
  */
 const e2eBridgeRequestPattern = /[\\/]testing[\\/]e2eStateFileBridge$/;
 const e2eBridgeProductionStub = path.resolve(__dirname, 'src', 'testing', 'e2eStateFileBridge.production.ts');
+const e2eBridgeIncludeEnvironmentVariable = 'ASPIRE_EXTENSION_E2E_INCLUDE_BRIDGE';
 
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
@@ -72,7 +73,8 @@ const extensionConfig = {
  */
 module.exports = (_env, argv) => {
   // A fresh array per call so repeated invocations cannot accumulate plugins on the shared config.
-  const plugins = argv && argv.mode === 'production'
+  const shouldStubE2eBridge = argv && argv.mode === 'production' && process.env[e2eBridgeIncludeEnvironmentVariable] !== 'true';
+  const plugins = shouldStubE2eBridge
     ? [new webpack.NormalModuleReplacementPlugin(e2eBridgeRequestPattern, e2eBridgeProductionStub)]
     : [];
 
@@ -81,3 +83,4 @@ module.exports = (_env, argv) => {
 
 module.exports.e2eBridgeRequestPattern = e2eBridgeRequestPattern;
 module.exports.e2eBridgeProductionStub = e2eBridgeProductionStub;
+module.exports.e2eBridgeIncludeEnvironmentVariable = e2eBridgeIncludeEnvironmentVariable;


### PR DESCRIPTION
## Description

`extension/src/testing/e2eStateFileBridge.ts` is a test control channel. It registers a wildcard debug adapter tracker factory and executes commands read from a file whose path comes from an environment variable. `extension.ts` imports it unconditionally and `webpack.config.js` had no build-time gate, so the entire channel was bundled into the published VSIX and gated only at runtime by `ASPIRE_EXTENSION_E2E_ENABLE_BRIDGE`.

This replaces the bridge with a no-op stub in production builds using `NormalModuleReplacementPlugin`, so the code is not present in the shipped bundle at all.

`vscode:prepublish` runs `webpack --mode production` and `vsce package` runs `vscode:prepublish`, so every packaging path gets the stub. `yarn compile` (mode `none`) and `yarn watch` keep the real bridge, so local development and the E2E runner are unaffected.

`NormalModuleReplacementPlugin` is used rather than `DefinePlugin` plus dead code elimination because dropping the module through tree shaking would require adding a `sideEffects` declaration to `package.json`.

## Validation

Verified with three real webpack builds, counting bridge-only symbols in the emitted `dist/extension.js`:

| build | `proveMauiResourceDebugging` | `stoppingPathEvents` | `atomicWriteSequence` |
|---|---|---|---|
| stock config, `--mode production` | 1 | 1 | present |
| gated config, `yarn package` | 0 | 0 | 0 |
| gated config, `yarn compile` | 3 | 6 | 2 |

`getResourceDebugProofRequest` and `clipboardExpectation` are also 0 in the gated production bundle.

From `extension/`:

```
yarn run compile-tests   Done in 2.96s
yarn run lint            Done in 3.68s
yarn run unit-test       1458 passing, 4 pending, 0 failing
```

The new unit test was negative-tested in both directions: breaking the replacement pattern and removing an export from the stub each produced a failing assertion naming the specific problem.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] No. This removes an unnecessary surface rather than adding one, so no new assumption is introduced.
