### PR TITLE
Ensure Aspire CLI bundle resolution

### DIFF
--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -1144,8 +1144,15 @@ function Invoke-AspireCliBundleSetup {
         [string]$TargetArchitecture
     )
 
-    $hostOS = Get-OperatingSystem
-    $hostArch = Get-CLIArchitectureFromArchitecture "<auto>"
+    try {
+        $hostOS = Get-OperatingSystem
+        $hostArch = Get-CLIArchitectureFromArchitecture "<auto>"
+    }
+    catch {
+        Write-Message "Skipping Aspire CLI bundle setup because the current platform could not be detected: $($_.Exception.Message)" -Level Warning
+        return
+    }
+
     if ($TargetOS -ne $hostOS -or $TargetArchitecture -ne $hostArch) {
         Write-Message "Skipping Aspire CLI bundle setup for $TargetOS-$TargetArchitecture on $hostOS-$hostArch." -Level Info
         return
@@ -1260,8 +1267,6 @@ function Install-AspireCli {
             Write-Host "What if: Route sidecar would be written to: $sidecarPath"
         }
 
-        Invoke-AspireCliBundleSetup -CliPath $cliPath -TargetOS $targetOS -TargetArchitecture $targetArch
-
         # Download and install VS Code extension if requested
         if ($InstallExtension) {
             Write-Message "" -Level Info
@@ -1282,6 +1287,8 @@ function Install-AspireCli {
                 Write-Message "Please ensure VS Code is installed and available in PATH" -Level Info
             }
         }
+
+        Invoke-AspireCliBundleSetup -CliPath $cliPath -TargetOS $targetOS -TargetArchitecture $targetArch
 
         # Return the target OS for the caller to use
         return $targetOS

--- a/eng/scripts/get-aspire-cli.ps1
+++ b/eng/scripts/get-aspire-cli.ps1
@@ -1133,6 +1133,34 @@ function Get-AspireCliUrl {
     }
 }
 
+function Invoke-AspireCliBundleSetup {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CliPath,
+        [Parameter(Mandatory = $true)]
+        [string]$TargetOS,
+        [Parameter(Mandatory = $true)]
+        [string]$TargetArchitecture
+    )
+
+    $hostOS = Get-OperatingSystem
+    $hostArch = Get-CLIArchitectureFromArchitecture "<auto>"
+    if ($TargetOS -ne $hostOS -or $TargetArchitecture -ne $hostArch) {
+        Write-Message "Skipping Aspire CLI bundle setup for $TargetOS-$TargetArchitecture on $hostOS-$hostArch." -Level Info
+        return
+    }
+
+    if ($PSCmdlet.ShouldProcess($CliPath, "Set up Aspire CLI bundle")) {
+        # Keep native stdout visible without adding it to Install-AspireCli's success output,
+        # whose sole return value is the target OS consumed by PATH configuration.
+        & $CliPath setup | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            throw "Aspire CLI bundle setup failed with exit code $LASTEXITCODE."
+        }
+    }
+}
+
 # Function to download and install the Aspire CLI
 function Install-AspireCli {
     [CmdletBinding(SupportsShouldProcess)]
@@ -1231,6 +1259,8 @@ function Install-AspireCli {
         else {
             Write-Host "What if: Route sidecar would be written to: $sidecarPath"
         }
+
+        Invoke-AspireCliBundleSetup -CliPath $cliPath -TargetOS $targetOS -TargetArchitecture $targetArch
 
         # Download and install VS Code extension if requested
         if ($InstallExtension) {

--- a/eng/scripts/get-aspire-cli.sh
+++ b/eng/scripts/get-aspire-cli.sh
@@ -21,6 +21,9 @@ VERSION=""
 QUALITY=""
 OS=""
 ARCH=""
+INSTALLED_CLI_PATH=""
+INSTALLED_CLI_OS=""
+INSTALLED_CLI_ARCH=""
 SHOW_HELP=false
 VERBOSE=false
 KEEP_ARCHIVE=false
@@ -995,6 +998,9 @@ download_and_install_archive() {
         cli_exe="aspire"
     fi
     cli_path="${INSTALL_PATH}/${cli_exe}"
+    INSTALLED_CLI_PATH="$cli_path"
+    INSTALLED_CLI_OS="$os"
+    INSTALLED_CLI_ARCH="$arch"
 
     say_info "Aspire CLI successfully installed to: ${GREEN}$cli_path${RESET}"
 
@@ -1017,6 +1023,33 @@ download_and_install_archive() {
             say_warn "Cannot install extension: VS Code CLI not found in PATH"
             say_info "Please ensure VS Code is installed and available in PATH"
         fi
+    fi
+}
+
+setup_cli_bundle() {
+    local host_os host_arch
+
+    if ! host_os=$(detect_os) || ! host_arch=$(get_cli_architecture_from_architecture "<auto>"); then
+        say_warn "Skipping Aspire CLI bundle setup because the current platform could not be detected."
+        return 0
+    fi
+
+    # Cross-target archive downloads are supported, but the downloaded executable cannot
+    # safely be run to extract its embedded bundle on a different host platform.
+    if [[ "$INSTALLED_CLI_OS" != "$host_os" || "$INSTALLED_CLI_ARCH" != "$host_arch" ]]; then
+        say_info "Skipping Aspire CLI bundle setup for ${INSTALLED_CLI_OS}-${INSTALLED_CLI_ARCH} on ${host_os}-${host_arch}."
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+        say_info "[DRY RUN] Would run: $INSTALLED_CLI_PATH setup"
+        return 0
+    fi
+
+    say_verbose "Running: $INSTALLED_CLI_PATH setup"
+    if ! "$INSTALLED_CLI_PATH" setup; then
+        say_error "Aspire CLI bundle setup failed"
+        return 1
     fi
 }
 
@@ -1104,6 +1137,10 @@ main() {
     else
         mkdir -p "$INSTALL_PATH"
         printf '{"source":"script"}\n' > "$sidecar_path"
+    fi
+
+    if ! setup_cli_bundle; then
+        exit 1
     fi
 
     # Skip PATH configuration if --skip-path is set

--- a/src/Aspire.Cli/Bundles/BundleService.cs
+++ b/src/Aspire.Cli/Bundles/BundleService.cs
@@ -586,7 +586,7 @@ internal sealed class BundleService(
 
     /// <summary>
     /// Returns <see langword="true"/> if <paramref name="versionDir"/> contains the
-    /// essential bundle components (<c>managed/aspire-managed</c> and a DCP directory).
+    /// essential bundle components (<c>managed/aspire-managed</c> and the DCP executable).
     /// </summary>
     internal static bool IsVersionedLayoutValid(string versionDir)
     {
@@ -617,7 +617,8 @@ internal sealed class BundleService(
         }
 
         var dcpDir = Path.Combine(versionDir, BundleDiscovery.DcpDirectoryName);
-        if (!Directory.Exists(dcpDir))
+        var dcpExe = BundleDiscovery.GetDcpExecutablePath(dcpDir);
+        if (!Directory.Exists(dcpDir) || !File.Exists(dcpExe))
         {
             return false;
         }

--- a/src/Aspire.Cli/Layout/LayoutDiscovery.cs
+++ b/src/Aspire.Cli/Layout/LayoutDiscovery.cs
@@ -251,6 +251,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         var bundleManagedPath = Path.Combine(bundlePath, BundleDiscovery.ManagedDirectoryName);
         var bundleDcpPath = Path.Combine(bundlePath, BundleDiscovery.DcpDirectoryName);
         var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
+        var bundleDcpExe = BundleDiscovery.GetDcpExecutablePath(bundleDcpPath);
 
         _logger.LogDebug("TryInferLayout: Checking layout at {Path}", layoutPath);
         _logger.LogDebug("  {Dir}/{Managed}/: {Exists}", BundleDiscovery.BundleDirectoryName, BundleDiscovery.ManagedDirectoryName, Directory.Exists(bundleManagedPath) ? "exists" : "MISSING");
@@ -260,8 +261,9 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         {
             var bundleManagedExe = Path.Combine(bundleManagedPath, managedExeName);
             _logger.LogDebug("  {Dir}/{Managed}/{Exe}: {Exists}", BundleDiscovery.BundleDirectoryName, BundleDiscovery.ManagedDirectoryName, managedExeName, File.Exists(bundleManagedExe) ? "exists" : "MISSING");
+            _logger.LogDebug("  {Dir}/{Dcp}/{Exe}: {Exists}", BundleDiscovery.BundleDirectoryName, BundleDiscovery.DcpDirectoryName, Path.GetFileName(bundleDcpExe), File.Exists(bundleDcpExe) ? "exists" : "MISSING");
 
-            if (File.Exists(bundleManagedExe))
+            if (File.Exists(bundleManagedExe) && File.Exists(bundleDcpExe))
             {
                 _logger.LogDebug("TryInferLayout: New bundle/ layout is valid");
                 return new LayoutConfiguration
@@ -279,6 +281,7 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         // Legacy layout: top-level managed/ and dcp/ directories (or reparse points).
         var managedPath = Path.Combine(layoutPath, BundleDiscovery.ManagedDirectoryName);
         var dcpPath = Path.Combine(layoutPath, BundleDiscovery.DcpDirectoryName);
+        var dcpExePath = BundleDiscovery.GetDcpExecutablePath(dcpPath);
 
         _logger.LogDebug("  {Dir}/: {Exists}", BundleDiscovery.ManagedDirectoryName, Directory.Exists(managedPath) ? "exists" : "MISSING");
         _logger.LogDebug("  {Dir}/: {Exists}", BundleDiscovery.DcpDirectoryName, Directory.Exists(dcpPath) ? "exists" : "MISSING");
@@ -292,10 +295,11 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
         // Check for aspire-managed executable
         var managedExePath = Path.Combine(managedPath, managedExeName);
         _logger.LogDebug("  managed/{ManagedExe}: {Exists}", managedExeName, File.Exists(managedExePath) ? "exists" : "MISSING");
+        _logger.LogDebug("  dcp/{DcpExe}: {Exists}", Path.GetFileName(dcpExePath), File.Exists(dcpExePath) ? "exists" : "MISSING");
 
-        if (!File.Exists(managedExePath))
+        if (!File.Exists(managedExePath) || !File.Exists(dcpExePath))
         {
-            _logger.LogDebug("TryInferLayout: Layout rejected - aspire-managed not found");
+            _logger.LogDebug("TryInferLayout: Layout rejected - required executable not found");
             return null;
         }
 
@@ -338,7 +342,9 @@ public sealed class LayoutDiscovery : ILayoutDiscovery
 
         // Require DCP for valid layouts
         var dcpPath = layout.GetComponentPath(LayoutComponent.Dcp);
-        if (dcpPath is null || !Directory.Exists(dcpPath))
+        if (dcpPath is null ||
+            !Directory.Exists(dcpPath) ||
+            !File.Exists(BundleDiscovery.GetDcpExecutablePath(dcpPath)))
         {
             _logger.LogDebug("Layout validation failed: DCP not found");
             return false;

--- a/src/Aspire.Cli/Projects/AppHostInfoResolver.cs
+++ b/src/Aspire.Cli/Projects/AppHostInfoResolver.cs
@@ -117,9 +117,9 @@ internal sealed class AppHostInfoResolver(IDotNetCliRunner runner, IAppHostInfoD
         var expectedCacheKey = diskCache.GetCacheKey(projectFile);
 
         // Mirror the property/item shape used by DotNetCliRunner.GetAppHostInformationAsync and
-        // additionally request AspireUseCliBundle, UserSecretsId, and run metadata so the CLI
-        // bundle handoff, --isolated user-secrets clone, and post-build AppHost launch path do
-        // not require their own MSBuild evaluations.
+        // additionally request AspireUseCliBundle, UserSecretsId, and run metadata so the CLI bundle
+        // handoff, --isolated user-secrets clone, and post-build AppHost launch path do not require
+        // their own MSBuild evaluations.
         // Adding extra -getProperty names is an evaluation-only cost.
         //
         // The Run* properties (RunCommand, RunArguments, RunWorkingDirectory) are only

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -1394,7 +1394,6 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
 
         // The resolver owns the cache/MSBuild fallback so validation and later run/publish
         // decisions share a single source of truth for AppHost project metadata.
-        using var cliBundleLease = await AcquireCliBundleLayoutAsync(cancellationToken);
         var information = await _appHostInfoResolver.GetAppHostInfoAsync(appHostFile, cancellationToken);
 
         if (information.ExitCode == 0 && information.IsAspireHost)
@@ -1426,7 +1425,6 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
         // Use the same MSBuild-based inspection as validation so version resolution
         // follows the project model that run/publish already rely on, including
         // SDK-style projects, package references, and Central Package Management.
-        using var cliBundleLease = await AcquireCliBundleLayoutAsync(cancellationToken);
         var information = await _appHostInfoResolver.GetAppHostInfoAsync(appHostFile, cancellationToken);
         return information.ExitCode == 0 && information.IsAspireHost
             ? information.AspireHostingVersion
@@ -1511,8 +1509,10 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
         //    is fine for non-CliBundle AppHosts that don't use WithTerminal() — the lease
         //    is best-effort and a missing layout just means no terminal host env vars.
         var canQueryCliBundleProperty = !isSingleFileAppHost || !context.NoBuild;
-        var injectDcpAndDashboard = canQueryCliBundleProperty
-            && await IsUsingCliBundleAsync(effectiveAppHostFile, cancellationToken);
+        var appHostInfo = canQueryCliBundleProperty
+            ? await _appHostInfoResolver.GetAppHostInfoAsync(effectiveAppHostFile, cancellationToken)
+            : null;
+        var injectDcpAndDashboard = appHostInfo?.IsUsingCliBundle == true;
         ConfigureCliBundleEnvironment(env, cliBundleLease, injectDcpAndDashboard);
 
         // RunCommand may display captured AppHost output as soon as BuildCompletionSource is signaled.
@@ -2278,9 +2278,6 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
         var effectiveAppHostFile = context.AppHostFile;
         var isSingleFileAppHost = !IsProjectFile(effectiveAppHostFile) && IsValidSingleFileAppHost(effectiveAppHostFile);
         var env = new Dictionary<string, string>(context.EnvironmentVariables);
-        var cliBundleLease = await AcquireCliBundleLayoutAsync(cancellationToken);
-        using var cliBundleLeaseScope = cliBundleLease;
-        ConfigureCliBundleEnvironment(env, cliBundleLease, injectDcpAndDashboard: false);
 
         // Check compatibility for project-based apphosts
         if (!isSingleFileAppHost)
@@ -2304,12 +2301,6 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
                 throw exception;
             }
         }
-
-        // See RunAsync for the rationale: terminal host env vars are injected even when
-        // the AppHost did not opt into AspireUseCliBundle, but DCP/Dashboard env vars are
-        // not (they would clobber per-RID NuGet metadata).
-        var injectDcpAndDashboardForPublish = await IsUsingCliBundleAsync(effectiveAppHostFile, cancellationToken);
-        ConfigureCliBundleEnvironment(env, cliBundleLease, injectDcpAndDashboardForPublish);
 
         // Build the apphost (unless --no-build is specified)
         if (!isSingleFileAppHost && !context.NoBuild)
@@ -2470,14 +2461,6 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
         }
     }
 
-    private async Task<bool> IsUsingCliBundleAsync(FileInfo projectFile, CancellationToken cancellationToken)
-    {
-        // Reuse the cached MSBuild result so `AspireUseCliBundle` is fetched alongside the
-        // IsAspireHost/version inspection rather than triggering a third project evaluation.
-        var info = await _appHostInfoResolver.GetAppHostInfoAsync(projectFile, cancellationToken);
-        return info.IsUsingCliBundle;
-    }
-
     private Task<BundleLayoutLease?> AcquireCliBundleLayoutAsync(CancellationToken cancellationToken)
         => _bundleService.EnsureExtractedAndAcquireLayoutAsync("cli", "dotnet-apphost", cancellationToken);
 
@@ -2494,28 +2477,32 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
             // disk) and would otherwise spam the debug log on every run.
             if (injectDcpAndDashboard)
             {
-                _logger.LogDebug("AspireUseCliBundle is enabled, but the Aspire CLI bundle layout was not available from this CLI process.");
+                _logger.LogDebug("AspireUseCliBundle is enabled, but the Aspire CLI bundle layout was not available from this CLI process. The AppHost will resolve configured, inherited, or assembly-metadata paths.");
             }
             // Don't return yet — repo-mode runs (DEBUG, `dotnet run --project src/Aspire.Cli`)
             // can still inject the terminal host path from the just-built artifact even when
             // no bundle layout exists at all (e.g. clean dev machine with no `aspire` install).
         }
 
-        if (!env.ContainsKey("AspireCliBundlePath") && !string.IsNullOrEmpty(layout?.LayoutPath))
+        if (!HasEnvironmentOverride(env, "AspireCliBundlePath") && !string.IsNullOrEmpty(layout?.LayoutPath))
         {
             env["AspireCliBundlePath"] = layout.LayoutPath;
         }
 
         if (injectDcpAndDashboard && layout is not null)
         {
-            if (!env.ContainsKey(BundleDiscovery.DcpPathEnvVar) && layout.GetDcpPath() is { } dcpPath)
+            if (!HasEnvironmentOverride(env, BundleDiscovery.DcpPathEnvVar) &&
+                layout.GetDcpPath() is { } layoutDcpPath &&
+                IsUsableDcpDirectory(layoutDcpPath))
             {
-                env[BundleDiscovery.DcpPathEnvVar] = dcpPath;
+                env[BundleDiscovery.DcpPathEnvVar] = layoutDcpPath;
             }
 
-            if (!env.ContainsKey(BundleDiscovery.DashboardPathEnvVar) && layout.GetManagedPath() is { } managedPath)
+            if (!HasEnvironmentOverride(env, BundleDiscovery.DashboardPathEnvVar) &&
+                layout.GetManagedPath() is { } layoutManagedPath &&
+                IsUsableDashboardPath(layoutManagedPath))
             {
-                env[BundleDiscovery.DashboardPathEnvVar] = managedPath;
+                env[BundleDiscovery.DashboardPathEnvVar] = layoutManagedPath;
             }
         }
 
@@ -2539,13 +2526,13 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
         //     "older CLI" diagnostic. Installed CLIs are unaffected because DetectRepositoryRoot
         //     only resolves via env var in release builds.
         //  3) Bundle layout aspire-managed (normal `aspire run` install path).
-        if (!env.ContainsKey(BundleDiscovery.TerminalHostPathEnvVar))
+        if (!HasEnvironmentOverride(env, BundleDiscovery.TerminalHostPathEnvVar))
         {
             var terminalHostPath = TryGetRepoLocalManagedPath() ?? layout?.GetManagedPath();
-            if (terminalHostPath is not null)
+            if (terminalHostPath is not null && IsUsableDashboardPath(terminalHostPath))
             {
                 env[BundleDiscovery.TerminalHostPathEnvVar] = terminalHostPath;
-                if (!env.ContainsKey(BundleDiscovery.TerminalHostInvocationArgsEnvVar))
+                if (!HasEnvironmentOverride(env, BundleDiscovery.TerminalHostInvocationArgsEnvVar))
                 {
                     env[BundleDiscovery.TerminalHostInvocationArgsEnvVar] = "terminalhost";
                 }
@@ -2555,11 +2542,17 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
         layoutLease?.AddEnvironment(env);
     }
 
-    /// <summary>
-    /// Resolves the repo-local <c>aspire-managed</c> binary when the CLI is running from
-    /// an Aspire repo checkout (typically <c>dotnet run --project src/Aspire.Cli</c>).
-    /// Returns <c>null</c> in release builds and when no repo-local build exists.
-    /// </summary>
+    private bool HasEnvironmentOverride(IReadOnlyDictionary<string, string> env, string name)
+        => env.ContainsKey(name) || _environment.GetEnvironmentVariable(name) is not null;
+
+    private static bool IsUsableDcpDirectory(string? path)
+        => !string.IsNullOrWhiteSpace(path) &&
+            Directory.Exists(path) &&
+            File.Exists(BundleDiscovery.GetDcpExecutablePath(path));
+
+    private static bool IsUsableDashboardPath(string? path)
+        => !string.IsNullOrWhiteSpace(path) && File.Exists(path);
+
     /// <summary>
     /// Resolves the repo-local <c>aspire-managed</c> binary when the CLI is running from
     /// an Aspire repo checkout (typically <c>dotnet run --project src/Aspire.Cli</c>).

--- a/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
+++ b/src/Aspire.Cli/Projects/DotNetAppHostProject.cs
@@ -2491,14 +2491,14 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
 
         if (injectDcpAndDashboard && layout is not null)
         {
-            if (!HasEnvironmentOverride(env, BundleDiscovery.DcpPathEnvVar) &&
+            if (!IsUsableDcpDirectory(GetEffectiveEnvironmentValue(env, BundleDiscovery.DcpPathEnvVar)) &&
                 layout.GetDcpPath() is { } layoutDcpPath &&
                 IsUsableDcpDirectory(layoutDcpPath))
             {
                 env[BundleDiscovery.DcpPathEnvVar] = layoutDcpPath;
             }
 
-            if (!HasEnvironmentOverride(env, BundleDiscovery.DashboardPathEnvVar) &&
+            if (!IsUsableDashboardPath(GetEffectiveEnvironmentValue(env, BundleDiscovery.DashboardPathEnvVar)) &&
                 layout.GetManagedPath() is { } layoutManagedPath &&
                 IsUsableDashboardPath(layoutManagedPath))
             {
@@ -2543,7 +2543,10 @@ internal sealed partial class DotNetAppHostProject : IAppHostProject
     }
 
     private bool HasEnvironmentOverride(IReadOnlyDictionary<string, string> env, string name)
-        => env.ContainsKey(name) || _environment.GetEnvironmentVariable(name) is not null;
+        => !string.IsNullOrWhiteSpace(GetEffectiveEnvironmentValue(env, name));
+
+    private string? GetEffectiveEnvironmentValue(IReadOnlyDictionary<string, string> env, string name)
+        => env.TryGetValue(name, out var value) ? value : _environment.GetEnvironmentVariable(name);
 
     private static bool IsUsableDcpDirectory(string? path)
         => !string.IsNullOrWhiteSpace(path) &&

--- a/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/RunCommandStrings.Designer.cs
@@ -332,5 +332,6 @@ namespace Aspire.Cli.Resources {
                 return ResourceManager.GetString("NoBuildNotSupportedWithWatchMode", resourceCulture);
             }
         }
+
     }
 }

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -231,12 +231,16 @@ namespace Projects%3B
          cannot supply runtime metadata. DNX layouts are resolved from Aspire home instead. -->
     <PropertyGroup>
       <_AspireCliBundleSelectedCliPath Condition="'$(_AspireResolvedCliInvocationMode)' == 'Aspire'">$(_AspireResolvedCliPath)</_AspireCliBundleSelectedCliPath>
+      <!-- Suppress the expected invalid-layout warning only when an existing CLI can prepare its
+           bundle. Explicit bundle paths and missing explicit CLI paths cannot be recovered. -->
+      <_AspireCliBundleWarnOnInvalidPaths>false</_AspireCliBundleWarnOnInvalidPaths>
+      <_AspireCliBundleWarnOnInvalidPaths Condition="'$(AspireCliBundlePath)' != '' or ('$(AspireCliPath)' != '' and !Exists('$(AspireCliPath)'))">true</_AspireCliBundleWarnOnInvalidPaths>
     </PropertyGroup>
 
     <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
                              AspireCliPath="$(_AspireCliBundleSelectedCliPath)"
                              SearchPathForAspireCli="false"
-                             WarnOnInvalidPaths="false">
+                             WarnOnInvalidPaths="$(_AspireCliBundleWarnOnInvalidPaths)">
       <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
       <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
       <Output TaskParameter="AspireDashboardPath" PropertyName="_AspireCliBundleDashboardPath" />

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -20,6 +20,8 @@
   <UsingTask Condition="'$(_AspireUseTaskHostFactory)' == 'true'" TaskName="ResolveAspireCliInvocation" AssemblyFile="$(_AspireTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask Condition="'$(_AspireUseTaskHostFactory)' != 'true'" TaskName="ResolveAspireCliBundle" AssemblyFile="$(_AspireTasksAssembly)" />
   <UsingTask Condition="'$(_AspireUseTaskHostFactory)' == 'true'" TaskName="ResolveAspireCliBundle" AssemblyFile="$(_AspireTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask Condition="'$(_AspireUseTaskHostFactory)' != 'true'" TaskName="RunAspireCliCommand" AssemblyFile="$(_AspireTasksAssembly)" />
+  <UsingTask Condition="'$(_AspireUseTaskHostFactory)' == 'true'" TaskName="RunAspireCliCommand" AssemblyFile="$(_AspireTasksAssembly)" TaskFactory="TaskHostFactory" />
 
   <ItemGroup>
     <ProjectCapability Include="Aspire" Condition=" '$(IsAspireHost)' == 'true' " />
@@ -215,6 +217,7 @@ namespace Projects%3B
       <Output TaskParameter="ResolvedDnxPath" PropertyName="_AspireResolvedDnxPath" />
       <Output TaskParameter="ResolvedDnxHostPath" PropertyName="_AspireResolvedDnxHostPath" />
       <Output TaskParameter="ResolvedDnxHostArguments" PropertyName="_AspireResolvedDnxHostArguments" />
+      <Output TaskParameter="ResolvedDnxHostArgumentItems" ItemName="_AspireResolvedDnxHostArgument" />
     </ResolveAspireCliInvocation>
 
     <PropertyGroup>
@@ -262,49 +265,61 @@ namespace Projects%3B
     <PropertyGroup Condition="'$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == '')">
       <_AspireCliSetupPath Condition="'$(AspireCliPath)' != ''">$(AspireCliPath)</_AspireCliSetupPath>
       <_AspireCliSetupPath Condition="'$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Aspire'">$(_AspireResolvedCliPath)</_AspireCliSetupPath>
-      <_AspireCliSetupPathIsWindowsCommandShim Condition="'$(OS)' == 'Windows_NT' and '$(_AspireCliSetupPath)' != '' and ($(_AspireCliSetupPath.ToLowerInvariant().EndsWith('.cmd')) or $(_AspireCliSetupPath.ToLowerInvariant().EndsWith('.bat')))">true</_AspireCliSetupPathIsWindowsCommandShim>
-      <_AspireCliSetupPathWithEscapedMetacharacters Condition="'$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPath), '[ \t()[\]{}!^`&lt;&gt;&amp;|;,+="~@]', '^$0'))</_AspireCliSetupPathWithEscapedMetacharacters>
-      <!-- Exec writes a temporary batch file, which invokes a nested cmd /C for command shims.
-           Each literal percent must survive both command processors: %% escapes the outer batch,
-           while the leading carets keep the resulting percent signs literal in the nested command. -->
-      <_AspireCliSetupPathForCommandShim Condition="'$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPathWithEscapedMetacharacters), '%', '^^%%'))</_AspireCliSetupPathForCommandShim>
-      <_AspireCliSetupPathForExecutable>$(_AspireCliSetupPath)</_AspireCliSetupPathForExecutable>
-      <!-- Exec writes a native executable command such as
-           "C:\install%NAME%\aspire.exe" setup
-           to one temporary Windows batch file. Double each percent sign once so cmd.exe
-           preserves the literal path instead of expanding %NAME% as an environment variable. -->
-      <_AspireCliSetupPathForExecutable Condition="'$(OS)' == 'Windows_NT' and '$(_AspireCliSetupPath)' != '' and '$(_AspireCliSetupPathIsWindowsCommandShim)' != 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPath), '%', '%%'))</_AspireCliSetupPathForExecutable>
       <_AspireCliSetupHome Condition="'$(_AspireCliSetupHome)' == ''">$(_AspireDefaultHomeDirectory)</_AspireCliSetupHome>
       <_AspireCliBundleSetupTimeout Condition="'$(_AspireCliBundleSetupTimeout)' == ''">120000</_AspireCliBundleSetupTimeout>
 
-      <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' != 'true'">"$(_AspireCliSetupPathForExecutable)" setup</_AspireCliSetupCommand>
-      <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">cmd /D /V:OFF /C $(_AspireCliSetupPathForCommandShim) setup</_AspireCliSetupCommand>
-      <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Dnx' and Exists('$(_AspireResolvedDnxHostPath)')">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliSetupCommand>
-      <!-- The escaped command-shim string is valid only inside Exec's temporary batch file. -->
-      <_AspireCliSetupDiagnosticCommand Condition="'$(_AspireCliSetupCommand)' != '' and '$(_AspireCliSetupPath)' != ''">"$(_AspireCliSetupPath)" setup</_AspireCliSetupDiagnosticCommand>
-      <_AspireCliSetupDiagnosticCommand Condition="'$(_AspireCliSetupCommand)' != '' and '$(_AspireCliSetupPath)' == ''">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliSetupDiagnosticCommand>
+      <_AspireCliSetupExecutable Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)')">$(_AspireCliSetupPath)</_AspireCliSetupExecutable>
+      <_AspireCliSetupExecutable Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Dnx' and Exists('$(_AspireResolvedDnxHostPath)')">$(_AspireResolvedDnxHostPath)</_AspireCliSetupExecutable>
+      <_AspireCliSetupDiagnosticCommand Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' != ''">"$(_AspireCliSetupPath)" setup</_AspireCliSetupDiagnosticCommand>
+      <_AspireCliSetupDiagnosticCommand Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' == ''">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliSetupDiagnosticCommand>
     </PropertyGroup>
+
+    <!-- Argument values are metadata so paths containing MSBuild item separators remain one argument. -->
+    <ItemGroup>
+      <_AspireCliSetupArgument Remove="@(_AspireCliSetupArgument)" />
+      <_AspireCliSetupArgument Include="AspireSetup" Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' != ''">
+        <Value>setup</Value>
+      </_AspireCliSetupArgument>
+      <_AspireCliSetupArgument Include="@(_AspireResolvedDnxHostArgument)" Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' == ''" />
+      <_AspireCliSetupArgument Include="DnxNonInteractive" Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' == ''">
+        <Value>--yes</Value>
+      </_AspireCliSetupArgument>
+      <_AspireCliSetupArgument Include="DnxPackage" Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' == ''">
+        <Value>$(_AspireCliDnxPackageReference)</Value>
+      </_AspireCliSetupArgument>
+      <_AspireCliSetupArgument Include="DnxSeparator" Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' == ''">
+        <Value>--</Value>
+      </_AspireCliSetupArgument>
+      <_AspireCliSetupArgument Include="DnxSetup" Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' == ''">
+        <Value>setup</Value>
+      </_AspireCliSetupArgument>
+      <_AspireCliSetupArgument Include="DnxInstallPathOption" Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' == ''">
+        <Value>--install-path</Value>
+      </_AspireCliSetupArgument>
+      <_AspireCliSetupArgument Include="DnxInstallPath" Condition="'$(_AspireCliSetupExecutable)' != '' and '$(_AspireCliSetupPath)' == ''">
+        <Value>$(_AspireCliSetupHome)</Value>
+      </_AspireCliSetupArgument>
+    </ItemGroup>
 
     <!-- Script installs normally extract during installation. This fallback also covers older
          installers and DNX-only machines, and runs during real builds so IDE and command-line
          builds stamp concrete DCP and dashboard assembly metadata. -->
     <Message Text="Aspire CLI bundle was not found. Running '$(_AspireCliSetupDiagnosticCommand)' to prepare it." Importance="Low"
-            Condition="'$(_AspireCliSetupCommand)' != '' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))" />
-    <Exec Command="$(_AspireCliSetupCommand)"
-          Condition="'$(_AspireCliSetupCommand)' != '' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))"
-          ConsoleToMSBuild="true"
-          IgnoreExitCode="true"
-          StandardOutputImportance="Low"
-          StandardErrorImportance="Low"
-          Timeout="$(_AspireCliBundleSetupTimeout)"
-          ContinueOnError="WarnAndContinue">
+            Condition="'$(_AspireCliSetupExecutable)' != '' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))" />
+    <RunAspireCliCommand FileName="$(_AspireCliSetupExecutable)"
+                         Arguments="@(_AspireCliSetupArgument)"
+                         TimeoutMilliseconds="$(_AspireCliBundleSetupTimeout)"
+                         Condition="'$(_AspireCliSetupExecutable)' != '' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))">
       <Output TaskParameter="ExitCode" PropertyName="_AspireCliSetupExitCode" />
-    </Exec>
+      <Output TaskParameter="TimedOut" PropertyName="_AspireCliSetupTimedOut" />
+      <Output TaskParameter="FailureMessage" PropertyName="_AspireCliSetupFailureMessage" />
+    </RunAspireCliCommand>
 
     <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
                             AspireCliPath="$(_AspireCliBundleSelectedCliPath)"
                             SearchPathForAspireCli="false"
-                            Condition="'$(_AspireCliSetupCommand)' != ''">
+                            WarnOnInvalidPaths="false"
+                            Condition="'$(_AspireCliSetupExecutable)' != ''">
       <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
       <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
       <Output TaskParameter="AspireDashboardPath" PropertyName="_AspireCliBundleDashboardPath" />
@@ -325,27 +340,49 @@ namespace Projects%3B
     <PropertyGroup Condition="'$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == '')">
       <!-- An unusable PATH CLI must not shadow the paired CLI package when DNX is available.
            Explicit AspireCliPath remains authoritative and never falls back. -->
-      <_AspireCliFallbackDnxSetupCommand Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Aspire' and Exists('$(_AspireResolvedDnxHostPath)')">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliFallbackDnxSetupCommand>
-      <_AspireCliFallbackDnxSetupDiagnosticCommand Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliFallbackDnxSetupDiagnosticCommand>
+      <_AspireCliFallbackDnxSetupExecutable Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Aspire' and Exists('$(_AspireResolvedDnxHostPath)')">$(_AspireResolvedDnxHostPath)</_AspireCliFallbackDnxSetupExecutable>
+      <_AspireCliFallbackDnxSetupDiagnosticCommand Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliFallbackDnxSetupDiagnosticCommand>
     </PropertyGroup>
 
+    <ItemGroup>
+      <_AspireCliFallbackDnxSetupArgument Remove="@(_AspireCliFallbackDnxSetupArgument)" />
+      <_AspireCliFallbackDnxSetupArgument Include="@(_AspireResolvedDnxHostArgument)" Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''" />
+      <_AspireCliFallbackDnxSetupArgument Include="DnxNonInteractive" Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">
+        <Value>--yes</Value>
+      </_AspireCliFallbackDnxSetupArgument>
+      <_AspireCliFallbackDnxSetupArgument Include="DnxPackage" Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">
+        <Value>$(_AspireCliDnxPackageReference)</Value>
+      </_AspireCliFallbackDnxSetupArgument>
+      <_AspireCliFallbackDnxSetupArgument Include="DnxSeparator" Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">
+        <Value>--</Value>
+      </_AspireCliFallbackDnxSetupArgument>
+      <_AspireCliFallbackDnxSetupArgument Include="DnxSetup" Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">
+        <Value>setup</Value>
+      </_AspireCliFallbackDnxSetupArgument>
+      <_AspireCliFallbackDnxSetupArgument Include="DnxInstallPathOption" Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">
+        <Value>--install-path</Value>
+      </_AspireCliFallbackDnxSetupArgument>
+      <_AspireCliFallbackDnxSetupArgument Include="DnxInstallPath" Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">
+        <Value>$(_AspireCliSetupHome)</Value>
+      </_AspireCliFallbackDnxSetupArgument>
+    </ItemGroup>
+
     <Message Text="The PATH Aspire CLI did not prepare a usable bundle. Running '$(_AspireCliFallbackDnxSetupDiagnosticCommand)' through DNX." Importance="Low"
-             Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''" />
-    <Exec Command="$(_AspireCliFallbackDnxSetupCommand)"
-          Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''"
-          ConsoleToMSBuild="true"
-          IgnoreExitCode="true"
-          StandardOutputImportance="Low"
-          StandardErrorImportance="Low"
-          Timeout="$(_AspireCliBundleSetupTimeout)"
-          ContinueOnError="WarnAndContinue">
+             Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''" />
+    <RunAspireCliCommand FileName="$(_AspireCliFallbackDnxSetupExecutable)"
+                         Arguments="@(_AspireCliFallbackDnxSetupArgument)"
+                         TimeoutMilliseconds="$(_AspireCliBundleSetupTimeout)"
+                         Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">
       <Output TaskParameter="ExitCode" PropertyName="_AspireCliFallbackDnxSetupExitCode" />
-    </Exec>
+      <Output TaskParameter="TimedOut" PropertyName="_AspireCliFallbackDnxSetupTimedOut" />
+      <Output TaskParameter="FailureMessage" PropertyName="_AspireCliFallbackDnxSetupFailureMessage" />
+    </RunAspireCliCommand>
 
     <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
                             AspireCliPath="$(_AspireCliBundleSelectedCliPath)"
                             SearchPathForAspireCli="false"
-                            Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''">
+                            WarnOnInvalidPaths="false"
+                            Condition="'$(_AspireCliFallbackDnxSetupExecutable)' != ''">
       <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
       <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
       <Output TaskParameter="AspireDashboardPath" PropertyName="_AspireCliBundleDashboardPath" />
@@ -368,15 +405,23 @@ namespace Projects%3B
         $(MSBuildProjectName) is configured to use the Aspire CLI bundle, but the bundle could not be resolved. New features require the Aspire CLI to be installed. The Aspire dashboard &amp; DCP packages will be deprecated in a future release.
         Install the Aspire CLI from https://get.aspire.dev and ensure the aspire command is available on PATH, or set AspireCliBundlePath/AspireCliPath to a valid Aspire CLI installation or bundle layout.
       </_AspireCliBundleNotFoundError>
-      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliSetupCommand)' != '' or '$(_AspireCliFallbackDnxSetupCommand)' != ''">
+      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliSetupExecutable)' != '' or '$(_AspireCliFallbackDnxSetupExecutable)' != ''">
         $(_AspireCliBundleNotFoundError)
         Automatic Aspire CLI bundle setup did not produce a usable DCP and dashboard layout.
       </_AspireCliBundleNotFoundError>
-      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliSetupExitCode)' != '' and '$(_AspireCliSetupExitCode)' != '0'">
+      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliSetupFailureMessage)' != ''">
+        $(_AspireCliBundleNotFoundError)
+        Automatic Aspire CLI bundle setup failed: $(_AspireCliSetupFailureMessage) Run '$(_AspireCliSetupDiagnosticCommand)' to diagnose the failure.
+      </_AspireCliBundleNotFoundError>
+      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliSetupFailureMessage)' == '' and '$(_AspireCliSetupExitCode)' != '' and '$(_AspireCliSetupExitCode)' != '0'">
         $(_AspireCliBundleNotFoundError)
         Automatic Aspire CLI bundle setup failed with exit code $(_AspireCliSetupExitCode). Run '$(_AspireCliSetupDiagnosticCommand)' to diagnose the failure.
       </_AspireCliBundleNotFoundError>
-      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliFallbackDnxSetupExitCode)' != '' and '$(_AspireCliFallbackDnxSetupExitCode)' != '0'">
+      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliFallbackDnxSetupFailureMessage)' != ''">
+        $(_AspireCliBundleNotFoundError)
+        Paired Aspire CLI bundle setup through DNX failed: $(_AspireCliFallbackDnxSetupFailureMessage) Run '$(_AspireCliFallbackDnxSetupDiagnosticCommand)' to diagnose the failure.
+      </_AspireCliBundleNotFoundError>
+      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliFallbackDnxSetupFailureMessage)' == '' and '$(_AspireCliFallbackDnxSetupExitCode)' != '' and '$(_AspireCliFallbackDnxSetupExitCode)' != '0'">
         $(_AspireCliBundleNotFoundError)
         Paired Aspire CLI bundle setup through DNX failed with exit code $(_AspireCliFallbackDnxSetupExitCode). Run '$(_AspireCliFallbackDnxSetupDiagnosticCommand)' to diagnose the failure.
       </_AspireCliBundleNotFoundError>

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -218,10 +218,6 @@ namespace Projects%3B
     </ResolveAspireCliInvocation>
 
     <PropertyGroup>
-      <!-- A usable DNX host can supply DCP/Dashboard paths at runtime when a PATH Aspire candidate
-           later fails its version probe. Explicit paths still require build-time validation so
-           configuration mistakes fail with ASPIRE009. -->
-      <_AspireCliBundleResolutionOptional Condition="'$(AspireCliPath)' == '' and '$(AspireCliBundlePath)' == '' and ('$(_AspireResolvedCliInvocationMode)' == 'Dnx' or '$(_AspireResolvedDnxHostPath)' != '')">true</_AspireCliBundleResolutionOptional>
       <_AspireResolvedDnxHostArgumentsPrefix Condition="'$(_AspireResolvedDnxHostArguments)' != ''">$(_AspireResolvedDnxHostArguments) </_AspireResolvedDnxHostArgumentsPrefix>
     </PropertyGroup>
 
@@ -230,9 +226,100 @@ namespace Projects%3B
 
   <Target Name="ResolveAspireCliBundlePaths"
           DependsOnTargets="_ResolveAspireCliInvocation"
-          Condition="'$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))">
+          Condition="'$(DesignTimeBuild)' != 'true' and '$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))">
     <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
                              AspireCliPath="$(AspireCliPath)">
+      <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
+      <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
+      <Output TaskParameter="AspireDashboardPath" PropertyName="_AspireCliBundleDashboardPath" />
+      <Output TaskParameter="AspireTerminalHostDir" PropertyName="_AspireCliBundleTerminalHostDir" />
+      <Output TaskParameter="AspireTerminalHostPath" PropertyName="_AspireCliBundleTerminalHostPath" />
+      <Output TaskParameter="AspireTerminalHostInvocationArgs" PropertyName="_AspireCliBundleTerminalHostInvocationArgs" />
+      <Output TaskParameter="AspireHomeDirectory" PropertyName="_AspireDefaultHomeDirectory" />
+    </ResolveAspireCliBundle>
+
+    <PropertyGroup>
+      <DcpDir Condition="'$(DcpDir)' == ''">$(_AspireCliBundleDcpDir)</DcpDir>
+      <AspireDashboardDir Condition="'$(AspireDashboardDir)' == ''">$(_AspireCliBundleDashboardDir)</AspireDashboardDir>
+      <AspireDashboardPath Condition="'$(AspireDashboardPath)' == ''">$(_AspireCliBundleDashboardPath)</AspireDashboardPath>
+      <AspireTerminalHostDir Condition="'$(AspireTerminalHostDir)' == ''">$(_AspireCliBundleTerminalHostDir)</AspireTerminalHostDir>
+      <AspireTerminalHostPath Condition="'$(AspireTerminalHostPath)' == ''">$(_AspireCliBundleTerminalHostPath)</AspireTerminalHostPath>
+      <AspireTerminalHostInvocationArgs Condition="'$(AspireTerminalHostInvocationArgs)' == ''">$(_AspireCliBundleTerminalHostInvocationArgs)</AspireTerminalHostInvocationArgs>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == '')">
+      <_AspireCliSetupPath Condition="'$(AspireCliPath)' != ''">$(AspireCliPath)</_AspireCliSetupPath>
+      <_AspireCliSetupPath Condition="'$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Aspire'">$(_AspireResolvedCliPath)</_AspireCliSetupPath>
+      <_AspireCliSetupPathIsWindowsCommandShim Condition="'$(OS)' == 'Windows_NT' and '$(_AspireCliSetupPath)' != '' and ($(_AspireCliSetupPath.ToLowerInvariant().EndsWith('.cmd')) or $(_AspireCliSetupPath.ToLowerInvariant().EndsWith('.bat')))">true</_AspireCliSetupPathIsWindowsCommandShim>
+      <_AspireCliSetupPathWithEscapedMetacharacters Condition="'$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPath), '[ \t()[\]{}!^`&lt;&gt;&amp;|;,+="~@]', '^$0'))</_AspireCliSetupPathWithEscapedMetacharacters>
+      <!-- Exec writes a temporary batch file, which invokes a nested cmd /C for command shims.
+           Each literal percent must survive both command processors: %% escapes the outer batch,
+           while the leading carets keep the resulting percent signs literal in the nested command. -->
+      <_AspireCliSetupPathForCommandShim Condition="'$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPathWithEscapedMetacharacters), '%', '^^%%'))</_AspireCliSetupPathForCommandShim>
+      <_AspireCliSetupHome Condition="'$(ASPIRE_HOME)' != ''">$(ASPIRE_HOME)</_AspireCliSetupHome>
+      <_AspireCliSetupHome Condition="'$(_AspireCliSetupHome)' == ''">$(_AspireDefaultHomeDirectory)</_AspireCliSetupHome>
+
+      <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' != 'true'">"$(_AspireCliSetupPath)" setup</_AspireCliSetupCommand>
+      <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">cmd /D /V:OFF /C $(_AspireCliSetupPathForCommandShim) setup</_AspireCliSetupCommand>
+      <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Dnx' and Exists('$(_AspireResolvedDnxHostPath)')">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliSetupCommand>
+    </PropertyGroup>
+
+    <!-- Script installs normally extract during installation. This fallback also covers older
+         installers and DNX-only machines, and runs during real builds so IDE and command-line
+         builds stamp concrete DCP and dashboard assembly metadata. -->
+    <Message Text="Aspire CLI bundle was not found. Running '$(_AspireCliSetupCommand)' to prepare it." Importance="Low"
+            Condition="'$(_AspireCliSetupCommand)' != '' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))" />
+    <Exec Command="$(_AspireCliSetupCommand)"
+          Condition="'$(_AspireCliSetupCommand)' != '' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="Low"
+          Timeout="120000">
+      <Output TaskParameter="ExitCode" PropertyName="_AspireCliSetupExitCode" />
+    </Exec>
+
+    <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
+                            AspireCliPath="$(AspireCliPath)"
+                            Condition="'$(_AspireCliSetupCommand)' != ''">
+      <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
+      <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
+      <Output TaskParameter="AspireDashboardPath" PropertyName="_AspireCliBundleDashboardPath" />
+      <Output TaskParameter="AspireTerminalHostDir" PropertyName="_AspireCliBundleTerminalHostDir" />
+      <Output TaskParameter="AspireTerminalHostPath" PropertyName="_AspireCliBundleTerminalHostPath" />
+      <Output TaskParameter="AspireTerminalHostInvocationArgs" PropertyName="_AspireCliBundleTerminalHostInvocationArgs" />
+    </ResolveAspireCliBundle>
+
+    <PropertyGroup>
+      <DcpDir Condition="'$(DcpDir)' == ''">$(_AspireCliBundleDcpDir)</DcpDir>
+      <AspireDashboardDir Condition="'$(AspireDashboardDir)' == ''">$(_AspireCliBundleDashboardDir)</AspireDashboardDir>
+      <AspireDashboardPath Condition="'$(AspireDashboardPath)' == ''">$(_AspireCliBundleDashboardPath)</AspireDashboardPath>
+      <AspireTerminalHostDir Condition="'$(AspireTerminalHostDir)' == ''">$(_AspireCliBundleTerminalHostDir)</AspireTerminalHostDir>
+      <AspireTerminalHostPath Condition="'$(AspireTerminalHostPath)' == ''">$(_AspireCliBundleTerminalHostPath)</AspireTerminalHostPath>
+      <AspireTerminalHostInvocationArgs Condition="'$(AspireTerminalHostInvocationArgs)' == ''">$(_AspireCliBundleTerminalHostInvocationArgs)</AspireTerminalHostInvocationArgs>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == '')">
+      <!-- An unusable PATH CLI must not shadow the paired CLI package when DNX is available.
+           Explicit AspireCliPath remains authoritative and never falls back. -->
+      <_AspireCliFallbackDnxSetupCommand Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Aspire' and Exists('$(_AspireResolvedDnxHostPath)')">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliFallbackDnxSetupCommand>
+    </PropertyGroup>
+
+    <Message Text="The PATH Aspire CLI did not prepare a usable bundle. Running '$(_AspireCliFallbackDnxSetupCommand)' through DNX." Importance="Low"
+             Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''" />
+    <Exec Command="$(_AspireCliFallbackDnxSetupCommand)"
+          Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="Low"
+          Timeout="120000">
+      <Output TaskParameter="ExitCode" PropertyName="_AspireCliFallbackDnxSetupExitCode" />
+    </Exec>
+
+    <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
+                            AspireCliPath="$(AspireCliPath)"
+                            Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''">
       <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
       <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
       <Output TaskParameter="AspireDashboardPath" PropertyName="_AspireCliBundleDashboardPath" />
@@ -255,10 +342,22 @@ namespace Projects%3B
         $(MSBuildProjectName) is configured to use the Aspire CLI bundle, but the bundle could not be resolved. New features require the Aspire CLI to be installed. The Aspire dashboard &amp; DCP packages will be deprecated in a future release.
         Install the Aspire CLI from https://get.aspire.dev and ensure the aspire command is available on PATH, or set AspireCliBundlePath/AspireCliPath to a valid Aspire CLI installation or bundle layout.
       </_AspireCliBundleNotFoundError>
+      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliSetupCommand)' != '' or '$(_AspireCliFallbackDnxSetupCommand)' != ''">
+        $(_AspireCliBundleNotFoundError)
+        Automatic Aspire CLI bundle setup did not produce a usable DCP and dashboard layout.
+      </_AspireCliBundleNotFoundError>
+      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliSetupExitCode)' != '' and '$(_AspireCliSetupExitCode)' != '0'">
+        $(_AspireCliBundleNotFoundError)
+        Automatic Aspire CLI bundle setup failed with exit code $(_AspireCliSetupExitCode). Run '$(_AspireCliSetupCommand)' to diagnose the failure.
+      </_AspireCliBundleNotFoundError>
+      <_AspireCliBundleNotFoundError Condition="'$(_AspireCliFallbackDnxSetupExitCode)' != '' and '$(_AspireCliFallbackDnxSetupExitCode)' != '0'">
+        $(_AspireCliBundleNotFoundError)
+        Paired Aspire CLI bundle setup through DNX failed with exit code $(_AspireCliFallbackDnxSetupExitCode). Run '$(_AspireCliFallbackDnxSetupCommand)' to diagnose the failure.
+      </_AspireCliBundleNotFoundError>
     </PropertyGroup>
 
     <Error Code="ASPIRE009"
-           Condition="'$(_AspireCliBundleResolutionOptional)' != 'true' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))"
+           Condition="'$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == '')"
            Text="$(_AspireCliBundleNotFoundError)" />
   </Target>
 

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -256,7 +256,6 @@ namespace Projects%3B
            Each literal percent must survive both command processors: %% escapes the outer batch,
            while the leading carets keep the resulting percent signs literal in the nested command. -->
       <_AspireCliSetupPathForCommandShim Condition="'$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPathWithEscapedMetacharacters), '%', '^^%%'))</_AspireCliSetupPathForCommandShim>
-      <_AspireCliSetupHome Condition="'$(ASPIRE_HOME)' != ''">$(ASPIRE_HOME)</_AspireCliSetupHome>
       <_AspireCliSetupHome Condition="'$(_AspireCliSetupHome)' == ''">$(_AspireDefaultHomeDirectory)</_AspireCliSetupHome>
       <_AspireCliBundleSetupTimeout Condition="'$(_AspireCliBundleSetupTimeout)' == ''">120000</_AspireCliBundleSetupTimeout>
 
@@ -280,7 +279,7 @@ namespace Projects%3B
           StandardOutputImportance="Low"
           StandardErrorImportance="Low"
           Timeout="$(_AspireCliBundleSetupTimeout)"
-          ContinueOnError="ErrorAndContinue">
+          ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_AspireCliSetupExitCode" />
     </Exec>
 
@@ -320,7 +319,7 @@ namespace Projects%3B
           StandardOutputImportance="Low"
           StandardErrorImportance="Low"
           Timeout="$(_AspireCliBundleSetupTimeout)"
-          ContinueOnError="ErrorAndContinue">
+          ContinueOnError="WarnAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_AspireCliFallbackDnxSetupExitCode" />
     </Exec>
 

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -235,7 +235,8 @@ namespace Projects%3B
 
     <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
                              AspireCliPath="$(_AspireCliBundleSelectedCliPath)"
-                             SearchPathForAspireCli="false">
+                             SearchPathForAspireCli="false"
+                             WarnOnInvalidPaths="false">
       <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
       <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
       <Output TaskParameter="AspireDashboardPath" PropertyName="_AspireCliBundleDashboardPath" />
@@ -263,10 +264,16 @@ namespace Projects%3B
            Each literal percent must survive both command processors: %% escapes the outer batch,
            while the leading carets keep the resulting percent signs literal in the nested command. -->
       <_AspireCliSetupPathForCommandShim Condition="'$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPathWithEscapedMetacharacters), '%', '^^%%'))</_AspireCliSetupPathForCommandShim>
+      <_AspireCliSetupPathForExecutable>$(_AspireCliSetupPath)</_AspireCliSetupPathForExecutable>
+      <!-- Exec writes a native executable command such as
+           "C:\install%NAME%\aspire.exe" setup
+           to one temporary Windows batch file. Double each percent sign once so cmd.exe
+           preserves the literal path instead of expanding %NAME% as an environment variable. -->
+      <_AspireCliSetupPathForExecutable Condition="'$(OS)' == 'Windows_NT' and '$(_AspireCliSetupPath)' != '' and '$(_AspireCliSetupPathIsWindowsCommandShim)' != 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPath), '%', '%%'))</_AspireCliSetupPathForExecutable>
       <_AspireCliSetupHome Condition="'$(_AspireCliSetupHome)' == ''">$(_AspireDefaultHomeDirectory)</_AspireCliSetupHome>
       <_AspireCliBundleSetupTimeout Condition="'$(_AspireCliBundleSetupTimeout)' == ''">120000</_AspireCliBundleSetupTimeout>
 
-      <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' != 'true'">"$(_AspireCliSetupPath)" setup</_AspireCliSetupCommand>
+      <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' != 'true'">"$(_AspireCliSetupPathForExecutable)" setup</_AspireCliSetupCommand>
       <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">cmd /D /V:OFF /C $(_AspireCliSetupPathForCommandShim) setup</_AspireCliSetupCommand>
       <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Dnx' and Exists('$(_AspireResolvedDnxHostPath)')">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliSetupCommand>
       <!-- The escaped command-shim string is valid only inside Exec's temporary batch file. -->

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -258,16 +258,20 @@ namespace Projects%3B
       <_AspireCliSetupPathForCommandShim Condition="'$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">$([System.Text.RegularExpressions.Regex]::Replace($(_AspireCliSetupPathWithEscapedMetacharacters), '%', '^^%%'))</_AspireCliSetupPathForCommandShim>
       <_AspireCliSetupHome Condition="'$(ASPIRE_HOME)' != ''">$(ASPIRE_HOME)</_AspireCliSetupHome>
       <_AspireCliSetupHome Condition="'$(_AspireCliSetupHome)' == ''">$(_AspireDefaultHomeDirectory)</_AspireCliSetupHome>
+      <_AspireCliBundleSetupTimeout Condition="'$(_AspireCliBundleSetupTimeout)' == ''">120000</_AspireCliBundleSetupTimeout>
 
       <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' != 'true'">"$(_AspireCliSetupPath)" setup</_AspireCliSetupCommand>
       <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and Exists('$(_AspireCliSetupPath)') and '$(_AspireCliSetupPathIsWindowsCommandShim)' == 'true'">cmd /D /V:OFF /C $(_AspireCliSetupPathForCommandShim) setup</_AspireCliSetupCommand>
       <_AspireCliSetupCommand Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Dnx' and Exists('$(_AspireResolvedDnxHostPath)')">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliSetupCommand>
+      <!-- The escaped command-shim string is valid only inside Exec's temporary batch file. -->
+      <_AspireCliSetupDiagnosticCommand Condition="'$(_AspireCliSetupCommand)' != '' and '$(_AspireCliSetupPath)' != ''">"$(_AspireCliSetupPath)" setup</_AspireCliSetupDiagnosticCommand>
+      <_AspireCliSetupDiagnosticCommand Condition="'$(_AspireCliSetupCommand)' != '' and '$(_AspireCliSetupPath)' == ''">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliSetupDiagnosticCommand>
     </PropertyGroup>
 
     <!-- Script installs normally extract during installation. This fallback also covers older
          installers and DNX-only machines, and runs during real builds so IDE and command-line
          builds stamp concrete DCP and dashboard assembly metadata. -->
-    <Message Text="Aspire CLI bundle was not found. Running '$(_AspireCliSetupCommand)' to prepare it." Importance="Low"
+    <Message Text="Aspire CLI bundle was not found. Running '$(_AspireCliSetupDiagnosticCommand)' to prepare it." Importance="Low"
             Condition="'$(_AspireCliSetupCommand)' != '' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))" />
     <Exec Command="$(_AspireCliSetupCommand)"
           Condition="'$(_AspireCliSetupCommand)' != '' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))"
@@ -275,7 +279,8 @@ namespace Projects%3B
           IgnoreExitCode="true"
           StandardOutputImportance="Low"
           StandardErrorImportance="Low"
-          Timeout="120000">
+          Timeout="$(_AspireCliBundleSetupTimeout)"
+          ContinueOnError="ErrorAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_AspireCliSetupExitCode" />
     </Exec>
 
@@ -303,9 +308,10 @@ namespace Projects%3B
       <!-- An unusable PATH CLI must not shadow the paired CLI package when DNX is available.
            Explicit AspireCliPath remains authoritative and never falls back. -->
       <_AspireCliFallbackDnxSetupCommand Condition="'$(AspireCliBundlePath)' == '' and '$(AspireCliPath)' == '' and '$(_AspireResolvedCliInvocationMode)' == 'Aspire' and Exists('$(_AspireResolvedDnxHostPath)')">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliFallbackDnxSetupCommand>
+      <_AspireCliFallbackDnxSetupDiagnosticCommand Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''">"$(_AspireResolvedDnxHostPath)" $(_AspireResolvedDnxHostArgumentsPrefix)--yes $(_AspireCliDnxPackageReference) -- setup --install-path "$(_AspireCliSetupHome)"</_AspireCliFallbackDnxSetupDiagnosticCommand>
     </PropertyGroup>
 
-    <Message Text="The PATH Aspire CLI did not prepare a usable bundle. Running '$(_AspireCliFallbackDnxSetupCommand)' through DNX." Importance="Low"
+    <Message Text="The PATH Aspire CLI did not prepare a usable bundle. Running '$(_AspireCliFallbackDnxSetupDiagnosticCommand)' through DNX." Importance="Low"
              Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''" />
     <Exec Command="$(_AspireCliFallbackDnxSetupCommand)"
           Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''"
@@ -313,7 +319,8 @@ namespace Projects%3B
           IgnoreExitCode="true"
           StandardOutputImportance="Low"
           StandardErrorImportance="Low"
-          Timeout="120000">
+          Timeout="$(_AspireCliBundleSetupTimeout)"
+          ContinueOnError="ErrorAndContinue">
       <Output TaskParameter="ExitCode" PropertyName="_AspireCliFallbackDnxSetupExitCode" />
     </Exec>
 
@@ -348,11 +355,11 @@ namespace Projects%3B
       </_AspireCliBundleNotFoundError>
       <_AspireCliBundleNotFoundError Condition="'$(_AspireCliSetupExitCode)' != '' and '$(_AspireCliSetupExitCode)' != '0'">
         $(_AspireCliBundleNotFoundError)
-        Automatic Aspire CLI bundle setup failed with exit code $(_AspireCliSetupExitCode). Run '$(_AspireCliSetupCommand)' to diagnose the failure.
+        Automatic Aspire CLI bundle setup failed with exit code $(_AspireCliSetupExitCode). Run '$(_AspireCliSetupDiagnosticCommand)' to diagnose the failure.
       </_AspireCliBundleNotFoundError>
       <_AspireCliBundleNotFoundError Condition="'$(_AspireCliFallbackDnxSetupExitCode)' != '' and '$(_AspireCliFallbackDnxSetupExitCode)' != '0'">
         $(_AspireCliBundleNotFoundError)
-        Paired Aspire CLI bundle setup through DNX failed with exit code $(_AspireCliFallbackDnxSetupExitCode). Run '$(_AspireCliFallbackDnxSetupCommand)' to diagnose the failure.
+        Paired Aspire CLI bundle setup through DNX failed with exit code $(_AspireCliFallbackDnxSetupExitCode). Run '$(_AspireCliFallbackDnxSetupDiagnosticCommand)' to diagnose the failure.
       </_AspireCliBundleNotFoundError>
     </PropertyGroup>
 

--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets
@@ -227,8 +227,15 @@ namespace Projects%3B
   <Target Name="ResolveAspireCliBundlePaths"
           DependsOnTargets="_ResolveAspireCliInvocation"
           Condition="'$(DesignTimeBuild)' != 'true' and '$(IsAspireHost)' == 'true' and '$(AspireUseCliBundle)' == 'true' and ('$(DcpDir)' == '' or ('$(AspireDashboardDir)' == '' and '$(AspireDashboardPath)' == ''))">
+    <!-- Bundle discovery must follow the invocation selected above so an unselected PATH CLI
+         cannot supply runtime metadata. DNX layouts are resolved from Aspire home instead. -->
+    <PropertyGroup>
+      <_AspireCliBundleSelectedCliPath Condition="'$(_AspireResolvedCliInvocationMode)' == 'Aspire'">$(_AspireResolvedCliPath)</_AspireCliBundleSelectedCliPath>
+    </PropertyGroup>
+
     <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
-                             AspireCliPath="$(AspireCliPath)">
+                             AspireCliPath="$(_AspireCliBundleSelectedCliPath)"
+                             SearchPathForAspireCli="false">
       <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
       <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
       <Output TaskParameter="AspireDashboardPath" PropertyName="_AspireCliBundleDashboardPath" />
@@ -284,7 +291,8 @@ namespace Projects%3B
     </Exec>
 
     <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
-                            AspireCliPath="$(AspireCliPath)"
+                            AspireCliPath="$(_AspireCliBundleSelectedCliPath)"
+                            SearchPathForAspireCli="false"
                             Condition="'$(_AspireCliSetupCommand)' != ''">
       <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
       <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />
@@ -324,7 +332,8 @@ namespace Projects%3B
     </Exec>
 
     <ResolveAspireCliBundle AspireCliBundlePath="$(AspireCliBundlePath)"
-                            AspireCliPath="$(AspireCliPath)"
+                            AspireCliPath="$(_AspireCliBundleSelectedCliPath)"
+                            SearchPathForAspireCli="false"
                             Condition="'$(_AspireCliFallbackDnxSetupCommand)' != ''">
       <Output TaskParameter="DcpDir" PropertyName="_AspireCliBundleDcpDir" />
       <Output TaskParameter="AspireDashboardDir" PropertyName="_AspireCliBundleDashboardDir" />

--- a/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
+++ b/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
@@ -29,6 +29,12 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
     public string? AspireCliPath { get; set; }
 
     /// <summary>
+    /// The Aspire home directory used to find and prepare extracted bundle layouts.
+    /// </summary>
+    [Output]
+    public string? AspireHomeDirectory { get; set; }
+
+    /// <summary>
     /// The resolved DCP directory.
     /// </summary>
     [Output]
@@ -69,6 +75,9 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
+        var aspireHomeDirectory = GetDefaultAspireHomeDirectory();
+        AspireHomeDirectory = aspireHomeDirectory;
+
         if (!string.IsNullOrWhiteSpace(AspireCliBundlePath))
         {
             if (TryResolveFromLayoutPath(AspireCliBundlePath, out var explicitBundle))
@@ -99,7 +108,7 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
             return true;
         }
 
-        if (TryResolveFromLayoutPath(GetDefaultAspireHomeDirectory(), out var aspireHomeBundle))
+        if (TryResolveFromLayoutPath(aspireHomeDirectory, out var aspireHomeBundle))
         {
             SetOutputs(aspireHomeBundle);
             return true;

--- a/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
+++ b/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
@@ -37,6 +37,11 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
     public bool SearchPathForAspireCli { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether invalid explicitly configured paths produce warnings.
+    /// </summary>
+    public bool WarnOnInvalidPaths { get; set; } = true;
+
+    /// <summary>
     /// The Aspire home directory used to find and prepare extracted bundle layouts.
     /// </summary>
     [Output]
@@ -94,7 +99,11 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
                 return true;
             }
 
-            Log.LogWarning("The AspireCliBundlePath value '{0}' does not point to a valid Aspire CLI bundle layout.", AspireCliBundlePath);
+            if (WarnOnInvalidPaths)
+            {
+                Log.LogWarning("The AspireCliBundlePath value '{0}' does not point to a valid Aspire CLI bundle layout.", AspireCliBundlePath);
+            }
+
             return true;
         }
 
@@ -106,7 +115,11 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
                 return true;
             }
 
-            Log.LogWarning("The AspireCliPath value '{0}' does not point to an existing Aspire CLI executable with a valid bundle layout.", AspireCliPath);
+            if (WarnOnInvalidPaths)
+            {
+                Log.LogWarning("The AspireCliPath value '{0}' does not point to an existing Aspire CLI executable with a valid bundle layout.", AspireCliPath);
+            }
+
             return true;
         }
 

--- a/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
+++ b/src/Aspire.Hosting.Tasks/ResolveAspireCliBundle.cs
@@ -29,6 +29,14 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
     public string? AspireCliPath { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to search <c>PATH</c> for Aspire CLI executables.
+    /// </summary>
+    /// <remarks>
+    /// Explicit paths and the Aspire home directory are still evaluated when this value is <see langword="false"/>.
+    /// </remarks>
+    public bool SearchPathForAspireCli { get; set; } = true;
+
+    /// <summary>
     /// The Aspire home directory used to find and prepare extracted bundle layouts.
     /// </summary>
     [Output]
@@ -102,7 +110,7 @@ public sealed class ResolveAspireCliBundle : Microsoft.Build.Utilities.Task
             return true;
         }
 
-        if (TryResolveFromPath(out var pathBundle))
+        if (SearchPathForAspireCli && TryResolveFromPath(out var pathBundle))
         {
             SetOutputs(pathBundle);
             return true;

--- a/src/Aspire.Hosting.Tasks/ResolveAspireCliInvocation.cs
+++ b/src/Aspire.Hosting.Tasks/ResolveAspireCliInvocation.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Aspire.Hosting.Tasks;
 
@@ -55,6 +56,12 @@ public sealed class ResolveAspireCliInvocation : Microsoft.Build.Utilities.Task
     /// </summary>
     [Output]
     public string? ResolvedDnxHostArguments { get; set; }
+
+    /// <summary>
+    /// Gets the individual arguments that select DNX on <see cref="ResolvedDnxHostPath"/>.
+    /// </summary>
+    [Output]
+    public ITaskItem[] ResolvedDnxHostArgumentItems { get; set; } = [];
 
     public override bool Execute()
     {
@@ -127,6 +134,12 @@ public sealed class ResolveAspireCliInvocation : Microsoft.Build.Utilities.Task
         // behavior while bypassing cmd.exe, which would reinterpret forwarded AppHost arguments.
         ResolvedDnxHostPath = dotnetPath;
         ResolvedDnxHostArguments = $"exec \"{sdkPath}\" dnx";
+        ResolvedDnxHostArgumentItems =
+        [
+            new TaskItem("exec"),
+            new TaskItem(sdkPath),
+            new TaskItem("dnx")
+        ];
         return true;
     }
 

--- a/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
+++ b/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
@@ -17,6 +17,9 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
     private const string ArgumentValueMetadataName = "Value";
     private const string CommandShimPathEnvironmentVariable = "__ASPIRE_MSBUILD_COMMAND_PATH";
     private const string CommandShimArgumentEnvironmentVariablePrefix = "__ASPIRE_MSBUILD_COMMAND_ARGUMENT_";
+#if NETFRAMEWORK
+    private const int ProcessTreeTerminationTimeoutMilliseconds = 5_000;
+#endif
 
     /// <summary>
     /// Gets or sets the executable or command shim to run.
@@ -156,13 +159,12 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
 
     private bool TerminateProcess(Process process)
     {
+#if NETFRAMEWORK
+        return TerminateProcessTree(process);
+#else
         try
         {
-#if NETFRAMEWORK
-            process.Kill();
-#else
             process.Kill(entireProcessTree: true);
-#endif
             return true;
         }
         catch (InvalidOperationException)
@@ -175,7 +177,91 @@ public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
             FailureMessage = $"The timed-out command '{FileName}' could not be terminated: {ex.Message}";
             return false;
         }
+#endif
     }
+
+#if NETFRAMEWORK
+    private bool TerminateProcessTree(Process process)
+    {
+        int processId;
+        try
+        {
+            processId = process.Id;
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the timeout and termination attempt.
+            return true;
+        }
+
+        var taskKillPath = Path.Combine(Environment.SystemDirectory, "taskkill.exe");
+        using var taskKill = new Process
+        {
+            StartInfo = new ProcessStartInfo(
+                taskKillPath,
+                $"/PID {processId.ToString(CultureInfo.InvariantCulture)} /T /F")
+            {
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            }
+        };
+
+        try
+        {
+            if (!taskKill.Start())
+            {
+                FailureMessage = $"The process-tree terminator '{taskKillPath}' could not be started.";
+                return false;
+            }
+
+            // taskkill is part of Windows and /T terminates the specified process and its descendants.
+            // Resolve it from the system directory so a restricted or test-modified PATH cannot redirect it.
+            // See https://learn.microsoft.com/windows-server/administration/windows-commands/taskkill.
+            var standardOutputTask = taskKill.StandardOutput.ReadToEndAsync();
+            var standardErrorTask = taskKill.StandardError.ReadToEndAsync();
+
+            if (!taskKill.WaitForExit(ProcessTreeTerminationTimeoutMilliseconds))
+            {
+                try
+                {
+                    taskKill.Kill();
+                }
+                catch (InvalidOperationException)
+                {
+                    // The helper exited between the timeout and termination attempt.
+                }
+
+                if (taskKill.HasExited || taskKill.WaitForExit(ProcessTreeTerminationTimeoutMilliseconds))
+                {
+                    _ = standardOutputTask.GetAwaiter().GetResult();
+                    _ = standardErrorTask.GetAwaiter().GetResult();
+                }
+
+                FailureMessage = $"The process-tree terminator '{taskKillPath}' did not exit within {ProcessTreeTerminationTimeoutMilliseconds} milliseconds.";
+                return false;
+            }
+
+            var standardOutput = standardOutputTask.GetAwaiter().GetResult();
+            var standardError = standardErrorTask.GetAwaiter().GetResult();
+            if (taskKill.ExitCode != 0)
+            {
+                var details = string.IsNullOrWhiteSpace(standardError) ? standardOutput : standardError;
+                FailureMessage = $"The process-tree terminator '{taskKillPath}' exited with code {taskKill.ExitCode}." +
+                    (string.IsNullOrWhiteSpace(details) ? string.Empty : $" {details.Trim()}");
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException or NotSupportedException)
+        {
+            FailureMessage = $"The process-tree terminator '{taskKillPath}' failed: {ex.Message}";
+            return false;
+        }
+    }
+#endif
 
     private void LogProcessOutput(string output)
     {

--- a/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
+++ b/src/Aspire.Hosting.Tasks/RunAspireCliCommand.cs
@@ -1,0 +1,272 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using Microsoft.Build.Framework;
+
+namespace Aspire.Hosting.Tasks;
+
+/// <summary>
+/// Runs an Aspire CLI command with structured arguments and bounded execution.
+/// </summary>
+public sealed class RunAspireCliCommand : Microsoft.Build.Utilities.Task
+{
+    private const string ArgumentValueMetadataName = "Value";
+    private const string CommandShimPathEnvironmentVariable = "__ASPIRE_MSBUILD_COMMAND_PATH";
+    private const string CommandShimArgumentEnvironmentVariablePrefix = "__ASPIRE_MSBUILD_COMMAND_ARGUMENT_";
+
+    /// <summary>
+    /// Gets or sets the executable or command shim to run.
+    /// </summary>
+    [Required]
+    public string FileName { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the ordered command arguments.
+    /// </summary>
+    /// <remarks>
+    /// An item can carry its argument in <c>Value</c> metadata when its item identity is used only
+    /// to preserve ordering or avoid MSBuild item-list splitting.
+    /// </remarks>
+    public ITaskItem[] Arguments { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the maximum command duration in milliseconds.
+    /// </summary>
+    public int TimeoutMilliseconds { get; set; } = 120_000;
+
+    /// <summary>
+    /// Gets the command exit code, or <c>-1</c> when the command did not exit normally.
+    /// </summary>
+    [Output]
+    public int ExitCode { get; set; } = -1;
+
+    /// <summary>
+    /// Gets a value indicating whether the command exceeded <see cref="TimeoutMilliseconds"/>.
+    /// </summary>
+    [Output]
+    public bool TimedOut { get; set; }
+
+    /// <summary>
+    /// Gets the process launch or timeout failure description.
+    /// </summary>
+    [Output]
+    public string? FailureMessage { get; set; }
+
+    public override bool Execute()
+    {
+        if (string.IsNullOrWhiteSpace(FileName))
+        {
+            Log.LogError("An executable path is required.");
+            return false;
+        }
+
+        if (TimeoutMilliseconds <= 0)
+        {
+            Log.LogError("The command timeout must be greater than zero.");
+            return false;
+        }
+
+        var arguments = Arguments.Select(GetArgumentValue).ToArray();
+        using var process = new Process
+        {
+            StartInfo = CreateStartInfo(arguments)
+        };
+
+        try
+        {
+            if (!process.Start())
+            {
+                FailureMessage = $"The command '{FileName}' could not be started.";
+                return true;
+            }
+        }
+        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException or NotSupportedException)
+        {
+            FailureMessage = $"The command '{FileName}' could not be started: {ex.Message}";
+            return true;
+        }
+
+        // Read both streams concurrently to avoid deadlock when a pipe buffer fills.
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit(TimeoutMilliseconds))
+        {
+            TimedOut = true;
+            if (!TerminateProcess(process))
+            {
+                return true;
+            }
+        }
+
+        process.WaitForExit();
+
+        var standardOutput = standardOutputTask.GetAwaiter().GetResult();
+        var standardError = standardErrorTask.GetAwaiter().GetResult();
+        LogProcessOutput(standardOutput);
+        LogProcessOutput(standardError);
+
+        if (TimedOut)
+        {
+            FailureMessage ??= $"The command timed out after {TimeoutMilliseconds} milliseconds.";
+            return true;
+        }
+
+        ExitCode = process.ExitCode;
+        return true;
+    }
+
+    private ProcessStartInfo CreateStartInfo(IReadOnlyList<string> arguments)
+    {
+        var startInfo = IsWindowsCommandShim(FileName)
+            ? new ProcessStartInfo(GetCommandProcessorPath(), BuildCommandProcessorArguments(arguments.Count))
+            : new ProcessStartInfo(FileName);
+
+        startInfo.CreateNoWindow = true;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+
+        if (IsWindowsCommandShim(FileName))
+        {
+            SetEnvironmentVariable(startInfo, CommandShimPathEnvironmentVariable, FileName);
+            for (var index = 0; index < arguments.Count; index++)
+            {
+                SetEnvironmentVariable(startInfo, $"{CommandShimArgumentEnvironmentVariablePrefix}{index}", arguments[index]);
+            }
+        }
+        else
+        {
+#if NETFRAMEWORK
+            startInfo.Arguments = string.Join(" ", arguments.Select(QuoteWindowsArgument));
+#else
+            foreach (var argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+#endif
+        }
+
+        return startInfo;
+    }
+
+    private bool TerminateProcess(Process process)
+    {
+        try
+        {
+#if NETFRAMEWORK
+            process.Kill();
+#else
+            process.Kill(entireProcessTree: true);
+#endif
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the timeout and termination attempt.
+            return true;
+        }
+        catch (Win32Exception ex)
+        {
+            FailureMessage = $"The timed-out command '{FileName}' could not be terminated: {ex.Message}";
+            return false;
+        }
+    }
+
+    private void LogProcessOutput(string output)
+    {
+        if (!string.IsNullOrEmpty(output))
+        {
+            // Setup output is diagnostic only. Logging it as a message prevents a recovered attempt
+            // from becoming a warning-as-error failure because the tool wrote warning-like text.
+            Log.LogMessage(MessageImportance.Low, "{0}", output);
+        }
+    }
+
+    private static string GetArgumentValue(ITaskItem argument)
+    {
+        var value = argument.GetMetadata(ArgumentValueMetadataName);
+        return string.IsNullOrEmpty(value) ? argument.ItemSpec : value;
+    }
+
+    private static bool IsWindowsCommandShim(string path)
+    {
+        return Path.DirectorySeparatorChar == '\\'
+            && (path.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".bat", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string GetCommandProcessorPath()
+    {
+        return Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe";
+    }
+
+    private static string BuildCommandProcessorArguments(int argumentCount)
+    {
+        var command = new StringBuilder($"\"%{CommandShimPathEnvironmentVariable}%\"");
+
+        for (var index = 0; index < argumentCount; index++)
+        {
+            command.Append(" \"%");
+            command.Append(CommandShimArgumentEnvironmentVariablePrefix);
+            command.Append(index.ToString(CultureInfo.InvariantCulture));
+            command.Append("%\"");
+        }
+
+        // Expand each child-only variable once. cmd.exe does not recursively expand percent-delimited
+        // text introduced by an environment variable, so literal %NAME% path segments remain intact.
+        return $"/D /V:OFF /S /C \"{command}\"";
+    }
+
+    private static void SetEnvironmentVariable(ProcessStartInfo startInfo, string name, string value)
+    {
+#if NETFRAMEWORK
+        startInfo.EnvironmentVariables[name] = value;
+#else
+        startInfo.Environment[name] = value;
+#endif
+    }
+
+#if NETFRAMEWORK
+    private static string QuoteWindowsArgument(string argument)
+    {
+        if (argument.Length > 0 && !argument.Any(static character => char.IsWhiteSpace(character) || character == '"'))
+        {
+            return argument;
+        }
+
+        var result = new StringBuilder(argument.Length + 2);
+        result.Append('"');
+        var backslashCount = 0;
+
+        foreach (var character in argument)
+        {
+            if (character == '\\')
+            {
+                backslashCount++;
+                continue;
+            }
+
+            if (character == '"')
+            {
+                result.Append('\\', (backslashCount * 2) + 1);
+                result.Append('"');
+                backslashCount = 0;
+                continue;
+            }
+
+            result.Append('\\', backslashCount);
+            backslashCount = 0;
+            result.Append(character);
+        }
+
+        result.Append('\\', backslashCount * 2);
+        result.Append('"');
+        return result.ToString();
+    }
+#endif
+}

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -142,18 +142,18 @@ internal sealed class DcpOptions
     public bool EnableAspireContainerTunnel { get; set; } = true;
 }
 
-internal class ValidateDcpOptions : IValidateOptions<DcpOptions>
+internal class ValidateDcpOptions(DistributedApplicationExecutionContext executionContext) : IValidateOptions<DcpOptions>
 {
     public ValidateOptionsResult Validate(string? name, DcpOptions options)
     {
         var builder = new ValidateOptionsResultBuilder();
 
-        if (string.IsNullOrWhiteSpace(options.CliPath))
+        if (executionContext.IsRunMode && string.IsNullOrWhiteSpace(options.CliPath))
         {
             builder.AddError("The path to the DCP executable used for Aspire orchestration is required.", "CliPath");
         }
 
-        if (string.IsNullOrWhiteSpace(options.DashboardPath))
+        if (executionContext.IsRunMode && string.IsNullOrWhiteSpace(options.DashboardPath))
         {
             builder.AddError("The path to the Aspire Dashboard binaries is missing.", "DashboardPath");
         }

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptFunctionTests.cs
@@ -428,6 +428,36 @@ public class ReleaseScriptFunctionTests(ITestOutputHelper testOutput)
 
     #endregion
 
+    #region setup_cli_bundle
+
+    [Fact]
+    public async Task SetupCliBundle_InvokesSetupAndPropagatesFailure()
+    {
+        using var env = new TestEnvironment();
+        var cliPath = Path.Combine(env.TempDirectory, "aspire");
+        var capturePath = Path.Combine(env.TempDirectory, "setup-args.txt");
+        await File.WriteAllTextAsync(cliPath, ($$"""
+            #!/bin/sh
+            printf '%s\n' "$@" > "{{capturePath}}"
+            exit 23
+            """).ReplaceLineEndings("\n"));
+        FileHelper.MakeExecutable(cliPath);
+
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            $"INSTALLED_CLI_PATH='{cliPath}'; INSTALLED_CLI_OS=\"$(detect_os)\"; INSTALLED_CLI_ARCH=\"$(get_cli_architecture_from_architecture '<auto>')\"; DRY_RUN=false; setup_cli_bundle",
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal("setup", (await File.ReadAllTextAsync(capturePath)).Trim());
+        Assert.Contains("bundle setup failed", result.Output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
+
     #region construct_aspire_extension_url
 
     [Theory]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
@@ -399,6 +399,48 @@ public class ReleaseScriptPSFunctionTests(ITestOutputHelper testOutput)
 
     #endregion
 
+    #region Invoke-AspireCliBundleSetup
+
+    [Fact]
+    public async Task InvokeAspireCliBundleSetup_InvokesSetupAndPropagatesFailure()
+    {
+        using var env = new TestEnvironment();
+        var cliPath = Path.Combine(env.TempDirectory, OperatingSystem.IsWindows() ? "aspire.cmd" : "aspire");
+        var capturePath = Path.Combine(env.TempDirectory, "setup-args.txt");
+        var contents = OperatingSystem.IsWindows()
+            ? $"""
+                @echo off
+                > "{capturePath}" echo %~1
+                exit /b 23
+                """
+            : $$"""
+                #!/bin/sh
+                printf '%s\n' "$@" > "{{capturePath}}"
+                exit 23
+                """;
+        await File.WriteAllTextAsync(cliPath, contents.ReplaceLineEndings(OperatingSystem.IsWindows() ? "\r\n" : "\n"));
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(cliPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        var escapedCliPath = cliPath.Replace("'", "''");
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            $"Invoke-AspireCliBundleSetup -CliPath '{escapedCliPath}' -TargetOS (Get-OperatingSystem) -TargetArchitecture (Get-CLIArchitectureFromArchitecture '<auto>')",
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Equal("setup", (await File.ReadAllTextAsync(capturePath)).Trim());
+        Assert.Contains("bundle setup failed", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("23", result.Output);
+    }
+
+    #endregion
+
     #region Get-AspireExtensionUrl
 
     [Theory]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPSFunctionTests.cs
@@ -439,6 +439,30 @@ public class ReleaseScriptPSFunctionTests(ITestOutputHelper testOutput)
         Assert.Contains("23", result.Output);
     }
 
+    [Fact]
+    public async Task InvokeAspireCliBundleSetup_UnsupportedHostArchitecture_SkipsSetup()
+    {
+        using var env = new TestEnvironment();
+        var cliPath = Path.Combine(env.TempDirectory, "setup-invoked.txt");
+        var escapedCliPath = cliPath.Replace("'", "''");
+        var expression = $$"""
+            function Get-MachineArchitecture { 'mips' }
+            Invoke-AspireCliBundleSetup -CliPath '{{escapedCliPath}}' -TargetOS (Get-OperatingSystem) -TargetArchitecture 'x64'
+            """;
+        using var cmd = new ScriptFunctionCommand(
+            s_releaseScript,
+            expression,
+            env,
+            _testOutput);
+
+        var result = await cmd.ExecuteAsync();
+
+        result.EnsureSuccessful();
+        Assert.Contains("Skipping Aspire CLI bundle setup because the current platform could not be detected", result.Output);
+        Assert.Contains("not supported", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(cliPath));
+    }
+
     #endregion
 
     #region Get-AspireExtensionUrl

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPowerShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPowerShellTests.cs
@@ -51,6 +51,11 @@ public class ReleaseScriptPowerShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("What if", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Set up Aspire CLI bundle", result.Output);
+        Assert.True(
+            result.Output.IndexOf("Write route sidecar", StringComparison.Ordinal) <
+            result.Output.IndexOf("Set up Aspire CLI bundle", StringComparison.Ordinal),
+            "Bundle setup should be planned after the install-route sidecar is written.");
     }
 
     [Fact]
@@ -127,6 +132,7 @@ public class ReleaseScriptPowerShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("Skipping PATH", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Set up Aspire CLI bundle", result.Output);
     }
 
     [Fact]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPowerShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptPowerShellTests.cs
@@ -224,6 +224,21 @@ public class ReleaseScriptPowerShellTests(ITestOutputHelper testOutput)
         Assert.Contains("dev", result.Output, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task WhatIfWithExtension_PlansExtensionBeforeBundleSetup()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptToolCommand(s_scriptPath, env, _testOutput);
+
+        var result = await cmd.ExecuteAsync("-Quality", "dev", "-InstallExtension", "-WhatIf");
+
+        result.EnsureSuccessful();
+        var extensionIndex = result.Output.IndexOf("Installing VS Code extension", StringComparison.Ordinal);
+        var setupIndex = result.Output.IndexOf("Set up Aspire CLI bundle", StringComparison.Ordinal);
+        Assert.True(extensionIndex >= 0, "VS Code extension installation should be planned.");
+        Assert.True(setupIndex > extensionIndex, "Bundle setup should be planned after VS Code extension installation.");
+    }
+
     [Theory]
     [InlineData("dev")]
     [InlineData("staging")]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptShellTests.cs
@@ -177,6 +177,21 @@ public class ReleaseScriptShellTests(ITestOutputHelper testOutput)
         Assert.Contains("--quality dev", result.Output, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task DryRunWithExtension_PlansExtensionBeforeBundleSetup()
+    {
+        using var env = new TestEnvironment();
+        using var cmd = new ScriptToolCommand(s_scriptPath, env, _testOutput);
+
+        var result = await cmd.ExecuteAsync("--dry-run", "--quality", "dev", "--install-extension");
+
+        result.EnsureSuccessful();
+        var extensionIndex = result.Output.IndexOf("Installing VS Code extension", StringComparison.Ordinal);
+        var setupIndex = result.Output.IndexOf("[DRY RUN] Would run:", StringComparison.Ordinal);
+        Assert.True(extensionIndex >= 0, "VS Code extension installation should be planned.");
+        Assert.True(setupIndex > extensionIndex, "Bundle setup should be planned after VS Code extension installation.");
+    }
+
     [Theory]
     [InlineData("dev")]
     [InlineData("staging")]

--- a/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptShellTests.cs
+++ b/tests/Aspire.Acquisition.Tests/Scripts/ReleaseScriptShellTests.cs
@@ -62,6 +62,12 @@ public class ReleaseScriptShellTests(ITestOutputHelper testOutput)
         Assert.Contains("download", result.Output, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("install", result.Output, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("[DRY RUN]", result.Output);
+        Assert.Contains("[DRY RUN] Would run:", result.Output);
+        Assert.Contains("aspire setup", result.Output);
+        Assert.True(
+            result.Output.IndexOf("route sidecar", StringComparison.OrdinalIgnoreCase) <
+            result.Output.IndexOf("[DRY RUN] Would run:", StringComparison.Ordinal),
+            "Bundle setup should be planned after the install-route sidecar is written.");
     }
 
     [Fact]
@@ -155,6 +161,7 @@ public class ReleaseScriptShellTests(ITestOutputHelper testOutput)
 
         result.EnsureSuccessful();
         Assert.Contains("Skipping PATH", result.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("aspire setup", result.Output);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceIntegrationTests.cs
@@ -197,6 +197,22 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ExtractAsync_PayloadWithoutDcpExecutableFailsVerification()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var payload = CreateFakeBundlePayload(includeDcpExecutable: false);
+        var service = CreateService(
+            new TestBundlePayloadProvider(payload),
+            new TestLayoutDiscovery(layoutRoot));
+
+        var result = await service.ExtractAsync(layoutRoot, force: true);
+
+        Assert.Equal(BundleExtractResult.ExtractionFailed, result);
+        Assert.False(Directory.Exists(Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName)));
+    }
+
+    [Fact]
     [SkipOnPlatform(TestPlatforms.Linux | TestPlatforms.OSX | TestPlatforms.FreeBSD, "Windows file sharing semantics are required.")]
     public async Task MoveDirectoryWithRetryAsync_FileTemporarilyLocked_RetriesUntilReleased()
     {
@@ -528,7 +544,7 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
     /// Creates a tar.gz byte array containing a fake bundle layout with the
     /// required wrapper directory for strip-components=1 extraction.
     /// </summary>
-    internal static byte[] CreateFakeBundlePayload(string contentMarker = "fake-bundle")
+    internal static byte[] CreateFakeBundlePayload(string contentMarker = "fake-bundle", bool includeDcpExecutable = true)
     {
         using var ms = new MemoryStream();
 
@@ -548,14 +564,19 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
             };
             tar.WriteEntry(managedEntry);
 
-            // dcp/ directory with a placeholder file.
+            // dcp/ directory and platform executable.
             tar.WriteEntry(new PaxTarEntry(TarEntryType.Directory, $"aspire-payload/{BundleDiscovery.DcpDirectoryName}/"));
 
-            var dcpEntry = new PaxTarEntry(TarEntryType.RegularFile, $"aspire-payload/{BundleDiscovery.DcpDirectoryName}/dcp-placeholder")
+            if (includeDcpExecutable)
             {
-                DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"dcp-{contentMarker}\n"))
-            };
-            tar.WriteEntry(dcpEntry);
+                var dcpEntry = new PaxTarEntry(
+                    TarEntryType.RegularFile,
+                    $"aspire-payload/{BundleDiscovery.DcpDirectoryName}/{BundleDiscovery.GetDcpExecutableName()}")
+                {
+                    DataStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes($"dcp-{contentMarker}\n"))
+                };
+                tar.WriteEntry(dcpEntry);
+            }
         }
 
         return ms.ToArray();
@@ -608,8 +629,9 @@ public class BundleServiceIntegrationTests(ITestOutputHelper outputHelper)
             var dcpDir = Path.Combine(bundleDir, BundleDiscovery.DcpDirectoryName);
             var managedExeName = BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName);
             var managedExe = Path.Combine(managedDir, managedExeName);
+            var dcpExe = BundleDiscovery.GetDcpExecutablePath(dcpDir);
 
-            if (!Directory.Exists(managedDir) || !File.Exists(managedExe) || !Directory.Exists(dcpDir))
+            if (!Directory.Exists(managedDir) || !File.Exists(managedExe) || !Directory.Exists(dcpDir) || !File.Exists(dcpExe))
             {
                 return null;
             }

--- a/tests/Aspire.Cli.Tests/BundleServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/BundleServiceTests.cs
@@ -117,7 +117,7 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void IsVersionedLayoutValid_RequiresManagedExecutableAndDcpDirectory()
+    public void IsVersionedLayoutValid_RequiresManagedExecutableAndDcpExecutable()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var dir = workspace.WorkspaceRoot.FullName;
@@ -146,6 +146,18 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
         CreateFakeBundleLayout(dir);
 
         Directory.Delete(Path.Combine(dir, BundleDiscovery.DcpDirectoryName), recursive: true);
+        Assert.False(BundleService.IsVersionedLayoutValid(dir));
+    }
+
+    [Fact]
+    public void IsVersionedLayoutValid_RequiresDcpExecutable()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var dir = workspace.WorkspaceRoot.FullName;
+        CreateFakeBundleLayout(dir);
+
+        File.Delete(BundleDiscovery.GetDcpExecutablePath(Path.Combine(dir, BundleDiscovery.DcpDirectoryName)));
+
         Assert.False(BundleService.IsVersionedLayoutValid(dir));
     }
 
@@ -224,6 +236,6 @@ public class BundleServiceTests(ITestOutputHelper outputHelper)
 
         var dcpDir = Path.Combine(root, BundleDiscovery.DcpDirectoryName);
         Directory.CreateDirectory(dcpDir);
-        File.WriteAllText(Path.Combine(dcpDir, "placeholder"), "dcp");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(dcpDir), "dcp");
     }
 }

--- a/tests/Aspire.Cli.Tests/Caching/AppHostInfoDiskCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/Caching/AppHostInfoDiskCacheTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Aspire.Cli.Caching;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Tests.TestServices;
@@ -49,6 +50,7 @@ public class AppHostInfoDiskCacheTests(ITestOutputHelper outputHelper)
         RunWorkingDirectory = "/repo/src/AppHost",
         RunArguments = "--from-msbuild",
         TargetFramework = "net10.0",
+        TargetFrameworks = "net10.0;net9.0",
     };
 
     private static IEnumerable<string> EnumerateCacheEntries(TemporaryWorkspace workspace)
@@ -95,6 +97,45 @@ public class AppHostInfoDiskCacheTests(ITestOutputHelper outputHelper)
         var hit = await cache.TryGetAsync(new FileInfo(projectFile.FullName), CancellationToken.None).DefaultTimeout();
 
         Assert.Null(hit);
+    }
+
+    [Fact]
+    public async Task CachePayloadContainsOnlyProjectInspectionMetadata()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var cache = CreateCache(workspace);
+        var projectFile = CreateProjectFile(workspace);
+
+        await cache.SetAsync(
+            projectFile,
+            cache.GetCacheKey(projectFile),
+            SampleEntry() with { IsUsingCliBundle = true },
+            CancellationToken.None).DefaultTimeout();
+
+        var cachePath = Assert.Single(EnumerateCacheEntries(workspace));
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(cachePath));
+        var propertyNames = document.RootElement
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            [
+                "aspireHostingVersion",
+                "exitCode",
+                "isAspireHost",
+                "isUsingCliBundle",
+                "runArguments",
+                "runCommand",
+                "runWorkingDirectory",
+                "schemaVersion",
+                "targetFramework",
+                "targetFrameworks",
+                "targetPath",
+                "userSecretsId",
+            ],
+            propertyNames);
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
+++ b/tests/Aspire.Cli.Tests/Layout/LayoutDiscoveryReparsePointTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Cli.Layout;
 using Aspire.Cli.Tests.Acquisition;
+using Aspire.Cli.Tests.Utils;
 using Aspire.Cli.Utils;
 using Aspire.Shared;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -101,6 +102,7 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         File.WriteAllText(
             Path.Combine(versionedManaged, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
             "stub");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(versionedDcp), "stub");
 
         // Create a single bundle/ link pointing at the versioned directory.
         var bundleLink = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);
@@ -210,6 +212,34 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         }
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DiscoverLayout_RejectsRelativeLayoutWithoutDcpExecutable(bool useBundleDirectory)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var layoutRoot = workspace.WorkspaceRoot.FullName;
+        var componentRoot = useBundleDirectory
+            ? Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName)
+            : layoutRoot;
+        var managedDir = Directory.CreateDirectory(Path.Combine(componentRoot, BundleDiscovery.ManagedDirectoryName));
+        Directory.CreateDirectory(Path.Combine(componentRoot, BundleDiscovery.DcpDirectoryName));
+        File.WriteAllText(
+            Path.Combine(managedDir.FullName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
+            "stub");
+        var binaryPath = Path.Combine(layoutRoot, OperatingSystem.IsWindows() ? "aspire.exe" : "aspire");
+        File.WriteAllText(binaryPath, "stub");
+
+        var discovery = new LayoutDiscovery(NullLogger<LayoutDiscovery>.Instance, new TestEnvironment())
+        {
+            ProcessPathOverride = binaryPath
+        };
+
+        var layout = discovery.DiscoverLayout();
+
+        Assert.NotEqual(layoutRoot, layout?.LayoutPath);
+    }
+
     private static void CreateValidBundleLayout(string layoutRoot)
     {
         var bundleDir = Path.Combine(layoutRoot, BundleDiscovery.BundleDirectoryName);
@@ -220,5 +250,6 @@ public class LayoutDiscoveryReparsePointTests(ITestOutputHelper outputHelper)
         File.WriteAllText(
             Path.Combine(managedDir, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
             "stub");
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(dcpDir), "stub");
     }
 }

--- a/tests/Aspire.Cli.Tests/Projects/AppHostInfoResolverTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/AppHostInfoResolverTests.cs
@@ -168,15 +168,17 @@ public sealed class AppHostInfoResolverTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task GetAppHostInfoAsync_RequestsComputeRunArgumentsTarget()
+    public async Task GetAppHostInfoAsync_RequestsOnlyEvaluationSafeTarget()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var projectFile = CreateProjectFile(workspace);
+        string[]? capturedProperties = null;
         string[]? capturedTargets = null;
         var runner = new TestDotNetCliRunner
         {
-            GetProjectItemsAndPropertiesAsyncCallbackWithTargets = (_, _, _, targets, _, _) =>
+            GetProjectItemsAndPropertiesAsyncCallbackWithTargets = (_, _, properties, targets, _, _) =>
             {
+                capturedProperties = properties;
                 capturedTargets = targets;
                 return (0, CreateAppHostInfoJson());
             },
@@ -189,8 +191,12 @@ public sealed class AppHostInfoResolverTests(ITestOutputHelper outputHelper)
         // The direct-launch path reads RunCommand/RunArguments/RunWorkingDirectory, which the
         // SDK only populates after ComputeRunArguments has run. The resolver must request that
         // target on its single MSBuild probe so the cached run metadata is correct.
+        Assert.NotNull(capturedProperties);
+        Assert.Equal(
+            ["IsAspireHost", "AspireHostingSDKVersion", "AspireUseCliBundle", "UserSecretsId", "RunCommand", "TargetPath", "RunWorkingDirectory", "RunArguments", "TargetFramework", "TargetFrameworks"],
+            capturedProperties);
         Assert.NotNull(capturedTargets);
-        Assert.Contains("ComputeRunArguments", capturedTargets);
+        Assert.Equal(["ComputeRunArguments"], capturedTargets);
     }
 
     private static FileInfo CreateProjectFile(TemporaryWorkspace workspace)

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -101,6 +101,50 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
     }
 
     [Fact]
+    public async Task ValidationAndVersionInspectionDoNotAcquireCliBundle()
+    {
+        var appHostFile = CreateProjectAppHost();
+        _ = CreateCliBundle(out var layout);
+        var bundleAcquisitionRequested = false;
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            Layout = layout,
+            EnsureExtractedAndAcquireLayoutAsyncCallback = _ =>
+            {
+                bundleAcquisitionRequested = true;
+                return Task.CompletedTask;
+            }
+        };
+        var resolver = new TestAppHostInfoResolver
+        {
+            GetAppHostInfoAsyncCallback = (_, _) => Task.FromResult(new AppHostProjectInfo(
+                ExitCode: 0,
+                IsAspireHost: true,
+                AspireHostingVersion: "13.0.0",
+                IsUsingCliBundle: true,
+                UserSecretsId: null,
+                RunCommand: null,
+                TargetPath: null,
+                RunWorkingDirectory: null,
+                RunArguments: null,
+                TargetFramework: "net10.0",
+                TargetFrameworks: null))
+        };
+        var project = CreateDotNetAppHostProject(
+            new TestDotNetCliRunner(),
+            layout,
+            resolver,
+            options => options.BundleServiceFactory = _ => bundleService);
+
+        var validation = await project.ValidateAppHostAsync(appHostFile, CancellationToken.None);
+        var version = await project.GetAspireHostingVersionAsync(appHostFile, CancellationToken.None);
+
+        Assert.True(validation.IsValid);
+        Assert.Equal("13.0.0", version);
+        Assert.False(bundleAcquisitionRequested);
+    }
+
+    [Fact]
     public async Task ValidateAppHostAsync_EvaluatesCleanlyButNotAspireHost_RejectsWithoutPossiblyUnbuildable()
     {
         // A project can pass the cheap name heuristic without being an Aspire host: e.g. a
@@ -426,6 +470,263 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         }, CancellationToken.None);
 
         Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostUsingCliBundlePreservesCallerProvidedRuntimePaths()
+    {
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        _ = CreateCliBundle(out var layout);
+        var customDcpDirectory = Directory.CreateDirectory(Path.Combine(_workspace.WorkspaceRoot.FullName, "custom-dcp"));
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(customDcpDirectory.FullName), "");
+        var customDashboardPath = Path.Combine(
+            _workspace.WorkspaceRoot.FullName,
+            BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName));
+        File.WriteAllText(customDashboardPath, "");
+
+        var runner = new TestDotNetCliRunner
+        {
+            BuildAsyncCallback = (_, _, _, _) => 0,
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+                (0, JsonSerializer.SerializeToDocument(new
+                {
+                    Properties = new
+                    {
+                        IsAspireHost = "true",
+                        AspireHostingSDKVersion = VersionHelper.GetDefaultTemplateVersion(),
+                        AspireUseCliBundle = "true",
+                    },
+                    Items = new { }
+                }))
+        };
+        var project = CreateDotNetAppHostProject(runner, layout);
+
+        runner.RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+        {
+            Assert.Equal(customDcpDirectory.FullName, env![BundleDiscovery.DcpPathEnvVar]);
+            Assert.Equal(customDashboardPath, env[BundleDiscovery.DashboardPathEnvVar]);
+            return Task.FromResult(0);
+        };
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                [BundleDiscovery.DcpPathEnvVar] = customDcpDirectory.FullName,
+                [BundleDiscovery.DashboardPathEnvVar] = customDashboardPath,
+            }
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostUsingCliBundlePreservesInheritedRuntimePaths()
+    {
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        var bundleRoot = CreateCliBundle(out var layout);
+        var inheritedDcpDirectory = Path.Combine(_workspace.WorkspaceRoot.FullName, "inherited-dcp");
+        var inheritedDashboardPath = Path.Combine(_workspace.WorkspaceRoot.FullName, "inherited-dashboard");
+        var environment = new TestEnvironment(new Dictionary<string, string?>
+        {
+            [BundleDiscovery.DcpPathEnvVar] = inheritedDcpDirectory,
+            [BundleDiscovery.DashboardPathEnvVar] = inheritedDashboardPath,
+        });
+
+        var runner = new TestDotNetCliRunner
+        {
+            BuildAsyncCallback = (_, _, _, _) => 0,
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+                (0, JsonSerializer.SerializeToDocument(new
+                {
+                    Properties = new
+                    {
+                        IsAspireHost = "true",
+                        AspireHostingSDKVersion = VersionHelper.GetDefaultTemplateVersion(),
+                        AspireUseCliBundle = "true",
+                    },
+                    Items = new { }
+                }))
+        };
+        var project = CreateDotNetAppHostProject(runner, layout, environment: environment);
+
+        runner.RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+        {
+            // Inherited values remain in the process environment. They must not be shadowed
+            // by values in the child-process overlay built from the current CLI layout.
+            Assert.False(env!.ContainsKey(BundleDiscovery.DcpPathEnvVar));
+            Assert.False(env.ContainsKey(BundleDiscovery.DashboardPathEnvVar));
+            Assert.Equal(bundleRoot.FullName, env["AspireCliBundlePath"]);
+            return Task.FromResult(0);
+        };
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>()
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostUsingCliBundleDoesNotInjectInspectionRuntimePaths()
+    {
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        var runnerCalled = false;
+        var runner = new TestDotNetCliRunner
+        {
+            BuildAsyncCallback = (_, _, _, _) => 0,
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+                (0, JsonSerializer.SerializeToDocument(new
+                {
+                    Properties = new
+                    {
+                        IsAspireHost = "true",
+                        AspireHostingSDKVersion = VersionHelper.GetDefaultTemplateVersion(),
+                        AspireUseCliBundle = "true",
+                        DcpDir = "inspection-dcp",
+                        AspireDashboardPath = "inspection-dashboard",
+                    },
+                    Items = new { }
+                })),
+            RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+            {
+                runnerCalled = true;
+                Assert.False(env!.ContainsKey(BundleDiscovery.DcpPathEnvVar));
+                Assert.False(env.ContainsKey(BundleDiscovery.DashboardPathEnvVar));
+                return Task.FromResult(42);
+            }
+        };
+        var project = CreateDotNetAppHostProject(runner);
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>()
+        }, CancellationToken.None);
+
+        Assert.Equal(42, exitCode);
+        Assert.True(runnerCalled);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProjectAppHostUsingCliBundleDoesNotInjectMissingLayoutComponents()
+    {
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        _ = CreateCliBundle(out var layout);
+        File.Delete(BundleDiscovery.GetDcpExecutablePath(layout.GetDcpPath()!));
+        File.Delete(layout.GetManagedPath()!);
+
+        var runner = new TestDotNetCliRunner
+        {
+            BuildAsyncCallback = (_, _, _, _) => 0,
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+                (0, JsonSerializer.SerializeToDocument(new
+                {
+                    Properties = new
+                    {
+                        IsAspireHost = "true",
+                        AspireHostingSDKVersion = VersionHelper.GetDefaultTemplateVersion(),
+                        AspireUseCliBundle = "true",
+                    },
+                    Items = new { }
+                })),
+            RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+            {
+                Assert.False(env!.ContainsKey(BundleDiscovery.DcpPathEnvVar));
+                Assert.False(env.ContainsKey(BundleDiscovery.DashboardPathEnvVar));
+                Assert.False(env.ContainsKey(BundleDiscovery.TerminalHostPathEnvVar));
+                return Task.FromResult(0);
+            }
+        };
+        var project = CreateDotNetAppHostProject(runner, layout);
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = new Dictionary<string, string>()
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PublishAsync_ProjectAppHostUsingCliBundleDoesNotAcquireOrInjectBundle(bool noBuild)
+    {
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        _ = CreateCliBundle(out var layout);
+        var bundleAcquisitionRequested = false;
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            Layout = layout,
+            EnsureExtractedAndAcquireLayoutAsyncCallback = _ =>
+            {
+                bundleAcquisitionRequested = true;
+                return Task.CompletedTask;
+            }
+        };
+        var runner = new TestDotNetCliRunner
+        {
+            BuildAsyncCallback = (_, _, _, _) => 0,
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+                (0, JsonSerializer.SerializeToDocument(new
+                {
+                    Properties = new
+                    {
+                        IsAspireHost = "true",
+                        AspireHostingSDKVersion = VersionHelper.GetDefaultTemplateVersion(),
+                        AspireUseCliBundle = "true",
+                    },
+                    Items = new { }
+                })),
+            RunAsyncCallback = (_, _, runnerNoBuild, _, _, env, _, options, _) =>
+            {
+                Assert.True(runnerNoBuild);
+                Assert.True(options.NoLaunchProfile);
+                Assert.False(env!.ContainsKey("AspireCliBundlePath"));
+                Assert.False(env.ContainsKey(BundleDiscovery.DcpPathEnvVar));
+                Assert.False(env.ContainsKey(BundleDiscovery.DashboardPathEnvVar));
+                Assert.False(env.ContainsKey(BundleDiscovery.TerminalHostPathEnvVar));
+                return Task.FromResult(0);
+            }
+        };
+        var project = CreateDotNetAppHostProject(
+            runner,
+            layout,
+            configureServices: options => options.BundleServiceFactory = _ => bundleService);
+
+        var exitCode = await project.PublishAsync(new PublishContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = noBuild,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            Arguments = ["--operation", "publish"],
+            EnvironmentVariables = new Dictionary<string, string>()
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(bundleAcquisitionRequested);
     }
 
     [Fact]
@@ -1530,29 +1831,25 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
     }
 
     [Fact]
-    public async Task PublishAsync_SingleFileAppHostUsingCliBundlePassesBundleEnvironmentToRunner()
+    public async Task PublishAsync_SingleFileAppHostUsingCliBundleDoesNotAcquireOrInjectBundle()
     {
         var appHostFile = CreateSingleFileAppHost(useCliBundle: true);
-        var bundleRoot = CreateCliBundle(out var layout);
-
-        var runner = new TestDotNetCliRunner
+        _ = CreateCliBundle(out var layout);
+        var bundleAcquisitionRequested = false;
+        var bundleService = new TestBundleService(isBundle: true)
         {
-            GetProjectItemsAndPropertiesAsyncCallback = (projectFile, _, properties, _, _) =>
+            Layout = layout,
+            EnsureExtractedAndAcquireLayoutAsyncCallback = _ =>
             {
-                Assert.Equal(appHostFile.FullName, projectFile.FullName);
-                Assert.Contains("AspireUseCliBundle", properties);
-                return (0, JsonDocument.Parse("""
-                    {
-                      "Properties": {
-                        "MSBuildVersion": "17.0.0",
-                        "AspireUseCliBundle": "true"
-                      },
-                      "Items": {}
-                    }
-                    """));
+                bundleAcquisitionRequested = true;
+                return Task.CompletedTask;
             }
         };
-        var project = CreateDotNetAppHostProject(runner, layout);
+        var runner = new TestDotNetCliRunner();
+        var project = CreateDotNetAppHostProject(
+            runner,
+            layout,
+            configureServices: options => options.BundleServiceFactory = _ => bundleService);
 
         runner.RunAsyncCallback = (projectFile, watch, noBuild, noRestore, args, env, _, options, _) =>
         {
@@ -1563,10 +1860,10 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             Assert.True(options.NoLaunchProfile);
             Assert.Equal(["--operation", "publish"], args);
             Assert.Equal("Production", env![KnownAspNetCoreConfigNames.DotNetEnvironment]);
-            Assert.Equal(Path.Combine(bundleRoot.FullName, BundleDiscovery.DcpDirectoryName), env[BundleDiscovery.DcpPathEnvVar]);
-            Assert.Equal(
-                Path.Combine(bundleRoot.FullName, BundleDiscovery.ManagedDirectoryName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
-                env[BundleDiscovery.DashboardPathEnvVar]);
+            Assert.False(env.ContainsKey("AspireCliBundlePath"));
+            Assert.False(env.ContainsKey(BundleDiscovery.DcpPathEnvVar));
+            Assert.False(env.ContainsKey(BundleDiscovery.DashboardPathEnvVar));
+            Assert.False(env.ContainsKey(BundleDiscovery.TerminalHostPathEnvVar));
             return Task.FromResult(0);
         };
 
@@ -1579,6 +1876,7 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         }, CancellationToken.None);
 
         Assert.Equal(0, exitCode);
+        Assert.False(bundleAcquisitionRequested);
     }
 
     [Fact]
@@ -3517,8 +3815,12 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
     private DirectoryInfo CreateCliBundle(out LayoutConfiguration layout)
     {
         var bundleRoot = Directory.CreateDirectory(Path.Combine(_workspace.WorkspaceRoot.FullName, Guid.NewGuid().ToString()));
-        Directory.CreateDirectory(Path.Combine(bundleRoot.FullName, BundleDiscovery.DcpDirectoryName));
-        Directory.CreateDirectory(Path.Combine(bundleRoot.FullName, BundleDiscovery.ManagedDirectoryName));
+        var dcpDirectory = Directory.CreateDirectory(Path.Combine(bundleRoot.FullName, BundleDiscovery.DcpDirectoryName));
+        var managedDirectory = Directory.CreateDirectory(Path.Combine(bundleRoot.FullName, BundleDiscovery.ManagedDirectoryName));
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(dcpDirectory.FullName), "");
+        File.WriteAllText(
+            Path.Combine(managedDirectory.FullName, BundleDiscovery.GetExecutableFileName(BundleDiscovery.ManagedExecutableName)),
+            "");
 
         layout = new LayoutConfiguration
         {
@@ -3537,7 +3839,8 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         TestDotNetCliRunner runner,
         LayoutConfiguration? layout = null,
         IAppHostInfoResolver? appHostInfoResolver = null,
-        Action<CliServiceCollectionTestOptions>? configureServices = null)
+        Action<CliServiceCollectionTestOptions>? configureServices = null,
+        IEnvironment? environment = null)
     {
         var services = CliTestHelper.CreateServiceCollection(_workspace, outputHelper, options =>
         {
@@ -3552,6 +3855,12 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
 
             configureServices?.Invoke(options);
         });
+
+        if (environment is not null)
+        {
+            services.RemoveAll<IEnvironment>();
+            services.AddSingleton(environment);
+        }
 
         if (appHostInfoResolver is not null)
         {

--- a/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
+++ b/tests/Aspire.Cli.Tests/Projects/DotNetAppHostProjectTests.cs
@@ -531,8 +531,10 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
         UseFakeRepoRoot();
         var appHostFile = CreateProjectAppHost();
         var bundleRoot = CreateCliBundle(out var layout);
-        var inheritedDcpDirectory = Path.Combine(_workspace.WorkspaceRoot.FullName, "inherited-dcp");
+        var inheritedDcpDirectory = Directory.CreateDirectory(Path.Combine(_workspace.WorkspaceRoot.FullName, "inherited-dcp")).FullName;
+        File.WriteAllText(BundleDiscovery.GetDcpExecutablePath(inheritedDcpDirectory), "");
         var inheritedDashboardPath = Path.Combine(_workspace.WorkspaceRoot.FullName, "inherited-dashboard");
+        File.WriteAllText(inheritedDashboardPath, "");
         var environment = new TestEnvironment(new Dictionary<string, string?>
         {
             [BundleDiscovery.DcpPathEnvVar] = inheritedDcpDirectory,
@@ -573,6 +575,69 @@ public class DotNetAppHostProjectTests(ITestOutputHelper outputHelper) : IDispos
             NoRestore = false,
             WorkingDirectory = _workspace.WorkspaceRoot,
             EnvironmentVariables = new Dictionary<string, string>()
+        }, CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task RunAsync_ProjectAppHostUsingCliBundleReplacesUnusableRuntimePaths(
+        bool useExplicitOverlay,
+        bool useEmptyValues)
+    {
+        UseFakeRepoRoot();
+        var appHostFile = CreateProjectAppHost();
+        _ = CreateCliBundle(out var layout);
+        var unusableDcpDirectory = useEmptyValues
+            ? ""
+            : Path.Combine(_workspace.WorkspaceRoot.FullName, "missing-dcp");
+        var unusableDashboardPath = useEmptyValues
+            ? ""
+            : Path.Combine(_workspace.WorkspaceRoot.FullName, "missing-dashboard");
+        var environmentVariables = new Dictionary<string, string>
+        {
+            [BundleDiscovery.DcpPathEnvVar] = unusableDcpDirectory,
+            [BundleDiscovery.DashboardPathEnvVar] = unusableDashboardPath,
+        };
+        var inheritedEnvironment = useExplicitOverlay
+            ? new TestEnvironment()
+            : new TestEnvironment(environmentVariables.ToDictionary(pair => pair.Key, pair => (string?)pair.Value));
+
+        var runner = new TestDotNetCliRunner
+        {
+            BuildAsyncCallback = (_, _, _, _) => 0,
+            GetProjectItemsAndPropertiesAsyncCallback = (_, _, _, _, _) =>
+                (0, JsonSerializer.SerializeToDocument(new
+                {
+                    Properties = new
+                    {
+                        IsAspireHost = "true",
+                        AspireHostingSDKVersion = VersionHelper.GetDefaultTemplateVersion(),
+                        AspireUseCliBundle = "true",
+                    },
+                    Items = new { }
+                }))
+        };
+        var project = CreateDotNetAppHostProject(runner, layout, environment: inheritedEnvironment);
+
+        runner.RunAsyncCallback = (_, _, _, _, _, env, _, _, _) =>
+        {
+            Assert.Equal(layout.GetDcpPath(), env![BundleDiscovery.DcpPathEnvVar]);
+            Assert.Equal(layout.GetManagedPath(), env[BundleDiscovery.DashboardPathEnvVar]);
+            return Task.FromResult(0);
+        };
+
+        var exitCode = await project.RunAsync(new AppHostProjectContext
+        {
+            AppHostFile = appHostFile,
+            NoBuild = false,
+            NoRestore = false,
+            WorkingDirectory = _workspace.WorkspaceRoot,
+            EnvironmentVariables = useExplicitOverlay ? environmentVariables : new Dictionary<string, string>()
         }, CancellationToken.None);
 
         Assert.Equal(0, exitCode);

--- a/tests/Aspire.Hosting.Sdk.Tests.FakeCommand/Program.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests.FakeCommand/Program.cs
@@ -10,6 +10,20 @@ if (args is ["--list-sdks"])
 var dnxArgumentIndex = Array.IndexOf(args, "dnx");
 var forwardedArgs = dnxArgumentIndex >= 0 ? args[(dnxArgumentIndex + 1)..] : args;
 
+var setupArgumentIndex = Array.IndexOf(forwardedArgs, "setup");
+var installPathArgumentIndex = Array.IndexOf(forwardedArgs, "--install-path");
+if (setupArgumentIndex >= 0 &&
+    installPathArgumentIndex >= 0 &&
+    installPathArgumentIndex + 1 < forwardedArgs.Length)
+{
+    var installPath = forwardedArgs[installPathArgumentIndex + 1];
+    var dcpDirectory = Directory.CreateDirectory(Path.Combine(installPath, "bundle", "dcp"));
+    var managedDirectory = Directory.CreateDirectory(Path.Combine(installPath, "bundle", "managed"));
+    File.WriteAllText(Path.Combine(dcpDirectory.FullName, OperatingSystem.IsWindows() ? "dcp.exe" : "dcp"), "");
+    File.WriteAllText(Path.Combine(managedDirectory.FullName, OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed"), "");
+    return;
+}
+
 if (forwardedArgs.Length > 0 && forwardedArgs[^1] == "--version")
 {
     if (File.Exists(Path.Combine(AppContext.BaseDirectory, "fail-version")))

--- a/tests/Aspire.Hosting.Sdk.Tests.FakeCommand/Program.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests.FakeCommand/Program.cs
@@ -12,13 +12,21 @@ var forwardedArgs = dnxArgumentIndex >= 0 ? args[(dnxArgumentIndex + 1)..] : arg
 
 var setupArgumentIndex = Array.IndexOf(forwardedArgs, "setup");
 var installPathArgumentIndex = Array.IndexOf(forwardedArgs, "--install-path");
-if (setupArgumentIndex >= 0 &&
-    installPathArgumentIndex >= 0 &&
-    installPathArgumentIndex + 1 < forwardedArgs.Length)
+// The targets exercise setup as either:
+//   aspire.exe setup
+//   dotnet ... dnx --yes aspire.cli@<version> -- setup --install-path <path>
+var setupInstallPath = forwardedArgs switch
 {
-    var installPath = forwardedArgs[installPathArgumentIndex + 1];
-    var dcpDirectory = Directory.CreateDirectory(Path.Combine(installPath, "bundle", "dcp"));
-    var managedDirectory = Directory.CreateDirectory(Path.Combine(installPath, "bundle", "managed"));
+    ["setup"] => AppContext.BaseDirectory,
+    _ when setupArgumentIndex >= 0 &&
+        installPathArgumentIndex >= 0 &&
+        installPathArgumentIndex + 1 < forwardedArgs.Length => forwardedArgs[installPathArgumentIndex + 1],
+    _ => null
+};
+if (setupInstallPath is not null)
+{
+    var dcpDirectory = Directory.CreateDirectory(Path.Combine(setupInstallPath, "bundle", "dcp"));
+    var managedDirectory = Directory.CreateDirectory(Path.Combine(setupInstallPath, "bundle", "managed"));
     File.WriteAllText(Path.Combine(dcpDirectory.FullName, OperatingSystem.IsWindows() ? "dcp.exe" : "dcp"), "");
     File.WriteAllText(Path.Combine(managedDirectory.FullName, OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed"), "");
     return;

--- a/tests/Aspire.Hosting.Sdk.Tests.FakeCommand/Program.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests.FakeCommand/Program.cs
@@ -14,7 +14,7 @@ var setupArgumentIndex = Array.IndexOf(forwardedArgs, "setup");
 var installPathArgumentIndex = Array.IndexOf(forwardedArgs, "--install-path");
 // The targets exercise setup as either:
 //   aspire.exe setup
-//   dotnet ... dnx --yes aspire.cli@<version> -- setup --install-path <path>
+//   dotnet ... dnx --yes aspire.cli[@<version>] -- setup --install-path <path>
 var setupInstallPath = forwardedArgs switch
 {
     ["setup"] => AppContext.BaseDirectory,

--- a/tests/Aspire.Hosting.Sdk.Tests.FakeCommand/Program.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests.FakeCommand/Program.cs
@@ -1,9 +1,20 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+
 if (args is ["--list-sdks"])
 {
     Console.WriteLine($"13.5.0 [{Path.Combine(AppContext.BaseDirectory, "sdk")}]");
+    return;
+}
+
+if (args is ["--hang"])
+{
+    var pidPath = Environment.GetEnvironmentVariable("ASPIRE_TEST_HANG_PID_PATH")
+        ?? throw new InvalidOperationException("ASPIRE_TEST_HANG_PID_PATH is not set.");
+    File.WriteAllText(pidPath, Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+    await Task.Delay(Timeout.InfiniteTimeSpan);
     return;
 }
 

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -559,7 +559,12 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "fake-cli"));
         await CreateFakeAspireCliWithVersionAsync(fakeCliDirectory.FullName, "13.4.5");
         var dnxPath = await CreateFakeDnxAsync(fakeCliDirectory.FullName);
-        var environment = CreatePathEnvironment(fakeCliDirectory.FullName);
+        var environment = new Dictionary<string, string>
+        {
+            [GetPathEnvironmentVariableName()] = CreatePathWithoutAspire(fakeCliDirectory.FullName)
+        };
+        var aspireHome = Path.Combine(workspace.Path, "aspire-home");
+        environment["ASPIRE_HOME"] = aspireHome;
 
         var buildResult = await RunDotNetWithArgumentsAsync(
             project.ProjectDirectory,
@@ -577,6 +582,12 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         Assert.Equal("true", properties["_AspireCliVersionSupportsRunHook"]);
         Assert.Equal(GetExpectedDnxRunCommand(dnxPath), properties["RunCommand"]);
         Assert.Equal(GetExpectedDnxRunArguments(dnxPath, project, "--custom foo"), properties["RunArguments"]);
+        Assert.True(
+            File.Exists(Path.Combine(aspireHome, "bundle", "dcp", OperatingSystem.IsWindows() ? "dcp.exe" : "dcp")),
+            buildResult.Output);
+        Assert.True(
+            File.Exists(Path.Combine(aspireHome, "bundle", "managed", OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed")),
+            buildResult.Output);
     }
 
     [Fact]
@@ -912,6 +923,12 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
                     echo "13.5.0"
                     exit 0
                 fi
+                if [ "$1" = "--yes" ] && [ "$2" = "aspire.cli@13.5.0" ] && [ "$3" = "--" ] && [ "$4" = "setup" ] && [ "$5" = "--install-path" ]; then
+                    mkdir -p "$6/bundle/dcp" "$6/bundle/managed"
+                    : > "$6/bundle/dcp/dcp"
+                    : > "$6/bundle/managed/aspire-managed"
+                    exit 0
+                fi
                 printf '%s\n' "$@" > "$ASPIRE_TEST_CAPTURE_PATH"
                 """).ReplaceLineEndings("\n"));
 
@@ -986,12 +1003,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
                     echo {{version}}
                     exit /b 0
                 )
-                type nul > "%ASPIRE_TEST_CAPTURE_PATH%"
-                :loop
-                if "%~1"=="" exit /b 0
-                >> "%ASPIRE_TEST_CAPTURE_PATH%" echo %~1
-                shift
-                goto loop
+                exit /b 42
                 """);
 
             return;
@@ -1004,7 +1016,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
                 echo "{{version}}"
                 exit 0
             fi
-            printf '%s\n' "$@" > "$ASPIRE_TEST_CAPTURE_PATH"
+            exit 42
             """).ReplaceLineEndings("\n"));
         File.SetUnixFileMode(aspirePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -586,6 +586,69 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResolveAspireCliBundlePathsUsesDnxBundleWhenDnxModeIsSelected()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var staleCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "stale-cli"));
+        await CreateFakeAspireCliWithVersionAsync(staleCliDirectory.FullName, AspireCliVersion);
+        var staleBundle = CreateFakeCliBundle(staleCliDirectory.FullName);
+        var dnxDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "dnx"));
+        await CreateFakeDnxAsync(dnxDirectory.FullName);
+        var aspireHome = Path.Combine(workspace.Path, "aspire-home");
+        var project = await CreateRunHookProjectAsync(workspace.Path, aspireUseCliBundle: true,
+            """
+              <PropertyGroup>
+                <AspireCliInvocationMode>Dnx</AspireCliInvocationMode>
+              </PropertyGroup>
+            """,
+            includeBundlePaths: false);
+        var environment = new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = aspireHome,
+            [GetPathEnvironmentVariableName()] = CreatePathWithoutAspire(staleCliDirectory.FullName, dnxDirectory.FullName)
+        };
+
+        var properties = await GetResolveAspireCliBundlePathPropertiesAsync(project, environment);
+        var dnxBundle = GetFakeCliBundlePaths(aspireHome);
+
+        Assert.Equal("Dnx", properties["_AspireResolvedCliInvocationMode"]);
+        Assert.Equal(dnxBundle.DcpDirectory, Path.TrimEndingDirectorySeparator(properties["DcpDir"]));
+        Assert.Equal(dnxBundle.ManagedDirectory, Path.TrimEndingDirectorySeparator(properties["AspireDashboardDir"]));
+        Assert.Equal(dnxBundle.ManagedPath, properties["AspireDashboardPath"]);
+        Assert.NotEqual(staleBundle.DcpDirectory, Path.TrimEndingDirectorySeparator(properties["DcpDir"]));
+        AssertCliBundleExists(aspireHome, JsonSerializer.Serialize(properties));
+    }
+
+    [Fact]
+    public async Task ResolveAspireCliBundlePathsUsesSelectedAspireCliWhenLaterPathCandidateHasBundle()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var selectedCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "selected-cli"));
+        var selectedCliPath = await CreateFakeAspireCliThatSetsUpBundleAsync(selectedCliDirectory.FullName);
+        var staleCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "stale-cli"));
+        await CreateFakeAspireCliWithVersionAsync(staleCliDirectory.FullName, AspireCliVersion);
+        var staleBundle = CreateFakeCliBundle(staleCliDirectory.FullName);
+        var aspireHome = Path.Combine(workspace.Path, "aspire-home");
+        var project = await CreateRunHookProjectAsync(workspace.Path, aspireUseCliBundle: true, includeBundlePaths: false);
+        var environment = new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = aspireHome,
+            [GetPathEnvironmentVariableName()] = CreatePathWithoutAspire(selectedCliDirectory.FullName, staleCliDirectory.FullName)
+        };
+
+        var properties = await GetResolveAspireCliBundlePathPropertiesAsync(project, environment);
+        var selectedBundle = GetFakeCliBundlePaths(selectedCliDirectory.FullName);
+
+        Assert.Equal("Aspire", properties["_AspireResolvedCliInvocationMode"]);
+        Assert.Equal(selectedCliPath, properties["_AspireResolvedCliPath"]);
+        Assert.Equal(selectedBundle.DcpDirectory, Path.TrimEndingDirectorySeparator(properties["DcpDir"]));
+        Assert.Equal(selectedBundle.ManagedDirectory, Path.TrimEndingDirectorySeparator(properties["AspireDashboardDir"]));
+        Assert.Equal(selectedBundle.ManagedPath, properties["AspireDashboardPath"]);
+        Assert.NotEqual(staleBundle.DcpDirectory, Path.TrimEndingDirectorySeparator(properties["DcpDir"]));
+        AssertCliBundleExists(selectedCliDirectory.FullName, JsonSerializer.Serialize(properties));
+    }
+
+    [Fact]
     public async Task BuildFallsBackToDnxWhenPathAspireCliSetupTimesOut()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -853,13 +916,40 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         string[]? extraArguments = null,
         IDictionary<string, string>? environment = null)
     {
+        return await GetTargetPropertiesAsync(
+            project,
+            "ComputeRunArguments",
+            "RunCommand,RunArguments,RunWorkingDirectory,_AspireResolvedCliInvocationMode,_AspireResolvedCliPath,_AspireResolvedDnxPath,_AspireResolvedDnxHostPath,_AspireResolvedDnxHostArguments,_AspireResolvedCliVersion,_AspireCliVersionSupportsRunHook,_AspireCliVersionCommand",
+            extraArguments,
+            environment);
+    }
+
+    private static async Task<Dictionary<string, string>> GetResolveAspireCliBundlePathPropertiesAsync(
+        RunHookProject project,
+        IDictionary<string, string> environment)
+    {
+        return await GetTargetPropertiesAsync(
+            project,
+            "ResolveAspireCliBundlePaths",
+            "DcpDir,AspireDashboardDir,AspireDashboardPath,_AspireResolvedCliInvocationMode,_AspireResolvedCliPath",
+            extraArguments: null,
+            environment: environment);
+    }
+
+    private static async Task<Dictionary<string, string>> GetTargetPropertiesAsync(
+        RunHookProject project,
+        string target,
+        string propertyNames,
+        string[]? extraArguments,
+        IDictionary<string, string>? environment)
+    {
         var arguments = new List<string>
         {
             "msbuild",
             "-nologo",
             "-restore",
-            "-t:ComputeRunArguments",
-            "-getProperty:RunCommand,RunArguments,RunWorkingDirectory,_AspireResolvedCliInvocationMode,_AspireResolvedCliPath,_AspireResolvedDnxPath,_AspireResolvedDnxHostPath,_AspireResolvedDnxHostArguments,_AspireResolvedCliVersion,_AspireCliVersionSupportsRunHook,_AspireCliVersionCommand",
+            $"-t:{target}",
+            $"-getProperty:{propertyNames}",
             project.ProjectFile
         };
 
@@ -900,6 +990,57 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         File.SetUnixFileMode(aspirePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
 
         return aspirePath;
+    }
+
+    private static async Task<string> CreateFakeAspireCliThatSetsUpBundleAsync(string fakeCliDirectory)
+    {
+        var aspirePath = Path.Combine(fakeCliDirectory, OperatingSystem.IsWindows() ? "aspire.cmd" : "aspire");
+        var contents = OperatingSystem.IsWindows()
+            ? """
+                @echo off
+                if not "%~1"=="setup" exit /b 2
+                mkdir "%~dp0bundle\dcp"
+                mkdir "%~dp0bundle\managed"
+                type nul > "%~dp0bundle\dcp\dcp.exe"
+                type nul > "%~dp0bundle\managed\aspire-managed.exe"
+                """
+            : """
+                #!/bin/sh
+                if [ "$1" != "setup" ]; then
+                    exit 2
+                fi
+                install_path="$(dirname "$0")"
+                mkdir -p "$install_path/bundle/dcp" "$install_path/bundle/managed"
+                : > "$install_path/bundle/dcp/dcp"
+                : > "$install_path/bundle/managed/aspire-managed"
+                """;
+
+        await File.WriteAllTextAsync(aspirePath, contents.ReplaceLineEndings(OperatingSystem.IsWindows() ? "\r\n" : "\n"));
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(aspirePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return aspirePath;
+    }
+
+    private static (string DcpDirectory, string ManagedDirectory, string ManagedPath) CreateFakeCliBundle(string layoutRoot)
+    {
+        var bundle = GetFakeCliBundlePaths(layoutRoot);
+        Directory.CreateDirectory(bundle.DcpDirectory);
+        Directory.CreateDirectory(bundle.ManagedDirectory);
+        File.WriteAllText(Path.Combine(bundle.DcpDirectory, OperatingSystem.IsWindows() ? "dcp.exe" : "dcp"), "");
+        File.WriteAllText(bundle.ManagedPath, "");
+        return bundle;
+    }
+
+    private static (string DcpDirectory, string ManagedDirectory, string ManagedPath) GetFakeCliBundlePaths(string layoutRoot)
+    {
+        var bundleRoot = Path.Combine(layoutRoot, "bundle");
+        var dcpDirectory = Path.Combine(bundleRoot, "dcp");
+        var managedDirectory = Path.Combine(bundleRoot, "managed");
+        var managedPath = Path.Combine(managedDirectory, OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed");
+        return (dcpDirectory, managedDirectory, managedPath);
     }
 
     private static async Task<string> CreateFakeAspireCommandShimAsync(string fakeCliDirectory, string extension = ".cmd")
@@ -1364,13 +1505,13 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         };
     }
 
-    private static string CreatePathWithoutAspire(string firstDirectory)
-        => CreatePathWithoutCommand(firstDirectory, "aspire");
+    private static string CreatePathWithoutAspire(params string[] firstDirectories)
+        => CreatePathWithoutCommand(firstDirectories, "aspire");
 
-    private static string CreatePathWithoutDnx(string firstDirectory)
-        => CreatePathWithoutCommand(firstDirectory, "dnx");
+    private static string CreatePathWithoutDnx(params string[] firstDirectories)
+        => CreatePathWithoutCommand(firstDirectories, "dnx");
 
-    private static string CreatePathWithoutCommand(string firstDirectory, string commandName)
+    private static string CreatePathWithoutCommand(string[] firstDirectories, string commandName)
     {
         var pathEnvironmentVariable = GetPathEnvironmentVariableName();
         var currentPath = Environment.GetEnvironmentVariable(pathEnvironmentVariable) ?? string.Empty;
@@ -1378,7 +1519,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
             .Where(directory => !ContainsCommand(directory, commandName));
 
-        return string.Join(Path.PathSeparator, pathDirectories.Prepend(firstDirectory));
+        return string.Join(Path.PathSeparator, firstDirectories.Concat(pathDirectories));
     }
 
     private static bool ContainsCommand(string directory, string commandName)

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -620,7 +620,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ResolveAspireCliBundlePathsUsesSelectedAspireCliWhenLaterPathCandidateHasBundle()
+    public async Task ResolveAspireCliBundlePathsUsesSelectedAspireCliWhenLaterPathCandidateHasBundleWithWarningsAsErrors()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
         var selectedCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "selected-cli"));
@@ -636,7 +636,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
             [GetPathEnvironmentVariableName()] = CreatePathWithoutAspire(selectedCliDirectory.FullName, staleCliDirectory.FullName)
         };
 
-        var properties = await GetResolveAspireCliBundlePathPropertiesAsync(project, environment);
+        var properties = await GetResolveAspireCliBundlePathPropertiesAsync(project, environment, ["-warnaserror"]);
         var selectedBundle = GetFakeCliBundlePaths(selectedCliDirectory.FullName);
 
         Assert.Equal("Aspire", properties["_AspireResolvedCliInvocationMode"]);
@@ -646,6 +646,33 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         Assert.Equal(selectedBundle.ManagedPath, properties["AspireDashboardPath"]);
         Assert.NotEqual(staleBundle.DcpDirectory, Path.TrimEndingDirectorySeparator(properties["DcpDir"]));
         AssertCliBundleExists(selectedCliDirectory.FullName, JsonSerializer.Serialize(properties));
+    }
+
+    [Fact]
+    public async Task ResolveAspireCliBundlePathsEscapesPercentSignsInNativeAspireCliPathOnWindows()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "This test validates native Windows executable setup.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "native%ASPIRE_TEST_LITERAL%"));
+        var aspireCliPath = CreateFakeNativeAspireCli(fakeCliDirectory.FullName);
+        var aspireHome = Path.Combine(workspace.Path, "aspire-home");
+        var project = await CreateRunHookProjectAsync(workspace.Path, aspireUseCliBundle: true, includeBundlePaths: false);
+        var environment = new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = aspireHome,
+            ["ASPIRE_TEST_LITERAL"] = "expanded",
+            ["AspireCliPath"] = aspireCliPath
+        };
+
+        var properties = await GetResolveAspireCliBundlePathPropertiesAsync(project, environment, ["-warnaserror"]);
+        var selectedBundle = GetFakeCliBundlePaths(fakeCliDirectory.FullName);
+
+        Assert.Equal(selectedBundle.DcpDirectory, Path.TrimEndingDirectorySeparator(properties["DcpDir"]));
+        Assert.Equal(selectedBundle.ManagedDirectory, Path.TrimEndingDirectorySeparator(properties["AspireDashboardDir"]));
+        Assert.Equal(selectedBundle.ManagedPath, properties["AspireDashboardPath"]);
+        AssertCliBundleExists(fakeCliDirectory.FullName, JsonSerializer.Serialize(properties));
+        Assert.False(Directory.Exists(Path.Combine(workspace.Path, "nativeexpanded")));
     }
 
     [Fact]
@@ -926,13 +953,14 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
 
     private static async Task<Dictionary<string, string>> GetResolveAspireCliBundlePathPropertiesAsync(
         RunHookProject project,
-        IDictionary<string, string> environment)
+        IDictionary<string, string> environment,
+        string[]? extraArguments = null)
     {
         return await GetTargetPropertiesAsync(
             project,
             "ResolveAspireCliBundlePaths",
             "DcpDir,AspireDashboardDir,AspireDashboardPath,_AspireResolvedCliInvocationMode,_AspireResolvedCliPath",
-            extraArguments: null,
+            extraArguments,
             environment: environment);
     }
 

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -582,12 +582,57 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         Assert.Equal("true", properties["_AspireCliVersionSupportsRunHook"]);
         Assert.Equal(GetExpectedDnxRunCommand(dnxPath), properties["RunCommand"]);
         Assert.Equal(GetExpectedDnxRunArguments(dnxPath, project, "--custom foo"), properties["RunArguments"]);
-        Assert.True(
-            File.Exists(Path.Combine(aspireHome, "bundle", "dcp", OperatingSystem.IsWindows() ? "dcp.exe" : "dcp")),
-            buildResult.Output);
-        Assert.True(
-            File.Exists(Path.Combine(aspireHome, "bundle", "managed", OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed")),
-            buildResult.Output);
+        AssertCliBundleExists(aspireHome, buildResult.Output);
+    }
+
+    [Fact]
+    public async Task BuildFallsBackToDnxWhenPathAspireCliSetupTimesOut()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var project = await CreateRunHookProjectAsync(workspace.Path, aspireUseCliBundle: true, includeBundlePaths: false);
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "fake-cli"));
+        await CreateFakeAspireCliThatHangsOnSetupAsync(fakeCliDirectory.FullName);
+        await CreateFakeDnxAsync(fakeCliDirectory.FullName);
+        var aspireHome = Path.Combine(workspace.Path, "aspire-home");
+        var environment = new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = aspireHome,
+            [GetPathEnvironmentVariableName()] = CreatePathWithoutAspire(fakeCliDirectory.FullName)
+        };
+
+        var buildResult = await RunDotNetWithArgumentsAsync(
+            project.ProjectDirectory,
+            ["build", "-nologo", project.ProjectFile, "-p:_AspireCliBundleSetupTimeout=100"],
+            environment);
+
+        Assert.True(buildResult.ExitCode == 0, buildResult.Output);
+        Assert.Contains("MSB5002", buildResult.Output);
+        AssertCliBundleExists(aspireHome, buildResult.Output);
+    }
+
+    [Fact]
+    public async Task BuildUsesEnvironmentAspireHomeWhenMsBuildPropertyDiffers()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var project = await CreateRunHookProjectAsync(workspace.Path, aspireUseCliBundle: true, includeBundlePaths: false);
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "fake-cli"));
+        await CreateFakeDnxAsync(fakeCliDirectory.FullName);
+        var environmentAspireHome = Path.Combine(workspace.Path, "environment-aspire-home");
+        var propertyAspireHome = Path.Combine(workspace.Path, "property-aspire-home");
+        var environment = new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = environmentAspireHome,
+            [GetPathEnvironmentVariableName()] = CreatePathWithoutAspire(fakeCliDirectory.FullName)
+        };
+
+        var buildResult = await RunDotNetWithArgumentsAsync(
+            project.ProjectDirectory,
+            ["build", "-nologo", project.ProjectFile, $"-p:ASPIRE_HOME={propertyAspireHome}"],
+            environment);
+
+        Assert.True(buildResult.ExitCode == 0, buildResult.Output);
+        AssertCliBundleExists(environmentAspireHome, buildResult.Output);
+        Assert.False(Directory.Exists(Path.Combine(propertyAspireHome, "bundle")));
     }
 
     [Fact]
@@ -1085,6 +1130,44 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         File.SetUnixFileMode(aspirePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
+    private static async Task CreateFakeAspireCliThatHangsOnSetupAsync(string fakeCliDirectory)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            await File.WriteAllTextAsync(Path.Combine(fakeCliDirectory, "aspire.cmd"), """
+                @echo off
+                if "%~1"=="--version" (
+                    echo 13.5.0
+                    exit /b 0
+                )
+                if "%~1"=="setup" (
+                    :loop
+                    ping -n 2 127.0.0.1 > nul
+                    goto loop
+                )
+                exit /b 0
+                """);
+
+            return;
+        }
+
+        var aspirePath = Path.Combine(fakeCliDirectory, "aspire");
+        await File.WriteAllTextAsync(aspirePath, ("""
+            #!/bin/sh
+            if [ "$1" = "--version" ]; then
+                echo "13.5.0"
+                exit 0
+            fi
+            if [ "$1" = "setup" ]; then
+                while true; do
+                    sleep 1
+                done
+            fi
+            exit 0
+            """).ReplaceLineEndings("\n"));
+        File.SetUnixFileMode(aspirePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
     private static async Task CreateFakeAspireCliThatFailsVersionAsync(string fakeCliDirectory)
     {
         if (OperatingSystem.IsWindows())
@@ -1247,6 +1330,16 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         Assert.Equal(GetExpectedDotNetRunCommand(project), properties["RunCommand"]);
         Assert.Equal(expectedArguments, properties["RunArguments"]);
         Assert.Equal(project.ProjectDirectory, properties["RunWorkingDirectory"]);
+    }
+
+    private static void AssertCliBundleExists(string aspireHome, string output)
+    {
+        Assert.True(
+            File.Exists(Path.Combine(aspireHome, "bundle", "dcp", OperatingSystem.IsWindows() ? "dcp.exe" : "dcp")),
+            output);
+        Assert.True(
+            File.Exists(Path.Combine(aspireHome, "bundle", "managed", OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed")),
+            output);
     }
 
     private static string GetExpectedDotNetRunCommand(RunHookProject project)

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -592,9 +592,15 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         var staleCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "stale-cli"));
         await CreateFakeAspireCliWithVersionAsync(staleCliDirectory.FullName, AspireCliVersion);
         var staleBundle = CreateFakeCliBundle(staleCliDirectory.FullName);
-        var dnxDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "dnx"));
+        var dnxDirectoryName = OperatingSystem.IsWindows()
+            ? "dnx"
+            : "dnx $HOME `aspire-test-command`";
+        var dnxDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, dnxDirectoryName));
         await CreateFakeDnxAsync(dnxDirectory.FullName);
-        var aspireHome = Path.Combine(workspace.Path, "aspire-home");
+        var aspireHomeDirectoryName = OperatingSystem.IsWindows()
+            ? "aspire-home"
+            : "aspire-home $HOME `aspire-test-command`";
+        var aspireHome = Path.Combine(workspace.Path, aspireHomeDirectoryName);
         var project = await CreateRunHookProjectAsync(workspace.Path, aspireUseCliBundle: true,
             """
               <PropertyGroup>
@@ -608,7 +614,12 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
             [GetPathEnvironmentVariableName()] = CreatePathWithoutAspire(staleCliDirectory.FullName, dnxDirectory.FullName)
         };
 
-        var properties = await GetResolveAspireCliBundlePathPropertiesAsync(project, environment);
+        // Explicit Dnx mode can use an unversioned package reference so a tool manifest can select
+        // the CLI version. Force that shape here because the fake setup must support both forms.
+        var properties = await GetResolveAspireCliBundlePathPropertiesAsync(
+            project,
+            environment,
+            ["-p:_AspireCliDnxPackageReference=aspire.cli"]);
         var dnxBundle = GetFakeCliBundlePaths(aspireHome);
 
         Assert.Equal("Dnx", properties["_AspireResolvedCliInvocationMode"]);
@@ -617,6 +628,33 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         Assert.Equal(dnxBundle.ManagedPath, properties["AspireDashboardPath"]);
         Assert.NotEqual(staleBundle.DcpDirectory, Path.TrimEndingDirectorySeparator(properties["DcpDir"]));
         AssertCliBundleExists(aspireHome, JsonSerializer.Serialize(properties));
+    }
+
+    [Fact]
+    public async Task ResolveAspireCliBundlePathsPreservesUnixShellMetacharactersInAspireCliPath()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(), "This test validates Unix process argument handling.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var fakeCliDirectory = Directory.CreateDirectory(
+            Path.Combine(workspace.Path, "cli $HOME `aspire-test-command`"));
+        var aspireCliPath = await CreateFakeAspireCliThatSetsUpBundleAsync(fakeCliDirectory.FullName);
+        var aspireHome = Path.Combine(workspace.Path, "empty-aspire-home");
+        var project = await CreateRunHookProjectAsync(workspace.Path, aspireUseCliBundle: true, includeBundlePaths: false);
+        var environment = new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = aspireHome,
+            ["AspireCliPath"] = aspireCliPath
+        };
+
+        var properties = await GetResolveAspireCliBundlePathPropertiesAsync(project, environment, ["-warnaserror"]);
+        var selectedBundle = GetFakeCliBundlePaths(fakeCliDirectory.FullName);
+
+        Assert.Equal(aspireCliPath, properties["_AspireResolvedCliPath"]);
+        Assert.Equal(selectedBundle.DcpDirectory, Path.TrimEndingDirectorySeparator(properties["DcpDir"]));
+        Assert.Equal(selectedBundle.ManagedDirectory, Path.TrimEndingDirectorySeparator(properties["AspireDashboardDir"]));
+        Assert.Equal(selectedBundle.ManagedPath, properties["AspireDashboardPath"]);
+        AssertCliBundleExists(fakeCliDirectory.FullName, JsonSerializer.Serialize(properties));
     }
 
     [Fact]
@@ -692,11 +730,10 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
 
         var buildResult = await RunDotNetWithArgumentsAsync(
             project.ProjectDirectory,
-            ["build", "-nologo", project.ProjectFile, "-p:_AspireCliBundleSetupTimeout=100"],
+            ["build", "-nologo", project.ProjectFile, "-p:_AspireCliBundleSetupTimeout=100", "-warnaserror"],
             environment);
 
         Assert.True(buildResult.ExitCode == 0, buildResult.Output);
-        Assert.Contains("MSB5002", buildResult.Output);
         AssertCliBundleExists(aspireHome, buildResult.Output);
     }
 
@@ -1137,7 +1174,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
                     echo "13.5.0"
                     exit 0
                 fi
-                if [ "$1" = "--yes" ] && [ "$2" = "aspire.cli@13.5.0" ] && [ "$3" = "--" ] && [ "$4" = "setup" ] && [ "$5" = "--install-path" ]; then
+                if [ "$1" = "--yes" ] && { [ "$2" = "aspire.cli@13.5.0" ] || [ "$2" = "aspire.cli" ]; } && [ "$3" = "--" ] && [ "$4" = "setup" ] && [ "$5" = "--install-path" ]; then
                     mkdir -p "$6/bundle/dcp" "$6/bundle/managed"
                     : > "$6/bundle/dcp/dcp"
                     : > "$6/bundle/managed/aspire-managed"

--- a/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
+++ b/tests/Aspire.Hosting.Sdk.Tests/AppHostSdkTargetsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Security;
 using System.Text.Json;
@@ -13,6 +14,7 @@ namespace Aspire.Hosting.Sdk.Tests;
 public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
 {
     private const string AspireCliVersion = "13.5.0";
+    private const string HangingCommandPidEnvironmentVariable = "ASPIRE_TEST_HANG_PID_PATH";
     private const string SuppressCliRunHookEnvironmentVariable = "ASPIRE_SUPPRESS_CLI_RUN_HOOK";
 
     private static readonly string[] s_supportedRids =
@@ -738,6 +740,77 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task RunAspireCliCommandKillsCommandShimProcessTreeOnTimeoutInFullFrameworkMsBuild()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "This test validates the net472 task under full-framework MSBuild.");
+
+        var msbuildPath = await FindFullFrameworkMSBuildAsync();
+        Assert.SkipUnless(msbuildPath is not null, "Full-framework MSBuild could not be found with vswhere.");
+
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var fakeCommandDirectory = Directory.CreateDirectory(Path.Combine(workspace.Path, "fake-command"));
+        CopyFakeCommandHost(fakeCommandDirectory.FullName);
+        var commandShimPath = Path.Combine(fakeCommandDirectory.FullName, "aspire.cmd");
+        await File.WriteAllTextAsync(commandShimPath, """
+            @echo off
+            "%~dp0dotnet.exe" --hang
+            """);
+
+        var childPidPath = Path.Combine(workspace.Path, "child.pid");
+        var taskAssemblyPath = GetAssemblyMetadataPath("AspireHostingTasksNetFrameworkAssemblyPath");
+        var projectPath = Path.Combine(workspace.Path, "RunAspireCliCommand.proj");
+        await File.WriteAllTextAsync(projectPath, $$"""
+            <Project>
+              <UsingTask TaskName="RunAspireCliCommand" AssemblyFile="{{SecurityElement.Escape(taskAssemblyPath)}}" />
+
+              <Target Name="Test">
+                <RunAspireCliCommand FileName="{{SecurityElement.Escape(commandShimPath)}}" TimeoutMilliseconds="5000">
+                  <Output TaskParameter="TimedOut" PropertyName="CommandTimedOut" />
+                  <Output TaskParameter="FailureMessage" PropertyName="CommandFailureMessage" />
+                </RunAspireCliCommand>
+                <Error Condition="'$(CommandTimedOut)' != 'true'" Text="The command did not report a timeout." />
+                <Error Condition="'$(CommandFailureMessage)' == ''" Text="The command did not report a timeout failure." />
+                <Message Text="CommandTimedOut=$(CommandTimedOut)" Importance="High" />
+              </Target>
+            </Project>
+            """);
+
+        int? childProcessId = null;
+        try
+        {
+            var result = await RunProcessWithArgumentsAsync(
+                msbuildPath!,
+                workspace.Path,
+                [projectPath, "-nologo", "-t:Test"],
+                new Dictionary<string, string>
+                {
+                    [HangingCommandPidEnvironmentVariable] = childPidPath
+                },
+                TimeSpan.FromSeconds(30));
+
+            Assert.True(result.ExitCode == 0, result.Output);
+            Assert.Contains("CommandTimedOut=true", result.Output, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(childPidPath), $"The child process did not record its PID. MSBuild output:{Environment.NewLine}{result.Output}");
+
+            childProcessId = int.Parse(await File.ReadAllTextAsync(childPidPath), CultureInfo.InvariantCulture);
+            using var survivingChild = TryGetProcessById(childProcessId.Value);
+            Assert.Null(survivingChild);
+            childProcessId = null;
+        }
+        finally
+        {
+            if (childProcessId is { } processId)
+            {
+                using var childProcess = TryGetProcessById(processId);
+                if (childProcess is not null && !childProcess.HasExited)
+                {
+                    childProcess.Kill(entireProcessTree: true);
+                }
+            }
+        }
+    }
+
+    [Fact]
     public async Task BuildUsesEnvironmentAspireHomeWhenMsBuildPropertyDiffers()
     {
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -1445,6 +1518,34 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         return taskAssemblyPath!;
     }
 
+    private static async Task<string?> FindFullFrameworkMSBuildAsync()
+    {
+        var vswherePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "Microsoft Visual Studio",
+            "Installer",
+            "vswhere.exe");
+        if (!File.Exists(vswherePath))
+        {
+            return null;
+        }
+
+        var result = await RunProcessWithArgumentsAsync(
+            vswherePath,
+            Path.GetDirectoryName(vswherePath)!,
+            ["-latest", "-products", "*", "-requires", "Microsoft.Component.MSBuild", "-find", @"MSBuild\**\Bin\MSBuild.exe"],
+            environment: null,
+            TimeSpan.FromSeconds(30));
+        if (result.ExitCode != 0)
+        {
+            return null;
+        }
+
+        return result.StandardOutput
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault(File.Exists);
+    }
+
     private static string GetAssemblyMetadataPath(string metadataName)
     {
         var path = typeof(AppHostSdkTargetsTests).Assembly
@@ -1630,9 +1731,17 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         return (process.ExitCode, output + error);
     }
 
-    private static async Task<DotNetResult> RunDotNetWithArgumentsAsync(string workingDirectory, string[] arguments, IDictionary<string, string>? environment = null)
+    private static Task<DotNetResult> RunDotNetWithArgumentsAsync(string workingDirectory, string[] arguments, IDictionary<string, string>? environment = null)
+        => RunProcessWithArgumentsAsync("dotnet", workingDirectory, arguments, environment, TimeSpan.FromMinutes(3));
+
+    private static async Task<DotNetResult> RunProcessWithArgumentsAsync(
+        string fileName,
+        string workingDirectory,
+        string[] arguments,
+        IDictionary<string, string>? environment,
+        TimeSpan timeout)
     {
-        var startInfo = new ProcessStartInfo("dotnet")
+        var startInfo = new ProcessStartInfo(fileName)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -1663,7 +1772,7 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         var outputTask = process.StandardOutput.ReadToEndAsync();
         var errorTask = process.StandardError.ReadToEndAsync();
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        using var cts = new CancellationTokenSource(timeout);
 
         try
         {
@@ -1672,10 +1781,22 @@ public class AppHostSdkTargetsTests(ITestOutputHelper outputHelper)
         catch (OperationCanceledException)
         {
             process.Kill(entireProcessTree: true);
-            throw new TimeoutException($"dotnet {string.Join(' ', arguments)} timed out after 3 minutes.");
+            throw new TimeoutException($"{fileName} {string.Join(' ', arguments)} timed out after {timeout}.");
         }
 
         return new DotNetResult(process.ExitCode, await outputTask, await errorTask);
+    }
+
+    private static Process? TryGetProcessById(int processId)
+    {
+        try
+        {
+            return Process.GetProcessById(processId);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
     }
 
     private static string GetRepoRoot()

--- a/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
+++ b/tests/Aspire.Hosting.Sdk.Tests/Aspire.Hosting.Sdk.Tests.csproj
@@ -41,6 +41,7 @@
     <!-- Expose the built RID tool path to tests via assembly metadata so the older-SDK fallback can be exercised. -->
     <AssemblyMetadata Include="AspireRuntimeIdentifierToolPath" Value="$(ArtifactsBinDir)Aspire.RuntimeIdentifier.Tool\$(Configuration)\$(DefaultTargetFramework)\Aspire.RuntimeIdentifier.Tool.dll" />
     <AssemblyMetadata Include="AspireHostingTasksAssemblyPath" Value="$(ArtifactsBinDir)Aspire.Hosting.Tasks\$(Configuration)\net8.0\Aspire.Hosting.Tasks.dll" />
+    <AssemblyMetadata Include="AspireHostingTasksNetFrameworkAssemblyPath" Value="$(ArtifactsBinDir)Aspire.Hosting.Tasks\$(Configuration)\net472\Aspire.Hosting.Tasks.dll" />
     <AssemblyMetadata Include="FakeCommandHostPath" Value="$(ArtifactsBinDir)Aspire.Hosting.Sdk.Tests.FakeCommand\$(Configuration)\$(DefaultTargetFramework)\$(FakeCommandHostFileName)" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpCliArgsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpCliArgsTests.cs
@@ -119,35 +119,40 @@ public class DcpCliArgsTests
         Assert.Equal(bundleDashboardPath, dcpOptions.DashboardPath);
     }
 
-    [Fact]
-    public void DcpOptionsValidationFailsForWhitespacePaths()
+    [Theory]
+    [InlineData(DistributedApplicationOperation.Run, true)]
+    [InlineData(DistributedApplicationOperation.Publish, false)]
+    public void DcpOptionsValidationRequiresPathsOnlyInRunMode(DistributedApplicationOperation operation, bool shouldFail)
     {
-        var validator = new ValidateDcpOptions();
+        var validator = new ValidateDcpOptions(new DistributedApplicationExecutionContext(operation));
         var result = validator.Validate(null, new DcpOptions
         {
             CliPath = " ",
             DashboardPath = "\t",
         });
 
-        Assert.True(result.Failed);
-        Assert.Contains("The path to the DCP executable used for Aspire orchestration is required.", result.FailureMessage);
-        Assert.Contains("The path to the Aspire Dashboard binaries is missing.", result.FailureMessage);
+        Assert.Equal(shouldFail, result.Failed);
+        if (shouldFail)
+        {
+            Assert.Contains("The path to the DCP executable used for Aspire orchestration is required.", result.FailureMessage);
+            Assert.Contains("The path to the Aspire Dashboard binaries is missing.", result.FailureMessage);
+        }
     }
 
     [Fact]
-    public void DcpOptionsValidationFailsForInvalidProxylessEndpointPortRange()
+    public void DcpOptionsValidationStillFailsForInvalidProxylessEndpointPortRangeInPublishMode()
     {
-        var validator = new ValidateDcpOptions();
+        var validator = new ValidateDcpOptions(new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish));
         var result = validator.Validate(null, new DcpOptions
         {
-            CliPath = "dcp",
-            DashboardPath = "dashboard",
             ProxylessEndpointPortRangeStart = 32767,
             ProxylessEndpointPortRangeEnd = 10000,
         });
 
         Assert.True(result.Failed);
-        Assert.Contains("The proxyless endpoint port range start must be less than or equal to the range end.", result.FailureMessage);
+        Assert.Contains(
+            "The proxyless endpoint port range start must be less than or equal to the range end.",
+            Assert.Single(result.Failures!));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -4,8 +4,10 @@
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Text;
+using System.Text.Json;
 using System.Xml.Linq;
 using Aspire.Hosting.Tests.Utils;
+using Aspire.Shared;
 
 namespace Aspire.Hosting.Tests;
 
@@ -320,6 +322,34 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void AppHostInspectionQuerySucceedsForPlainAppHostNamedProject()
+    {
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+        var projectPath = Path.Combine(workspace.WorkspaceRoot.FullName, "Plain.AppHost.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var result = RunDotNet(
+            workspace.WorkspaceRoot.FullName,
+            $"msbuild -getProperty:MSBuildVersion,IsAspireHost,AspireHostingSDKVersion,AspireUseCliBundle,UserSecretsId,RunCommand,TargetPath,RunWorkingDirectory,RunArguments,TargetFramework,TargetFrameworks -getItem:PackageReference,AspireProjectOrPackageReference,PackageVersion -t:ComputeRunArguments \"{projectPath}\"",
+            timeoutMilliseconds: 180_000,
+            new Dictionary<string, string>
+            {
+                ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1",
+                ["DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE"] = "1",
+            });
+
+        Assert.True(result.ExitCode == 0, $"MSBuild query failed: {Environment.NewLine}{result.Output}");
+        using var document = JsonDocument.Parse(result.Output);
+        Assert.Equal(string.Empty, document.RootElement.GetProperty("Properties").GetProperty("IsAspireHost").GetString());
+    }
+
+    [Fact]
     public async Task CliBundleOptInResolvesExplicitBundlePath()
     {
         var repoRoot = MSBuildUtils.GetRepoRoot();
@@ -433,6 +463,124 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
         Assert.Equal(bundle.DcpDir, resolvedPaths[0]);
         Assert.Equal(bundle.ManagedDir, resolvedPaths[1]);
         Assert.Equal(bundle.ManagedPath, resolvedPaths[2]);
+    }
+
+    [Fact]
+    public async Task CliBundleOptInPreparesMissingAspireHomeBundle()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var aspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, "empty-aspire-home");
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "fake-cli"));
+        _ = CreateFakeAspireCliThatSetsUpBundle(fakeCliDirectory.FullName);
+        var appHostDirectory = CreateSdkBundleAppHostProject(workspace.WorkspaceRoot.FullName, repoRoot, additionalProperties: "");
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        BuildProject(appHostDirectory, new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = aspireHome,
+            ["PATH"] = GetPathWithoutAspire(fakeCliDirectory.FullName)
+        });
+
+        var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
+        var bundleRoot = Path.Combine(aspireHome, "bundle");
+        var expectedDcpDir = EnsureTrailingSeparator(Path.Combine(bundleRoot, "dcp"));
+        var expectedManagedDir = EnsureTrailingSeparator(Path.Combine(bundleRoot, "managed"));
+        Assert.Equal(expectedDcpDir, resolvedPaths[0]);
+        Assert.Equal(expectedManagedDir, resolvedPaths[1]);
+        Assert.Equal(Path.Combine(expectedManagedDir, OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed"), resolvedPaths[2]);
+    }
+
+    [Fact]
+    public void CliBundleOptInSkipsSetupDuringDesignTimeBuild()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var aspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, "empty-aspire-home");
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "fake-cli"));
+        var fakeCliPath = CreateFakeAspireCliThatSetsUpBundle(fakeCliDirectory.FullName);
+        var appHostDirectory = CreateSdkBundleAppHostProject(
+            workspace.WorkspaceRoot.FullName,
+            repoRoot,
+            $"""
+              <AspireCliPath>{fakeCliPath}</AspireCliPath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var result = RunDotNet(
+            appHostDirectory,
+            "build --disable-build-servers -p:DesignTimeBuild=true",
+            timeoutMilliseconds: 180_000,
+            new Dictionary<string, string> { ["ASPIRE_HOME"] = aspireHome });
+
+        Assert.True(result.ExitCode == 0, $"Design-time build failed: {Environment.NewLine}{result.Output}");
+        Assert.False(Directory.Exists(Path.Combine(aspireHome, BundleDiscovery.BundleDirectoryName)));
+    }
+
+    [Fact]
+    public void CliBundleSetupFailureReportsAspire009WhenWarningsAreErrors()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var aspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, "empty-aspire-home");
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "fake-cli"));
+        var fakeCliPath = CreateFakeAspireCliThatFailsSetup(fakeCliDirectory.FullName);
+        var appHostDirectory = CreateSdkBundleAppHostProject(
+            workspace.WorkspaceRoot.FullName,
+            repoRoot,
+            $"""
+              <AspireCliPath>{fakeCliPath}</AspireCliPath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var result = RunDotNet(
+            appHostDirectory,
+            "build --disable-build-servers -warnaserror",
+            timeoutMilliseconds: 180_000,
+            new Dictionary<string, string> { ["ASPIRE_HOME"] = aspireHome });
+
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains("ASPIRE009", result.Output);
+        Assert.Contains("failed with exit code 42", result.Output);
+    }
+
+    [Fact]
+    public async Task CliBundleOptInPreservesLiteralPercentCharactersInWindowsCommandShimPath()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Windows command-shim escaping is required.");
+
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var aspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, "empty-aspire-home");
+        var literalSegment = "%ASPIRE_LITERAL_SEGMENT%";
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, literalSegment));
+        var fakeCliPath = CreateFakeAspireCliThatSetsUpBundle(fakeCliDirectory.FullName);
+        var appHostDirectory = CreateSdkBundleAppHostProject(
+            workspace.WorkspaceRoot.FullName,
+            repoRoot,
+            $"""
+              <AspireCliPath>{fakeCliPath}</AspireCliPath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        BuildProject(appHostDirectory, new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = aspireHome,
+            ["ASPIRE_LITERAL_SEGMENT"] = "expanded-segment"
+        });
+
+        var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
+        var bundleRoot = Path.Combine(aspireHome, BundleDiscovery.BundleDirectoryName);
+        Assert.Equal(EnsureTrailingSeparator(Path.Combine(bundleRoot, BundleDiscovery.DcpDirectoryName)), resolvedPaths[0]);
+        Assert.Equal(EnsureTrailingSeparator(Path.Combine(bundleRoot, BundleDiscovery.ManagedDirectoryName)), resolvedPaths[1]);
     }
 
     [Fact]
@@ -553,7 +701,7 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
     [Theory]
     [InlineData(null)]
     [InlineData("Dnx")]
-    public void CliBundleDnxInvocationAllowsMissingBuildTimeBundle(string? invocationMode)
+    public void CliBundleDnxInvocationFailsWhenSetupCannotProduceLayout(string? invocationMode)
     {
         var repoRoot = MSBuildUtils.GetRepoRoot();
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -569,27 +717,28 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
             additionalProperties);
         var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "fake-cli"));
         var dnxPath = Path.Combine(fakeCliDirectory.FullName, OperatingSystem.IsWindows() ? "dnx.exe" : "dnx");
-        File.WriteAllText(dnxPath, "");
-        if (!OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
+            // Use a terminating PE executable. A copied cmd.exe starts an interactive shell
+            // because the DNX arguments do not include /C and leaves the test waiting for timeout.
+            File.Copy(Path.Combine(Environment.SystemDirectory, "where.exe"), dnxPath);
+        }
+        else
+        {
+            File.WriteAllText(dnxPath, "#!/bin/sh\nexit 42\n");
             File.SetUnixFileMode(dnxPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
         }
 
         CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
 
-        BuildProject(appHostDirectory, new Dictionary<string, string>
+        var output = BuildProjectWithFailure(appHostDirectory, new Dictionary<string, string>
         {
             ["ASPIRE_HOME"] = Path.Combine(workspace.WorkspaceRoot.FullName, "empty-aspire-home"),
             ["PATH"] = $"{fakeCliDirectory.FullName}{Path.PathSeparator}{GetDotNetOnlyPath()}"
         });
 
-        var appHostIdentityMetadata = File.ReadAllLines(Path.Combine(appHostDirectory, "obj", "apphost-identity-metadata.txt"));
-        Assert.Equal(
-            [
-                $"apphostprojectpath={appHostDirectory}",
-                "apphostprojectname=AppHost.csproj"
-            ],
-            appHostIdentityMetadata);
+        Assert.Contains("ASPIRE009", output);
+        Assert.Contains("the bundle could not be resolved", output);
     }
 
     [Fact]
@@ -797,6 +946,65 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
         return cliPath;
     }
 
+    private static string CreateFakeAspireCliThatSetsUpBundle(string directory)
+    {
+        var cliPath = Path.Combine(directory, OperatingSystem.IsWindows() ? "aspire.cmd" : "aspire");
+        var dcpExecutable = OperatingSystem.IsWindows() ? "dcp.exe" : "dcp";
+        var managedExecutable = OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed";
+        var contents = OperatingSystem.IsWindows()
+            ? $$"""
+                @echo off
+                if not "%~1"=="setup" exit /b 2
+                mkdir "%ASPIRE_HOME%\bundle\dcp"
+                mkdir "%ASPIRE_HOME%\bundle\managed"
+                type nul > "%ASPIRE_HOME%\bundle\dcp\{{dcpExecutable}}"
+                type nul > "%ASPIRE_HOME%\bundle\managed\{{managedExecutable}}"
+                """
+            : $$"""
+                #!/bin/sh
+                if [ "$1" != "setup" ]; then
+                    exit 2
+                fi
+                mkdir -p "$ASPIRE_HOME/bundle/dcp" "$ASPIRE_HOME/bundle/managed"
+                : > "$ASPIRE_HOME/bundle/dcp/{{dcpExecutable}}"
+                : > "$ASPIRE_HOME/bundle/managed/{{managedExecutable}}"
+                """;
+
+        File.WriteAllText(cliPath, contents.ReplaceLineEndings(OperatingSystem.IsWindows() ? "\r\n" : "\n"));
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(cliPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return cliPath;
+    }
+
+    private static string CreateFakeAspireCliThatFailsSetup(string directory)
+    {
+        var cliPath = Path.Combine(directory, OperatingSystem.IsWindows() ? "aspire.cmd" : "aspire");
+        var contents = OperatingSystem.IsWindows()
+            ? """
+                @echo off
+                if not "%~1"=="setup" exit /b 2
+                exit /b 42
+                """
+            : """
+                #!/bin/sh
+                if [ "$1" != "setup" ]; then
+                    exit 2
+                fi
+                exit 42
+                """;
+
+        File.WriteAllText(cliPath, contents.ReplaceLineEndings(OperatingSystem.IsWindows() ? "\r\n" : "\n"));
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(cliPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return cliPath;
+    }
+
     private static string EnsureTrailingSeparator(string path)
     {
         return path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
@@ -810,6 +1018,25 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
         Assert.False(string.IsNullOrEmpty(dotnetDirectory), $"Could not determine the directory for dotnet path '{dotnetPath}'.");
 
         return dotnetDirectory;
+    }
+
+    private static string GetPathWithoutAspire(string firstDirectory)
+    {
+        var currentPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var pathDirectories = currentPath
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(directory => !ContainsCommand(directory, "aspire"));
+
+        return string.Join(Path.PathSeparator, pathDirectories.Prepend(firstDirectory));
+    }
+
+    private static bool ContainsCommand(string directory, string commandName)
+    {
+        var executableNames = OperatingSystem.IsWindows()
+            ? new[] { $"{commandName}.exe", $"{commandName}.cmd", $"{commandName}.bat", commandName }
+            : [commandName];
+
+        return executableNames.Any(executableName => File.Exists(Path.Combine(directory.Trim().Trim('"'), executableName)));
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -576,9 +576,9 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
             appHostDirectory,
             new Dictionary<string, string> { ["ASPIRE_HOME"] = aspireHome });
 
-        Assert.Contains("MSB5002", output);
         Assert.Contains("ASPIRE009", output);
         Assert.Contains("Automatic Aspire CLI bundle setup did not produce a usable DCP and dashboard layout.", output);
+        Assert.Contains("The command timed out after 100 milliseconds.", output);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -466,7 +466,7 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task CliBundleOptInPreparesMissingAspireHomeBundle()
+    public async Task CliBundleOptInPreparesMissingBundleBesidePathCli()
     {
         var repoRoot = MSBuildUtils.GetRepoRoot();
         using var workspace = TemporaryWorkspace.Create(outputHelper);
@@ -485,12 +485,13 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
         });
 
         var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
-        var bundleRoot = Path.Combine(aspireHome, "bundle");
+        var bundleRoot = Path.Combine(workspace.WorkspaceRoot.FullName, BundleDiscovery.BundleDirectoryName);
         var expectedDcpDir = EnsureTrailingSeparator(Path.Combine(bundleRoot, "dcp"));
         var expectedManagedDir = EnsureTrailingSeparator(Path.Combine(bundleRoot, "managed"));
         Assert.Equal(expectedDcpDir, resolvedPaths[0]);
         Assert.Equal(expectedManagedDir, resolvedPaths[1]);
         Assert.Equal(Path.Combine(expectedManagedDir, OperatingSystem.IsWindows() ? "aspire-managed.exe" : "aspire-managed"), resolvedPaths[2]);
+        Assert.False(Directory.Exists(Path.Combine(aspireHome, BundleDiscovery.BundleDirectoryName)));
     }
 
     [Fact]
@@ -519,6 +520,7 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
 
         Assert.True(result.ExitCode == 0, $"Design-time build failed: {Environment.NewLine}{result.Output}");
         Assert.False(Directory.Exists(Path.Combine(aspireHome, BundleDiscovery.BundleDirectoryName)));
+        Assert.False(Directory.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, BundleDiscovery.BundleDirectoryName)));
     }
 
     [Fact]
@@ -548,6 +550,35 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
         Assert.NotEqual(0, result.ExitCode);
         Assert.Contains("ASPIRE009", result.Output);
         Assert.Contains("failed with exit code 42", result.Output);
+        Assert.Contains($"Run '\"{fakeCliPath}\" setup'", result.Output);
+    }
+
+    [Fact]
+    public void CliBundleSetupTimeoutReportsAspire009()
+    {
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var aspireHome = Path.Combine(workspace.WorkspaceRoot.FullName, "empty-aspire-home");
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, "fake-cli"));
+        var fakeCliPath = CreateFakeAspireCliThatTimesOutSetup(fakeCliDirectory.FullName);
+        var appHostDirectory = CreateSdkBundleAppHostProject(
+            workspace.WorkspaceRoot.FullName,
+            repoRoot,
+            $"""
+              <AspireCliPath>{fakeCliPath}</AspireCliPath>
+              <_AspireCliBundleSetupTimeout>100</_AspireCliBundleSetupTimeout>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var output = BuildProjectWithFailure(
+            appHostDirectory,
+            new Dictionary<string, string> { ["ASPIRE_HOME"] = aspireHome });
+
+        Assert.Contains("MSB5002", output);
+        Assert.Contains("ASPIRE009", output);
+        Assert.Contains("Automatic Aspire CLI bundle setup did not produce a usable DCP and dashboard layout.", output);
     }
 
     [Fact]
@@ -578,9 +609,40 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
         });
 
         var resolvedPaths = await File.ReadAllLinesAsync(Path.Combine(appHostDirectory, "obj", "resolved-aspire-paths.txt"));
-        var bundleRoot = Path.Combine(aspireHome, BundleDiscovery.BundleDirectoryName);
+        var bundleRoot = Path.Combine(workspace.WorkspaceRoot.FullName, BundleDiscovery.BundleDirectoryName);
         Assert.Equal(EnsureTrailingSeparator(Path.Combine(bundleRoot, BundleDiscovery.DcpDirectoryName)), resolvedPaths[0]);
         Assert.Equal(EnsureTrailingSeparator(Path.Combine(bundleRoot, BundleDiscovery.ManagedDirectoryName)), resolvedPaths[1]);
+    }
+
+    [Fact]
+    public void CliBundleSetupFailureDiagnosticPreservesLiteralPercentCharacters()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Windows command-shim escaping is required.");
+
+        var repoRoot = MSBuildUtils.GetRepoRoot();
+        using var workspace = TemporaryWorkspace.Create(outputHelper);
+
+        var literalSegment = "%ASPIRE_LITERAL_SEGMENT%";
+        var fakeCliDirectory = Directory.CreateDirectory(Path.Combine(workspace.WorkspaceRoot.FullName, literalSegment));
+        var fakeCliPath = CreateFakeAspireCliThatFailsSetup(fakeCliDirectory.FullName);
+        var appHostDirectory = CreateSdkBundleAppHostProject(
+            workspace.WorkspaceRoot.FullName,
+            repoRoot,
+            $"""
+              <AspireCliPath>{fakeCliPath}</AspireCliPath>
+            """);
+
+        CreateAppHostPackageDirectoryBuildFiles(appHostDirectory, repoRoot);
+
+        var output = BuildProjectWithFailure(appHostDirectory, new Dictionary<string, string>
+        {
+            ["ASPIRE_HOME"] = Path.Combine(workspace.WorkspaceRoot.FullName, "empty-aspire-home"),
+            ["ASPIRE_LITERAL_SEGMENT"] = "expanded-segment"
+        });
+
+        Assert.Contains($"Run '\"{fakeCliPath}\" setup'", output);
+        Assert.DoesNotContain("^^%%", output);
+        Assert.DoesNotContain("cmd /D /V:OFF", output);
     }
 
     [Fact]
@@ -734,11 +796,16 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
         var output = BuildProjectWithFailure(appHostDirectory, new Dictionary<string, string>
         {
             ["ASPIRE_HOME"] = Path.Combine(workspace.WorkspaceRoot.FullName, "empty-aspire-home"),
-            ["PATH"] = $"{fakeCliDirectory.FullName}{Path.PathSeparator}{GetDotNetOnlyPath()}"
+            ["PATH"] = GetPathWithoutAspire(fakeCliDirectory.FullName)
         });
 
         Assert.Contains("ASPIRE009", output);
         Assert.Contains("the bundle could not be resolved", output);
+        Assert.Contains("failed with exit code", output);
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Contains("failed with exit code 42", output);
+        }
     }
 
     [Fact]
@@ -955,19 +1022,46 @@ public class MSBuildTests(ITestOutputHelper outputHelper)
             ? $$"""
                 @echo off
                 if not "%~1"=="setup" exit /b 2
-                mkdir "%ASPIRE_HOME%\bundle\dcp"
-                mkdir "%ASPIRE_HOME%\bundle\managed"
-                type nul > "%ASPIRE_HOME%\bundle\dcp\{{dcpExecutable}}"
-                type nul > "%ASPIRE_HOME%\bundle\managed\{{managedExecutable}}"
+                mkdir "%~dp0..\bundle\dcp"
+                mkdir "%~dp0..\bundle\managed"
+                type nul > "%~dp0..\bundle\dcp\{{dcpExecutable}}"
+                type nul > "%~dp0..\bundle\managed\{{managedExecutable}}"
                 """
             : $$"""
                 #!/bin/sh
                 if [ "$1" != "setup" ]; then
                     exit 2
                 fi
-                mkdir -p "$ASPIRE_HOME/bundle/dcp" "$ASPIRE_HOME/bundle/managed"
-                : > "$ASPIRE_HOME/bundle/dcp/{{dcpExecutable}}"
-                : > "$ASPIRE_HOME/bundle/managed/{{managedExecutable}}"
+                install_path="$(dirname "$0")/.."
+                mkdir -p "$install_path/bundle/dcp" "$install_path/bundle/managed"
+                : > "$install_path/bundle/dcp/{{dcpExecutable}}"
+                : > "$install_path/bundle/managed/{{managedExecutable}}"
+                """;
+
+        File.WriteAllText(cliPath, contents.ReplaceLineEndings(OperatingSystem.IsWindows() ? "\r\n" : "\n"));
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(cliPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return cliPath;
+    }
+
+    private static string CreateFakeAspireCliThatTimesOutSetup(string directory)
+    {
+        var cliPath = Path.Combine(directory, OperatingSystem.IsWindows() ? "aspire.cmd" : "aspire");
+        var contents = OperatingSystem.IsWindows()
+            ? """
+                @echo off
+                if not "%~1"=="setup" exit /b 2
+                ping -n 6 127.0.0.1 > nul
+                """
+            : """
+                #!/bin/sh
+                if [ "$1" != "setup" ]; then
+                    exit 2
+                fi
+                sleep 5
                 """;
 
         File.WriteAllText(cliPath, contents.ReplaceLineEndings(OperatingSystem.IsWindows() ? "\r\n" : "\n"));


### PR DESCRIPTION
## Description

Fresh Aspire CLI installations can have a valid embedded bundle that has not been extracted yet. When an AppHost uses `AspireUseCliBundle=true`, that previously allowed the build to complete without DCP or dashboard metadata, causing direct or IDE launches to fail before the first successful CLI run.

This change ensures the bundle is available across installation and launch paths:

- AppHost targets resolve an existing layout, run `aspire setup` through the selected PATH or paired DNX CLI only when needed, then resolve the layout again.
- Release installers eagerly run setup after writing the install sidecar.
- CLI project inspection carries build-resolved DCP and dashboard paths into direct launches and rejects launches that still lack usable paths.
- Bundle-aware cache entries are invalidated when their runtime files no longer exist.
- Setup failures produce actionable diagnostics instead of a metadata-free AppHost.

### User-facing behavior

After installing the Aspire CLI, users can build and launch an `AspireUseCliBundle=true` AppHost directly from an IDE without first running an Aspire CLI command. Installations that did not use the release scripts are recovered by the build targets on demand.

Validation included:

- PowerShell and shell installer coverage, including setup ordering and failure propagation.
- Hosting target coverage for PATH and DNX setup, invalid explicit paths, and missing layouts.
- CLI resolver, cache, environment precedence, and pre-launch guard coverage.
- Installation of the exact staging CLI `13.5.0+cfbf1c432e94dfe4a3261593eeef8c93913079bb` through both updated scripts.
- A direct launch of the original minimal AppHost with `ASPIRE_DCP_PATH` and `ASPIRE_DASHBOARD_PATH` removed, reaching a healthy dashboard.

Fixes #19227

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
