### PR TITLE
Make CheckCopilotCliAsync_UsesOverallGitHubTokenCandidateTimeout able to fail

### DIFF
--- a/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
+++ b/src/Aspire.Cli/Telemetry/InternalMicrosoftDetector.cs
@@ -49,6 +49,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
     private readonly IProcessExecutionFactory _processExecutionFactory;
     private readonly HttpMessageHandler? _gitHubHttpMessageHandler;
     private readonly TimeSpan _gitHubCandidateTimeout;
+    private readonly TimeSpan _gitHubHttpTimeout;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<InternalMicrosoftDetector> _logger;
     private readonly IReadOnlyList<IReadOnlyList<InternalMicrosoftProbe>> _probeStages;
@@ -74,7 +75,8 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         IProcessExecutionFactory processExecutionFactory,
         IReadOnlyList<IReadOnlyList<InternalMicrosoftProbe>>? probeStages,
         HttpMessageHandler? gitHubHttpMessageHandler = null,
-        TimeSpan? gitHubCandidateTimeout = null)
+        TimeSpan? gitHubCandidateTimeout = null,
+        TimeSpan? gitHubHttpTimeout = null)
     {
         _cacheFilePath = cacheFilePath;
         _executionContext = executionContext;
@@ -82,6 +84,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         _processExecutionFactory = processExecutionFactory;
         _gitHubHttpMessageHandler = gitHubHttpMessageHandler;
         _gitHubCandidateTimeout = gitHubCandidateTimeout ?? s_gitHubCandidateTimeout;
+        _gitHubHttpTimeout = gitHubHttpTimeout ?? s_gitHubHttpTimeout;
         _timeProvider = timeProvider;
         _logger = logger;
         _probeStages = probeStages ?? CreateDefaultProbeStages();
@@ -728,7 +731,7 @@ internal sealed partial class InternalMicrosoftDetector : IInternalMicrosoftDete
         var http = _gitHubHttpMessageHandler is null
             ? new HttpClient()
             : new HttpClient(_gitHubHttpMessageHandler, disposeHandler: false);
-        http.Timeout = s_gitHubHttpTimeout;
+        http.Timeout = _gitHubHttpTimeout;
 
         http.DefaultRequestHeaders.UserAgent.ParseAdd("aspire-cli-internal-microsoft-detector/1.0");
         return http;

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -493,12 +493,14 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
 
         Assert.False(result.IsInternalMicrosoft);
 
-        // The handler blocks for a minute per request, so if the overall candidate budget were not
-        // enforced this would take at least that long. The bound only has to separate "budget enforced"
-        // (~500ms of real work: 5 candidates at the 100ms per-candidate timeout) from "not enforced"
-        // (>= 1 minute). A tight bound buys no extra proof and does fail: at 2 seconds this test flaked on
-        // a loaded windows-latest runner at 2s 064ms while macOS and ubuntu passed on the same commit
-        // (https://github.com/microsoft/aspire/issues/19181).
+        // CheckAnyGitHubMembershipCandidateAsync starts all five candidate probes concurrently under a
+        // single CancellationTokenSource(_gitHubCandidateTimeout), so the budget is one overall 100ms
+        // window shared by every probe - not 100ms per candidate, and not serial. The handler blocks for
+        // a minute per request, so an unenforced budget shows up as >= 1 minute. The bound therefore only
+        // has to separate "enforced" (~100ms plus cancellation, drain, and scheduling overhead) from
+        // "not enforced" (>= 1 minute), and a tight bound buys no extra proof while genuinely failing:
+        // at 2 seconds this flaked on a loaded windows-latest runner at 2s 064ms while macOS and ubuntu
+        // passed on the same commit (https://github.com/microsoft/aspire/issues/19181).
         Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10), $"Elapsed {stopwatch.Elapsed} exceeded the overall candidate timeout budget.");
         Assert.Equal(5, handler.GetRequestPaths().Count(path => path == "/user"));
     }

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -470,10 +470,29 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
     public async Task CheckCopilotCliAsync_UsesOverallGitHubTokenCandidateTimeout()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var concurrencyLock = new Lock();
+        var inFlightRequests = 0;
+        var peakInFlightRequests = 0;
         var handler = new TestGitHubHttpMessageHandler(async (_, cancellationToken) =>
         {
-            await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
-            return new HttpResponseMessage(HttpStatusCode.OK);
+            lock (concurrencyLock)
+            {
+                inFlightRequests++;
+                peakInFlightRequests = Math.Max(peakInFlightRequests, inFlightRequests);
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+            finally
+            {
+                lock (concurrencyLock)
+                {
+                    inFlightRequests--;
+                }
+            }
         });
         var environmentVariables = Enumerable.Range(0, 7)
             .ToDictionary(index => $"COPILOT_GH_ACCOUNT_{index}", index => (string?)CreateGitHubToken(index));
@@ -498,15 +517,24 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
 
         Assert.False(result.IsInternalMicrosoft);
 
-        // CheckAnyGitHubMembershipCandidateAsync starts all five candidate probes concurrently under a
-        // single CancellationTokenSource(_gitHubCandidateTimeout), so the budget is one overall 100ms
-        // window shared by every probe - not 100ms per candidate, and not serial. The handler blocks for
-        // a minute per request, so an unenforced budget shows up as >= 1 minute. The bound therefore only
-        // has to separate "enforced" (~100ms plus cancellation, drain, and scheduling overhead) from
-        // "not enforced" (>= 1 minute), and a tight bound buys no extra proof while genuinely failing:
-        // at 2 seconds this flaked on a loaded windows-latest runner at 2s 064ms while macOS and ubuntu
+        // Two independent regressions have to be ruled out here, and the wall clock alone cannot do it.
+        //
+        // "No budget at all" is what the elapsed bound catches. The handler blocks for a minute per
+        // request, so an unenforced budget shows up as >= 1 minute. The bound therefore only has to
+        // separate "enforced" (~100ms plus cancellation, drain, and scheduling overhead) from "not
+        // enforced" (>= 1 minute), and a tight bound buys no extra proof while genuinely failing: at
+        // 2 seconds this flaked on a loaded windows-latest runner at 2s 064ms while macOS and ubuntu
         // passed on the same commit (https://github.com/microsoft/aspire/issues/19181).
+        //
+        // "A fresh budget per candidate, applied serially" is invisible to that bound: five sequential
+        // probes each cancelled after 100ms would finish in roughly half a second, issue all five
+        // requests, and pass comfortably. Peak overlap separates the two without a clock, because a
+        // serial implementation can never have more than one request in flight. Every request blocks
+        // until the shared budget cancels it, so all five that reach the handler necessarily overlap;
+        // this asserts the same count as the request assertion below and so adds no timing sensitivity
+        // of its own.
         Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10), $"Elapsed {stopwatch.Elapsed} exceeded the overall candidate timeout budget.");
+        Assert.Equal(5, peakInFlightRequests);
         Assert.Equal(5, handler.GetRequestPaths().Count(path => path == "/user"));
     }
 

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -492,7 +492,14 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         stopwatch.Stop();
 
         Assert.False(result.IsInternalMicrosoft);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2));
+
+        // The handler blocks for a minute per request, so if the overall candidate budget were not
+        // enforced this would take at least that long. The bound only has to separate "budget enforced"
+        // (~500ms of real work: 5 candidates at the 100ms per-candidate timeout) from "not enforced"
+        // (>= 1 minute). A tight bound buys no extra proof and does fail: at 2 seconds this test flaked on
+        // a loaded windows-latest runner at 2s 064ms while macOS and ubuntu passed on the same commit
+        // (https://github.com/microsoft/aspire/issues/19181).
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10), $"Elapsed {stopwatch.Elapsed} exceeded the overall candidate timeout budget.");
         Assert.Equal(5, handler.GetRequestPaths().Count(path => path == "/user"));
     }
 

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -485,7 +485,12 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
             probeStages: [],
             environmentVariables: environmentVariables,
             gitHubHttpMessageHandler: handler,
-            gitHubCandidateTimeout: TimeSpan.FromMilliseconds(100));
+            gitHubCandidateTimeout: TimeSpan.FromMilliseconds(100),
+            // HttpClient.Timeout defaults to 3 seconds here, which would independently cancel every
+            // probe well inside the assertion bound below and make this test pass even with no candidate
+            // budget at all. Disabling the per-request timeout leaves the overall budget as the only
+            // thing that can stop the handler's one-minute delay, so the assertion measures what it claims.
+            gitHubHttpTimeout: Timeout.InfiniteTimeSpan);
 
         var stopwatch = Stopwatch.StartNew();
         var result = await detector.CheckCopilotCliAsync(CancellationToken.None);
@@ -512,7 +517,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
         TestProcessExecutionFactory? processFactory = null,
         IReadOnlyDictionary<string, string?>? environmentVariables = null,
         HttpMessageHandler? gitHubHttpMessageHandler = null,
-        TimeSpan? gitHubCandidateTimeout = null)
+        TimeSpan? gitHubCandidateTimeout = null,
+        TimeSpan? gitHubHttpTimeout = null)
     {
         var executionContext = Utils.TestExecutionContextHelper.CreateExecutionContext(
             new DirectoryInfo(Path.GetDirectoryName(cacheFilePath) ?? AppContext.BaseDirectory));
@@ -526,7 +532,8 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
             processFactory ?? new TestProcessExecutionFactory(),
             probeStages,
             gitHubHttpMessageHandler,
-            gitHubCandidateTimeout);
+            gitHubCandidateTimeout,
+            gitHubHttpTimeout);
     }
 
     private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json)

--- a/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
+++ b/tests/Aspire.Cli.Tests/Telemetry/InternalMicrosoftDetectorTests.cs
@@ -1,15 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Net;
+using System.Text;
 using Aspire.Cli.DotNet;
 using Aspire.Cli.Telemetry;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.Diagnostics;
-using System.Net;
-using System.Text;
 
 namespace Aspire.Cli.Tests.Telemetry;
 
@@ -470,29 +470,10 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
     public async Task CheckCopilotCliAsync_UsesOverallGitHubTokenCandidateTimeout()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var concurrencyLock = new Lock();
-        var inFlightRequests = 0;
-        var peakInFlightRequests = 0;
         var handler = new TestGitHubHttpMessageHandler(async (_, cancellationToken) =>
         {
-            lock (concurrencyLock)
-            {
-                inFlightRequests++;
-                peakInFlightRequests = Math.Max(peakInFlightRequests, inFlightRequests);
-            }
-
-            try
-            {
-                await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
-                return new HttpResponseMessage(HttpStatusCode.OK);
-            }
-            finally
-            {
-                lock (concurrencyLock)
-                {
-                    inFlightRequests--;
-                }
-            }
+            await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
         });
         var environmentVariables = Enumerable.Range(0, 7)
             .ToDictionary(index => $"COPILOT_GH_ACCOUNT_{index}", index => (string?)CreateGitHubToken(index));
@@ -517,25 +498,65 @@ public sealed class InternalMicrosoftDetectorTests(ITestOutputHelper outputHelpe
 
         Assert.False(result.IsInternalMicrosoft);
 
-        // Two independent regressions have to be ruled out here, and the wall clock alone cannot do it.
-        //
-        // "No budget at all" is what the elapsed bound catches. The handler blocks for a minute per
-        // request, so an unenforced budget shows up as >= 1 minute. The bound therefore only has to
-        // separate "enforced" (~100ms plus cancellation, drain, and scheduling overhead) from "not
-        // enforced" (>= 1 minute), and a tight bound buys no extra proof while genuinely failing: at
-        // 2 seconds this flaked on a loaded windows-latest runner at 2s 064ms while macOS and ubuntu
-        // passed on the same commit (https://github.com/microsoft/aspire/issues/19181).
-        //
-        // "A fresh budget per candidate, applied serially" is invisible to that bound: five sequential
-        // probes each cancelled after 100ms would finish in roughly half a second, issue all five
-        // requests, and pass comfortably. Peak overlap separates the two without a clock, because a
-        // serial implementation can never have more than one request in flight. Every request blocks
-        // until the shared budget cancels it, so all five that reach the handler necessarily overlap;
-        // this asserts the same count as the request assertion below and so adds no timing sensitivity
-        // of its own.
+        // The handler blocks for a minute per request and HttpClient.Timeout is disabled above, so an
+        // unenforced candidate budget takes at least a minute. Ten seconds leaves ample cancellation,
+        // drain, and scheduler headroom while still proving the overall budget stops the probes. The
+        // previous two-second bound failed at 2.064s on a loaded windows-latest runner:
+        // https://github.com/microsoft/aspire/issues/19181.
         Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10), $"Elapsed {stopwatch.Elapsed} exceeded the overall candidate timeout budget.");
-        Assert.Equal(5, peakInFlightRequests);
         Assert.Equal(5, handler.GetRequestPaths().Count(path => path == "/user"));
+    }
+
+    [Fact]
+    public async Task CheckCopilotCliAsync_ProbesGitHubTokenCandidatesConcurrently()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        const int candidateCount = 5;
+        var allCandidatesEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCandidates = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var enteredCandidates = 0;
+        var handler = new TestGitHubHttpMessageHandler(async (_, cancellationToken) =>
+        {
+            if (Interlocked.Increment(ref enteredCandidates) == candidateCount)
+            {
+                allCandidatesEntered.TrySetResult();
+            }
+
+            await releaseCandidates.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        });
+        var environmentVariables = Enumerable.Range(0, 7)
+            .ToDictionary(index => $"COPILOT_GH_ACCOUNT_{index}", index => (string?)CreateGitHubToken(index));
+        environmentVariables["PATH"] = workspace.Path;
+        environmentVariables["PATHEXT"] = ".EXE";
+        var detector = CreateDetector(
+            Path.Combine(workspace.Path, "cache", "detector.json"),
+            new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.Zero),
+            probeStages: [],
+            environmentVariables: environmentVariables,
+            gitHubHttpMessageHandler: handler,
+            gitHubCandidateTimeout: Timeout.InfiniteTimeSpan,
+            gitHubHttpTimeout: Timeout.InfiniteTimeSpan);
+
+        using var safetyTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var checkTask = detector.CheckCopilotCliAsync(safetyTimeout.Token);
+
+        // The test releases the handlers only after all five have entered. A serial implementation
+        // cannot reach that point; the independent timeout keeps that regression from hanging the suite.
+        try
+        {
+            await allCandidatesEntered.Task.WaitAsync(safetyTimeout.Token);
+        }
+        finally
+        {
+            releaseCandidates.TrySetResult();
+        }
+
+        var result = await checkTask.WaitAsync(safetyTimeout.Token);
+
+        Assert.False(result.IsInternalMicrosoft);
+        Assert.Equal(candidateCount, enteredCandidates);
+        Assert.Equal(candidateCount, handler.GetRequestPaths().Count(path => path == "/user"));
     }
 
     private static InternalMicrosoftDetector CreateDetector(


### PR DESCRIPTION
## Description

Fixes #19181.

`CheckCopilotCliAsync_UsesOverallGitHubTokenCandidateTimeout` exists to prove that the detector enforces an **overall** budget across GitHub token candidates rather than paying each candidate's timeout in series. Its handler blocks for a minute per request:

```csharp
await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
```

The test was failing intermittently: `windows-latest` failed at **2s 064ms** against a 2-second bound while `macos-latest` and `ubuntu-latest` passed on the identical commit. Cross-OS divergence on one commit is the signature of a timing flake rather than a behavioral defect.

## The first fix was wrong, and the test could no longer fail

Raising the bound to 10 seconds stopped the flake but also made the assertion vacuous, because the elapsed time was never bounded by the candidate budget in the first place:

`CreateGitHubHttpClient` set `http.Timeout` from a hardcoded static `s_gitHubHttpTimeout` of **3 seconds**, which is not injectable. `HttpClient.Timeout` cancels each request independently of the candidate budget, and all five probes run concurrently — so with the overall budget removed entirely, the test still finished in about 3 seconds and still passed a 10-second bound.

Measured, by setting `gitHubCandidateTimeout` to 10 minutes to disable the budget:

| Bound | Budget enforced | Budget removed | Detects the regression? |
| --- | --- | --- | --- |
| 2 s (original) | ~100 ms | ~3 s | yes, but flakes under runner contention |
| 10 s (first fix) | ~100 ms | ~3 s | **no — passed** |
| 10 s + this change | ~100 ms | **1m 00.018s** | yes |

So the table this PR originally claimed — "budget not enforced ⇒ ≥ 1 minute" — was not true of the code as written. The per-request timeout masked it.

## Change

Add an internal `gitHubHttpTimeout` constructor parameter to `InternalMicrosoftDetector`, defaulting to `s_gitHubHttpTimeout`, and use it in `CreateGitHubHttpClient`. This mirrors the `gitHubCandidateTimeout` seam that already exists directly above it; no production behavior changes, since the default is the same 3 seconds.

The test passes `Timeout.InfiniteTimeSpan` for it. With the per-request timeout out of the way, the overall candidate budget is the only thing that can interrupt the handler's one-minute delay, so the 10-second bound now separates the two states by 6×, and the comment in the test describes what the code actually does.

Quarantining was the alternative and is the wrong call here: the test verifies real behavior and would stop running.

## Testing

```
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile \
  -- --filter-class "*.InternalMicrosoftDetectorTests"
```
→ `succeeded: 16, failed: 0`.

Mutation-verified rather than assumed. With `gitHubCandidateTimeout` set to 10 minutes:

- before this change: `succeeded: 1, failed: 0` — the regression was undetectable
- after this change: `failed: 1`, reporting `Elapsed 00:01:00.0187366 exceeded the overall candidate timeout budget`

Restoring the 100 ms budget returns it to passing.

## Checklist

- [x] Test fails if the behavior it covers regresses — demonstrated above, not assumed
- [x] Production code change is limited to an optional test seam whose default preserves the existing 3-second timeout
