### PR TITLE
Warn when version update notification cannot be ignored

### DIFF
--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -162,16 +162,16 @@ internal sealed class VersionCheckService : BackgroundService
         {
             _logger.LogDebug("User chose to ignore version {Version}.", latestVersion);
 
-            if (latestVersion.IsPrerelease)
+            // Store a wildcard pattern that ignores all pre-release versions with the same major.minor.patch.
+            // For example, 13.5.0-preview1 becomes 13.5.0-* which will ignore all 13.5.0 pre-releases
+            // but still notify when the stable 13.5.0 is released.
+            var ignoredVersion = latestVersion.IsPrerelease
+                ? $"{latestVersion.Major}.{latestVersion.Minor}.{latestVersion.Patch}-*"
+                : latestVersion.ToString();
+
+            if (!_userSecretsManager.TrySetSecret(IgnoreVersionKey, ignoredVersion))
             {
-                // Store a wildcard pattern that ignores all pre-release versions with the same major.minor.patch.
-                // For example, 13.5.0-preview1 becomes 13.5.0-* which will ignore all 13.5.0 pre-releases
-                // but still notify when the stable 13.5.0 is released.
-                _userSecretsManager.TrySetSecret(IgnoreVersionKey, $"{latestVersion.Major}.{latestVersion.Minor}.{latestVersion.Patch}-*");
-            }
-            else
-            {
-                _userSecretsManager.TrySetSecret(IgnoreVersionKey, latestVersion.ToString());
+                _logger.LogWarning("Could not ignore the notification to update to version {Version} because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", latestVersion);
             }
         }
     }

--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -171,7 +171,7 @@ internal sealed class VersionCheckService : BackgroundService
 
             if (!_userSecretsManager.TrySetSecret(IgnoreVersionKey, ignoredVersion))
             {
-                _logger.LogWarning("Could not ignore the notification to update to version {Version} because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", latestVersion);
+                _logger.LogWarning("Could not ignore the version update notification to {Version} because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", latestVersion);
             }
         }
     }

--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -162,15 +162,15 @@ internal sealed class VersionCheckService : BackgroundService
         {
             _logger.LogDebug("User chose to ignore version {Version}.", latestVersion);
 
-            // Store a wildcard pattern that ignores all pre-release versions with the same major.minor.patch.
-            // For example, 13.5.0-preview1 becomes 13.5.0-* which will ignore all 13.5.0 pre-releases
-            // but still notify when the stable 13.5.0 is released.
-            var ignoredVersion = latestVersion.IsPrerelease
-                ? $"{latestVersion.Major}.{latestVersion.Minor}.{latestVersion.Patch}-*"
-                : latestVersion.ToString();
-
             if (_userSecretsManager.IsAvailable)
             {
+                // Store a wildcard pattern that ignores all pre-release versions with the same major.minor.patch.
+                // For example, 13.5.0-preview1 becomes 13.5.0-* which will ignore all 13.5.0 pre-releases
+                // but still notify when the stable 13.5.0 is released.
+                var ignoredVersion = latestVersion.IsPrerelease
+                    ? $"{latestVersion.Major}.{latestVersion.Minor}.{latestVersion.Patch}-*"
+                    : latestVersion.ToString();
+
                 _userSecretsManager.TrySetSecret(IgnoreVersionKey, ignoredVersion);
             }
             else

--- a/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
+++ b/src/Aspire.Hosting/VersionChecking/VersionCheckService.cs
@@ -169,7 +169,11 @@ internal sealed class VersionCheckService : BackgroundService
                 ? $"{latestVersion.Major}.{latestVersion.Minor}.{latestVersion.Patch}-*"
                 : latestVersion.ToString();
 
-            if (!_userSecretsManager.TrySetSecret(IgnoreVersionKey, ignoredVersion))
+            if (_userSecretsManager.IsAvailable)
+            {
+                _userSecretsManager.TrySetSecret(IgnoreVersionKey, ignoredVersion);
+            }
+            else
             {
                 _logger.LogWarning("Could not ignore the version update notification to {Version} because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", latestVersion);
             }

--- a/tests/Aspire.Hosting.TestUtilities/Utils/MockUserSecretsManager.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/MockUserSecretsManager.cs
@@ -11,20 +11,26 @@ namespace Aspire.Hosting.Tests.Utils;
 internal sealed class MockUserSecretsManager : IUserSecretsManager
 {
     private readonly bool _canSetSecret;
+    private readonly bool _isAvailable;
 
-    public MockUserSecretsManager(bool canSetSecret = true)
+    public MockUserSecretsManager(bool canSetSecret = true, bool? isAvailable = null)
     {
         _canSetSecret = canSetSecret;
+        _isAvailable = isAvailable ?? canSetSecret;
     }
 
     public Dictionary<string, string> Secrets { get; } = new(StringComparer.OrdinalIgnoreCase);
 
-    public bool IsAvailable => _canSetSecret;
+    public List<string> SetSecretCalls { get; } = [];
+
+    public bool IsAvailable => _isAvailable;
 
     public string FilePath => "/mock/path/secrets.json";
 
     public bool TrySetSecret(string name, string value)
     {
+        SetSecretCalls.Add(name);
+
         // Simulate an environment where persistence is unavailable (e.g. user secrets are not
         // enabled): report failure without recording the value so callers exercise their
         // persistence-failure handling.

--- a/tests/Aspire.Hosting.TestUtilities/Utils/MockUserSecretsManager.cs
+++ b/tests/Aspire.Hosting.TestUtilities/Utils/MockUserSecretsManager.cs
@@ -21,16 +21,12 @@ internal sealed class MockUserSecretsManager : IUserSecretsManager
 
     public Dictionary<string, string> Secrets { get; } = new(StringComparer.OrdinalIgnoreCase);
 
-    public List<string> SetSecretCalls { get; } = [];
-
     public bool IsAvailable => _isAvailable;
 
     public string FilePath => "/mock/path/secrets.json";
 
     public bool TrySetSecret(string name, string value)
     {
-        SetSecretCalls.Add(name);
-
         // Simulate an environment where persistence is unavailable (e.g. user secrets are not
         // enabled): report failure without recording the value so callers exercise their
         // persistence-failure handling.

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -10,7 +10,9 @@ using Aspire.Hosting.VersionChecking;
 using Aspire.Shared;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Semver;
 
 namespace Aspire.Hosting.Tests.VersionChecking;
@@ -352,6 +354,31 @@ public class VersionCheckServiceTests
         Assert.Equal("100.0.0", mockSecretsManager.Secrets[VersionCheckService.IgnoreVersionKey]);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_IgnoreVersionWithoutUserSecrets_LogsWarning()
+    {
+        var interactionService = new TestInteractionService();
+        var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
+        var logger = new FakeLogger<VersionCheckService>();
+        var service = CreateVersionCheckService(
+            interactionService: interactionService,
+            packageFetcher: new TestPackageFetcher(packagesTcs.Task),
+            userSecretsManager: new MockUserSecretsManager(canSetSecret: false),
+            logger: logger);
+
+        _ = service.StartAsync(CancellationToken.None);
+
+        packagesTcs.TrySetResult([new NuGetPackage { Id = PackageFetcher.PackageId, Version = "100.0.0" }]);
+
+        var interaction = await interactionService.Interactions.Reader.ReadAsync().DefaultTimeout();
+        interaction.CompletionTcs.TrySetResult(InteractionResult.Ok(true));
+
+        await service.ExecuteTask!.DefaultTimeout();
+
+        var warning = Assert.Single(logger.Collector.GetSnapshot(), log => log.Level == LogLevel.Warning);
+        Assert.Equal("Could not ignore the notification to update to version 100.0.0 because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", warning.Message);
+    }
+
     private static VersionCheckService CreateVersionCheckService(
         IInteractionService? interactionService = null,
         IPackageFetcher? packageFetcher = null,
@@ -359,11 +386,12 @@ public class VersionCheckServiceTests
         TimeProvider? timeProvider = null,
         DistributedApplicationOptions? options = null,
         IPackageVersionProvider? packageVersionProvider = null,
-        IUserSecretsManager? userSecretsManager = null)
+        IUserSecretsManager? userSecretsManager = null,
+        ILogger<VersionCheckService>? logger = null)
     {
         return new VersionCheckService(
             interactionService ?? new TestInteractionService(),
-            NullLogger<VersionCheckService>.Instance,
+            logger ?? NullLogger<VersionCheckService>.Instance,
             configuration ?? new ConfigurationManager(),
             options ?? new DistributedApplicationOptions(),
             packageFetcher ?? new TestPackageFetcher(),

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -354,16 +354,19 @@ public class VersionCheckServiceTests
         Assert.Equal("100.0.0", mockSecretsManager.Secrets[VersionCheckService.IgnoreVersionKey]);
     }
 
-    [Fact]
-    public async Task ExecuteAsync_IgnoreVersionWithoutUserSecrets_LogsWarning()
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(true, false, false)]
+    public async Task ExecuteAsync_IgnoreVersion_LogsWarningOnlyWhenUserSecretsUnavailable(bool isAvailable, bool canSetSecret, bool expectWarning)
     {
         var interactionService = new TestInteractionService();
         var packagesTcs = new TaskCompletionSource<List<NuGetPackage>>();
         var logger = new FakeLogger<VersionCheckService>();
+        var userSecretsManager = new MockUserSecretsManager(canSetSecret, isAvailable);
         var service = CreateVersionCheckService(
             interactionService: interactionService,
             packageFetcher: new TestPackageFetcher(packagesTcs.Task),
-            userSecretsManager: new MockUserSecretsManager(canSetSecret: false),
+            userSecretsManager: userSecretsManager,
             logger: logger);
 
         _ = service.StartAsync(CancellationToken.None);
@@ -375,8 +378,14 @@ public class VersionCheckServiceTests
 
         await service.ExecuteTask!.DefaultTimeout();
 
-        var warning = Assert.Single(logger.Collector.GetSnapshot(), log => log.Level == LogLevel.Warning);
-        Assert.Equal("Could not ignore the version update notification to 100.0.0 because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", warning.Message);
+        var warnings = logger.Collector.GetSnapshot().Where(log => log.Level == LogLevel.Warning).ToList();
+        Assert.Equal(expectWarning ? 1 : 0, warnings.Count);
+        Assert.Equal(isAvailable ? 1 : 0, userSecretsManager.SetSecretCalls.Count(name => name == VersionCheckService.IgnoreVersionKey));
+
+        if (expectWarning)
+        {
+            Assert.Equal("Could not ignore the version update notification to 100.0.0 because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", warnings[0].Message);
+        }
     }
 
     private static VersionCheckService CreateVersionCheckService(

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -376,7 +376,7 @@ public class VersionCheckServiceTests
         await service.ExecuteTask!.DefaultTimeout();
 
         var warning = Assert.Single(logger.Collector.GetSnapshot(), log => log.Level == LogLevel.Warning);
-        Assert.Equal("Could not ignore the notification to update to version 100.0.0 because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", warning.Message);
+        Assert.Equal("Could not ignore the version update notification to 100.0.0 because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.", warning.Message);
     }
 
     private static VersionCheckService CreateVersionCheckService(

--- a/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/VersionCheckServiceTests.cs
@@ -380,7 +380,6 @@ public class VersionCheckServiceTests
 
         var warnings = logger.Collector.GetSnapshot().Where(log => log.Level == LogLevel.Warning).ToList();
         Assert.Equal(expectWarning ? 1 : 0, warnings.Count);
-        Assert.Equal(isAvailable ? 1 : 0, userSecretsManager.SetSecretCalls.Count(name => name == VersionCheckService.IgnoreVersionKey));
 
         if (expectWarning)
         {


### PR DESCRIPTION
## Description

Clicking **Ignore** on the AppHost update notification silently failed when user secrets were not configured correctly, causing the notification to return on later runs.

This change checks whether the ignored version was persisted and logs the following warning when persistence fails:

> Could not ignore the version update notification to `{Version}` because user secrets are not configured correctly. See https://aka.ms/aspire/user-secrets for more information.

The existing stable and prerelease ignore behavior is unchanged. A unit test covers the failed-persistence path.

### User-facing usage

When an update notification cannot be ignored because AppHost user secrets are unavailable, the AppHost log now explains the failure and links to the user-secrets documentation.

Validation:

```text
dotnet test --project tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj --no-launch-profile -- --filter-class "*.VersionCheckServiceTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

Passed: 19, Failed: 0
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
