### PR TITLE
Honor ASPIRE_HOME for deployment state

### DIFF
--- a/extension/src/server/interactionService.ts
+++ b/extension/src/server/interactionService.ts
@@ -160,6 +160,7 @@ function getConsoleLineText(line: ConsoleLine): string {
 type DebugSessionOptions = {
     command?: string;
     args?: string[];
+    env?: { [key: string]: string };
 };
 
 export class InteractionService implements IInteractionService {
@@ -673,6 +674,7 @@ export class InteractionService implements IInteractionService {
             program: projectFile ?? workingDirectory,
             command: command as AspireExtendedDebugConfiguration['command'],
             args: options?.args,
+            env: options?.env,
             noDebug: !debug,
         };
 

--- a/extension/src/test/rpc/interactionServiceTests.test.ts
+++ b/extension/src/test/rpc/interactionServiceTests.test.ts
@@ -153,6 +153,32 @@ suite('InteractionService endpoints', () => {
 		showQuickPickStub.restore();
 	});
 
+	test('startDebugSession forwards CLI environment to the debug configuration', async () => {
+		const testInfo = await createTestRpcServer();
+		const startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').resolves(true);
+
+		try {
+			await testInfo.interactionService.startDebugSession(
+				'/workspace',
+				'/workspace/apphost.cs',
+				true,
+				{
+					command: 'deploy',
+					env: {
+						ASPIRE_HOME: '/isolated/aspire-home',
+					},
+				});
+
+			const debugConfiguration = startDebuggingStub.firstCall.args[1] as vscode.DebugConfiguration;
+			assert.deepStrictEqual(debugConfiguration.env, {
+				ASPIRE_HOME: '/isolated/aspire-home',
+			});
+		}
+		finally {
+			startDebuggingStub.restore();
+		}
+	});
+
 	test('displayError endpoint', async () => {
 		const testInfo = await createTestRpcServer();
 		const showErrorMessageSpy = sinon.spy(vscode.window, 'showErrorMessage');

--- a/src/Aspire.Cli/Backchannel/ExtensionBackchannelDataTypes.cs
+++ b/src/Aspire.Cli/Backchannel/ExtensionBackchannelDataTypes.cs
@@ -79,4 +79,10 @@ internal sealed class DebugSessionOptions
     /// </summary>
     [JsonPropertyName("args")]
     public string[]? Args { get; set; }
+
+    /// <summary>
+    /// Gets or sets environment variables to pass to the CLI process started by the debug session.
+    /// </summary>
+    [JsonPropertyName("env")]
+    public Dictionary<string, string>? EnvironmentVariables { get; set; }
 }

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -153,7 +153,19 @@ internal abstract class PipelineCommandBase : BaseCommand
             var commandArgs = GetCommandArgs(parseResult).Concat(parseResult.UnmatchedTokens).ToArray();
 
             extensionInteractionService.DisplayConsolePlainText($"Detected aspire {Name} inside the Aspire extension, starting a debug session in VS Code...");
-            await extensionInteractionService.StartDebugSessionAsync(ExecutionContext.WorkingDirectory.FullName, passedAppHostProjectFile?.FullName, debug: true, new DebugSessionOptions { Command = Name, Args = commandArgs.Length > 0 ? commandArgs : null });
+            await extensionInteractionService.StartDebugSessionAsync(
+                ExecutionContext.WorkingDirectory.FullName,
+                passedAppHostProjectFile?.FullName,
+                debug: true,
+                new DebugSessionOptions
+                {
+                    Command = Name,
+                    Args = commandArgs.Length > 0 ? commandArgs : null,
+                    EnvironmentVariables = new Dictionary<string, string>
+                    {
+                        [KnownConfigNames.AspireHome] = ExecutionContext.AspireHomeDirectory.FullName
+                    }
+                });
             return CommandResult.Success();
         }
 
@@ -184,7 +196,10 @@ internal abstract class PipelineCommandBase : BaseCommand
 
             var project = _projectFactory.GetProject(effectiveAppHostFile);
 
-            var env = new Dictionary<string, string>();
+            var env = new Dictionary<string, string>
+            {
+                [KnownConfigNames.AspireHome] = ExecutionContext.AspireHomeDirectory.FullName
+            };
 
             // Set interactivity enabled based on host environment capabilities
             if (!_hostEnvironment.SupportsInteractiveInput)

--- a/src/Aspire.Cli/Projects/GuestAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/GuestAppHostProject.cs
@@ -1016,6 +1016,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                 defaultEnvironment: AppHostEnvironmentDefaults.ProductionEnvironmentName,
                 includeLaunchProfileEnvironmentVariables: false,
                 args: context.Arguments);
+            launchSettingsEnvVars[KnownConfigNames.AspireHome] = _executionContext.AspireHomeDirectory.FullName;
 
             // Generate a backchannel socket path for CLI to connect to AppHost server
             var backchannelSocketPath = GetBackchannelSocketPath();
@@ -1120,6 +1121,7 @@ internal sealed class GuestAppHostProject : IAppHostProject, IGuestAppHostSdkGen
                     defaultEnvironment: AppHostEnvironmentDefaults.ProductionEnvironmentName,
                     includeLaunchProfileEnvironmentVariables: false,
                     args: context.Arguments);
+                environmentVariables[KnownConfigNames.AspireHome] = _executionContext.AspireHomeDirectory.FullName;
                 environmentVariables["REMOTE_APP_HOST_SOCKET_PATH"] = jsonRpcSocketPath;
                 environmentVariables["ASPIRE_PROJECT_DIRECTORY"] = directory.FullName;
                 environmentVariables["ASPIRE_APPHOST_FILEPATH"] = appHostFile.FullName;

--- a/src/Aspire.Hosting/Pipelines/Internal/FileDeploymentStateManager.cs
+++ b/src/Aspire.Hosting/Pipelines/Internal/FileDeploymentStateManager.cs
@@ -67,9 +67,16 @@ internal sealed partial class FileDeploymentStateManager(
             throw new ArgumentException($"The environment name '{environment}' contains invalid characters. Environment names must only contain alphanumeric characters, underscores, and hyphens ([a-zA-Z0-9_-]+).", "EnvironmentName");
         }
 
+        var aspireHome = configuration[KnownConfigNames.AspireHome];
+        if (string.IsNullOrWhiteSpace(aspireHome))
+        {
+            aspireHome = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".aspire");
+        }
+
         var aspireDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".aspire",
+            aspireHome,
             "deployments",
             appHostSha
         );

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -61,6 +61,7 @@ internal static class KnownConfigNames
     public const string TestingDisableHttpClient = "ASPIRE_TESTING_DISABLE_HTTP_CLIENT";
     public const string InteractivityEnabled = "ASPIRE_INTERACTIVITY_ENABLED";
     public const string EnableContainerTunnel = "ASPIRE_ENABLE_CONTAINER_TUNNEL";
+    public const string AspireHome = "ASPIRE_HOME";
     public const string AspireUserSecretsId = "ASPIRE_USER_SECRETS_ID";
     public const string MaxFileUploadSize = "ASPIRE_MAX_FILE_UPLOAD_SIZE";
 

--- a/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/DeployCommandTests.cs
@@ -9,6 +9,7 @@ using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Tests.TestServices;
 using Microsoft.Extensions.DependencyInjection;
 using Aspire.Cli.Utils;
+using Aspire.Hosting;
 using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Cli.Tests.Commands;
@@ -28,6 +29,43 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task DeployCommandInExtensionForwardsResolvedAspireHome()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var expectedAspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, ".home", ".aspire");
+        DebugSessionOptions? capturedOptions = null;
+
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
+        {
+            options.ProjectLocatorFactory = _ => new TestProjectLocator();
+            options.ExtensionBackchannelFactory = _ => new TestExtensionBackchannel();
+            options.InteractionServiceFactory = sp =>
+            {
+                var interactionService = new TestExtensionInteractionService(sp);
+                interactionService.StartDebugSessionCallback = (_, _, _, debugSessionOptions) =>
+                {
+                    capturedOptions = debugSessionOptions;
+                };
+                return interactionService;
+            };
+        });
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<RootCommand>();
+
+        var result = command.Parse("deploy");
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(0, exitCode);
+        Assert.NotNull(capturedOptions);
+        Assert.Equal(
+            new Dictionary<string, string>
+            {
+                [KnownConfigNames.AspireHome] = expectedAspireHome
+            },
+            capturedOptions.EnvironmentVariables);
     }
 
     [Fact]
@@ -202,6 +240,7 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
     public async Task DeployCommandSucceedsEndToEnd()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var expectedAspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, ".home", ".aspire");
 
         // Arrange
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -225,6 +264,8 @@ public class DeployCommandTests(ITestOutputHelper outputHelper)
                     RunAsyncCallback = async (projectFile, watch, noBuild, noRestore, args, env, backchannelCompletionSource, options, cancellationToken) =>
                     {
                         Assert.True(options.NoLaunchProfile);
+                        Assert.NotNull(env);
+                        Assert.Equal(expectedAspireHome, env[KnownConfigNames.AspireHome]);
 
                         // Verify the complete set of expected arguments for deploy command
                         Assert.Contains("--operation", args);

--- a/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/GuestAppHostProjectTests.cs
@@ -1000,6 +1000,46 @@ public class GuestAppHostProjectTests : IDisposable
     }
 
     [Fact]
+    public async Task PublishAsync_PassesResolvedAspireHomeToAppHostServerEnvironment()
+    {
+        var appHostPath = Path.Combine(_workspace.WorkspaceRoot.FullName, "apphost.ts");
+        await File.WriteAllTextAsync(appHostPath, "// test apphost");
+        var appHostFile = new FileInfo(appHostPath);
+
+        var projectFactory = new TestAppHostServerProjectFactory
+        {
+            CreateAsyncCallback = (path, _) =>
+                Task.FromResult<IAppHostServerProject>(new FakeSucceedingAppHostServerProject(path))
+        };
+        var serverSession = new FakeAppHostServerSession
+        {
+            GetRpcClientAsyncCallback = _ => Task.FromException<IAppHostRpcClient>(
+                new InvalidOperationException("Stop after the server launch environment has been captured."))
+        };
+        var sessionFactory = new FakeAppHostServerSessionFactory
+        {
+            Session = serverSession
+        };
+        var project = CreateGuestAppHostProject(
+            appHostServerProjectFactory: projectFactory,
+            serverSessionFactory: sessionFactory);
+        var context = new PublishContext
+        {
+            AppHostFile = appHostFile,
+            WorkingDirectory = _workspace.WorkspaceRoot
+        };
+
+        var exitCode = await project.PublishAsync(context, CancellationToken.None);
+
+        Assert.Equal(CliExitCodes.FailedToDotnetRunAppHost, exitCode);
+        Assert.True(serverSession.StartAsyncCalled);
+        Assert.NotNull(sessionFactory.CapturedEnvironmentVariables);
+        Assert.Equal(
+            Path.Combine(AppContext.BaseDirectory, ".home", ".aspire"),
+            sessionFactory.CapturedEnvironmentVariables[KnownConfigNames.AspireHome]);
+    }
+
+    [Fact]
     public void IsUsingProjectReferencesReturnsFalseWhenIdentityIsOverridden()
     {
         // When ASPIRE_CLI_* identity overrides (or the install sidecar) are active the CLI is

--- a/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/KubernetesIngressTests.cs
@@ -75,7 +75,7 @@ public class KubernetesIngressTests(ITestOutputHelper outputHelper)
         // override file (and chart values.yaml placeholder) include the entry.
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         // Pipeline:ClearCache=true prevents loading of leaked deployment state from
-        // ~/.aspire/deployments/<sha>/<env>.json (which would otherwise auto-resolve
+        // <ASPIRE_HOME>/deployments/<sha>/<env>.json (which would otherwise auto-resolve
         // parameters from prior test runs and bypass the MissingParameterValueException path).
         var builder = TestDistributedApplicationBuilder.Create(
             "AppHost:Operation=publish",

--- a/tests/Aspire.Hosting.Tests/Publishing/DeploymentStateManagerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/DeploymentStateManagerTests.cs
@@ -16,8 +16,10 @@ using Microsoft.Extensions.Options;
 namespace Aspire.Hosting.Tests.Pipelines;
 
 [Trait("Partition", "4")]
-public class DeploymentStateManagerTests
+public class DeploymentStateManagerTests : IDisposable
 {
+    private readonly DirectoryInfo _aspireHome = Directory.CreateTempSubdirectory("aspire-deployment-state-tests-");
+
     [Fact]
     public async Task AcquireSectionAsync_ReturnsEmptySection_WhenStateIsNew()
     {
@@ -378,14 +380,54 @@ public class DeploymentStateManagerTests
         }
     }
 
-    private static FileDeploymentStateManager CreateFileDeploymentStateManager(string? sha = null)
+    [Fact]
+    public void GetStatePath_UsesConfiguredAspireHome()
+    {
+        var sha = Guid.NewGuid().ToString("N");
+        var stateManager = CreateFileDeploymentStateManager(sha);
+
+        Assert.Equal(
+            Path.Combine(_aspireHome.FullName, "deployments", sha, "development.json"),
+            stateManager.StateFilePath);
+    }
+
+    [Fact]
+    public void GetStatePath_UsesDefaultAspireHome_WhenAspireHomeIsNotConfigured()
+    {
+        var sha = Guid.NewGuid().ToString("N");
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppHost:PathSha256"] = sha
+            })
+            .Build();
+        var hostEnvironment = new TestHostEnvironment { EnvironmentName = "Development" };
+        var pipelineOptions = Options.Create(new Hosting.Pipelines.PipelineOptions());
+        var stateManager = new FileDeploymentStateManager(
+            NullLogger<FileDeploymentStateManager>.Instance,
+            configuration,
+            hostEnvironment,
+            pipelineOptions);
+
+        Assert.Equal(
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".aspire",
+                "deployments",
+                sha,
+                "development.json"),
+            stateManager.StateFilePath);
+    }
+
+    private FileDeploymentStateManager CreateFileDeploymentStateManager(string? sha = null)
     {
         // Use a unique SHA per test by default to avoid test interference,
         // but allow tests to share state by passing the same SHA
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["AppHost:PathSha256"] = sha ?? Guid.NewGuid().ToString("N")
+                ["AppHost:PathSha256"] = sha ?? Guid.NewGuid().ToString("N"),
+                [KnownConfigNames.AspireHome] = _aspireHome.FullName
             })
             .Build();
 
@@ -397,6 +439,12 @@ public class DeploymentStateManagerTests
             configuration,
             hostEnvironment,
             pipelineOptions);
+    }
+
+    public void Dispose()
+    {
+        _aspireHome.Delete(recursive: true);
+        GC.SuppressFinalize(this);
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Deployment state currently ignores the CLI's effective `ASPIRE_HOME`, which breaks isolated CI and side-by-side CLI runs and can leave deployment parameters or secrets in the persistent user profile.

This change stores deployment state under `<ASPIRE_HOME>/deployments/<AppHostSha>/<environment>.json`, while preserving `~/.aspire` as the fallback for AppHosts launched without a configured Aspire home. The CLI forwards its fully resolved home to .NET and polyglot deployment AppHosts, including CLI processes relaunched through the VS Code extension.

### User-facing usage

```bash
export ASPIRE_HOME="$(mktemp -d)"
aspire deploy --environment isolated
aspire destroy --environment isolated --non-interactive --yes
```

Deployment state is now read, written, and cleared under `$ASPIRE_HOME/deployments` for both commands.

### Security considerations

Deployment state can contain provisioning parameters and secrets. This change keeps that state inside the caller-selected Aspire home instead of writing it to the persistent user profile. The existing environment-name validation and user-only directory permissions remain unchanged.

Validation includes focused Aspire CLI, polyglot AppHost, hosting deployment-state, and VS Code extension RPC tests, plus extension compilation and linting.

Fixes: #19211

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No