### PR TITLE
Use official Aspire branding in dashboard

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -37,8 +37,12 @@
 
 <body class="before-upgrade"
       data-scroll-to-bottom-label="@ControlsLoc[nameof(Aspire.Dashboard.Resources.ControlsStrings.ScrollToBottom)]">
-    <Routes @rendermode="@(new InteractiveServerRenderMode(prerender: false))" />
-    <ReconnectModal />
+    @* Fluent design tokens are element-scoped. This ancestor gives app-theme.js one stable target whose
+       emitted token properties are inherited by every Fluent Blazor component in the dashboard. *@
+    <div id="aspire-design-system">
+        <Routes @rendermode="@(new InteractiveServerRenderMode(prerender: false))" />
+        <ReconnectModal />
+    </div>
     <BlazorScript />
     <script src="js/app.js"></script>
     <script src="js/app-reconnect.js"></script>

--- a/src/Aspire.Dashboard/Components/Controls/AspireLogo.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireLogo.razor
@@ -1,92 +1,14 @@
-﻿<svg width="@Height" height="@Width" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <mask id="mask0_449_831" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="22">
-        <path fill-rule="evenodd" clip-rule="evenodd" d="M5.39001 12C4.49001 12 3.67 12.4799 3.22 13.2499L6.67 7.27994L6.6817 7.25982L9.84001 1.79005C10.05 1.43005 10.36 1.11005 10.75 0.880049C11.14 0.650049 11.57 0.550049 12 0.550049C12.86 0.550049 13.7 0.990049 14.17 1.80005L17.33 7.28005L23.67 18.25C23.88 18.62 24 19.05 24 19.5C24 20.88 22.88 22 21.5 22H8.27002C8.27001 22 8.27002 22 8.27002 22H2.5C1.12 22 0 20.88 0 19.5C0 19.05 0.12 18.62 0.33 18.25L3.22 13.2499C3.67 12.4799 4.49001 12 5.39001 12C5.39002 12 5.39001 12 5.39001 12Z" fill="url(#paint0_linear_449_831)" />
-    </mask>
-    <g mask="url(#mask0_449_831)">
-        <path d="M20.06 12H13.72L11 7.28005C10.79 6.91005 10.48 6.59005 10.08 6.37005C8.88998 5.67005 7.35998 6.08005 6.66998 7.28005L9.83998 1.79005C10.05 1.43005 10.36 1.11005 10.75 0.880049C11.14 0.650049 11.57 0.550049 12 0.550049C12.86 0.550049 13.7 0.990049 14.17 1.80005L17.33 7.28005L20.06 12Z" fill="url(#paint1_linear_449_831)" />
-        <g filter="url(#filter0_dd_449_831)">
-            <path d="M5.38997 11.9999H13.72L11 7.27994C10.79 6.90994 10.48 6.58994 10.08 6.36994C8.88997 5.66994 7.35997 6.07994 6.66997 7.27994L3.21997 13.2499C3.66997 12.4799 4.48997 11.9999 5.38997 11.9999Z" fill="url(#paint2_linear_449_831)" />
-            <path d="M21.5 22C22.88 22 24 20.88 24 19.5C24 19.05 23.88 18.62 23.67 18.25L20.06 12L13.72 11.9999L17.33 18.25C17.55 18.62 17.67 19.05 17.67 19.5C17.67 20.88 16.55 22 15.17 22H21.5Z" fill="url(#paint3_linear_449_831)" />
-        </g>
-        <g filter="url(#filter1_dd_449_831)">
-            <path d="M17.67 19.5C17.67 20.88 16.55 22 15.17 22H8.27002C9.65002 22 10.77 20.88 10.77 19.5C10.77 19.05 10.65 18.62 10.44 18.25L7.55001 13.25C7.52002 13.19 7.48001 13.14 7.44001 13.08C6.99001 12.42 6.23001 12 5.39001 12H13.72L17.33 18.25C17.55 18.62 17.67 19.05 17.67 19.5Z" fill="url(#paint4_linear_449_831)" />
-        </g>
-        <g filter="url(#filter2_dd_449_831)">
-            <path d="M10.77 19.5C10.77 20.88 9.65 22 8.27 22H2.5C1.12 22 0 20.88 0 19.5C0 19.05 0.12 18.62 0.33 18.25L3.22 13.25C3.67 12.48 4.49 12 5.39 12C6.23 12 6.99 12.42 7.44 13.08C7.48 13.14 7.52 13.19 7.55 13.25L10.44 18.25C10.65 18.62 10.77 19.05 10.77 19.5Z" fill="url(#paint5_linear_449_831)" />
-        </g>
-    </g>
-    <defs>
-        <filter id="filter0_dd_449_831" x="1.21997" y="4.52808" width="24.78" height="19.9719" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-            <feFlood flood-opacity="0" result="BackgroundImageFix" />
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-            <feOffset dy="0.095" />
-            <feGaussianBlur stdDeviation="0.095" />
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.24 0" />
-            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_449_831" />
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-            <feOffset dy="0.5" />
-            <feGaussianBlur stdDeviation="1" />
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.32 0" />
-            <feBlend mode="normal" in2="effect1_dropShadow_449_831" result="effect2_dropShadow_449_831" />
-            <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_449_831" result="shape" />
-        </filter>
-        <filter id="filter1_dd_449_831" x="3.39001" y="10.5" width="16.28" height="14" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-            <feFlood flood-opacity="0" result="BackgroundImageFix" />
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-            <feOffset dy="0.095" />
-            <feGaussianBlur stdDeviation="0.095" />
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.24 0" />
-            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_449_831" />
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-            <feOffset dy="0.5" />
-            <feGaussianBlur stdDeviation="1" />
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.32 0" />
-            <feBlend mode="normal" in2="effect1_dropShadow_449_831" result="effect2_dropShadow_449_831" />
-            <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_449_831" result="shape" />
-        </filter>
-        <filter id="filter2_dd_449_831" x="-2" y="10.5" width="14.77" height="14" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-            <feFlood flood-opacity="0" result="BackgroundImageFix" />
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-            <feOffset dy="0.095" />
-            <feGaussianBlur stdDeviation="0.095" />
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.24 0" />
-            <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_449_831" />
-            <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha" />
-            <feOffset dy="0.5" />
-            <feGaussianBlur stdDeviation="1" />
-            <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.32 0" />
-            <feBlend mode="normal" in2="effect1_dropShadow_449_831" result="effect2_dropShadow_449_831" />
-            <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_449_831" result="shape" />
-        </filter>
-        <linearGradient id="paint0_linear_449_831" x1="1.88475" y1="11.1667" x2="10.31" y2="23.1443" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#CBBFF2" />
-            <stop offset="1" stop-color="#B9AAEE" />
-        </linearGradient>
-        <linearGradient id="paint1_linear_449_831" x1="9.6127" y1="-0.685575" x2="16.8764" y2="13.8912" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#7455DD" />
-            <stop stop-color="#6745DA" />
-            <stop offset="1" stop-color="#512BD4" />
-        </linearGradient>
-        <linearGradient id="paint2_linear_449_831" x1="7.90532" y1="3.78438" x2="19.1767" y2="23.0023" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#856AE1" />
-            <stop offset="1" stop-color="#7455DD" />
-        </linearGradient>
-        <linearGradient id="paint3_linear_449_831" x1="7.90532" y1="3.78438" x2="19.1767" y2="23.0023" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#856AE1" />
-            <stop offset="1" stop-color="#7455DD" />
-        </linearGradient>
-        <linearGradient id="paint4_linear_449_831" x1="5.4257" y1="9.22222" x2="13.2216" y2="21.4193" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#A895E9" />
-            <stop offset="1" stop-color="#9780E5" />
-        </linearGradient>
-        <linearGradient id="paint5_linear_449_831" x1="1.88475" y1="11.1667" x2="10.31" y2="23.1443" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#CBBFF2" />
-            <stop offset="1" stop-color="#B9AAEE" />
-        </linearGradient>
-    </defs>
+<svg width="@Width" height="@Height" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M28 240C12.56 240 0 227.44 0 212C0 206.968 1.328 202.072 3.84 197.832L70.544 82.296L70.816 81.888L103.744 24.792C108.744 16.152 118.032 10.792 128 10.792C137.968 10.792 147.256 16.152 152.248 24.784L252.248 197.992C254.664 202.064 255.992 206.96 255.992 211.992C255.992 227.432 243.432 239.992 227.992 239.992L28 240Z" fill="#512BD4" />
+    <path d="M202.64 144H135.92L128 130.24L105.04 90.48C104 88.72 102.56 87.2 100.64 86.16C94.96 82.8 87.6 84.8 84.24 90.56L117.6 32.8C119.68 29.2 123.52 26.8 128 26.8C132.48 26.8 136.32 29.2 138.4 32.8L171.6 90.32L171.68 90.48L171.84 90.72L202.64 144Z" fill="#7455DD" />
+    <path d="M240 212C240 218.64 234.64 224 228 224H161.36C168 224 173.36 218.64 173.36 212C173.36 209.84 172.72 207.76 171.76 206L138.4 148.24L135.92 144H202.64L238.4 206C239.44 207.76 240 209.84 240 212Z" fill="#9780E5" />
+    <path d="M173.36 212C173.36 218.64 168 224 161.36 224H94.6399C101.28 224 106.64 218.64 106.64 212C106.64 209.84 106.08 207.76 105.04 206C105.04 205.92 104.96 205.84 104.88 205.76L94.3199 188.56L70.5599 149.76C68.3999 146.24 64.5599 144 60.3199 144H135.92L138.4 148.24L139.416 150L171.76 206C172.72 207.76 173.36 209.84 173.36 212Z" fill="#B9AAEE" />
+    <path d="M106.64 212C106.64 218.64 101.28 224 94.64 224H28C21.36 224 16 218.64 16 212C16 209.84 16.56 207.76 17.6 206L49.92 150C52.08 146.32 56.08 144 60.32 144C64.56 144 68.4 146.24 70.56 149.76L94.32 188.56L104.88 205.76C104.96 205.84 105.04 205.92 105.04 206C106.08 207.76 106.64 209.84 106.64 212Z" fill="#DCD5F6" />
+    <path d="M135.92 144H60.32C56.08 144 52.08 146.32 49.92 150L53.36 144L83.92 91.12L84.24 90.64V90.56C87.6 84.8 94.96 82.8 100.64 86.16C102.56 87.2 104 88.72 105.04 90.48L128 130.24L135.92 144Z" fill="#9780E5" />
 </svg>
 
-@code {
+@code
+{
     [Parameter]
     public int Height { get; set; } = 24;
 

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -15,7 +15,7 @@
             <FluentAnchor Appearance="Appearance.Stealth" Href="/" Class="logo brand-logo"
                           title="@Loc[nameof(Layout.MainLayoutAspire)]"
                           aria-label="@Loc[nameof(Layout.MainLayoutAspire)]">
-                <FluentIcon Value="@(new AspireIcons.Size24.Logo())"/>
+                <AspireLogo />
             </FluentAnchor>
             <FluentAnchor Appearance="Appearance.Stealth" Href="/" Class="logo">
                 <ApplicationName/>
@@ -83,7 +83,7 @@
             <FluentAnchor Appearance="Appearance.Stealth" Href="/" Class="logo"
                           title="@Loc[nameof(Layout.MainLayoutAspire)]"
                           aria-label="@Loc[nameof(Layout.MainLayoutAspire)]">
-                <FluentIcon Value="@(new AspireIcons.Size24.Logo())"/>
+                <AspireLogo />
             </FluentAnchor>
         </div>
         <FluentHeader>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -365,9 +365,9 @@ fluent-combobox {
     /* A 10% black mix subtly darkens dialogs while preserving the ramp's blue-violet undertone. */
     --dialog-background-color: color-mix(in srgb, var(--neutral-layer-2) 90%, #000000);
     --dialog-border-color: var(--neutral-stroke-rest);
-    /* A mid periwinkle-violet keeps the focus ring above the WCAG 1.4.11 3:1 non-text contrast
-       minimum on the generated dark surfaces without becoming a near-white halo. */
-    --dash-focus-ring-color: #a98eff;
+    /* The secondary brand purple emitted by Fluent's accent token keeps the focus ring above the
+       WCAG 1.4.11 3:1 non-text contrast minimum without introducing a custom blend. */
+    --dash-focus-ring-color: var(--accent-fill-rest);
     /* Message bar surfaces derive from the shared --aspire-status-* seeds (tokens.css).
        Dark theme: a restrained tint of the seed over the neutral layer replaces the old
        near-black / over-saturated floods (#3F1011, #411200, #052505), while the border stays

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -238,9 +238,8 @@ fluent-combobox {
     --focus-stroke-width: var(--aspire-focus-stroke-width);
     --focus-stroke-outer: var(--dash-focus-ring-color);
     --focus-stroke-inner: var(--dash-focus-ring-color);
-    /* Defaults to the accent fill (a dark violet on light theme, which reads fine on white); dark theme
-       overrides it to a tamed violet because the dark accent fill (--accent-fill-rest #e5bfff) is a
-       near-white lavender that paints a loud halo on violet panels. */
+    /* This default supports content outside the application token scope. The application scope below
+       redeclares the focus properties so they resolve against its explicit Fluent accent tokens. */
     --dash-focus-ring-color: var(--accent-fill-rest);
     /* Message bar surfaces derive from the shared --aspire-status-* seeds (tokens.css)
        so each intent hue is defined once and every theme mixes its own surface from it.
@@ -342,6 +341,14 @@ fluent-combobox {
     --accent-olive-text: #fff;
 }
 
+#aspire-design-system {
+    /* Fluent emits the approved semantic accent values on this scope. Resolve the focus-ring variables
+       here as well so they do not capture the generated accent value from the document ancestor. */
+    --dash-focus-ring-color: var(--accent-fill-rest);
+    --focus-stroke-outer: var(--dash-focus-ring-color);
+    --focus-stroke-inner: var(--dash-focus-ring-color);
+}
+
 [data-theme="dark"] {
     --scrollbar-color: #9F9F9F;
     /* Quiet, tint-free neutral thumb on dark: a semi-transparent white so the scrollbar reads as a
@@ -365,9 +372,6 @@ fluent-combobox {
     /* A 10% black mix subtly darkens dialogs while preserving the ramp's blue-violet undertone. */
     --dialog-background-color: color-mix(in srgb, var(--neutral-layer-2) 90%, #000000);
     --dialog-border-color: var(--neutral-stroke-rest);
-    /* The secondary brand purple emitted by Fluent's accent token keeps the focus ring above the
-       WCAG 1.4.11 3:1 non-text contrast minimum without introducing a custom blend. */
-    --dash-focus-ring-color: var(--accent-fill-rest);
     /* Message bar surfaces derive from the shared --aspire-status-* seeds (tokens.css).
        Dark theme: a restrained tint of the seed over the neutral layer replaces the old
        near-black / over-saturated floods (#3F1011, #411200, #052505), while the border stays

--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -1,5 +1,17 @@
 import {
     accentBaseColor,
+    accentFillActive,
+    accentFillFocus,
+    accentFillHover,
+    accentFillRest,
+    accentForegroundActive,
+    accentForegroundFocus,
+    accentForegroundHover,
+    accentForegroundRest,
+    accentStrokeControlActive,
+    accentStrokeControlFocus,
+    accentStrokeControlHover,
+    accentStrokeControlRest,
     baseLayerLuminance,
     SwatchRGB,
     fillColor,
@@ -45,6 +57,14 @@ const themeSettingLight = "Light";
 const darkThemeLuminance = 0.17;
 const lightThemeLuminance = 1.0;
 const darknessLuminanceTarget = (-0.1 + Math.sqrt(0.21)) / 2;
+const brandPurple = createSwatch(0x51, 0x2B, 0xD4);
+const brandPrimary = createSwatch(0x74, 0x55, 0xDD);
+const brandSecondary = createSwatch(0xB9, 0xAA, 0xEE);
+const brandLogoLight = createSwatch(0xC2, 0xB4, 0xEF);
+
+function createSwatch(r, g, b) {
+    return SwatchRGB.create(r / 255.0, g / 255.0, b / 255.0);
+}
 
 /**
  * Updates the current theme on the site based on the specified theme
@@ -170,19 +190,42 @@ function getBaseLayerLuminanceForTheme(theme) {
 }
 
 /**
- * Configures the accent color palette based on the .NET purple
+ * Configures Fluent's accent seed and semantic color tokens from the approved Aspire brand palette.
+ * Fluent UI Blazor exposes the underlying FAST design tokens from its JavaScript module. Setting those
+ * tokens keeps JavaScript token consumers and emitted CSS custom properties aligned, unlike overriding
+ * the generated custom properties in a linked stylesheet.
+ * @param {string} theme The theme to use. Should be Light or Dark
  */
-function setAccentColor() {
-    // Convert the base color ourselves to avoid pulling in the
-    // @microsoft/fast-colors library just for one call to parseColorHexRGB
-    const baseColor = { // #512BD4
-        r: 0x51 / 255.0,
-        g: 0x2B / 255.0,
-        b: 0xD4 / 255.0
-    };
+function setAccentColor(theme) {
+    accentBaseColor.withDefault(brandPurple);
 
-    const accentBase = SwatchRGB.create(baseColor.r, baseColor.g, baseColor.b);
-    accentBaseColor.withDefault(accentBase);
+    // The adaptive recipes interpolate additional shades from accentBaseColor. Pin the semantic roles
+    // used by Fluent controls so the rendered colors remain in the approved palette while retaining
+    // distinct interaction states and WCAG contrast in each theme.
+    const rest = theme === themeSettingDark ? brandSecondary : brandPurple;
+    const hover = theme === themeSettingDark ? brandLogoLight : brandPrimary;
+    const active = rest;
+    const focus = rest;
+    // Fluent design tokens are scoped to an element subtree. The body already receives generated
+    // defaults during Fluent initialization, so use the dashboard's dedicated ancestor to ensure
+    // FAST emits these explicit semantic values and every Fluent Blazor component inherits them.
+    const root = document.getElementById("aspire-design-system");
+    if (!root) {
+        throw new Error("The Aspire design-system token scope was not found.");
+    }
+
+    accentFillRest.setValueFor(root, rest);
+    accentFillHover.setValueFor(root, hover);
+    accentFillActive.setValueFor(root, active);
+    accentFillFocus.setValueFor(root, focus);
+    accentForegroundRest.setValueFor(root, rest);
+    accentForegroundHover.setValueFor(root, hover);
+    accentForegroundActive.setValueFor(root, active);
+    accentForegroundFocus.setValueFor(root, focus);
+    accentStrokeControlRest.setValueFor(root, rest);
+    accentStrokeControlHover.setValueFor(root, hover);
+    accentStrokeControlActive.setValueFor(root, active);
+    accentStrokeControlFocus.setValueFor(root, focus);
 }
 
 /**
@@ -216,11 +259,13 @@ function setNeutralBaseColor(theme) {
  */
 function applyTheme(theme) {
     setBaseLayerLuminance(theme);
-    setAccentColor();
     // Set the neutral ramp base before deriving the fill color, since the body fill is taken
     // from neutralLayerL2 (which is generated from the neutral palette we're adjusting here).
     setNeutralBaseColor(theme);
     setFillColor();
+    // Accent recipes depend on the fill color. Apply the explicit brand semantics after all recipe
+    // inputs are settled so a dependency update does not regenerate and re-emit interpolated colors.
+    setAccentColor(theme);
     setThemeOnDocument(theme);
 }
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -60,7 +60,7 @@ const darknessLuminanceTarget = (-0.1 + Math.sqrt(0.21)) / 2;
 const brandPurple = createSwatch(0x51, 0x2B, 0xD4);
 const brandPrimary = createSwatch(0x74, 0x55, 0xDD);
 const brandSecondary = createSwatch(0xB9, 0xAA, 0xEE);
-const brandLogoLight = createSwatch(0xC2, 0xB4, 0xEF);
+const brandLight = createSwatch(0xDC, 0xD5, 0xF6);
 
 function createSwatch(r, g, b) {
     return SwatchRGB.create(r / 255.0, g / 255.0, b / 255.0);
@@ -203,7 +203,7 @@ function setAccentColor(theme) {
     // used by Fluent controls so the rendered colors remain in the approved palette while retaining
     // distinct interaction states and WCAG contrast in each theme.
     const rest = theme === themeSettingDark ? brandSecondary : brandPurple;
-    const hover = theme === themeSettingDark ? brandLogoLight : brandPrimary;
+    const hover = theme === themeSettingDark ? brandLight : brandPrimary;
     const active = rest;
     const focus = rest;
     // Fluent design tokens are scoped to an element subtree. The body already receives generated

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/AspireLogoTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/AspireLogoTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Controls;
+using Bunit;
+using Xunit;
+
+namespace Aspire.Dashboard.Components.Tests.Controls;
+
+public class AspireLogoTests : Bunit.TestContext
+{
+    [Fact]
+    public void Render_UsesCurrentBrandArtwork()
+    {
+        var cut = RenderComponent<AspireLogo>();
+
+        var svg = cut.Find("svg");
+        var paths = cut.FindAll("path");
+
+        Assert.Equal("0 0 256 256", svg.GetAttribute("viewBox"));
+        Assert.Equal("true", svg.GetAttribute("aria-hidden"));
+        Assert.Collection(
+            paths,
+            path => Assert.Equal("#512BD4", path.GetAttribute("fill")),
+            path => Assert.Equal("#7455DD", path.GetAttribute("fill")),
+            path => Assert.Equal("#9780E5", path.GetAttribute("fill")),
+            path => Assert.Equal("#B9AAEE", path.GetAttribute("fill")),
+            path => Assert.Equal("#DCD5F6", path.GetAttribute("fill")),
+            path => Assert.Equal("#9780E5", path.GetAttribute("fill")));
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
@@ -194,7 +194,11 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
                 button.setAttribute('appearance', 'accent');
                 button.textContent = 'Primary action';
                 button.style.cssText = 'position:fixed;left:16px;top:16px;z-index:10000;';
-                document.body.appendChild(button);
+                const root = document.getElementById('aspire-design-system');
+                if (!root) {
+                    throw new Error('The Aspire design-system token scope was not found.');
+                }
+                root.appendChild(button);
                 await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
             }
             """).DefaultTimeout();

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -64,4 +64,59 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
             }
         });
     }
+
+    [Theory]
+    [OuterloopTest("Resource-intensive Playwright browser test")]
+    [InlineData("Light", "rgb(81, 43, 212)", "rgb(116, 85, 221)")]
+    [InlineData("Dark", "rgb(185, 170, 238)", "rgb(194, 180, 239)")]
+    public async Task AppBar_AccentColors_UseFluentDesignTokens(string theme, string expectedRest, string expectedHover)
+    {
+        await RunTestAsync(async page =>
+        {
+            await PlaywrightFixture.GoToHomeAndWaitForDataGridLoad(page).DefaultTimeout();
+
+            await page.EvaluateAsync(
+                """
+                theme => import('/js/app-theme.js').then(module => module.updateTheme(theme))
+                """,
+                theme).DefaultTimeout();
+
+            await Assertions
+                .Expect(page.Locator("html"))
+                .ToHaveAttributeAsync("data-theme", theme.ToLowerInvariant());
+
+            var colors = await page.EvaluateAsync<string[]>(
+                """
+                async () => {
+                    const fluent = await import('/_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js');
+                    const root = document.getElementById('aspire-design-system');
+                    const style = getComputedStyle(root);
+
+                    function normalize(color) {
+                        const probe = document.createElement('span');
+                        probe.style.color = color;
+                        document.body.appendChild(probe);
+                        const normalized = getComputedStyle(probe).color;
+                        probe.remove();
+                        return normalized;
+                    }
+
+                    return [
+                        normalize(fluent.accentFillRest.getValueFor(root).createCSS()),
+                        normalize(fluent.accentForegroundRest.getValueFor(root).createCSS()),
+                        normalize(fluent.accentStrokeControlRest.getValueFor(root).createCSS()),
+                        normalize(style.getPropertyValue('--accent-fill-rest')),
+                        normalize(style.getPropertyValue('--accent-foreground-rest')),
+                        normalize(style.getPropertyValue('--accent-stroke-control-rest')),
+                        normalize(fluent.accentFillHover.getValueFor(root).createCSS()),
+                        normalize(fluent.accentForegroundHover.getValueFor(root).createCSS()),
+                        normalize(fluent.accentStrokeControlHover.getValueFor(root).createCSS()),
+                    ];
+                }
+                """).DefaultTimeout();
+
+            Assert.All(colors[..6], color => Assert.Equal(expectedRest, color));
+            Assert.All(colors[6..], color => Assert.Equal(expectedHover, color));
+        });
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -68,7 +68,7 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
     [Theory]
     [OuterloopTest("Resource-intensive Playwright browser test")]
     [InlineData("Light", "rgb(81, 43, 212)", "rgb(116, 85, 221)")]
-    [InlineData("Dark", "rgb(185, 170, 238)", "rgb(194, 180, 239)")]
+    [InlineData("Dark", "rgb(185, 170, 238)", "rgb(220, 213, 246)")]
     public async Task AppBar_AccentColors_UseFluentDesignTokens(string theme, string expectedRest, string expectedHover)
     {
         await RunTestAsync(async page =>
@@ -111,12 +111,31 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
                         normalize(fluent.accentFillHover.getValueFor(root).createCSS()),
                         normalize(fluent.accentForegroundHover.getValueFor(root).createCSS()),
                         normalize(fluent.accentStrokeControlHover.getValueFor(root).createCSS()),
+                        normalize(style.getPropertyValue('--accent-fill-hover')),
+                        normalize(style.getPropertyValue('--accent-foreground-hover')),
+                        normalize(style.getPropertyValue('--accent-stroke-control-hover')),
+                        normalize(fluent.accentFillActive.getValueFor(root).createCSS()),
+                        normalize(fluent.accentForegroundActive.getValueFor(root).createCSS()),
+                        normalize(fluent.accentStrokeControlActive.getValueFor(root).createCSS()),
+                        normalize(style.getPropertyValue('--accent-fill-active')),
+                        normalize(style.getPropertyValue('--accent-foreground-active')),
+                        normalize(style.getPropertyValue('--accent-stroke-control-active')),
+                        normalize(fluent.accentFillFocus.getValueFor(root).createCSS()),
+                        normalize(fluent.accentForegroundFocus.getValueFor(root).createCSS()),
+                        normalize(fluent.accentStrokeControlFocus.getValueFor(root).createCSS()),
+                        normalize(style.getPropertyValue('--accent-fill-focus')),
+                        normalize(style.getPropertyValue('--accent-foreground-focus')),
+                        normalize(style.getPropertyValue('--accent-stroke-control-focus')),
+                        normalize(style.getPropertyValue('--dash-focus-ring-color')),
                     ];
                 }
                 """).DefaultTimeout();
 
             Assert.All(colors[..6], color => Assert.Equal(expectedRest, color));
-            Assert.All(colors[6..], color => Assert.Equal(expectedHover, color));
+            Assert.All(colors[6..12], color => Assert.Equal(expectedHover, color));
+            Assert.All(colors[12..18], color => Assert.Equal(expectedRest, color));
+            Assert.All(colors[18..24], color => Assert.Equal(expectedRest, color));
+            Assert.Equal(expectedRest, colors[24]);
         });
     }
 }


### PR DESCRIPTION
## Description

The dashboard's accent colors and embedded logo had drifted from the current Aspire brand palette. This updates the dashboard to use official Aspire colors while preserving WCAG AA contrast for normal text in both light and dark themes.

The theme now applies branded semantic accent values through Fluent UI Blazor's FAST design-token registry rather than overriding generated CSS. Light mode uses the official `#512BD4` brand purple, while dark mode uses the lighter official palette values needed for accessible contrast. The header, login, and error surfaces now share the current flat Aspire logo artwork.

### User-facing usage

The branded palette is applied automatically when users switch between light and dark dashboard themes.

### Screenshots / Recordings

Light theme:

![Aspire dashboard using the official logo and light-theme brand palette](https://github.com/user-attachments/assets/926ba9b9-51e9-4205-8e3d-08c2081dfa7e)

Dark theme:

![Aspire dashboard using the official logo and dark-theme brand palette](https://github.com/user-attachments/assets/86c0a1db-1fc7-4d89-989e-178bac6d09fc)

### Validation

- 1,719 dashboard tests passed.
- 206 dashboard component tests passed.
- 28 Playwright accessibility tests passed.
- Dashboard build completed with no warnings or errors.
- Manually verified both themes in the Stress playground.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
