### PR TITLE
Pin Azure Functions Core Tools in test workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -257,8 +257,25 @@ jobs:
 
       - name: Install Azure Functions Core Tools
         if: runner.os == 'Linux' && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
+        shell: bash
         run: |
-          npm i -g azure-functions-core-tools@4 --unsafe-perm true
+          set -euo pipefail
+
+          # The npm package downloads a moving CDN artifact during installation. Use the same
+          # pinned GitHub release as the extension E2E tests so the tool remains reproducible.
+          core_tools_version='4.12.1'
+          core_tools_directory="$RUNNER_TEMP/azure-functions-core-tools"
+          core_tools_archive="$RUNNER_TEMP/Azure.Functions.Cli.linux-x64.${core_tools_version}.zip"
+          curl --fail --location --retry 3 --retry-all-errors \
+            --output "$core_tools_archive" \
+            "https://github.com/Azure/azure-functions-core-tools/releases/download/${core_tools_version}/Azure.Functions.Cli.linux-x64.${core_tools_version}.zip"
+          echo 'faf8fb8d50b5293df338bec70594b12f45730e9fe251805298859b2238cf627e  '"$core_tools_archive" | sha256sum --check -
+          mkdir -p "$core_tools_directory"
+          unzip -q "$core_tools_archive" -d "$core_tools_directory"
+          chmod +x "$core_tools_directory/func"
+          echo "$core_tools_directory" >> "$GITHUB_PATH"
+          export PATH="$core_tools_directory:$PATH"
+          func --version
 
       - name: Compute test project path
         id: compute_project_path

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -257,25 +257,8 @@ jobs:
 
       - name: Install Azure Functions Core Tools
         if: runner.os == 'Linux' && (inputs.testShortName == 'Playground' || inputs.testShortName == 'Azure')
-        shell: bash
         run: |
-          set -euo pipefail
-
-          # The npm package downloads a moving CDN artifact during installation. Use the same
-          # pinned GitHub release as the extension E2E tests so the tool remains reproducible.
-          core_tools_version='4.12.1'
-          core_tools_directory="$RUNNER_TEMP/azure-functions-core-tools"
-          core_tools_archive="$RUNNER_TEMP/Azure.Functions.Cli.linux-x64.${core_tools_version}.zip"
-          curl --fail --location --retry 3 --retry-all-errors \
-            --output "$core_tools_archive" \
-            "https://github.com/Azure/azure-functions-core-tools/releases/download/${core_tools_version}/Azure.Functions.Cli.linux-x64.${core_tools_version}.zip"
-          echo 'faf8fb8d50b5293df338bec70594b12f45730e9fe251805298859b2238cf627e  '"$core_tools_archive" | sha256sum --check -
-          mkdir -p "$core_tools_directory"
-          unzip -q "$core_tools_archive" -d "$core_tools_directory"
-          chmod +x "$core_tools_directory/func"
-          echo "$core_tools_directory" >> "$GITHUB_PATH"
-          export PATH="$core_tools_directory:$PATH"
-          func --version
+          npm i -g azure-functions-core-tools@4.12.1 --unsafe-perm true
 
       - name: Compute test project path
         id: compute_project_path


### PR DESCRIPTION
## Description

The Playground CI leg failed while installing Azure Functions Core Tools in [job 93372495155](https://github.com/microsoft/aspire/actions/runs/31285923571/job/93372495155). The moving `azure-functions-core-tools@4` npm tag resolved to `4.13.2`, whose install script attempted to download `Azure.Functions.Cli.linux-x64.4.13.2.zip` from CDN build `4.0.296705`, which returns HTTP 404.

Pin the existing npm install to `4.12.1`, the latest non-preview GitHub release and the version already used by extension E2E CI. The package is not deprecated, its CDN artifact remains available, and installing it successfully reports Core Tools `4.12.1`.

Validation:

- Installed `azure-functions-core-tools@4.12.1` through npm in an isolated prefix and ran `func --version`.
- Parsed `.github/workflows/run-tests.yml` as YAML.
- Ran 79 `Infrastructure.Tests` workflow-routing tests.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No