### PR TITLE
Fix persistent resources using port 0 (auto-allocated)

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -211,6 +211,9 @@ public sealed class EndpointAnnotation : IResourceAnnotation
 
     internal int? SpecifiedPort => _port;
 
+    // For most cases "port==0" is equivalent to "port is unspecified". Both should be treated as "port should be allocated dynamically".
+    internal static int? NormalizePort(int? port) => port is 0 ? null : port;
+
     /// <summary>
     /// This is the port the resource is listening on. If the endpoint is used for the container, it is the container port.
     /// </summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -800,8 +800,11 @@ public static class ResourceExtensions
 
         foreach (var endpoint in endpoints)
         {
+            var publicPort = EndpointAnnotation.NormalizePort(endpoint.Port);
+            var configuredTargetPort = EndpointAnnotation.NormalizePort(endpoint.TargetPort);
+
             // Compute target port based on resource type and endpoint configuration
-            ResolvedPort targetPort = (resource, endpoint.UriScheme, endpoint.TargetPort, endpoint.Port) switch
+            ResolvedPort targetPort = (resource, endpoint.UriScheme, configuredTargetPort, publicPort) switch
             {
                 // The port was explicitly specified so use it
                 (_, _, int target, _) => ResolvedPort.Explicit(target),
@@ -824,7 +827,7 @@ public static class ResourceExtensions
             }
 
             // Compute exposed port (host port)
-            ResolvedPort exposedPort = (endpoint.UriScheme, endpoint.Port, targetPort.Value) switch
+            ResolvedPort exposedPort = (endpoint.UriScheme, publicPort, targetPort.Value) switch
             {
                 // Port set explicitly, use it
                 (_, int port, _) => ResolvedPort.Explicit(port),

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -772,6 +772,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
     /// Use this when deciding whether DCP should bind a service to a known public port. Proxied endpoints
     /// with randomized ports deliberately do not report a fixed port so DCP can allocate the public port
     /// instead of reserving the configured value.
+    /// Port 0 requests dynamic allocation and therefore does not count as a fixed public port.
     /// Container endpoint definitions keep the public host port separate from the target container port, so
     /// only an explicitly specified public port counts as fixed. Executable endpoint definitions use the same
     /// port value for the process and the public endpoint, so the effective public port can come from either
@@ -789,7 +790,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             return false;
         }
 
-        if (effectivePublicPort is int fixedPublicPort)
+        if (effectivePublicPort is int fixedPublicPort and not 0)
         {
             publicPort = fixedPublicPort;
             return true;

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -662,7 +662,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             foreach (var endpoint in sp.Endpoints)
             {
                 endpoint.SetResolvedIsProxied(GetEffectiveIsProxied(sp.ModelResource, endpoint, _options.Value.RandomizePorts));
-                ValidateEndpointBeforeDynamicPublicPortAllocation(sp.ModelResource, endpoint);
+                DcpModelUtilities.ValidateEndpointPorts(sp.ModelResource, endpoint);
 
                 if (TryGetEffectiveFixedPublicPort(sp.ModelResource, endpoint, _options.Value.RandomizePorts, out var fixedPublicPort))
                 {
@@ -780,7 +780,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
     /// </remarks>
     private static bool TryGetEffectiveFixedPublicPort(IResource resource, EndpointAnnotation endpoint, bool randomizePorts, out int publicPort)
     {
-        var effectivePublicPort = resource.IsContainer() ? endpoint.SpecifiedPort : endpoint.Port;
+        var effectivePublicPort = EndpointAnnotation.NormalizePort(resource.IsContainer() ? endpoint.SpecifiedPort : endpoint.Port);
 
         // When port randomization is enabled, proxied endpoints intentionally ignore the defined public
         // port so DCP can allocate one dynamically instead.
@@ -790,7 +790,7 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
             return false;
         }
 
-        if (effectivePublicPort is int fixedPublicPort and not 0)
+        if (effectivePublicPort is int fixedPublicPort)
         {
             publicPort = fixedPublicPort;
             return true;
@@ -868,14 +868,6 @@ internal sealed partial class DcpExecutor : IDcpExecutor, IDcpObjectFactory, IAs
         // Schema suggested by https://github.com/microsoft/aspire/issues/13597:
         // Resources:<resource-name>:<endpoint-name>:port
         return $"Resources:{resource.Name}:{endpoint.Name}:port";
-    }
-
-    private static void ValidateEndpointBeforeDynamicPublicPortAllocation(IResource resource, EndpointAnnotation endpoint)
-    {
-        if (resource.IsContainer() && endpoint.TargetPort is null)
-        {
-            throw new InvalidOperationException($"The endpoint '{endpoint.Name}' for container resource '{resource.Name}' must specify the {nameof(EndpointAnnotation.TargetPort)} value");
-        }
     }
 
     internal static void SetInitialResourceState(IResource resource, IAnnotationHolder annotationHolder)

--- a/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
+++ b/src/Aspire.Hosting/Dcp/DcpModelUtilities.cs
@@ -28,6 +28,23 @@ internal static class DcpModelUtilities
             modelResource.GetLifetimeType() != Lifetime.Persistent;
     }
 
+    internal static void ValidateEndpointPorts(IResource modelResource, EndpointAnnotation endpoint)
+    {
+        var modelResourceName = modelResource.Name ?? "(unknown)";
+
+        if (modelResource.IsContainer())
+        {
+            if (EndpointAnnotation.NormalizePort(endpoint.TargetPort) is null)
+            {
+                throw new InvalidOperationException($"The endpoint '{endpoint.Name}' for container resource '{modelResourceName}' must specify the {nameof(EndpointAnnotation.TargetPort)} value");
+            }
+        }
+        else if (!endpoint.IsProxied && endpoint.Port is int && endpoint.Port != endpoint.TargetPort)
+        {
+            throw new InvalidOperationException($"The endpoint '{endpoint.Name}' for resource '{modelResourceName}' is not using a proxy, and it has a value of {nameof(EndpointAnnotation.Port)} property that is different from the value of {nameof(EndpointAnnotation.TargetPort)} property. For proxy-less endpoints they must match.");
+        }
+    }
+
     /// <summary>
     /// Examines the Aspire resource annotations and adds equivalent ServiceProducerAnnotations to the corresponding DCP resource.
     /// </summary>
@@ -43,40 +60,32 @@ internal static class DcpModelUtilities
         foreach (var sp in servicesProduced)
         {
             var ea = sp.EndpointAnnotation;
+            ValidateEndpointPorts(modelResource, ea);
 
-            if (modelResource.IsContainer())
+            if (!modelResource.IsContainer())
             {
-                if (ea.TargetPort is null)
+                if (!ea.IsProxied)
                 {
-                    throw new InvalidOperationException($"The endpoint '{ea.Name}' for container resource '{modelResourceName}' must specify the {nameof(EndpointAnnotation.TargetPort)} value");
+                    if (HasMultipleReplicas(appResource.DcpResource))
+                    {
+                        throw new InvalidOperationException($"Resource '{modelResourceName}' uses multiple replicas and a proxy-less endpoint '{ea.Name}'. These features do not work together.");
+                    }
                 }
-            }
-            else if (!ea.IsProxied)
-            {
-                if (HasMultipleReplicas(appResource.DcpResource))
+                else
                 {
-                    throw new InvalidOperationException($"Resource '{modelResourceName}' uses multiple replicas and a proxy-less endpoint '{ea.Name}'. These features do not work together.");
-                }
+                    Debug.Assert(ea.IsProxied);
 
-                if (ea.Port is int && ea.Port != ea.TargetPort)
-                {
-                    throw new InvalidOperationException($"The endpoint '{ea.Name}' for resource '{modelResourceName}' is not using a proxy, and it has a value of {nameof(EndpointAnnotation.Port)} property that is different from the value of {nameof(EndpointAnnotation.TargetPort)} property. For proxy-less endpoints they must match.");
-                }
-            }
-            else
-            {
-                Debug.Assert(ea.IsProxied);
+                    if (ea.TargetPort is int && ea.Port is int && ea.TargetPort == ea.Port)
+                    {
+                        throw new InvalidOperationException(
+                            $"The endpoint '{ea.Name}' for resource '{modelResourceName}' requested a proxy ({nameof(ea.IsProxied)} is true). Non-container resources cannot be proxied when both {nameof(ea.TargetPort)} and {nameof(ea.Port)} are specified with the same value.");
+                    }
 
-                if (ea.TargetPort is int && ea.Port is int && ea.TargetPort == ea.Port)
-                {
-                    throw new InvalidOperationException(
-                        $"The endpoint '{ea.Name}' for resource '{modelResourceName}' requested a proxy ({nameof(ea.IsProxied)} is true). Non-container resources cannot be proxied when both {nameof(ea.TargetPort)} and {nameof(ea.Port)} are specified with the same value.");
-                }
-
-                if (HasMultipleReplicas(appResource.DcpResource) && ea.TargetPort is int)
-                {
-                    throw new InvalidOperationException(
-                        $"Resource '{modelResourceName}' can have multiple replicas, and it uses endpoint '{ea.Name}' that has {nameof(ea.TargetPort)} property set. Each replica must have a unique port; setting {nameof(ea.TargetPort)} is not allowed.");
+                    if (HasMultipleReplicas(appResource.DcpResource) && ea.TargetPort is int)
+                    {
+                        throw new InvalidOperationException(
+                            $"Resource '{modelResourceName}' can have multiple replicas, and it uses endpoint '{ea.Name}' that has {nameof(ea.TargetPort)} property set. Each replica must have a unique port; setting {nameof(ea.TargetPort)} is not allowed.");
+                    }
                 }
             }
 

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesPublisherTests.cs
@@ -697,6 +697,22 @@ public class KubernetesPublisherTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task KubernetesTreatsZeroPublicPortAsUnspecified()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+        builder.AddKubernetesEnvironment("env");
+        builder.AddContainer("database", "image")
+            .WithEndpoint(name: "tcp", port: 0, targetPort: 1433);
+
+        var app = builder.Build();
+        app.Run();
+
+        var servicePath = Path.Combine(workspace.Path, "templates/database/service.yaml");
+        await Verify(File.ReadAllText(servicePath), "yaml");
+    }
+
+    [Fact]
     public async Task KubernetesEndpointReferenceUsesServicePortNotTargetPort()
     {
         // Regression test for https://github.com/microsoft/aspire/issues/18321

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesTreatsZeroPublicPortAsUnspecified.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesTreatsZeroPublicPortAsUnspecified.verified.yaml
@@ -1,0 +1,20 @@
+﻿---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "database-service"
+  labels:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "database"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+spec:
+  type: "ClusterIP"
+  selector:
+    app.kubernetes.io/name: "{{ .Chart.Name }}"
+    app.kubernetes.io/component: "database"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+  ports:
+    - name: "tcp"
+      protocol: "TCP"
+      port: 1433
+      targetPort: 1433

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -1248,6 +1248,12 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             (
                 er => er.WithEndpoint(name: "PortAndTargetPortSetDifferently", port: desiredPortOne, targetPort: desiredPortTwo, env: "PORT_AND_TARGET_PORT_SET_DIFFERENTLY", isProxied: false),
                 "has a value of Port property that is different from the value of TargetPort property"
+            ),
+
+            // Invalid configuration: Port requests dynamic allocation while TargetPort is fixed.
+            (
+                er => er.WithEndpoint(name: "ZeroPortAndTargetPortSetDifferently", port: 0, targetPort: desiredPortOne, env: "ZERO_PORT_AND_TARGET_PORT_SET_DIFFERENTLY", isProxied: false),
+                "has a value of Port property that is different from the value of TargetPort property"
             )
         ];
 
@@ -3309,6 +3315,12 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             // Invalid configuration: TargetPort is empty (and Port too) (proxy-less).
             (
                 cr => cr.WithEndpoint(name: "NoPortNoTargetPortProxyless", env: "NO_PORT_NO_TARGET_PORT_PROXYLESS", isProxied: false),
+                "must specify the TargetPort"
+            ),
+
+            // Invalid configuration: Port requests dynamic allocation, but no container target port is available.
+            (
+                cr => cr.WithEndpoint(name: "ZeroPortNoTargetPortProxyless", port: 0, env: "ZERO_PORT_NO_TARGET_PORT_PROXYLESS", isProxied: false),
                 "must specify the TargetPort"
             ),
         ];

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -994,15 +994,17 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         Assert.Equal(allocatedPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
     }
 
-    [Fact]
-    public async Task PersistentProxylessExecutableWithoutPortPersistsAllocatedPort()
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public async Task PersistentProxylessExecutableWithUnspecifiedPortPersistsAllocatedPort(int? port)
     {
         var (allocatedPort, _) = GetAvailableConsecutivePortPair();
         var builder = DistributedApplication.CreateBuilder();
 
         builder.AddExecutable("CoolProgram", "cool", Environment.CurrentDirectory, "--alpha", "--bravo")
             .WithPersistentLifetime()
-            .WithEndpoint(name: "http", env: "HTTP_PORT", isProxied: false);
+            .WithEndpoint(name: "http", port: port, env: "HTTP_PORT");
 
         var configDict = new Dictionary<string, string?>
         {
@@ -1024,12 +1026,15 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         await appExecutor.RunApplicationAsync();
 
         var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "CoolProgram");
+        Assert.Equal(AddressAllocationModes.Proxyless, svc.Spec.AddressAllocationMode);
         Assert.Equal(allocatedPort, svc.Status?.EffectivePort);
         Assert.Equal(allocatedPort.ToString(CultureInfo.InvariantCulture), userSecretsManager.Secrets["Resources:CoolProgram:http:port"]);
     }
 
-    [Fact]
-    public async Task PersistentProxylessContainerWithoutPortPersistsAllocatedPort()
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public async Task PersistentProxylessContainerWithUnspecifiedPortPersistsAllocatedPort(int? port)
     {
         var (allocatedPort, _) = GetAvailableConsecutivePortPair();
         var builder = DistributedApplication.CreateBuilder();
@@ -1037,7 +1042,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         const int targetPort = TestKubernetesService.StartOfAutoPortRange - 999;
         builder.AddContainer("database", "image")
             .WithPersistentLifetime()
-            .WithEndpoint(name: "http", targetPort: targetPort, isProxied: false);
+            .WithEndpoint(name: "http", port: port, targetPort: targetPort);
 
         var configDict = new Dictionary<string, string?>
         {
@@ -1058,9 +1063,12 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration, dcpOptions: dcpOptions, userSecretsManager: userSecretsManager);
         await appExecutor.RunApplicationAsync();
 
+        var dcpCtr = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());
         var svc = kubernetesService.CreatedResources.OfType<Service>().Single(s => s.Name() == "database");
+        Assert.Equal(AddressAllocationModes.Proxyless, svc.Spec.AddressAllocationMode);
         Assert.Equal(allocatedPort, svc.Status?.EffectivePort);
         Assert.Equal(allocatedPort, svc.Spec.Port);
+        Assert.Contains(dcpCtr.Spec.Ports!, p => p.HostPort == allocatedPort && p.ContainerPort == targetPort);
         Assert.Equal(allocatedPort.ToString(CultureInfo.InvariantCulture), userSecretsManager.Secrets["Resources:database:http:port"]);
     }
 

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -669,4 +669,23 @@ public class ResourceExtensionsTests
 
         Assert.Equal(["test-abc123", "test-def456"], result);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public void ResolveEndpointsTreatsZeroPublicPortAsUnspecified(int? port)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        var resource = builder.AddContainer("container", "image")
+            .WithEndpoint(name: "tcp", port: port, targetPort: 1234);
+
+        var endpoint = Assert.Single(resource.Resource.ResolveEndpoints());
+
+        Assert.Equal(1234, endpoint.TargetPort.Value);
+        Assert.False(endpoint.TargetPort.IsAllocated);
+        Assert.False(endpoint.TargetPort.IsImplicit);
+        Assert.Equal(1234, endpoint.ExposedPort.Value);
+        Assert.False(endpoint.ExposedPort.IsAllocated);
+        Assert.True(endpoint.ExposedPort.IsImplicit);
+    }
 }


### PR DESCRIPTION
## Description

Root of the issue is that port 0 means "port is automatically allocated" but some code is treating it as "specific port to be used, prescribed by app host code".

Fixes https://github.com/microsoft/aspire/issues/19194

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
