### PR TITLE
Fix flaky environment checker timeout test

### DIFF
--- a/tests/Aspire.Cli.Tests/Utils/EnvironmentCheckerTests.cs
+++ b/tests/Aspire.Cli.Tests/Utils/EnvironmentCheckerTests.cs
@@ -16,6 +16,9 @@ public class EnvironmentCheckerTests
         using var releaseCheck = new ManualResetEventSlim();
         var checkStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var checkExited = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // This test intentionally blocks a ThreadPool worker. Keep the timeout large enough that
+        // the next check doesn't fail just because a loaded CI worker takes >100 ms to dispatch Task.Run.
+        var checkTimeout = TimeSpan.FromSeconds(2);
         var completedResult = new EnvironmentCheckResult
         {
             Category = EnvironmentCheckCategories.Environment,
@@ -35,8 +38,8 @@ public class EnvironmentCheckerTests
                 new TestEnvironmentCheck(1, _ => Task.FromResult<IReadOnlyList<EnvironmentCheckResult>>([completedResult])),
             ],
             NullLogger<EnvironmentChecker>.Instance,
-            checkTimeout: TimeSpan.FromMilliseconds(100),
-            totalTimeout: TimeSpan.FromSeconds(5));
+            checkTimeout: checkTimeout,
+            totalTimeout: TimeSpan.FromSeconds(10));
 
         var checkAllTask = checker.CheckAllAsync(TestContext.Current.CancellationToken);
         IReadOnlyList<EnvironmentCheckResult> results;
@@ -59,7 +62,7 @@ public class EnvironmentCheckerTests
                 Assert.Equal("test-environment", timeoutResult.Name);
                 Assert.Equal(EnvironmentCheckStatus.Warning, timeoutResult.Status);
                 Assert.Equal(nameof(TestEnvironmentCheck), timeoutResult.Metadata!["checkType"]!.GetValue<string>());
-                Assert.Equal(0.1, timeoutResult.Metadata["timeoutSeconds"]!.GetValue<double>());
+                Assert.Equal(checkTimeout.TotalSeconds, timeoutResult.Metadata["timeoutSeconds"]!.GetValue<double>());
             },
             result => Assert.Same(completedResult, result));
     }


### PR DESCRIPTION
## Description

This fixes the flaky `Aspire.Cli.Tests.Utils.EnvironmentCheckerTests.CheckAllAsync_TimedOutCheckReportsWarningAndContinues` failure seen in CI run `31331527196`, job `93290683752` (`Tests / Cli / Cli (windows-latest)`) on 2026-08-09.

Observed assertion:

```text
Assert.Collection() Failure: Item comparison failure
Collection: [EnvironmentCheckResult { ... Message = "Environment check 'test-environment' timed out aft"..., ... },
             EnvironmentCheckResult { ... Message = "Environment check 'test-environment' timed out aft"..., ... }]
Error:      Assert.Same() Failure: Values are not the same instance
Expected: EnvironmentCheckResult { ... Message = "Completed", ... }
Actual:   EnvironmentCheckResult { ... Message = "Environment check 'test-environment' timed out aft"..., ... }
```

Root cause verified from source: `EnvironmentChecker.CheckAllAsync` creates the per-check timeout CTS and calls `CancelAfter(_checkTimeout)` before scheduling the check with `Task.Run(...)`. This test used a 100 ms per-check budget while the first check synchronously blocked a ThreadPool worker until the test released it. On a loaded worker, the second check's `Task.Run` can sit queued for more than 100 ms, so its wall-clock timeout expires before its instant body runs. That produces two timeout results and the `Assert.Same(completedResult, result)` fails.

I changed this test's per-check timeout from 100 ms to 2 seconds and the total timeout from 5 seconds to 10 seconds, then made the metadata assertion use `checkTimeout.TotalSeconds`. 2 seconds keeps the test reasonably short, but gives a 20x margin over the old 100 ms scheduling budget. I left production behavior alone: starting the per-check clock after `Task.Run` begins would be a broader behavior change and would let queued work consume only the total timeout rather than the per-check budget. `ThreadPool.SetMinThreads` would be process-wide and risky for concurrently running tests. Restructuring the second check does not remove the wall-clock race because production still schedules every check through `Task.Run`.

I checked the sibling `CheckAllAsync_TotalTimeoutReportsWarningAndStops` test too. Its 100 ms budget is the total timeout on the first blocked check, and delayed dispatch still produces the expected single total-timeout result with no successful second-check assertion, so I did not change it.

## Verification

```text
dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.EnvironmentCheckerTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"
Test run summary: Passed!
  total: 3
  failed: 0
  succeeded: 3
  skipped: 0
```

20-iteration loop over the full class:

```text
post-fix class loop summary: 20 passed, 0 failed
```

Mutation / pressure proof from a scratch harness that uses the real `EnvironmentChecker` path and saturates ThreadPool workers when the first check's timeout fires:

```text
old configuration (100ms check timeout):
timeoutMs=100; totalTimeoutSeconds=10; pressureHoldMs=750; blockerCount=64; maxWorkerThreads=8; pressureStarted=1; blockersStarted=64; results=2; timeoutResults=2; completedResultSeen=False
- harness-environment: Warning: Environment check 'harness-environment' timed out after 0.1 seconds.
- harness-environment: Warning: Environment check 'harness-environment' timed out after 0.1 seconds.
old exit code: 1

new configuration (2000ms check timeout):
timeoutMs=2000; totalTimeoutSeconds=10; pressureHoldMs=750; blockerCount=64; maxWorkerThreads=8; pressureStarted=1; blockersStarted=64; results=2; timeoutResults=1; completedResultSeen=True
- harness-environment: Warning: Environment check 'harness-environment' timed out after 2 seconds.
- completed: Pass: Completed
new exit code: 0
```

What I could not prove: I could not naturally reproduce the flake on my macOS machine without artificial scheduling pressure (`20/20` pre-fix single-test runs passed). The pressure harness is the evidence that the old 100 ms budget fails under the scheduling condition shown by the CI failure, while the new 2 second budget passes under the same injected pressure.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
