### PR TITLE
Merge API compatibility fixes into release/13.5

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -281,7 +281,10 @@ public class AzureBicepResource : Resource, IAzureResource, IResourceWithParamet
         if (Scope is not null)
         {
             context.Writer.WriteStartObject("scope");
-            WriteScopeValue(context, "resourceGroup", Scope.ResourceGroup);
+            if (Scope.HasResourceGroup)
+            {
+                WriteScopeValue(context, "resourceGroup", Scope.ResourceGroup);
+            }
             WriteScopeValue(context, "subscription", Scope.Subscription);
             if (Scope.IsTenantScope)
             {

--- a/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
@@ -8,6 +8,8 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 public sealed class AzureBicepResourceScope
 {
+    private readonly object? _resourceGroup;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureBicepResourceScope"/> class with a resource group scope.
     /// </summary>
@@ -16,7 +18,7 @@ public sealed class AzureBicepResourceScope
     {
         ArgumentNullException.ThrowIfNull(resourceGroup);
 
-        ResourceGroup = resourceGroup;
+        _resourceGroup = resourceGroup;
     }
 
     /// <summary>
@@ -31,11 +33,26 @@ public sealed class AzureBicepResourceScope
         Subscription = subscription;
     }
 
-    private AzureBicepResourceScope(object? resourceGroup, object? subscription, bool isTenantScope)
+    private AzureBicepResourceScope(ScopeKind scopeKind)
     {
-        ResourceGroup = resourceGroup;
+        if (scopeKind is not ScopeKind.Tenant)
+        {
+            throw new ArgumentOutOfRangeException(nameof(scopeKind));
+        }
+
+        IsTenantScope = true;
+    }
+
+    private AzureBicepResourceScope(ScopeKind scopeKind, object subscription)
+    {
+        if (scopeKind is not ScopeKind.Subscription)
+        {
+            throw new ArgumentOutOfRangeException(nameof(scopeKind));
+        }
+
+        ArgumentNullException.ThrowIfNull(subscription);
+
         Subscription = subscription;
-        IsTenantScope = isTenantScope;
     }
 
     /// <summary>
@@ -47,7 +64,7 @@ public sealed class AzureBicepResourceScope
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
-        return new AzureBicepResourceScope(resourceGroup: null, subscription, isTenantScope: false);
+        return new AzureBicepResourceScope(ScopeKind.Subscription, subscription);
     }
 
     /// <summary>
@@ -56,13 +73,14 @@ public sealed class AzureBicepResourceScope
     /// <returns>A new <see cref="AzureBicepResourceScope"/> scoped to the current tenant.</returns>
     public static AzureBicepResourceScope ForTenant()
     {
-        return new AzureBicepResourceScope(resourceGroup: null, subscription: null, isTenantScope: true);
+        return new AzureBicepResourceScope(ScopeKind.Tenant);
     }
 
     /// <summary>
     /// Represents the resource group to encode in the scope.
     /// </summary>
-    public object? ResourceGroup { get; }
+    /// <exception cref="InvalidOperationException">The scope does not target a resource group.</exception>
+    public object ResourceGroup => _resourceGroup ?? throw new InvalidOperationException("The Azure Bicep resource scope does not target a resource group.");
 
     /// <summary>
     /// Represents the subscription to encode in the scope.
@@ -73,6 +91,8 @@ public sealed class AzureBicepResourceScope
     /// Gets a value indicating whether the scope targets the current tenant.
     /// </summary>
     public bool IsTenantScope { get; }
+
+    internal bool HasResourceGroup => _resourceGroup is not null;
 
     internal static AzureBicepResourceScope? FromExistingResourceAnnotation(ExistingAzureResourceAnnotation annotation)
     {
@@ -90,5 +110,11 @@ public sealed class AzureBicepResourceScope
             (null, { } subscription) => ForSubscription(subscription),
             _ => null
         };
+    }
+
+    private enum ScopeKind
+    {
+        Subscription,
+        Tenant
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
@@ -60,7 +60,7 @@ public sealed class AzureBicepResourceScope
     /// </summary>
     /// <param name="subscription">The subscription identifier for subscription-level resources.</param>
     /// <returns>A new <see cref="AzureBicepResourceScope"/> scoped to the subscription.</returns>
-    public static AzureBicepResourceScope ForSubscription(object subscription)
+    public static AzureBicepResourceScope CreateForSubscription(object subscription)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
@@ -71,7 +71,7 @@ public sealed class AzureBicepResourceScope
     /// Creates a scope for tenant-level resources in the current tenant.
     /// </summary>
     /// <returns>A new <see cref="AzureBicepResourceScope"/> scoped to the current tenant.</returns>
-    public static AzureBicepResourceScope ForTenant()
+    public static AzureBicepResourceScope CreateForTenant()
     {
         return new AzureBicepResourceScope(ScopeKind.Tenant);
     }
@@ -100,14 +100,14 @@ public sealed class AzureBicepResourceScope
 
         if (annotation.IsTenantScope)
         {
-            return ForTenant();
+            return CreateForTenant();
         }
 
         return (annotation.ResourceGroup, annotation.Subscription) switch
         {
             ({ } resourceGroup, { } subscription) => new AzureBicepResourceScope(resourceGroup, subscription),
             ({ } resourceGroup, null) => new AzureBicepResourceScope(resourceGroup),
-            (null, { } subscription) => ForSubscription(subscription),
+            (null, { } subscription) => CreateForSubscription(subscription),
             _ => null
         };
     }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
@@ -198,7 +198,8 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
     private static bool ScopeEquals(AzureBicepResourceScope expected, AzureBicepResourceScope? actual)
     {
         return actual is not null &&
-            ScopeValueEquals(expected.ResourceGroup, actual.ResourceGroup) &&
+            expected.HasResourceGroup == actual.HasResourceGroup &&
+            (!expected.HasResourceGroup || ScopeValueEquals(expected.ResourceGroup, actual.ResourceGroup)) &&
             ScopeValueEquals(expected.Subscription, actual.Subscription) &&
             expected.IsTenantScope == actual.IsTenantScope;
     }
@@ -220,7 +221,7 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
             return new FunctionCallExpression(new IdentifierExpression("tenant"));
         }
 
-        if (scope.ResourceGroup is not null && scope.Subscription is not null)
+        if (scope.HasResourceGroup && scope.Subscription is not null)
         {
             return (scope.Subscription, scope.ResourceGroup) switch
             {
@@ -232,7 +233,7 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
             };
         }
 
-        if (scope.ResourceGroup is not null)
+        if (scope.HasResourceGroup)
         {
             return scope.ResourceGroup switch
             {

--- a/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
+++ b/src/Aspire.Hosting.Azure/AzurePublishingContext.cs
@@ -181,7 +181,10 @@ public sealed class AzurePublishingContext(
 
             if (resource.Scope is { } scope)
             {
-                await VisitAsync(scope.ResourceGroup, MapParameterAsync, cancellationToken).ConfigureAwait(false);
+                if (scope.HasResourceGroup)
+                {
+                    await VisitAsync(scope.ResourceGroup, MapParameterAsync, cancellationToken).ConfigureAwait(false);
+                }
                 await VisitAsync(scope.Subscription, MapParameterAsync, cancellationToken).ConfigureAwait(false);
             }
 
@@ -263,27 +266,29 @@ public sealed class AzurePublishingContext(
                 return new IdentifierExpression(rg.BicepIdentifier);
             }
 
-            if (resource.Scope.IsTenantScope)
+            var scope = resource.Scope;
+
+            if (scope.IsTenantScope)
             {
                 return new FunctionCallExpression(new IdentifierExpression("tenant"));
             }
 
-            if (resource.Scope.ResourceGroup is not null && resource.Scope.Subscription is not null)
+            if (scope.HasResourceGroup && scope.Subscription is not null)
             {
                 return new FunctionCallExpression(
                     new IdentifierExpression("resourceGroup"),
-                    ResolveValue(Eval(resource.Scope.Subscription)).Compile(),
-                    ResolveValue(Eval(resource.Scope.ResourceGroup)).Compile());
+                    ResolveValue(Eval(scope.Subscription)).Compile(),
+                    ResolveValue(Eval(scope.ResourceGroup)).Compile());
             }
 
-            if (resource.Scope.ResourceGroup is not null)
+            if (scope.HasResourceGroup)
             {
-                return new FunctionCallExpression(new IdentifierExpression("resourceGroup"), ResolveValue(Eval(resource.Scope.ResourceGroup)).Compile());
+                return new FunctionCallExpression(new IdentifierExpression("resourceGroup"), ResolveValue(Eval(scope.ResourceGroup)).Compile());
             }
 
-            if (resource.Scope.Subscription is not null)
+            if (scope.Subscription is not null)
             {
-                return new FunctionCallExpression(new IdentifierExpression("subscription"), ResolveValue(Eval(resource.Scope.Subscription)).Compile());
+                return new FunctionCallExpression(new IdentifierExpression("subscription"), ResolveValue(Eval(scope.Subscription)).Compile());
             }
 
             throw new InvalidOperationException("The Azure Bicep resource scope must specify a resource group, subscription, or tenant scope.");

--- a/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/BicepUtilities.cs
@@ -86,7 +86,10 @@ internal static class BicepUtilities
             return;
         }
 
-        await SetScopeValueAsync(scope, "resourceGroup", targetScope.ResourceGroup, cancellationToken).ConfigureAwait(false);
+        if (targetScope.HasResourceGroup)
+        {
+            await SetScopeValueAsync(scope, "resourceGroup", targetScope.ResourceGroup, cancellationToken).ConfigureAwait(false);
+        }
         await SetScopeValueAsync(scope, "subscription", targetScope.Subscription, cancellationToken).ConfigureAwait(false);
         if (targetScope.IsTenantScope)
         {

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -511,7 +511,7 @@ internal sealed class BicepProvisioner(
         var targetScope = BicepUtilities.GetExistingResourceScope(resource);
         var isTenantScoped = targetScope?.IsTenantScope == true;
         var isSubscriptionScoped = !isTenantScoped &&
-            targetScope is { Subscription: not null, ResourceGroup: null };
+            targetScope is { Subscription: not null, HasResourceGroup: false };
 
         if (targetScope?.Subscription is { } existingSubscription)
         {
@@ -519,8 +519,9 @@ internal sealed class BicepProvisioner(
             subscription = await context.ArmClient.GetSubscriptionAsync(existingSubscriptionId, cancellationToken).ConfigureAwait(false);
         }
 
-        if (targetScope?.ResourceGroup is { } existingResourceGroup)
+        if (targetScope?.HasResourceGroup == true)
         {
+            var existingResourceGroup = targetScope.ResourceGroup;
             var existingResourceGroupName = await ResolveScopeValueAsync(existingResourceGroup, cancellationToken).ConfigureAwait(false);
             var response = await subscription.GetResourceGroups().GetAsync(existingResourceGroupName, cancellationToken).ConfigureAwait(false);
             resourceGroup = response.Value;

--- a/src/Aspire.Hosting.Go/DelveServerOptions.cs
+++ b/src/Aspire.Hosting.Go/DelveServerOptions.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Go;
+
+/// <summary>
+/// Configures the headless Delve debug server used for remote debugging of a Go application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The server listens on the loopback interface. By default, it accepts a single debugger client
+/// and relies on Delve's default same-user connection policy.
+/// </para>
+/// <para>
+/// Set <see cref="AcceptMultiClient"/> only when the server must remain available after a debugger
+/// disconnects or when multiple debugger clients need to attach.
+/// </para>
+/// </remarks>
+/// <example>
+/// Configure a Delve server that continues the application immediately and accepts multiple debugger clients:
+/// <code lang="csharp">
+/// builder.AddGoApp("api", "../go-api")
+///        .WithDelveServer(new DelveServerOptions
+///        {
+///            AcceptMultiClient = true,
+///            ContinueOnStart = true
+///        });
+/// </code>
+/// </example>
+[AspireDto]
+public sealed class DelveServerOptions
+{
+    /// <summary>
+    /// Gets the TCP port on which Delve listens. The default is <c>2345</c>.
+    /// </summary>
+    public int Port { get; init; } = 2345;
+
+    /// <summary>
+    /// Gets a value indicating whether Delve accepts multiple debugger clients.
+    /// The default is <see langword="false"/>.
+    /// </summary>
+    public bool AcceptMultiClient { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Delve allows connections only from the same operating system user.
+    /// When <see langword="null"/>, Delve's default same-user policy is used.
+    /// </summary>
+    public bool? OnlySameUser { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Delve continues the application immediately after startup.
+    /// The default is <see langword="false"/>.
+    /// </summary>
+    public bool ContinueOnStart { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether Delve server logging is enabled.
+    /// The default is <see langword="false"/>.
+    /// </summary>
+    public bool Log { get; init; }
+
+    /// <summary>
+    /// Gets the Delve logging components enabled when <see cref="Log"/> is <see langword="true"/>.
+    /// When <see langword="null"/> or empty, Delve uses its default logging components.
+    /// </summary>
+    public string? LogOutput { get; init; }
+}

--- a/src/Aspire.Hosting.Go/GoDelveServerAnnotation.cs
+++ b/src/Aspire.Hosting.Go/GoDelveServerAnnotation.cs
@@ -11,16 +11,16 @@ namespace Aspire.Hosting.Go;
 /// </summary>
 internal sealed class GoDelveServerAnnotation(
     int port,
-    bool acceptMulticlient,
+    bool acceptMultiClient,
     bool? onlySameUser,
     bool continueOnStart,
     bool log,
-    string logOutput) : IResourceAnnotation
+    string? logOutput) : IResourceAnnotation
 {
     public int Port { get; } = port;
-    public bool AcceptMulticlient { get; } = acceptMulticlient;
+    public bool AcceptMultiClient { get; } = acceptMultiClient;
     public bool? OnlySameUser { get; } = onlySameUser;
     public bool ContinueOnStart { get; } = continueOnStart;
     public bool Log { get; } = log;
-    public string LogOutput { get; } = logOutput;
+    public string? LogOutput { get; } = logOutput;
 }

--- a/src/Aspire.Hosting.Go/GoHostingExtensions.cs
+++ b/src/Aspire.Hosting.Go/GoHostingExtensions.cs
@@ -51,7 +51,7 @@ public static class GoHostingExtensions
     /// Use <see cref="WithModTidy{T}"/>, <see cref="WithModVendor{T}"/>, or <see cref="WithModDownload{T}"/>
     /// to manage module dependencies before startup, and <see cref="WithVetTool{T}"/> to run static analysis.
     /// Use <see cref="WithAppArgs{T}"/> to pass runtime program arguments, and
-    /// <see cref="WithDelveServer{T}"/> to enable remote debugging via a headless Delve server.
+    /// <see cref="WithDelveServer{T}(IResourceBuilder{T}, DelveServerOptions)"/> to enable remote debugging via a headless Delve server.
     /// </para>
     /// </remarks>
     /// <example>
@@ -108,7 +108,7 @@ public static class GoHostingExtensions
                     ctx.Args.Add("--headless=true");
                     ctx.Args.Add($"--listen=127.0.0.1:{delveAnnotation!.Port}");
                     ctx.Args.Add("--api-version=2");
-                    if (delveAnnotation.AcceptMulticlient)
+                    if (delveAnnotation.AcceptMultiClient)
                     {
                         ctx.Args.Add("--accept-multiclient");
                     }
@@ -619,21 +619,13 @@ public static class GoHostingExtensions
     }
 
     /// <summary>
-    /// Starts a headless Delve debug server so that any DAP-compatible client can attach remotely.
-    /// The application is launched as
-    /// <c>dlv --headless=true --listen=127.0.0.1:&lt;port&gt; --api-version=2 --accept-multiclient debug .</c>
-    /// instead of <c>go run .</c>. Delve must be available on the PATH.
+    /// Starts a headless Delve debug server so that a DAP-compatible client can attach remotely.
+    /// The application is launched with <c>dlv debug</c> instead of <c>go run</c>.
+    /// Delve must be available on the PATH.
     /// </summary>
     /// <typeparam name="T">The type of the Go application resource.</typeparam>
     /// <param name="builder">The resource builder for the Go application.</param>
-    /// <param name="port">The TCP port Delve listens on. Defaults to <c>2345</c>.</param>
-    /// <param name="acceptMulticlient">Whether Delve accepts multiple debugger clients with <c>--accept-multiclient</c>. Defaults to <see langword="true"/>.</param>
-    /// <param name="onlySameUser">Whether Delve allows connections only from the same operating system user. When <see langword="null"/>, the <c>--only-same-user</c> flag is not passed.</param>
-    /// <param name="continueOnStart">Whether Delve passes <c>--continue</c> to continue the debuggee immediately after startup. Defaults to <see langword="false"/>.</param>
-    /// <param name="log">Whether Delve debug server logging is enabled with <c>--log</c>. Defaults to <see langword="false"/>.</param>
-    /// <param name="logOutput">The Delve logging components passed with <c>--log-output</c> when <paramref name="log"/> is <see langword="true"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
-    /// <ats-returns>The resource builder.</ats-returns>
     /// <remarks>
     /// <para>
     /// Delve is the only Go debugger; both GoLand and VS Code use it under the hood, just in
@@ -661,21 +653,73 @@ public static class GoHostingExtensions
     /// <example>
     /// <code lang="csharp">
     /// builder.AddGoApp("api", "../go-api")
-    ///        .WithDelveServer(port: 2345);
+    ///        .WithDelveServer();
+    /// </code>
+    /// </example>
+    [AspireExportIgnore(Reason = "This C# convenience overload uses default options. Polyglot AppHosts use the DelveServerOptions overload.")]
+    public static IResourceBuilder<T> WithDelveServer<T>(this IResourceBuilder<T> builder)
+        where T : GoAppResource
+        => builder.WithDelveServer(new DelveServerOptions());
+
+    /// <summary>
+    /// Starts a headless Delve debug server on the specified port.
+    /// </summary>
+    /// <typeparam name="T">The type of the Go application resource.</typeparam>
+    /// <param name="builder">The resource builder for the Go application.</param>
+    /// <param name="port">The TCP port Delve listens on. Defaults to <c>2345</c>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <remarks>
+    /// This overload is retained for binary compatibility. Use <see cref="WithDelveServer{T}(IResourceBuilder{T})"/>
+    /// for the default port or <see cref="WithDelveServer{T}(IResourceBuilder{T}, DelveServerOptions)"/>
+    /// to configure the port and other Delve server options.
+    /// </remarks>
+    /// <example>
+    /// <code lang="csharp">
+    /// builder.AddGoApp("api", "../go-api")
+    ///        .WithDelveServer(new DelveServerOptions { Port = 3456 });
+    /// </code>
+    /// </example>
+    [Obsolete("Use WithDelveServer() or WithDelveServer(DelveServerOptions) instead.")]
+    [AspireExportIgnore(Reason = "This obsolete compatibility overload is C#-only. Polyglot AppHosts use the DelveServerOptions overload.")]
+    public static IResourceBuilder<T> WithDelveServer<T>(this IResourceBuilder<T> builder, int port = 2345)
+        where T : GoAppResource
+        => builder.WithDelveServer(new DelveServerOptions { Port = port });
+
+    /// <summary>
+    /// Starts a configurable headless Delve debug server so that DAP-compatible clients can attach remotely.
+    /// The application is launched with <c>dlv debug</c> instead of <c>go run</c>.
+    /// Delve must be available on the PATH.
+    /// </summary>
+    /// <typeparam name="T">The type of the Go application resource.</typeparam>
+    /// <param name="builder">The resource builder for the Go application.</param>
+    /// <param name="options">The options that configure the Delve server. When <see langword="null"/>, the default options are used.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/> for chaining.</returns>
+    /// <ats-returns>The resource builder.</ats-returns>
+    /// <remarks>
+    /// The server listens on <c>127.0.0.1</c> and accepts a single debugger client by default.
+    /// Set <see cref="DelveServerOptions.AcceptMultiClient"/> to <see langword="true"/> only when
+    /// multiple clients or reconnections are required.
+    /// </remarks>
+    /// <example>
+    /// <code lang="csharp">
+    /// builder.AddGoApp("api", "../go-api")
+    ///        .WithDelveServer(new DelveServerOptions
+    ///        {
+    ///            Port = 2345,
+    ///            ContinueOnStart = true,
+    ///            Log = true,
+    ///            LogOutput = "rpc,dap,debugger"
+    ///        });
     /// </code>
     /// </example>
     [AspireExport]
     public static IResourceBuilder<T> WithDelveServer<T>(
         this IResourceBuilder<T> builder,
-        int port = 2345,
-        bool acceptMulticlient = true,
-        bool? onlySameUser = null,
-        bool continueOnStart = false,
-        bool log = false,
-        string logOutput = "")
+        DelveServerOptions? options = null)
         where T : GoAppResource
     {
         ArgumentNullException.ThrowIfNull(builder);
+        options ??= new DelveServerOptions();
 
         // WithDelveServer changes the resource into a headless Delve process that IDEs attach to
         // manually. Leaving the VS Code launch annotation in place would make DCP hand execution to
@@ -692,7 +736,15 @@ public static class GoHostingExtensions
             .WithAnnotation(
                 new ExecutableAnnotation { Command = "dlv", WorkingDirectory = builder.Resource.WorkingDirectory },
                 ResourceAnnotationMutationBehavior.Replace)
-            .WithAnnotation(new GoDelveServerAnnotation(port, acceptMulticlient, onlySameUser, continueOnStart, log, logOutput), ResourceAnnotationMutationBehavior.Replace)
+            .WithAnnotation(
+                new GoDelveServerAnnotation(
+                    options.Port,
+                    options.AcceptMultiClient,
+                    options.OnlySameUser,
+                    options.ContinueOnStart,
+                    options.Log,
+                    options.LogOutput),
+                ResourceAnnotationMutationBehavior.Replace)
             .WithRequiredCommand("dlv", "https://github.com/go-delve/delve");
     }
 

--- a/src/Aspire.Hosting.Go/README.md
+++ b/src/Aspire.Hosting.Go/README.md
@@ -90,28 +90,52 @@ application is replaced by a headless Delve server:
 
 ```csharp
 builder.AddGoApp("api", "../go-api")
-    .WithDelveServer(port: 2345)
+    .WithDelveServer()
     .WithHttpEndpoint(port: 8080);
 ```
 
 This launches:
 ```sh
-dlv --headless=true --listen=127.0.0.1:2345 --api-version=2 --accept-multiclient debug .
+dlv --headless=true --listen=127.0.0.1:2345 --api-version=2 debug .
 ```
 
-`WithDelveServer` passes `--accept-multiclient` by default so the Delve server remains available
-after a debugger detaches. Set `acceptMulticlient: false` if you need Delve to exit when the first
-debugger disconnects. To customize Delve server flags, use named arguments:
+The default accepts one debugger client. To keep the server available after a debugger disconnects
+or allow multiple debugger clients, opt in with `AcceptMultiClient`. Configure additional Delve
+server flags with `DelveServerOptions`:
 
 ```csharp
 builder.AddGoApp("api", "../go-api")
-    .WithDelveServer(
-        continueOnStart: true,
-        log: true,
-        logOutput: "rpc,dap,debugger");
+    .WithDelveServer(new DelveServerOptions
+    {
+        AcceptMultiClient = true,
+        ContinueOnStart = true,
+        Log = true,
+        LogOutput = "rpc,dap,debugger"
+    });
 ```
 
-Set `continueOnStart: true` when you want the Go application to run immediately under Delve and
+For a TypeScript AppHost, pass the same options as an object:
+
+```typescript
+const api = await builder.addGoApp("api", "../go-api");
+await api.withDelveServer({
+    acceptMultiClient: true,
+    continueOnStart: true,
+    log: true,
+    logOutput: "rpc,dap,debugger",
+});
+```
+
+| Option | Default | Delve behavior |
+|---|---|---|
+| `Port` | `2345` | Sets the loopback listener port. |
+| `AcceptMultiClient` | `false` | Passes `--accept-multiclient` when enabled. |
+| `OnlySameUser` | `null` | Passes `--only-same-user=true` or `--only-same-user=false` when set. |
+| `ContinueOnStart` | `false` | Passes `--continue` when enabled. |
+| `Log` | `false` | Passes `--log` when enabled. |
+| `LogOutput` | `null` | Passes `--log-output=<components>` when logging is enabled and components are specified. |
+
+Set `ContinueOnStart` to `true` when you want the Go application to run immediately under Delve and
 attach a debugger later.
 
 If an IDE fails to attach, enable Delve logging first and inspect the resource logs. Some IDE and
@@ -121,13 +145,15 @@ can disable that check:
 
 ```csharp
 builder.AddGoApp("api", "../go-api")
-    .WithDelveServer(
-        onlySameUser: false,
-        log: true,
-        logOutput: "rpc,dap,debugger");
+    .WithDelveServer(new DelveServerOptions
+    {
+        OnlySameUser = false,
+        Log = true,
+        LogOutput = "rpc,dap,debugger"
+    });
 ```
 
-`onlySameUser: false` maps to `--only-same-user=false`. Use it only when needed; the Delve listener
+`OnlySameUser = false` maps to `--only-same-user=false`. Use it only when needed; the Delve listener
 remains bound to `127.0.0.1`.
 
 **GoLand** — create a **Go Remote** run/debug configuration (**Edit | Run Configurations**):

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeExtensions.cs
@@ -91,7 +91,7 @@ public static class KubernetesPersistentVolumeExtensions
     /// <param name="storageClassName">A parameter resource builder for the storage
     /// class name.</param>
     /// <returns>The same builder for chaining.</returns>
-    [AspireExport("withPvStorageClassParam")]
+    [AspireExport("withStorageClassParam")]
     public static IResourceBuilder<KubernetesPersistentVolumeResource> WithStorageClass(
         this IResourceBuilder<KubernetesPersistentVolumeResource> builder,
         IResourceBuilder<ParameterResource> storageClassName)
@@ -132,7 +132,7 @@ public static class KubernetesPersistentVolumeExtensions
     /// <param name="capacity">A parameter resource builder for the capacity quantity
     /// string.</param>
     /// <returns>The same builder for chaining.</returns>
-    [AspireExport("withPvCapacityParam")]
+    [AspireExport("withCapacityParam")]
     public static IResourceBuilder<KubernetesPersistentVolumeResource> WithCapacity(
         this IResourceBuilder<KubernetesPersistentVolumeResource> builder,
         IResourceBuilder<ParameterResource> capacity)

--- a/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesPersistentVolumeResource.cs
@@ -61,6 +61,7 @@ namespace Aspire.Hosting.Kubernetes;
 /// </code>
 /// </example>
 [Experimental("ASPIRECOMPUTE002", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
+[AspireExport]
 public sealed class KubernetesPersistentVolumeResource(
     string name,
     KubernetesEnvironmentResource environment) : Resource(name), IResourceWithParent<KubernetesEnvironmentResource>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUrlAnnotation.cs
@@ -30,6 +30,10 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
     /// <summary>
     /// The display order the URL. Higher values mean sort higher in the list.
     /// </summary>
+    /// <remarks>
+    /// This member was incorrectly created as a field. It will be re-added as a property in a future Aspire version.
+    /// </remarks>
+    [Obsolete("DisplayOrder was incorrectly created as a field. It will be re-added as a property in a future Aspire version.")]
     public int? DisplayOrder;
 
     /// <summary>
@@ -41,6 +45,7 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
 
     internal ResourceUrlAnnotation WithEndpoint(EndpointReference endpoint)
     {
+#pragma warning disable CS0618 // DisplayOrder is obsolete but must still be copied for compatibility.
         return new()
         {
             Url = Url,
@@ -49,6 +54,7 @@ public sealed class ResourceUrlAnnotation : IResourceAnnotation
             DisplayOrder = DisplayOrder,
             DisplayLocation = DisplayLocation
         };
+#pragma warning restore CS0618
     }
 }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardEventHandlers.cs
@@ -462,7 +462,9 @@ internal sealed class DashboardEventHandlers(IConfiguration configuration,
                         // Other endpoints are for the dashboard UI. There are typically dashboard UI endpoints for http and https.
                         // Order these before non-browser usable endpoints.
                         url.DisplayText = $"Dashboard ({endpoint.EndpointName})";
+#pragma warning disable CS0618 // DisplayOrder is obsolete but must still be set for compatibility.
                         url.DisplayOrder = 1;
+#pragma warning restore CS0618
 
                         // Append the browser token to the URL as a query string parameter if token is configured
                         if (!string.IsNullOrEmpty(browserToken))

--- a/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceSnapshotBuilder.cs
@@ -307,7 +307,9 @@ internal class ResourceSnapshotBuilder
                             endpointUrl.IsInternal)
                         {
                             IsInactive = isInactive,
+#pragma warning disable CS0618 // DisplayOrder is obsolete but must still be flowed for compatibility.
                             DisplayProperties = new(endpointUrl.DisplayText ?? "", endpointUrl.DisplayOrder ?? 0)
+#pragma warning restore CS0618
                         });
                     processedEndpointUrls.Add(endpointUrl);
                 }
@@ -333,7 +335,9 @@ internal class ResourceSnapshotBuilder
                     new(Name: endpointName, Url: endpointUrl.Url, IsInternal: endpointUrl.IsInternal)
                     {
                         IsInactive = !isActive,
+#pragma warning disable CS0618 // DisplayOrder is obsolete but must still be flowed for compatibility.
                         DisplayProperties = new(endpointUrl.DisplayText ?? "", endpointUrl.DisplayOrder ?? 0)
+#pragma warning restore CS0618
                     });
             }
 
@@ -344,7 +348,9 @@ internal class ResourceSnapshotBuilder
                     new(Name: null, Url: url.Url, IsInternal: url.IsInternal)
                     {
                         IsInactive = !resourceRunning,
+#pragma warning disable CS0618 // DisplayOrder is obsolete but must still be flowed for compatibility.
                         DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0)
+#pragma warning restore CS0618
                     });
             }
         }

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -205,7 +205,9 @@ internal sealed class ApplicationOrchestrator
                 // Endpoint URLs are inactive (hidden in the dashboard) when published here. It is assumed they will get activated later when the endpoint is considered active
                 // by whatever allocated the endpoint in the first place, e.g. for resources controlled by DCP, when DCP detects the endpoint is listening.
                 IsInactive = url.Endpoint is not null,
+#pragma warning disable CS0618 // DisplayOrder is obsolete but must still be flowed for compatibility.
                 DisplayProperties = new(url.DisplayText ?? "", url.DisplayOrder ?? 0)
+#pragma warning restore CS0618
             });
         }
         return urls;

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepProvisionerTests.cs
@@ -160,7 +160,7 @@ public class AzureBicepProvisionerTests
             targetScope = 'subscription'
             output result string = 'ok'
             """);
-        resource.Scope = AzureBicepResourceScope.ForSubscription(subscription.Id.Name);
+        resource.Scope = AzureBicepResourceScope.CreateForSubscription(subscription.Id.Name);
 
         var provisioner = CreateProvisioner(services);
         var context = ProvisioningTestHelpers.CreateTestProvisioningContext(
@@ -195,7 +195,7 @@ public class AzureBicepProvisionerTests
             targetScope = 'tenant'
             output result string = 'ok'
             """);
-        resource.Scope = AzureBicepResourceScope.ForTenant();
+        resource.Scope = AzureBicepResourceScope.CreateForTenant();
 
         var provisioner = CreateProvisioner(services);
         var context = ProvisioningTestHelpers.CreateTestProvisioningContext(
@@ -293,7 +293,7 @@ public class AzureBicepProvisionerTests
             targetScope = 'subscription'
             output result string = 'ok'
             """);
-        resource.Scope = AzureBicepResourceScope.ForSubscription(subscription.Id.Name);
+        resource.Scope = AzureBicepResourceScope.CreateForSubscription(subscription.Id.Name);
 
         var provisioner = CreateProvisioner(services, DistributedApplicationOperation.Run);
         var context = ProvisioningTestHelpers.CreateTestProvisioningContext(
@@ -671,7 +671,7 @@ public class AzureBicepProvisionerTests
         var tenant = new TestTenantResource();
         var resource = new AzureBicepResource("subscriptionDeployment", templateString: "output name string = 'subscriptionDeployment'")
         {
-            Scope = AzureBicepResourceScope.ForSubscription(subscription.Id.Name)
+            Scope = AzureBicepResourceScope.CreateForSubscription(subscription.Id.Name)
         };
 
         var provisioner = new BicepProvisioner(

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
@@ -16,7 +16,7 @@ public class AzureBicepResourceScopeTests
     [Fact]
     public void ResourceGroupThrowsForSubscriptionScope()
     {
-        var scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+        var scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
         var exception = Assert.Throws<InvalidOperationException>(() => scope.ResourceGroup);
 
@@ -26,7 +26,7 @@ public class AzureBicepResourceScopeTests
     [Fact]
     public void ResourceGroupThrowsForTenantScope()
     {
-        var scope = AzureBicepResourceScope.ForTenant();
+        var scope = AzureBicepResourceScope.CreateForTenant();
 
         var exception = Assert.Throws<InvalidOperationException>(() => scope.ResourceGroup);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceScopeTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureBicepResourceScopeTests
+{
+    [Fact]
+    public void ResourceGroupReturnsConstructorValue()
+    {
+        var scope = new AzureBicepResourceScope("test-rg");
+
+        Assert.Equal("test-rg", scope.ResourceGroup);
+    }
+
+    [Fact]
+    public void ResourceGroupThrowsForSubscriptionScope()
+    {
+        var scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => scope.ResourceGroup);
+
+        Assert.Equal("The Azure Bicep resource scope does not target a resource group.", exception.Message);
+    }
+
+    [Fact]
+    public void ResourceGroupThrowsForTenantScope()
+    {
+        var scope = AzureBicepResourceScope.ForTenant();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => scope.ResourceGroup);
+
+        Assert.Equal("The Azure Bicep resource scope does not target a resource group.", exception.Message);
+    }
+}

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceTests.cs
@@ -200,7 +200,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
 
             output value string = 'subscription'
             """);
-        subscriptionScoped.Resource.Scope = AzureBicepResourceScope.ForSubscription(subscription.Resource);
+        subscriptionScoped.Resource.Scope = AzureBicepResourceScope.CreateForSubscription(subscription.Resource);
 
         var tenantScoped = builder.AddBicepTemplateString("tenantScoped",
             """
@@ -210,7 +210,7 @@ public class AzureEnvironmentResourceTests(ITestOutputHelper output)
 
             output value string = 'tenant'
             """);
-        tenantScoped.Resource.Scope = AzureBicepResourceScope.ForTenant();
+        tenantScoped.Resource.Scope = AzureBicepResourceScope.CreateForTenant();
 
         var app = builder.Build();
         app.Run();

--- a/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/BicepUtilitiesTests.cs
@@ -364,7 +364,7 @@ public class BicepUtilitiesTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
-        bicep.Scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+        bicep.Scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
         var scope = new JsonObject();
 
@@ -379,7 +379,7 @@ public class BicepUtilitiesTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
-        bicep.Scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+        bicep.Scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
         var scope = new JsonObject
         {
@@ -398,7 +398,7 @@ public class BicepUtilitiesTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var bicep = builder.AddBicepTemplateString("test", "param name string").Resource;
-        bicep.Scope = AzureBicepResourceScope.ForTenant();
+        bicep.Scope = AzureBicepResourceScope.CreateForTenant();
 
         var scope = new JsonObject();
 
@@ -489,7 +489,7 @@ public class BicepUtilitiesTests
         await BicepUtilities.SetParametersAsync(legacyParameters, bicep);
         var legacyChecksum = BicepUtilities.GetChecksum(bicep, legacyParameters, scope: null);
 
-        bicep.Scope = AzureBicepResourceScope.ForSubscription("12345678-1234-1234-1234-123456789012");
+        bicep.Scope = AzureBicepResourceScope.CreateForSubscription("12345678-1234-1234-1234-123456789012");
 
         var configurationBuilder = new ConfigurationBuilder();
         configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>

--- a/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/ExistingAzureResourceTests.cs
@@ -585,7 +585,7 @@ public class ExistingAzureResourceTests
             output id string = 'subscription'
             """)
             .WithParameter("value", "unused");
-        resource.Resource.Scope = AzureBicepResourceScope.ForSubscription(existingSubscriptionId.Resource);
+        resource.Resource.Scope = AzureBicepResourceScope.CreateForSubscription(existingSubscriptionId.Resource);
 
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(resource.Resource, skipPreparer: true);
 
@@ -604,7 +604,7 @@ public class ExistingAzureResourceTests
 
             output id string = 'tenant'
             """);
-        resource.Resource.Scope = AzureBicepResourceScope.ForTenant();
+        resource.Resource.Scope = AzureBicepResourceScope.CreateForTenant();
 
         var (manifest, bicep) = await AzureManifestUtils.GetManifestWithBicep(resource.Resource, skipPreparer: true);
 

--- a/tests/Aspire.Hosting.Go.Tests/AddGoAppTests.cs
+++ b/tests/Aspire.Hosting.Go.Tests/AddGoAppTests.cs
@@ -338,7 +338,34 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
+
+        var manifest = await ManifestUtils.GetManifest(app.Resource);
+
+        var expected = """
+            {
+              "type": "executable.v0",
+              "workingDirectory": ".",
+              "command": "dlv",
+              "args": [
+                "--headless=true",
+                "--listen=127.0.0.1:2345",
+                "--api-version=2",
+                "debug",
+                "."
+              ]
+            }
+            """;
+        Assert.Equal(expected, manifest.ToString());
+    }
+
+    [Fact]
+    public async Task VerifyManifest_WithDelveServer_EnableAcceptMultiClient()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+
+        var app = builder.AddGoApp("api", AppContext.BaseDirectory)
+            .WithDelveServer(new DelveServerOptions { AcceptMultiClient = true });
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -352,33 +379,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
                 "--accept-multiclient",
-                "debug",
-                "."
-              ]
-            }
-            """;
-        Assert.Equal(expected, manifest.ToString());
-    }
-
-    [Fact]
-    public async Task VerifyManifest_WithDelveServer_DisableAcceptMulticlient()
-    {
-        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
-
-        var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(acceptMulticlient: false);
-
-        var manifest = await ManifestUtils.GetManifest(app.Resource);
-
-        var expected = """
-            {
-              "type": "executable.v0",
-              "workingDirectory": ".",
-              "command": "dlv",
-              "args": [
-                "--headless=true",
-                "--listen=127.0.0.1:2345",
-                "--api-version=2",
                 "debug",
                 "."
               ]
@@ -393,7 +393,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(onlySameUser: false);
+            .WithDelveServer(new DelveServerOptions { OnlySameUser = false });
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -406,7 +406,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "--only-same-user=false",
                 "debug",
                 "."
@@ -422,7 +421,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(continueOnStart: true);
+            .WithDelveServer(new DelveServerOptions { ContinueOnStart = true });
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -435,7 +434,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "--continue",
                 "."
@@ -451,7 +449,11 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(log: true, logOutput: "rpc,dap,debugger");
+            .WithDelveServer(new DelveServerOptions
+            {
+                Log = true,
+                LogOutput = "rpc,dap,debugger"
+            });
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -464,7 +466,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "--log",
                 "--log-output=rpc,dap,debugger",
                 "debug",
@@ -476,14 +477,25 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void WithDelveServer_RemovesVSCodeDebuggingAnnotation()
+    public async Task WithDelveServer_UsesDelveCommandWhenGoLaunchConfigurationIsSupported()
     {
-        using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        var runSessionInfo = new RunSessionInfo
+        {
+            ProtocolsSupported = ["test"],
+            SupportedLaunchConfigurations = ["go"]
+        };
+        builder.Configuration["DEBUG_SESSION_INFO"] = JsonSerializer.Serialize(runSessionInfo);
+        builder.Configuration["DEBUG_SESSION_PORT"] = "5678";
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
+        var application = builder.Build();
 
-        Assert.DoesNotContain(app.Resource.Annotations, annotation => annotation is SupportsDebuggingAnnotation);
+        var commandArguments = await ArgumentEvaluator.GetArgumentListAsync(app.Resource, application.Services);
+
+        Assert.Equal("dlv", app.Resource.Command);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "."], commandArguments);
     }
 
     // ---- VS Code debugging --------------------------------------------------
@@ -603,7 +615,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         var app = builder.AddGoApp("api", AppContext.BaseDirectory,
                 buildTags: ["netgo"],
                 ldFlags: "-s -w")
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -616,7 +628,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "--build-flags=-tags=\u0027netgo\u0027 -ldflags=\u0027-s -w\u0027",
                 "."
@@ -634,7 +645,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory, raceDetector: true)
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -647,7 +658,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "--build-flags=-race",
                 "."
@@ -665,7 +675,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
         using var builder = TestDistributedApplicationBuilder.Create().WithResourceCleanUp(true);
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory, gcFlags: "all=-N -l")
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -678,7 +688,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 "--build-flags=-gcflags=\u0027all=-N -l\u0027",
                 "."
@@ -697,7 +706,7 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
 
         var app = builder.AddGoApp("api", AppContext.BaseDirectory)
             .WithAppArgs("--port", "9090")
-            .WithDelveServer(port: 2345);
+            .WithDelveServer();
 
         var manifest = await ManifestUtils.GetManifest(app.Resource);
 
@@ -710,7 +719,6 @@ public class AddGoAppTests(ITestOutputHelper outputHelper)
                 "--headless=true",
                 "--listen=127.0.0.1:2345",
                 "--api-version=2",
-                "--accept-multiclient",
                 "debug",
                 ".",
                 "--",

--- a/tests/Aspire.Hosting.Go.Tests/GoPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Go.Tests/GoPublicApiTests.cs
@@ -137,11 +137,11 @@ public class GoPublicApiTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var app = builder.AddGoApp("api", builder.AppHostDirectory, packagePath: "./cmd/server")
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
-        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "--accept-multiclient", "debug", "./cmd/server"], args);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "./cmd/server"], args);
     }
 
     [Fact]
@@ -426,11 +426,33 @@ public class GoPublicApiTests
     }
 
     [Fact]
+    public async Task WithDelveServerNullOptionsUseDefaults()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddGoApp("api", builder.AppHostDirectory)
+            .WithDelveServer(options: null);
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
+
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "."], args);
+    }
+
+    [Fact]
+    public void DelveServerOptionsHaveSafeDefaults()
+    {
+        var options = new DelveServerOptions();
+
+        Assert.Equal(
+            (Port: 2345, AcceptMultiClient: false, OnlySameUser: (bool?)null, ContinueOnStart: false, Log: false, LogOutput: (string?)null),
+            (options.Port, options.AcceptMultiClient, options.OnlySameUser, options.ContinueOnStart, options.Log, options.LogOutput));
+    }
+
+    [Fact]
     public void WithDelveServerSwitchesCommandToDlv()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var app = builder.AddGoApp("api", builder.AppHostDirectory)
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         Assert.Equal("dlv", app.Resource.Command);
     }
@@ -440,11 +462,58 @@ public class GoPublicApiTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
         var app = builder.AddGoApp("api", builder.AppHostDirectory)
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
-        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "--accept-multiclient", "debug", "."], args);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "."], args);
+    }
+
+    [Fact]
+    public async Task ObsoleteWithDelveServerPortOverloadPreservesBehavior()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+#pragma warning disable CS0618 // The obsolete overload must remain callable for source and binary compatibility.
+        var app = builder.AddGoApp("api", builder.AppHostDirectory)
+            .WithDelveServer(port: 3456);
+#pragma warning restore CS0618
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
+
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:3456", "--api-version=2", "debug", "."], args);
+    }
+
+    [Fact]
+    public async Task WithDelveServerOptionsProduceCorrectArgs()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var app = builder.AddGoApp("api", builder.AppHostDirectory)
+            .WithDelveServer(new DelveServerOptions
+            {
+                Port = 3456,
+                AcceptMultiClient = true,
+                OnlySameUser = false,
+                ContinueOnStart = true,
+                Log = true,
+                LogOutput = "rpc,dap,debugger"
+            });
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
+
+        Assert.Equal(
+            [
+                "--headless=true",
+                "--listen=127.0.0.1:3456",
+                "--api-version=2",
+                "--accept-multiclient",
+                "--only-same-user=false",
+                "--log",
+                "--log-output=rpc,dap,debugger",
+                "debug",
+                "--continue",
+                "."
+            ],
+            args);
     }
 
     [Fact]
@@ -454,12 +523,12 @@ public class GoPublicApiTests
         var app = builder.AddGoApp("api", builder.AppHostDirectory,
                             buildTags: ["netgo"],
                             ldFlags: "-s -w")
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
         // All user-influenced values are shell-quoted so the Delve parser keeps them as single tokens.
-        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "--accept-multiclient", "debug", "--build-flags=-tags='netgo' -ldflags='-s -w'", "."], args);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", "--build-flags=-tags='netgo' -ldflags='-s -w'", "."], args);
     }
 
     [Fact]
@@ -468,10 +537,10 @@ public class GoPublicApiTests
         using var builder = TestDistributedApplicationBuilder.Create();
         var app = builder.AddGoApp("api", builder.AppHostDirectory)
                          .WithAppArgs("--config", "dev.yaml")
-                         .WithDelveServer(port: 2345);
+                         .WithDelveServer();
 
         var args = await ArgumentEvaluator.GetArgumentListAsync(app.Resource);
 
-        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "--accept-multiclient", "debug", ".", "--", "--config", "dev.yaml"], args);
+        Assert.Equal(["--headless=true", "--listen=127.0.0.1:2345", "--api-version=2", "debug", ".", "--", "--config", "dev.yaml"], args);
     }
 }

--- a/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithUrlsTests.cs
@@ -338,6 +338,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+#pragma warning disable CS0618 // This test intentionally verifies the obsolete DisplayOrder behavior.
         var projectA = builder.AddProject<ProjectA>("projecta")
             .WithHttpEndpoint(name: "test")
             .WithUrlForEndpoint("test", u =>
@@ -362,6 +363,7 @@ public class WithUrlsTests(ITestOutputHelper testOutputHelper)
             && u.DisplayText == "Link Text"
             && u.Endpoint?.EndpointName == "test"
             && u.DisplayOrder == 1000);
+#pragma warning restore CS0618
 
         await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutDuration);
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Go/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Go/Go/apphost.go
@@ -45,7 +45,7 @@ func main() {
 
 	// Go app with headless Delve server for remote debugging (GoLand / VS Code attach)
 	debugService := builder.AddGoApp("debug-service", "../go-debug-service").
-		WithDelveServer(&aspire.WithDelveServerOptions{
+		WithDelveServer(&aspire.DelveServerOptions{
 			Port: aspire.Float64Ptr(2345),
 		})
 	if err = debugService.Err(); err != nil {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Go/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Go/Java/AppHost.java
@@ -26,8 +26,14 @@ void main() throws Exception {
             .withAppArgs(new String[] { "--config", "prod.yaml" });
 
         // Go app with headless Delve server for remote debugging (GoLand / VS Code attach)
+        var delveServerOptions = new DelveServerOptions();
+        // Java DTOs serialize unset fields as null, so specify every non-nullable default.
+        delveServerOptions.setPort(2345.0);
+        delveServerOptions.setAcceptMultiClient(false);
+        delveServerOptions.setContinueOnStart(false);
+        delveServerOptions.setLog(false);
         var debugService = builder.addGoApp("debug-service", "../go-debug-service")
-            .withDelveServer();
+            .withDelveServer(delveServerOptions);
 
         builder.build().run();
     }

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Go/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Go/Python/apphost.py
@@ -26,6 +26,6 @@ with create_builder() as builder:
 
     # Go app with headless Delve server for remote debugging
     debug_service = builder.add_go_app("debug-service", "../go-debug-service")
-    debug_service.with_delve_server()
+    debug_service.with_delve_server({"Port": 2345})
 
     builder.run()

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Go/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Go/TypeScript/apphost.mts
@@ -26,6 +26,6 @@ await managed.withAppArgs(['--config', 'prod.yaml']);
 
 // Go app with headless Delve server for remote debugging (GoLand / VS Code attach)
 const debugService = await builder.addGoApp('debug-service', '../go-debug-service');
-await debugService.withDelveServer({ port: 2345 });
+await debugService.withDelveServer();
 
 await builder.build().run();

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Go/apphost.go
@@ -17,6 +17,8 @@ func main() {
 	helmChartName := builder.AddParameter("helm-chart-name")
 	helmChartVersion := builder.AddParameter("helm-chart-version")
 	helmChartDescription := builder.AddParameter("helm-chart-description")
+	persistentVolumeStorageClass := builder.AddParameter("persistent-volume-storage-class")
+	persistentVolumeCapacity := builder.AddParameter("persistent-volume-capacity")
 
 	kubernetes := builder.AddKubernetesEnvironment("kube")
 	kubernetes.WithHelm(&aspire.WithHelmOptions{
@@ -60,6 +62,15 @@ func main() {
 	ingress := kubernetes.AddIngress("public-ingress")
 	ingress.WithHostname("ingress.example.com")
 	ingress.WithTls("ingress-tls")
+
+	persistentVolume := kubernetes.AddPersistentVolume("data")
+	persistentVolume.WithStorageClass("fast-storage")
+	persistentVolume.WithCapacity("5Gi")
+	_, _ = persistentVolume.GetResourceName()
+
+	parameterizedPersistentVolume := kubernetes.AddPersistentVolume("parameterized-data")
+	parameterizedPersistentVolume.WithStorageClassParam(persistentVolumeStorageClass)
+	parameterizedPersistentVolume.WithCapacityParam(persistentVolumeCapacity)
 
 	serviceContainer := builder.AddContainer("kube-service", "redis:alpine")
 	serviceContainer.WithComputeEnvironment(kubernetes)

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Java/AppHost.java
@@ -7,6 +7,8 @@ void main() throws Exception {
         var helmChartName = builder.addParameter("helm-chart-name");
         var helmChartVersion = builder.addParameter("helm-chart-version");
         var helmChartDescription = builder.addParameter("helm-chart-description");
+        var persistentVolumeStorageClass = builder.addParameter("persistent-volume-storage-class");
+        var persistentVolumeCapacity = builder.addParameter("persistent-volume-capacity");
         var kubernetes = builder.addKubernetesEnvironment("kube");
         kubernetes.withHelm((helm) -> {
             helm.withNamespace("validation-namespace");
@@ -42,6 +44,13 @@ void main() throws Exception {
         var ingress = kubernetes.addIngress("public-ingress");
         ingress.withHostname("ingress.example.com");
         ingress.withTls("ingress-tls");
+        var persistentVolume = kubernetes.addPersistentVolume("data");
+        persistentVolume.withStorageClass("fast-storage");
+        persistentVolume.withCapacity("5Gi");
+        var _persistentVolumeResourceName = persistentVolume.getResourceName();
+        var parameterizedPersistentVolume = kubernetes.addPersistentVolume("parameterized-data");
+        parameterizedPersistentVolume.withStorageClassParam(persistentVolumeStorageClass);
+        parameterizedPersistentVolume.withCapacityParam(persistentVolumeCapacity);
         var serviceContainer = builder.addContainer("kube-service", "redis:alpine");
         serviceContainer.withComputeEnvironment(kubernetes);
         serviceContainer.publishAsKubernetesService((service) -> {

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/Python/apphost.py
@@ -10,6 +10,8 @@ with create_builder() as builder:
     helm_chart_name = builder.add_parameter("helm-chart-name")
     helm_chart_version = builder.add_parameter("helm-chart-version")
     helm_chart_description = builder.add_parameter("helm-chart-description")
+    persistent_volume_storage_class = builder.add_parameter("persistent-volume-storage-class")
+    persistent_volume_capacity = builder.add_parameter("persistent-volume-capacity")
     kubernetes = builder.add_kubernetes_environment("resource")
 
     def configure_helm(helm):
@@ -34,6 +36,13 @@ with create_builder() as builder:
     ingress = kubernetes.add_ingress("public-ingress")
     ingress.with_hostname("ingress.example.com")
     ingress.with_tls("ingress-tls")
+    persistent_volume = kubernetes.add_persistent_volume("data")
+    persistent_volume.with_storage_class("fast-storage")
+    persistent_volume.with_capacity("5Gi")
+    _persistent_volume_resource_name = persistent_volume.get_resource_name()
+    parameterized_persistent_volume = kubernetes.add_persistent_volume("parameterized-data")
+    parameterized_persistent_volume.with_storage_class_param(persistent_volume_storage_class)
+    parameterized_persistent_volume.with_capacity_param(persistent_volume_capacity)
     service_container = builder.add_container("resource", "image")
     service_container.with_compute_environment(kubernetes)
 

--- a/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.mts
+++ b/tests/PolyglotAppHosts/Aspire.Hosting.Kubernetes/TypeScript/apphost.mts
@@ -7,6 +7,8 @@ const helmReleaseName = await builder.addParameter('helm-release-name');
 const helmChartName = await builder.addParameter('helm-chart-name');
 const helmChartVersion = await builder.addParameter('helm-chart-version');
 const helmChartDescription = await builder.addParameter('helm-chart-description');
+const persistentVolumeStorageClass = await builder.addParameter('persistent-volume-storage-class');
+const persistentVolumeCapacity = await builder.addParameter('persistent-volume-capacity');
 
 const kubernetes = await builder.addKubernetesEnvironment('kube');
 
@@ -55,6 +57,15 @@ await gateway.withTls('gateway-tls');
 const ingress = await kubernetes.addIngress('public-ingress');
 await ingress.withHostname('ingress.example.com');
 await ingress.withTls('ingress-tls');
+
+const persistentVolume = await kubernetes.addPersistentVolume('data');
+await persistentVolume.withStorageClass('fast-storage');
+await persistentVolume.withCapacity('5Gi');
+const _persistentVolumeResourceName: string = await persistentVolume.getResourceName();
+
+const parameterizedPersistentVolume = await kubernetes.addPersistentVolume('parameterized-data');
+await parameterizedPersistentVolume.withStorageClassParam(persistentVolumeStorageClass);
+await parameterizedPersistentVolume.withCapacityParam(persistentVolumeCapacity);
 
 // === cert-manager ===
 // Validates the typed cert-manager API surface generated for TypeScript:


### PR DESCRIPTION
## Description

Merges the API compatibility fixes already landed on `main` into `release/13.5` so the release branch preserves the expected Azure, Go/Delve, and Kubernetes APIs.

This includes:

- Preserve Azure Bicep scope API compatibility (#19084)
- Fix Delve server API compatibility (#19081)
- Fix Kubernetes persistent volume ATS export names (#18979)
- Rename Azure scope factories (#18976)

The accompanying unit and polyglot AppHost tests are included from the original changes.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
