### PR TITLE
Fix CreateFailingTestIssue failing on job logs that contain terminal escape sequences

### DIFF
--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.TestTools;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+/// <summary>
+/// Guards the <c>gh</c> argument list built for GitHub API calls.
+/// </summary>
+/// <remarks>
+/// The fixture-directory seam used by the other CreateFailingTestIssue tests returns canned content before
+/// any process arguments are constructed, so those tests cannot observe this. These tests replace the
+/// invoker itself, which is the only place the flag is visible.
+///
+/// All tests live in one class so they share a collection and never run concurrently against the static
+/// <see cref="GitHubCli.GhInvokerOverride"/>.
+/// </remarks>
+public class GitHubCliArgumentTests
+{
+    [Fact]
+    public async Task JobLogDownloadAllowsTerminalEscapeSequences()
+    {
+        var arguments = await CaptureArgumentsAsync(
+            () => GitHubActionsApi.DownloadJobLogAsync("microsoft/aspire", 12345, CancellationToken.None));
+
+        // CLI end-to-end job logs embed the raw terminal recording, so `gh` refuses to write them to a
+        // non-TTY stdout without this flag and fails the whole call.
+        Assert.Equal(
+            ["api", "-H", "Accept: application/vnd.github+json", "--allow-escape-sequences", "repos/microsoft/aspire/actions/jobs/12345/logs"],
+            arguments);
+    }
+
+    [Fact]
+    public async Task OrdinaryApiCallsDoNotAllowTerminalEscapeSequences()
+    {
+        var arguments = await CaptureArgumentsAsync(
+            () => GitHubCli.GetStringAsync("repos/microsoft/aspire/actions/runs/1", CancellationToken.None));
+
+        // A JSON payload carrying terminal control characters is worth failing on, so the flag stays off
+        // everywhere except the logs endpoint.
+        Assert.Equal(
+            ["api", "-H", "Accept: application/vnd.github+json", "repos/microsoft/aspire/actions/runs/1"],
+            arguments);
+    }
+
+    private static async Task<IReadOnlyList<string>> CaptureArgumentsAsync(Func<Task<string>> call)
+    {
+        IReadOnlyList<string> captured = [];
+
+        // The fixture seam runs ahead of argument construction, so it has to be off for this to observe
+        // anything. Other tests in this assembly set it per-process for the tool subprocess, not here.
+        var previousFixtureDirectory = Environment.GetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR");
+        Environment.SetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR", null);
+
+        GitHubCli.GhInvokerOverride = (arguments, _) =>
+        {
+            captured = arguments;
+            return Task.FromResult("{}");
+        };
+
+        try
+        {
+            await call();
+        }
+        finally
+        {
+            GitHubCli.GhInvokerOverride = null;
+            Environment.SetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR", previousFixtureDirectory);
+        }
+
+        return captured;
+    }
+}

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
@@ -9,21 +9,14 @@ namespace Infrastructure.Tests;
 /// <summary>
 /// Guards the <c>gh</c> argument list built for GitHub API calls.
 /// </summary>
-/// <remarks>
-/// The fixture-directory seam used by the other CreateFailingTestIssue tests returns canned content before
-/// any process arguments are constructed, so those tests cannot observe this. These tests replace the
-/// invoker itself, which is the only place the flag is visible.
-///
-/// All tests live in one class so they share a collection and never run concurrently against the static
-/// <see cref="GitHubCli.GhInvokerOverride"/>.
-/// </remarks>
 public class GitHubCliArgumentTests
 {
     [Fact]
-    public async Task JobLogDownloadAllowsTerminalEscapeSequences()
+    public void JobLogDownloadAllowsTerminalEscapeSequences()
     {
-        var arguments = await CaptureArgumentsAsync(
-            () => GitHubActionsApi.DownloadJobLogAsync("microsoft/aspire", 12345, CancellationToken.None));
+        var arguments = GitHubCli.BuildApiArguments(
+            "repos/microsoft/aspire/actions/jobs/12345/logs",
+            allowEscapeSequences: true);
 
         // CLI end-to-end job logs embed the raw terminal recording, so `gh` refuses to write them to a
         // non-TTY stdout without this flag and fails the whole call.
@@ -33,43 +26,16 @@ public class GitHubCliArgumentTests
     }
 
     [Fact]
-    public async Task OrdinaryApiCallsDoNotAllowTerminalEscapeSequences()
+    public void OrdinaryApiCallsDoNotAllowTerminalEscapeSequences()
     {
-        var arguments = await CaptureArgumentsAsync(
-            () => GitHubCli.GetStringAsync("repos/microsoft/aspire/actions/runs/1", CancellationToken.None));
+        var arguments = GitHubCli.BuildApiArguments(
+            "repos/microsoft/aspire/actions/runs/1",
+            allowEscapeSequences: false);
 
         // A JSON payload carrying terminal control characters is worth failing on, so the flag stays off
         // everywhere except the logs endpoint.
         Assert.Equal(
             ["api", "-H", "Accept: application/vnd.github+json", "repos/microsoft/aspire/actions/runs/1"],
             arguments);
-    }
-
-    private static async Task<IReadOnlyList<string>> CaptureArgumentsAsync(Func<Task<string>> call)
-    {
-        IReadOnlyList<string> captured = [];
-
-        // The fixture seam runs ahead of argument construction, so it has to be off for this to observe
-        // anything. Other tests in this assembly set it per-process for the tool subprocess, not here.
-        var previousFixtureDirectory = Environment.GetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR");
-        Environment.SetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR", null);
-
-        GitHubCli.GhInvokerOverride = (arguments, _) =>
-        {
-            captured = arguments;
-            return Task.FromResult("{}");
-        };
-
-        try
-        {
-            await call();
-        }
-        finally
-        {
-            GitHubCli.GhInvokerOverride = null;
-            Environment.SetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR", previousFixtureDirectory);
-        }
-
-        return captured;
     }
 }

--- a/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
+++ b/tests/Infrastructure.Tests/CreateFailingTestIssue/GitHubCliArgumentTests.cs
@@ -9,14 +9,20 @@ namespace Infrastructure.Tests;
 /// <summary>
 /// Guards the <c>gh</c> argument list built for GitHub API calls.
 /// </summary>
+/// <remarks>
+/// The fixture-directory seam used by the other CreateFailingTestIssue tests returns canned content before
+/// any process arguments are constructed, so those tests cannot observe this. These tests replace the
+/// invoker itself, which is the only place the flag is visible. Both tests stay in one class so xUnit keeps
+/// them in the same collection and never runs them concurrently against the static
+/// <see cref="GitHubCli.GhInvokerOverride"/>.
+/// </remarks>
 public class GitHubCliArgumentTests
 {
     [Fact]
-    public void JobLogDownloadAllowsTerminalEscapeSequences()
+    public async Task JobLogDownloadAllowsTerminalEscapeSequences()
     {
-        var arguments = GitHubCli.BuildApiArguments(
-            "repos/microsoft/aspire/actions/jobs/12345/logs",
-            allowEscapeSequences: true);
+        var arguments = await CaptureArgumentsAsync(
+            () => GitHubActionsApi.DownloadJobLogAsync("microsoft/aspire", 12345, CancellationToken.None));
 
         // CLI end-to-end job logs embed the raw terminal recording, so `gh` refuses to write them to a
         // non-TTY stdout without this flag and fails the whole call.
@@ -26,16 +32,43 @@ public class GitHubCliArgumentTests
     }
 
     [Fact]
-    public void OrdinaryApiCallsDoNotAllowTerminalEscapeSequences()
+    public async Task OrdinaryApiCallsDoNotAllowTerminalEscapeSequences()
     {
-        var arguments = GitHubCli.BuildApiArguments(
-            "repos/microsoft/aspire/actions/runs/1",
-            allowEscapeSequences: false);
+        var arguments = await CaptureArgumentsAsync(
+            () => GitHubCli.GetStringAsync("repos/microsoft/aspire/actions/runs/1", CancellationToken.None));
 
         // A JSON payload carrying terminal control characters is worth failing on, so the flag stays off
         // everywhere except the logs endpoint.
         Assert.Equal(
             ["api", "-H", "Accept: application/vnd.github+json", "repos/microsoft/aspire/actions/runs/1"],
             arguments);
+    }
+
+    private static async Task<IReadOnlyList<string>> CaptureArgumentsAsync(Func<Task<string>> call)
+    {
+        IReadOnlyList<string> captured = [];
+
+        // The fixture seam returns canned content before argument construction, so clear it here to ensure
+        // these tests exercise the production call path all the way down to the gh invoker.
+        var previousFixtureDirectory = Environment.GetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR");
+        Environment.SetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR", null);
+
+        GitHubCli.GhInvokerOverride = (arguments, _) =>
+        {
+            captured = arguments;
+            return Task.FromResult("{}");
+        };
+
+        try
+        {
+            await call();
+        }
+        finally
+        {
+            GitHubCli.GhInvokerOverride = null;
+            Environment.SetEnvironmentVariable("ASPIRE_FAILING_TEST_ISSUE_FIXTURE_DIR", previousFixtureDirectory);
+        }
+
+        return captured;
     }
 }

--- a/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\Aspire.TestUtilities\Aspire.TestUtilities.csproj" />
     <ProjectReference Include="..\..\tools\TypeScriptApiCompat\TypeScriptApiCompat.csproj" />
     <ProjectReference Include="..\..\tools\SelectTests\SelectTests.csproj" />
+    <ProjectReference Include="..\..\tools\Aspire.TestTools\Aspire.TestTools.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)TemporaryWorkspace.cs" Link="shared/TemporaryWorkspace.cs" />

--- a/tools/Aspire.TestTools/Aspire.TestTools.csproj
+++ b/tools/Aspire.TestTools/Aspire.TestTools.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Infrastructure.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tools/Aspire.TestTools/GitHubActionsApi.cs
+++ b/tools/Aspire.TestTools/GitHubActionsApi.cs
@@ -84,8 +84,12 @@ public static class GitHubActionsApi
         return artifacts;
     }
 
+    // Job logs for CLI end-to-end tests embed the raw terminal recording, so they routinely contain ANSI
+    // control characters. `gh api` refuses to write those to a non-TTY stdout and fails the call with
+    // "the response contains terminal escape sequences; pass --allow-escape-sequences to output it anyway",
+    // which previously made this tool unable to file an issue for any terminal-driven test.
     public static Task<string> DownloadJobLogAsync(string repository, long jobId, CancellationToken cancellationToken)
-        => GitHubCli.GetStringAsync($"repos/{repository}/actions/jobs/{jobId}/logs", cancellationToken);
+        => GitHubCli.GetStringAsync($"repos/{repository}/actions/jobs/{jobId}/logs", allowEscapeSequences: true, cancellationToken);
 
     public static Task DownloadArtifactZipAsync(string repository, long artifactId, string outputPath, CancellationToken cancellationToken)
         => GitHubCli.DownloadFileAsync($"repos/{repository}/actions/artifacts/{artifactId}/zip", outputPath, cancellationToken);

--- a/tools/Aspire.TestTools/GitHubCli.cs
+++ b/tools/Aspire.TestTools/GitHubCli.cs
@@ -20,6 +20,14 @@ public static class GitHubCli
     }
 
     public static Task<string> GetStringAsync(string endpoint, CancellationToken cancellationToken)
+        => GetStringAsync(endpoint, allowEscapeSequences: false, cancellationToken);
+
+    /// <param name="allowEscapeSequences">
+    /// When <see langword="true"/>, passes <c>--allow-escape-sequences</c> to <c>gh api</c>. Required for
+    /// endpoints whose payload can contain terminal control characters; <c>gh</c> refuses to write those to
+    /// a non-TTY stdout otherwise and fails the whole call.
+    /// </param>
+    public static Task<string> GetStringAsync(string endpoint, bool allowEscapeSequences, CancellationToken cancellationToken)
     {
         if (TryGetFixturePath(endpoint, ".json", out var fixturePath))
         {
@@ -36,7 +44,15 @@ public static class GitHubCli
             return Task.FromException<string>(new InvalidOperationException(File.ReadAllText(fixturePath)));
         }
 
-        return RunGhAsync(["api", "-H", "Accept: application/vnd.github+json", endpoint], cancellationToken);
+        List<string> arguments = ["api", "-H", "Accept: application/vnd.github+json"];
+        if (allowEscapeSequences)
+        {
+            arguments.Add("--allow-escape-sequences");
+        }
+
+        arguments.Add(endpoint);
+
+        return RunGhAsync(arguments, cancellationToken);
     }
 
     public static async Task DownloadFileAsync(string endpoint, string outputPath, CancellationToken cancellationToken)

--- a/tools/Aspire.TestTools/GitHubCli.cs
+++ b/tools/Aspire.TestTools/GitHubCli.cs
@@ -22,11 +22,9 @@ public static class GitHubCli
     public static Task<string> GetStringAsync(string endpoint, CancellationToken cancellationToken)
         => GetStringAsync(endpoint, allowEscapeSequences: false, cancellationToken);
 
-    /// <param name="allowEscapeSequences">
-    /// When <see langword="true"/>, passes <c>--allow-escape-sequences</c> to <c>gh api</c>. Required for
-    /// endpoints whose payload can contain terminal control characters; <c>gh</c> refuses to write those to
-    /// a non-TTY stdout otherwise and fails the whole call.
-    /// </param>
+    // allowEscapeSequences passes `--allow-escape-sequences` to `gh api`. Required for endpoints whose
+    // payload can contain terminal control characters; `gh` refuses to write those to a non-TTY stdout
+    // and fails the whole call otherwise.
     public static Task<string> GetStringAsync(string endpoint, bool allowEscapeSequences, CancellationToken cancellationToken)
     {
         if (TryGetFixturePath(endpoint, ".json", out var fixturePath))
@@ -226,8 +224,19 @@ public static class GitHubCli
 
     private static readonly TimeSpan s_defaultProcessTimeout = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// Test seam that replaces the <c>gh</c> invocation so tests can observe the argument list that would
+    /// be passed to the process. Production code never sets this.
+    /// </summary>
+    internal static Func<IReadOnlyList<string>, CancellationToken, Task<string>>? GhInvokerOverride { get; set; }
+
     private static async Task<string> RunGhAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken)
     {
+        if (GhInvokerOverride is { } invoker)
+        {
+            return await invoker(arguments, cancellationToken).ConfigureAwait(false);
+        }
+
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(s_defaultProcessTimeout);
 

--- a/tools/Aspire.TestTools/GitHubCli.cs
+++ b/tools/Aspire.TestTools/GitHubCli.cs
@@ -42,6 +42,11 @@ public static class GitHubCli
             return Task.FromException<string>(new InvalidOperationException(File.ReadAllText(fixturePath)));
         }
 
+        return RunGhAsync(BuildApiArguments(endpoint, allowEscapeSequences), cancellationToken);
+    }
+
+    internal static IReadOnlyList<string> BuildApiArguments(string endpoint, bool allowEscapeSequences)
+    {
         List<string> arguments = ["api", "-H", "Accept: application/vnd.github+json"];
         if (allowEscapeSequences)
         {
@@ -50,7 +55,7 @@ public static class GitHubCli
 
         arguments.Add(endpoint);
 
-        return RunGhAsync(arguments, cancellationToken);
+        return arguments;
     }
 
     public static async Task DownloadFileAsync(string endpoint, string outputPath, CancellationToken cancellationToken)
@@ -224,19 +229,8 @@ public static class GitHubCli
 
     private static readonly TimeSpan s_defaultProcessTimeout = TimeSpan.FromMinutes(5);
 
-    /// <summary>
-    /// Test seam that replaces the <c>gh</c> invocation so tests can observe the argument list that would
-    /// be passed to the process. Production code never sets this.
-    /// </summary>
-    internal static Func<IReadOnlyList<string>, CancellationToken, Task<string>>? GhInvokerOverride { get; set; }
-
     private static async Task<string> RunGhAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken)
     {
-        if (GhInvokerOverride is { } invoker)
-        {
-            return await invoker(arguments, cancellationToken).ConfigureAwait(false);
-        }
-
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(s_defaultProcessTimeout);
 

--- a/tools/Aspire.TestTools/GitHubCli.cs
+++ b/tools/Aspire.TestTools/GitHubCli.cs
@@ -45,7 +45,7 @@ public static class GitHubCli
         return RunGhAsync(BuildApiArguments(endpoint, allowEscapeSequences), cancellationToken);
     }
 
-    internal static IReadOnlyList<string> BuildApiArguments(string endpoint, bool allowEscapeSequences)
+    private static IReadOnlyList<string> BuildApiArguments(string endpoint, bool allowEscapeSequences)
     {
         List<string> arguments = ["api", "-H", "Accept: application/vnd.github+json"];
         if (allowEscapeSequences)
@@ -229,8 +229,19 @@ public static class GitHubCli
 
     private static readonly TimeSpan s_defaultProcessTimeout = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// Test seam that replaces the string-returning <c>gh</c> invocation so tests can observe the argument
+    /// list that would be passed to the process. Production code never sets this.
+    /// </summary>
+    internal static Func<IReadOnlyList<string>, CancellationToken, Task<string>>? GhInvokerOverride { get; set; }
+
     private static async Task<string> RunGhAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken)
     {
+        if (GhInvokerOverride is { } invoker)
+        {
+            return await invoker(arguments, cancellationToken).ConfigureAwait(false);
+        }
+
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(s_defaultProcessTimeout);
 


### PR DESCRIPTION
## Description

`CreateFailingTestIssue` and `tools/scripts/DownloadFailingJobLogs.cs` both read GitHub Actions job logs through `GitHubActionsApi.DownloadJobLogAsync`, which shells out to `gh api`.

CLI end-to-end job logs embed the raw terminal recording, so they routinely contain ANSI control characters. `gh` refuses to write those to a non-TTY stdout and fails the entire call:

```
gh api -H "Accept: application/vnd.github+json" repos/microsoft/aspire/actions/jobs/93212557004/logs failed:
the response contains terminal escape sequences; pass --allow-escape-sequences to output it anyway
```

The failure happens during log download, which is the fallback path used whenever `.trx` artifacts are missing or the run is still active. The practical effect was that **no failing-test issue could be filed for any terminal-driven test** — the tool aborted before it could enumerate failures.

## Fix

Pass `--allow-escape-sequences` for the job-logs endpoint only. Other API responses keep `gh`'s existing protection, since a JSON payload containing terminal control characters is a signal worth failing on.

## Verification

Against the real API, on run [31298893091](https://github.com/microsoft/aspire/actions/runs/31298893091) (a CLI E2E failure whose logs contain escape sequences):

Before:

```json
{ "success": false,
  "err": "gh api ... /logs failed: the response contains terminal escape sequences; ..." }
```

After:

```json
{ "success": true,
  "tests": ["Aspire.Cli.EndToEnd.Tests.TypeScriptSqlServerNativeAssetsBundleTests.StartAndWaitForTypeScriptSqlServerAppHostWithNativeAssets"] }
```

The fixed tool then filed #19179 end to end.

## Checklist

- [x] Change is manually tested against the live GitHub API (before/after above)
- [x] Fix is scoped to the endpoint that needs it
