### PR TITLE
Remove Publish-Build-Assets variable group from release/13.5

### DIFF
--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -32,7 +32,6 @@ variables:
       value: True
     - name: _SignType
       value: real
-    # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     # SDL_Settings provides Guardian/SDL tooling credentials
     #
@@ -47,7 +46,6 @@ variables:
     # a branch the ACLs accept so manual / non-PR builds on ankj/* etc. can
     # still validate the rest of the pipeline (including signing).
     - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/')) }}:
-      - group: Publish-Build-Assets
       - group: DotNet-HelixApi-Access
       - group: SDL_Settings
     - name: _InternalBuildArgs


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `eng/pipelines/common-variables.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131