### PR TITLE
Fix metric label selection behavior

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -144,14 +144,16 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
 
     private static bool MatchFilter(KeyValuePair<string, string>[] attributes, DimensionFilterViewModel filter)
     {
+        var selectedValues = filter.SelectedValues;
+
         // No filter selected.
-        if (filter.SelectedValues.Count == 0)
+        if (selectedValues.Count == 0)
         {
             return false;
         }
 
         var value = OtlpHelpers.GetValue(attributes, filter.Name);
-        foreach (var item in filter.SelectedValues)
+        foreach (var item in selectedValues)
         {
             if (item.Value == value)
             {
@@ -243,15 +245,10 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
 
             foreach (var item in filters)
             {
-                item.SelectedValues.Clear();
-
                 if (hasInstrumentChanged)
                 {
                     // Select all by default.
-                    foreach (var v in item.Values)
-                    {
-                        item.SelectedValues.Add(v);
-                    }
+                    item.SetSelectedValues(item.Values);
                 }
                 else
                 {
@@ -264,18 +261,12 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
                             ? item.Values
                             : item.Values.Where(newValue => existing.SelectedValues.Any(existingValue => existingValue.Value == newValue.Value));
 
-                        foreach (var v in newSelectedValues)
-                        {
-                            item.SelectedValues.Add(v);
-                        }
+                        item.SetSelectedValues(newSelectedValues);
                     }
                     else
                     {
                         // New filter. Select all by default.
-                        foreach (var v in item.Values)
-                        {
-                            item.SelectedValues.Add(v);
-                        }
+                        item.SetSelectedValues(item.Values);
                     }
                 }
             }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -31,8 +31,8 @@
                       role="button"
                       tabindex="0"
                       aria-pressed="@isIncludedInFilters"
-                      @onclick="@(() => OnTagSelectionChangedAsync(item, !Filter.SelectedValues.Contains(item)))"
-                      @onkeydown="@(args => OnTagKeyDownAsync(args, item, !Filter.SelectedValues.Contains(item)))">
+                      @onclick="args => OnTagClickedAsync(args, item)"
+                      @onkeydown="args => OnTagKeyDownAsync(args, item)">
                     @item.Text
                 </span>
             </FluentOverflowItem>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor
@@ -27,14 +27,12 @@
 
             // Always display the first item by setting a fixed value.
             <FluentOverflowItem Fixed="@((i == 0) ? OverflowItemFixed.Ellipsis : OverflowItemFixed.None)" AdditionalAttributes="additionalAttributes">
-                <span class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
-                      role="button"
-                      tabindex="0"
-                      aria-pressed="@isIncludedInFilters"
-                      @onclick="args => OnTagClickedAsync(args, item)"
-                      @onkeydown="args => OnTagKeyDownAsync(args, item)">
+                <button type="button"
+                        class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
+                        aria-pressed="@isIncludedInFilters"
+                        @onclick="args => OnTagClickedAsync(args, item)">
                     @item.Text
-                </span>
+                </button>
             </FluentOverflowItem>
             i++;
         }
@@ -50,14 +48,12 @@
             var isIncludedInFiltersClass = hasSelectedInOverflow ? "included-in-filters" : "";
         }
         @* Display must be inline block so the width is correctly calculated. *@
-        <span class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
-              role="button"
-              tabindex="0"
-              style="display:inline-block;"
-              @onclick="@ShowPopover"
-              @onkeydown="@(args => OnOverflowTagKeyDownAsync(args))">
+        <button type="button"
+                class="dimension-tag filter-value-tag @isIncludedInFiltersClass"
+                style="display:inline-block;"
+                @onclick="@ShowPopover">
             @($"+{overflow.ItemsOverflow.Count() + preOverflowedCount}")
-        </span>
+        </button>
     </MoreButtonTemplate>
     <OverflowTemplate Context="overflow">
         @* Intentionally empty. Don't display an overflow template here. *@

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
@@ -43,12 +43,6 @@ public partial class ChartFilterTags : IDisposable
         InvokeAsync(StateHasChanged);
     }
 
-    private async Task OnTagSelectionChangedAsync(DimensionValueViewModel tag, bool isChecked)
-    {
-        Filter.OnTagSelectionChanged(tag, isChecked);
-        await OnSelectionChanged.InvokeAsync(Filter);
-    }
-
     private Task OnTagClickedAsync(MouseEventArgs args, DimensionValueViewModel tag)
     {
         return OnTagActivatedAsync(tag, args.ShiftKey);
@@ -56,43 +50,22 @@ public partial class ChartFilterTags : IDisposable
 
     private async Task OnTagActivatedAsync(DimensionValueViewModel tag, bool toggleSelection)
     {
-        var isChecked = true;
         if (toggleSelection)
         {
-            isChecked = !Filter.SelectedValues.Contains(tag);
+            Filter.OnTagSelectionChanged(tag, !Filter.SelectedValues.Contains(tag));
         }
         else
         {
-            Filter.SelectedValues.Clear();
+            Filter.SetSelectedValues([tag]);
         }
 
-        await OnTagSelectionChangedAsync(tag, isChecked);
-    }
-
-    private Task OnTagKeyDownAsync(KeyboardEventArgs args, DimensionValueViewModel tag)
-    {
-        if (args.Key is "Enter" or " ")
-        {
-            return OnTagActivatedAsync(tag, args.ShiftKey);
-        }
-
-        return Task.CompletedTask;
+        await OnSelectionChanged.InvokeAsync(Filter);
     }
 
     private void ShowPopover()
     {
         Filter.PopupVisible = true;
         Filter.NotifyStateChanged?.Invoke();
-    }
-
-    private Task OnOverflowTagKeyDownAsync(KeyboardEventArgs args)
-    {
-        if (args.Key is "Enter" or " ")
-        {
-            ShowPopover();
-        }
-
-        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.cs
@@ -49,12 +49,34 @@ public partial class ChartFilterTags : IDisposable
         await OnSelectionChanged.InvokeAsync(Filter);
     }
 
-    private async Task OnTagKeyDownAsync(KeyboardEventArgs args, DimensionValueViewModel tag, bool isChecked)
+    private Task OnTagClickedAsync(MouseEventArgs args, DimensionValueViewModel tag)
+    {
+        return OnTagActivatedAsync(tag, args.ShiftKey);
+    }
+
+    private async Task OnTagActivatedAsync(DimensionValueViewModel tag, bool toggleSelection)
+    {
+        var isChecked = true;
+        if (toggleSelection)
+        {
+            isChecked = !Filter.SelectedValues.Contains(tag);
+        }
+        else
+        {
+            Filter.SelectedValues.Clear();
+        }
+
+        await OnTagSelectionChangedAsync(tag, isChecked);
+    }
+
+    private Task OnTagKeyDownAsync(KeyboardEventArgs args, DimensionValueViewModel tag)
     {
         if (args.Key is "Enter" or " ")
         {
-            await OnTagSelectionChangedAsync(tag, isChecked);
+            return OnTagActivatedAsync(tag, args.ShiftKey);
         }
+
+        return Task.CompletedTask;
     }
 
     private void ShowPopover()

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilterTags.razor.css
@@ -5,6 +5,8 @@
     background: var(--neutral-fill-secondary-rest);
     font-size: var(--type-ramp-minus-1-font-size);
     line-height: var(--type-ramp-minus-1-line-height);
+    color: inherit;
+    font-family: inherit;
 }
 
 ::deep .dimension-overflow {

--- a/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
+++ b/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Aspire.Dashboard.Extensions;
 
@@ -10,10 +11,11 @@ namespace Aspire.Dashboard.Model;
 public class DimensionFilterViewModel
 {
     private string? _sanitizedHtmlId;
+    private ImmutableHashSet<DimensionValueViewModel> _selectedValues = [];
 
     public required string Name { get; init; }
     public List<DimensionValueViewModel> Values { get; } = [];
-    public HashSet<DimensionValueViewModel> SelectedValues { get; } = [];
+    public IReadOnlySet<DimensionValueViewModel> SelectedValues => Volatile.Read(ref _selectedValues);
     public bool PopupVisible { get; set; }
 
     /// <summary>
@@ -26,9 +28,10 @@ public class DimensionFilterViewModel
     {
         get
         {
-            return SelectedValues.SetEquals(Values)
+            var selectedValues = SelectedValues;
+            return selectedValues.SetEquals(Values)
                 ? true
-                : SelectedValues.Count == 0
+                : selectedValues.Count == 0
                     ? false
                     : null;
         }
@@ -36,7 +39,7 @@ public class DimensionFilterViewModel
         {
             if (value is true)
             {
-                SelectedValues.UnionWith(Values);
+                Interlocked.Exchange(ref _selectedValues, Values.ToImmutableHashSet());
             }
             else if (value is false)
             {
@@ -45,10 +48,11 @@ public class DimensionFilterViewModel
                 // when the state transitions from true to null (intermediate) due to individual
                 // checkbox changes. In that case, AreAllValuesSelected is already null/false,
                 // and we should not clear the remaining selections.
-                if (AreAllValuesSelected is true)
-                {
-                    SelectedValues.Clear();
-                }
+                var allValues = Values.ToImmutableHashSet();
+                ImmutableInterlocked.Update(
+                    ref _selectedValues,
+                    static (selectedValues, allValues) => selectedValues.SetEquals(allValues) ? [] : selectedValues,
+                    allValues);
             }
             // When value is null (intermediate state), do nothing.
         }
@@ -56,16 +60,19 @@ public class DimensionFilterViewModel
 
     public string SanitizedHtmlId => _sanitizedHtmlId ??= StringExtensions.SanitizeHtmlId(Name);
 
+    public void SetSelectedValues(IEnumerable<DimensionValueViewModel> dimensionValues)
+    {
+        Interlocked.Exchange(ref _selectedValues, dimensionValues.ToImmutableHashSet());
+    }
+
     public void OnTagSelectionChanged(DimensionValueViewModel dimensionValue, bool isChecked)
     {
-        if (isChecked)
-        {
-            SelectedValues.Add(dimensionValue);
-        }
-        else
-        {
-            SelectedValues.Remove(dimensionValue);
-        }
+        ImmutableInterlocked.Update(
+            ref _selectedValues,
+            static (selectedValues, state) => state.IsChecked
+                ? selectedValues.Add(state.DimensionValue)
+                : selectedValues.Remove(state.DimensionValue),
+            (DimensionValue: dimensionValue, IsChecked: isChecked));
     }
 
     private string DebuggerToString() => $"Name = {Name}, SelectedValues = {SelectedValues.Count}";

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
@@ -97,6 +97,7 @@ public class ChartFiltersTests : DashboardTestContext
     {
         SetupChartFilters();
         var dimensionFilter = CreateDimensionFilter();
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
         var changed = false;
 
         var cut = RenderChartFilters(dimensionFilter, _ => changed = true);
@@ -108,8 +109,67 @@ public class ChartFiltersTests : DashboardTestContext
         getTag.KeyDown(new KeyboardEventArgs { Key = "Enter" });
 
         Assert.True(changed);
-        Assert.Single(dimensionFilter.SelectedValues);
-        Assert.Equal("GET", dimensionFilter.SelectedValues.Single().Text);
+        var selectedValue = Assert.Single(dimensionFilter.SelectedValues);
+        Assert.Equal("GET", selectedValue.Text);
+    }
+
+    [Fact]
+    public void ShiftKeyDown_UnselectedFilterValueTag_AddsValue()
+    {
+        SetupChartFilters();
+        var dimensionFilter = CreateDimensionFilter();
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
+        var cut = RenderChartFilters(dimensionFilter);
+        var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
+
+        getTag.KeyDown(new KeyboardEventArgs { Key = "Enter", ShiftKey = true });
+
+        Assert.Equal(["GET", "POST"], dimensionFilter.SelectedValues.Select(v => v.Text).Order());
+    }
+
+    [Fact]
+    public void Click_FilterValueTag_SelectsOnlyClickedValue()
+    {
+        SetupChartFilters();
+        var dimensionFilter = CreateDimensionFilter();
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
+        var cut = RenderChartFilters(dimensionFilter);
+        var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
+
+        getTag.Click(new MouseEventArgs());
+
+        var selectedValue = Assert.Single(dimensionFilter.SelectedValues);
+        Assert.Equal("GET", selectedValue.Text);
+    }
+
+    [Fact]
+    public void ShiftClick_UnselectedFilterValueTag_AddsClickedValue()
+    {
+        SetupChartFilters();
+        var dimensionFilter = CreateDimensionFilter();
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
+        var cut = RenderChartFilters(dimensionFilter);
+        var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
+
+        getTag.Click(new MouseEventArgs { ShiftKey = true });
+
+        Assert.Equal(["GET", "POST"], dimensionFilter.SelectedValues.Select(v => v.Text).Order());
+    }
+
+    [Fact]
+    public void ShiftClick_SelectedFilterValueTag_RemovesClickedValue()
+    {
+        SetupChartFilters();
+        var dimensionFilter = CreateDimensionFilter();
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "GET"));
+        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
+        var cut = RenderChartFilters(dimensionFilter);
+        var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
+
+        getTag.Click(new MouseEventArgs { ShiftKey = true });
+
+        var selectedValue = Assert.Single(dimensionFilter.SelectedValues);
+        Assert.Equal("POST", selectedValue.Text);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ChartFiltersTests.cs
@@ -20,8 +20,7 @@ public class ChartFiltersTests : DashboardTestContext
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
         dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", });
         dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", });
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values[0]);
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values[1]);
+        dimensionFilter.SetSelectedValues(dimensionFilter.Values);
 
         Assert.True(dimensionFilter.AreAllValuesSelected);
 
@@ -36,7 +35,7 @@ public class ChartFiltersTests : DashboardTestContext
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
         dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", });
         dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", });
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values[0]);
+        dimensionFilter.SetSelectedValues([dimensionFilter.Values[0]]);
 
         Assert.Null(dimensionFilter.AreAllValuesSelected);
 
@@ -52,7 +51,7 @@ public class ChartFiltersTests : DashboardTestContext
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
         dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "GET", Value = "GET", });
         dimensionFilter.Values.Add(new DimensionValueViewModel { Text = "POST", Value = "POST", });
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values[0]);
+        dimensionFilter.SetSelectedValues([dimensionFilter.Values[0]]);
 
         dimensionFilter.AreAllValuesSelected = true;
 
@@ -61,21 +60,21 @@ public class ChartFiltersTests : DashboardTestContext
     }
 
     [Fact]
-    public void OnTagSelectionChanged_RemovesValue_LeavesOthersSelected()
+    public void OnTagSelectionChanged_ReplacesSnapshotAndRemovesValue()
     {
         var dimensionFilter = new DimensionFilterViewModel { Name = "http.method" };
         var getValue = new DimensionValueViewModel { Text = "GET", Value = "GET", };
         var postValue = new DimensionValueViewModel { Text = "POST", Value = "POST", };
         dimensionFilter.Values.Add(getValue);
         dimensionFilter.Values.Add(postValue);
-        dimensionFilter.SelectedValues.Add(getValue);
-        dimensionFilter.SelectedValues.Add(postValue);
+        dimensionFilter.SetSelectedValues([getValue, postValue]);
+        var selectedValuesSnapshot = dimensionFilter.SelectedValues;
 
         dimensionFilter.OnTagSelectionChanged(getValue, isChecked: false);
 
         Assert.Single(dimensionFilter.SelectedValues);
         Assert.Contains(postValue, dimensionFilter.SelectedValues);
-        Assert.DoesNotContain(getValue, dimensionFilter.SelectedValues);
+        Assert.True(selectedValuesSnapshot.SetEquals([getValue, postValue]));
     }
 
     [Fact]
@@ -93,38 +92,17 @@ public class ChartFiltersTests : DashboardTestContext
     }
 
     [Fact]
-    public void Render_FilterValueTags_AreKeyboardAccessible()
+    public void Render_FilterValueTags_UseNativeButtons()
     {
         SetupChartFilters();
         var dimensionFilter = CreateDimensionFilter();
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
-        var changed = false;
+        dimensionFilter.SetSelectedValues([dimensionFilter.Values.Single(v => v.Text == "POST")]);
 
-        var cut = RenderChartFilters(dimensionFilter, _ => changed = true);
-        var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
-
-        Assert.Equal("button", getTag.GetAttribute("role"));
-        Assert.Equal("0", getTag.GetAttribute("tabindex"));
-
-        getTag.KeyDown(new KeyboardEventArgs { Key = "Enter" });
-
-        Assert.True(changed);
-        var selectedValue = Assert.Single(dimensionFilter.SelectedValues);
-        Assert.Equal("GET", selectedValue.Text);
-    }
-
-    [Fact]
-    public void ShiftKeyDown_UnselectedFilterValueTag_AddsValue()
-    {
-        SetupChartFilters();
-        var dimensionFilter = CreateDimensionFilter();
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
         var cut = RenderChartFilters(dimensionFilter);
         var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
 
-        getTag.KeyDown(new KeyboardEventArgs { Key = "Enter", ShiftKey = true });
-
-        Assert.Equal(["GET", "POST"], dimensionFilter.SelectedValues.Select(v => v.Text).Order());
+        Assert.Equal("BUTTON", getTag.TagName);
+        Assert.Equal("button", getTag.GetAttribute("type"));
     }
 
     [Fact]
@@ -132,7 +110,7 @@ public class ChartFiltersTests : DashboardTestContext
     {
         SetupChartFilters();
         var dimensionFilter = CreateDimensionFilter();
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
+        dimensionFilter.SetSelectedValues([dimensionFilter.Values.Single(v => v.Text == "POST")]);
         var cut = RenderChartFilters(dimensionFilter);
         var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
 
@@ -147,7 +125,7 @@ public class ChartFiltersTests : DashboardTestContext
     {
         SetupChartFilters();
         var dimensionFilter = CreateDimensionFilter();
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
+        dimensionFilter.SetSelectedValues([dimensionFilter.Values.Single(v => v.Text == "POST")]);
         var cut = RenderChartFilters(dimensionFilter);
         var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
 
@@ -161,8 +139,7 @@ public class ChartFiltersTests : DashboardTestContext
     {
         SetupChartFilters();
         var dimensionFilter = CreateDimensionFilter();
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "GET"));
-        dimensionFilter.SelectedValues.Add(dimensionFilter.Values.Single(v => v.Text == "POST"));
+        dimensionFilter.SetSelectedValues(dimensionFilter.Values);
         var cut = RenderChartFilters(dimensionFilter);
         var getTag = cut.FindAll(".filter-value-tag").Single(e => e.TextContent.Trim() == "GET");
 


### PR DESCRIPTION
## Description

Clicking a metric dimension label now selects only that label, making it possible to focus a chart on one value without deselecting every other value. Holding Shift while clicking retains the existing toggle behavior so multiple values can be selected or removed individually.

Keyboard activation has the same behavior: Enter or Space selects only the focused label, while Shift+Enter or Shift+Space toggles it. Mouse and keyboard activation share the same selection logic.

### User-facing usage

- Click a metric dimension label to show only that value.
- Shift+click labels to add or remove values from the current selection.
- Use Enter/Space and Shift+Enter/Shift+Space for the equivalent keyboard interactions.

### Validation

- `dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (1,514 passed)
- `dotnet test --project tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj --no-launch-profile -- --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (206 passed)

Fixes #19046

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
