### PR TITLE
Update Aspire Team App ship milestone to 13.5

### DIFF
--- a/.github/extensions/aspire-team-app/constants.mjs
+++ b/.github/extensions/aspire-team-app/constants.mjs
@@ -1,6 +1,6 @@
 // Shared constants ported from davidfowl/pr-dashboard frontend/src/constants.ts.
 
-export const currentRelease = "13.4";
+export const currentRelease = "13.5";
 export const hourMs = 1000 * 60 * 60;
 export const dayMs = hourMs * 24;
 

--- a/.github/extensions/aspire-team-app/render.mjs
+++ b/.github/extensions/aspire-team-app/render.mjs
@@ -2990,7 +2990,7 @@ function settingsView() {
     "</div>" +
     '<div class="section"><h3>Ship milestone</h3>' +
       '<p class="hint">Used by Ship mode to group work for the active release.</p>' +
-      '<div class="field"><input type="text" id="release-input" value="' + esc(prefs.release || "") + '" placeholder="13.4" /></div></div>' +
+      '<div class="field"><input type="text" id="release-input" value="' + esc(prefs.release || "") + '" placeholder="13.5" /></div></div>' +
     pipelineEditorHtml() +
     '<div class="section" id="notif-settings"><h3>Notifications</h3>' +
       '<p class="hint">Live in-session alerts surface in the bell. Choose what counts.</p>' +


### PR DESCRIPTION
## Description

The Aspire Team App Ship tab still defaulted to the completed 13.4 milestone, so it did not show the current 13.5 release work without a manual settings change.

Update the default Ship milestone and its settings placeholder to 13.5. Ship mode remains milestone-only; its filtering behavior is otherwise unchanged.

Validation:
- `node --test .github/extensions/aspire-team-app/*.test.mjs`
- Reloaded the extension and confirmed Ship mode loads milestone 13.5.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No