### PR TITLE
Don't select skipped Gateways and Ingresses for TLS work

### DIFF
--- a/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/CertManagerExtensions.cs
@@ -612,25 +612,31 @@ public static class CertManagerExtensions
                     // attach to the Gateway being validated. Without parentRefs, the route is
                     // orphaned and the ACME challenge URL is unreachable.
                     // See https://cert-manager.io/docs/configuration/acme/http01/#configuring-the-http01-gateway-api-solver
+                    // Route-less gateways are excluded because they are skipped during
+                    // materialization: a parentRef to a Gateway that is never created is just as
+                    // orphaned, and it would also mask the warning below.
                     var nameComparer = new ResourceNameComparer();
                     var parentGateways = model.Resources
                         .OfType<KubernetesGatewayResource>()
                         .Where(g => nameComparer.Equals(g.Parent, certManager.Parent)
+                                    && g.ShouldMaterialize
                                     && g.GatewayAnnotations.TryGetValue(ClusterIssuerAnnotationKey, out var v)
                                     && string.Equals(v.Format, issuer.Name, StringComparison.Ordinal))
                         .ToList();
 
                     if (parentGateways.Count == 0)
                     {
-                        // No annotated gateway found. cert-manager will accept this manifest but
-                        // the HTTP-01 challenge can never be satisfied because there's no parent
-                        // Gateway for the solver's HTTPRoute to attach to. Emit a warning so the
+                        // No eligible gateway found — either none is annotated for this issuer, or
+                        // the annotated ones have no routes and are therefore skipped during
+                        // materialization. Either way cert-manager will accept this manifest but the
+                        // HTTP-01 challenge can never be satisfied, because there's no parent Gateway
+                        // for the solver's HTTPRoute to attach to. Emit a warning so the
                         // misconfiguration is visible at deploy time instead of leaving the user
                         // to discover it via Certificates stuck in 'Pending' indefinitely.
                         logger.LogWarning(
-                            "ClusterIssuer '{IssuerName}' has an HTTP-01 solver but no Gateway in environment '{EnvironmentName}' is annotated with " +
-                            ClusterIssuerAnnotationKey + "={IssuerName}. cert-manager will not be able to satisfy ACME challenges until at least " +
-                            "one Gateway adopts this issuer (e.g. via WithTls(issuer)).",
+                            "ClusterIssuer '{IssuerName}' has an HTTP-01 solver but no Gateway in environment '{EnvironmentName}' is both annotated with " +
+                            ClusterIssuerAnnotationKey + "={IssuerName} and configured with at least one route. cert-manager will not be able to satisfy " +
+                            "ACME challenges until at least one routed Gateway adopts this issuer (e.g. via WithRoute(...) and WithTls(issuer)).",
                             issuer.Name,
                             certManager.Parent.Name,
                             issuer.Name);

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -1516,7 +1516,10 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
     /// <summary>
     /// Polls for the Gateway's assigned hostname address using a Polly retry pipeline.
-    /// Retries up to 60 times with 5-second delays (5 minutes total).
+    /// Retries up to 180 times with 5-second delays (~15 minutes total); see the comment on the
+    /// retry budget below. Only call this for a Gateway that is actually materialized: kubectl
+    /// failures are indistinguishable from "no address yet" here, so a Gateway that is never
+    /// created consumes the entire budget before failing.
     /// </summary>
     private static async Task<string?> DiscoverGatewayFqdnAsync(
         string gatewayName,

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -1181,7 +1181,8 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     /// are being built, so it cannot see whether an Ingress ultimately rendered — each entry carries
     /// its owner so <see cref="BootstrapTlsSecretsAsync"/> can re-check that at deploy time.
     /// </remarks>
-    internal static List<TlsSecretRequest> CollectTlsSecrets(DistributedApplicationModel model, KubernetesEnvironmentResource environment)    {
+    internal static List<TlsSecretRequest> CollectTlsSecrets(DistributedApplicationModel model, KubernetesEnvironmentResource environment)
+    {
         var tlsSecrets = new List<TlsSecretRequest>();
 
         var gateways = model.Resources

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -666,9 +666,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         foreach (var ingressResource in ingressResources)
         {
-            if (ingressResource.Paths.Count == 0 && ingressResource.DefaultBackend is null)
+            if (!ingressResource.ShouldMaterialize)
             {
-                logger.LogWarning("Ingress '{IngressName}' has no path rules or default backend configured. Skipping.", ingressResource.Name);
+                logger.LogWarning(
+                    "Ingress '{IngressName}' has no path rules or default backend configured. The Ingress and its TLS certificate will not be created.",
+                    ingressResource.Name);
                 continue;
             }
 
@@ -877,9 +879,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
 
         foreach (var gatewayResource in gatewayResources)
         {
-            if (gatewayResource.Routes.Count == 0)
+            if (!gatewayResource.ShouldMaterialize)
             {
-                logger.LogWarning("Gateway '{GatewayName}' has no routes configured. Skipping.", gatewayResource.Name);
+                logger.LogWarning(
+                    "Gateway '{GatewayName}' has no routes configured. The Gateway, routes, TLS certificate, and load-balancer frontend will not be created.",
+                    gatewayResource.Name);
                 continue;
             }
 
@@ -1158,7 +1162,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     {
         var tlsSecrets = new HashSet<(ReferenceExpression SecretName, ReferenceExpression Hostname)>();
 
-        foreach (var gateway in model.Resources.OfType<KubernetesGatewayResource>().Where(g => g.Parent == environment))
+        var gateways = model.Resources
+            .OfType<KubernetesGatewayResource>()
+            .Where(g => g.Parent == environment && g.ShouldMaterialize);
+
+        foreach (var gateway in gateways)
         {
             foreach (var tls in gateway.TlsConfigs)
             {
@@ -1169,7 +1177,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             }
         }
 
-        foreach (var ingress in model.Resources.OfType<KubernetesIngressResource>().Where(i => i.Parent == environment))
+        var ingresses = model.Resources
+            .OfType<KubernetesIngressResource>()
+            .Where(i => i.Parent == environment && i.ShouldMaterialize);
+
+        foreach (var ingress in ingresses)
         {
             foreach (var tls in ingress.TlsConfigs)
             {
@@ -1193,7 +1205,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     {
         var results = new List<(KubernetesGatewayResource Gateway, ReferenceExpression SecretName)>();
 
-        foreach (var gateway in model.Resources.OfType<KubernetesGatewayResource>().Where(g => g.Parent == environment))
+        var gateways = model.Resources
+            .OfType<KubernetesGatewayResource>()
+            .Where(g => g.Parent == environment && g.ShouldMaterialize);
+
+        foreach (var gateway in gateways)
         {
             foreach (var tls in gateway.TlsConfigs)
             {
@@ -1218,7 +1234,11 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     {
         var results = new List<KubernetesGatewayResource>();
 
-        foreach (var gateway in model.Resources.OfType<KubernetesGatewayResource>().Where(g => g.Parent == environment))
+        var gateways = model.Resources
+            .OfType<KubernetesGatewayResource>()
+            .Where(g => g.Parent == environment && g.ShouldMaterialize);
+
+        foreach (var gateway in gateways)
         {
             if (gateway.TlsConfigs.Count > 0)
             {

--- a/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesEnvironmentResource.cs
@@ -188,6 +188,21 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     internal sealed record CapturedHelmValueProvider(string Section, string ResourceKey, string ValueKey, IValueProvider ValueProvider);
 
     /// <summary>
+    /// A TLS secret that may need a self-signed bootstrap certificate, together with the routing
+    /// resource that requested it.
+    /// </summary>
+    /// <remarks>
+    /// The owner is carried through to deploy time because eligibility is only partially known when
+    /// the pipeline steps are built. Step factories run before any step executes (see
+    /// <c>DistributedApplicationPipeline.ResolveStepsAsync</c>), so at collection time we can only
+    /// tell whether a resource is *configured* to materialize — the actual rendered object does not
+    /// exist yet. An Ingress can still drop out later when none of its backends resolve, so the
+    /// bootstrap step re-checks the owner before creating a certificate. Without this, we would
+    /// create a secret for an Ingress that never made it into the chart.
+    /// </remarks>
+    internal sealed record TlsSecretRequest(ReferenceExpression SecretName, ReferenceExpression Hostname, IResource Owner);
+
+    /// <summary>
     /// Captured value provider references populated during publish, consumed during deploy
     /// to resolve values from external sources (e.g., Azure Bicep outputs).
     /// </summary>
@@ -1158,9 +1173,16 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
         };
     }
 
-    private static HashSet<(ReferenceExpression SecretName, ReferenceExpression Hostname)> CollectTlsSecrets(DistributedApplicationModel model, KubernetesEnvironmentResource environment)
-    {
-        var tlsSecrets = new HashSet<(ReferenceExpression SecretName, ReferenceExpression Hostname)>();
+    /// <summary>
+    /// Collects the TLS secrets that may need a self-signed bootstrap certificate.
+    /// </summary>
+    /// <remarks>
+    /// Only resources configured to materialize are considered. This runs while the pipeline steps
+    /// are being built, so it cannot see whether an Ingress ultimately rendered — each entry carries
+    /// its owner so <see cref="BootstrapTlsSecretsAsync"/> can re-check that at deploy time.
+    /// </remarks>
+    internal static List<TlsSecretRequest> CollectTlsSecrets(DistributedApplicationModel model, KubernetesEnvironmentResource environment)    {
+        var tlsSecrets = new List<TlsSecretRequest>();
 
         var gateways = model.Resources
             .OfType<KubernetesGatewayResource>()
@@ -1172,7 +1194,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             {
                 foreach (var host in gateway.Hostnames)
                 {
-                    tlsSecrets.Add((tls.SecretName, host));
+                    tlsSecrets.Add(new TlsSecretRequest(tls.SecretName, host, gateway));
                 }
             }
         }
@@ -1187,13 +1209,29 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             {
                 foreach (var host in ingress.Hostnames)
                 {
-                    tlsSecrets.Add((tls.SecretName, host));
+                    tlsSecrets.Add(new TlsSecretRequest(tls.SecretName, host, ingress));
                 }
             }
         }
 
         return tlsSecrets;
     }
+
+    /// <summary>
+    /// Determines whether the routing resource that requested a TLS secret actually made it into
+    /// the rendered chart. Called at deploy time, once publish has populated the generated objects.
+    /// </summary>
+    internal static bool OwnerWasMaterialized(IResource owner) => owner switch
+    {
+        // BuildIngressObject returns null when every configured path and the default backend fail
+        // to resolve to a deployment target, so a configured Ingress can still be absent from the
+        // chart. GeneratedIngress is the authoritative signal for whether it rendered.
+        KubernetesIngressResource ingress => ingress.GeneratedIngress is not null,
+
+        // BuildGatewayObjects always emits the Gateway once it has routes, so ShouldMaterialize
+        // (already applied during collection) is sufficient for gateways.
+        _ => true,
+    };
 
     /// <summary>
     /// Collects gateway TLS configurations that have no hostnames specified and need
@@ -2015,7 +2053,7 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
     private static async Task BootstrapTlsSecretsAsync(
         PipelineStepContext context,
         KubernetesEnvironmentResource environment,
-        HashSet<(ReferenceExpression SecretName, ReferenceExpression Hostname)> tlsSecrets)
+        List<TlsSecretRequest> tlsSecrets)
     {
         var @namespace = "default";
         if (environment.TryGetLastAnnotation<KubernetesNamespaceAnnotation>(out var nsAnnotation))
@@ -2027,8 +2065,29 @@ public sealed class KubernetesEnvironmentResource : Resource, IComputeEnvironmen
             }
         }
 
-        foreach (var (secretNameExpr, hostnameExpr) in tlsSecrets)
+        // Re-check materialization now that publish has run. An Ingress that was configured with
+        // paths can still be dropped from the chart if none of its backends resolved, and
+        // bootstrapping a certificate for it would leave an orphaned secret in the cluster.
+        // Dedupe on (secret, hostname) so two routing resources sharing a secret only bootstrap it
+        // once, matching the behavior before owners were tracked.
+        var seen = new HashSet<(ReferenceExpression SecretName, ReferenceExpression Hostname)>();
+
+        foreach (var tlsSecret in tlsSecrets)
         {
+            if (!OwnerWasMaterialized(tlsSecret.Owner))
+            {
+                context.Logger.LogDebug(
+                    "Skipping TLS bootstrap for '{ResourceName}' because it was not included in the generated chart.",
+                    tlsSecret.Owner.Name);
+                continue;
+            }
+
+            if (!seen.Add((tlsSecret.SecretName, tlsSecret.Hostname)))
+            {
+                continue;
+            }
+
+            var (secretNameExpr, hostnameExpr) = (tlsSecret.SecretName, tlsSecret.Hostname);
             var secretName = await ResolveExpressionAtDeployTimeAsync(secretNameExpr, context.CancellationToken).ConfigureAwait(false);
             var hostname = await ResolveExpressionAtDeployTimeAsync(hostnameExpr, context.CancellationToken).ConfigureAwait(false);
 

--- a/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesGatewayResource.cs
@@ -81,6 +81,14 @@ public class KubernetesGatewayResource(
     /// Gets the generated K8S HTTPRoute objects, populated during infrastructure processing.
     /// </summary>
     internal List<Resources.HttpRouteV1> GeneratedHttpRoutes { get; } = [];
+
+    /// <summary>
+    /// Gets a value indicating whether this gateway is emitted into the deployment artifacts.
+    /// A gateway with no routes is skipped, so nothing downstream (TLS bootstrap, FQDN discovery,
+    /// field-manager cleanup, cert-manager solver parentRefs) may select it — those steps would
+    /// otherwise act on a Gateway that never exists in the cluster.
+    /// </summary>
+    internal bool ShouldMaterialize => Routes.Count > 0;
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesIngressResource.cs
@@ -84,6 +84,14 @@ public class KubernetesIngressResource(
     /// Gets the generated K8S Ingress object, populated during infrastructure processing.
     /// </summary>
     internal Resources.Ingress? GeneratedIngress { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this ingress is emitted into the deployment artifacts.
+    /// An ingress with neither path rules nor a default backend is skipped, so TLS secret
+    /// collection must not select it — bootstrapping a secret for an Ingress that is never
+    /// created leaves an orphaned self-signed certificate in the cluster.
+    /// </summary>
+    internal bool ShouldMaterialize => Paths.Count > 0 || DefaultBackend is not null;
 }
 
 /// <summary>

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Aspire.Hosting.Kubernetes.Tests.csproj
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Aspire.Hosting.Kubernetes.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Verify.XunitV3" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
@@ -120,9 +120,16 @@ public class CertManagerTests
             .WithHttp01Solver();
 
         // A gateway that adopts this issuer must end up referenced as a parentRef on the
-        // generated solver, so cert-manager's HTTP-01 HTTPRoute can attach to it.
+        // generated solver, so cert-manager's HTTP-01 HTTPRoute can attach to it. The gateway
+        // needs a route, otherwise it is skipped during materialization and referencing it
+        // would produce a parentRef to a Gateway that never exists in the cluster.
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
         k8s.AddGateway("PUBLIC-GW")
             .WithGatewayClass("nginx")
+            .WithRoute("/", api.GetEndpoint("http"))
             .WithTls(issuer);
 
         using var app = builder.Build();
@@ -149,6 +156,43 @@ public class CertManagerTests
         Assert.Contains("gatewayHTTPRoute:", yaml);
         // Gateway parentRef must also be lowercase to match the actual emitted Gateway name.
         Assert.Contains("name: public-gw", yaml);
+    }
+
+    [Fact]
+    public async Task BuildClusterIssuerManifest_RouteLessGateway_IsNotEmittedAsParentRef()
+    {
+        // A gateway with no routes is skipped during materialization, so emitting it as a
+        // solver parentRef would point cert-manager's HTTP-01 HTTPRoute at a Gateway that
+        // never exists in the cluster, leaving Certificates stuck in 'Pending' forever.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var issuer = k8s.AddCertManager("cert-manager")
+            .AddIssuer("le-prod")
+            .WithLetsEncryptProduction("ops@contoso.com")
+            .WithHttp01Solver();
+
+        k8s.AddGateway("public")
+            .WithGatewayClass("nginx")
+            .WithTls(issuer);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var certManagerResource = model.Resources.OfType<CertManagerResource>().Single();
+        var issuerResource = certManagerResource.Issuers.Single();
+
+        var yaml = await CertManagerExtensions.BuildClusterIssuerManifestAsync(
+            model,
+            certManagerResource,
+            issuerResource,
+            NullLogger.Instance,
+            TestContext.Current.CancellationToken);
+
+        // The solver is still emitted, but with no parentRefs block at all, which is also what
+        // makes the "no routed Gateway adopts this issuer" warning fire.
+        Assert.Contains("- http01:", yaml);
+        Assert.Contains("gatewayHTTPRoute:", yaml);
+        Assert.DoesNotContain("parentRefs:", yaml);
+        Assert.DoesNotContain("name: public", yaml);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/CertManagerTests.cs
@@ -4,7 +4,9 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
 
@@ -193,6 +195,47 @@ public class CertManagerTests
         Assert.Contains("gatewayHTTPRoute:", yaml);
         Assert.DoesNotContain("parentRefs:", yaml);
         Assert.DoesNotContain("name: public", yaml);
+    }
+
+    [Fact]
+    public async Task BuildClusterIssuerManifest_RouteLessGateway_WarnsThatChallengesCannotBeSatisfied()
+    {
+        // Without a parentRef the manifest is still valid YAML and cert-manager accepts it, so the
+        // warning is the only thing that tells the user why their Certificates never leave
+        // 'Pending'. Assert it explicitly so it cannot be dropped without a test failing.
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var issuer = k8s.AddCertManager("cert-manager")
+            .AddIssuer("le-prod")
+            .WithLetsEncryptProduction("ops@contoso.com")
+            .WithHttp01Solver();
+
+        k8s.AddGateway("public")
+            .WithGatewayClass("nginx")
+            .WithTls(issuer);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var certManagerResource = model.Resources.OfType<CertManagerResource>().Single();
+        var issuerResource = certManagerResource.Issuers.Single();
+
+        var testSink = new TestSink();
+        using var loggerProvider = new TestLoggerProvider(testSink);
+
+        await CertManagerExtensions.BuildClusterIssuerManifestAsync(
+            model,
+            certManagerResource,
+            issuerResource,
+            loggerProvider.CreateLogger("test"),
+            TestContext.Current.CancellationToken);
+
+        var warning = Assert.Single(testSink.Writes, w => w.LogLevel == LogLevel.Warning);
+
+        Assert.Equal(
+            "ClusterIssuer 'le-prod' has an HTTP-01 solver but no Gateway in environment 'env' is both annotated with " +
+            "cert-manager.io/cluster-issuer=le-prod and configured with at least one route. cert-manager will not be able to " +
+            "satisfy ACME challenges until at least one routed Gateway adopts this issuer (e.g. via WithRoute(...) and WithTls(issuer)).",
+            warning.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
+using static Aspire.Hosting.Kubernetes.Tests.PipelineStepTestHelpers;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
 
@@ -107,6 +108,9 @@ public class KubernetesGatewayTests(ITestOutputHelper outputHelper)
         Assert.Contains("api.example.com", content);
         // Should also have HTTP listener
         Assert.Contains("HTTP", content);
+
+        var steps = await CreateStepsAsync(app.Services, k8s.Resource);
+        Assert.Equal(["gateway-field-cleanup-env", "tls-bootstrap-env"], GatewayOrTlsStepNames(steps));
     }
 
     [Fact]
@@ -167,23 +171,41 @@ public class KubernetesGatewayTests(ITestOutputHelper outputHelper)
         Assert.Equal(2, routeFiles.Length);
     }
 
-    [Fact]
-    public async Task AddGateway_NoRoutes_DoesNotGenerateYaml()
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task AddGateway_NoRoutes_DoesNotGenerateYamlOrTlsSteps(bool hasTls, bool hasHostname)
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
 
         var k8s = builder.AddKubernetesEnvironment("env");
-        k8s.AddGateway("empty");
+        var gateway = k8s.AddGateway("empty");
+
+        if (hasTls)
+        {
+            gateway.WithTls("my-tls-secret");
+        }
+
+        if (hasHostname)
+        {
+            gateway.WithHostname("api.example.com");
+        }
 
         builder.AddContainer("myapi", "nginx")
             .WithHttpEndpoint(targetPort: 8080);
 
-        var app = builder.Build();
+        using var app = builder.Build();
         app.Run();
 
         var gatewayDir = Path.Combine(workspace.Path, "templates", "empty");
         Assert.False(Directory.Exists(gatewayDir), $"Gateway directory should not exist at {gatewayDir}");
+
+        // Assert on the whole filtered set rather than probing known step names one by one, so a
+        // future gateway/TLS step added without the route-eligibility filter also fails here.
+        var steps = await CreateStepsAsync(app.Services, k8s.Resource);
+        Assert.Empty(GatewayOrTlsStepNames(steps));
     }
 
     [Fact]
@@ -275,6 +297,9 @@ public class KubernetesGatewayTests(ITestOutputHelper outputHelper)
         var nextListenerOrEnd = lines.FindIndex(httpsIndex + 1, l => l.StartsWith("- name:") || l == "");
         var httpsSection = lines.Skip(httpsIndex).Take((nextListenerOrEnd > httpsIndex ? nextListenerOrEnd : lines.Count) - httpsIndex);
         Assert.DoesNotContain(httpsSection, l => l.StartsWith("hostname:") || l.StartsWith("hostname "));
+
+        var steps = await CreateStepsAsync(app.Services, k8s.Resource);
+        Assert.Equal(["gateway-field-cleanup-env", "tls-fqdn-discovery-env"], GatewayOrTlsStepNames(steps));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesGatewayTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using static Aspire.Hosting.Kubernetes.Tests.PipelineStepTestHelpers;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
@@ -206,6 +209,35 @@ public class KubernetesGatewayTests(ITestOutputHelper outputHelper)
         // future gateway/TLS step added without the route-eligibility filter also fails here.
         var steps = await CreateStepsAsync(app.Services, k8s.Resource);
         Assert.Empty(GatewayOrTlsStepNames(steps));
+    }
+
+    [Fact]
+    public async Task AddGateway_NoRoutes_WarnsThatGatewayAndTlsAreSkipped()
+    {
+        // The warning is the only signal a user gets that their Gateway (and its certificate) was
+        // silently dropped, so assert its content rather than just the absence of artifacts.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var testSink = new TestSink();
+        builder.Services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        k8s.AddGateway("empty").WithTls("my-tls-secret");
+
+        builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        using var app = builder.Build();
+        app.Run();
+
+        var warning = Assert.Single(
+            testSink.Writes,
+            w => w.LogLevel == LogLevel.Warning && w.Message is not null && w.Message.Contains("empty", StringComparison.Ordinal));
+
+        Assert.Equal(
+            "Gateway 'empty' has no routes configured. The Gateway, routes, TLS certificate, and load-balancer frontend will not be created.",
+            warning.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -290,6 +290,33 @@ public class KubernetesIngressTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AddIngress_NoPathsWithTls_DoesNotRegisterTlsBootstrapStep()
+    {
+        // An ingress with no paths and no default backend is skipped during materialization, so
+        // collecting its TLS secret would bootstrap a self-signed cert for an Ingress that is
+        // never created, leaving an orphaned secret in the cluster.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        k8s.AddIngress("empty")
+            .WithHostname("api.example.com")
+            .WithTls("my-tls-secret");
+
+        builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        using var app = builder.Build();
+        app.Run();
+
+        var ingressDir = Path.Combine(workspace.Path, "templates", "empty");
+        Assert.False(Directory.Exists(ingressDir), $"Ingress directory should not exist at {ingressDir}");
+
+        var steps = await PipelineStepTestHelpers.CreateStepsAsync(app.Services, k8s.Resource);
+        Assert.Empty(PipelineStepTestHelpers.GatewayOrTlsStepNames(steps));
+    }
+
+    [Fact]
     public async Task AddIngress_NoPaths_DoesNotGenerateYaml()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
 
@@ -314,6 +316,80 @@ public class KubernetesIngressTests(ITestOutputHelper outputHelper)
 
         var steps = await PipelineStepTestHelpers.CreateStepsAsync(app.Services, k8s.Resource);
         Assert.Empty(PipelineStepTestHelpers.GatewayOrTlsStepNames(steps));
+    }
+
+    [Fact]
+    public async Task AddIngress_UnresolvableBackendWithTls_NotEligibleForTlsBootstrap()
+    {
+        // An Ingress can be configured with paths (so it passes the publish-time materialization
+        // check) and still be dropped from the chart when none of its backends resolve to a
+        // deployment target. Bootstrapping its certificate anyway would leave an orphaned secret in
+        // the cluster, so eligibility is re-checked at deploy time.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        var otherEnvironment = builder.AddKubernetesEnvironment("other");
+
+        // Assigning the container to a different environment keeps it out of "env"'s deployment
+        // targets, so the Ingress backend cannot be resolved.
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints()
+            .WithComputeEnvironment(otherEnvironment);
+
+        var ingress = k8s.AddIngress("public")
+            .WithHostname("api.example.com")
+            .WithTls("my-tls-secret");
+        ingress.WithPath("/", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        app.Run();
+
+        var ingressDir = Path.Combine(workspace.Path, "templates", "public");
+        Assert.False(Directory.Exists(ingressDir), $"Ingress directory should not exist at {ingressDir}");
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // The secret is still collected, because step factories run before publish populates the
+        // generated objects and therefore cannot know the Ingress will be dropped.
+        var collected = KubernetesEnvironmentResource.CollectTlsSecrets(model, k8s.Resource);
+        var request = Assert.Single(collected);
+        Assert.Same(ingress.Resource, request.Owner);
+
+        // The deploy-time re-check is what prevents the orphaned secret.
+        Assert.False(KubernetesEnvironmentResource.OwnerWasMaterialized(request.Owner));
+    }
+
+    [Fact]
+    public async Task AddIngress_ResolvableBackendWithTls_EligibleForTlsBootstrap()
+    {
+        // Positive control for AddIngress_UnresolvableBackendWithTls_NotEligibleForTlsBootstrap:
+        // an Ingress that does render must remain eligible, so the deploy-time re-check cannot
+        // silently suppress every certificate.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        var ingress = k8s.AddIngress("public")
+            .WithHostname("api.example.com")
+            .WithTls("my-tls-secret");
+        ingress.WithPath("/", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        app.Run();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var collected = KubernetesEnvironmentResource.CollectTlsSecrets(model, k8s.Resource);
+        var request = Assert.Single(collected);
+        Assert.Same(ingress.Resource, request.Owner);
+        Assert.True(KubernetesEnvironmentResource.OwnerWasMaterialized(request.Owner));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -4,6 +4,8 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Aspire.Hosting.Kubernetes.Tests;
 
@@ -319,6 +321,37 @@ public class KubernetesIngressTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task AddIngress_NoPaths_WarnsThatIngressAndTlsAreSkipped()
+    {
+        // The warning is the only signal a user gets that their Ingress (and its certificate) was
+        // silently dropped, so assert its content rather than just the absence of artifacts.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var testSink = new TestSink();
+        builder.Services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(testSink)));
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+        k8s.AddIngress("empty")
+            .WithHostname("api.example.com")
+            .WithTls("my-tls-secret");
+
+        builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080);
+
+        using var app = builder.Build();
+        app.Run();
+
+        var warning = Assert.Single(
+            testSink.Writes,
+            w => w.LogLevel == LogLevel.Warning && w.Message is not null && w.Message.Contains("empty", StringComparison.Ordinal));
+
+        Assert.Equal(
+            "Ingress 'empty' has no path rules or default backend configured. The Ingress and its TLS certificate will not be created.",
+            warning.Message);
+    }
+
+    [Fact]
     public async Task AddIngress_UnresolvableBackendWithTls_NotEligibleForTlsBootstrap()
     {
         // An Ingress can be configured with paths (so it passes the publish-time materialization
@@ -390,6 +423,41 @@ public class KubernetesIngressTests(ITestOutputHelper outputHelper)
         var request = Assert.Single(collected);
         Assert.Same(ingress.Resource, request.Owner);
         Assert.True(KubernetesEnvironmentResource.OwnerWasMaterialized(request.Owner));
+    }
+
+    [Fact]
+    public async Task CollectTlsSecrets_BeforePublish_DoesNotDependOnGeneratedIngress()
+    {
+        // Guards the trap that makes this area easy to "fix" incorrectly. In production the pipeline
+        // builds every step before running any of them, so CollectTlsSecrets always executes while
+        // GeneratedIngress is still null. Moving the materialization check into collection would
+        // therefore disable TLS bootstrap for *every* Ingress, yet the other tests here would not
+        // notice, because they inspect collection after app.Run() has already populated it.
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish, workspace.Path);
+
+        var k8s = builder.AddKubernetesEnvironment("env");
+
+        var api = builder.AddContainer("myapi", "nginx")
+            .WithHttpEndpoint(targetPort: 8080)
+            .WithExternalHttpEndpoints();
+
+        var ingress = k8s.AddIngress("public")
+            .WithHostname("api.example.com")
+            .WithTls("my-tls-secret");
+        ingress.WithPath("/", api.GetEndpoint("http"));
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        Assert.Null(ingress.Resource.GeneratedIngress);
+        var collectedBeforePublish = KubernetesEnvironmentResource.CollectTlsSecrets(model, k8s.Resource);
+        Assert.Same(ingress.Resource, Assert.Single(collectedBeforePublish).Owner);
+
+        // The Ingress does render, so the deploy-time re-check still lets the bootstrap through.
+        app.Run();
+        Assert.NotNull(ingress.Resource.GeneratedIngress);
+        Assert.True(KubernetesEnvironmentResource.OwnerWasMaterialized(ingress.Resource));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Kubernetes.Tests/PipelineStepTestHelpers.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/PipelineStepTestHelpers.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable ASPIREPIPELINES001
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aspire.Hosting.Kubernetes.Tests;
+
+/// <summary>
+/// Helpers for inspecting the pipeline steps a resource registers, without needing a cluster.
+/// </summary>
+internal static class PipelineStepTestHelpers
+{
+    /// <summary>
+    /// Re-creates the pipeline steps contributed by <paramref name="resource"/>. Steps are built
+    /// from the resource's <see cref="PipelineStepAnnotation"/>s, which is how the deploy pipeline
+    /// discovers them, so tests can assert on which steps a given app model produces.
+    /// </summary>
+    public static async Task<List<PipelineStep>> CreateStepsAsync(IServiceProvider services, IResource resource)
+    {
+        var pipelineContext = new PipelineContext(
+            services.GetRequiredService<DistributedApplicationModel>(),
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
+            services,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        var results = new List<PipelineStep>();
+        foreach (var annotation in resource.Annotations.OfType<PipelineStepAnnotation>())
+        {
+            results.AddRange(await annotation.CreateStepsAsync(new PipelineStepFactoryContext
+            {
+                PipelineContext = pipelineContext,
+                Resource = resource
+            }));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Returns the sorted names of gateway- and TLS-related steps. Tests assert on this whole set
+    /// rather than probing individual step names, so a newly added gateway/TLS step that skips the
+    /// materialization-eligibility filter is caught rather than silently ignored.
+    /// </summary>
+    public static List<string> GatewayOrTlsStepNames(IEnumerable<PipelineStep> steps) =>
+        [.. steps
+            .Select(step => step.Name)
+            .Where(name => name.Contains("tls", StringComparison.Ordinal) || name.Contains("gateway", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)];
+}


### PR DESCRIPTION
## Description

Deploying an AppHost that declares a Gateway without any routes made `aspire deploy` hang for roughly 15 minutes before failing. The reported symptom turned out to be one instance of a broader problem, so this PR fixes the class rather than the single case.

A Gateway with no routes, and an Ingress with no paths and no default backend, are intentionally skipped during materialization — they are never written into the deployment artifacts. But **five other sites re-selected those same resources independently, with no eligibility check**, so deployment steps ran against Kubernetes objects that are never created:

| Site | Effect on a skipped resource |
|---|---|
| `CollectGatewaysNeedingFqdnDiscovery` | **The reported hang** — `tls-fqdn-discovery-{env}` polls `kubectl get gateway` 180 × 5s (~15 min) waiting for an address on a Gateway that was never rendered |
| `CertManagerExtensions.AppendSolver` | Emits an HTTP-01 solver `parentRef` to the missing Gateway |
| `CollectGatewaysWithTls` | Field-manager cleanup targets a non-existent Gateway |
| `CollectTlsSecrets` (gateway loop) | Orphaned self-signed Secret |
| `CollectTlsSecrets` (ingress loop) | Orphaned self-signed Secret |

The cert-manager case is the most damaging and is not visible in the original issue. `WithTls(issuer)` sets the `cert-manager.io/cluster-issuer` annotation, so a route-less Gateway still reached the solver and became a `parentRef` to a Gateway that never exists. The solver's HTTPRoute has nothing to attach to, the ACME challenge URL is unreachable, and **Certificates sit in `Pending` indefinitely**. Worse, `AppendSolver` already had a guard that warns when no eligible Gateway is found — written precisely to surface this at deploy time — but the ineligible Gateway made `parentGateways.Count == 1`, so **the one diagnostic that would have explained the failure was suppressed**.

### User-facing behavior

Given an AppHost with a Gateway that has no routes:

```csharp
var builder = DistributedApplication.CreateBuilder(args);

var k8s = builder.AddKubernetesEnvironment("env");

// No .WithRoute(...) call, so this Gateway is never materialized.
builder.AddGateway("public")
       .WithParent(k8s)
       .WithTls(issuer);

builder.Build().Run();
```

**Before:** `aspire deploy` registered `tls-fqdn-discovery-env` and blocked for ~15 minutes polling for a Gateway that would never appear, then failed. If cert-manager was in play, the ClusterIssuer manifest also shipped a dangling `parentRef` and no warning was emitted.

**After:** no TLS or gateway steps are registered for the skipped Gateway, deployment does not stall, no dangling `parentRef` is emitted, and a warning names what was omitted:

```text
warn: Gateway 'public' has no routes configured. The Gateway, routes, TLS certificate, and load-balancer frontend will not be created.
warn: ClusterIssuer 'letsencrypt' has an HTTP-01 solver but no Gateway in environment 'env' is both annotated with
      cert-manager.io/cluster-issuer=letsencrypt and configured with at least one route. cert-manager will not be able
      to satisfy ACME challenges until at least one routed Gateway adopts this issuer (e.g. via WithRoute(...) and
      WithTls(issuer)).
```

### Implementation

The eligibility rule is centralized as `internal bool ShouldMaterialize` on `KubernetesGatewayResource` (`Routes.Count > 0`) and `KubernetesIngressResource` (`Paths.Count > 0 || DefaultBackend is not null`), and applied at all five selection sites plus the two existing materialization skips. Previously the rule was inlined in exactly one place, which is what allowed the other sites to drift.

`ShouldMaterialize` is a *static* eligibility rule, and it is evaluated while pipeline steps are being collected. `DistributedApplicationPipeline.ResolveStepsAsync` builds the complete step list before any step executes, so at selection time `KubernetesIngressResource.GeneratedIngress` is always `null`. That leaves one residual gap: `BuildIngressObject` can still return `null` later, when an Ingress path's backend cannot be resolved, so a `tls-bootstrap` step could remain registered for an Ingress that never reaches the chart, creating an orphaned Secret.

`CollectTlsSecrets` therefore returns `List<TlsSecretRequest>` (secret name, hostname, **owning resource**) instead of a `HashSet<(ReferenceExpression, ReferenceExpression)>`, and `BootstrapTlsSecretsAsync` re-checks `OwnerWasMaterialized(owner)` at action time. That step depends on `helm-deploy-{env}`, so it runs after `prepare-deployment-targets` and `GeneratedIngress` is authoritative there. A `seen` set preserves the secret+host de-duplication the `HashSet` previously provided. Gateways need no second check: `BuildGatewayObjects` always emits the Gateway once `ShouldMaterialize` is true, and only skips individual `HTTPRoute`s on resolution failure.

The 15-minute retry budget (`MaxRetryAttempts = 179`, 5s delay) is deliberately unchanged. AGC and other Gateway controllers legitimately take 5–10 minutes to assign an address to a *materialized* Gateway; the bug was waiting for a Gateway that would never exist, not waiting too long for one that would.

### Validation

Each fix was confirmed to be load-bearing by temporarily reverting only the selection-site filters — leaving the materialization skips intact, i.e. the exact pre-fix state — and re-running the suite:

```text
failed CertManagerTests.BuildClusterIssuerManifest_RouteLessGateway_IsNotEmittedAsParentRef
       Assert.DoesNotContain() Failure: Sub-string found
failed KubernetesGatewayTests.AddGateway_NoRoutes_DoesNotGenerateYamlOrTlsSteps(hasTls: True, hasHostname: True)
       Assert.Empty() Failure: Collection was not empty
failed KubernetesGatewayTests.AddGateway_NoRoutes_DoesNotGenerateYamlOrTlsSteps(hasTls: True, hasHostname: False)
       Assert.Empty() Failure: Collection was not empty
failed KubernetesIngressTests.AddIngress_NoPathsWithTls_DoesNotRegisterTlsBootstrapStep
       Assert.Empty() Failure: Collection was not empty
```

The `hasTls: False` variant correctly passed in both states, confirming it is genuine additional coverage rather than a false positive. With the fixes in place, `Aspire.Hosting.Kubernetes` builds with 0 warnings and all 277 tests in `Aspire.Hosting.Kubernetes.Tests` pass with no snapshot drift.

One existing test had codified the cert-manager bug: `BuildClusterIssuerManifest_EmitsExpectedYamlForLetsEncryptHttp01` used a route-less Gateway and asserted the `parentRef` was present. It now gives the Gateway a route, and a new test covers the route-less case.

Tests assert the **complete** set of TLS/gateway step names rather than using `Assert.DoesNotContain`. The regression class here is "a new gateway step is added without the eligibility filter", which a name-by-name absence check cannot catch — and `Assert.DoesNotContain` is discouraged by `AGENTS.md` as a weak assertion. The duplicated per-file pipeline-step harness was extracted into a shared `PipelineStepTestHelpers`.

Both diagnostics are now asserted by tests. They were previously emitted but unverified, so the route-less Gateway warning and the cert-manager solver warning could each have been weakened or dropped silently — and those messages are the only signal a user gets that their Gateway or certificate was skipped.

No new deployment E2E test is added. The regression mechanism is pure pipeline-step *selection*: deterministic, cluster-independent, and fully observable from the step assertions above, which fail without the fix. The existing Kubernetes deployment E2E suite was run against this branch on real Azure and all five classes passed, including `KubernetesGatewayTlsDeploymentTests` and both cert-manager classes ([run 31481521922](https://github.com/microsoft/aspire/actions/runs/31481521922)).

Fixes #19217

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No