### PR TITLE
Pin AKS credential pipeline to the deployment subscription

### DIFF
--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -639,17 +639,19 @@ public partial class AzureKubernetesEnvironmentResource
     /// null result from a provider. Falling back to the app's own subscription in that case would
     /// be worse than failing: provisioning would have thrown, while the credential fetch would
     /// quietly target the wrong scope and could adopt a same-named cluster there. Empty is rejected
-    /// for the same reason, since it would be dropped by the string.IsNullOrEmpty checks downstream.
+    /// for the same reason, since the string.IsNullOrEmpty checks downstream would treat it as
+    /// unpinned. Nothing upstream rejects empty (the scope constructors and
+    /// <c>AsExistingInResourceGroup</c> only guard against null), so a literal is checked too.
     /// </remarks>
     internal static async Task<string?> ResolveScopeValueAsync(object? value, CancellationToken cancellationToken)
         => value switch
         {
             null => null,
-            string s => s,
-            IValueProvider provider =>
-                await provider.GetValueAsync(cancellationToken).ConfigureAwait(false) is { Length: > 0 } resolved
-                    ? resolved
-                    : throw new InvalidOperationException("The Azure resource scope value cannot be null or empty."),
+            string { Length: > 0 } s => s,
+            IValueProvider provider when
+                await provider.GetValueAsync(cancellationToken).ConfigureAwait(false) is { Length: > 0 } resolved => resolved,
+            string or IValueProvider => throw new InvalidOperationException(
+                "The Azure resource scope value cannot be null or empty."),
             _ => throw new NotSupportedException(
                 $"The Azure scope value type {value.GetType()} is not supported.")
         };

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -229,7 +229,14 @@ public partial class AzureKubernetesEnvironmentResource
                 // contain only expected characters (alphanumeric, hyphens, underscores, dots).
                 ValidateAzureResourceName(clusterName, "cluster name");
 
-                var (subscriptionId, savedResourceGroup) = await GetAzureDeploymentContextAsync(
+                // Resolve the scope this cluster actually lives in before touching the CLI. A cluster
+                // adopted via AsExistingInResourceGroup(...) can sit outside the app's own
+                // subscription/resource group, and the provisioner already targets that scope.
+                var (scopedSubscription, scopedResourceGroup) = GetExplicitScopeValues();
+
+                var (subscriptionId, savedResourceGroup) = await ResolveDeploymentScopeAsync(
+                    scopedSubscription,
+                    scopedResourceGroup,
                     context.Services,
                     context.CancellationToken).ConfigureAwait(false);
 
@@ -559,9 +566,48 @@ public partial class AzureKubernetesEnvironmentResource
     }
 
     /// <summary>
+    /// Gets the subscription and resource group this resource explicitly targets, if any.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ExistingAzureResourceAnnotation"/> is what <c>AsExistingInResourceGroup</c> and
+    /// friends attach, and it is the same annotation the provisioner turns into the deployment
+    /// scope. Values are returned unresolved because they may be a literal string, a
+    /// <see cref="ParameterResource"/>, or a <see cref="BicepOutputReference"/>.
+    /// </remarks>
+    private (object? Subscription, object? ResourceGroup) GetExplicitScopeValues()
+    {
+        // A tenant-scoped resource pins neither value, so fall through to the deployment state.
+        if (this.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existing) && !existing.IsTenantScope)
+        {
+            return (existing.Subscription, existing.ResourceGroup);
+        }
+
+        return (null, null);
+    }
+
+    /// <summary>
     /// Gets the current Azure subscription and resource group from deployment state.
     /// </summary>
     internal static async Task<(string SubscriptionId, string? ResourceGroup)> GetAzureDeploymentContextAsync(
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+    {
+        var (subscriptionId, resourceGroup) = await TryGetAzureDeploymentStateAsync(services, cancellationToken).ConfigureAwait(false);
+
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            throw new InvalidOperationException(
+                "Could not resolve the Azure subscription selected for deployment. " +
+                "Ensure Azure provisioning has completed, or set the Azure:SubscriptionId configuration value.");
+        }
+
+        return (subscriptionId, resourceGroup);
+    }
+
+    /// <summary>
+    /// Reads the global Azure deployment state without requiring a subscription to be present.
+    /// </summary>
+    internal static async Task<(string? SubscriptionId, string? ResourceGroup)> TryGetAzureDeploymentStateAsync(
         IServiceProvider services,
         CancellationToken cancellationToken)
     {
@@ -571,7 +617,60 @@ public partial class AzureKubernetesEnvironmentResource
         // Use ToString() rather than GetValue<string>() to match how AzureEnvironmentResource reads
         // these same keys, and because GetValue<string>() throws if hand-edited state stores a
         // non-string JSON value.
-        var subscriptionId = azureState.Data["SubscriptionId"]?.ToString();
+        return (azureState.Data["SubscriptionId"]?.ToString(), azureState.Data["ResourceGroup"]?.ToString());
+    }
+
+    /// <summary>
+    /// Resolves a scope value that may be a literal string or a deferred value such as a
+    /// <see cref="ParameterResource"/> or a <see cref="BicepOutputReference"/>.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors how <c>BicepUtilities</c> materializes scope values when emitting the deployment
+    /// scope, so the credential fetch resolves the same way the provisioner does.
+    /// </remarks>
+    internal static async Task<string?> ResolveScopeValueAsync(object? value, CancellationToken cancellationToken)
+        => value switch
+        {
+            null => null,
+            string s => s,
+            IValueProvider provider => await provider.GetValueAsync(cancellationToken).ConfigureAwait(false),
+            _ => throw new NotSupportedException(
+                $"The Azure scope value type {value.GetType()} is not supported.")
+        };
+
+    /// <summary>
+    /// Resolves the subscription and resource group that this AKS cluster actually lives in.
+    /// </summary>
+    /// <remarks>
+    /// A cluster adopted with <c>AsExistingInResourceGroup(...)</c> can sit in a different
+    /// subscription and resource group than the one Aspire deploys the rest of the app into, and the
+    /// provisioner targets that per-resource scope. The Azure CLI calls here have to agree with it,
+    /// otherwise we would authenticate against the wrong subscription and could even find a
+    /// same-named cluster in the wrong place. Values the resource does not pin fall back to the
+    /// global deployment state.
+    /// </remarks>
+    internal static async Task<(string SubscriptionId, string? ResourceGroup)> ResolveDeploymentScopeAsync(
+        object? scopedSubscription,
+        object? scopedResourceGroup,
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+    {
+        var subscriptionId = await ResolveScopeValueAsync(scopedSubscription, cancellationToken).ConfigureAwait(false);
+        var resourceGroup = await ResolveScopeValueAsync(scopedResourceGroup, cancellationToken).ConfigureAwait(false);
+
+        // Fully pinned by the resource, so the global deployment state is irrelevant and must not be
+        // required. This matters because the app's own subscription may legitimately be absent when
+        // every Azure resource is an adopted existing one.
+        if (!string.IsNullOrEmpty(subscriptionId) && !string.IsNullOrEmpty(resourceGroup))
+        {
+            return (subscriptionId, resourceGroup);
+        }
+
+        var (globalSubscriptionId, globalResourceGroup) =
+            await TryGetAzureDeploymentStateAsync(services, cancellationToken).ConfigureAwait(false);
+
+        var pinnedSubscription = !string.IsNullOrEmpty(subscriptionId);
+        subscriptionId = pinnedSubscription ? subscriptionId : globalSubscriptionId;
 
         if (string.IsNullOrEmpty(subscriptionId))
         {
@@ -580,7 +679,16 @@ public partial class AzureKubernetesEnvironmentResource
                 "Ensure Azure provisioning has completed, or set the Azure:SubscriptionId configuration value.");
         }
 
-        var resourceGroup = azureState.Data["ResourceGroup"]?.ToString();
+        if (string.IsNullOrEmpty(resourceGroup))
+        {
+            // The saved resource group only names a group inside the saved subscription. Inheriting it
+            // across a subscription boundary would point at a group that may not exist there, or worse
+            // at an unrelated group that happens to share the name, so force discovery instead.
+            resourceGroup = pinnedSubscription && !string.Equals(subscriptionId, globalSubscriptionId, StringComparison.OrdinalIgnoreCase)
+                ? null
+                : globalResourceGroup;
+        }
+
         return (subscriptionId, resourceGroup);
     }
 

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -296,10 +296,14 @@ public partial class AzureKubernetesEnvironmentResource
                     "☸ AKS Cluster",
                     new MarkdownString($"**{clusterName}** in resource group **{resourceGroup}**"));
 
+                // Quote the values: ValidateAzureResourceName permits parentheses in resource group
+                // names, and an unquoted `team(prod)` is a syntax error in bash and zsh. This hint is
+                // advertised as copy-pasteable, so it has to survive the same names the real
+                // invocation built by BuildGetCredentialsArguments already handles.
                 context.Summary.Add(
                     "🔑 Connect to cluster",
                     new MarkdownString(
-                        $"`az aks get-credentials --resource-group {resourceGroup} --name {clusterName} --subscription {subscriptionId}`"));
+                        $"`az aks get-credentials --resource-group '{resourceGroup}' --name '{clusterName}' --subscription {subscriptionId}`"));
 
                 await getCredsTask.SucceedAsync(
                     $"AKS credentials fetched for cluster {clusterName}",
@@ -596,25 +600,6 @@ public partial class AzureKubernetesEnvironmentResource
     }
 
     /// <summary>
-    /// Gets the current Azure subscription and resource group from deployment state.
-    /// </summary>
-    internal static async Task<(string SubscriptionId, string? ResourceGroup)> GetAzureDeploymentContextAsync(
-        IServiceProvider services,
-        CancellationToken cancellationToken)
-    {
-        var (subscriptionId, resourceGroup) = await TryGetAzureDeploymentStateAsync(services, cancellationToken).ConfigureAwait(false);
-
-        if (string.IsNullOrEmpty(subscriptionId))
-        {
-            throw new InvalidOperationException(
-                "Could not resolve the Azure subscription selected for deployment. " +
-                "Ensure Azure provisioning has completed, or set the Azure:SubscriptionId configuration value.");
-        }
-
-        return (subscriptionId, resourceGroup);
-    }
-
-    /// <summary>
     /// Reads the global Azure deployment state without requiring a subscription to be present.
     /// </summary>
     internal static async Task<(string? SubscriptionId, string? ResourceGroup)> TryGetAzureDeploymentStateAsync(
@@ -711,11 +696,21 @@ public partial class AzureKubernetesEnvironmentResource
     }
 
     /// <summary>
-    /// Gets the resource group, trying deployment state first, falling back to an Azure CLI query.
+    /// Gets the resource group the cluster lives in, preferring an already-resolved one and falling
+    /// back to an Azure CLI query.
     /// </summary>
     /// <remarks>
+    /// <paramref name="savedResourceGroup"/> is the resource group from the resolved deployment
+    /// scope, which may have come from <c>AzureBicepResource.Scope</c> or an
+    /// <c>ExistingAzureResourceAnnotation</c> rather than from deployment state. It is null when the
+    /// resource group is genuinely unknown: either deployment state predates it being recorded, or
+    /// <see cref="ResolveDeploymentScopeAsync"/> deliberately dropped it because the resource pins a
+    /// different subscription than the app deploys into, where the saved name would be meaningless
+    /// or, worse, match an unrelated group.
+    /// <para>
     /// <paramref name="runAzCommandAsync"/> is injected so tests can verify that the Azure CLI
-    /// fallback is scoped to the deployment subscription without invoking the real az CLI.
+    /// fallback is scoped to the resolved subscription without invoking the real az CLI.
+    /// </para>
     /// </remarks>
     internal static async Task<string> GetResourceGroupAsync(
         string azPath,
@@ -730,8 +725,8 @@ public partial class AzureKubernetesEnvironmentResource
             return savedResourceGroup;
         }
 
-        // Older or incomplete deployment state may not contain the resource group. Keep the
-        // Azure query scoped to the subscription selected by Aspire rather than the CLI default.
+        // Keep the query scoped to the resolved subscription rather than the CLI default, otherwise
+        // a same-named cluster in the ambient subscription could be picked up instead.
         logger.LogDebug(
             "Resource group not in deployment state, querying Azure for cluster '{ClusterName}'",
             clusterName);

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -569,14 +569,24 @@ public partial class AzureKubernetesEnvironmentResource
     /// Gets the subscription and resource group this resource explicitly targets, if any.
     /// </summary>
     /// <remarks>
-    /// <see cref="ExistingAzureResourceAnnotation"/> is what <c>AsExistingInResourceGroup</c> and
-    /// friends attach, and it is the same annotation the provisioner turns into the deployment
-    /// scope. Values are returned unresolved because they may be a literal string, a
+    /// Mirrors the precedence in <c>BicepUtilities.GetExistingResourceScope</c>: an explicitly
+    /// assigned <see cref="AzureBicepResource.Scope"/> (which <c>ConfigureInfrastructure</c> can set)
+    /// wins over the <see cref="ExistingAzureResourceAnnotation"/> that <c>AsExistingInResourceGroup</c>
+    /// and friends attach. The credential fetch has to agree with whatever the provisioner deployed
+    /// against. Values are returned unresolved because they may be a literal string, a
     /// <see cref="ParameterResource"/>, or a <see cref="BicepOutputReference"/>.
     /// </remarks>
     private (object? Subscription, object? ResourceGroup) GetExplicitScopeValues()
     {
-        // A tenant-scoped resource pins neither value, so fall through to the deployment state.
+        if (Scope is not null)
+        {
+            // A tenant-scoped resource pins neither value. HasResourceGroup must be checked first
+            // because the ResourceGroup getter throws for subscription- and tenant-scoped resources.
+            return Scope.IsTenantScope
+                ? (null, null)
+                : (Scope.Subscription, Scope.HasResourceGroup ? Scope.ResourceGroup : null);
+        }
+
         if (this.TryGetLastAnnotation<ExistingAzureResourceAnnotation>(out var existing) && !existing.IsTenantScope)
         {
             return (existing.Subscription, existing.ResourceGroup);
@@ -625,15 +635,21 @@ public partial class AzureKubernetesEnvironmentResource
     /// <see cref="ParameterResource"/> or a <see cref="BicepOutputReference"/>.
     /// </summary>
     /// <remarks>
-    /// Mirrors how <c>BicepUtilities</c> materializes scope values when emitting the deployment
-    /// scope, so the credential fetch resolves the same way the provisioner does.
+    /// Matches <c>BicepProvisioner.ResolveScopeValueAsync</c>, including its refusal to accept a
+    /// null result from a provider. Falling back to the app's own subscription in that case would
+    /// be worse than failing: provisioning would have thrown, while the credential fetch would
+    /// quietly target the wrong scope and could adopt a same-named cluster there. Empty is rejected
+    /// for the same reason, since it would be dropped by the string.IsNullOrEmpty checks downstream.
     /// </remarks>
     internal static async Task<string?> ResolveScopeValueAsync(object? value, CancellationToken cancellationToken)
         => value switch
         {
             null => null,
             string s => s,
-            IValueProvider provider => await provider.GetValueAsync(cancellationToken).ConfigureAwait(false),
+            IValueProvider provider =>
+                await provider.GetValueAsync(cancellationToken).ConfigureAwait(false) is { Length: > 0 } resolved
+                    ? resolved
+                    : throw new InvalidOperationException("The Azure resource scope value cannot be null or empty."),
             _ => throw new NotSupportedException(
                 $"The Azure scope value type {value.GetType()} is not supported.")
         };

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -23,6 +23,14 @@ namespace Aspire.Hosting.Azure.Kubernetes;
 /// </summary>
 public partial class AzureKubernetesEnvironmentResource
 {
+    // Test seams. These let tests execute the registered aks-get-credentials-{name} pipeline
+    // step end-to-end without the Azure CLI on PATH and without spawning a process, so the
+    // assertions cover the call site rather than only the helpers it delegates to. Asserting
+    // on the helpers alone would let the original wrong-subscription bug be reintroduced here
+    // undetected, which is precisely how #19216 shipped.
+    internal Func<string>? AzCliPathResolverForTesting { get; set; }
+    internal Func<string, string, ILogger, Task<AzCommandResult>>? AzCommandRunnerForTesting { get; set; }
+
     /// <summary>
     /// Per-environment AKS preparation work invoked by the <c>prepare-aks-{name}</c> pipeline
     /// step. Ensures a default user node pool exists and applies node-pool affinity and
@@ -215,7 +223,7 @@ public partial class AzureKubernetesEnvironmentResource
                 var clusterName = await NameOutputReference.GetValueAsync(context.CancellationToken).ConfigureAwait(false)
                     ?? Name;
 
-                var azPath = FindAzCli();
+                var azPath = (AzCliPathResolverForTesting ?? FindAzCli)();
 
                 // Defense-in-depth: validate that values used as CLI arguments
                 // contain only expected characters (alphanumeric, hyphens, underscores, dots).
@@ -228,7 +236,7 @@ public partial class AzureKubernetesEnvironmentResource
                 ValidateAzureResourceName(subscriptionId, "subscription ID");
 
                 Task<AzCommandResult> RunAzAsync(string path, string arguments)
-                    => RunAzCommandAsync(path, arguments, context.Logger);
+                    => (AzCommandRunnerForTesting ?? RunAzCommandAsync)(path, arguments, context.Logger);
 
                 var resourceGroup = await GetResourceGroupAsync(
                     azPath,

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -741,16 +741,31 @@ public partial class AzureKubernetesEnvironmentResource
                 $"az resource list failed (exit code {result.ExitCode}): {result.StandardError}");
         }
 
-        var resourceGroup = result.StandardOutput.Trim().ReplaceLineEndings("").Trim();
+        // With '-o tsv' the query emits one resource group per matching cluster, newline separated:
+        //   my-rg
+        //   other-rg
+        // A cluster name is only unique within a resource group, not within a subscription, so the
+        // query can legitimately return several rows. Picking one would silently deploy into, and
+        // hand back credentials for, an unrelated cluster.
+        var resourceGroups = result.StandardOutput
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        if (string.IsNullOrEmpty(resourceGroup))
+        if (resourceGroups.Length == 0)
         {
             throw new InvalidOperationException(
                 $"Could not resolve resource group for AKS cluster '{clusterName}'. " +
                 "Ensure Azure provisioning has completed.");
         }
 
-        return resourceGroup;
+        if (resourceGroups.Length > 1)
+        {
+            throw new InvalidOperationException(
+                $"Found {resourceGroups.Length} AKS clusters named '{clusterName}' in subscription " +
+                $"'{subscriptionId}' (resource groups: {string.Join(", ", resourceGroups)}). " +
+                "Specify which one to use by calling AsExistingInResourceGroup on the resource.");
+        }
+
+        return resourceGroups[0];
     }
 
     /// <summary>
@@ -787,7 +802,7 @@ public partial class AzureKubernetesEnvironmentResource
         => $"aks get-credentials --resource-group \"{resourceGroup}\" --name \"{clusterName}\" --file - --subscription \"{subscriptionId}\"";
 
     internal static string BuildResourceGroupQueryArguments(string subscriptionId, string clusterName)
-        => $"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"{clusterName}\" --query [0].resourceGroup -o tsv --subscription \"{subscriptionId}\"";
+        => $"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"{clusterName}\" --query [].resourceGroup -o tsv --subscription \"{subscriptionId}\"";
 
     /// <summary>
     /// Runs an az CLI command using the shared ProcessSpec/ProcessUtil infrastructure.

--- a/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
+++ b/src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesEnvironmentResource.AksPipeline.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #pragma warning disable ASPIREPIPELINES001 // Pipeline step types used for push/deploy dependency wiring
+#pragma warning disable ASPIREPIPELINES002 // IDeploymentStateManager is experimental
 #pragma warning disable ASPIREAZURE001 // AzureEnvironmentResource.ProvisionInfrastructureStepName for pipeline ordering
 #pragma warning disable ASPIREFILESYSTEM001 // IFileSystemService/TempDirectory are experimental
 
@@ -12,7 +13,6 @@ using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Kubernetes;
 using Aspire.Hosting.Kubernetes.Resources;
 using Aspire.Hosting.Pipelines;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -221,7 +221,22 @@ public partial class AzureKubernetesEnvironmentResource
                 // contain only expected characters (alphanumeric, hyphens, underscores, dots).
                 ValidateAzureResourceName(clusterName, "cluster name");
 
-                var resourceGroup = await GetResourceGroupAsync(azPath, clusterName, context)
+                var (subscriptionId, savedResourceGroup) = await GetAzureDeploymentContextAsync(
+                    context.Services,
+                    context.CancellationToken).ConfigureAwait(false);
+
+                ValidateAzureResourceName(subscriptionId, "subscription ID");
+
+                Task<AzCommandResult> RunAzAsync(string path, string arguments)
+                    => RunAzCommandAsync(path, arguments, context.Logger);
+
+                var resourceGroup = await GetResourceGroupAsync(
+                    azPath,
+                    clusterName,
+                    subscriptionId,
+                    savedResourceGroup,
+                    context.Logger,
+                    RunAzAsync)
                     .ConfigureAwait(false);
 
                 ValidateAzureResourceName(resourceGroup, "resource group");
@@ -237,20 +252,16 @@ public partial class AzureKubernetesEnvironmentResource
                     "Fetching AKS credentials: cluster={ClusterName}, resourceGroup={ResourceGroup}",
                     clusterName, resourceGroup);
 
-                var result = await RunAzCommandAsync(
+                var kubeConfigContent = await FetchKubeConfigAsync(
                     azPath,
-                    $"aks get-credentials --resource-group \"{resourceGroup}\" --name \"{clusterName}\" --file -",
-                    context.Logger).ConfigureAwait(false);
-
-                if (result.ExitCode != 0)
-                {
-                    throw new InvalidOperationException(
-                        $"az aks get-credentials failed (exit code {result.ExitCode}): {result.StandardError}");
-                }
+                    subscriptionId,
+                    resourceGroup,
+                    clusterName,
+                    RunAzAsync).ConfigureAwait(false);
 
                 // Write kubeconfig content to a temp file we control.
                 // The IFileSystemService temp directory is auto-cleaned on dispose.
-                await File.WriteAllTextAsync(kubeConfigPath, result.StandardOutput, context.CancellationToken).ConfigureAwait(false);
+                await File.WriteAllTextAsync(kubeConfigPath, kubeConfigContent, context.CancellationToken).ConfigureAwait(false);
 
                 // On Unix, restrict file permissions to owner-only (0600)
                 if (!OperatingSystem.IsWindows())
@@ -272,7 +283,8 @@ public partial class AzureKubernetesEnvironmentResource
 
                 context.Summary.Add(
                     "🔑 Connect to cluster",
-                    new MarkdownString($"`az aks get-credentials --resource-group {resourceGroup} --name {clusterName}`"));
+                    new MarkdownString(
+                        $"`az aks get-credentials --resource-group {resourceGroup} --name {clusterName} --subscription {subscriptionId}`"));
 
                 await getCredsTask.SucceedAsync(
                     $"AKS credentials fetched for cluster {clusterName}",
@@ -539,33 +551,60 @@ public partial class AzureKubernetesEnvironmentResource
     }
 
     /// <summary>
-    /// Gets the resource group, trying deployment state first, falling back to az CLI query.
-    /// On first deploy, the deployment state may not be loaded into IConfiguration yet
-    /// because it's written during the pipeline run (after create-provisioning-context).
+    /// Gets the current Azure subscription and resource group from deployment state.
     /// </summary>
-    private static async Task<string> GetResourceGroupAsync(
-        string azPath,
-        string clusterName,
-        PipelineStepContext context)
+    internal static async Task<(string SubscriptionId, string? ResourceGroup)> GetAzureDeploymentContextAsync(
+        IServiceProvider services,
+        CancellationToken cancellationToken)
     {
-        // Try deployment state first (works on re-deploys)
-        var configuration = context.Services.GetRequiredService<IConfiguration>();
-        var resourceGroup = configuration["Azure:ResourceGroup"];
+        var deploymentStateManager = services.GetRequiredService<IDeploymentStateManager>();
+        var azureState = await deploymentStateManager.AcquireSectionAsync("Azure", cancellationToken).ConfigureAwait(false);
 
-        if (!string.IsNullOrEmpty(resourceGroup))
+        // Use ToString() rather than GetValue<string>() to match how AzureEnvironmentResource reads
+        // these same keys, and because GetValue<string>() throws if hand-edited state stores a
+        // non-string JSON value.
+        var subscriptionId = azureState.Data["SubscriptionId"]?.ToString();
+
+        if (string.IsNullOrEmpty(subscriptionId))
         {
-            return resourceGroup;
+            throw new InvalidOperationException(
+                "Could not resolve the Azure subscription selected for deployment. " +
+                "Ensure Azure provisioning has completed, or set the Azure:SubscriptionId configuration value.");
         }
 
-        // Fallback for first deploy: query Azure directly
-        context.Logger.LogDebug(
+        var resourceGroup = azureState.Data["ResourceGroup"]?.ToString();
+        return (subscriptionId, resourceGroup);
+    }
+
+    /// <summary>
+    /// Gets the resource group, trying deployment state first, falling back to an Azure CLI query.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="runAzCommandAsync"/> is injected so tests can verify that the Azure CLI
+    /// fallback is scoped to the deployment subscription without invoking the real az CLI.
+    /// </remarks>
+    internal static async Task<string> GetResourceGroupAsync(
+        string azPath,
+        string clusterName,
+        string subscriptionId,
+        string? savedResourceGroup,
+        ILogger logger,
+        Func<string, string, Task<AzCommandResult>> runAzCommandAsync)
+    {
+        if (!string.IsNullOrEmpty(savedResourceGroup))
+        {
+            return savedResourceGroup;
+        }
+
+        // Older or incomplete deployment state may not contain the resource group. Keep the
+        // Azure query scoped to the subscription selected by Aspire rather than the CLI default.
+        logger.LogDebug(
             "Resource group not in deployment state, querying Azure for cluster '{ClusterName}'",
             clusterName);
 
-        var result = await RunAzCommandAsync(
+        var result = await runAzCommandAsync(
             azPath,
-            $"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"{clusterName}\" --query [0].resourceGroup -o tsv",
-            context.Logger).ConfigureAwait(false);
+            BuildResourceGroupQueryArguments(subscriptionId, clusterName)).ConfigureAwait(false);
 
         if (result.ExitCode != 0)
         {
@@ -573,7 +612,7 @@ public partial class AzureKubernetesEnvironmentResource
                 $"az resource list failed (exit code {result.ExitCode}): {result.StandardError}");
         }
 
-        resourceGroup = result.StandardOutput.Trim().ReplaceLineEndings("").Trim();
+        var resourceGroup = result.StandardOutput.Trim().ReplaceLineEndings("").Trim();
 
         if (string.IsNullOrEmpty(resourceGroup))
         {
@@ -584,6 +623,42 @@ public partial class AzureKubernetesEnvironmentResource
 
         return resourceGroup;
     }
+
+    /// <summary>
+    /// Fetches the kubeconfig content for the cluster from the Azure CLI.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="runAzCommandAsync"/> is injected so tests can verify that the credential
+    /// fetch is scoped to the deployment subscription without invoking the real az CLI.
+    /// </remarks>
+    internal static async Task<string> FetchKubeConfigAsync(
+        string azPath,
+        string subscriptionId,
+        string resourceGroup,
+        string clusterName,
+        Func<string, string, Task<AzCommandResult>> runAzCommandAsync)
+    {
+        var result = await runAzCommandAsync(
+            azPath,
+            BuildGetCredentialsArguments(subscriptionId, resourceGroup, clusterName)).ConfigureAwait(false);
+
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"az aks get-credentials failed (exit code {result.ExitCode}): {result.StandardError}");
+        }
+
+        return result.StandardOutput;
+    }
+
+    internal static string BuildGetCredentialsArguments(
+        string subscriptionId,
+        string resourceGroup,
+        string clusterName)
+        => $"aks get-credentials --resource-group \"{resourceGroup}\" --name \"{clusterName}\" --file - --subscription \"{subscriptionId}\"";
+
+    internal static string BuildResourceGroupQueryArguments(string subscriptionId, string clusterName)
+        => $"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"{clusterName}\" --query [0].resourceGroup -o tsv --subscription \"{subscriptionId}\"";
 
     /// <summary>
     /// Runs an az CLI command using the shared ProcessSpec/ProcessUtil infrastructure.
@@ -620,7 +695,7 @@ public partial class AzureKubernetesEnvironmentResource
         }
     }
 
-    private sealed record AzCommandResult(int ExitCode, string StandardOutput, string StandardError);
+    internal sealed record AzCommandResult(int ExitCode, string StandardOutput, string StandardError);
 
     /// <summary>
     /// Validates that an Azure resource name contains only expected characters.

--- a/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceScope.cs
@@ -92,7 +92,14 @@ public sealed class AzureBicepResourceScope
     /// </summary>
     public bool IsTenantScope { get; }
 
-    internal bool HasResourceGroup => _resourceGroup is not null;
+    /// <summary>
+    /// Gets a value indicating whether the scope targets a resource group.
+    /// </summary>
+    /// <remarks>
+    /// Use this to test the scope before reading <see cref="ResourceGroup"/>, which throws for
+    /// subscription- and tenant-scoped resources.
+    /// </remarks>
+    public bool HasResourceGroup => _resourceGroup is not null;
 
     internal static AzureBicepResourceScope? FromExistingResourceAnnotation(ExistingAzureResourceAnnotation annotation)
     {

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Aspire.Hosting.Azure.Kubernetes.Tests.csproj
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/Aspire.Hosting.Azure.Kubernetes.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)\TestModuleInitializer.cs" />
     <Compile Include="$(TestsSharedDir)\TestPipelineActivityReporter.cs" />
+    <Compile Include="$(TestsSharedDir)\InMemoryDeploymentStateManager.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -288,8 +288,49 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
 
         Assert.Equal("queried-rg", resourceGroup);
         Assert.Equal(
-            [$"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"deployment-aks\" --query [0].resourceGroup -o tsv --subscription \"{subscriptionId}\""],
+            [$"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"deployment-aks\" --query [].resourceGroup -o tsv --subscription \"{subscriptionId}\""],
             invocations);
+    }
+
+    [Fact]
+    public async Task GetResourceGroupThrowsWhenClusterNameIsAmbiguous()
+    {
+        const string subscriptionId = "00000000-0000-0000-0000-000000000001";
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureKubernetesEnvironmentResource.GetResourceGroupAsync(
+                "/usr/bin/az",
+                "deployment-aks",
+                subscriptionId,
+                savedResourceGroup: null,
+                NullLogger.Instance,
+                (path, arguments) => Task.FromResult(
+                    new AzureKubernetesEnvironmentResource.AzCommandResult(0, "first-rg\nsecond-rg\n", ""))));
+
+        Assert.Equal(
+            $"Found 2 AKS clusters named 'deployment-aks' in subscription '{subscriptionId}' " +
+            "(resource groups: first-rg, second-rg). Specify which one to use by calling " +
+            "AsExistingInResourceGroup on the resource.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task GetResourceGroupThrowsWhenClusterIsNotFound()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureKubernetesEnvironmentResource.GetResourceGroupAsync(
+                "/usr/bin/az",
+                "deployment-aks",
+                "00000000-0000-0000-0000-000000000001",
+                savedResourceGroup: null,
+                NullLogger.Instance,
+                (path, arguments) => Task.FromResult(
+                    new AzureKubernetesEnvironmentResource.AzCommandResult(0, "\n", ""))));
+
+        Assert.Equal(
+            "Could not resolve resource group for AKS cluster 'deployment-aks'. " +
+            "Ensure Azure provisioning has completed.",
+            exception.Message);
     }
 
     [Fact]
@@ -409,7 +450,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
         // guard the call site: reverting either call to an unscoped invocation fails here.
         Assert.Equal(
             [
-                $"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"{clusterName}\" --query [0].resourceGroup -o tsv --subscription \"{subscriptionId}\"",
+                $"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"{clusterName}\" --query [].resourceGroup -o tsv --subscription \"{subscriptionId}\"",
                 $"aks get-credentials --resource-group \"queried-rg\" --name \"{clusterName}\" --file - --subscription \"{subscriptionId}\""
             ],
             invocations);

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -326,4 +326,99 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
             "az aks get-credentials failed (exit code 1): subscription not found",
             exception.Message);
     }
+
+    [Fact]
+    public async Task GetCredentialsStepScopesEveryAzureCliCallToDeploymentSubscription()
+    {
+        const string subscriptionId = "00000000-0000-0000-0000-000000000001";
+        const string clusterName = "provisioned-aks";
+
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish);
+
+        var deploymentStateManager = new InMemoryDeploymentStateManager();
+        deploymentStateManager.SetSection("Azure", new JsonObject
+        {
+            ["SubscriptionId"] = subscriptionId
+        });
+        builder.Services.AddSingleton<IDeploymentStateManager>(deploymentStateManager);
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        // The provisioned cluster name comes from a Bicep output, and no resource group is
+        // saved in deployment state, so the step must fall back to the az resource list query.
+        aks.Resource.Outputs["name"] = clusterName;
+
+        var invocations = new List<string>();
+        aks.Resource.AzCliPathResolverForTesting = () => "/usr/bin/az";
+        aks.Resource.AzCommandRunnerForTesting = (path, arguments, logger) =>
+        {
+            invocations.Add(arguments);
+
+            // The resource-group query runs first and returns the group the cluster lives in;
+            // the get-credentials call that follows returns kubeconfig content.
+            return Task.FromResult(arguments.StartsWith("resource list", StringComparison.Ordinal)
+                ? new AzureKubernetesEnvironmentResource.AzCommandResult(0, "queried-rg\n", "")
+                : new AzureKubernetesEnvironmentResource.AzCommandResult(0, "kubeconfig-content", ""));
+        };
+
+        await using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var pipelineContext = new PipelineContext(
+            model,
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        // The resource carries several PipelineStepAnnotations (the base provisioning resource
+        // contributes its own), so collect every step and select the one under test by name.
+        var steps = new List<PipelineStep>();
+        foreach (var annotation in aks.Resource.Annotations.OfType<PipelineStepAnnotation>())
+        {
+            steps.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = aks.Resource
+            }));
+        }
+
+        var getCredentialsStep = Assert.Single(steps, step => step.Name == "aks-get-credentials-aks");
+
+        // BicepOutputReference.GetValueAsync awaits this source before reading Outputs, so the
+        // step would block forever without it. Provisioning normally completes it, and nothing
+        // provisions here. It must be signalled after step creation because the base resource's
+        // PipelineStepAnnotation assigns a fresh, incomplete source each time steps are built.
+        aks.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        await using var reportingStep = await new NullPublishingActivityReporter().CreateStepAsync("test");
+        await getCredentialsStep.Action(new PipelineStepContext
+        {
+            PipelineContext = pipelineContext,
+            ReportingStep = reportingStep
+        });
+
+        // Assert on the exact command lines the step issued. This is what makes the test
+        // guard the call site: reverting either call to an unscoped invocation fails here.
+        Assert.Equal(
+            [
+                $"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"{clusterName}\" --query [0].resourceGroup -o tsv --subscription \"{subscriptionId}\"",
+                $"aks get-credentials --resource-group \"queried-rg\" --name \"{clusterName}\" --file - --subscription \"{subscriptionId}\""
+            ],
+            invocations);
+
+        // The copy-paste hint shown to users must carry the subscription too, otherwise it
+        // reproduces the original bug by hand on whatever subscription az defaults to.
+        var connectHint = Assert.Single(
+            pipelineContext.Summary.Items,
+            item => item.Key == "🔑 Connect to cluster");
+        Assert.Equal(
+            $"`az aks get-credentials --resource-group queried-rg --name {clusterName} --subscription {subscriptionId}`",
+            connectHint.Value);
+
+        Assert.Equal(
+            "kubeconfig-content",
+            await File.ReadAllTextAsync(aks.Resource.KubernetesEnvironment.KubeConfigPath!, TestContext.Current.CancellationToken));
+    }
 }

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -595,8 +595,184 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
         Assert.Equal(("sub-from-parameter", "rg-from-parameter"), scope);
     }
 
-    private static ServiceProvider CreateServicesWithAzureState(string subscriptionId, string? resourceGroup)
+    [Fact]
+    public async Task DeploymentScopeThrowsWhenScopeProviderResolvesNull()
     {
+        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+
+        // Provisioning rejects a null scope value outright. Silently substituting the app's own
+        // subscription here would diverge from that and could adopt a same-named cluster elsewhere.
+        var unavailableSubscription = new ParameterResource("sub", _ => null!);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+                unavailableSubscription,
+                scopedResourceGroup: null,
+                services,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("The Azure resource scope value cannot be null or empty.", exception.Message);
+    }
+
+    [Fact]
+    public async Task DeploymentScopeThrowsWhenScopeProviderResolvesEmpty()
+    {
+        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+
+        // An empty value is dropped by the string.IsNullOrEmpty checks downstream, silently
+        // reintroducing the global-scope fallback, so it has to be rejected just like null.
+        var emptyResourceGroup = new ParameterResource("rg", _ => "");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+                scopedSubscription: null,
+                emptyResourceGroup,
+                services,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("The Azure resource scope value cannot be null or empty.", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetCredentialsStepPrefersExplicitScopeOverExistingResourceAnnotation()
+    {
+        const string scopeSubscriptionId = "00000000-0000-0000-0000-000000000003";
+        const string scopeResourceGroup = "scope-assigned-rg";
+        const string clusterName = "scoped-aks";
+
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish);
+
+        var deploymentStateManager = new InMemoryDeploymentStateManager();
+        deploymentStateManager.SetSection("Azure", new JsonObject
+        {
+            ["SubscriptionId"] = "00000000-0000-0000-0000-000000000001",
+            ["ResourceGroup"] = "app-rg"
+        });
+        builder.Services.AddSingleton<IDeploymentStateManager>(deploymentStateManager);
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks")
+            .AsExistingInResourceGroup(clusterName, "annotation-rg", "00000000-0000-0000-0000-000000000002");
+
+        // ConfigureInfrastructure can assign Scope directly, and the provisioner gives it precedence
+        // over the annotation, so the credential fetch has to follow the same precedence.
+        aks.Resource.Scope = new AzureBicepResourceScope(scopeResourceGroup, scopeSubscriptionId);
+        aks.Resource.Outputs["name"] = clusterName;
+
+        var invocations = new List<string>();
+        aks.Resource.AzCliPathResolverForTesting = () => "/usr/bin/az";
+        aks.Resource.AzCommandRunnerForTesting = (path, arguments, logger) =>
+        {
+            invocations.Add(arguments);
+            return Task.FromResult(new AzureKubernetesEnvironmentResource.AzCommandResult(0, "kubeconfig-content", ""));
+        };
+
+        await using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var pipelineContext = new PipelineContext(
+            model,
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        var steps = new List<PipelineStep>();
+        foreach (var annotation in aks.Resource.Annotations.OfType<PipelineStepAnnotation>())
+        {
+            steps.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = aks.Resource
+            }));
+        }
+
+        var getCredentialsStep = Assert.Single(steps, step => step.Name == "aks-get-credentials-aks");
+
+        aks.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        await using var reportingStep = await new NullPublishingActivityReporter().CreateStepAsync("test");
+        await getCredentialsStep.Action(new PipelineStepContext
+        {
+            PipelineContext = pipelineContext,
+            ReportingStep = reportingStep
+        });
+
+        Assert.Equal(
+            [$"aks get-credentials --resource-group \"{scopeResourceGroup}\" --name \"{clusterName}\" --file - --subscription \"{scopeSubscriptionId}\""],
+            invocations);
+    }
+
+    [Fact]
+    public async Task GetCredentialsStepFallsBackToDeploymentStateForSubscriptionScopedResources()
+    {
+        const string subscriptionId = "00000000-0000-0000-0000-000000000001";
+        const string clusterName = "subscription-scoped-aks";
+
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish);
+
+        var deploymentStateManager = new InMemoryDeploymentStateManager();
+        deploymentStateManager.SetSection("Azure", new JsonObject
+        {
+            ["SubscriptionId"] = subscriptionId,
+            ["ResourceGroup"] = "app-rg"
+        });
+        builder.Services.AddSingleton<IDeploymentStateManager>(deploymentStateManager);
+
+        var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+        // A subscription-scoped Scope pins no resource group, and reading AzureBicepResourceScope.ResourceGroup
+        // in that state throws, so the step must fall back rather than fail.
+        aks.Resource.Scope = AzureBicepResourceScope.CreateForSubscription(subscriptionId);
+        aks.Resource.Outputs["name"] = clusterName;
+
+        var invocations = new List<string>();
+        aks.Resource.AzCliPathResolverForTesting = () => "/usr/bin/az";
+        aks.Resource.AzCommandRunnerForTesting = (path, arguments, logger) =>
+        {
+            invocations.Add(arguments);
+            return Task.FromResult(new AzureKubernetesEnvironmentResource.AzCommandResult(0, "kubeconfig-content", ""));
+        };
+
+        await using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var pipelineContext = new PipelineContext(
+            model,
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        var steps = new List<PipelineStep>();
+        foreach (var annotation in aks.Resource.Annotations.OfType<PipelineStepAnnotation>())
+        {
+            steps.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = aks.Resource
+            }));
+        }
+
+        var getCredentialsStep = Assert.Single(steps, step => step.Name == "aks-get-credentials-aks");
+
+        aks.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        await using var reportingStep = await new NullPublishingActivityReporter().CreateStepAsync("test");
+        await getCredentialsStep.Action(new PipelineStepContext
+        {
+            PipelineContext = pipelineContext,
+            ReportingStep = reportingStep
+        });
+
+        // The scope subscription matches deployment state, so the saved resource group still applies.
+        Assert.Equal(
+            [$"aks get-credentials --resource-group \"app-rg\" --name \"{clusterName}\" --file - --subscription \"{subscriptionId}\""],
+            invocations);
+    }
+
+    private static ServiceProvider CreateServicesWithAzureState(string subscriptionId, string? resourceGroup)    {
         var deploymentStateManager = new InMemoryDeploymentStateManager();
         var azureState = new JsonObject { ["SubscriptionId"] = subscriptionId };
 

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -772,6 +772,24 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
             invocations);
     }
 
+    [Fact]
+    public async Task DeploymentScopeThrowsWhenScopeValueIsEmptyString()
+    {
+        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+
+        // Nothing upstream rejects an empty scope string: AsExistingInResourceGroup and the
+        // AzureBicepResourceScope constructors only guard against null. Without this check the
+        // value would be treated as unpinned and silently fall back to the global scope.
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+                scopedSubscription: "",
+                scopedResourceGroup: null,
+                services,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal("The Azure resource scope value cannot be null or empty.", exception.Message);
+    }
+
     private static ServiceProvider CreateServicesWithAzureState(string subscriptionId, string? resourceGroup)    {
         var deploymentStateManager = new InMemoryDeploymentStateManager();
         var azureState = new JsonObject { ["SubscriptionId"] = subscriptionId };

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -196,7 +196,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task AzureDeploymentContextUsesCurrentDeploymentState()
+    public async Task DeploymentScopeUsesCurrentDeploymentState()
     {
         const string subscriptionId = "00000000-0000-0000-0000-000000000001";
         const string resourceGroup = "deployment-rg";
@@ -211,16 +211,19 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
             .AddSingleton<IDeploymentStateManager>(deploymentStateManager)
             .BuildServiceProvider();
 
-        var deploymentContext = await AzureKubernetesEnvironmentResource.GetAzureDeploymentContextAsync(
+        // Nothing is pinned on the resource, so the scope falls back to global deployment state.
+        var deploymentScope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+            scopedSubscription: null,
+            scopedResourceGroup: null,
             services,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(subscriptionId, deploymentContext.SubscriptionId);
-        Assert.Equal(resourceGroup, deploymentContext.ResourceGroup);
+        Assert.Equal(subscriptionId, deploymentScope.SubscriptionId);
+        Assert.Equal(resourceGroup, deploymentScope.ResourceGroup);
     }
 
     [Fact]
-    public async Task AzureDeploymentContextRequiresSubscription()
+    public async Task DeploymentScopeRequiresSubscription()
     {
         var deploymentStateManager = new InMemoryDeploymentStateManager();
         deploymentStateManager.SetSection("Azure", new JsonObject
@@ -233,7 +236,9 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
             .BuildServiceProvider();
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => AzureKubernetesEnvironmentResource.GetAzureDeploymentContextAsync(
+            () => AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+                scopedSubscription: null,
+                scopedResourceGroup: null,
                 services,
                 TestContext.Current.CancellationToken));
 
@@ -390,7 +395,8 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
         // step would block forever without it. Provisioning normally completes it, and nothing
         // provisions here. It must be signalled after step creation because the base resource's
         // PipelineStepAnnotation assigns a fresh, incomplete source each time steps are built.
-        aks.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+        Assert.NotNull(aks.Resource.ProvisioningTaskCompletionSource);
+        aks.Resource.ProvisioningTaskCompletionSource.TrySetResult();
 
         await using var reportingStep = await new NullPublishingActivityReporter().CreateStepAsync("test");
         await getCredentialsStep.Action(new PipelineStepContext
@@ -414,7 +420,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
             pipelineContext.Summary.Items,
             item => item.Key == "🔑 Connect to cluster");
         Assert.Equal(
-            $"`az aks get-credentials --resource-group queried-rg --name {clusterName} --subscription {subscriptionId}`",
+            $"`az aks get-credentials --resource-group 'queried-rg' --name '{clusterName}' --subscription {subscriptionId}`",
             connectHint.Value);
 
         Assert.Equal(
@@ -478,7 +484,8 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
 
         var getCredentialsStep = Assert.Single(steps, step => step.Name == "aks-get-credentials-aks");
 
-        aks.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+        Assert.NotNull(aks.Resource.ProvisioningTaskCompletionSource);
+        aks.Resource.ProvisioningTaskCompletionSource.TrySetResult();
 
         await using var reportingStep = await new NullPublishingActivityReporter().CreateStepAsync("test");
         await getCredentialsStep.Action(new PipelineStepContext
@@ -498,14 +505,14 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
             pipelineContext.Summary.Items,
             item => item.Key == "🔑 Connect to cluster");
         Assert.Equal(
-            $"`az aks get-credentials --resource-group {clusterResourceGroup} --name {clusterName} --subscription {clusterSubscriptionId}`",
+            $"`az aks get-credentials --resource-group '{clusterResourceGroup}' --name '{clusterName}' --subscription {clusterSubscriptionId}`",
             connectHint.Value);
     }
 
     [Fact]
     public async Task DeploymentScopeFallsBackToDeploymentStateWhenResourcePinsNothing()
     {
-        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+        using var services = CreateServicesWithAzureState("sub-global", "rg-global");
 
         var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
             scopedSubscription: null,
@@ -519,7 +526,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
     [Fact]
     public async Task DeploymentScopeKeepsDeploymentResourceGroupWhenResourcePinsSameSubscription()
     {
-        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+        using var services = CreateServicesWithAzureState("sub-global", "rg-global");
 
         var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
             scopedSubscription: "sub-global",
@@ -533,7 +540,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
     [Fact]
     public async Task DeploymentScopeDropsDeploymentResourceGroupWhenResourcePinsAnotherSubscription()
     {
-        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+        using var services = CreateServicesWithAzureState("sub-global", "rg-global");
 
         var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
             scopedSubscription: "sub-other",
@@ -550,7 +557,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
     [Fact]
     public async Task DeploymentScopeUsesDeploymentSubscriptionWhenResourcePinsOnlyResourceGroup()
     {
-        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+        using var services = CreateServicesWithAzureState("sub-global", "rg-global");
 
         var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
             scopedSubscription: null,
@@ -581,7 +588,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
     [Fact]
     public async Task DeploymentScopeResolvesParameterBackedScopeValues()
     {
-        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+        using var services = CreateServicesWithAzureState("sub-global", "rg-global");
 
         var subscriptionParameter = new ParameterResource("sub", _ => "sub-from-parameter");
         var resourceGroupParameter = new ParameterResource("rg", _ => "rg-from-parameter");
@@ -598,7 +605,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
     [Fact]
     public async Task DeploymentScopeThrowsWhenScopeProviderResolvesNull()
     {
-        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+        using var services = CreateServicesWithAzureState("sub-global", "rg-global");
 
         // Provisioning rejects a null scope value outright. Silently substituting the app's own
         // subscription here would diverge from that and could adopt a same-named cluster elsewhere.
@@ -617,7 +624,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
     [Fact]
     public async Task DeploymentScopeThrowsWhenScopeProviderResolvesEmpty()
     {
-        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+        using var services = CreateServicesWithAzureState("sub-global", "rg-global");
 
         // An empty value is dropped by the string.IsNullOrEmpty checks downstream, silently
         // reintroducing the global-scope fallback, so it has to be rejected just like null.
@@ -689,7 +696,8 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
 
         var getCredentialsStep = Assert.Single(steps, step => step.Name == "aks-get-credentials-aks");
 
-        aks.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+        Assert.NotNull(aks.Resource.ProvisioningTaskCompletionSource);
+        aks.Resource.ProvisioningTaskCompletionSource.TrySetResult();
 
         await using var reportingStep = await new NullPublishingActivityReporter().CreateStepAsync("test");
         await getCredentialsStep.Action(new PipelineStepContext
@@ -757,7 +765,8 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
 
         var getCredentialsStep = Assert.Single(steps, step => step.Name == "aks-get-credentials-aks");
 
-        aks.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+        Assert.NotNull(aks.Resource.ProvisioningTaskCompletionSource);
+        aks.Resource.ProvisioningTaskCompletionSource.TrySetResult();
 
         await using var reportingStep = await new NullPublishingActivityReporter().CreateStepAsync("test");
         await getCredentialsStep.Action(new PipelineStepContext
@@ -775,7 +784,7 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
     [Fact]
     public async Task DeploymentScopeThrowsWhenScopeValueIsEmptyString()
     {
-        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+        using var services = CreateServicesWithAzureState("sub-global", "rg-global");
 
         // Nothing upstream rejects an empty scope string: AsExistingInResourceGroup and the
         // AzureBicepResourceScope constructors only guard against null. Without this check the
@@ -790,7 +799,8 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
         Assert.Equal("The Azure resource scope value cannot be null or empty.", exception.Message);
     }
 
-    private static ServiceProvider CreateServicesWithAzureState(string subscriptionId, string? resourceGroup)    {
+    private static ServiceProvider CreateServicesWithAzureState(string subscriptionId, string? resourceGroup)
+    {
         var deploymentStateManager = new InMemoryDeploymentStateManager();
         var azureState = new JsonObject { ["SubscriptionId"] = subscriptionId };
 

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -3,9 +3,11 @@
 
 #pragma warning disable ASPIREAZURE003
 #pragma warning disable ASPIREPIPELINES001
+#pragma warning disable ASPIREPIPELINES002
 #pragma warning disable ASPIREPIPELINES003
 
 using System.Runtime.CompilerServices;
+using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Kubernetes;
 using Aspire.Hosting.Kubernetes;
@@ -14,6 +16,7 @@ using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -190,5 +193,137 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
         Assert.Contains(logs, msg => msg.Contains("helm-deploy-aks"));
         Assert.Contains(logs, msg => msg.Contains("aks-get-credentials-aks"));
         Assert.DoesNotContain(logs, msg => msg.Contains("aks-k8s"));
+    }
+
+    [Fact]
+    public async Task AzureDeploymentContextUsesCurrentDeploymentState()
+    {
+        const string subscriptionId = "00000000-0000-0000-0000-000000000001";
+        const string resourceGroup = "deployment-rg";
+        var deploymentStateManager = new InMemoryDeploymentStateManager();
+        deploymentStateManager.SetSection("Azure", new JsonObject
+        {
+            ["SubscriptionId"] = subscriptionId,
+            ["ResourceGroup"] = resourceGroup
+        });
+
+        using var services = new ServiceCollection()
+            .AddSingleton<IDeploymentStateManager>(deploymentStateManager)
+            .BuildServiceProvider();
+
+        var deploymentContext = await AzureKubernetesEnvironmentResource.GetAzureDeploymentContextAsync(
+            services,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(subscriptionId, deploymentContext.SubscriptionId);
+        Assert.Equal(resourceGroup, deploymentContext.ResourceGroup);
+    }
+
+    [Fact]
+    public async Task AzureDeploymentContextRequiresSubscription()
+    {
+        var deploymentStateManager = new InMemoryDeploymentStateManager();
+        deploymentStateManager.SetSection("Azure", new JsonObject
+        {
+            ["ResourceGroup"] = "deployment-rg"
+        });
+
+        using var services = new ServiceCollection()
+            .AddSingleton<IDeploymentStateManager>(deploymentStateManager)
+            .BuildServiceProvider();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureKubernetesEnvironmentResource.GetAzureDeploymentContextAsync(
+                services,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            "Could not resolve the Azure subscription selected for deployment. Ensure Azure provisioning has completed, or set the Azure:SubscriptionId configuration value.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task GetResourceGroupUsesDeploymentStateWithoutQueryingAzure()
+    {
+        var invocations = new List<string>();
+
+        var resourceGroup = await AzureKubernetesEnvironmentResource.GetResourceGroupAsync(
+            "/usr/bin/az",
+            "deployment-aks",
+            "00000000-0000-0000-0000-000000000001",
+            "deployment-rg",
+            NullLogger.Instance,
+            (path, arguments) =>
+            {
+                invocations.Add(arguments);
+                return Task.FromResult(new AzureKubernetesEnvironmentResource.AzCommandResult(0, "unexpected-rg", ""));
+            });
+
+        Assert.Equal("deployment-rg", resourceGroup);
+        Assert.Empty(invocations);
+    }
+
+    [Fact]
+    public async Task GetResourceGroupQueryIsScopedToDeploymentSubscription()
+    {
+        const string subscriptionId = "00000000-0000-0000-0000-000000000001";
+        var invocations = new List<string>();
+
+        var resourceGroup = await AzureKubernetesEnvironmentResource.GetResourceGroupAsync(
+            "/usr/bin/az",
+            "deployment-aks",
+            subscriptionId,
+            savedResourceGroup: null,
+            NullLogger.Instance,
+            (path, arguments) =>
+            {
+                invocations.Add(arguments);
+                return Task.FromResult(new AzureKubernetesEnvironmentResource.AzCommandResult(0, "queried-rg\n", ""));
+            });
+
+        Assert.Equal("queried-rg", resourceGroup);
+        Assert.Equal(
+            [$"resource list --resource-type Microsoft.ContainerService/managedClusters --name \"deployment-aks\" --query [0].resourceGroup -o tsv --subscription \"{subscriptionId}\""],
+            invocations);
+    }
+
+    [Fact]
+    public async Task FetchKubeConfigIsScopedToDeploymentSubscription()
+    {
+        const string subscriptionId = "00000000-0000-0000-0000-000000000001";
+        var invocations = new List<string>();
+
+        var kubeConfig = await AzureKubernetesEnvironmentResource.FetchKubeConfigAsync(
+            "/usr/bin/az",
+            subscriptionId,
+            "deployment-rg",
+            "deployment-aks",
+            (path, arguments) =>
+            {
+                invocations.Add(arguments);
+                return Task.FromResult(new AzureKubernetesEnvironmentResource.AzCommandResult(0, "kubeconfig-content", ""));
+            });
+
+        Assert.Equal("kubeconfig-content", kubeConfig);
+        Assert.Equal(
+            [$"aks get-credentials --resource-group \"deployment-rg\" --name \"deployment-aks\" --file - --subscription \"{subscriptionId}\""],
+            invocations);
+    }
+
+    [Fact]
+    public async Task FetchKubeConfigThrowsWhenAzureCliFails()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => AzureKubernetesEnvironmentResource.FetchKubeConfigAsync(
+                "/usr/bin/az",
+                "00000000-0000-0000-0000-000000000001",
+                "deployment-rg",
+                "deployment-aks",
+                (path, arguments) => Task.FromResult(
+                    new AzureKubernetesEnvironmentResource.AzCommandResult(1, "", "subscription not found"))));
+
+        Assert.Equal(
+            "az aks get-credentials failed (exit code 1): subscription not found",
+            exception.Message);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
+++ b/tests/Aspire.Hosting.Azure.Kubernetes.Tests/AzureKubernetesInfrastructureTests.cs
@@ -421,4 +421,194 @@ public class AzureKubernetesInfrastructureTests(ITestOutputHelper output)
             "kubeconfig-content",
             await File.ReadAllTextAsync(aks.Resource.KubernetesEnvironment.KubeConfigPath!, TestContext.Current.CancellationToken));
     }
+
+    [Fact]
+    public async Task GetCredentialsStepUsesExistingClusterScopeInsteadOfDeploymentState()
+    {
+        const string appSubscriptionId = "00000000-0000-0000-0000-000000000001";
+        const string clusterSubscriptionId = "00000000-0000-0000-0000-000000000002";
+        const string clusterResourceGroup = "shared-platform-rg";
+        const string clusterName = "shared-aks";
+
+        using var builder = TestDistributedApplicationBuilder.Create(
+            DistributedApplicationOperation.Publish);
+
+        // The app deploys into its own subscription and resource group...
+        var deploymentStateManager = new InMemoryDeploymentStateManager();
+        deploymentStateManager.SetSection("Azure", new JsonObject
+        {
+            ["SubscriptionId"] = appSubscriptionId,
+            ["ResourceGroup"] = "app-rg"
+        });
+        builder.Services.AddSingleton<IDeploymentStateManager>(deploymentStateManager);
+
+        // ...but the cluster it targets already exists somewhere else entirely.
+        var aks = builder.AddAzureKubernetesEnvironment("aks")
+            .AsExistingInResourceGroup(clusterName, clusterResourceGroup, clusterSubscriptionId);
+
+        aks.Resource.Outputs["name"] = clusterName;
+
+        var invocations = new List<string>();
+        aks.Resource.AzCliPathResolverForTesting = () => "/usr/bin/az";
+        aks.Resource.AzCommandRunnerForTesting = (path, arguments, logger) =>
+        {
+            invocations.Add(arguments);
+            return Task.FromResult(new AzureKubernetesEnvironmentResource.AzCommandResult(0, "kubeconfig-content", ""));
+        };
+
+        await using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var pipelineContext = new PipelineContext(
+            model,
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>(),
+            app.Services,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        var steps = new List<PipelineStep>();
+        foreach (var annotation in aks.Resource.Annotations.OfType<PipelineStepAnnotation>())
+        {
+            steps.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = aks.Resource
+            }));
+        }
+
+        var getCredentialsStep = Assert.Single(steps, step => step.Name == "aks-get-credentials-aks");
+
+        aks.Resource.ProvisioningTaskCompletionSource?.TrySetResult();
+
+        await using var reportingStep = await new NullPublishingActivityReporter().CreateStepAsync("test");
+        await getCredentialsStep.Action(new PipelineStepContext
+        {
+            PipelineContext = pipelineContext,
+            ReportingStep = reportingStep
+        });
+
+        // Only get-credentials should run: the resource group is pinned by the annotation, so no
+        // discovery query is needed. Both scope values must come from the annotation, not the
+        // app's own deployment state.
+        Assert.Equal(
+            [$"aks get-credentials --resource-group \"{clusterResourceGroup}\" --name \"{clusterName}\" --file - --subscription \"{clusterSubscriptionId}\""],
+            invocations);
+
+        var connectHint = Assert.Single(
+            pipelineContext.Summary.Items,
+            item => item.Key == "🔑 Connect to cluster");
+        Assert.Equal(
+            $"`az aks get-credentials --resource-group {clusterResourceGroup} --name {clusterName} --subscription {clusterSubscriptionId}`",
+            connectHint.Value);
+    }
+
+    [Fact]
+    public async Task DeploymentScopeFallsBackToDeploymentStateWhenResourcePinsNothing()
+    {
+        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+
+        var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+            scopedSubscription: null,
+            scopedResourceGroup: null,
+            services,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(("sub-global", "rg-global"), scope);
+    }
+
+    [Fact]
+    public async Task DeploymentScopeKeepsDeploymentResourceGroupWhenResourcePinsSameSubscription()
+    {
+        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+
+        var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+            scopedSubscription: "sub-global",
+            scopedResourceGroup: null,
+            services,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(("sub-global", "rg-global"), scope);
+    }
+
+    [Fact]
+    public async Task DeploymentScopeDropsDeploymentResourceGroupWhenResourcePinsAnotherSubscription()
+    {
+        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+
+        var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+            scopedSubscription: "sub-other",
+            scopedResourceGroup: null,
+            services,
+            TestContext.Current.CancellationToken);
+
+        // "rg-global" names a group inside "sub-global" only. Carrying it across the subscription
+        // boundary could miss entirely or hit an unrelated group with the same name, so the step
+        // must rediscover it instead.
+        Assert.Equal(("sub-other", (string?)null), scope);
+    }
+
+    [Fact]
+    public async Task DeploymentScopeUsesDeploymentSubscriptionWhenResourcePinsOnlyResourceGroup()
+    {
+        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+
+        var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+            scopedSubscription: null,
+            scopedResourceGroup: "rg-pinned",
+            services,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(("sub-global", "rg-pinned"), scope);
+    }
+
+    [Fact]
+    public async Task DeploymentScopeIgnoresDeploymentStateWhenResourcePinsBothValues()
+    {
+        // No Azure section at all: a fully pinned resource must not depend on deployment state.
+        var services = new ServiceCollection()
+            .AddSingleton<IDeploymentStateManager>(new InMemoryDeploymentStateManager())
+            .BuildServiceProvider();
+
+        var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+            scopedSubscription: "sub-pinned",
+            scopedResourceGroup: "rg-pinned",
+            services,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(("sub-pinned", "rg-pinned"), scope);
+    }
+
+    [Fact]
+    public async Task DeploymentScopeResolvesParameterBackedScopeValues()
+    {
+        var services = CreateServicesWithAzureState("sub-global", "rg-global");
+
+        var subscriptionParameter = new ParameterResource("sub", _ => "sub-from-parameter");
+        var resourceGroupParameter = new ParameterResource("rg", _ => "rg-from-parameter");
+
+        var scope = await AzureKubernetesEnvironmentResource.ResolveDeploymentScopeAsync(
+            subscriptionParameter,
+            resourceGroupParameter,
+            services,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(("sub-from-parameter", "rg-from-parameter"), scope);
+    }
+
+    private static ServiceProvider CreateServicesWithAzureState(string subscriptionId, string? resourceGroup)
+    {
+        var deploymentStateManager = new InMemoryDeploymentStateManager();
+        var azureState = new JsonObject { ["SubscriptionId"] = subscriptionId };
+
+        if (resourceGroup is not null)
+        {
+            azureState["ResourceGroup"] = resourceGroup;
+        }
+
+        deploymentStateManager.SetSection("Azure", azureState);
+
+        return new ServiceCollection()
+            .AddSingleton<IDeploymentStateManager>(deploymentStateManager)
+            .BuildServiceProvider();
+    }
 }


### PR DESCRIPTION
## Description

When deploying an AKS environment, the post-provisioning step that fetches cluster credentials invoked the Azure CLI **without `--subscription`**. Both `az aks get-credentials` and the `az resource list` resource-group fallback therefore ran against whatever subscription the ambient `az` CLI happened to default to, rather than the subscription Aspire selected for the deployment.

This is easy to hit in practice: anyone whose `az account show` default differs from the subscription they deploy to (multi-subscription tenants, CI agents, or after an `az account set` elsewhere) would either get a confusing "cluster not found" failure or, worse, silently pull a kubeconfig for a *same-named cluster in a different subscription* and deploy into it.

The resource-group lookup compounded the problem. It read `IConfiguration["Azure:ResourceGroup"]`, which is only populated at host startup. Provisioning writes the resource group into deployment state *during* the pipeline run, so on a first deploy that config value is empty — the fallback `az resource list` query always fired, and it was the unscoped query.

### What changed for users

- `aspire deploy` against an AKS environment now always targets the subscription Aspire selected, regardless of the ambient `az` CLI default. No more wrong-subscription credential fetches or spurious "cluster not found" errors on first deploy.
- The deploy summary's reconnect command is now copy-pasteable on a machine with a different CLI default:

  ```text
  🔑 Connect to cluster
  az aks get-credentials --resource-group <rg> --name <cluster> --subscription <subscription-id>
  ```

- If the Azure subscription genuinely cannot be resolved from deployment state, the step now fails fast with an actionable message instead of silently falling back to the ambient CLI context:

  ```text
  Could not resolve the Azure subscription selected for deployment. Ensure Azure
  provisioning has completed, or set the Azure:SubscriptionId configuration value.
  ```

  In practice this should not surface during a normal deploy: the `aks-get-credentials-{name}` step declares `DependsOnSteps = [AzureEnvironmentResource.ProvisionInfrastructureStepName]`, so provisioning (which persists `SubscriptionId`) always completes first.

### Implementation

`GetAzureDeploymentContextAsync` reads `SubscriptionId`/`ResourceGroup` from the `Azure` deployment-state section via `IDeploymentStateManager` rather than `IConfiguration`. This is the key correctness point: `SaveSectionAsync` updates the same in-memory `_state` that `AcquireSectionAsync` reads back, so the values are current even on a first deploy when nothing has been written to disk-backed configuration yet. Both Azure CLI call sites then pass `--subscription` explicitly, and the subscription ID goes through the existing `ValidateAzureResourceName` defense-in-depth check before being embedded in a command line.

The `az` command runner is injected into `GetResourceGroupAsync` and the new `FetchKubeConfigAsync` so tests can assert the exact command lines without spawning the CLI. This seam is load-bearing rather than cosmetic — see the testing note below.

### Testing

Unit tests in `tests/Aspire.Hosting.Azure.Kubernetes.Tests` cover:

- Reading subscription/resource group from current deployment state.
- Failing with an actionable message when the subscription is absent.
- The saved-resource-group path short-circuiting **without** invoking `az` at all.
- The resource-group fallback query being scoped to the deployment subscription.
- The credential fetch being scoped to the deployment subscription.
- `az` failure surfacing as an `InvalidOperationException`.

An earlier revision of these tests asserted only the output of the argument-builder helpers. That was verified to be inadequate: reverting the `--subscription` fix at the call site left the entire suite green, because nothing proved the pipeline actually *called* those helpers. The tests now drive the real call paths through an injected runner and assert the captured command lines, so a regression that drops `--subscription` fails the suite.

`Aspire.Hosting.Azure.Kubernetes` builds with 0 warnings; 73/73 tests pass.

### Security considerations

This change affects how cluster credentials are acquired, so calling it out for reviewer awareness:

- **Net positive on scoping.** Pinning `--subscription` removes an ambient-authority failure mode where a kubeconfig could be fetched from an unintended subscription that happens to contain a same-named cluster.
- **Command construction.** The subscription ID is read from persisted deployment state and embedded in an `az` argument string. It is validated with the pre-existing `ValidateAzureResourceName` regex (`^[a-zA-Z0-9\-_\.\(\)]+$`) before use, matching how the cluster name and resource group were already handled.
- **No change to credential storage.** Kubeconfig content is still fetched to stdout via `--file -` and written by Aspire to a temp file with owner-only (0600) permissions on Unix; that behavior is untouched.
- Subscription IDs are identifiers rather than secrets, and are already logged elsewhere during provisioning, so including one in the deploy summary does not expose new sensitive data.

Fixes #19216

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No

  <sub>`AzureBicepResourceScope.HasResourceGroup` changes from `internal` to `public`. `AzureBicepResourceScope` is already a public sealed type and `AzureBicepResource.Scope` is already public, but `ResourceGroup` is a public property that throws for subscription- and tenant-scoped resources, with no public way to test the scope first. This closes that guard gap. Flagging for API review.</sub>
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No

