### PR TITLE
Match dark accent buttons to hyperlinks

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -871,8 +871,8 @@ fluent-dialog td[cell-type=columnheader] fluent-button[appearance=stealth]:not(:
 [data-theme="dark"] fluent-button[appearance='accent'],
 [data-theme="dark"] fluent-anchor[appearance='accent'] {
     --foreground-on-accent-rest: color-mix(in srgb, var(--accent-base-color) 85%, #000000);
-    --foreground-on-accent-hover: color-mix(in srgb, var(--accent-base-color) 80%, #000000);
-    --foreground-on-accent-active: color-mix(in srgb, var(--accent-base-color) 75%, #000000);
+    --foreground-on-accent-hover: color-mix(in srgb, var(--accent-base-color) 65%, #000000);
+    --foreground-on-accent-active: color-mix(in srgb, var(--accent-base-color) 55%, #000000);
 }
 
 [data-theme="dark"] fluent-button[appearance='accent']:not(:hover):not(:active)::part(control),
@@ -884,14 +884,14 @@ fluent-dialog td[cell-type=columnheader] fluent-button[appearance=stealth]:not(:
 
 [data-theme="dark"] fluent-button[appearance='accent']:hover::part(control),
 [data-theme="dark"] fluent-anchor[appearance='accent']:hover::part(control) {
-    background: var(--accent-fill-hover);
-    color: color-mix(in srgb, var(--accent-base-color) 80%, #000000);
+    background: color-mix(in srgb, var(--accent-fill-rest) 90%, #000000);
+    color: color-mix(in srgb, var(--accent-base-color) 65%, #000000);
 }
 
 [data-theme="dark"] fluent-button[appearance='accent']:active::part(control),
 [data-theme="dark"] fluent-anchor[appearance='accent']:active::part(control) {
-    background: var(--accent-fill-active);
-    color: color-mix(in srgb, var(--accent-base-color) 75%, #000000);
+    background: color-mix(in srgb, var(--accent-fill-rest) 85%, #000000);
+    color: color-mix(in srgb, var(--accent-base-color) 55%, #000000);
 }
 
 /* Secondary buttons (Cancel / Manage, neutral or default appearance): FAST's neutral fill is nearly the

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -862,13 +862,9 @@ fluent-dialog td[cell-type=columnheader] fluent-button[appearance=stealth]:not(:
     border-color: var(--neutral-stroke-rest) !important;
 }
 
-/* Primary action buttons on DARK theme: a soft LIGHT-purple fill with a dark-violet label, so the
-   primary action reads as a bright, inviting chip against the dark chrome. FAST's stock dark
-   accent recipe is a near-white lavender (looks washed-out/disabled) and the brand-violet + white
-   treatment we used before read heavy; a light-purple fill + dark text is the requested look. The fill
-   and label are mixed from the brand seed (--accent-base-color #512bd4) so they track the theme. Each
-   interaction state darkens both the fill and label in tandem, preserving at least 4.5:1 text contrast.
-   Applies to every accent button/anchor - dialogs AND page toolbars.
+/* Primary action buttons on DARK theme use the same semantic accent colors as hyperlinks, with a
+    dark-violet label that preserves at least 4.5:1 text contrast in every interaction state.
+    Applies to every accent button/anchor - dialogs AND page toolbars.
    IMPORTANT: LIGHT theme is intentionally NOT touched here (stays on the stock saturated violet + white
    recipe), per the design ask. --foreground-on-accent is pinned to the dark label so FluentUI's own
    slotted label/icon colour follows it instead of painting white. */
@@ -881,20 +877,20 @@ fluent-dialog td[cell-type=columnheader] fluent-button[appearance=stealth]:not(:
 
 [data-theme="dark"] fluent-button[appearance='accent']:not(:hover):not(:active)::part(control),
 [data-theme="dark"] fluent-anchor[appearance='accent']:not(:hover):not(:active)::part(control) {
-    background: color-mix(in srgb, var(--accent-base-color) 30%, #ffffff);
+    background: var(--accent-fill-rest);
     color: color-mix(in srgb, var(--accent-base-color) 85%, #000000);
-    border-color: color-mix(in srgb, var(--accent-base-color) 45%, #ffffff);
+    border-color: var(--accent-fill-rest);
 }
 
 [data-theme="dark"] fluent-button[appearance='accent']:hover::part(control),
 [data-theme="dark"] fluent-anchor[appearance='accent']:hover::part(control) {
-    background: color-mix(in srgb, var(--accent-base-color) 40%, #ffffff);
+    background: var(--accent-fill-hover);
     color: color-mix(in srgb, var(--accent-base-color) 80%, #000000);
 }
 
 [data-theme="dark"] fluent-button[appearance='accent']:active::part(control),
 [data-theme="dark"] fluent-anchor[appearance='accent']:active::part(control) {
-    background: color-mix(in srgb, var(--accent-base-color) 45%, #ffffff);
+    background: var(--accent-fill-active);
     color: color-mix(in srgb, var(--accent-base-color) 75%, #000000);
 }
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
@@ -212,6 +212,13 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
         var hover = await ReadFluentControlColorsAsync(button);
         states.Add(("hover", hover.Foreground, hover.Background));
 
+        Assert.True(
+            RelativeLuminance(hover.Background.R, hover.Background.G, hover.Background.B) <
+                RelativeLuminance(rest.Background.R, rest.Background.G, rest.Background.B),
+            $"Dark accent button hover background should be darker than rest: " +
+            $"rest rgb({rest.Background.R},{rest.Background.G},{rest.Background.B}), " +
+            $"hover rgb({hover.Background.R},{hover.Background.G},{hover.Background.B}).");
+
         await page.Mouse.DownAsync();
         var active = await ReadFluentControlColorsAsync(button);
         states.Add(("active", active.Foreground, active.Background));

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
@@ -212,13 +212,6 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
         var hover = await ReadFluentControlColorsAsync(button);
         states.Add(("hover", hover.Foreground, hover.Background));
 
-        Assert.True(
-            RelativeLuminance(hover.Background.R, hover.Background.G, hover.Background.B) <
-                RelativeLuminance(rest.Background.R, rest.Background.G, rest.Background.B),
-            $"Dark accent button hover background should be darker than rest: " +
-            $"rest rgb({rest.Background.R},{rest.Background.G},{rest.Background.B}), " +
-            $"hover rgb({hover.Background.R},{hover.Background.G},{hover.Background.B}).");
-
         await page.Mouse.DownAsync();
         var active = await ReadFluentControlColorsAsync(button);
         states.Add(("active", active.Foreground, active.Background));


### PR DESCRIPTION
## Description

Dark-mode accent buttons used a lighter lavender fill than dashboard hyperlinks, making primary actions look disconnected from the established accent color. This updates accent buttons and anchors to use the same Fluent semantic accent tokens as hyperlinks for their rest, hover, and active states.

Light mode is unchanged: both buttons and hyperlinks continue to use `#512BD4`. In dark mode, the resting button fill and hyperlinks now both use `#B9AAEE`.

### User-facing usage

Primary dashboard actions now match the hyperlink accent color in dark mode while retaining their existing dark label and accessible contrast.

### Screenshots / Recordings

<img width="493" height="253" alt="image" src="https://github.com/user-attachments/assets/41afaaca-301d-4304-8ffe-e4de33e73279" />

### Validation

- Verified in the TestShop dashboard login page that the dark-mode button fill and hyperlink both resolve to `#B9AAEE`.
- Verified light mode remains `#512BD4` for both the button and hyperlink.
- Verified dark button text contrast is at least 4.64:1 and light button text contrast is 7.94:1.
- `git diff --check`
- CSS diagnostics report no errors.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No