### PR TITLE
Add third-party signing entries for Hex1b and QRCoder

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -22,12 +22,14 @@
 
   <ItemGroup>
     <FileSignInfo Include="Fractions.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Hex1b.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="IdentityModel.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="IdentityModel.OidcClient.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="KubernetesClient.Basic.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="KubernetesClient.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="KubernetesClient.Models.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Prometheus.NetStandard.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="QRCoder.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="YamlDotNet.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Grpc.AspNetCore.Server.ClientFactory.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Grpc.AspNetCore.Server.dll" CertificateName="3PartySHA2" />


### PR DESCRIPTION
## Description

`WithTerminal()` support now ships Hex1b and its transitive QRCoder dependency as part of the Aspire CLI bundle and dashboard payload. Official builds therefore need to classify both assemblies for third-party signing instead of attempting to sign them with a Microsoft certificate.

This was discovered in the `release/13.5` internal build, where signing is enabled and Arcade reported `SIGN004` errors for `Hex1b.dll` and `QRCoder.dll`. This change adds both assemblies to `eng/Signing.props` with the existing `3PartySHA2` policy used for other third-party dependencies.

FYI @mitchdenny.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
