### PR TITLE
Report actionable errors when DotnetProjectResource is published

### DIFF
--- a/src/Aspire.Hosting.Dotnet/DotnetProjectResource.cs
+++ b/src/Aspire.Hosting.Dotnet/DotnetProjectResource.cs
@@ -3,8 +3,12 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 #pragma warning disable ASPIREPROJECTS001 // ProjectLaunchDefaultsAnnotation is experimental.
+#pragma warning disable ASPIREPIPELINES001 // Pipeline APIs are experimental.
 
 namespace Aspire.Hosting.Dotnet;
 
@@ -17,11 +21,37 @@ namespace Aspire.Hosting.Dotnet;
 /// launched as an executable: <c>dotnet run --project &lt;path&gt;</c> for a project file, or
 /// <c>dotnet run --file &lt;path&gt;</c> for a file-based app (a <c>.cs</c> file).
 /// </para>
+/// <para>
+/// Automatic publishing is not supported. Use <c>AddProject&lt;TProject&gt;(...)</c> or
+/// <c>AddCSharpApp(...)</c> for standard .NET project publishing, explicitly configure container
+/// publishing with <c>PublishAsDockerFile(...)</c>, or exclude an intentionally run-only resource
+/// with <c>ExcludeFromManifest()</c>.
+/// </para>
 /// </remarks>
 [Experimental("ASPIREDOTNETPROJECT001", UrlFormat = "https://aka.ms/aspire/diagnostics/{0}")]
 [AspireExport(ExposeProperties = true)]
 public class DotnetProjectResource : ExecutableResource, IResourceWithServiceDiscovery
 {
+    private const string PublishManifestStepName = "publish-manifest";
+    private const string ValidateDotnetProjectPublishStepName = "validate-dotnet-project-publish";
+    private static readonly string[] s_publishAndDeployRootStepNames =
+    [
+        WellKnownPipelineSteps.Publish,
+        WellKnownPipelineSteps.PublishPrereq,
+        WellKnownPipelineSteps.Deploy,
+        WellKnownPipelineSteps.DeployPrereq,
+        PublishManifestStepName
+    ];
+    private static readonly string[] s_publishAndDeployWorkRootStepNames =
+    [
+        .. s_publishAndDeployRootStepNames,
+        WellKnownPipelineSteps.Build,
+        WellKnownPipelineSteps.BuildPrereq,
+        WellKnownPipelineSteps.Push,
+        WellKnownPipelineSteps.PushPrereq
+    ];
+    private readonly ManifestPublishingCallbackAnnotation _unsupportedPublishCallback;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DotnetProjectResource"/> class.
     /// </summary>
@@ -31,5 +61,153 @@ public class DotnetProjectResource : ExecutableResource, IResourceWithServiceDis
     {
         // Ensure uniform C# project defaults, including the Rebuild command and Kestrel endpoint wiring.
         Annotations.Add(new ProjectLaunchDefaultsAnnotation());
+
+        _unsupportedPublishCallback = new ManifestPublishingCallbackAnnotation(_ =>
+            Task.FromException(new DistributedApplicationException(GetUnsupportedPublishMessage(Name))));
+
+        // PublishAsDockerFile replaces the executable with a container that shares this annotation collection,
+        // while ExcludeFromManifest appends the ignore callback and WithManifestPublishingCallback replaces the
+        // default callback. Evaluate the effective publisher so explicit choices remain valid and only an
+        // untransformed DotnetProjectResource fails.
+        Annotations.Add(new PipelineStepAnnotation(context =>
+        {
+            var unsupportedResources = context.PipelineContext.Model.Resources
+                .OfType<DotnetProjectResource>()
+                .Where(static resource => resource.RequiresPublishValidation())
+                .ToArray();
+
+            if (unsupportedResources.Length == 0 || !ReferenceEquals(context.Resource, unsupportedResources[0]))
+            {
+                return [];
+            }
+
+            return
+            [
+                new PipelineStep
+                {
+                    Name = ValidateDotnetProjectPublishStepName,
+                    Description = "Validates publish support for .NET project resources.",
+                    Action = _ => throw new DistributedApplicationException(
+                        GetUnsupportedPublishMessage(unsupportedResources.Select(resource => resource.Name).ToArray())),
+                    Resource = unsupportedResources[0]
+                }
+            ];
+        }));
+
+        // Configuration callbacks run in model order, so later compute-environment callbacks may not have attached
+        // build and push work to publish or deploy yet. Use those steps' stable aggregation roots to add the
+        // validation dependency before any step action can be scheduled.
+        Annotations.Add(new PipelineConfigurationAnnotation(context =>
+        {
+            var validationStep = context.Steps.SingleOrDefault(step =>
+                step.Name == ValidateDotnetProjectPublishStepName &&
+                step.Resource is DotnetProjectResource resource &&
+                resource.RequiresPublishValidation());
+
+            if (validationStep is null)
+            {
+                return;
+            }
+
+            foreach (var step in GetPublishAndDeploySteps(context))
+            {
+                if (!ReferenceEquals(step, validationStep) &&
+                    !step.DependsOnSteps.Contains(ValidateDotnetProjectPublishStepName))
+                {
+                    step.DependsOn(validationStep);
+                }
+            }
+        }));
+
+        // Prevent legacy manifest publishing from falling back to executable.v0, which would serialize
+        // `dotnet run` arguments containing machine-local project paths.
+        Annotations.Add(_unsupportedPublishCallback);
+    }
+
+    private bool RequiresPublishValidation() =>
+        this.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var effectiveCallback) &&
+        ReferenceEquals(effectiveCallback, _unsupportedPublishCallback);
+
+    private static IEnumerable<PipelineStep> GetPublishAndDeploySteps(PipelineConfigurationContext context)
+    {
+        var selectedStepName = context.Services.GetRequiredService<IOptions<PipelineOptions>>().Value.Step;
+        if (!string.IsNullOrWhiteSpace(selectedStepName) &&
+            !GetStepsRequiredByRoots(context.Steps, [selectedStepName])
+                .Any(step => s_publishAndDeployRootStepNames.Contains(step.Name, StringComparer.Ordinal)))
+        {
+            return [];
+        }
+
+        // Before-start resolves the same pipeline graph before publish execution and can share preparation steps
+        // with deploy. Keep that branch usable, while gating build and push work only when the selected target
+        // actually reaches publish or deploy.
+        var beforeStartStepNames = GetStepsRequiredByRoots(
+            context.Steps,
+            [WellKnownPipelineSteps.BeforeStart])
+            .Select(step => step.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return GetStepsRequiredByRoots(context.Steps, s_publishAndDeployWorkRootStepNames, beforeStartStepNames);
+    }
+
+    private static IEnumerable<PipelineStep> GetStepsRequiredByRoots(
+        IReadOnlyList<PipelineStep> steps,
+        IReadOnlyList<string> rootStepNames,
+        IReadOnlySet<string>? excludedStepNames = null)
+    {
+        var stepsByName = steps.ToLookup(step => step.Name, StringComparer.Ordinal);
+        var requiredStepsByName = steps
+            .SelectMany(step => step.RequiredBySteps.Select(requiredByStepName => (requiredByStepName, step)))
+            .ToLookup(item => item.requiredByStepName, item => item.step, StringComparer.Ordinal);
+        var pendingSteps = new Queue<PipelineStep>();
+        var visitedStepNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var rootStepName in rootStepNames)
+        {
+            if (stepsByName[rootStepName].FirstOrDefault() is { } rootStep)
+            {
+                pendingSteps.Enqueue(rootStep);
+            }
+        }
+
+        while (pendingSteps.TryDequeue(out var step))
+        {
+            if (!visitedStepNames.Add(step.Name) || excludedStepNames?.Contains(step.Name) is true)
+            {
+                continue;
+            }
+
+            yield return step;
+
+            foreach (var dependencyStepName in step.DependsOnSteps)
+            {
+                if (stepsByName[dependencyStepName].FirstOrDefault() is { } dependencyStep)
+                {
+                    pendingSteps.Enqueue(dependencyStep);
+                }
+            }
+
+            foreach (var requiredStep in requiredStepsByName[step.Name])
+            {
+                pendingSteps.Enqueue(requiredStep);
+            }
+        }
+    }
+
+    private static string GetUnsupportedPublishMessage(string resourceName) => GetUnsupportedPublishMessage([resourceName]);
+
+    private static string GetUnsupportedPublishMessage(IReadOnlyList<string> resourceNames)
+    {
+        var subject = resourceNames.Count == 1
+            ? $"Resource '{resourceNames[0]}' is a {nameof(DotnetProjectResource)}."
+            : $"Resources {string.Join(", ", resourceNames.Select(name => $"'{name}'"))} are {nameof(DotnetProjectResource)} instances.";
+        var publishTarget = resourceNames.Count == 1 ? "this resource" : "these resources";
+        var runOnlySubject = resourceNames.Count == 1 ? "it" : "a resource";
+
+        return $"{subject} Automatic project publishing for this experimental resource type is not supported. " +
+            $"For a C# AppHost project reference, use {nameof(ProjectResourceBuilderExtensions.AddProject)}<TProject>(...). " +
+            $"For a path-based project or file-based app, use {nameof(ProjectResourceBuilderExtensions.AddCSharpApp)}(...) in C# or addCSharpApp(...) in TypeScript. " +
+            $"To publish {publishTarget} using explicit container configuration, call {nameof(ExecutableResourceBuilderExtensions.PublishAsDockerFile)}(...) in C# or publishAsDockerFile(...) in TypeScript. " +
+            $"If {runOnlySubject} is intentionally run-only, call {nameof(ResourceBuilderExtensions.ExcludeFromManifest)}() in C# or excludeFromManifest() in TypeScript.";
     }
 }

--- a/src/Aspire.Hosting.Dotnet/README.md
+++ b/src/Aspire.Hosting.Dotnet/README.md
@@ -58,6 +58,22 @@ The resource is launched with `dotnet run --project <path>` (or `dotnet run --fi
 file-based app). Endpoints, environment variables, and service discovery are configured from the
 project's `launchSettings.json` and Kestrel configuration, matching `AddProject<T>`.
 
+## Publishing
+
+Automatic project publishing for `DotnetProjectResource` is not currently supported. A plain
+`DotnetProjectResource` causes `aspire publish` and `aspire deploy` to fail with an actionable error
+instead of emitting an `executable.v0` manifest containing machine-local paths.
+
+Use one of these alternatives:
+
+- Use `AddProject<TProject>(...)` for a project referenced by a C# AppHost.
+- Use `AddCSharpApp(...)` or `addCSharpApp(...)` for a path-based project or file-based app that
+  should use standard .NET project publishing.
+- Call `PublishAsDockerFile(...)` or `publishAsDockerFile(...)` to configure container publishing
+  explicitly.
+- Call `ExcludeFromManifest()` or `excludeFromManifest()` when the resource is intentionally
+  available only during local orchestration.
+
 ## Additional documentation
 
 - https://aspire.dev/integrations/gallery/

--- a/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Dotnet.Tests/DotnetProjectResourceTests.cs
@@ -4,18 +4,36 @@
 #pragma warning disable ASPIREDOTNETPROJECT001
 #pragma warning disable ASPIREEXTENSION001
 #pragma warning disable ASPIREPERSISTENCE001
+#pragma warning disable ASPIREPIPELINES001
 
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Model;
+using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Resources;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Dotnet.Tests;
 
 public class DotnetProjectResourceTests(ITestOutputHelper outputHelper)
 {
+    private static readonly string[] s_unsupportedPublishMessageFragments =
+    [
+        "is not supported",
+        "C# AppHost",
+        "AddProject<TProject>(...)",
+        "AddCSharpApp(...)",
+        "addCSharpApp(...)",
+        "PublishAsDockerFile(...)",
+        "publishAsDockerFile(...)",
+        "ExcludeFromManifest()",
+        "excludeFromManifest()",
+        "TypeScript"
+    ];
+
     [Fact]
     public async Task AddDotnetProject_ProjectFile_ProducesDotnetRunProjectArgs()
     {
@@ -85,6 +103,321 @@ public class DotnetProjectResourceTests(ITestOutputHelper outputHelper)
 
         Assert.True(app.Resource.TryGetLastAnnotation<IProjectMetadata>(out var metadata));
         Assert.Equal(projectPath, metadata.ProjectPath);
+    }
+
+    [Theory]
+    [InlineData("project")]
+    [InlineData("directory")]
+    [InlineData("file")]
+    public async Task AddDotnetProject_InPublishMode_ManifestPublishingThrows(string appKind)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var appPath = appKind switch
+        {
+            "project" => CreateFile(workspace.Path, "MyService.csproj"),
+            "directory" => CreateProjectDirectory(workspace.Path),
+            "file" => CreateFile(workspace.Path, "service.cs"),
+            _ => throw new ArgumentOutOfRangeException(nameof(appKind), appKind, null)
+        };
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var app = builder.AddDotnetProject("svc", appPath, o => o.ExcludeLaunchProfile = true);
+
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => ManifestUtils.GetManifest(app.Resource, workspace.Path));
+
+        AssertUnsupportedPublishMessage(exception, "Resource 'svc' is a DotnetProjectResource.");
+    }
+
+    [Theory]
+    [InlineData(WellKnownPipelineSteps.Publish)]
+    [InlineData(WellKnownPipelineSteps.Deploy)]
+    public async Task AddDotnetProject_InPublishMode_PipelineThrows(string step)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectPath = CreateFile(workspace.Path, "MyService.csproj");
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: step);
+        builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true);
+
+        using var app = builder.Build();
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => ExecutePipelineAsync(app));
+
+        AssertUnsupportedPublishMessage(exception, "Resource 'svc' is a DotnetProjectResource.");
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_InPublishMode_ManifestPipelineFailsBeforeCreatingOutput()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            workspace.Path,
+            step: "publish-manifest");
+        builder.AddDotnetProject("svc", CreateFile(workspace.Path, "MyService.csproj"), o => o.ExcludeLaunchProfile = true);
+
+        using var app = builder.Build();
+        await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => ExecutePipelineAsync(app));
+
+        Assert.False(File.Exists(Path.Combine(workspace.Path, "aspire-manifest.json")));
+    }
+
+    [Theory]
+    [InlineData(WellKnownPipelineSteps.Publish)]
+    [InlineData(WellKnownPipelineSteps.Deploy)]
+    public async Task AddDotnetProject_InPublishMode_BlocksSiblingPublishAndDeployWork(string step)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, step: step);
+        builder.AddDotnetProject("svc", CreateFile(workspace.Path, "MyService.csproj"), o => o.ExcludeLaunchProfile = true);
+
+        // This matches publish steps such as Docker Compose's:
+        //   test-{step}-work --RequiredBy--> publish/deploy
+        // The sibling intentionally has no dependency on publish-prereq/deploy-prereq.
+        var workExecuted = false;
+        builder.Pipeline.AddStep(new PipelineStep
+        {
+            Name = $"test-{step}-work",
+            Action = _ =>
+            {
+                workExecuted = true;
+                return Task.CompletedTask;
+            },
+            RequiredBySteps = [step]
+        });
+
+        using var app = builder.Build();
+        await Assert.ThrowsAsync<DistributedApplicationException>(() => ExecutePipelineAsync(app));
+
+        Assert.False(workExecuted);
+    }
+
+    [Theory]
+    [InlineData(WellKnownPipelineSteps.Build)]
+    [InlineData(WellKnownPipelineSteps.Push)]
+    public async Task AddDotnetProject_InDeployMode_BlocksWorkWiredByLaterConfigurationCallback(string workRootStep)
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            step: WellKnownPipelineSteps.Deploy);
+        builder.AddDotnetProject("svc", CreateFile(workspace.Path, "MyService.csproj"), o => o.ExcludeLaunchProfile = true);
+
+        var workStepName = $"test-{workRootStep}-work";
+        var deployStepName = $"test-{workRootStep}-deploy";
+        var workExecuted = 0;
+        builder.Pipeline.AddStep(new PipelineStep
+        {
+            Name = workStepName,
+            Action = _ =>
+            {
+                Interlocked.Exchange(ref workExecuted, 1);
+                return Task.CompletedTask;
+            },
+            RequiredBySteps = [workRootStep]
+        });
+        builder.Pipeline.AddStep(new PipelineStep
+        {
+            Name = deployStepName,
+            Action = _ => Task.CompletedTask,
+            RequiredBySteps = [WellKnownPipelineSteps.Deploy]
+        });
+
+        // The resource is deliberately added after the .NET project so this callback runs after the validation
+        // callback, matching compute environments that attach build and push work to deploy late.
+        builder.AddContainer("late-wiring", "image")
+            .WithPipelineConfiguration(context =>
+                context.Steps.Single(step => step.Name == deployStepName).DependsOn(workStepName));
+
+        using var app = builder.Build();
+        await Assert.ThrowsAsync<DistributedApplicationException>(() => ExecutePipelineAsync(app));
+
+        Assert.Equal(0, Volatile.Read(ref workExecuted));
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_InBuildMode_DoesNotRunPublishValidation()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            step: WellKnownPipelineSteps.Build);
+        builder.AddDotnetProject("svc", CreateFile(workspace.Path, "MyService.csproj"), o => o.ExcludeLaunchProfile = true);
+
+        // This matches build work registered by buildable project and container resources:
+        //   build -> test-build-work -> build-prereq -> process-parameters
+        var workExecuted = false;
+        builder.Pipeline.AddStep(new PipelineStep
+        {
+            Name = "test-build-work",
+            Action = _ =>
+            {
+                workExecuted = true;
+                return Task.CompletedTask;
+            },
+            DependsOnSteps = [WellKnownPipelineSteps.BuildPrereq],
+            RequiredBySteps = [WellKnownPipelineSteps.Build]
+        });
+
+        using var app = builder.Build();
+        await ExecutePipelineAsync(app);
+
+        Assert.True(workExecuted);
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_InPushMode_DoesNotRunPublishValidation()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish,
+            step: WellKnownPipelineSteps.Push);
+        builder.AddDotnetProject("svc", CreateFile(workspace.Path, "MyService.csproj"), o => o.ExcludeLaunchProfile = true);
+
+        var workExecuted = false;
+        builder.Pipeline.AddStep(new PipelineStep
+        {
+            Name = "test-push-work",
+            Action = _ =>
+            {
+                workExecuted = true;
+                return Task.CompletedTask;
+            },
+            DependsOnSteps = [WellKnownPipelineSteps.PushPrereq],
+            RequiredBySteps = [WellKnownPipelineSteps.Push]
+        });
+
+        using var app = builder.Build();
+        await ExecutePipelineAsync(app);
+
+        Assert.True(workExecuted);
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_InRunMode_DoesNotGateSharedBeforeStartWork()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+        builder.Services.Configure<PipelineOptions>(options => options.Step = WellKnownPipelineSteps.BeforeStart);
+        builder.AddDotnetProject("svc", CreateFile(workspace.Path, "MyService.csproj"), o => o.ExcludeLaunchProfile = true);
+
+        // This matches the Docker Compose dependency shape:
+        //   deploy -> test-deploy -> test-prepare -> validate-compute-environments <- before-start
+        // The shared validation step must remain usable by Run mode without invoking publish validation.
+        builder.Pipeline.AddStep(new PipelineStep
+        {
+            Name = "test-prepare",
+            Action = _ => Task.CompletedTask,
+            DependsOnSteps = [WellKnownPipelineSteps.ValidateComputeEnvironments]
+        });
+        builder.Pipeline.AddStep(new PipelineStep
+        {
+            Name = "test-deploy",
+            Action = _ => Task.CompletedTask,
+            DependsOnSteps = ["test-prepare"],
+            RequiredBySteps = [WellKnownPipelineSteps.Deploy]
+        });
+
+        using var app = builder.Build();
+        await ExecutePipelineAsync(app);
+    }
+
+    [Fact]
+    public async Task DirectlyConstructedDotnetProjectResource_InPublishMode_PipelineThrows()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddResource(new DotnetProjectResource("svc", workspace.Path));
+
+        using var app = builder.Build();
+        await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => ExecutePipelineAsync(app));
+    }
+
+    [Fact]
+    public async Task MultipleDotnetProjectResources_WithExplicitOptIns_InPublishMode_PipelineThrows()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        builder.AddDotnetProject("api", CreateFile(workspace.Path, "Api.csproj"), o => o.ExcludeLaunchProfile = true);
+        builder.AddDotnetProject("worker", CreateFile(workspace.Path, "Worker.csproj"), o => o.ExcludeLaunchProfile = true);
+        builder.AddDotnetProject("excluded", CreateFile(workspace.Path, "Excluded.csproj"), o => o.ExcludeLaunchProfile = true)
+            .ExcludeFromManifest();
+        builder.AddDotnetProject("containerized", CreateFile(workspace.Path, "Containerized.csproj"), o => o.ExcludeLaunchProfile = true)
+            .PublishAsDockerFile();
+
+        using var app = builder.Build();
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(
+            () => ExecutePipelineAsync(app));
+
+        AssertUnsupportedPublishMessage(
+            exception,
+            "Resources 'api', 'worker' are DotnetProjectResource instances.");
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_ExcludedFromManifest_DoesNotFailPublishing()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectPath = CreateFile(workspace.Path, "MyService.csproj");
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var resource = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true)
+            .ExcludeFromManifest();
+
+        using var app = builder.Build();
+        await ExecutePipelineAsync(app);
+
+        var manifest = await ManifestUtils.GetManifestOrNull(resource.Resource, workspace.Path);
+        Assert.Null(manifest);
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_WithManifestPublishingCallback_ProducesCustomManifest()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectPath = CreateFile(workspace.Path, "MyService.csproj");
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var resource = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true)
+            .WithManifestPublishingCallback(context => context.Writer.WriteString("type", "custom.v0"));
+
+        using var app = builder.Build();
+        await ExecutePipelineAsync(app);
+
+        var manifest = await ManifestUtils.GetManifest(resource.Resource, workspace.Path);
+        Assert.Equal("""{"type":"custom.v0"}""", manifest.ToJsonString());
+    }
+
+    [Fact]
+    public async Task AddDotnetProject_PublishAsDockerFile_ProducesContainerManifest()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectPath = CreateFile(workspace.Path, "MyService.csproj");
+        await File.WriteAllTextAsync(Path.Combine(workspace.Path, "Dockerfile"), "FROM scratch");
+
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var resource = builder.AddDotnetProject("svc", projectPath, o => o.ExcludeLaunchProfile = true)
+            .PublishAsDockerFile();
+
+        using var app = builder.Build();
+        await ExecutePipelineAsync(app);
+
+        var manifest = await ManifestUtils.GetManifest(resource.Resource, workspace.Path);
+        var expected =
+            """
+            {
+              "type": "container.v1",
+              "build": {
+                "context": ".",
+                "dockerfile": "Dockerfile"
+              },
+              "env": {
+                "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
+              }
+            }
+            """;
+
+        Assert.Equal(expected, manifest.ToString(), ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
     }
 
     [Fact]
@@ -567,5 +900,42 @@ public class DotnetProjectResourceTests(ITestOutputHelper outputHelper)
         context.Args.Add("package");
         context.Args.Add("--yes");
         context.Args.Add("--");
+    }
+
+    private static void AssertUnsupportedPublishMessage(
+        DistributedApplicationException exception,
+        string expectedSubject)
+    {
+        Assert.StartsWith($"{expectedSubject} Automatic project publishing", exception.Message);
+        Assert.All(
+            s_unsupportedPublishMessageFragments,
+            fragment => Assert.Contains(fragment, exception.Message));
+    }
+
+    private static Task ExecutePipelineAsync(DistributedApplication app)
+    {
+        var pipeline = app.Services.GetRequiredService<IDistributedApplicationPipeline>();
+        var context = new PipelineContext(
+            app.Services.GetRequiredService<DistributedApplicationModel>(),
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services,
+            app.Services.GetRequiredService<ILogger<DotnetProjectResourceTests>>(),
+            CancellationToken.None);
+
+        return pipeline.ExecuteAsync(context);
+    }
+
+    private static string CreateProjectDirectory(string workspacePath)
+    {
+        var projectDirectory = Directory.CreateDirectory(Path.Combine(workspacePath, "MyService"));
+        CreateFile(projectDirectory.FullName, "MyService.csproj");
+        return projectDirectory.FullName;
+    }
+
+    private static string CreateFile(string directory, string fileName)
+    {
+        var path = Path.Combine(directory, fileName);
+        File.WriteAllText(path, string.Empty);
+        return path;
     }
 }


### PR DESCRIPTION
## Description

The new `DotnetProjectResource` does not support publishing yet, but the current implementation just silently fails when someone tries publishing. This PR replaces that with an actionable error. 

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
