### PR TITLE
Fix database resource peer resolution

### DIFF
--- a/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
+++ b/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
@@ -50,6 +50,8 @@ internal static partial class ConnectionStringParser
 
     private static readonly string[] s_databaseAliases = ["database", "initial catalog", "database name", "databasename"];
 
+    private static readonly string[] s_databaseUriSchemes = ["mongodb", "mongodb+srv", "mssql", "mysql", "postgres", "postgresql"];
+
     private static readonly string[] s_knownProtocols = ["tcp", "udp", "ssl", "tls", "http", "https", "ftp", "ssh"];
 
     /// <summary>
@@ -125,7 +127,7 @@ internal static partial class ConnectionStringParser
     }
 
     /// <summary>
-    /// Attempts to extract a database name from a key-value connection string.
+    /// Attempts to extract a database name from a URI or key-value connection string.
     /// </summary>
     /// <param name="connectionString">The connection string to parse. Examples: "Host=localhost;Database=catalogdb" and "Server=localhost;Initial Catalog=Catalog".</param>
     /// <param name="databaseName">When this method returns <c>true</c>, contains the database name; otherwise, <c>null</c>.</param>
@@ -137,6 +139,11 @@ internal static partial class ConnectionStringParser
         if (string.IsNullOrWhiteSpace(connectionString))
         {
             return false;
+        }
+
+        if (TryParseDatabaseNameAsUri(connectionString, out databaseName))
+        {
+            return true;
         }
 
         try
@@ -168,6 +175,35 @@ internal static partial class ConnectionStringParser
         }
 
         return false;
+    }
+
+    private static bool TryParseDatabaseNameAsUri(string connectionString, [NotNullWhen(true)] out string? databaseName)
+    {
+        const string jdbcPrefix = "jdbc:";
+
+        databaseName = null;
+
+        // Database URI paths use these shapes:
+        //   mongodb://user:password@localhost:27017/catalogdb
+        //   jdbc:postgresql://localhost:5432/catalogdb
+        // Restrict parsing to database schemes so paths in endpoint URLs aren't treated as database names.
+        var uriValue = connectionString.StartsWith(jdbcPrefix, StringComparison.OrdinalIgnoreCase)
+            ? connectionString[jdbcPrefix.Length..]
+            : connectionString;
+        if (!Uri.TryCreate(uriValue, UriKind.Absolute, out var uri) ||
+            !s_databaseUriSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var escapedDatabaseName = uri.AbsolutePath.Trim('/');
+        if (escapedDatabaseName.Length == 0 || escapedDatabaseName.Contains('/'))
+        {
+            return false;
+        }
+
+        databaseName = Uri.UnescapeDataString(escapedDatabaseName);
+        return databaseName.Length > 0;
     }
 
     /// <summary>

--- a/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
+++ b/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -46,6 +47,8 @@ internal static partial class ConnectionStringParser
     };
 
     private static readonly string[] s_hostAliases = ["host", "server", "data source", "addr", "address", "endpoint", "contact points"];
+
+    private static readonly string[] s_databaseAliases = ["database", "initial catalog", "database name", "databasename"];
 
     private static readonly string[] s_knownProtocols = ["tcp", "udp", "ssl", "tls", "http", "https", "ftp", "ssh"];
 
@@ -116,6 +119,52 @@ internal static partial class ConnectionStringParser
         if (TryParseAsSingleHost(connectionString, out host, out port))
         {
             return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to extract a database name from a key-value connection string.
+    /// </summary>
+    /// <param name="connectionString">The connection string to parse. Examples: "Host=localhost;Database=catalogdb" and "Server=localhost;Initial Catalog=Catalog".</param>
+    /// <param name="databaseName">When this method returns <c>true</c>, contains the database name; otherwise, <c>null</c>.</param>
+    /// <returns><c>true</c> if a database name was found; otherwise, <c>false</c>.</returns>
+    public static bool TryDetectDatabaseName(string connectionString, [NotNullWhen(true)] out string? databaseName)
+    {
+        databaseName = null;
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return false;
+        }
+
+        try
+        {
+            var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
+            foreach (var alias in s_databaseAliases)
+            {
+                if (builder.TryGetValue(alias, out var value) && Convert.ToString(value, CultureInfo.InvariantCulture) is { Length: > 0 } parsedDatabaseName)
+                {
+                    databaseName = parsedDatabaseName;
+                    return true;
+                }
+            }
+        }
+        catch (ArgumentException)
+        {
+            // Some providers allow connection-string values that DbConnectionStringBuilder rejects.
+            // Fall back to the same tolerant parser used for host and port extraction.
+        }
+
+        var keyValuePairs = SplitIntoDictionary(connectionString);
+        foreach (var alias in s_databaseAliases)
+        {
+            if (keyValuePairs.TryGetValue(alias, out var value))
+            {
+                databaseName = value;
+                return true;
+            }
         }
 
         return false;

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -98,6 +98,11 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
             return false;
         }
 
+        if (!ArePropertyValuesEquivalent(resource1, resource2, KnownProperties.Resource.ConnectionProperties))
+        {
+            return false;
+        }
+
         // Check if parameter value properties are equivalent
         if (!ArePropertyValuesEquivalent(resource1, resource2, KnownProperties.Parameter.Value))
         {
@@ -146,11 +151,8 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
             return false;
         }
 
-        // Both have the property, compare values
-        var value1 = property1!.Value.TryConvertToString(out var str1) ? str1 : string.Empty;
-        var value2 = property2!.Value.TryConvertToString(out var str2) ? str2 : string.Empty;
-
-        return string.Equals(value1, value2, StringComparison.Ordinal);
+        // Protobuf value equality handles scalar and structured values recursively.
+        return property1!.Value.Equals(property2!.Value);
     }
 
     public bool TryResolvePeer(KeyValuePair<string, string>[] attributes, out string? name, out ResourceViewModel? matchedResource)

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -163,14 +163,15 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
         var address = OtlpHelpers.GetPeerAddress(attributes);
         if (address != null)
         {
-            var databaseName = attributes.GetValueWithFallback(DatabaseNamespaceAttribute, DatabaseNameAttribute);
+            var matchContext = new PeerMatchContext(resources, attributes.GetValueWithFallback(DatabaseNamespaceAttribute, DatabaseNameAttribute));
 
             // Apply transformers to the peer address cumulatively
             var transformedAddress = address;
 
             // First check exact match
-            if (TryMatchAgainstResources(transformedAddress, databaseName, resources, out name, out resourceMatch))
+            if (TryMatchAgainstResources(transformedAddress, matchContext, out resourceMatch))
             {
+                name = ResourceViewModel.GetResourceName(resourceMatch, resources);
                 return true;
             }
 
@@ -178,10 +179,18 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
             foreach (var transformer in s_addressTransformers)
             {
                 transformedAddress = transformer(transformedAddress);
-                if (TryMatchAgainstResources(transformedAddress, databaseName, resources, out name, out resourceMatch))
+                if (TryMatchAgainstResources(transformedAddress, matchContext, out resourceMatch))
                 {
+                    name = ResourceViewModel.GetResourceName(resourceMatch, resources);
                     return true;
                 }
+            }
+
+            resourceMatch = matchContext.FallbackMatch;
+            if (resourceMatch is not null)
+            {
+                name = ResourceViewModel.GetResourceName(resourceMatch, resources);
+                return true;
             }
         }
 
@@ -193,36 +202,31 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
     /// <summary>
     /// Checks if a transformed peer address matches any of the resource addresses using their cached addresses.
     /// Applies the same transformations to resource addresses for consistent matching.
-    /// Prefers a resource whose database matches the telemetry, then a database server resource, then the first resource with a different database, and finally the first address match.
+    /// Returns a resource whose database matches the telemetry and records lower-priority matches for fallback after all peer address transformations have been checked.
     /// </summary>
-    private static bool TryMatchAgainstResources(string peerAddress, string? databaseName, IDictionary<string, ResourceViewModel> resources, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out ResourceViewModel? resourceMatch)
+    private static bool TryMatchAgainstResources(string peerAddress, PeerMatchContext context, [NotNullWhen(true)] out ResourceViewModel? resourceMatch)
     {
-        ResourceViewModel? firstAddressMatch = null;
-        ResourceViewModel? firstServerMatch = null;
-        ResourceViewModel? firstDatabaseMatch = null;
-
-        foreach (var (_, resource) in resources)
+        foreach (var (_, resource) in context.Resources)
         {
             foreach (var resourceAddress in resource.CachedAddresses)
             {
                 if (DoesAddressMatch(resourceAddress, peerAddress))
                 {
-                    firstAddressMatch ??= resource;
+                    context.FirstAddressMatch ??= resource;
 
                     if (resource.CachedDatabaseName is { } resourceDatabaseName)
                     {
-                        firstDatabaseMatch ??= resource;
+                        context.FirstDatabaseMatch ??= resource;
 
-                        if (databaseName is not null && string.Equals(resourceDatabaseName, databaseName, StringComparison.OrdinalIgnoreCase))
+                        if (context.DatabaseName is not null && string.Equals(resourceDatabaseName, context.DatabaseName, StringComparison.OrdinalIgnoreCase))
                         {
-                            name = ResourceViewModel.GetResourceName(resource, resources);
                             resourceMatch = resource;
                             return true;
                         }
                     }
                     else if (resource.Properties.ContainsKey(KnownProperties.Resource.ConnectionString))
                     {
-                        firstServerMatch ??= resource;
+                        context.FirstServerMatch ??= resource;
                     }
 
                     break;
@@ -230,9 +234,8 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
             }
         }
 
-        resourceMatch = firstServerMatch ?? firstDatabaseMatch ?? firstAddressMatch;
-        name = resourceMatch is not null ? ResourceViewModel.GetResourceName(resourceMatch, resources) : null;
-        return resourceMatch is not null;
+        resourceMatch = null;
+        return false;
     }
 
     private static bool DoesAddressMatch(string endpoint, string value)
@@ -317,5 +320,15 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
         _watchContainersTokenSource.Dispose();
 
         await TaskHelpers.WaitIgnoreCancelAsync(_watchTask).ConfigureAwait(false);
+    }
+
+    private sealed class PeerMatchContext(IDictionary<string, ResourceViewModel> resources, string? databaseName)
+    {
+        public IDictionary<string, ResourceViewModel> Resources { get; } = resources;
+        public string? DatabaseName { get; } = databaseName;
+        public ResourceViewModel? FirstAddressMatch { get; set; }
+        public ResourceViewModel? FirstServerMatch { get; set; }
+        public ResourceViewModel? FirstDatabaseMatch { get; set; }
+        public ResourceViewModel? FallbackMatch => FirstServerMatch ?? FirstDatabaseMatch ?? FirstAddressMatch;
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -220,10 +220,15 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
                     {
                         context.FirstDatabaseMatch ??= resource;
 
-                        if (context.DatabaseName is not null && string.Equals(resourceDatabaseName, context.DatabaseName, StringComparison.OrdinalIgnoreCase))
+                        if (context.DatabaseName is not null && string.Equals(resourceDatabaseName, context.DatabaseName, StringComparison.Ordinal))
                         {
                             resourceMatch = resource;
                             return true;
+                        }
+
+                        if (context.DatabaseName is not null && string.Equals(resourceDatabaseName, context.DatabaseName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            context.CaseInsensitiveDatabaseMatch ??= resource;
                         }
                     }
                     else if (resource.Properties.ContainsKey(KnownProperties.Resource.ConnectionString))
@@ -331,6 +336,7 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
         public ResourceViewModel? FirstAddressMatch { get; set; }
         public ResourceViewModel? FirstServerMatch { get; set; }
         public ResourceViewModel? FirstDatabaseMatch { get; set; }
-        public ResourceViewModel? FallbackMatch => FirstServerMatch ?? FirstDatabaseMatch ?? FirstAddressMatch;
+        public ResourceViewModel? CaseInsensitiveDatabaseMatch { get; set; }
+        public ResourceViewModel? FallbackMatch => CaseInsensitiveDatabaseMatch ?? FirstServerMatch ?? FirstDatabaseMatch ?? FirstAddressMatch;
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -193,13 +193,13 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
     /// <summary>
     /// Checks if a transformed peer address matches any of the resource addresses using their cached addresses.
     /// Applies the same transformations to resource addresses for consistent matching.
-    /// Prefers a resource whose database matches the telemetry, then a database server resource, then the first address match.
+    /// Prefers a resource whose database matches the telemetry, then a database server resource, then the first resource with a different database, and finally the first address match.
     /// </summary>
     private static bool TryMatchAgainstResources(string peerAddress, string? databaseName, IDictionary<string, ResourceViewModel> resources, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out ResourceViewModel? resourceMatch)
     {
-        ResourceViewModel? firstMatch = null;
-        ResourceViewModel? serverMatch = null;
-        var hasDatabaseResourceMatch = false;
+        ResourceViewModel? firstAddressMatch = null;
+        ResourceViewModel? firstServerMatch = null;
+        ResourceViewModel? firstDatabaseMatch = null;
 
         foreach (var (_, resource) in resources)
         {
@@ -207,11 +207,11 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
             {
                 if (DoesAddressMatch(resourceAddress, peerAddress))
                 {
-                    firstMatch ??= resource;
+                    firstAddressMatch ??= resource;
 
                     if (resource.CachedDatabaseName is { } resourceDatabaseName)
                     {
-                        hasDatabaseResourceMatch = true;
+                        firstDatabaseMatch ??= resource;
 
                         if (databaseName is not null && string.Equals(resourceDatabaseName, databaseName, StringComparison.OrdinalIgnoreCase))
                         {
@@ -222,7 +222,7 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
                     }
                     else if (resource.Properties.ContainsKey(KnownProperties.Resource.ConnectionString))
                     {
-                        serverMatch ??= resource;
+                        firstServerMatch ??= resource;
                     }
 
                     break;
@@ -230,7 +230,7 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
             }
         }
 
-        resourceMatch = hasDatabaseResourceMatch ? serverMatch ?? firstMatch : firstMatch;
+        resourceMatch = firstServerMatch ?? firstDatabaseMatch ?? firstAddressMatch;
         name = resourceMatch is not null ? ResourceViewModel.GetResourceName(resourceMatch, resources) : null;
         return resourceMatch is not null;
     }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -13,6 +13,11 @@ namespace Aspire.Dashboard.Model;
 
 public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsyncDisposable
 {
+    // db.name was renamed to db.namespace in the stable OpenTelemetry database semantic conventions.
+    // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+    private const string DatabaseNamespaceAttribute = "db.namespace";
+    private const string DatabaseNameAttribute = "db.name";
+
     // Some libraries use "127.0.0.1" instead of "localhost".
     // Also handle container to host addresses.
     [GeneratedRegex(@"^(?:127\.0\.0\.1|host\.docker\.internal|host\.containers\.internal):", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
@@ -158,11 +163,13 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
         var address = OtlpHelpers.GetPeerAddress(attributes);
         if (address != null)
         {
+            var databaseName = attributes.GetValueWithFallback(DatabaseNamespaceAttribute, DatabaseNameAttribute);
+
             // Apply transformers to the peer address cumulatively
             var transformedAddress = address;
 
             // First check exact match
-            if (TryMatchAgainstResources(transformedAddress, resources, out name, out resourceMatch))
+            if (TryMatchAgainstResources(transformedAddress, databaseName, resources, out name, out resourceMatch))
             {
                 return true;
             }
@@ -171,7 +178,7 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
             foreach (var transformer in s_addressTransformers)
             {
                 transformedAddress = transformer(transformedAddress);
-                if (TryMatchAgainstResources(transformedAddress, resources, out name, out resourceMatch))
+                if (TryMatchAgainstResources(transformedAddress, databaseName, resources, out name, out resourceMatch))
                 {
                     return true;
                 }
@@ -186,26 +193,46 @@ public sealed partial class ResourceOutgoingPeerResolver : IOutgoingPeerResolver
     /// <summary>
     /// Checks if a transformed peer address matches any of the resource addresses using their cached addresses.
     /// Applies the same transformations to resource addresses for consistent matching.
-    /// Returns true and outputs the first matching resource if a match is found; otherwise, returns false.
+    /// Prefers a resource whose database matches the telemetry, then a database server resource, then the first address match.
     /// </summary>
-    private static bool TryMatchAgainstResources(string peerAddress, IDictionary<string, ResourceViewModel> resources, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out ResourceViewModel? resourceMatch)
+    private static bool TryMatchAgainstResources(string peerAddress, string? databaseName, IDictionary<string, ResourceViewModel> resources, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out ResourceViewModel? resourceMatch)
     {
+        ResourceViewModel? firstMatch = null;
+        ResourceViewModel? serverMatch = null;
+        var hasDatabaseResourceMatch = false;
+
         foreach (var (_, resource) in resources)
         {
             foreach (var resourceAddress in resource.CachedAddresses)
             {
                 if (DoesAddressMatch(resourceAddress, peerAddress))
                 {
-                    name = ResourceViewModel.GetResourceName(resource, resources);
-                    resourceMatch = resource;
-                    return true;
+                    firstMatch ??= resource;
+
+                    if (resource.CachedDatabaseName is { } resourceDatabaseName)
+                    {
+                        hasDatabaseResourceMatch = true;
+
+                        if (databaseName is not null && string.Equals(resourceDatabaseName, databaseName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            name = ResourceViewModel.GetResourceName(resource, resources);
+                            resourceMatch = resource;
+                            return true;
+                        }
+                    }
+                    else if (resource.Properties.ContainsKey(KnownProperties.Resource.ConnectionString))
+                    {
+                        serverMatch ??= resource;
+                    }
+
+                    break;
                 }
             }
         }
 
-        name = null;
-        resourceMatch = null;
-        return false;
+        resourceMatch = hasDatabaseResourceMatch ? serverMatch ?? firstMatch : firstMatch;
+        name = resourceMatch is not null ? ResourceViewModel.GetResourceName(resourceMatch, resources) : null;
+        return resourceMatch is not null;
     }
 
     private static bool DoesAddressMatch(string endpoint, string value)

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -60,7 +60,7 @@ public sealed class ResourceViewModel
     /// </summary>
     public ImmutableArray<string> CachedAddresses => (_cachedAddresses ??= new Lazy<ImmutableArray<string>>(ExtractResourceAddresses)).Value;
 
-    /// <summary>Gets the database name parsed from the resource connection string.</summary>
+    /// <summary>Gets the database name from resource metadata or the parsed connection string.</summary>
     internal string? CachedDatabaseName => (_cachedDatabaseName ??= new Lazy<string?>(ExtractDatabaseName)).Value;
 
     private ImmutableArray<string> ExtractResourceAddresses()
@@ -97,9 +97,17 @@ public sealed class ResourceViewModel
 
     private string? ExtractDatabaseName()
     {
+        if (Properties.TryGetValue(KnownProperties.Resource.ConnectionProperties, out var connectionPropertiesProperty) &&
+            connectionPropertiesProperty.Value.StructValue is { } connectionProperties &&
+            connectionProperties.Fields.TryGetValue("DatabaseName", out var databaseNameProperty) &&
+            databaseNameProperty.TryConvertToString(out var databaseName))
+        {
+            return databaseName;
+        }
+
         if (Properties.TryGetValue(KnownProperties.Resource.ConnectionString, out var connectionStringProperty) &&
             connectionStringProperty.Value.TryConvertToString(out var connectionString) &&
-            ConnectionStringParser.TryDetectDatabaseName(connectionString, out var databaseName))
+            ConnectionStringParser.TryDetectDatabaseName(connectionString, out databaseName))
         {
             return databaseName;
         }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -22,6 +22,7 @@ public sealed class ResourceViewModel
     private readonly ImmutableArray<HealthReportViewModel> _healthReports = [];
     private readonly KnownResourceState? _knownState;
     private Lazy<ImmutableArray<string>>? _cachedAddresses;
+    private Lazy<string?>? _cachedDatabaseName;
 
     public required string Name { get; init; }
     public required string ResourceType { get; init; }
@@ -59,6 +60,9 @@ public sealed class ResourceViewModel
     /// </summary>
     public ImmutableArray<string> CachedAddresses => (_cachedAddresses ??= new Lazy<ImmutableArray<string>>(ExtractResourceAddresses)).Value;
 
+    /// <summary>Gets the database name parsed from the resource connection string.</summary>
+    internal string? CachedDatabaseName => (_cachedDatabaseName ??= new Lazy<string?>(ExtractDatabaseName)).Value;
+
     private ImmutableArray<string> ExtractResourceAddresses()
     {
         var addresses = new List<string>();
@@ -89,6 +93,18 @@ public sealed class ResourceViewModel
         }
 
         return addresses.ToImmutableArray();
+    }
+
+    private string? ExtractDatabaseName()
+    {
+        if (Properties.TryGetValue(KnownProperties.Resource.ConnectionString, out var connectionStringProperty) &&
+            connectionStringProperty.Value.TryConvertToString(out var connectionString) &&
+            ConnectionStringParser.TryDetectDatabaseName(connectionString, out var databaseName))
+        {
+            return databaseName;
+        }
+
+        return null;
     }
 
     public required ImmutableArray<HealthReportViewModel> HealthReports

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -97,9 +97,7 @@ public sealed class ResourceViewModel
 
     private string? ExtractDatabaseName()
     {
-        if (Properties.TryGetValue(KnownProperties.Resource.ConnectionProperties, out var connectionPropertiesProperty) &&
-            connectionPropertiesProperty.Value.StructValue is { } connectionProperties &&
-            connectionProperties.Fields.TryGetValue("DatabaseName", out var databaseNameProperty) &&
+        if (TryGetConnectionProperty("DatabaseName", out var databaseNameProperty) &&
             databaseNameProperty.TryConvertToString(out var databaseName))
         {
             return databaseName;
@@ -113,6 +111,33 @@ public sealed class ResourceViewModel
         }
 
         return null;
+    }
+
+    private bool TryGetConnectionProperty(string propertyName, [NotNullWhen(true)] out Value? propertyValue)
+    {
+        if (!Properties.TryGetValue(KnownProperties.Resource.ConnectionProperties, out var connectionPropertiesProperty) ||
+            connectionPropertiesProperty.Value.StructValue is not { } connectionProperties)
+        {
+            propertyValue = null;
+            return false;
+        }
+
+        if (connectionProperties.Fields.TryGetValue(propertyName, out propertyValue))
+        {
+            return true;
+        }
+
+        foreach (var (name, value) in connectionProperties.Fields)
+        {
+            if (string.Equals(name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                propertyValue = value;
+                return true;
+            }
+        }
+
+        propertyValue = null;
+        return false;
     }
 
     public required ImmutableArray<HealthReportViewModel> HealthReports

--- a/src/Aspire.Dashboard/Model/TelemetryExportService.cs
+++ b/src/Aspire.Dashboard/Model/TelemetryExportService.cs
@@ -802,6 +802,17 @@ public sealed class TelemetryExportService
             return JsonValue.Create(value.BoolValue);
         }
 
+        if (value.StructValue is not null)
+        {
+            var jsonObject = new JsonObject();
+            foreach (var field in value.StructValue.Fields)
+            {
+                jsonObject[field.Key] = ConvertPropertyValueToJsonNode(field.Value);
+            }
+
+            return jsonObject;
+        }
+
         if (value.ListValue is not null)
         {
             var array = new JsonArray();

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceKnownProperties.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceKnownProperties.cs
@@ -19,4 +19,9 @@ public static class CustomResourceKnownProperties
     /// The connection string of the resource
     /// </summary>
     public static string ConnectionString { get; } = KnownProperties.Resource.ConnectionString;
+
+    /// <summary>
+    /// The connection properties of the resource.
+    /// </summary>
+    public static string ConnectionProperties { get; } = KnownProperties.Resource.ConnectionProperties;
 }

--- a/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AuxiliaryBackchannelRpcTarget.cs
@@ -1298,9 +1298,21 @@ internal sealed class AuxiliaryBackchannelRpcTarget(
             float floatValue => JsonValue.Create(floatValue),
             double doubleValue => JsonValue.Create(doubleValue),
             decimal decimalValue => JsonValue.Create(decimalValue),
+            IEnumerable<KeyValuePair<string, string>> properties => ConvertNameValuePropertyToJsonObject(properties),
             System.Collections.IEnumerable enumerable => ConvertEnumerablePropertyValueToJsonArray(enumerable),
             _ => JsonValue.Create(value.ToString())
         };
+    }
+
+    private static JsonObject ConvertNameValuePropertyToJsonObject(IEnumerable<KeyValuePair<string, string>> properties)
+    {
+        var jsonObject = new JsonObject();
+        foreach (var property in properties)
+        {
+            jsonObject[property.Key] = property.Value;
+        }
+
+        return jsonObject;
     }
 
     private static JsonNode? ConvertPropertyValueToLegacyJsonNode(object? value)

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -63,10 +63,22 @@ internal abstract class ResourceSnapshot
         {
             string s => Value.ForString(s),
             int i => Value.ForNumber(i),
+            IEnumerable<KeyValuePair<string, string>> properties => ConvertToValue(properties),
             IEnumerable<string> list => Value.ForList(list.Select(Value.ForString).ToArray()),
             IEnumerable<int> list => Value.ForList(list.Select(i => Value.ForNumber(i)).ToArray()),
             null => Value.ForNull(),
             _ => Value.ForString(value.ToString())
         };
+    }
+
+    private static Value ConvertToValue(IEnumerable<KeyValuePair<string, string>> properties)
+    {
+        var structValue = new Struct();
+        foreach (var property in properties)
+        {
+            structValue.Fields[property.Key] = ConvertToValue(property.Value);
+        }
+
+        return new Value { StructValue = structValue };
     }
 }

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -87,7 +87,18 @@ internal sealed class ApplicationOrchestrator
             var connectionProperties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
             foreach (var property in resourceWithConnectionString.GetConnectionProperties())
             {
-                connectionProperties[property.Key] = await property.Value.GetValueAsync(token).ConfigureAwait(false);
+                try
+                {
+                    connectionProperties[property.Key] = await property.Value.GetValueAsync(token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to resolve connection property {ConnectionPropertyName} for resource {ResourceName}.", property.Key, resourceWithConnectionString.Name);
+                }
             }
 
             await _notificationService.PublishUpdateAsync(resourceWithConnectionString, state => state with

--- a/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestrator/ApplicationOrchestrator.cs
@@ -84,10 +84,17 @@ internal sealed class ApplicationOrchestrator
         if (@event.Resource is IResourceWithConnectionString resourceWithConnectionString)
         {
             var connectionString = await resourceWithConnectionString.GetConnectionStringAsync(token).ConfigureAwait(false);
+            var connectionProperties = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var property in resourceWithConnectionString.GetConnectionProperties())
+            {
+                connectionProperties[property.Key] = await property.Value.GetValueAsync(token).ConfigureAwait(false);
+            }
 
             await _notificationService.PublishUpdateAsync(resourceWithConnectionString, state => state with
             {
-                Properties = [.. state.Properties, new(CustomResourceKnownProperties.ConnectionString, connectionString) { IsSensitive = true }]
+                Properties = [.. state.Properties,
+                    new(CustomResourceKnownProperties.ConnectionString, connectionString) { IsSensitive = true },
+                    new(CustomResourceKnownProperties.ConnectionProperties, connectionProperties) { IsSensitive = true }]
             })
             .ConfigureAwait(false);
         }

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -26,6 +26,7 @@ internal static class KnownProperties
         public const string Source = "resource.source";
         public const string HealthState = "resource.healthState";
         public const string ConnectionString = "resource.connectionString";
+        public const string ConnectionProperties = "resource.connectionProperties";
         public const string ParentName = "resource.parentName";
         public const string AppArgs = "resource.appArgs";
         public const string AppArgsSensitivity = "resource.appArgsSensitivity";

--- a/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DescribeCommandTests.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Runtime.CompilerServices;
 using Aspire.Cli.Backchannel;
 using Aspire.Cli.Commands;
 using Aspire.Cli.Resources;
 using Aspire.Cli.Tests.TestServices;
 using Aspire.Cli.Tests.Utils;
+using Aspire.Dashboard.Model;
 using Aspire.Shared.Model.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.InternalTesting;
@@ -442,6 +444,48 @@ public class DescribeCommandTests(ITestOutputHelper outputHelper)
         Assert.Single(deserialized.Resources);
 
         Assert.Equal("http://localhost:18888/?resource=redis", deserialized.Resources[0].DashboardUrl);
+    }
+
+    [Fact]
+    public async Task DescribeCommand_JsonFormat_PreservesObjectProperties()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var outputWriter = new TestOutputTextWriter(outputHelper);
+        using var provider = CreateDescribeTestServices(workspace, outputWriter, [
+            new ResourceSnapshot
+            {
+                Name = "postgres",
+                DisplayName = "postgres",
+                ResourceType = "Container",
+                State = "Running",
+                Properties = new Dictionary<string, JsonNode?>
+                {
+                    [KnownProperties.Resource.ConnectionProperties] = new JsonObject
+                    {
+                        ["Host"] = "localhost",
+                        ["DatabaseName"] = "catalogdb"
+                    }
+                }
+            },
+        ]);
+
+        var command = provider.GetRequiredService<RootCommand>();
+        var result = command.Parse("describe --format json");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+
+        var jsonOutput = string.Join("", outputWriter.Logs);
+        using var document = JsonDocument.Parse(jsonOutput);
+        var connectionProperties = document.RootElement
+            .GetProperty("resources")[0]
+            .GetProperty("properties")
+            .GetProperty(KnownProperties.Resource.ConnectionProperties);
+
+        Assert.Equal(JsonValueKind.Object, connectionProperties.ValueKind);
+        Assert.Equal("localhost", connectionProperties.GetProperty("Host").GetString());
+        Assert.Equal("catalogdb", connectionProperties.GetProperty("DatabaseName").GetString());
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/ConnectionStringParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConnectionStringParserTests.cs
@@ -119,6 +119,20 @@ public class ConnectionStringParserTests
         }
     }
 
+    [Theory]
+    [InlineData("Host=localhost;Port=5432;Database=catalogdb", true, "catalogdb")]
+    [InlineData("Data Source=localhost;Initial Catalog=Catalog", true, "Catalog")]
+    [InlineData("Server=localhost;Database Name=Catalog", true, "Catalog")]
+    [InlineData("jdbc:sqlserver://localhost:1433;databaseName=Catalog", true, "Catalog")]
+    [InlineData("Host=localhost;Port=5432", false, null)]
+    public void TryDetectDatabaseName_VariousFormats_ReturnsExpectedResults(string connectionString, bool expectedResult, string? expectedDatabaseName)
+    {
+        var result = ConnectionStringParser.TryDetectDatabaseName(connectionString, out var databaseName);
+
+        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedDatabaseName, databaseName);
+    }
+
     [Fact]
     public void TryDetectHostAndPort_IPv6URI_ReturnsCorrectHost()
     {

--- a/tests/Aspire.Dashboard.Tests/ConnectionStringParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConnectionStringParserTests.cs
@@ -124,6 +124,13 @@ public class ConnectionStringParserTests
     [InlineData("Data Source=localhost;Initial Catalog=Catalog", true, "Catalog")]
     [InlineData("Server=localhost;Database Name=Catalog", true, "Catalog")]
     [InlineData("jdbc:sqlserver://localhost:1433;databaseName=Catalog", true, "Catalog")]
+    [InlineData("mongodb://user:password@localhost:27017/catalogdb", true, "catalogdb")]
+    [InlineData("mongodb+srv://cluster0.example.mongodb.net/catalogdb", true, "catalogdb")]
+    [InlineData("mssql://localhost:1433/Catalog", true, "Catalog")]
+    [InlineData("postgresql://localhost:5432/catalog%20db", true, "catalog db")]
+    [InlineData("jdbc:postgresql://localhost:5432/catalogdb", true, "catalogdb")]
+    [InlineData("mongodb://localhost:27017/", false, null)]
+    [InlineData("https://models.github.ai/inference", false, null)]
     [InlineData("Host=localhost;Port=5432", false, null)]
     public void TryDetectDatabaseName_VariousFormats_ReturnsExpectedResults(string connectionString, bool expectedResult, string? expectedDatabaseName)
     {

--- a/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TelemetryExportServiceTests.cs
@@ -1178,6 +1178,10 @@ public sealed class TelemetryExportServiceTests
             resourceType: "Container",
             state: KnownResourceState.Running);
 
+        var connectionProperties = new Struct();
+        connectionProperties.Fields["Host"] = Value.ForString("localhost");
+        connectionProperties.Fields["DatabaseName"] = Value.ForString("catalogdb");
+
         var resource = ModelTestHelpers.CreateResource(
             resourceName: "test-resource",
             displayName: "Test Resource",
@@ -1191,6 +1195,14 @@ public sealed class TelemetryExportServiceTests
                     KnownProperties.Resource.WaitingFor,
                     Value.ForList(Value.ForString("dependency-resource")),
                     isValueSensitive: false,
+                    knownProperty: null,
+                    sortOrder: 0,
+                    displayName: null,
+                    isHighlighted: false),
+                [KnownProperties.Resource.ConnectionProperties] = new(
+                    KnownProperties.Resource.ConnectionProperties,
+                    new Value { StructValue = connectionProperties },
+                    isValueSensitive: true,
                     knownProperty: null,
                     sortOrder: 0,
                     displayName: null,
@@ -1216,6 +1228,9 @@ public sealed class TelemetryExportServiceTests
         var waitingForProperty = Assert.IsType<JsonArray>(deserialized.Properties[KnownProperties.Resource.WaitingFor]);
         var waitingForPropertyValue = Assert.Single(waitingForProperty);
         Assert.Equal("dependency-resource", waitingForPropertyValue?.GetValue<string>());
+        var connectionPropertiesObject = Assert.IsType<JsonObject>(deserialized.Properties[KnownProperties.Resource.ConnectionProperties]);
+        Assert.Equal("localhost", connectionPropertiesObject["Host"]?.GetValue<string>());
+        Assert.Equal("catalogdb", connectionPropertiesObject["DatabaseName"]?.GetValue<string>());
 
         Assert.NotNull(deserialized.Urls);
         Assert.Single(deserialized.Urls);

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Aspire.Dashboard.Model;
@@ -121,6 +122,51 @@ public class ResourceOutgoingPeerResolverTests
         // Act & Assert
         Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("server.port", "5000")], out var value));
         Assert.Equal("test", value);
+    }
+
+    [Theory]
+    [InlineData("db.namespace", "catalogdb")]
+    [InlineData("db.name", "CATALOGDB")]
+    public void DatabaseAttributeMatchesDatabaseResourceOverContainerResource(string databaseAttribute, string databaseName)
+    {
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["postgres-evxqcrgg"] = CreateResourceWithConnectionString("postgres-evxqcrgg", "Host=localhost;Port=50267;Username=postgres;Password=password", resourceType: KnownResourceTypes.Container, displayName: "postgres"),
+            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=catalogdb", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")])
+        };
+        var attributes = new[]
+        {
+            KeyValuePair.Create("server.address", "localhost"),
+            KeyValuePair.Create("server.port", "50267"),
+            KeyValuePair.Create(databaseAttribute, databaseName)
+        };
+
+        Assert.True(TryResolvePeerName(resources, attributes, out var value));
+        Assert.Equal("catalogdb", value);
+    }
+
+    [Theory]
+    [InlineData("unknown")]
+    [InlineData(null)]
+    public void DatabaseAttributeDoesNotMatchDatabaseResource_MatchesContainerResource(string? databaseName)
+    {
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=catalogdb", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")]),
+            ["postgres-evxqcrgg"] = CreateResourceWithConnectionString("postgres-evxqcrgg", "Host=localhost;Port=50267;Username=postgres;Password=password", resourceType: KnownResourceTypes.Container, displayName: "postgres")
+        };
+        var attributes = new List<KeyValuePair<string, string>>
+        {
+            KeyValuePair.Create("server.address", "localhost"),
+            KeyValuePair.Create("server.port", "50267")
+        };
+        if (databaseName is not null)
+        {
+            attributes.Add(KeyValuePair.Create("db.namespace", databaseName));
+        }
+
+        Assert.True(TryResolvePeerName(resources, attributes.ToArray(), out var value));
+        Assert.Equal("postgres", value);
     }
 
     [Fact]
@@ -326,7 +372,7 @@ public class ResourceOutgoingPeerResolverTests
         Assert.Equal("key-vault", value);
     }
 
-    private static ResourceViewModel CreateResourceWithConnectionString(string name, string connectionString)
+    private static ResourceViewModel CreateResourceWithConnectionString(string name, string connectionString, string resourceType = KnownResourceTypes.ConnectionString, string? displayName = null, ImmutableArray<RelationshipViewModel>? relationships = null)
     {
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
@@ -342,7 +388,9 @@ public class ResourceOutgoingPeerResolverTests
 
         return ModelTestHelpers.CreateResource(
             resourceName: name,
-            resourceType: KnownResourceTypes.ConnectionString,
+            displayName: displayName,
+            resourceType: resourceType,
+            relationships: relationships,
             properties: properties);
     }
 

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -146,6 +146,25 @@ public class ResourceOutgoingPeerResolverTests
         Assert.Equal("catalogdb", value);
     }
 
+    [Fact]
+    public void DatabaseAttributeMatchesDatabaseResourceAfterAddressTransformationOverExactContainerResource()
+    {
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["postgres-evxqcrgg"] = CreateResourceWithConnectionString("postgres-evxqcrgg", "Host=127.0.0.1;Port=50267;Username=postgres;Password=password", resourceType: KnownResourceTypes.Container, displayName: "postgres"),
+            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=catalogdb", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")])
+        };
+        var attributes = new[]
+        {
+            KeyValuePair.Create("server.address", "127.0.0.1"),
+            KeyValuePair.Create("server.port", "50267"),
+            KeyValuePair.Create("db.namespace", "catalogdb")
+        };
+
+        Assert.True(TryResolvePeerName(resources, attributes, out var value));
+        Assert.Equal("catalogdb", value);
+    }
+
     [Theory]
     [InlineData("unknown")]
     [InlineData(null)]

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -170,6 +170,32 @@ public class ResourceOutgoingPeerResolverTests
     }
 
     [Fact]
+    public void DatabaseAttributeMatchesMongoDbUriResourceOverContainerResource()
+    {
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["mongodb"] = CreateResourceWithConnectionString("mongodb", "mongodb://localhost:27017", resourceType: KnownResourceTypes.Container),
+            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "mongodb://localhost:27017/catalogdb", resourceType: "MongoDBDatabaseResource", relationships: [new("mongodb", "Parent")])
+        };
+
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("server.port", "27017"), KeyValuePair.Create("db.namespace", "catalogdb")], out var value));
+        Assert.Equal("catalogdb", value);
+    }
+
+    [Fact]
+    public void DatabaseAttributeDoesNotMatchMongoDbUriResource_MatchesContainerResource()
+    {
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "mongodb://localhost:27017/catalogdb", resourceType: "MongoDBDatabaseResource", relationships: [new("mongodb", "Parent")]),
+            ["mongodb"] = CreateResourceWithConnectionString("mongodb", "mongodb://localhost:27017", resourceType: KnownResourceTypes.Container)
+        };
+
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("server.port", "27017"), KeyValuePair.Create("db.namespace", "unknown")], out var value));
+        Assert.Equal("mongodb", value);
+    }
+
+    [Fact]
     public async Task OnPeerChanges_DataUpdates_EventRaised()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -153,6 +153,7 @@ public class ResourceOutgoingPeerResolverTests
     {
         var resources = new Dictionary<string, ResourceViewModel>
         {
+            ["unrelated"] = CreateResource("unrelated", "localhost", 50267),
             ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=catalogdb", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")]),
             ["postgres-evxqcrgg"] = CreateResourceWithConnectionString("postgres-evxqcrgg", "Host=localhost;Port=50267;Username=postgres;Password=password", resourceType: KnownResourceTypes.Container, displayName: "postgres")
         };
@@ -168,6 +169,31 @@ public class ResourceOutgoingPeerResolverTests
 
         Assert.True(TryResolvePeerName(resources, attributes.ToArray(), out var value));
         Assert.Equal("postgres", value);
+    }
+
+    [Theory]
+    [InlineData("unknown")]
+    [InlineData(null)]
+    public void DatabaseAttributeDoesNotMatchAndNoContainerResource_MatchesFirstDatabaseResource(string? databaseName)
+    {
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["unrelated"] = CreateResource("unrelated", "localhost", 50267),
+            ["jobsdb"] = CreateResourceWithConnectionString("jobsdb", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=jobsdb", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")]),
+            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=catalogdb", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")])
+        };
+        var attributes = new List<KeyValuePair<string, string>>
+        {
+            KeyValuePair.Create("server.address", "localhost"),
+            KeyValuePair.Create("server.port", "50267")
+        };
+        if (databaseName is not null)
+        {
+            attributes.Add(KeyValuePair.Create("db.namespace", databaseName));
+        }
+
+        Assert.True(TryResolvePeerName(resources, attributes.ToArray(), out var value));
+        Assert.Equal("jobsdb", value);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -9,6 +9,7 @@ using Aspire.DashboardService.Proto.V1;
 using Aspire.Tests.Shared.DashboardModel;
 using Microsoft.AspNetCore.InternalTesting;
 using Xunit;
+using Struct = Google.Protobuf.WellKnownTypes.Struct;
 using Value = Google.Protobuf.WellKnownTypes.Value;
 
 namespace Aspire.Dashboard.Tests;
@@ -229,6 +230,19 @@ public class ResourceOutgoingPeerResolverTests
     }
 
     [Fact]
+    public void DatabaseAttributeMatchesDatabaseNameConnectionProperty()
+    {
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["jobsdb"] = CreateResourceWithConnectionString("jobsdb", "user id=system;password=password;data source=localhost:1521/FREEPDB1", resourceType: "OracleDatabaseResource", databaseName: "jobsdb"),
+            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "user id=system;password=password;data source=localhost:1521/FREEPDB1", resourceType: "OracleDatabaseResource", databaseName: "catalogdb")
+        };
+
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("db.namespace", "catalogdb")], out var value));
+        Assert.Equal("catalogdb", value);
+    }
+
+    [Fact]
     public void DatabaseAttributeDoesNotMatchMongoDbUriResource_MatchesContainerResource()
     {
         var resources = new Dictionary<string, ResourceViewModel>
@@ -444,7 +458,7 @@ public class ResourceOutgoingPeerResolverTests
         Assert.Equal("key-vault", value);
     }
 
-    private static ResourceViewModel CreateResourceWithConnectionString(string name, string connectionString, string resourceType = KnownResourceTypes.ConnectionString, string? displayName = null, ImmutableArray<RelationshipViewModel>? relationships = null)
+    private static ResourceViewModel CreateResourceWithConnectionString(string name, string connectionString, string resourceType = KnownResourceTypes.ConnectionString, string? displayName = null, ImmutableArray<RelationshipViewModel>? relationships = null, string? databaseName = null)
     {
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
@@ -457,6 +471,20 @@ public class ResourceOutgoingPeerResolverTests
                 displayName: null,
                 isHighlighted: false)
         };
+
+        if (databaseName is not null)
+        {
+            var connectionProperties = new Struct();
+            connectionProperties.Fields["DatabaseName"] = Value.ForString(databaseName);
+            properties[KnownProperties.Resource.ConnectionProperties] = new(
+                name: KnownProperties.Resource.ConnectionProperties,
+                value: new Value { StructValue = connectionProperties },
+                isValueSensitive: false,
+                knownProperty: null,
+                sortOrder: 0,
+                displayName: null,
+                isHighlighted: false);
+        }
 
         return ModelTestHelpers.CreateResource(
             resourceName: name,

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -131,6 +131,7 @@ public class ResourceOutgoingPeerResolverTests
     {
         var resources = new Dictionary<string, ResourceViewModel>
         {
+            ["jobsdb"] = CreateResourceWithConnectionString("jobsdb", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=jobsdb", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")]),
             ["postgres-evxqcrgg"] = CreateResourceWithConnectionString("postgres-evxqcrgg", "Host=localhost;Port=50267;Username=postgres;Password=password", resourceType: KnownResourceTypes.Container, displayName: "postgres"),
             ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=catalogdb", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")])
         };

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -148,6 +148,19 @@ public class ResourceOutgoingPeerResolverTests
     }
 
     [Fact]
+    public void DatabaseAttributePrefersExactDatabaseNameMatchOverCaseInsensitiveMatch()
+    {
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["Catalog"] = CreateResourceWithConnectionString("Catalog", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=Catalog", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")]),
+            ["catalog"] = CreateResourceWithConnectionString("catalog", "Host=localhost;Port=50267;Username=postgres;Password=password;Database=catalog", resourceType: "PostgresDatabaseResource", relationships: [new("postgres", "Parent")])
+        };
+
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("server.port", "50267"), KeyValuePair.Create("db.namespace", "catalog")], out var value));
+        Assert.Equal("catalog", value);
+    }
+
+    [Fact]
     public void DatabaseAttributeMatchesDatabaseResourceAfterAddressTransformationOverExactContainerResource()
     {
         var resources = new Dictionary<string, ResourceViewModel>
@@ -229,13 +242,15 @@ public class ResourceOutgoingPeerResolverTests
         Assert.Equal("catalogdb", value);
     }
 
-    [Fact]
-    public void DatabaseAttributeMatchesDatabaseNameConnectionProperty()
+    [Theory]
+    [InlineData("DatabaseName")]
+    [InlineData("databaseName")]
+    public void DatabaseAttributeMatchesDatabaseNameConnectionProperty(string databaseNamePropertyName)
     {
         var resources = new Dictionary<string, ResourceViewModel>
         {
-            ["jobsdb"] = CreateResourceWithConnectionString("jobsdb", "user id=system;password=password;data source=localhost:1521/FREEPDB1", resourceType: "OracleDatabaseResource", databaseName: "jobsdb"),
-            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "user id=system;password=password;data source=localhost:1521/FREEPDB1", resourceType: "OracleDatabaseResource", databaseName: "catalogdb")
+            ["jobsdb"] = CreateResourceWithConnectionString("jobsdb", "user id=system;password=password;data source=localhost:1521/FREEPDB1", resourceType: "OracleDatabaseResource", databaseName: "jobsdb", databaseNamePropertyName: databaseNamePropertyName),
+            ["catalogdb"] = CreateResourceWithConnectionString("catalogdb", "user id=system;password=password;data source=localhost:1521/FREEPDB1", resourceType: "OracleDatabaseResource", databaseName: "catalogdb", databaseNamePropertyName: databaseNamePropertyName)
         };
 
         Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("db.namespace", "catalogdb")], out var value));
@@ -458,7 +473,7 @@ public class ResourceOutgoingPeerResolverTests
         Assert.Equal("key-vault", value);
     }
 
-    private static ResourceViewModel CreateResourceWithConnectionString(string name, string connectionString, string resourceType = KnownResourceTypes.ConnectionString, string? displayName = null, ImmutableArray<RelationshipViewModel>? relationships = null, string? databaseName = null)
+    private static ResourceViewModel CreateResourceWithConnectionString(string name, string connectionString, string resourceType = KnownResourceTypes.ConnectionString, string? displayName = null, ImmutableArray<RelationshipViewModel>? relationships = null, string? databaseName = null, string databaseNamePropertyName = "DatabaseName")
     {
         var properties = new Dictionary<string, ResourcePropertyViewModel>
         {
@@ -475,7 +490,7 @@ public class ResourceOutgoingPeerResolverTests
         if (databaseName is not null)
         {
             var connectionProperties = new Struct();
-            connectionProperties.Fields["DatabaseName"] = Value.ForString(databaseName);
+            connectionProperties.Fields[databaseNamePropertyName] = Value.ForString(databaseName);
             properties[KnownProperties.Resource.ConnectionProperties] = new(
                 name: KnownProperties.Resource.ConnectionProperties,
                 value: new Value { StructValue = connectionProperties },

--- a/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AuxiliaryBackchannelRpcTargetTests.cs
@@ -641,6 +641,11 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
                 new ResourcePropertySnapshot("number", 42),
                 new ResourcePropertySnapshot("flag", true),
                 new ResourcePropertySnapshot("list", new[] { "one", "two" }),
+                new ResourcePropertySnapshot("object", new KeyValuePair<string, string>[]
+                {
+                    new("Host", "localhost"),
+                    new("DatabaseName", "catalogdb")
+                }),
                 new ResourcePropertySnapshot("ConnectionString", "secret-value") { IsSensitive = true }
             ]
         }).DefaultTimeout();
@@ -664,6 +669,9 @@ public class AuxiliaryBackchannelRpcTargetTests(ITestOutputHelper outputHelper)
             list,
             value => Assert.Equal("one", value?.GetValue<string>()),
             value => Assert.Equal("two", value?.GetValue<string>()));
+        var nameValueObject = Assert.IsAssignableFrom<JsonObject>(snapshot.Properties["object"]);
+        Assert.Equal("localhost", nameValueObject["Host"]?.GetValue<string>());
+        Assert.Equal("catalogdb", nameValueObject["DatabaseName"]?.GetValue<string>());
         Assert.Null(snapshot.Properties["ConnectionString"]);
 
         await app.StopAsync().DefaultTimeout(TestConstants.LongTimeoutTimeSpan);

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -11,6 +11,25 @@ namespace Aspire.Hosting.Tests.Dashboard;
 public class ResourcePublisherTests
 {
     [Fact]
+    public void ConnectionPropertiesAreConvertedToStructuredValue()
+    {
+        var snapshot = CreateResourceSnapshot(
+            "A",
+            new ResourcePropertySnapshot(
+                KnownProperties.Resource.ConnectionProperties,
+                new KeyValuePair<string, string>[]
+                {
+                    new("Host", "localhost"),
+                    new("DatabaseName", "catalogdb")
+                }));
+
+        var property = Assert.Single(snapshot.Properties, p => p.Name == KnownProperties.Resource.ConnectionProperties);
+        var connectionProperties = Assert.IsType<Google.Protobuf.WellKnownTypes.Struct>(property.Value.StructValue);
+        Assert.Equal("localhost", connectionProperties.Fields["Host"].StringValue);
+        Assert.Equal("catalogdb", connectionProperties.Fields["DatabaseName"].StringValue);
+    }
+
+    [Fact]
     public async Task ProducesExpectedSnapshotAndUpdates()
     {
         CancellationTokenSource cts = new();
@@ -180,11 +199,11 @@ public class ResourcePublisherTests
         await task.DefaultTimeout();
     }
 
-    private static GenericResourceSnapshot CreateResourceSnapshot(string name)
+    private static GenericResourceSnapshot CreateResourceSnapshot(string name, params ResourcePropertySnapshot[] properties)
     {
         return new GenericResourceSnapshot(new()
         {
-            Properties = [],
+            Properties = [.. properties],
             ResourceType = KnownResourceTypes.Container
         })
         {

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -447,12 +447,12 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task ConnectionStringAvailableEventPublishesUpdateWithConnectionStringValue()
+    public async Task ConnectionStringAvailableEventPublishesConnectionStringAndProperties()
     {
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var resource = builder.AddResource(new TestResourceWithConnectionString("test-resource", "Server=localhost:5432;Database=testdb"));
+        var resource = builder.AddResource(new TestResourceWithConnectionString("test-resource", "Server=localhost:5432;Database=testdb", "testdb", "localhost"));
 
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -465,7 +465,10 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         await appOrchestrator.RunApplicationAsync();
 
         string? connectionStringProperty = null;
-        bool? isSensitive = null;
+        IReadOnlyDictionary<string, string?>? connectionProperties = null;
+        bool? isConnectionStringSensitive = null;
+        bool? areConnectionPropertiesSensitive = null;
+        var hasDatabaseNameProperty = false;
         var watchResourceTask = Task.Run(async () =>
         {
             await foreach (var item in resourceNotificationService.WatchAsync())
@@ -476,7 +479,11 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
                     if (connectionStringProp is not null)
                     {
                         connectionStringProperty = connectionStringProp.Value?.ToString();
-                        isSensitive = connectionStringProp.IsSensitive;
+                        isConnectionStringSensitive = connectionStringProp.IsSensitive;
+                        var connectionPropertiesProp = item.Snapshot.Properties.Single(p => p.Name == KnownProperties.Resource.ConnectionProperties);
+                        connectionProperties = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string?>>(connectionPropertiesProp.Value);
+                        areConnectionPropertiesSensitive = connectionPropertiesProp.IsSensitive;
+                        hasDatabaseNameProperty = item.Snapshot.Properties.Any(p => p.Name == "resource.DatabaseName");
                         return;
                     }
                 }
@@ -489,7 +496,16 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         await watchResourceTask.DefaultTimeout();
 
         Assert.Equal("Server=localhost:5432;Database=testdb", connectionStringProperty);
-        Assert.True(isSensitive);
+        Assert.True(isConnectionStringSensitive);
+        Assert.Equal(
+            new Dictionary<string, string?>
+            {
+                ["DatabaseName"] = "testdb",
+                ["Host"] = "localhost"
+            },
+            connectionProperties);
+        Assert.True(areConnectionPropertiesSensitive);
+        Assert.False(hasDatabaseNameProperty);
     }
 
     [Fact]
@@ -1249,7 +1265,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         public IResource Parent { get; } = parent;
     }
 
-    private sealed class TestResourceWithConnectionString(string name, string connectionString)
+    private sealed class TestResourceWithConnectionString(string name, string connectionString, string? databaseName = null, string? host = null)
         : Resource(name), IResourceWithConnectionString
     {
         public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{connectionString}");
@@ -1257,6 +1273,19 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
         {
             return ValueTask.FromResult<string?>(connectionString);
+        }
+
+        public IEnumerable<KeyValuePair<string, ReferenceExpression>> GetConnectionProperties()
+        {
+            if (databaseName is not null)
+            {
+                yield return new("DatabaseName", ReferenceExpression.Create($"{databaseName}"));
+            }
+
+            if (host is not null)
+            {
+                yield return new("Host", ReferenceExpression.Create($"{host}"));
+            }
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -447,12 +447,13 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task ConnectionStringAvailableEventPublishesConnectionStringAndProperties()
+    public async Task ConnectionStringAvailableEventPublishesConnectionStringAndResolvableProperties()
     {
         var builder = DistributedApplication.CreateBuilder();
         builder.WithTestAndResourceLogging(testOutputHelper);
 
-        var resource = builder.AddResource(new TestResourceWithConnectionString("test-resource", "Server=localhost:5432;Database=testdb", "testdb", "localhost"));
+        var unresolvedProperty = ReferenceExpression.Create($"{new ThrowingValueProvider()}");
+        var resource = builder.AddResource(new TestResourceWithConnectionString("test-resource", "Server=localhost:5432;Database=testdb", "testdb", "localhost", unresolvedProperty));
 
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -1265,7 +1266,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         public IResource Parent { get; } = parent;
     }
 
-    private sealed class TestResourceWithConnectionString(string name, string connectionString, string? databaseName = null, string? host = null)
+    private sealed class TestResourceWithConnectionString(string name, string connectionString, string? databaseName = null, string? host = null, ReferenceExpression? unresolvedProperty = null)
         : Resource(name), IResourceWithConnectionString
     {
         public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{connectionString}");
@@ -1285,6 +1286,11 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
             if (host is not null)
             {
                 yield return new("Host", ReferenceExpression.Create($"{host}"));
+            }
+
+            if (unresolvedProperty is not null)
+            {
+                yield return new("Unavailable", unresolvedProperty);
             }
         }
     }
@@ -1544,5 +1550,15 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
         await watchResourceTask.DefaultTimeout();
 
         Assert.Equal(parentProjectResourceId, childProjectParentResourceId);
+    }
+
+    private sealed class ThrowingValueProvider : IValueProvider, IManifestExpressionProvider
+    {
+        public string ValueExpression => "{throwing.value}";
+
+        public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("The connection property isn't available.");
+        }
     }
 }


### PR DESCRIPTION
## Description

SQL spans can report the same server address for a database container and every database resource hosted by that container. The dashboard previously selected the first resource with a matching address, which could attribute spans to the container or the wrong database.

This change uses `db.namespace`, with `db.name` as a legacy fallback, to prefer the resource whose database name matches the span. Database matches are considered across all address transformations before falling back to the matching server/container resource and then the first address match.

The AppHost now publishes successfully resolved values from `IResourceWithConnectionString.GetConnectionProperties()` as a sensitive `resource.connectionProperties` name/value object. The dashboard reads the canonical `DatabaseName` property, which supports integrations such as Oracle whose database name cannot be reliably parsed from the connection string. Connection-string parsing remains as a compatibility fallback for older AppHosts and custom resources. An auxiliary connection property that cannot be resolved is omitted with a warning and does not prevent the resource from starting.

Structured resource properties are preserved as objects in dashboard telemetry exports and V3 backchannel JSON. Sensitive properties remain redacted from backchannel clients such as `aspire describe`; non-sensitive object-valued properties are serialized as JSON objects.

Tests cover:

- Multiple databases sharing one server address.
- `db.namespace` and legacy `db.name` matching.
- Case-insensitive database-name matching.
- Address transformations before container fallback.
- PostgreSQL, MongoDB URI, and Oracle connection-property shapes.
- Structured property transport through dashboard, telemetry export, backchannel, and CLI serializers.
- Unresolvable auxiliary connection properties being omitted without failing publication.

Validation:

```text
ApplicationOrchestratorTests: 28 passed
DescribeCommandTests: 30 passed
ResourceOutgoingPeerResolverTests: 34 passed
Resource JSON conversion tests: 4 passed
```

Fixes #18831

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add XML documentation?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - Connection properties are marked sensitive and redacted from backchannel clients.
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No