### PR TITLE
Preserve CLI status messages without interactive spinners

### DIFF
--- a/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
+++ b/src/Aspire.Cli/Interaction/ConsoleInteractionService.cs
@@ -62,6 +62,28 @@ internal class ConsoleInteractionService : IInteractionService
 
     private bool UsesConsoleLogging => _executionContext.ConsoleLogLevel is not null and not LogLevel.None;
 
+    private bool ShouldShowInteractiveStatus(string statusText)
+    {
+        // Use atomic check-and-set to prevent nested Spectre.Console Status operations.
+        // Spectre.Console throws if multiple interactive operations run concurrently.
+        // If already in a status, or in debug/non-interactive/console logging mode, fall back without a spinner.
+        // Also skip status display if statusText is empty (e.g., when outputting JSON).
+        // IMPORTANT: CompareExchange must be evaluated last so that short-circuit evaluation
+        // skips the swap when an earlier condition forces the fallback path. Otherwise the
+        // swap would set _inStatus to 1 but the try/finally that resets it would never run,
+        // permanently disabling interactive status for the lifetime of the service.
+        if (_executionContext.DebugMode ||
+            UsesConsoleLogging ||
+            !_hostEnvironment.SupportsInteractiveOutput ||
+            string.IsNullOrEmpty(statusText) ||
+            Interlocked.CompareExchange(ref _inStatus, 1, 0) != 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     public ConsoleInteractionService(ConsoleEnvironment consoleEnvironment, CliExecutionContext executionContext, ICliHostEnvironment hostEnvironment, IProcessPathProvider processPathProvider, ILoggerFactory loggerFactory, ConsoleLogBufferContext logBufferContext)
     {
         ArgumentNullException.ThrowIfNull(consoleEnvironment);
@@ -82,11 +104,6 @@ internal class ConsoleInteractionService : IInteractionService
 
     public async Task<T> ShowStatusAsync<T>(string statusText, Func<Task<T>> action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        if (UsesConsoleLogging)
-        {
-            return await action();
-        }
-
         if (!allowMarkup)
         {
             statusText = statusText.EscapeMarkup();
@@ -97,17 +114,7 @@ internal class ConsoleInteractionService : IInteractionService
             statusText = ConsoleHelpers.FormatEmojiPrefix(e, MessageConsole) + statusText;
         }
 
-        // Use atomic check-and-set to prevent nested Spectre.Console Status operations.
-        // Spectre.Console throws if multiple interactive operations run concurrently.
-        // If already in a status or non-interactive mode is active, fall back to subtle message.
-        // Also skip status display if statusText is empty (e.g., when outputting JSON).
-        // IMPORTANT: CompareExchange must be evaluated last so that short-circuit evaluation
-        // skips the swap when an earlier condition forces the fallback path. Otherwise the
-        // swap would set _inStatus to 1 but the try/finally that resets it would never run,
-        // permanently disabling interactive status for the lifetime of the service.
-        if (!_hostEnvironment.SupportsInteractiveOutput ||
-            string.IsNullOrEmpty(statusText) ||
-            Interlocked.CompareExchange(ref _inStatus, 1, 0) != 0)
+        if (!ShouldShowInteractiveStatus(statusText))
         {
             // Skip displaying if status text is empty (e.g., when outputting JSON)
             if (!string.IsNullOrEmpty(statusText))
@@ -136,22 +143,10 @@ internal class ConsoleInteractionService : IInteractionService
 
     public async Task<T> ShowDynamicStatusAsync<T>(string initialStatusText, Func<Action<string>, Task<T>> action, KnownEmoji? emoji = null)
     {
-        if (UsesConsoleLogging)
-        {
-            return await action(_ => { });
-        }
-
         var emojiPrefix = emoji is { } e ? ConsoleHelpers.FormatEmojiPrefix(e, MessageConsole) : string.Empty;
         var initialDisplayText = emojiPrefix + initialStatusText.EscapeMarkup();
 
-        // Mirrors ShowStatusAsync: prevent nested Spectre.Console Status operations, skip with non-interactive output,
-        // and treat empty text as "no status UI". The fallback path still drives the action so progress logic runs;
-        // we just hand it an updater that emits subtle messages instead of mutating a live spinner.
-        // IMPORTANT: CompareExchange must be evaluated last so that short-circuit evaluation skips the swap when
-        // an earlier condition forces the fallback path; otherwise _inStatus would be left set to 1.
-        if (!_hostEnvironment.SupportsInteractiveOutput ||
-            string.IsNullOrEmpty(initialStatusText) ||
-            Interlocked.CompareExchange(ref _inStatus, 1, 0) != 0)
+        if (!ShouldShowInteractiveStatus(initialStatusText))
         {
             if (!string.IsNullOrEmpty(initialStatusText))
             {
@@ -185,12 +180,6 @@ internal class ConsoleInteractionService : IInteractionService
 
     public void ShowStatus(string statusText, Action action, KnownEmoji? emoji = null, bool allowMarkup = false)
     {
-        if (UsesConsoleLogging)
-        {
-            action();
-            return;
-        }
-
         MessageLogger.LogInformation("Status: {StatusText}", statusText);
 
         if (!allowMarkup)
@@ -203,15 +192,7 @@ internal class ConsoleInteractionService : IInteractionService
             statusText = ConsoleHelpers.FormatEmojiPrefix(e, MessageConsole) + statusText;
         }
 
-        // Use atomic check-and-set to prevent nested Spectre.Console Status operations.
-        // Spectre.Console throws if multiple interactive operations run concurrently.
-        // If already in a status or non-interactive mode is active, fall back to subtle message.
-        // Also skip status display if statusText is empty (e.g., when outputting JSON).
-        // IMPORTANT: CompareExchange must be evaluated last so that short-circuit evaluation skips the swap when
-        // an earlier condition forces the fallback path; otherwise _inStatus would be left set to 1.
-        if (!_hostEnvironment.SupportsInteractiveOutput ||
-            string.IsNullOrEmpty(statusText) ||
-            Interlocked.CompareExchange(ref _inStatus, 1, 0) != 0)
+        if (!ShouldShowInteractiveStatus(statusText))
         {
             if (!string.IsNullOrEmpty(statusText))
             {

--- a/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
@@ -103,13 +103,16 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task DoctorCommand_WithTraceLogging_DoesNotRenderProgress()
+    public async Task DoctorCommand_WithDebugLogging_DoesNotRenderSpinner()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
         var workspace = TemporaryWorkspace.Create(output);
-        var testName = nameof(DoctorCommand_WithTraceLogging_DoesNotRenderProgress);
+        var testName = nameof(DoctorCommand_WithDebugLogging_DoesNotRenderSpinner);
         var recordingPath = CliE2ETestHelpers.GetTestResultsRecordingPath(testName);
+
+        // The recording path is stable across retries, so remove stale output before the recorder starts.
+        File.Delete(recordingPath);
 
         using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace, testName: testName);
 
@@ -122,14 +125,14 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
         await auto.ClearScreenAsync(counter);
 
         var recordingOffset = File.Exists(recordingPath) ? new FileInfo(recordingPath).Length : 0;
-        await auto.TypeAsync("aspire doctor -l trace");
+        await auto.TypeAsync("aspire doctor -l debug");
         await auto.EnterAsync();
         await auto.WaitForSuccessPromptAsync(counter, TimeSpan.FromMinutes(2));
 
         var commandOutput = ReadRecordingOutput(recordingPath, recordingOffset);
         Assert.Contains("[dbug]", commandOutput, StringComparison.Ordinal);
         Assert.Contains(DoctorCommandStrings.EnvironmentCheckHeader, commandOutput, StringComparison.Ordinal);
-        Assert.DoesNotContain(DoctorCommandStrings.CheckingPrerequisites, commandOutput, StringComparison.Ordinal);
+        Assert.Contains(DoctorCommandStrings.CheckingPrerequisites, commandOutput, StringComparison.Ordinal);
         Assert.DoesNotContain(commandOutput, SpinnerCharacters.Contains);
     }
 

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -274,16 +274,14 @@ public class ConsoleInteractionServiceTests
         var executionContext = CreateExecutionContext(debugMode: true);
         var interactionService = CreateInteractionService(console, executionContext);
         var statusText = "Processing request...";
-        var result = "test result";
 
         // Act
-        var actualResult = await interactionService.ShowStatusAsync(statusText, () => Task.FromResult(result)).DefaultTimeout();
+        var statusValue = await interactionService.ShowStatusAsync(statusText, () => Task.FromResult(GetInStatus(interactionService))).DefaultTimeout();
 
         // Assert
-        Assert.Equal(result, actualResult);
+        Assert.Equal(0, statusValue);
         var outputString = output.ToString();
         Assert.Contains(statusText, outputString);
-        // In debug mode, should use DisplaySubtleMessage instead of spinner
     }
 
     [Fact]
@@ -299,13 +297,13 @@ public class ConsoleInteractionServiceTests
 
         var interactionService = CreateInteractionService(console, CreateExecutionContext(debugMode: true));
 
-        var result = await interactionService.ShowDynamicStatusAsync("Processing request...", updateStatus =>
+        var statusValue = await interactionService.ShowDynamicStatusAsync("Processing request...", updateStatus =>
         {
             updateStatus("Still processing...");
-            return Task.FromResult("test result");
+            return Task.FromResult(GetInStatus(interactionService));
         }).DefaultTimeout();
 
-        Assert.Equal("test result", result);
+        Assert.Equal(0, statusValue);
         Assert.Contains("Processing request...", output.ToString());
         Assert.Contains("Still processing...", output.ToString());
     }
@@ -370,16 +368,15 @@ public class ConsoleInteractionServiceTests
         var executionContext = CreateExecutionContext(debugMode: true);
         var interactionService = CreateInteractionService(console, executionContext);
         var statusText = "Processing synchronous request...";
-        var actionCalled = false;
+        var statusValue = -1;
 
         // Act
-        interactionService.ShowStatus(statusText, () => actionCalled = true);
+        interactionService.ShowStatus(statusText, () => statusValue = GetInStatus(interactionService));
 
         // Assert
-        Assert.True(actionCalled);
+        Assert.Equal(0, statusValue);
         var outputString = output.ToString();
         Assert.Contains(statusText, outputString);
-        // In debug mode, should use DisplaySubtleMessage instead of spinner
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/ConsoleInteractionServiceTests.cs
@@ -26,11 +26,11 @@ public class ConsoleInteractionServiceTests
     private static CliExecutionContext CreateExecutionContext(bool debugMode = false, LogLevel? consoleLogLevel = null, string? logFilePath = null) =>
         new(new DirectoryInfo("."), new DirectoryInfo("."), new DirectoryInfo("."), s_runtimeDirectory, s_logsDirectory, logFilePath ?? "test.log", identityChannel: "local", debugMode: debugMode, consoleLogLevel: consoleLogLevel);
 
-    private static ConsoleInteractionService CreateInteractionService(IAnsiConsole console, CliExecutionContext? executionContext = null, ICliHostEnvironment? hostEnvironment = null)
+    private static ConsoleInteractionService CreateInteractionService(IAnsiConsole console, CliExecutionContext? executionContext = null, ICliHostEnvironment? hostEnvironment = null, ILoggerFactory? loggerFactory = null)
     {
         executionContext ??= CreateExecutionContext();
         var consoleEnvironment = new ConsoleEnvironment(console, console);
-        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment ?? TestHelpers.CreateInteractiveHostEnvironment(), new EnvironmentProcessPathProvider(), NullLoggerFactory.Instance, new ConsoleLogBufferContext());
+        return new ConsoleInteractionService(consoleEnvironment, executionContext, hostEnvironment ?? TestHelpers.CreateInteractiveHostEnvironment(), new EnvironmentProcessPathProvider(), loggerFactory ?? NullLoggerFactory.Instance, new ConsoleLogBufferContext());
     }
 
     [Fact]
@@ -286,6 +286,30 @@ public class ConsoleInteractionServiceTests
         // In debug mode, should use DisplaySubtleMessage instead of spinner
     }
 
+    [Fact]
+    public async Task ShowDynamicStatusAsync_InDebugMode_DisplaysSubtleMessagesInsteadOfSpinner()
+    {
+        var output = new StringBuilder();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(new StringWriter(output))
+        });
+
+        var interactionService = CreateInteractionService(console, CreateExecutionContext(debugMode: true));
+
+        var result = await interactionService.ShowDynamicStatusAsync("Processing request...", updateStatus =>
+        {
+            updateStatus("Still processing...");
+            return Task.FromResult("test result");
+        }).DefaultTimeout();
+
+        Assert.Equal("test result", result);
+        Assert.Contains("Processing request...", output.ToString());
+        Assert.Contains("Still processing...", output.ToString());
+    }
+
     [Theory]
     [InlineData(LogLevel.Trace)]
     [InlineData(LogLevel.Debug)]
@@ -296,13 +320,14 @@ public class ConsoleInteractionServiceTests
     public async Task StatusMethods_WithConsoleLogging_DoNotStartSpinner(LogLevel consoleLogLevel)
     {
         var output = new StringBuilder();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new SpectreConsoleLoggerProvider(new StringWriter(output), new ConsoleLogBufferContext())));
         var console = AnsiConsole.Create(new AnsiConsoleSettings
         {
             Ansi = AnsiSupport.No,
             ColorSystem = ColorSystemSupport.NoColors,
             Out = new AnsiConsoleOutput(new StringWriter(output))
         });
-        var interactionService = CreateInteractionService(console, CreateExecutionContext(consoleLogLevel: consoleLogLevel));
+        var interactionService = CreateInteractionService(console, CreateExecutionContext(consoleLogLevel: consoleLogLevel), loggerFactory: loggerFactory);
 
         var asyncStatusValue = await interactionService.ShowStatusAsync("Working...", () => Task.FromResult(GetInStatus(interactionService))).DefaultTimeout();
         var dynamicStatusValue = await interactionService.ShowDynamicStatusAsync("Working...", updateStatus =>
@@ -316,7 +341,8 @@ public class ConsoleInteractionServiceTests
         Assert.Equal(0, asyncStatusValue);
         Assert.Equal(0, dynamicStatusValue);
         Assert.Equal(0, synchronousStatusValue);
-        Assert.Empty(output.ToString());
+        Assert.Contains("Working...", output.ToString());
+        Assert.Contains("Still working...", output.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Cli.Tests/Interaction/SpectreConsoleLoggerProviderTests.cs
+++ b/tests/Aspire.Cli.Tests/Interaction/SpectreConsoleLoggerProviderTests.cs
@@ -33,6 +33,7 @@ public class SpectreConsoleLoggerProviderTests
         var systemLogger = new SpectreConsoleLogger(output, "System.Test", bufferContext);
 
         // Act & Assert
+        Assert.False(aspireLogger.IsEnabled(LogLevel.Trace));
         Assert.True(aspireLogger.IsEnabled(LogLevel.Debug));
         Assert.True(aspireLogger.IsEnabled(LogLevel.Information));
         Assert.True(aspireLogger.IsEnabled(LogLevel.Warning));


### PR DESCRIPTION
## Description

Console logging and debug mode should not use Spectre.Console's interactive status renderer because spinner frames can interleave with diagnostic logs. They should still show status updates as stable, subtle messages so users retain progress context.

This follow-up to #19214 and the review feedback on #19256:

- Centralizes interactive status eligibility in `ShouldShowInteractiveStatus`, including the atomic nested-status guard.
- Restores debug-mode spinner suppression across synchronous, asynchronous, and dynamic status methods.
- Keeps status messages visible when console logging is enabled while suppressing spinner rendering.
- Makes the doctor regression recording resilient to stale files and validates debug logging explicitly.

### User-facing usage

Running doctor with console debug logging keeps readable status messages without interactive spinner frames:

```bash
aspire doctor --log-level debug
```

### Screenshots / Recordings

> **This PR includes UI changes.** Please add screenshots or screen recordings so reviewers can evaluate the visual changes without running locally.
>
> - For before/after comparisons, place them side-by-side or label them clearly.
> - For interactive changes (animations, transitions, new flows), prefer a short screen recording (GIF or video).
> - If you cannot capture visuals now, note what scenario to test and mark this section as TODO.

TODO: Run `aspire doctor --log-level debug` in an interactive terminal and confirm status messages remain visible without spinner glyphs. Local archive creation was blocked by unrelated existing Dashboard package path-length errors (`NU5123`).

### Validation

- `ConsoleInteractionServiceTests` and `SpectreConsoleLoggerProviderTests`: 119 passed.
- `Aspire.Cli.EndToEnd.Tests` project build passed.
- `git diff --check` passed.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
