### PR TITLE
Stabilize Azure Functions Core Tools install in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -257,8 +257,26 @@ jobs:
 
       - name: Install Azure Functions Core Tools
         if: runner.os == 'Linux' && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
+        shell: bash
         run: |
-          npm i -g azure-functions-core-tools@4 --unsafe-perm true
+          set -euo pipefail
+
+          # The npm package floats a nested CDN payload from its postinstall script, so a bad publish
+          # can break CI even when the package version range has not changed. Download the same
+          # pinned release shape used by extension E2E instead.
+          core_tools_version='4.12.1'
+          core_tools_directory="$RUNNER_TEMP/azure-functions-core-tools"
+          core_tools_archive="$RUNNER_TEMP/Azure.Functions.Cli.linux-x64.${core_tools_version}.zip"
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output "$core_tools_archive" \
+            "https://github.com/Azure/azure-functions-core-tools/releases/download/${core_tools_version}/Azure.Functions.Cli.linux-x64.${core_tools_version}.zip"
+          echo 'faf8fb8d50b5293df338bec70594b12f45730e9fe251805298859b2238cf627e  '"$core_tools_archive" | sha256sum --check -
+          mkdir -p "$core_tools_directory"
+          unzip -q "$core_tools_archive" -d "$core_tools_directory"
+          chmod +x "$core_tools_directory/func"
+          echo "$core_tools_directory" >> "$GITHUB_PATH"
+          export PATH="$core_tools_directory:$PATH"
+          func --version
 
       - name: Compute test project path
         id: compute_project_path

--- a/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/NpmCliPackageTests.cs
@@ -418,6 +418,18 @@ public sealed class NpmCliPackageTests : IDisposable
     }
 
     [Fact]
+    public async Task RunTestsInstallsAzureFunctionsCoreToolsFromPinnedGitHubRelease()
+    {
+        var workflow = await ReadRepoFileAsync(".github/workflows/run-tests.yml");
+
+        Assert.DoesNotContain("npm i -g azure-functions-core-tools@4", workflow);
+        Assert.Contains("core_tools_version='4.12.1'", workflow);
+        Assert.Contains("https://github.com/Azure/azure-functions-core-tools/releases/download/${core_tools_version}/Azure.Functions.Cli.linux-x64.${core_tools_version}.zip", workflow);
+        Assert.Contains("sha256sum --check -", workflow);
+        Assert.Contains("func --version", workflow);
+    }
+
+    [Fact]
     public async Task NpmSigningScopeCoversNestedTarballPayloads()
     {
         var signingProps = XDocument.Parse(await ReadRepoFileAsync("eng/Signing.props"));


### PR DESCRIPTION

Unblocks the shared Playground/Core Tools gate for #18602, #18604, #18626, #18642, #19072, #19124, #19125, #19126, #19127, #19128, #19130, #19131, #19132, #19133, #19134, #19135, #19142, #19145, #19147, #19152, #19154, #19157, #19158, #19176, #19177, #19178, #19180, #19182, and #19183 — **29 PRs**, re-derived from a live `gh pr checks` sweep rather than carried forward.

## Problem

The `run-tests.yml` Playground leg currently installs Azure Functions Core Tools through npm:

```bash
npm i -g azure-functions-core-tools@4 --unsafe-perm true
```

That package does not carry the Linux x64 `func` payload. Its postinstall script selects a mutable CDN zip, and the current floating 4.x zip is missing:

```text
npm error attempting to GET "https://cdn.functions.azure.com/public/4.0.296705/Azure.Functions.Cli.linux-x64.4.13.2.zip"
npm error Error downloading zip file from https://cdn.functions.azure.com/public/4.0.296705/Azure.Functions.Cli.linux-x64.4.13.2.zip
npm error Expected: 200, Actual: 404
EXIT:1
```

Fresh probes while preparing this PR:

```text
floating_cdn_4_latest=404
github_release_4_12_1=200
```

So the useful change is not just retrying a transient outage. It moves CI off a CDN-selected payload and onto a versioned release artifact.

## Fix

Install Core Tools `4.12.1` directly from the Azure Functions Core Tools GitHub release, verify the archive hash, add the extracted directory to `PATH`, and print `func --version`.

The release asset is:

```text
https://github.com/Azure/azure-functions-core-tools/releases/download/4.12.1/Azure.Functions.Cli.linux-x64.4.12.1.zip
```

The workflow verifies:

```text
faf8fb8d50b5293df338bec70594b12f45730e9fe251805298859b2238cf627e
```

This matches the existing VS Code extension E2E install shape: direct GitHub release archive + checksum + `func --version`.

## Why not just pin npm to `azure-functions-core-tools@4.12.1`?

I checked the smaller one-token fix because #18626 briefly carried it. It works today, but it is deferred rather than durable.

Same-session Linux x64 proof:

```text
COMMAND: npm i -g azure-functions-core-tools@4 --unsafe-perm true
npm error attempting to GET "https://cdn.functions.azure.com/public/4.0.296705/Azure.Functions.Cli.linux-x64.4.13.2.zip"
npm error Expected: 200, Actual: 404
FLOATING_EXIT:1

COMMAND: npm i -g azure-functions-core-tools@4.12.1 --unsafe-perm true
added 34 packages in 52s
PIN_INSTALL_EXIT:0
```

But the npm pin still uses the same CDN class of URL:

```text
https://cdn.functions.azure.com/public/4.0.286861/Azure.Functions.Cli.linux-x64.4.12.1.zip
```

Probe results:

```text
floating_cdn_4_latest=404
pin_cdn_4_12_1=200
github_release_4_12_1=200
```

That means `@4.12.1` only works while the older CDN object happens to stay present. If that object is removed, the pin fails the same way the floating install fails now. The release-archive path is still external, but it is a versioned artifact with checksum verification, and it is already used elsewhere in the repo.

## Install-site audit

I searched `.github/` and `eng/` for Core Tools installs (`azure-functions-core-tools`, `Azure.Functions.Cli`, `functions.azure.com`, `func --version`). There are two install sites in that requested scope, and no `eng/` install:

| Site | Current source | Covered here? | Notes |
|---|---|---:|---|
| `.github/workflows/run-tests.yml` | `npm i -g azure-functions-core-tools@4`, which dereferences the broken CDN zip | yes | This is the failing Playground gate. |
| `.github/workflows/extension-e2e-tests.yml` | GitHub release archive `4.12.1` + SHA check + `func --version` | no | Already uses the durable shape; the extension E2E workflow is currently disabled behind `false &&` in `tests.yml`. |

A whole-repo grep also finds Helix setup outside `.github/`/`eng/`:

| Site | Current source | Covered here? | Notes |
|---|---|---:|---|
| `tests/helix/send-to-helix-inner.proj` | GitHub release archives `4.0.7512` for `win-x64` and `linux-x64` | no | Already a release-archive payload; not the GitHub Actions failing step. Both release asset URLs probe 200. |

So this PR changes one install site: the only site in the audited CI workflows that still goes through the npm/CDN postinstall path.

## Platform coverage

The changed `run-tests.yml` step only executes when:

```text
runner.os == 'Linux' && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
```

The GitHub matrix maps Linux to `ubuntu-latest`; a current full main run had exactly one non-skipped instance of the step: `Tests / Playground / Playground (ubuntu-latest)`. `Tests / Hosting.Azure / Hosting.Azure (ubuntu-latest)` has the step present but skipped because its short name is `Hosting.Azure`, not `Azure`.

The failing npm postinstall requested `Azure.Functions.Cli.linux-x64.4.13.2.zip`, and the local control/fixed proof ran on `uname=x86_64`. I found no Windows, macOS, or arm64 execution path for this `run-tests.yml` step.

Release asset probes:

```text
run_tests_github_4_12_1_linux_x64=200
helix_github_4_0_7512_linux_x64=200
helix_github_4_0_7512_win_x64=200
```

## #18626 follow-up / collision

#18626 briefly reintroduced the npm `@4.12.1` workaround in the same `run-tests.yml` step. At that head (`565b06ae41`), the edits touched the same lines and produced a textual merge conflict with this branch, not a silent semantic merge:

```text
<<<<<<< .our
  set -euo pipefail
  ... GitHub release archive + sha256sum --check ...
=======
  npm i -g azure-functions-core-tools@4.12.1 --unsafe-perm true
>>>>>>> .their
```

Current #18626 head `afefed3456` has already reverted that local pin, so there is no current `run-tests.yml` diff on #18626. If that workaround comes back, the precise instruction is:

- In `.github/workflows/run-tests.yml`, remove the local line `npm i -g azure-functions-core-tools@4.12.1 --unsafe-perm true` from the `Install Azure Functions Core Tools` step.
- Let this shared PR provide the final step body: `shell: bash`, `core_tools_version='4.12.1'`, GitHub release archive download, `sha256sum --check -`, and `func --version`.

Landing order: land this shared azfunc fix first, then let #18626 rebase/update on top of it. That unblocks the other affected PRs and avoids carrying a browser-debugging PR-local CI workaround.

## Testing / proof

Local Linux x64 control, current `main` workflow command:

```text
COMMAND: npm i -g azure-functions-core-tools@4 --unsafe-perm true
uname=x86_64
npm error attempting to GET "https://cdn.functions.azure.com/public/4.0.296705/Azure.Functions.Cli.linux-x64.4.13.2.zip"
npm error Error downloading zip file from https://cdn.functions.azure.com/public/4.0.296705/Azure.Functions.Cli.linux-x64.4.13.2.zip
npm error Expected: 200, Actual: 404
EXIT:1
```

Local Linux x64 fixed script from this branch:

```text
/work/runner-temp/Azure.Functions.Cli.linux-x64.4.12.1.zip: OK
4.12.1
EXIT:0
```

Latest current Playground failures verified through the Actions API fail at the install step, not in tests:

```text
#18602  job 93173659113  Install Azure Functions Core Tools
#18626  job 93175160325  Install Azure Functions Core Tools
#19032  job 93149929479  Install Azure Functions Core Tools
#19077  job 93148910064  Install Azure Functions Core Tools
#19125  job 93147004699  Install Azure Functions Core Tools
#19128  job 93140273560  Install Azure Functions Core Tools
#19129  job 93145123442  Install Azure Functions Core Tools
#19130  job 93168922208  Install Azure Functions Core Tools
#19131  job 93180568364  Install Azure Functions Core Tools
#19133  job 93149852344  Install Azure Functions Core Tools
#19134  job 93179569389  Install Azure Functions Core Tools
#19146  job 93168909513  Install Azure Functions Core Tools
#19152  job 93156061209  Install Azure Functions Core Tools
#19154  job 93149174862  Install Azure Functions Core Tools
#19157  job 93168528753  Install Azure Functions Core Tools
#19158  job 93135024740  Install Azure Functions Core Tools
#19147  job 93198297604  Install Azure Functions Core Tools
#19176  job 93196452407  Install Azure Functions Core Tools
#19177  job 93196447130  Install Azure Functions Core Tools
#19178  job 93196431646  Install Azure Functions Core Tools
```

This branch also adds an Infrastructure test that guards `run-tests.yml` against regressing back to the npm install path and requires the release URL, checksum verification, and `func --version` probe.

