### PR TITLE
[auto-sec] extension: js-yaml 4.3.0 -> 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1108,7 +1108,7 @@
     "fast-uri": "3.1.5",
     "qs": "6.15.2",
     "ws": "8.21.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "markdown-it": "14.2.0",
     "form-data": "4.0.6",
     "body-parser": "2.3.0"

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -3949,10 +3949,10 @@ js-tokens@^4.0.0:
   resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha1-GSA/tZmR35jjoocFDUZHzerzJJk=
 
-js-yaml@4.3.0, js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.3.0"
-  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=
+js-yaml@4.3.1, js-yaml@^4.1.0, js-yaml@^4.1.1:
+  version "4.3.1"
+  resolved "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Canonical npm remediation — js-yaml (extension) · microsoft/aspire

**Cluster:** `js-yaml` GHSA-5p4m-2wfm-xmqj (high) — deferred manifest from #19123.
**Branch:** `dapire/security-deps/aspire-js-yaml-extension` · **Label:** `automated-security`

### Alert addressed — 1

| Alert | Manifest | Package | From → To |
|-------|----------|---------|-----------|
| [#1959](https://github.com/microsoft/aspire/security/dependabot/1959) | `extension/yarn.lock` | js-yaml | 4.3.0 → **4.3.1** |

GHSA-5p4m-2wfm-xmqj is quadratic CPU consumption in `!!omap` resolution. The
vulnerable range is `>= 4.0.0, < 4.3.1`; **4.3.1** is the first patched 4.x
release. The extension pinned `js-yaml` to `4.3.0` via `resolutions`; bumping
that pin to `4.3.1` clears the alert with **no behavior change** — 4.3.1
satisfies every requester (`^4.1.0`, `^4.1.1`) and keeps the same dependency
(`argparse ^2.0.1`).

### Why this was previously deferred

The prior canonical PR **#19123** (merged) remediated 9 of 11 js-yaml alerts and
deferred #1959, on the basis that only a behavior-changing bump to js-yaml v5
was available for the Yarn 1 extension toolchain. The advisory now provides a
same-major **4.3.1** patch, so the deferral no longer applies.

### Verification

- `extension/yarn.lock` regenerated with **yarn 1.22.22** (the pinned
  `packageManager`) resolving from the dnceng public feed.
- `yarn install --frozen-lockfile --non-interactive` → **success / "Already
  up-to-date"** (the exact gate `extension-e2e-tests.yml` runs).
- Diff is surgical: 2 files, +5 −5 (resolution pin + single lock stanza).

### Scope / dedupe

- No overlapping open PR or Dependabot PR targets `extension/yarn.lock`.
- `[auto-sec]` = active canonical remediation for the extension js-yaml alert.

---
*Automation-owned canonical PR.*
