### PR TITLE
Fix VS Code extension self-signed certificate serial flake

### DIFF
--- a/extension/src/test/security.test.ts
+++ b/extension/src/test/security.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import { X509Certificate } from 'crypto';
+import forge from 'node-forge';
 import { createSelfSignedCertAsync, generateCertificateSerialNumber, generateToken } from '../utils/security';
 
 suite('Security utilities', () => {
@@ -35,7 +36,20 @@ suite('Security utilities', () => {
         }
     });
 
-    test('generateCertificateSerialNumber does not emit a DER-invalid leading zero', () => {
+    test('generateCertificateSerialNumber emits a serial that OpenSSL can parse', () => {
+        const serial = generateCertificateSerialNumber(Buffer.from([
+            0x80, 0x00, 0x01, 0x45,
+            0x67, 0x89, 0xab, 0xcd,
+            0xef, 0x01, 0x23, 0x45,
+            0x67, 0x89, 0xab, 0xcd,
+        ]));
+
+        const certPem = createCertificatePemWithSerialNumber(serial);
+
+        assert.doesNotThrow(() => new X509Certificate(certPem));
+    });
+
+    test('generateCertificateSerialNumber normalizes the first byte to a non-zero positive value', () => {
         const serial = generateCertificateSerialNumber(Buffer.from([
             0x80, 0x01, 0x23, 0x45,
             0x67, 0x89, 0xab, 0xcd,
@@ -43,9 +57,9 @@ suite('Security utilities', () => {
             0x67, 0x89, 0xab, 0xcd,
         ]));
 
-        assert.strictEqual(serial.length, 32);
         assert.ok(!serial.startsWith('00'));
         assert.ok(Number.parseInt(serial.slice(0, 2), 16) < 0x80);
+        assert.strictEqual(serial.length, 32);
     });
 
     test('generateToken returns a base64 string', () => {
@@ -64,3 +78,21 @@ suite('Security utilities', () => {
         assert.strictEqual(tokens.size, 100, 'All tokens should be unique');
     });
 });
+
+function createCertificatePemWithSerialNumber(serialNumber: string): string {
+    const pki = forge.pki;
+    // The key strength is irrelevant to this test; keep it small so the DER serial regression stays fast.
+    const keys = pki.rsa.generateKeyPair(512);
+    const cert = pki.createCertificate();
+    cert.publicKey = keys.publicKey;
+    cert.serialNumber = serialNumber;
+    cert.validity.notBefore = new Date();
+    cert.validity.notAfter = new Date(Date.now() + 60_000);
+
+    const attrs = [{ name: 'commonName', value: 'localhost' }];
+    cert.setSubject(attrs);
+    cert.setIssuer(attrs);
+    cert.sign(keys.privateKey);
+
+    return pki.certificateToPem(cert);
+}

--- a/extension/src/test/security.test.ts
+++ b/extension/src/test/security.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { X509Certificate } from 'crypto';
-import { createSelfSignedCertAsync, generateToken } from '../utils/security';
+import { createSelfSignedCertAsync, generateCertificateSerialNumber, generateToken } from '../utils/security';
 
 suite('Security utilities', () => {
     test('createSelfSignedCertAsync generates a valid certificate', async () => {
@@ -33,6 +33,19 @@ suite('Security utilities', () => {
             const serialHex = x509.serialNumber.replace(/:/g, '');
             assert.ok(/^[0-9a-fA-F]+$/.test(serialHex), `Iteration ${i}: Serial number should be valid hex`);
         }
+    });
+
+    test('generateCertificateSerialNumber does not emit a DER-invalid leading zero', () => {
+        const serial = generateCertificateSerialNumber(Buffer.from([
+            0x80, 0x01, 0x23, 0x45,
+            0x67, 0x89, 0xab, 0xcd,
+            0xef, 0x01, 0x23, 0x45,
+            0x67, 0x89, 0xab, 0xcd,
+        ]));
+
+        assert.strictEqual(serial.length, 32);
+        assert.ok(!serial.startsWith('00'));
+        assert.ok(Number.parseInt(serial.slice(0, 2), 16) < 0x80);
     });
 
     test('generateToken returns a base64 string', () => {

--- a/extension/src/utils/security.ts
+++ b/extension/src/utils/security.ts
@@ -10,25 +10,27 @@ interface SelfSignedCert {
 /**
  * Generates a valid X.509 serial number as a hexadecimal string.
  * Per RFC 5280, serial numbers must be positive integers up to 20 octets.
- * DER encoding requires minimal representation (no unnecessary leading zeros)
- * and a leading 0x00 byte if the high bit of the first byte is set (to ensure positive).
+ * DER INTEGER encoding is minimal: a leading 0x00 is only legal when the next
+ * byte would otherwise make the integer negative.
+ * See https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.2.
  */
-function generateSerialNumber(): string {
-  // Generate 16 random bytes (128 bits) - plenty of entropy while leaving room for padding
-  const bytes = randomBytes(16);
-
-  // Ensure the first byte doesn't have its high bit set to avoid needing a 0x00 prefix.
-  // This guarantees the number is positive without extra padding.
-  // We mask off the high bit (AND with 0x7F) to ensure it's always < 128.
-  bytes[0] = bytes[0] & 0x7f;
-
-  // Ensure the serial number is non-zero by setting the least significant bit if all bytes are zero
-  // (extremely unlikely with 16 random bytes, but handles the edge case)
-  if (bytes.every(b => b === 0)) {
-    bytes[15] = 1;
+export function generateCertificateSerialNumber(bytes: Buffer = randomBytes(16)): string {
+  if (bytes.length !== 16) {
+    throw new Error(`Certificate serial numbers must use exactly 16 bytes, got ${bytes.length}.`);
   }
 
-  return bytes.toString('hex');
+  const serialBytes = Buffer.from(bytes);
+
+  // Keep the value positive without requiring DER to prepend a 0x00 byte.
+  serialBytes[0] = serialBytes[0] & 0x7f;
+  // If masking produces a leading zero, the serialized INTEGER would either be
+  // non-minimal or shorter than the fixed 16-byte value. Force a non-zero
+  // positive first byte so node-forge emits a stable DER-valid serial.
+  if (serialBytes[0] === 0) {
+    serialBytes[0] = 1;
+  }
+
+  return serialBytes.toString('hex');
 }
 
 export async function createSelfSignedCertAsync(commonName: string = 'localhost'): Promise<SelfSignedCert> {
@@ -46,7 +48,7 @@ export async function createSelfSignedCertAsync(commonName: string = 'localhost'
 
   const cert = pki.createCertificate();
   cert.publicKey = keys.publicKey;
-  cert.serialNumber = generateSerialNumber();
+  cert.serialNumber = generateCertificateSerialNumber();
   cert.validity.notBefore = new Date();
   cert.validity.notAfter = new Date();
   cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);

--- a/extension/src/utils/security.ts
+++ b/extension/src/utils/security.ts
@@ -23,9 +23,9 @@ export function generateCertificateSerialNumber(bytes: Buffer = randomBytes(16))
 
   // Keep the value positive without requiring DER to prepend a 0x00 byte.
   serialBytes[0] = serialBytes[0] & 0x7f;
-  // If masking produces a leading zero, the serialized INTEGER would either be
-  // non-minimal or shorter than the fixed 16-byte value. Force a non-zero
-  // positive first byte so node-forge emits a stable DER-valid serial.
+  // node-forge strips at most one redundant leading 0x00 when DER-encoding INTEGERs.
+  // Avoid a leading zero entirely so draws with multiple zero bytes cannot leave
+  // illegal padding after that normalization.
   if (serialBytes[0] === 0) {
     serialBytes[0] = 1;
   }


### PR DESCRIPTION

## Description

The VS Code extension unit test that repeatedly creates a self-signed certificate has been intermittently failing in `new X509Certificate(...)` with an OpenSSL ASN.1 `INVALID_INTEGER` / illegal-padding error.

The serial generator was already masking off the high bit so the value stayed positive, but it could still hand `node-forge` a serial with leading zero bytes. `node-forge` strips at most one redundant leading `00` while DER-encoding INTEGERs, so a draw with multiple leading zeroes can still leave invalid padding in the certificate serial.

The earlier `0.392%` number was a leading-zero proxy, not the actual bad-DER rate. A direct probe of the `node-forge` encoder path saw 7 invalid encodings in 200,000 generated serials, which is in the expected ~1/65,536 range per generated certificate.

This keeps generated serials positive and non-zero in the first byte before passing them to `node-forge`, and adds a deterministic regression test for the malformed DER INTEGER case (`80 00 01 ...`) instead of relying on the probabilistic ten-certificate loop.

No dedicated issue yet; this was observed while investigating the VS Code extension unit-test failure in PR #19069 run `31222085874`.

Validation:

```text
corepack yarn run compile-tests
./node_modules/.bin/mocha --ui tdd --timeout 20000 out/test/security.test.js
corepack yarn run lint
```

Mutation check:

```text
With the zero-bucket production fix reverted, the targeted regression test fails deterministically with:
Actual message: "error:068000DD:asn1 encoding routines::illegal padding"
```

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
