### PR TITLE
Pin published Aspire Dashboard image to a reproducible tag

### DIFF
--- a/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
+++ b/src/Aspire.Hosting.Docker/Aspire.Hosting.Docker.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Shared\ProcessSpec.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessOutputCapture.cs" Link="Shared\ProcessOutputCapture.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Shared\ProcessUtil.cs" />
+    <Compile Include="$(SharedDir)DashboardImage.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)PathLookupHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)ResourceNameComparer.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)KnownOtelConfigNames.cs" LinkBase="Shared" />

--- a/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Docker/DockerComposeAspireDashboardResourceBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Docker;
+using Aspire.Shared;
 
 namespace Aspire.Hosting;
 
@@ -33,9 +34,11 @@ public static class DockerComposeAspireDashboardResourceBuilderExtensions
 
         var resource = new DockerComposeAspireDashboardResource(name);
 
-        // Initialize the dashboard resource
+        // Initialize the dashboard resource. Pin the image to the app's Aspire major.minor version
+        // instead of the default (untagged) reference, which resolves to a mutable ":latest" and
+        // makes the published compose file non-reproducible.
         return builder.CreateResourceBuilder(resource)
-                      .WithImage("mcr.microsoft.com/dotnet/nightly/aspire-dashboard")
+                      .WithImage(DashboardImage.Name, DashboardImage.ResolveTag())
                       .WithHttpEndpoint(targetPort: 18888)
                       // Expose the HTTP endpoint externally for the dashboard, it is password protected
                       // and disabled by default so an explicit call is required to turn it on.

--- a/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
+++ b/src/Aspire.Hosting.Kubernetes/Aspire.Hosting.Kubernetes.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="Shared\ComputeEnvironmentEndpointResolver.cs" />
+    <Compile Include="$(SharedDir)DashboardImage.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)PublishingContextUtils.cs" LinkBase="Shared" />
     <Compile Include="$(SharedDir)Yaml\*.cs" LinkBase="Shared\Yaml" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Kubernetes/KubernetesAspireDashboardResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kubernetes/KubernetesAspireDashboardResourceBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Kubernetes;
+using Aspire.Shared;
 
 namespace Aspire.Hosting;
 
@@ -34,8 +35,11 @@ public static class KubernetesAspireDashboardResourceBuilderExtensions
 
         var resource = new KubernetesAspireDashboardResource(name);
 
+        // Pin the image to the app's Aspire major.minor version instead of the default (untagged)
+        // reference, which resolves to a mutable ":latest" and makes the published chart
+        // non-reproducible.
         return builder.CreateResourceBuilder(resource)
-                      .WithImage("mcr.microsoft.com/dotnet/nightly/aspire-dashboard")
+                      .WithImage(DashboardImage.Name, DashboardImage.ResolveTag())
                       .WithHttpEndpoint(targetPort: 18888)
                       // Expose the HTTP endpoint so ingress or explicit host port mapping can route browser traffic to the dashboard.
                       .WithEndpoint("http", e => e.IsExternal = true)

--- a/src/Shared/DashboardImage.cs
+++ b/src/Shared/DashboardImage.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Reflection;
+
+namespace Aspire.Shared;
+
+/// <summary>
+/// Resolves the Aspire Dashboard container image reference used by the Docker Compose and
+/// Kubernetes publishers when they inject a dashboard into generated deployment artifacts.
+/// </summary>
+internal static class DashboardImage
+{
+    /// <summary>
+    /// The Aspire Dashboard container image (without a tag), published to the .NET nightly registry.
+    /// See <see href="https://mcr.microsoft.com/artifact/mar/dotnet/nightly/aspire-dashboard/about"/>.
+    /// </summary>
+    public const string Name = "mcr.microsoft.com/dotnet/nightly/aspire-dashboard";
+
+    /// <summary>
+    /// Resolves the tag to pin the dashboard image to, derived from the running Aspire product
+    /// version's <c>major.minor</c> (for example <c>13.5</c>).
+    /// </summary>
+    /// <remarks>
+    /// The publishers previously emitted the image without a tag, which Docker and Kubernetes both
+    /// resolve to the mutable <c>:latest</c> tag. That made generated manifests non-reproducible and
+    /// let the dashboard drift away from the app's Aspire version. Pinning to <c>major.minor</c> keeps
+    /// the dashboard on the same Aspire line that generated the manifest and always resolves to a tag
+    /// that exists on the registry — including for prerelease/CI builds, where a full
+    /// <c>major.minor.patch-prerelease</c> tag is not published.
+    /// </remarks>
+    public static string ResolveTag()
+        => ResolveTag(typeof(DashboardImage).Assembly);
+
+    internal static string ResolveTag(Assembly assembly)
+    {
+        // The product version is stamped into AssemblyInformationalVersion at build time, e.g.:
+        //   "13.5.0-preview.1.25111.1+ad18db0213e9db8209bca0feb83fc801f34634f5"
+        // The assembly version (e.g. "13.5.0.0") is used as a fallback when it is unavailable.
+        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        return ResolveTag(informationalVersion, assembly.GetName().Version?.ToString());
+    }
+
+    internal static string ResolveTag(string? informationalVersion, string? assemblyVersion)
+    {
+        if (TryGetMajorMinor(informationalVersion, out var majorMinor) ||
+            TryGetMajorMinor(assemblyVersion, out majorMinor))
+        {
+            return majorMinor;
+        }
+
+        // Defensive only: shipped assemblies always carry a version, so this guards against a stripped
+        // version attribute. Preserve the historical ":latest" behavior rather than emitting an
+        // invalid tag.
+        return "latest";
+    }
+
+    private static bool TryGetMajorMinor(string? version, out string majorMinor)
+    {
+        majorMinor = string.Empty;
+
+        if (string.IsNullOrEmpty(version))
+        {
+            return false;
+        }
+
+        // Strip any prerelease label ("-preview...") and build metadata ("+sha") before splitting so
+        // that both SemVer informational versions and 4-part assembly versions ("13.5.0.0") parse the
+        // same way.
+        var core = version.Split('-', '+')[0];
+        var segments = core.Split('.');
+
+        if (segments.Length < 2 ||
+            !int.TryParse(segments[0], NumberStyles.None, CultureInfo.InvariantCulture, out var major) ||
+            !int.TryParse(segments[1], NumberStyles.None, CultureInfo.InvariantCulture, out var minor))
+        {
+            return false;
+        }
+
+        majorMinor = string.Create(CultureInfo.InvariantCulture, $"{major}.{minor}");
+        return true;
+    }
+}

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppliesServiceCustomizations.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeAppliesServiceCustomizations.verified.yaml
@@ -1,7 +1,7 @@
 ﻿name: "my application"
 services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeCorrectlyEmitsPortMappings.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeCorrectlyEmitsPortMappings.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeWithProjectResources.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.DockerComposeWithProjectResources.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_ResolvesArbitraryIValueProviderSource.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PrepareStep_ResolvesArbitraryIValueProviderSource.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_GeneratesValidDockerComposeFile.verified.yaml
@@ -1,6 +1,6 @@
 services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_HandlesConditionalReferenceExpression.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_HandlesConditionalReferenceExpression.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_MultipleResourcesWithOtlp_ConfiguresAllForDashboard.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_MultipleResourcesWithOtlp_ConfiguresAllForDashboard.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_WithDashboardEnabled_IncludesDashboardService.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposePublisherTests.PublishAsync_WithDashboardEnabled_IncludesDashboardService.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DashboardWithForwardedHeadersWritesEnvVar.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DashboardWithForwardedHeadersWritesEnvVar.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   env-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     environment:
       ASPIRE_DASHBOARD_FORWARDEDHEADERS_ENABLED: "true"
     ports:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerComposeOnlyExposesExternalEndpoints.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerComposeOnlyExposesExternalEndpoints.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmDeploymentLabelsSerializedCorrectly.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmDeploymentLabelsSerializedCorrectly.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   swarm-env-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmUpdateConfigSerializedCorrectly.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.DockerSwarmUpdateConfigSerializedCorrectly.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   swarm-env-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env1/docker-compose.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env1/docker-compose.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   env1-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env2/docker-compose.verified.yaml
+++ b/tests/Aspire.Hosting.Docker.Tests/Snapshots/DockerComposeTests.MultipleDockerComposeEnvironmentsSupported/env2/docker-compose.verified.yaml
@@ -1,6 +1,6 @@
 ﻿services:
   env2-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888"
     expose:

--- a/tests/Aspire.Hosting.Kubernetes.Tests/DashboardImageTests.cs
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/DashboardImageTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Shared;
+
+namespace Aspire.Hosting.Kubernetes.Tests;
+
+public class DashboardImageTests
+{
+    [Theory]
+    // Informational version (SemVer with prerelease + build metadata) is preferred and reduced to major.minor.
+    [InlineData("13.5.0-preview.1.25111.1+ad18db0213e9db8209bca0feb83fc801f34634f5", "13.5.0.0", "13.5")]
+    [InlineData("13.5.0", "13.5.0.0", "13.5")]
+    [InlineData("14.0.0-dev", "14.0.0.0", "14.0")]
+    // Falls back to the 4-part assembly version when the informational version is missing.
+    [InlineData(null, "13.5.0.0", "13.5")]
+    [InlineData("", "9.2.1.0", "9.2")]
+    // Falls back to the assembly version when the informational version is not parseable.
+    [InlineData("not-a-version", "10.3.0.0", "10.3")]
+    public void ResolveTag_ReturnsMajorMinor(string? informationalVersion, string? assemblyVersion, string expected)
+    {
+        Assert.Equal(expected, DashboardImage.ResolveTag(informationalVersion, assemblyVersion));
+    }
+
+    [Theory]
+    // When no version is available at all, preserve the historical ":latest" behavior rather than emitting an invalid tag.
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData("garbage", "also-garbage")]
+    public void ResolveTag_WithoutParseableVersion_FallsBackToLatest(string? informationalVersion, string? assemblyVersion)
+    {
+        Assert.Equal("latest", DashboardImage.ResolveTag(informationalVersion, assemblyVersion));
+    }
+
+    [Fact]
+    public void ResolveTag_FromRunningAssembly_MatchesPinnedImageName()
+    {
+        // The running assembly always carries a version, so a real tag (never "latest") is produced.
+        var tag = DashboardImage.ResolveTag();
+
+        Assert.NotEqual("latest", tag);
+        Assert.Matches(@"^\d+\.\d+$", tag);
+    }
+}

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/env1-dashboard/deployment.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env1/templates/env1-dashboard/deployment.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env1-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/env2-dashboard/deployment.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesEnvironmentResourceTests.MultipleKubernetesEnvironmentsSupported/env2/templates/env2-dashboard/deployment.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env2-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesMapsPortsForBaitAndSwitchResources#02.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.KubernetesWithProjectResources#02.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ConditionalWithParameterBranch_UsesIfElseSyntax#02.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_CustomWorkloadAndResourceType#02.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_GeneratesValidHelmChart#02.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpression#02.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesConditionalReferenceExpressionWithParameterCondition#02.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#02.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_HandlesSpecialResourceName#02.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ResourceWithProbes#00.verified.yaml
+++ b/tests/Aspire.Hosting.Kubernetes.Tests/Snapshots/KubernetesPublisherTests.PublishAsync_ResourceWithProbes#00.verified.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       containers:
-        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+        - image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
           name: "env-dashboard"
           ports:
             - name: "http"

--- a/tests/Aspire.Hosting.Yarp.Tests/Snapshots/YarpConfigGeneratorTests.GenerateEnvVariablesConfigurationDockerCompose.verified.env
+++ b/tests/Aspire.Hosting.Yarp.Tests/Snapshots/YarpConfigGeneratorTests.GenerateEnvVariablesConfigurationDockerCompose.verified.env
@@ -1,6 +1,6 @@
 services:
   docker-compose-dashboard:
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest"
+    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5"
     ports:
       - "18888:18888"
     expose:


### PR DESCRIPTION
## Description

`aspire publish` for Docker Compose and Kubernetes injected the Aspire Dashboard as `mcr.microsoft.com/dotnet/nightly/aspire-dashboard` **without a tag**. Both Docker and Kubernetes resolve an untagged image to the mutable `:latest`, so generated `docker-compose.yaml` files and Helm charts were **not reproducible** and could pull a nightly dashboard build that doesn't match the app's Aspire version.

This change adds a shared `DashboardImage` helper that pins the dashboard image to the app's Aspire `major.minor` version (for example `13.5`), derived from the running assembly's informational version. Deriving `major.minor` at runtime:

- always resolves to a tag that **exists on the registry** — including for prerelease/CI builds, where a full `major.minor.patch-prerelease` tag is never published;
- keeps the dashboard on the **same Aspire line** that generated the manifest; and
- is **deterministic** across builds, so publish snapshots stay stable (the build number never leaks into the tag).

Both the Docker Compose and Kubernetes dashboard resources now emit `mcr.microsoft.com/dotnet/nightly/aspire-dashboard:13.5` on this `release/13.5` line (the helper self-adjusts on other branches). Publish snapshots were regenerated accordingly, and a focused unit test covers the tag-resolution logic (prerelease, stable, 4-part assembly version, and the `:latest` fallback when no version is available).

> Targets `release/13.5` as requested.
>
> **Scope note:** this is the minimal, low-risk fix for the reproducibility problem. The issue also suggested exposing the tag as an overridable Helm `values.yaml` key; that larger enhancement is intentionally **not** included here and can be a follow-up.

Fixes #19239.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
