### PR TITLE
Fix /quarantine-test and sibling test-management commands failing at Setup .NET

### DIFF
--- a/.github/workflows/apply-test-attributes.yml
+++ b/.github/workflows/apply-test-attributes.yml
@@ -27,9 +27,26 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+    # The helpers are only needed to parse the comment, which happens before the commenter is
+    # authorized, so they are checked out sparsely and without credentials.
+    #
+    # IMPORTANT: this must use a dedicated `path` and not the job workspace root. actions/checkout
+    # records sparse state in the repository it creates (`core.sparseCheckout=true` in .git/config
+    # plus the patterns in .git/info/sparse-checkout). When a later checkout targets the same
+    # directory it runs `git sparse-checkout disable`, which writes `core.sparseCheckout=false` into
+    # the per-worktree config, and then unsets `extensions.worktreeConfig` - so git stops reading
+    # that file and the original `core.sparseCheckout=true` takes effect again. The following
+    # `git checkout --force` then re-applies the stale patterns and prunes the "full" checkout back
+    # to just the helper file, leaving global.json and tools/QuarantineTools missing.
+    # See https://github.com/microsoft/aspire/actions/runs/31212187976.
+    #
+    # The `Checkout repo` step below clears the workspace, so `.workflow-helpers` is gone from that
+    # point on. Nothing after comment parsing reads it, and the checkout post-step tolerates the
+    # missing directory.
     - name: Checkout workflow helpers
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        path: .workflow-helpers
         sparse-checkout: .github/workflows/workflow-command-helpers.js
         sparse-checkout-cone-mode: false
         persist-credentials: false
@@ -77,7 +94,7 @@ jobs:
           const matched = commandConfig[commandName];
 
           // Parse arguments using shared quote-aware tokenizer
-          const { tokenizeArguments } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/workflow-command-helpers.js`);
+          const { tokenizeArguments } = require(`${process.env.GITHUB_WORKSPACE}/.workflow-helpers/.github/workflows/workflow-command-helpers.js`);
 
           let allTokens;
           try {

--- a/tests/Infrastructure.Tests/WorkflowScripts/ApplyTestAttributesWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/WorkflowScripts/ApplyTestAttributesWorkflowTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+public sealed class ApplyTestAttributesWorkflowTests
+{
+    [Fact]
+    public void WorkflowHelperCheckoutDoesNotPoisonRepositoryCheckout()
+    {
+        var workflow = File.ReadAllText(Path.Combine(RepoRoot.Path, ".github", "workflows", "apply-test-attributes.yml")).ReplaceLineEndings("\n");
+
+        Assert.Equal(
+            string.Join('\n',
+            [
+                "        path: .workflow-helpers",
+                "        sparse-checkout: .github/workflows/workflow-command-helpers.js",
+                "        sparse-checkout-cone-mode: false",
+                "        persist-credentials: false"
+            ]),
+            MatchStepInputs(workflow, "Checkout workflow helpers"));
+
+        Assert.Equal(
+            "const { tokenizeArguments } = require(`${process.env.GITHUB_WORKSPACE}/.workflow-helpers/.github/workflows/workflow-command-helpers.js`);",
+            MatchLineContaining(workflow, "const { tokenizeArguments } = require(").Trim());
+
+        Assert.Equal(
+            string.Join('\n',
+            [
+                "        ref: ${{ steps.determine-target.outputs.checkout_ref }}",
+                "        fetch-depth: 0",
+                "        token: ${{ steps.app-token.outputs.token }}"
+            ]),
+            MatchStepInputs(workflow, "Checkout repo"));
+    }
+
+    private static string MatchStepInputs(string workflow, string stepName)
+    {
+        var step = MatchStep(workflow, stepName);
+        var match = System.Text.RegularExpressions.Regex.Match(step, "(?ms)^      with:\n(?<inputs>.*)\\z");
+
+        Assert.True(match.Success, $"Could not find the '{stepName}' inputs.");
+
+        return match.Groups["inputs"].Value.TrimEnd();
+    }
+
+    private static string MatchStep(string workflow, string stepName)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(
+            workflow,
+            $@"(?ms)^    - name: {System.Text.RegularExpressions.Regex.Escape(stepName)}\n(?<body>.*?)(?=^    - name: |\z)");
+
+        Assert.True(match.Success, $"Could not find the '{stepName}' step.");
+
+        return match.Value;
+    }
+
+    private static string MatchLineContaining(string text, string marker)
+    {
+        var lines = text.Split('\n').Where(line => line.Contains(marker, StringComparison.Ordinal)).ToArray();
+
+        Assert.Single(lines);
+
+        return lines[0];
+    }
+}


### PR DESCRIPTION
## Description

The `/quarantine-test`, `/unquarantine-test`, `/disable-test`, and `/enable-test` comment commands all run in the single `quarantine_test` job in `.github/workflows/apply-test-attributes.yml`, so all four are affected. Both invocations on 2026-08-07 failed at `Setup .NET`:

- https://github.com/microsoft/aspire/actions/runs/31212187976
- https://github.com/microsoft/aspire/actions/runs/31212187255

```
##[error]The specified global.json file 'global.json' does not exist
```

`global.json` is present at the repository root, and the `Checkout repo` step ran to completion before `Setup .NET`. The actual cause is that the "full" checkout is not full.

### Root cause

The job checks out twice into the same workspace directory:

1. `Checkout workflow helpers` performs a sparse, blobless, depth-1 checkout so the comment can be parsed before the commenter is authorized. `actions/checkout` writes `core.sparseCheckout=true` into `.git/config` and the single pattern into `.git/info/sparse-checkout`.
2. `Checkout repo` targets the same directory. `actions/checkout` runs `git sparse-checkout disable`, which records `core.sparseCheckout=false` in the per-worktree config and enables `extensions.worktreeConfig`. `actions/checkout` then runs `git config --local --unset-all extensions.worktreeConfig` to clean up that side effect, at which point git stops reading the worktree config and the `core.sparseCheckout=true` written in step 1 is in effect again, with the pattern file still on disk.
3. The `git checkout --progress --force -B main refs/remotes/origin/main` that follows re-applies the stale sparse pattern and prunes the working tree back to the one helper file.

`global.json` and `tools/QuarantineTools` are therefore absent when `Setup .NET` and `Run QuarantineTools` execute.

Reproduced on a fork with the same action SHAs and step order, adding instrumentation between the two checkouts (https://github.com/adamint/aspire/actions/runs/31212896051):

```
--- global.json exists: NO
--- tracked file count: 11234
--- present file count: 1
--- git config (sparse/partial):
core.sparsecheckout=true
remote.origin.partialclonefilter=blob:none
--- sparse-checkout list:
.github/workflows/workflow-command-helpers.js
```

The run then failed at `Setup .NET` with the same error, confirming that checkout ordering is correct and that the sparse state surviving into the second checkout is the defect.

### Fix

The helper checkout now uses `path: .workflow-helpers`, so it creates its own git directory and cannot leave sparse state behind in the repository that `Checkout repo` populates. The `require` in the comment-parsing step is updated to the new location. `Checkout repo` clears the workspace, which removes `.workflow-helpers`; nothing after comment parsing reads it, and the `actions/checkout` post-step returns early when the directory is gone.

No other workflow in `.github/workflows` combines a sparse and a non-sparse `actions/checkout` on the same path within one job. `pr-docs-check.lock.yml` also uses a sparse checkout, but it targets a separate `path` and is unaffected.

No issue tracks this break; the two failed runs linked above are the report.

## Verification

The fixed step sequence was run on a fork with the same action SHAs (https://github.com/adamint/aspire/actions/runs/31213668553):

```
["Some.Type.Method","https://github.com/microsoft/aspire/issues/18880"]   <- helper require from .workflow-helpers
--- global.json exists: YES
--- QuarantineTools exists: YES
--- tracked file count: 11234
--- present file count: 11234
--- git config (sparse/partial):
(none)
--- helpers dir still present: NO
```

`Setup .NET` succeeded, and `dotnet run --project tools/QuarantineTools ...` ran end to end and modified `tests/Aspire.Cli.Tests/Projects/ProcessGuestLauncherTests.cs`. The job, including all post-steps, completed successfully.

`actionlint` reports the same seven pre-existing shellcheck findings before and after this change.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
