### PR TITLE
[Broken main] Track the disabled Azure Functions E2E shard in the matrix allowlist

### DIFF
--- a/extension/src/test/e2eShardMatrix.test.ts
+++ b/extension/src/test/e2eShardMatrix.test.ts
@@ -12,7 +12,17 @@ suite('E2E shard matrix', () => {
     const workflowPath = path.join(extensionRoot, '..', '.github', 'workflows', 'extension-e2e-tests.yml');
     const specDirectory = path.join(extensionRoot, 'src', 'test-e2e');
     const disabledIssuePattern = /^https:\/\/github\.com\/microsoft\/aspire\/issues\/\d+$/;
-    const expectedDisabledRows = new Map<string, string>();
+
+    // Hand-maintained on purpose: disabling an E2E shard must be an explicit, reviewable code change
+    // rather than something a workflow edit can do silently. Deriving this from the workflow would
+    // make the assertion vacuous. Keys are `name|shardName|spec` and values are the tracking issue.
+    // Add an entry when a row gains `disabledIssue`, and delete it when the shard is re-enabled.
+    const expectedDisabledRows = new Map<string, string>([
+        [
+            'Linux|azure-functions|out/test-e2e/test-e2e/azureFunctions.e2e.test.js',
+            'https://github.com/microsoft/aspire/issues/19151',
+        ],
+    ]);
 
     function canonicalSpecPaths(specFileNames: readonly string[]): string[] {
         return specFileNames


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> **`main` is currently RED.** This unblocks it. Please prioritize review.

The CI job `Tests / Run VS Code extension unit tests (Windows)` fails on **every** run of `main`, including on `main` itself, and has since 2026-08-11. It is the only failing job in an otherwise green run.

### Root cause

A semantic merge conflict between two PRs that merged 80 seconds apart. Each was green on its own branch; `main` went red only once both landed, so neither PR's CI could have caught it.

| PR | Commit | Merged (EDT) | What it did |
|----|--------|--------------|-------------|
| #19146 | `dfa7428851` | 20:47:47 | Added an assertion that disabled E2E matrix rows exactly match `expectedDisabledRows` in `extension/src/test/e2eShardMatrix.test.ts`. The map was introduced **empty**, because no disabled row existed at the time. |
| #19142 | `ff0dbb4bdb` | 20:49:07 | Added a disabled matrix row for the Linux `azure-functions` shard in `.github/workflows/extension-e2e-tests.yml` (`disabledIssue: 'https://github.com/microsoft/aspire/issues/19151'`). |

The workflow now has one disabled row while the allowlist is empty, so the guard fails:

```text
AssertionError [ERR_ASSERTION]: Disabled E2E matrix rows must exactly match the explicit allowlist in e2eShardMatrix.test.ts.
+ actual - expected
+ [
+   [
+     'Linux|azure-functions|out/test-e2e/test-e2e/azureFunctions.e2e.test.js',
+     'https://github.com/microsoft/aspire/issues/19151'
+   ]
+ ]
- []
  at assertDisabledRowsAreTracked (extension/out/test/e2eShardMatrix.test.js:124:16)
```

### The fix

Add the tracking entry for the already-disabled Linux `azure-functions` shard so the allowlist matches the workflow. One file, one map literal — no behavior change to the extension, the E2E workflow, or the shard's disabled state.

### Why not derive the allowlist from the workflow?

That was considered and deliberately rejected. Reading the expected rows out of the same workflow the assertion validates would make the check vacuously true, and the whole point of the guard (per #19146) is that **disabling an E2E shard must be an explicit, reviewable code change** rather than something a workflow edit does silently. The hand-maintained map is the mechanism, not the bug — the drift here came from concurrent merges, which is a merge-ordering hazard rather than a design flaw. Keeping this PR to the smallest correct change so it can merge quickly; a comment now documents the map's contract and the add/remove lifecycle so the next person hits less friction.

cc @adamint — this is your area (both #19146 and #19142).

## Validation

Built and ran the extension unit tests locally per `.agents/skills/vscode-extension/SKILL.md` (`extension/build.sh`, then `corepack yarn run test`).

Full extension unit suite — the job that is red on `main`:

```console
$ corepack yarn run test
  1509 passing (50s)
  5 pending
Exit code:   0
```

The previously-failing suite specifically, **after** the fix:

```console
$ ./node_modules/.bin/mocha out/test/e2eShardMatrix.test.js --ui tdd
  E2E shard matrix
    ✔ runs exactly the set of E2E specs in the CI matrix
    ✔ rejects a spec that has no matrix row
    ✔ rejects a matrix row that does not point at an E2E spec
    ✔ discovers nested E2E specs recursively
    ✔ accepts one spec on multiple platform rows
    ✔ does not treat nested or unrelated spec fields as matrix.spec
    ✔ rejects a matrix row with an empty spec
    ✔ requires disabled rows to be explicitly tracked
    ✔ tracks disabled platform rows separately and validates issue URLs
    ✔ rejects a disabled row when disabledIssue is present but empty
  10 passing (14ms)
```

And the same suite with the fix stashed, confirming this change is what repairs it and that the local repro matches CI exactly:

```console
  9 passing (15ms)
  1 failing
  AssertionError [ERR_ASSERTION]: Disabled E2E matrix rows must exactly match the explicit allowlist in e2eShardMatrix.test.ts.
```

The guard's own negative tests (`requires disabled rows to be explicitly tracked`, `tracks disabled platform rows separately and validates issue URLs`, `rejects a disabled row when disabledIssue is present but empty`) still pass, so the tripwire is intact and would still catch an untracked or malformed disabled row.

No screenshots: this is a test-only change with no user-visible UI surface.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No