### PR TITLE
Fix build break in AzureBicepResourceScopeTests

### DIFF
--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
@@ -16,7 +16,7 @@ public class AzureBicepResourceScopeTests
     [Fact]
     public void ResourceGroupThrowsForSubscriptionScope()
     {
-        var scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+        var scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
         var exception = Assert.Throws<InvalidOperationException>(() => scope.ResourceGroup);
 
@@ -26,7 +26,7 @@ public class AzureBicepResourceScopeTests
     [Fact]
     public void ResourceGroupThrowsForTenantScope()
     {
-        var scope = AzureBicepResourceScope.ForTenant();
+        var scope = AzureBicepResourceScope.CreateForTenant();
 
         var exception = Assert.Throws<InvalidOperationException>(() => scope.ResourceGroup);
 


### PR DESCRIPTION
## Description

`main` has not compiled since 2026-08-07T17:08Z in `Aspire.Hosting.Azure.Tests`.

- #19084 by `sebastienros` merged at 17:07:49Z and added `AzureBicepResourceScopeTests.cs` calling `ForSubscription`/`ForTenant`.
- #18976 by `sebastienros` merged at 17:08:16Z, 27 seconds later, and renamed those factories to `CreateForSubscription`/`CreateForTenant`.

Neither PR conflicted textually and each was green against the `main` it branched from, so CI could not catch this semantic merge conflict. This updates the two test call sites to the current API. No product code changes.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
