### PR TITLE
Bound the NuGet package search timeout

### DIFF
--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -137,7 +137,7 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
             ? new Dictionary<string, string>(StringComparer.Ordinal)
             : new Dictionary<string, string>(environmentVariables, StringComparer.Ordinal);
 
-    private static string BuildTimeoutMessage(string toolPath, IReadOnlyList<string> arguments, DirectoryInfo workingDirectory, TimeSpan timeout)
+    internal static string BuildTimeoutMessage(string toolPath, IReadOnlyList<string> arguments, DirectoryInfo workingDirectory, TimeSpan timeout)
     {
         var timeoutText = FormatTimeout(timeout);
         if (arguments is ["nuget", "search", ..])

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -174,14 +174,22 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
     {
         if (timeout.TotalMinutes >= 1 && timeout.TotalSeconds % 60 == 0)
         {
-            return string.Create(CultureInfo.InvariantCulture, $"{timeout.TotalMinutes:0} minutes");
+            return FormatTimeoutUnit(timeout.TotalMinutes, "0", "minute", "minutes");
         }
 
         if (timeout.TotalSeconds >= 1)
         {
-            return string.Create(CultureInfo.InvariantCulture, $"{timeout.TotalSeconds:0.###} seconds");
+            return FormatTimeoutUnit(timeout.TotalSeconds, "0.###", "second", "seconds");
         }
 
-        return string.Create(CultureInfo.InvariantCulture, $"{timeout.TotalMilliseconds:0.###} milliseconds");
+        return FormatTimeoutUnit(timeout.TotalMilliseconds, "0.###", "millisecond", "milliseconds");
+    }
+
+    private static string FormatTimeoutUnit(double value, string format, string singularUnit, string pluralUnit)
+    {
+        var formattedValue = value.ToString(format, CultureInfo.InvariantCulture);
+        var unit = string.Equals(formattedValue, "1", StringComparison.Ordinal) ? singularUnit : pluralUnit;
+
+        return $"{formattedValue} {unit}";
     }
 }

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -137,9 +137,9 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
             ? new Dictionary<string, string>(StringComparer.Ordinal)
             : new Dictionary<string, string>(environmentVariables, StringComparer.Ordinal);
 
-    internal static string BuildTimeoutMessage(string toolPath, IReadOnlyList<string> arguments, DirectoryInfo workingDirectory, TimeSpan timeout)
+    private static string BuildTimeoutMessage(string toolPath, IReadOnlyList<string> arguments, DirectoryInfo workingDirectory, TimeSpan timeout)
     {
-        var timeoutText = FormatTimeout(timeout);
+        var timeoutText = timeout.ToString("g", CultureInfo.InvariantCulture);
         if (arguments is ["nuget", "search", ..])
         {
             var query = TryGetArgumentValue(arguments, "--query");
@@ -168,28 +168,5 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         }
 
         return null;
-    }
-
-    private static string FormatTimeout(TimeSpan timeout)
-    {
-        if (timeout.TotalMinutes >= 1 && timeout.TotalSeconds % 60 == 0)
-        {
-            return FormatTimeoutUnit(timeout.TotalMinutes, "0", "minute", "minutes");
-        }
-
-        if (timeout.TotalSeconds >= 1)
-        {
-            return FormatTimeoutUnit(timeout.TotalSeconds, "0.###", "second", "seconds");
-        }
-
-        return FormatTimeoutUnit(timeout.TotalMilliseconds, "0.###", "millisecond", "milliseconds");
-    }
-
-    private static string FormatTimeoutUnit(double value, string format, string singularUnit, string pluralUnit)
-    {
-        var formattedValue = value.ToString(format, CultureInfo.InvariantCulture);
-        var unit = string.Equals(formattedValue, "1", StringComparison.Ordinal) ? singularUnit : pluralUnit;
-
-        return $"{formattedValue} {unit}";
     }
 }

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -139,7 +139,7 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
 
     private static string BuildTimeoutMessage(string toolPath, IReadOnlyList<string> arguments, DirectoryInfo workingDirectory, TimeSpan timeout)
     {
-        var timeoutText = timeout.ToString("g", CultureInfo.InvariantCulture);
+        var timeoutText = FormatTimeout(timeout);
         if (arguments is ["nuget", "search", ..])
         {
             var query = TryGetArgumentValue(arguments, "--query");
@@ -168,5 +168,33 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         }
 
         return null;
+    }
+
+    private static string FormatTimeout(TimeSpan timeout)
+    {
+        if (timeout.TotalHours >= 1 && timeout.TotalMinutes % 60 == 0)
+        {
+            return FormatTimeoutUnit(timeout.TotalHours, "0", "hour", "hours");
+        }
+
+        if (timeout.TotalMinutes >= 1 && timeout.TotalSeconds % 60 == 0)
+        {
+            return FormatTimeoutUnit(timeout.TotalMinutes, "0", "minute", "minutes");
+        }
+
+        if (timeout.TotalSeconds >= 1)
+        {
+            return FormatTimeoutUnit(timeout.TotalSeconds, "0.###", "second", "seconds");
+        }
+
+        return FormatTimeoutUnit(timeout.TotalMilliseconds, "0.###", "millisecond", "milliseconds");
+    }
+
+    private static string FormatTimeoutUnit(double value, string format, string singularUnit, string pluralUnit)
+    {
+        var formattedValue = value.ToString(format, CultureInfo.InvariantCulture);
+        var unit = string.Equals(formattedValue, "1", StringComparison.Ordinal) ? singularUnit : pluralUnit;
+
+        return $"{formattedValue} {unit}";
     }
 }

--- a/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
+++ b/src/Aspire.Cli/Layout/LayoutProcessRunner.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Text;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Processes;
@@ -12,6 +13,10 @@ namespace Aspire.Cli.Layout;
 /// </summary>
 internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFactory)
 {
+    // Layout helpers include network-bound NuGet operations. If one wedges, the helper needs its own
+    // command-level bound instead of relying on an outer test hang dump or a hard-killed parent CLI.
+    internal static TimeSpan DefaultRunTimeout { get; } = TimeSpan.FromMinutes(3);
+
     /// <inheritdoc />
     public async Task<(int ExitCode, string Output, string Error)> RunAsync(
         string toolPath,
@@ -19,10 +24,16 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         string? workingDirectory = null,
         IDictionary<string, string>? environmentVariables = null,
         bool killOnParentExit = false,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        TimeSpan? timeout = null)
     {
         var outputBuilder = new StringBuilder();
         var errorBuilder = new StringBuilder();
+        var effectiveTimeout = timeout ?? DefaultRunTimeout;
+        if (effectiveTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "The process timeout must be greater than zero.");
+        }
 
         var options = new ProcessInvocationOptions
         {
@@ -55,7 +66,17 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
             throw new InvalidOperationException($"Failed to start process: {toolPath}");
         }
 
-        var exitCode = await execution.WaitForExitAsync(ct).ConfigureAwait(false);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(effectiveTimeout);
+        int exitCode;
+        try
+        {
+            exitCode = await execution.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+        {
+            throw new TimeoutException(BuildTimeoutMessage(toolPath, args, workDir, effectiveTimeout));
+        }
 
         return (exitCode, outputBuilder.ToString(), errorBuilder.ToString());
     }
@@ -115,4 +136,52 @@ internal sealed class LayoutProcessRunner(IProcessExecutionFactory executionFact
         => environmentVariables is null
             ? new Dictionary<string, string>(StringComparer.Ordinal)
             : new Dictionary<string, string>(environmentVariables, StringComparer.Ordinal);
+
+    private static string BuildTimeoutMessage(string toolPath, IReadOnlyList<string> arguments, DirectoryInfo workingDirectory, TimeSpan timeout)
+    {
+        var timeoutText = FormatTimeout(timeout);
+        if (arguments is ["nuget", "search", ..])
+        {
+            var query = TryGetArgumentValue(arguments, "--query");
+            var packageDescription = string.IsNullOrEmpty(query)
+                ? "NuGet package search"
+                : $"NuGet package search for '{query}'";
+            return $"{packageDescription} timed out after {timeoutText} contacting configured NuGet sources from '{workingDirectory.FullName}'.";
+        }
+
+        if (arguments is ["nuget", "restore", ..])
+        {
+            return $"NuGet package restore timed out after {timeoutText} contacting configured NuGet sources from '{workingDirectory.FullName}'.";
+        }
+
+        return $"Process '{Path.GetFileName(toolPath)}' timed out after {timeoutText} in '{workingDirectory.FullName}'.";
+    }
+
+    private static string? TryGetArgumentValue(IReadOnlyList<string> arguments, string name)
+    {
+        for (var i = 0; i < arguments.Count - 1; i++)
+        {
+            if (string.Equals(arguments[i], name, StringComparison.Ordinal))
+            {
+                return arguments[i + 1];
+            }
+        }
+
+        return null;
+    }
+
+    private static string FormatTimeout(TimeSpan timeout)
+    {
+        if (timeout.TotalMinutes >= 1 && timeout.TotalSeconds % 60 == 0)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{timeout.TotalMinutes:0} minutes");
+        }
+
+        if (timeout.TotalSeconds >= 1)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"{timeout.TotalSeconds:0.###} seconds");
+        }
+
+        return string.Create(CultureInfo.InvariantCulture, $"{timeout.TotalMilliseconds:0.###} milliseconds");
+    }
 }

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -323,5 +323,4 @@ public class LayoutProcessRunnerTests
             Assert.True(capturedEnv.ContainsKey("ASPIRE_CLI_PID"));
         }
     }
-
 }

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Reflection;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Tests.TestServices;
@@ -253,6 +254,27 @@ public class LayoutProcessRunnerTests
         Assert.Contains("timed out", exception.Message);
     }
 
+    [Theory]
+    [InlineData(3_600_000, "1 hour")]
+    [InlineData(7_200_000, "2 hours")]
+    [InlineData(60_000, "1 minute")]
+    [InlineData(180_000, "3 minutes")]
+    [InlineData(1_000, "1 second")]
+    [InlineData(2_000, "2 seconds")]
+    [InlineData(1, "1 millisecond")]
+    [InlineData(2, "2 milliseconds")]
+    [InlineData(1_000.4, "1 second")]
+    [InlineData(1.0004, "1 millisecond")]
+    public void BuildTimeoutMessage_FormatsTimeoutUnits(double timeoutMilliseconds, string expectedTimeoutText)
+    {
+        var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
+        var workingDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        var message = BuildTimeoutMessage(timeout, workingDirectory);
+
+        Assert.Equal($"Process 'aspire-managed' timed out after {expectedTimeoutText} in '{workingDirectory.FullName}'.", message);
+    }
+
     [Fact]
     public async Task RunAsync_WhenCallerTokenIsCanceled_PropagatesCancellation()
     {
@@ -303,5 +325,13 @@ public class LayoutProcessRunnerTests
         {
             Assert.True(capturedEnv.ContainsKey("ASPIRE_CLI_PID"));
         }
+    }
+
+    private static string BuildTimeoutMessage(TimeSpan timeout, DirectoryInfo workingDirectory)
+    {
+        var method = typeof(LayoutProcessRunner).GetMethod("BuildTimeoutMessage", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        return Assert.IsType<string>(method.Invoke(null, new object[] { "aspire-managed", Array.Empty<string>(), workingDirectory, timeout }));
     }
 }

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Reflection;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Tests.TestServices;
@@ -253,6 +254,25 @@ public class LayoutProcessRunnerTests
         Assert.Contains("timed out", exception.Message);
     }
 
+    [Theory]
+    [InlineData(60_000, "1 minute")]
+    [InlineData(120_000, "2 minutes")]
+    [InlineData(1_000, "1 second")]
+    [InlineData(2_000, "2 seconds")]
+    [InlineData(1, "1 millisecond")]
+    [InlineData(2, "2 milliseconds")]
+    [InlineData(1_000.4, "1 second")]
+    [InlineData(1.0004, "1 millisecond")]
+    public void BuildTimeoutMessage_FormatsTimeoutUnits(double timeoutMilliseconds, string expectedTimeoutText)
+    {
+        var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
+        var workingDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        var message = BuildTimeoutMessage(timeout, workingDirectory);
+
+        Assert.Equal($"Process 'aspire-managed' timed out after {expectedTimeoutText} in '{workingDirectory.FullName}'.", message);
+    }
+
     [Fact]
     public async Task RunAsync_WhenCallerTokenIsCanceled_PropagatesCancellation()
     {
@@ -303,5 +323,13 @@ public class LayoutProcessRunnerTests
         {
             Assert.True(capturedEnv.ContainsKey("ASPIRE_CLI_PID"));
         }
+    }
+
+    private static string BuildTimeoutMessage(TimeSpan timeout, DirectoryInfo workingDirectory)
+    {
+        var method = typeof(LayoutProcessRunner).GetMethod("BuildTimeoutMessage", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        return Assert.IsType<string>(method.Invoke(null, new object[] { "aspire-managed", Array.Empty<string>(), workingDirectory, timeout }));
     }
 }

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -253,25 +253,6 @@ public class LayoutProcessRunnerTests
         Assert.Contains("timed out", exception.Message);
     }
 
-    [Theory]
-    [InlineData(60_000, "1 minute")]
-    [InlineData(120_000, "2 minutes")]
-    [InlineData(1_000, "1 second")]
-    [InlineData(2_000, "2 seconds")]
-    [InlineData(1, "1 millisecond")]
-    [InlineData(2, "2 milliseconds")]
-    [InlineData(1_000.4, "1 second")]
-    [InlineData(1.0004, "1 millisecond")]
-    public void BuildTimeoutMessage_FormatsTimeoutUnits(double timeoutMilliseconds, string expectedTimeoutText)
-    {
-        var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
-        var workingDirectory = new DirectoryInfo(AppContext.BaseDirectory);
-
-        var message = LayoutProcessRunner.BuildTimeoutMessage("aspire-managed", [], workingDirectory, timeout);
-
-        Assert.Equal($"Process 'aspire-managed' timed out after {expectedTimeoutText} in '{workingDirectory.FullName}'.", message);
-    }
-
     [Fact]
     public async Task RunAsync_WhenCallerTokenIsCanceled_PropagatesCancellation()
     {

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -228,6 +228,55 @@ public class LayoutProcessRunnerTests
     }
 
     [Fact]
+    public async Task RunAsync_WhenProcessDoesNotExitWithinTimeout_ThrowsTimeoutException()
+    {
+        var factory = new TestProcessExecutionFactory
+        {
+            AsyncAttemptCallback = async (_, _, cancellationToken) =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+
+                return (0, null);
+            }
+        };
+        var runner = new LayoutProcessRunner(factory);
+        using var cancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => runner.RunAsync(
+            "aspire-managed",
+            ["nuget", "search", "--query", "Aspire.Hosting"],
+            timeout: TimeSpan.FromMilliseconds(50),
+            ct: cancellationSource.Token));
+
+        Assert.Contains("NuGet package search", exception.Message);
+        Assert.Contains("Aspire.Hosting", exception.Message);
+        Assert.Contains("timed out", exception.Message);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCallerTokenIsCanceled_PropagatesCancellation()
+    {
+        var factory = new TestProcessExecutionFactory
+        {
+            AsyncAttemptCallback = async (_, _, cancellationToken) =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+
+                return (0, null);
+            }
+        };
+        var runner = new LayoutProcessRunner(factory);
+
+        using var cancellationSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runner.RunAsync(
+            "aspire-managed",
+            ["nuget", "search", "--query", "Aspire.Hosting"],
+            timeout: TimeSpan.FromMinutes(1),
+            ct: cancellationSource.Token));
+    }
+
+    [Fact]
     public async Task StartAsync_WhenKillOnParentExit_DisarmsCooperativeWatchdogOnWindowsOnly()
     {
         // Same mutual-exclusion contract as RunAsync above, for the long-lived StartAsync helpers

--- a/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutProcessRunnerTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Reflection;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Tests.TestServices;
@@ -268,7 +267,7 @@ public class LayoutProcessRunnerTests
         var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
         var workingDirectory = new DirectoryInfo(AppContext.BaseDirectory);
 
-        var message = BuildTimeoutMessage(timeout, workingDirectory);
+        var message = LayoutProcessRunner.BuildTimeoutMessage("aspire-managed", [], workingDirectory, timeout);
 
         Assert.Equal($"Process 'aspire-managed' timed out after {expectedTimeoutText} in '{workingDirectory.FullName}'.", message);
     }
@@ -325,11 +324,4 @@ public class LayoutProcessRunnerTests
         }
     }
 
-    private static string BuildTimeoutMessage(TimeSpan timeout, DirectoryInfo workingDirectory)
-    {
-        var method = typeof(LayoutProcessRunner).GetMethod("BuildTimeoutMessage", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
-        return Assert.IsType<string>(method.Invoke(null, new object[] { "aspire-managed", Array.Empty<string>(), workingDirectory, timeout }));
-    }
 }


### PR DESCRIPTION
## Description

`aspire add` can hang while the bundled NuGet helper is searching package metadata. The helper was already launched with `killOnParentExit`, but that only prevents a leaked child after a hard-killed CLI; it does not bound the wait for a live but wedged helper. In CI, that left the 10-minute MTP hang timeout as the first clear failure.

This adds a 3-minute timeout to synchronous `LayoutProcessRunner.RunAsync` helper executions. NuGet search and restore timeouts now fail with a clear message, for example `NuGet package search for 'Aspire.Hosting' timed out after 3 minutes contacting configured NuGet sources...`, while caller cancellation still flows as cancellation.

The bound lives in `LayoutProcessRunner` rather than `BundleNuGetPackageCache` because search, restore, manifest creation, DCP stop, and DCP cleanup all share the same synchronous helper wait path. `StartAsync` is unchanged because it intentionally returns a background process whose lifetime is owned by the caller.

Validation:

- Red: the new timeout test failed before the implementation because `RunAsync` had no timeout parameter.
- Mutation: removing `CancelAfter(effectiveTimeout)` makes `RunAsync_WhenProcessDoesNotExitWithinTimeout_ThrowsTimeoutException` fail with `TaskCanceledException` after the test guard expires.
- Green: `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` passes: 4,786 succeeded, 33 skipped, 0 failed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

