### PR TITLE
Quarantine two flaky ProcessGuestLauncherTests

### DIFF
--- a/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
 using static Aspire.Cli.Tests.TestServices.ProcessTestHelpers;
+using Aspire.TestUtilities;
 
 namespace Aspire.Cli.Tests.Projects;
 
@@ -138,6 +139,7 @@ public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper) : IDispos
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/18880")]
     public async Task LaunchAsync_WithGracefulServices_BlockingSignalerDoesNotConsumeGracefulBudget()
     {
         // Regression coverage for DCP's stop-process-tree behavior: the graceful signaler can
@@ -194,6 +196,7 @@ public class ProcessGuestLauncherTests(ITestOutputHelper outputHelper) : IDispos
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/microsoft/aspire/issues/18667")]
     public async Task LaunchAsync_WithGracefulServices_ProcessIgnoresSignal_ExpireEscalatesToTreeKill()
     {
         // Run-path bad-citizen case: graceful signaler accepts the request but the process ignores


### PR DESCRIPTION
## Description

Adds `[QuarantinedTest]` to two tests in `tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs`. Both already have open tracking issues; neither had been quarantined.

| Test | Tracking issue |
|---|---|
| `LaunchAsync_WithGracefulServices_BlockingSignalerDoesNotConsumeGracefulBudget` | https://github.com/microsoft/aspire/issues/18880 |
| `LaunchAsync_WithGracefulServices_ProcessIgnoresSignal_ExpireEscalatesToTreeKill` | https://github.com/microsoft/aspire/issues/18667 |

Both tests launch a real child process and assert on wall-clock elapsed time:

```csharp
await Task.Delay(500);
cts.Cancel();

var stopwatch = Stopwatch.StartNew();
var (exitCode, _) = await launchTask.WaitAsync(TimeSpan.FromSeconds(10));
stopwatch.Stop();
...
Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5), ...);
```

`BlockingSignalerDoesNotConsumeGracefulBudget` carries the tightest budget in the file, a 5-second elapsed assertion. `ProcessIgnoresSignal_ExpireEscalatesToTreeKill` combines a 10-second signal wait with a 15-second elapsed assertion. Those budgets measure host scheduling latency in addition to the behavior under test, so they fail when the CI machine is saturated. On https://github.com/microsoft/aspire/pull/19133, the run that failed `BlockingSignalerDoesNotConsumeGracefulBudget` reported CPU at 98.2% in the heartbeat output, with two concurrent `csc` processes at 146% and 71%. The failures carry no signal about `ProcessGuestLauncher` itself, which matches the "contention-only failure" pattern documented in `.github/instructions/test-review-guidelines.instructions.md`: passing in isolation, failing under load.

The attributes were applied with `tools/QuarantineTools`. No test logic changed, and no other test in the class was touched. The four remaining tests in the class continue to run in `tests.yml`; the two quarantined tests now run in `tests-quarantine.yml`.

Addresses #18880
Addresses #18667

These issues stay open and track the real fix, which is to replace the wall-clock assertions with deterministic sequencing.

## Verification

Filter behavior, run on macOS arm64 against `tests/Aspire.Cli.Tests`:

```
$ dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- \
    --filter-class "*.ProcessGuestLauncherTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Test run summary: Passed!  total: 4  failed: 0  succeeded: 4  skipped: 0

$ ... --filter-method "*.LaunchAsync_WithGracefulServices_BlockingSignalerDoesNotConsumeGracefulBudget" --filter-not-trait "quarantined=true"
Test run summary: Zero tests ran  total: 0

$ ... --filter-method "*.LaunchAsync_WithGracefulServices_ProcessIgnoresSignal_ExpireEscalatesToTreeKill" --filter-not-trait "quarantined=true"
Test run summary: Zero tests ran  total: 0

$ ... --filter-class "*.ProcessGuestLauncherTests" --filter-trait "quarantined=true"
Test run summary: Passed!  total: 2  failed: 0  succeeded: 2  skipped: 0
```

The class contains six tests; four run under the standard exclusion filter and the two quarantined tests are excluded. Both quarantined tests pass when run in isolation, which is consistent with contention-induced failures rather than a product defect.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
