### PR TITLE
Suppress CLI progress when console logging is enabled

### DIFF
--- a/src/Aspire.Cli/CliExecutionContext.cs
+++ b/src/Aspire.Cli/CliExecutionContext.cs
@@ -4,10 +4,11 @@
 using System.CommandLine;
 using Aspire.Cli.Resources;
 using Aspire.Shared;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli;
 
-internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, string identityChannel, bool debugMode = false, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null, DirectoryInfo? aspireHomeDirectory = null, string? identityVersion = null, string? identityCommit = null, string? nugetServiceIndexOverride = null, bool identityOverridden = false, DirectoryInfo? identityPackagesDirectory = null)
+internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, DirectoryInfo hivesDirectory, DirectoryInfo cacheDirectory, DirectoryInfo sdksDirectory, DirectoryInfo logsDirectory, string logFilePath, string identityChannel, bool debugMode = false, LogLevel? consoleLogLevel = null, DirectoryInfo? homeDirectory = null, DirectoryInfo? packagesDirectory = null, DirectoryInfo? aspireHomeDirectory = null, string? identityVersion = null, string? identityCommit = null, string? nugetServiceIndexOverride = null, bool identityOverridden = false, DirectoryInfo? identityPackagesDirectory = null)
 {
     public DirectoryInfo WorkingDirectory { get; } = workingDirectory;
     public DirectoryInfo HivesDirectory { get; } = hivesDirectory;
@@ -179,6 +180,8 @@ internal sealed class CliExecutionContext(DirectoryInfo workingDirectory, Direct
             : Utils.CliPathHelper.GetAspireHomeDirectory());
 
     public bool DebugMode { get; } = debugMode;
+
+    public LogLevel? ConsoleLogLevel { get; } = consoleLogLevel;
 
     private Command? _command;
 

--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -60,6 +60,8 @@ internal class ConsoleInteractionService : IInteractionService
 
     public bool SupportsLinks => MessageConsole.Profile.Capabilities.Links;
 
+    private bool UsesConsoleLogging => _executionContext.ConsoleLogLevel is not null and not LogLevel.None;
+
     public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IProcessPathProvider processPathProvider, ILoggerFactory loggerFactory, ConsoleLogBufferContext logBufferContext)
     {
         ArgumentNullException.ThrowIfNull(consoleEnvironment);
@@ -80,6 +82,11 @@ internal class ConsoleInteractionService : IInteractionService
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
+        if (UsesConsoleLogging)
+        {
+            return await action();
+        }
+
         if (!allowMarkup)
         {
             statusText = statusText.EscapeMarkup();
@@ -92,14 +99,13 @@ internal class ConsoleInteractionService : IInteractionService
 
         // Use atomic check-and-set to prevent nested Spectre.Console Status operations.
         // Spectre.Console throws if multiple interactive operations run concurrently.
-        // If already in a status, or in debug/non-interactive mode, fall back to subtle message.
+        // If already in a status or non-interactive mode is active, fall back to subtle message.
         // Also skip status display if statusText is empty (e.g., when outputting JSON).
         // IMPORTANT: CompareExchange must be evaluated last so that short-circuit evaluation
         // skips the swap when an earlier condition forces the fallback path. Otherwise the
         // swap would set _inStatus to 1 but the try/finally that resets it would never run,
         // permanently disabling interactive status for the lifetime of the service.
-        if (_executionContext.DebugMode ||
-            !_hostEnvironment.SupportsInteractiveOutput ||
+        if (!_hostEnvironment.SupportsInteractiveOutput ||
             string.IsNullOrEmpty(statusText) ||
             Interlocked.CompareExchange(ref _inStatus, 1, 0) != 0)
         {
@@ -130,16 +136,20 @@ internal class ConsoleInteractionService : IInteractionService
 
     public async Task<T> ShowDynamicStatusAsync<T>(string initialStatusText, Func<Action<string>, Task<T>> action, KnownEmoji? emoji = null)
     {
+        if (UsesConsoleLogging)
+        {
+            return await action(_ => { });
+        }
+
         var emojiPrefix = emoji is { } e ? ConsoleHelpers.FormatEmojiPrefix(e, MessageConsole) : string.Empty;
         var initialDisplayText = emojiPrefix + initialStatusText.EscapeMarkup();
 
-        // Mirrors ShowStatusAsync: prevent nested Spectre.Console Status operations, skip when debug/non-interactive,
+        // Mirrors ShowStatusAsync: prevent nested Spectre.Console Status operations, skip with non-interactive output,
         // and treat empty text as "no status UI". The fallback path still drives the action so progress logic runs;
         // we just hand it an updater that emits subtle messages instead of mutating a live spinner.
         // IMPORTANT: CompareExchange must be evaluated last so that short-circuit evaluation skips the swap when
         // an earlier condition forces the fallback path; otherwise _inStatus would be left set to 1.
-        if (_executionContext.DebugMode ||
-            !_hostEnvironment.SupportsInteractiveOutput ||
+        if (!_hostEnvironment.SupportsInteractiveOutput ||
             string.IsNullOrEmpty(initialStatusText) ||
             Interlocked.CompareExchange(ref _inStatus, 1, 0) != 0)
         {
@@ -175,6 +185,12 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
+        if (UsesConsoleLogging)
+        {
+            action();
+            return;
+        }
+
         MessageLogger.LogInformation("Status: {StatusText}", statusText);
 
         if (!allowMarkup)
@@ -189,12 +205,11 @@ internal class ConsoleInteractionService : IInteractionService
 
         // Use atomic check-and-set to prevent nested Spectre.Console Status operations.
         // Spectre.Console throws if multiple interactive operations run concurrently.
-        // If already in a status, or in debug/non-interactive mode, fall back to subtle message.
+        // If already in a status or non-interactive mode is active, fall back to subtle message.
         // Also skip status display if statusText is empty (e.g., when outputting JSON).
         // IMPORTANT: CompareExchange must be evaluated last so that short-circuit evaluation skips the swap when
         // an earlier condition forces the fallback path; otherwise _inStatus would be left set to 1.
-        if (_executionContext.DebugMode ||
-            !_hostEnvironment.SupportsInteractiveOutput ||
+        if (!_hostEnvironment.SupportsInteractiveOutput ||
             string.IsNullOrEmpty(statusText) ||
             Interlocked.CompareExchange(ref _inStatus, 1, 0) != 0)
         {

--- a/src/Aspire.Cli/Program.cs
+++ b/src/Aspire.Cli/Program.cs
@@ -414,6 +414,7 @@ public class Program
             var resolver = sp.GetRequiredService<IIdentityResolver>();
             return BuildCliExecutionContext(
                 startupContext.LoggingOptions.DebugMode,
+                startupContext.LoggingOptions.ConsoleLogLevel,
                 startupContext.LoggingOptions.LogsDirectory,
                 startupContext.LoggingOptions.LogFilePath,
                 resolver);
@@ -693,7 +694,7 @@ public class Program
         return new DirectoryInfo(sdksPath);
     }
 
-    internal static CliExecutionContext BuildCliExecutionContext(bool debugMode, string logsDirectory, string logFilePath, IIdentityResolver identityResolver, string? processPath = null)
+    internal static CliExecutionContext BuildCliExecutionContext(bool debugMode, LogLevel? consoleLogLevel, string logsDirectory, string logFilePath, IIdentityResolver identityResolver, string? processPath = null)
     {
         ArgumentNullException.ThrowIfNull(identityResolver);
 
@@ -738,6 +739,7 @@ public class Program
             identityOverridden: identityOverridden,
             identityPackagesDirectory: identityPackagesDirectory,
             debugMode: debugMode,
+            consoleLogLevel: consoleLogLevel,
             packagesDirectory: packagesDirectory,
             aspireHomeDirectory: aspireHomeDirectory);
     }

--- a/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
+++ b/tests/Aspire.Cli.EndToEnd.Tests/Aspire.Cli.EndToEnd.Tests.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="..\..\src\Aspire.Cli\Resources\AddCommandStrings.Designer.cs" Link="Resources\AddCommandStrings.Designer.cs" />
     <Compile Include="..\..\src\Aspire.Cli\Resources\ConsoleActivityLoggerStrings.Designer.cs" Link="Resources\ConsoleActivityLoggerStrings.Designer.cs" />
+    <Compile Include="..\..\src\Aspire.Cli\Resources\DoctorCommandStrings.Designer.cs" Link="Resources\DoctorCommandStrings.Designer.cs" />
     <Compile Include="..\..\src\Aspire.Cli\Resources\HelpGroupStrings.Designer.cs" Link="Resources\HelpGroupStrings.Designer.cs" />
     <Compile Include="..\..\src\Aspire.Cli\Resources\RootCommandStrings.Designer.cs" Link="Resources\RootCommandStrings.Designer.cs" />
     <Compile Include="..\..\src\Aspire.Cli\Resources\RunCommandStrings.Designer.cs" Link="Resources\RunCommandStrings.Designer.cs" />
@@ -82,6 +83,7 @@
   <ItemGroup>
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\AddCommandStrings.resx" Link="Resources\AddCommandStrings.resx" LogicalName="Aspire.Cli.Resources.AddCommandStrings.resources" />
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\ConsoleActivityLoggerStrings.resx" Link="Resources\ConsoleActivityLoggerStrings.resx" LogicalName="Aspire.Cli.Resources.ConsoleActivityLoggerStrings.resources" />
+    <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\DoctorCommandStrings.resx" Link="Resources\DoctorCommandStrings.resx" LogicalName="Aspire.Cli.Resources.DoctorCommandStrings.resources" />
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\HelpGroupStrings.resx" Link="Resources\HelpGroupStrings.resx" LogicalName="Aspire.Cli.Resources.HelpGroupStrings.resources" />
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\RootCommandStrings.resx" Link="Resources\RootCommandStrings.resx" LogicalName="Aspire.Cli.Resources.RootCommandStrings.resources" />
     <EmbeddedResource Include="..\..\src\Aspire.Cli\Resources\RunCommandStrings.resx" Link="Resources\RunCommandStrings.resx" LogicalName="Aspire.Cli.Resources.RunCommandStrings.resources" />

--- a/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
+using System.Text.Json;
 using Aspire.Cli.EndToEnd.Tests.Helpers;
+using Aspire.Cli.Resources;
 using Hex1b.Automation;
 using Xunit;
 
@@ -13,6 +16,8 @@ namespace Aspire.Cli.EndToEnd.Tests;
 /// </summary>
 public sealed class DoctorCommandTests(ITestOutputHelper output)
 {
+    private const string SpinnerCharacters = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏";
+
     public static TheoryData<string> AlternativeToolchains => new()
     {
         "bun",
@@ -95,6 +100,57 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
                    s.ContainsText("Developer Control Plane (DCP) connection health checks succeeded");
         }, timeout: TimeSpan.FromSeconds(60), description: "doctor to complete with trusted certificate");
         await auto.WaitForSuccessPromptAsync(counter);
+    }
+
+    [Fact]
+    public async Task DoctorCommand_WithTraceLogging_DoesNotRenderProgress()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+        var testName = nameof(DoctorCommand_WithTraceLogging_DoesNotRenderProgress);
+        var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(testName);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace, testName: testName);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+        await auto.ClearScreenAsync(counter);
+
+        var recordingOffset = File.Exists(recordingPath) ? new FileInfo(recordingPath).Length : 0;
+        await auto.TypeAsync("aspire doctor -l trace");
+        await auto.EnterAsync();
+        await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
+
+        var commandOutput = ReadRecordingOutput(recordingPath, recordingOffset);
+        Assert.Contains("[dbug]", commandOutput, StringComparison.Ordinal);
+        Assert.Contains(DoctorCommandStrings.EnvironmentCheckHeader, commandOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(DoctorCommandStrings.CheckingPrerequisites, commandOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(commandOutput, SpinnerCharacters.Contains);
+    }
+
+    private static string ReadRecordingOutput(string recordingPath, long recordingOffset)
+    {
+        using var stream = new FileStream(recordingPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        stream.Position = recordingOffset;
+        using var reader = new StreamReader(stream);
+        var outputBuilder = new StringBuilder();
+
+        while (reader.ReadLine() is { } eventLine)
+        {
+            using var eventDocument = JsonDocument.Parse(eventLine);
+            var recordingEvent = eventDocument.RootElement;
+            if (recordingEvent.GetArrayLength() >= 3 && recordingEvent[1].GetString() == "o")
+            {
+                outputBuilder.Append(recordingEvent[2].GetString());
+            }
+        }
+
+        return outputBuilder.ToString();
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Acquisition/IdentityResolverTests.cs
@@ -447,6 +447,7 @@ public class IdentityResolverTests(ITestOutputHelper outputHelper)
     {
         return Program.BuildCliExecutionContext(
             debugMode: false,
+            consoleLogLevel: null,
             logsDirectory: Path.Combine(workspace.WorkspaceRoot.FullName, "logs"),
             logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "logs", "test.log"),
             identityResolver: resolver);

--- a/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
+++ b/tests/Aspire.Cli.Tests/CliBootstrapTests.cs
@@ -147,6 +147,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
 
         var context = Program.BuildCliExecutionContext(
             debugMode: true,
+            consoleLogLevel: null,
             logsDirectory: logsDirectory,
             logFilePath: logFilePath,
             identityResolver: resolver,
@@ -180,6 +181,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
 
         var context = Program.BuildCliExecutionContext(
             debugMode: false,
+            consoleLogLevel: null,
             logsDirectory: Path.Combine(workspace.WorkspaceRoot.FullName, "logs"),
             logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "logs", "aspire.log"),
             identityResolver: resolver);
@@ -201,6 +203,7 @@ public class CliBootstrapTests(ITestOutputHelper outputHelper)
 
         var context = Program.BuildCliExecutionContext(
             debugMode: false,
+            consoleLogLevel: null,
             logsDirectory: Path.Combine(workspace.WorkspaceRoot.FullName, "logs"),
             logFilePath: Path.Combine(workspace.WorkspaceRoot.FullName, "logs", "aspire.log"),
             identityResolver: resolver);

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -7,6 +7,7 @@ using Aspire.Cli.Interaction;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -22,8 +23,8 @@ public class ConsoleInteractionServiceTests
     private static readonly DirectoryInfo s_runtimeDirectory = s_tempRoot.CreateSubdirectory("runtimes");
     private static readonly DirectoryInfo s_logsDirectory = s_tempRoot.CreateSubdirectory("logs");
 
-    private static CliExecutionContext CreateExecutionContext(bool debugMode = false, string? logFilePath = null) =>
-        new(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), s_runtimeDirectory, s_logsDirectory, logFilePath ?? "test.log", identityChannel: "local", debugMode: debugMode);
+    private static CliExecutionContext CreateExecutionContext(bool debugMode = false, LogLevel? consoleLogLevel = null, string? logFilePath = null) =>
+        new(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), s_runtimeDirectory, s_logsDirectory, logFilePath ?? "test.log", identityChannel: "local", debugMode: debugMode, consoleLogLevel: consoleLogLevel);
 
     private static ConsoleInteractionService CreateInteractionService(IAnsiConsole console, CliExecutionContext? executionContext = null, ICliHostEnvironment? hostEnvironment = null)
     {
@@ -283,6 +284,45 @@ public class ConsoleInteractionServiceTests
         var outputString = output.ToString();
         Assert.Contains(statusText, outputString);
         // In debug mode, should use DisplaySubtleMessage instead of spinner
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public async Task StatusMethods_WithConsoleLogging_DoNotStartSpinner(LogLevel consoleLogLevel)
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+        var interactionService = CreateInteractionService(console, CreateExecutionContext(consoleLogLevel: consoleLogLevel));
+
+        var asyncStatusValue = await interactionService.ShowStatusAsync("Working...", () => Task.FromResult(GetInStatus(interactionService))).DefaultTimeout();
+        var dynamicStatusValue = await interactionService.ShowDynamicStatusAsync("Working...", _ => Task.FromResult(GetInStatus(interactionService))).DefaultTimeout();
+        var synchronousStatusValue = -1;
+        interactionService.ShowStatus("Working...", () => synchronousStatusValue = GetInStatus(interactionService));
+
+        Assert.Equal(0, asyncStatusValue);
+        Assert.Equal(0, dynamicStatusValue);
+        Assert.Equal(0, synchronousStatusValue);
+        Assert.Empty(output.ToString());
+    }
+
+    [Fact]
+    public async Task ShowStatusAsync_WithConsoleLoggingDisabled_StartsSpinner()
+    {
+        var interactionService = CreateInteractionService(AnsiConsole.Console, CreateExecutionContext(consoleLogLevel: LogLevel.None));
+
+        var statusValue = await interactionService.ShowStatusAsync("Working...", () => Task.FromResult(GetInStatus(interactionService))).DefaultTimeout();
+
+        Assert.Equal(1, statusValue);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -305,7 +305,11 @@ public class ConsoleInteractionServiceTests
         var interactionService = CreateInteractionService(console, CreateExecutionContext(consoleLogLevel: consoleLogLevel));
 
         var asyncStatusValue = await interactionService.ShowStatusAsync("Working...", () => Task.FromResult(GetInStatus(interactionService))).DefaultTimeout();
-        var dynamicStatusValue = await interactionService.ShowDynamicStatusAsync("Working...", _ => Task.FromResult(GetInStatus(interactionService))).DefaultTimeout();
+        var dynamicStatusValue = await interactionService.ShowDynamicStatusAsync("Working...", updateStatus =>
+        {
+            updateStatus("Still working...");
+            return Task.FromResult(GetInStatus(interactionService));
+        }).DefaultTimeout();
         var synchronousStatusValue = -1;
         interactionService.ShowStatus("Working...", () => synchronousStatusValue = GetInStatus(interactionService));
 


### PR DESCRIPTION
## Description

Console status spinners could write cursor updates while diagnostic logs were being emitted, causing `aspire doctor -l trace` timestamps to be shifted or progress text to appear in the middle of log lines.

This change carries the configured console log level into the CLI execution context and suppresses status/progress rendering whenever console logging is enabled. The underlying actions still run normally, and regular command output is unchanged. `LogLevel.None` and the default configuration without console logging continue to use interactive status rendering.

Fixes #19017

### User-facing usage

Running doctor with console logging now emits aligned diagnostic logs without progress frames or cursor control sequences:

```powershell
aspire doctor -l trace
```

The locally built CLI completed with exit code 0. Its 214-line output contained zero spinner glyphs, zero escape characters, and zero `Checking Aspire environment...` progress messages.

### Screenshots / Recordings

```
[09:08:25] [info] Cli: Aspire CLI version: 13.6.0-dev
[09:08:25] [info] Cli: Aspire CLI build ID: 42.42.42.42424
[09:08:25] [info] Cli: Aspire CLI path: C:\Program Files\dotnet\dotnet.exe
[09:08:25] [info] Cli: Aspire CLI channel: local
[09:08:25] [info] Cli: Working directory: C:\Development\Source\aspire
[09:08:25] [info] Cli: Log file: C:\Users\jamesnk\.aspire\logs\cli_20260811T010825_9fa2dae7.log
[09:08:25] [info] Cli: CLI process ID: 61568
[09:08:25] [dbug] InstallSidecarReader: Install sidecar file 'C:\Program Files\dotnet\.aspire-install.json' does not exist.
[09:08:25] [dbug] Features: Feature aspireSkillsRemoteFetchEnabled = False (default: False)
[09:08:25] [dbug] Features: Feature defaultWatchEnabled = False (default: False)
[09:08:25] [dbug] Features: Feature experimentalPolyglot:go = False (default: False)
[09:08:25] [dbug] Features: Feature experimentalPolyglot:java = False (default: False)
[09:08:25] [dbug] Features: Feature experimentalPolyglot:python = False (default: False)
[09:08:25] [dbug] Features: Feature experimentalPolyglot:rust = False (default: False)
[09:08:25] [dbug] Features: Feature nugetSignatureVerificationEnabled = True (default: True)
[09:08:25] [dbug] Features: Feature showAllTemplates = False (default: False)
[09:08:25] [dbug] Features: Feature showDeprecatedPackages = False (default: False)
[09:08:25] [dbug] Features: Feature stagingChannelEnabled = False (default: False)
[09:08:25] [dbug] Features: Feature terminalCommandsEnabled = False (default: False)
[09:08:25] [dbug] Features: Feature updateNotificationsEnabled = True (default: True)
[09:08:26] [info] Cli: Command: aspire doctor -l trace
[09:08:26] [dbug] Cli: Parsing arguments: doctor -l trace
[09:08:26] [dbug] Cli: Executing command: aspire doctor
[09:08:26] [dbug] AuxiliaryBackchannelMonitor: Current command is not MCP start command. Auxiliary backchannel monitoring disabled.
[09:08:26] [dbug] EnvironmentChecker: Starting environment check AspireVersionCheck.
[09:08:26] [dbug] DoctorCommand: Discovering Aspire CLI installations for doctor output.
[09:08:26] [dbug] InstallSidecarReader: Install sidecar file 'C:\Program Files\dotnet\.aspire-install.json' does not exist.
[09:08:26] [dbug] InstallationDiscovery: Discovery: starting walk. self.Path='C:\Program Files\dotnet\dotnet.exe', self.Canonical='C:\Program Files\dotnet\dotnet.exe', AspireHome='C:\Users\jamesnk\.aspire'.
[09:08:26] [dbug] InstallationDiscovery: Discovery: $PATH match: 'C:\Users\jamesnk\.aspire\dogfood\pr-18925\bin\aspire.EXE' (canonical: 'C:\Users\jamesnk\.aspire\dogfood\pr-18925\bin\aspire.EXE').
[09:08:26] [dbug] InstallationDiscovery: Discovery: $PATH match: 'C:\Users\jamesnk\.aspire\bin\aspire.EXE' (canonical: 'C:\Users\jamesnk\.aspire\bin\aspire.EXE').
[09:08:26] [dbug] InstallationDiscovery: Discovery: $PATH match: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (canonical: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE').
[09:08:26] [dbug] InstallationDiscovery: Discovery: $PATH match: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (canonical: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE').
[09:08:26] [dbug] InstallationDiscovery: Discovery: $PATH match: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (canonical: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE').
[09:08:26] [dbug] InstallationDiscovery: Discovery: $PATH match: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (canonical: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE').
[09:08:26] [dbug] InstallationDiscovery: Discovery: $PATH match: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (canonical: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE').
[09:08:26] [dbug] InstallationDiscovery: Discovery: $PATH match: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (canonical: 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE').
[09:08:26] [dbug] InstallationDiscovery: Discovery: considering candidate #1 'C:\Users\jamesnk\.aspire\dogfood\pr-18925\bin\aspire.EXE' (origin: $PATH).
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #2 'C:\Users\jamesnk\.aspire\bin\aspire.EXE' (origin: $PATH).
[09:08:27] [dbug] InstallSidecarReader: Install sidecar file 'C:\Users\jamesnk\.aspire\bin\.aspire-install.json' does not exist.
[09:08:27] [dbug] InstallationDiscovery: Discovery: candidate 'C:\Users\jamesnk\.aspire\bin\aspire.EXE' (origin: $PATH) did not pass install metadata sidecar read (NotFound) — treating as not-probed.
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #3 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (origin: $PATH).
[09:08:27] [dbug] InstallSidecarReader: Install sidecar file 'C:\Users\jamesnk\.dotnet\tools\.aspire-install.json' does not exist.
[09:08:27] [dbug] InstallationDiscovery: Discovery: candidate 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (origin: $PATH) did not pass install metadata sidecar read (NotFound) — treating as not-probed.
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #4 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (origin: $PATH).
[09:08:27] [dbug] InstallationDiscovery: Discovery: skipping duplicate of 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' found via $PATH at 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE'.
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #5 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (origin: $PATH).
[09:08:27] [dbug] InstallationDiscovery: Discovery: skipping duplicate of 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' found via $PATH at 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE'.
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #6 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (origin: $PATH).
[09:08:27] [dbug] InstallationDiscovery: Discovery: skipping duplicate of 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' found via $PATH at 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE'.
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #7 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (origin: $PATH).
[09:08:27] [dbug] InstallationDiscovery: Discovery: skipping duplicate of 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' found via $PATH at 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE'.
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #8 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' (origin: $PATH).
[09:08:27] [dbug] InstallationDiscovery: Discovery: skipping duplicate of 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE' found via $PATH at 'C:\Users\jamesnk\.dotnet\tools\aspire.EXE'.
[09:08:27] [dbug] InstallationDiscovery: Discovery: release prefix walk yielded 'C:\Users\jamesnk\.aspire\bin\aspire.exe'.
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #9 'C:\Users\jamesnk\.aspire\bin\aspire.exe' (origin: well-known release prefix).
[09:08:27] [dbug] InstallationDiscovery: Discovery: skipping duplicate of 'C:\Users\jamesnk\.aspire\bin\aspire.exe' found via well-known release prefix at 'C:\Users\jamesnk\.aspire\bin\aspire.exe'.
[09:08:27] [dbug] InstallationDiscovery: Discovery: dogfood walk yielded 'C:\Users\jamesnk\.aspire\dogfood\pr-18259\bin\aspire.exe'.
[09:08:27] [dbug] InstallationDiscovery: Discovery: considering candidate #10 'C:\Users\jamesnk\.aspire\dogfood\pr-18259\bin\aspire.exe' (origin: dogfood prefix).
[09:08:27] [dbug] CliUpdateNotifier: Current version: 13.6.0-dev
Newest stable version: 13.4.6
Newest prerelease version: 13.6.0-preview.1.26410.6
[09:08:27] [dbug] CliUpdateNotifier: Current version 13.6.0-dev is prerelease and older than newest prerelease version 13.6.0-preview.1.26410.6.
[09:08:27] [dbug] ProjectLocator: Searching for project files in C:\Development\Source\aspire
[09:08:27] [dbug] ProjectLocator: Searching for patterns: *.csproj, *.fsproj, *.vbproj, apphost.cs, apphost.mts, apphost.ts
[09:08:27] [dbug] ProjectLocator: NuGet cache path to exclude: C:\Users\jamesnk\.nuget\packages
[09:08:27] [dbug] ProjectLocator: Found 0 files matching pattern '*.csproj'
[09:08:27] [dbug] ProjectLocator: Found 0 files matching pattern '*.fsproj'
[09:08:27] [dbug] ProjectLocator: Found 0 files matching pattern '*.vbproj'
[09:08:27] [dbug] ProjectLocator: Found 0 files matching pattern 'apphost.cs'
[09:08:27] [dbug] ProjectLocator: Found 0 files matching pattern 'apphost.mts'
[09:08:27] [dbug] ProjectLocator: Found 0 files matching pattern 'apphost.ts'
[09:08:27] [dbug] ProjectLocator: Found 0 unique candidate files matching AppHost detection patterns
[09:08:27] [dbug] EnvironmentChecker: Environment check AspireVersionCheck completed in 1882 ms.
[09:08:27] [dbug] EnvironmentChecker: Starting environment check OperatingSystemCheck.
[09:08:27] [dbug] EnvironmentChecker: Environment check OperatingSystemCheck completed in 1 ms.
[09:08:27] [dbug] EnvironmentChecker: Starting environment check WslEnvironmentCheck.
[09:08:27] [dbug] EnvironmentChecker: Environment check WslEnvironmentCheck completed in 0 ms.
[09:08:27] [dbug] EnvironmentChecker: Starting environment check DotNetSdkCheck.
[09:08:28] [dbug] EnvironmentChecker: Environment check DotNetSdkCheck completed in 65 ms.
[09:08:28] [dbug] EnvironmentChecker: Starting environment check TypeScriptAppHostToolingCheck.
[09:08:28] [dbug] EnvironmentChecker: Environment check TypeScriptAppHostToolingCheck completed in 6 ms.
[09:08:28] [dbug] EnvironmentChecker: Starting environment check DeprecatedWorkloadCheck.
[09:08:28] [dbug] EnvironmentChecker: Environment check DeprecatedWorkloadCheck completed in 759 ms.
[09:08:28] [dbug] EnvironmentChecker: Starting environment check DevCertsCheck.
[09:08:28] [dbug] NativeCertificateToolRunner: Listing certificates from CurrentUser\My
[09:08:28] [dbug] NativeCertificateToolRunner: Found certificates: 1 certificate
    1) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: true
[09:08:28] [dbug] NativeCertificateToolRunner: Checking certificates validity
[09:08:28] [dbug] NativeCertificateToolRunner: Valid certificates: 1 certificate
    1) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: true
[09:08:28] [dbug] NativeCertificateToolRunner: Invalid certificates: no certificates
[09:08:28] [dbug] NativeCertificateToolRunner: Meets minimum version certificates: 1 certificate
    1) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: true
[09:08:28] [dbug] NativeCertificateToolRunner: Below minimum version certificates: no certificates
[09:08:28] [dbug] NativeCertificateToolRunner: Finished listing certificates.
[09:08:28] [dbug] NativeCertificateToolRunner: Listing certificates from CurrentUser\Root
[09:08:28] [dbug] NativeCertificateToolRunner: Found certificates: 2 certificates
    1) 6EC692B2666990E4A32BA784E978E101EF188514 - CN=localhost - Valid from 2025-11-06 13:40:39Z to 2026-11-06 13:40:39Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
    2) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
[09:08:28] [dbug] NativeCertificateToolRunner: Checking certificates validity
[09:08:28] [dbug] NativeCertificateToolRunner: Valid certificates: 2 certificates
    1) 6EC692B2666990E4A32BA784E978E101EF188514 - CN=localhost - Valid from 2025-11-06 13:40:39Z to 2026-11-06 13:40:39Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
    2) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
[09:08:28] [dbug] NativeCertificateToolRunner: Invalid certificates: no certificates
[09:08:28] [dbug] NativeCertificateToolRunner: Meets minimum version certificates: 2 certificates
    1) 6EC692B2666990E4A32BA784E978E101EF188514 - CN=localhost - Valid from 2025-11-06 13:40:39Z to 2026-11-06 13:40:39Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
    2) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
[09:08:28] [dbug] NativeCertificateToolRunner: Below minimum version certificates: no certificates
[09:08:28] [dbug] NativeCertificateToolRunner: Finished listing certificates.
[09:08:28] [dbug] EnvironmentChecker: Environment check DevCertsCheck completed in 69 ms.
[09:08:28] [dbug] EnvironmentChecker: Starting environment check ContainerRuntimeCheck.
[09:08:28] [dbug] ContainerRuntimeCheck: Probing container runtime 'Docker' (docker)...
[09:08:28] [dbug] ContainerRuntimeCheck: Probing container runtime 'Podman' (podman)...
[09:08:28] [dbug] ContainerRuntimeCheck: Podman: not found on PATH (An error occurred trying to start process 'podman' with working directory 'C:\Development\Source\aspire'. The system cannot find the file specified.)
[09:08:28] [dbug] ContainerRuntimeCheck: Docker is running, gathering version info...
[09:08:29] [dbug] ContainerRuntimeCheck: Docker: client=29.6.2, server=29.6.2, desktop=True
[09:08:29] [dbug] EnvironmentChecker: Environment check ContainerRuntimeCheck completed in 387 ms.
[09:08:29] [dbug] EnvironmentChecker: Starting environment check DcpConnectionHealthCheck.
[09:08:29] [dbug] LayoutDiscovery: TryDiscoverRelativeLayout: CLI at C:\Program Files\dotnet, checking for layout...
[09:08:29] [dbug] LayoutDiscovery: TryInferLayout: Checking layout at C:\Program Files\dotnet
[09:08:29] [dbug] LayoutDiscovery:   bundle/managed/: MISSING
[09:08:29] [dbug] LayoutDiscovery:   bundle/dcp/: MISSING
[09:08:29] [dbug] LayoutDiscovery:   managed/: MISSING
[09:08:29] [dbug] LayoutDiscovery:   dcp/: MISSING
[09:08:29] [dbug] LayoutDiscovery: TryInferLayout: Layout rejected - missing required directories
[09:08:29] [dbug] LayoutDiscovery: TryDiscoverRelativeLayout: Checking parent directory C:\Program Files...
[09:08:29] [dbug] LayoutDiscovery: TryInferLayout: Checking layout at C:\Program Files
[09:08:29] [dbug] LayoutDiscovery:   bundle/managed/: MISSING
[09:08:29] [dbug] LayoutDiscovery:   bundle/dcp/: MISSING
[09:08:29] [dbug] LayoutDiscovery:   managed/: MISSING
[09:08:29] [dbug] LayoutDiscovery:   dcp/: MISSING
[09:08:29] [dbug] LayoutDiscovery: TryInferLayout: Layout rejected - missing required directories
[09:08:29] [dbug] LayoutDiscovery: TryDiscoverAspireHomeLayout: Checking Aspire home C:\Users\jamesnk\.aspire...
[09:08:29] [dbug] LayoutDiscovery: TryInferLayout: Checking layout at C:\Users\jamesnk\.aspire
[09:08:29] [dbug] LayoutDiscovery:   bundle/managed/: exists
[09:08:29] [dbug] LayoutDiscovery:   bundle/dcp/: exists
[09:08:29] [dbug] LayoutDiscovery:   bundle/managed/aspire-managed.exe: exists
[09:08:29] [dbug] LayoutDiscovery: TryInferLayout: New bundle/ layout is valid
[09:08:29] [dbug] LayoutDiscovery: Discovered layout in Aspire home: C:\Users\jamesnk\.aspire
[09:08:29] [dbug] ProcessExecutionFactory: Running C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe in C:\Development\Source\aspire with args: start-apiserver --kubeconfig C:\Users\jamesnk\AppData\Local\Temp\aspire-dcp-doctor-gdjjvhgx.j2s\kubeconfig
[09:08:29] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe env: DCP_SESSION_FOLDER=C:\Users\jamesnk\AppData\Local\Temp\aspire-dcp-doctor-gdjjvhgx.j2s
[09:08:29] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(30076) started in C:\Development\Source\aspire
[09:08:29] [dbug] NativeCertificateToolRunner: Listing certificates from CurrentUser\My
[09:08:29] [dbug] NativeCertificateToolRunner: Found certificates: 1 certificate
    1) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: true
[09:08:29] [dbug] NativeCertificateToolRunner: Checking certificates validity
[09:08:29] [dbug] NativeCertificateToolRunner: Valid certificates: 1 certificate
    1) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: true
[09:08:29] [dbug] NativeCertificateToolRunner: Invalid certificates: no certificates
[09:08:29] [dbug] NativeCertificateToolRunner: Meets minimum version certificates: 1 certificate
    1) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: true
[09:08:29] [dbug] NativeCertificateToolRunner: Below minimum version certificates: no certificates
[09:08:29] [dbug] NativeCertificateToolRunner: Finished listing certificates.
[09:08:29] [dbug] NativeCertificateToolRunner: Listing certificates from CurrentUser\Root
[09:08:29] [dbug] NativeCertificateToolRunner: Found certificates: 2 certificates
    1) 6EC692B2666990E4A32BA784E978E101EF188514 - CN=localhost - Valid from 2025-11-06 13:40:39Z to 2026-11-06 13:40:39Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
    2) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
[09:08:29] [dbug] NativeCertificateToolRunner: Checking certificates validity
[09:08:29] [dbug] NativeCertificateToolRunner: Valid certificates: 2 certificates
    1) 6EC692B2666990E4A32BA784E978E101EF188514 - CN=localhost - Valid from 2025-11-06 13:40:39Z to 2026-11-06 13:40:39Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
    2) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
[09:08:29] [dbug] NativeCertificateToolRunner: Invalid certificates: no certificates
[09:08:29] [dbug] NativeCertificateToolRunner: Meets minimum version certificates: 2 certificates
    1) 6EC692B2666990E4A32BA784E978E101EF188514 - CN=localhost - Valid from 2025-11-06 13:40:39Z to 2026-11-06 13:40:39Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
    2) C2D9E727877F50178B850CE95801C230203C8C2D - CN=localhost - Valid from 2026-03-12 15:44:44Z to 2027-03-12 15:44:44Z - IsHttpsDevelopmentCertificate: true - IsExportable: false
[09:08:29] [dbug] NativeCertificateToolRunner: Below minimum version certificates: no certificates
[09:08:29] [dbug] NativeCertificateToolRunner: Finished listing certificates.
[09:08:29] [dbug] ProcessExecutionFactory: Running C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe in C:\Development\Source\aspire with args: start-apiserver --kubeconfig C:\Users\jamesnk\AppData\Local\Temp\aspire-dcp-doctor-rtd5s2l1.efi\kubeconfig --tls-cert-thumbprint C2D9E727877F50178B850CE95801C230203C8C2D
[09:08:29] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe env: DCP_SESSION_FOLDER=C:\Users\jamesnk\AppData\Local\Temp\aspire-dcp-doctor-rtd5s2l1.efi
[09:08:29] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(75328) started in C:\Development\Source\aspire
[09:08:29] [dbug] DcpConnectionChecker: DCP doctor stop request returned HTTP UnsupportedMediaType.
[09:08:29] [dbug] PeerInstallProbe: Timed out waiting 2s for process output capture. System.TimeoutException: The operation has timed out.
   at Aspire.Cli.Utils.ProcessCaptureRunner.SwallowCaptureAsync[TCapture](Task`1 task, Func`1 createEmptyCapture, ILogger logger, Nullable`1 bound) in C:\Development\Source\aspire\src\Aspire.Cli\Utils\ProcessCaptureRunner.cs:line 226
[09:08:29] [dbug] PeerInstallProbe: Peer probe at C:\Users\jamesnk\.aspire\dogfood\pr-18259\bin\aspire.exe produced no rich JSON output.
[09:08:29] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(75328) waiting for exit
[09:08:29] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(75328) exited with code: -1
[09:08:29] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(75328) output drained
[09:08:29] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(75328) output drained
[09:08:30] [dbug] InstallationDiscovery: Discovery: dogfood walk yielded 'C:\Users\jamesnk\.aspire\dogfood\pr-18925\bin\aspire.exe'.
[09:08:30] [dbug] InstallationDiscovery: Discovery: considering candidate #11 'C:\Users\jamesnk\.aspire\dogfood\pr-18925\bin\aspire.exe' (origin: dogfood prefix).
[09:08:30] [dbug] InstallationDiscovery: Discovery: skipping duplicate of 'C:\Users\jamesnk\.aspire\dogfood\pr-18925\bin\aspire.exe' found via dogfood prefix at 'C:\Users\jamesnk\.aspire\dogfood\pr-18925\bin\aspire.exe'.
[09:08:30] [dbug] InstallationDiscovery: Discovery: dotnet-tool store 'C:\Users\jamesnk\.dotnet\tools\.store\aspire.cli' exists but contains no 'aspire.exe' binary — not classifying as a real install.
[09:08:30] [dbug] InstallationDiscovery: Discovery: walk complete. Considered 11 candidate(s); produced 5 row(s) total (including self).
[09:08:30] [dbug] DoctorCommand: Discovered 5 Aspire CLI installation(s) for doctor output.
[09:08:30] [dbug] DcpConnectionChecker: DCP doctor stop request returned HTTP UnsupportedMediaType.
[09:08:30] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(30076) waiting for exit
[09:08:30] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(30076) exited with code: -1
[09:08:30] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(30076) output drained
[09:08:30] [dbug] ProcessExecutionFactory: C:\Users\jamesnk\.aspire\bundle\dcp\dcp.exe(30076) output drained
[09:08:30] [dbug] EnvironmentChecker: Environment check DcpConnectionHealthCheck completed in 1126 ms.
[09:08:30] [dbug] EnvironmentChecker: Starting environment check VsCodeExtensionCheck.
[09:08:30] [dbug] EnvironmentChecker: Environment check VsCodeExtensionCheck completed in 36 ms.
[09:08:30] [dbug] EnvironmentChecker: Starting environment check DeprecatedAgentConfigCheck.
[09:08:30] [dbug] EnvironmentChecker: Environment check DeprecatedAgentConfigCheck completed in 1 ms.
[09:08:30] [dbug] EnvironmentChecker: Starting environment check LegacySettingsFileCheck.
[09:08:30] [dbug] EnvironmentChecker: Environment check LegacySettingsFileCheck completed in 0 ms.
[09:08:30] [dbug] EnvironmentChecker: Starting environment check PendingMigrationsCheck.
[09:08:30] [dbug] EnvironmentChecker: Environment check PendingMigrationsCheck completed in 4 ms.

Aspire Environment Check
========================

Aspire
  ⚠️ Aspire CLI version 13.6.0-dev (channel: local) is out of date. Latest version is 13.6.0-preview.1.26410.6
     (channel: prerelease)
       Run 'aspire update' to update Aspire CLI.
  ✅ Developer Control Plane (DCP) connection health checks succeeded

.NET SDK
  ✅ .NET 11.0.100-preview.4.26203.108 installed (x64)

Container Runtime
  ✅ Docker v29.6.2: running (auto-detected (default)) ← active

Environment
  ✅ Operating system: Windows 10.0.26200.0
  ✅ HTTPS development certificate is trusted

Development Tools
  ✅ Aspire extension for VS Code is installed

Summary: 6 passed, 1 warnings, 0 failed
For detailed prerequisites: https://aka.ms/aspire-prerequisites

Aspire CLI Installations
========================

╭──────────────────────────────────────────────┬───────────────────────────┬──────────────┬──────────────┬─────────────╮
│ Path                                         │ Version                   │ Channel      │ Route        │ PATH status │
├──────────────────────────────────────────────┼───────────────────────────┼──────────────┼──────────────┼─────────────┤
│ C:\Program Files\dotnet\dotnet.exe (current) │ 13.6.0-dev                │ local        │ (unknown)    │ not on PATH │
│ C:\Users\jamesnk\.aspire\dogfood\pr-18925\bi │ 13.5.0-pr.18925.gb595ef3c │ pr-18925     │ pr           │ active      │
│ n\aspire.EXE                                 │                           │              │              │             │
│ C:\Users\jamesnk\.aspire\bin\aspire.EXE      │ (not probed)              │ (not probed) │ (not probed) │ shadowed    │
│ C:\Users\jamesnk\.dotnet\tools\aspire.EXE    │ (not probed)              │ (not probed) │ (not probed) │ shadowed    │
│ C:\Users\jamesnk\.aspire\dogfood\pr-18259\bi │ 13.5.0-pr.18259.g5289871d │ pr-18259     │ pr           │ not on PATH │
│ n\aspire.exe                                 │                           │              │              │             │
╰──────────────────────────────────────────────┴───────────────────────────┴──────────────┴──────────────┴─────────────╯
[09:08:30] [info] Cli: Exit code: 0
```

### Validation

- `ConsoleInteractionServiceTests`: 106 passed
- `CliBootstrapTests`: 12 passed
- Manual `aspire doctor -l trace`: exit code 0, no spinner glyphs, escape characters, or progress messages
- Manual `aspire doctor -l information`: exit code 0, no progress rendering

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No