### PR TITLE
Fix concurrent enumeration race in DistributedApplicationModel.Resources

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCollection.cs
@@ -7,12 +7,42 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting.ApplicationModel;
 
+/// <summary>
+/// The default <see cref="IResourceCollection"/> implementation backing
+/// <see cref="DistributedApplicationModel.Resources"/>. Maintains a name index alongside the
+/// ordered resource list and supports reads that are concurrent with mutations.
+/// </summary>
+/// <remarks>
+/// This collection is safe to read (enumerate, index, look up by name) while it is being mutated
+/// from another thread. That matters because <see cref="DistributedApplicationModel.Resources"/> is a
+/// single shared instance handed to every pipeline step, and <c>DistributedApplicationPipeline</c>
+/// runs independent steps concurrently (see <c>ExecuteStepsAsTaskDag</c>). Steps that only declare a
+/// <c>RequiredBySteps</c> relationship to a common aggregation step — for example
+/// <c>azure-prepare-resources</c>, which appends role-assignment and identity resources, and
+/// <c>validate-compute-environments</c>, which enumerates the model — have no ordering relative to
+/// one another and therefore genuinely overlap. Backing the reads with a plain <see cref="List{T}"/>
+/// meant an append on one step invalidated an in-flight enumerator on another
+/// ("Collection was modified; enumeration operation may not execute"), and two concurrent appends
+/// could corrupt the list and the name index. See https://github.com/microsoft/aspire/issues/19266.
+/// <para>
+/// Reads are served from an immutable copy-on-write snapshot rather than the live list, so a reader
+/// observes a stable point-in-time view for the duration of its enumeration and never sees a torn
+/// state. The snapshot is built lazily and cached, so a burst of mutations (the common case, during
+/// application build) costs a single rebuild on the next read instead of one per mutation. Writes
+/// take the lock, which also protects the name index and the backing list from concurrent writers.
+/// </para>
+/// </remarks>
 [DebuggerDisplay("Count = {Count}")]
 [DebuggerTypeProxy(typeof(ApplicationResourceCollectionDebugView))]
 internal sealed class ResourceCollection : IResourceCollection
 {
     private readonly List<IResource> _resources = [];
     private readonly Dictionary<string, IResource> _resourcesByName = new(StringComparers.ResourceName);
+    private readonly object _lock = new();
+
+    // Cached copy-on-write view of _resources, or null when a mutation has invalidated it.
+    // Only ever published from inside _lock so it always matches _resources at publication time.
+    private IResource[]? _snapshot;
 
     public ResourceCollection() { }
 
@@ -31,74 +61,129 @@ internal sealed class ResourceCollection : IResourceCollection
 
     public IResource this[int index]
     {
-        get => _resources[index];
+        get => GetSnapshot()[index];
         set
         {
-            var old = _resources[index];
-
-            // Allow replacing with same name (same slot), but reject if a *different* slot already has this name.
-            if (!StringComparers.ResourceName.Equals(old.Name, value.Name) &&
-                _resourcesByName.TryGetValue(value.Name, out var existing))
+            lock (_lock)
             {
-                ThrowDuplicateResource(value, existing);
-            }
+                var old = _resources[index];
 
-            _resources[index] = value;
-            _resourcesByName.Remove(old.Name);
-            _resourcesByName[value.Name] = value;
+                // Allow replacing with same name (same slot), but reject if a *different* slot already has this name.
+                if (!StringComparers.ResourceName.Equals(old.Name, value.Name) &&
+                    _resourcesByName.TryGetValue(value.Name, out var existing))
+                {
+                    ThrowDuplicateResource(value, existing);
+                }
+
+                _resources[index] = value;
+                _resourcesByName.Remove(old.Name);
+                _resourcesByName[value.Name] = value;
+                _snapshot = null;
+            }
         }
     }
 
-    public int Count => _resources.Count;
+    public int Count
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _resources.Count;
+            }
+        }
+    }
+
     public bool IsReadOnly => false;
 
     public void Add(IResource item)
     {
-        if (!_resourcesByName.TryAdd(item.Name, item))
+        lock (_lock)
         {
-            ThrowDuplicateResource(item, _resourcesByName[item.Name]);
-        }
+            if (!_resourcesByName.TryAdd(item.Name, item))
+            {
+                ThrowDuplicateResource(item, _resourcesByName[item.Name]);
+            }
 
-        _resources.Add(item);
+            _resources.Add(item);
+            _snapshot = null;
+        }
     }
 
     public void Clear()
     {
-        _resources.Clear();
-        _resourcesByName.Clear();
+        lock (_lock)
+        {
+            _resources.Clear();
+            _resourcesByName.Clear();
+            _snapshot = null;
+        }
     }
 
-    public bool Contains(IResource item) => _resources.Contains(item);
-    public void CopyTo(IResource[] array, int arrayIndex) => _resources.CopyTo(array, arrayIndex);
-    public IEnumerator<IResource> GetEnumerator() => _resources.GetEnumerator();
-    public int IndexOf(IResource item) => _resources.IndexOf(item);
+    public bool Contains(IResource item)
+    {
+        lock (_lock)
+        {
+            return _resources.Contains(item);
+        }
+    }
+
+    public void CopyTo(IResource[] array, int arrayIndex)
+    {
+        lock (_lock)
+        {
+            _resources.CopyTo(array, arrayIndex);
+        }
+    }
+
+    public IEnumerator<IResource> GetEnumerator() => ((IEnumerable<IResource>)GetSnapshot()).GetEnumerator();
+
+    public int IndexOf(IResource item)
+    {
+        lock (_lock)
+        {
+            return _resources.IndexOf(item);
+        }
+    }
 
     public void Insert(int index, IResource item)
     {
-        if (!_resourcesByName.TryAdd(item.Name, item))
+        lock (_lock)
         {
-            ThrowDuplicateResource(item, _resourcesByName[item.Name]);
-        }
+            if (!_resourcesByName.TryAdd(item.Name, item))
+            {
+                ThrowDuplicateResource(item, _resourcesByName[item.Name]);
+            }
 
-        _resources.Insert(index, item);
+            _resources.Insert(index, item);
+            _snapshot = null;
+        }
     }
 
     public bool Remove(IResource item)
     {
-        if (_resources.Remove(item))
+        lock (_lock)
         {
-            _resourcesByName.Remove(item.Name);
-            return true;
-        }
+            if (_resources.Remove(item))
+            {
+                _resourcesByName.Remove(item.Name);
+                _snapshot = null;
+                return true;
+            }
 
-        return false;
+            return false;
+        }
     }
 
     public void RemoveAt(int index)
     {
-        var item = _resources[index];
-        _resources.RemoveAt(index);
-        _resourcesByName.Remove(item.Name);
+        lock (_lock)
+        {
+            var item = _resources[index];
+            _resources.RemoveAt(index);
+            _resourcesByName.Remove(item.Name);
+            _snapshot = null;
+        }
     }
 
     public bool TryGetByName(string name, [NotNullWhen(true)] out IResource? resource)
@@ -109,10 +194,37 @@ internal sealed class ResourceCollection : IResourceCollection
             return false;
         }
 
-        return _resourcesByName.TryGetValue(name, out resource);
+        lock (_lock)
+        {
+            return _resourcesByName.TryGetValue(name, out resource);
+        }
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => _resources.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private IResource[] GetSnapshot()
+    {
+        // Lock-free fast path. A snapshot that a concurrent mutation invalidates immediately after
+        // this read is still a valid point-in-time view, which is exactly what a reader wants.
+        var snapshot = Volatile.Read(ref _snapshot);
+        if (snapshot is not null)
+        {
+            return snapshot;
+        }
+
+        lock (_lock)
+        {
+            // Another reader may have published a snapshot while this one waited for the lock.
+            snapshot = _snapshot;
+            if (snapshot is null)
+            {
+                snapshot = _resources.ToArray();
+                Volatile.Write(ref _snapshot, snapshot);
+            }
+
+            return snapshot;
+        }
+    }
 
     [DoesNotReturn]
     private static void ThrowDuplicateResource(IResource newResource, IResource existingResource)

--- a/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
+++ b/src/Aspire.Hosting/Pipelines/DistributedApplicationPipeline.cs
@@ -388,6 +388,11 @@ internal sealed class DistributedApplicationPipeline : IDistributedApplicationPi
         // the environments' steps silently skip it (which would result in the resource
         // never being deployed).
 
+        // This step is only wired as RequiredBy 'before-start', so the task DAG schedules it
+        // concurrently with any other step that shares that relationship — including
+        // 'azure-prepare-resources', which appends resources to the model. Enumerating the live
+        // model here is safe because IResourceCollection serves reads from an immutable
+        // copy-on-write snapshot; see ResourceCollection for the hazard this protects against.
         var computeEnvironments = model.Resources.OfType<IComputeEnvironmentResource>().ToList();
         if (computeEnvironments.Count <= 1)
         {

--- a/tests/Aspire.Hosting.Tests/ApplicationModel/ResourceCollectionTests.cs
+++ b/tests/Aspire.Hosting.Tests/ApplicationModel/ResourceCollectionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.ObjectModel;
+using Microsoft.AspNetCore.InternalTesting;
 
 namespace Aspire.Hosting.Tests.ApplicationModel;
 
@@ -235,6 +236,129 @@ public class ResourceCollectionTests
         Assert.True(collection.TryGetByName("TEST", out _));
 
         Assert.False(collection.TryGetByName("nonexistent", out _));
+    }
+
+    [Fact]
+    public void Enumeration_IsNotInvalidatedByConcurrentMutation()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/19266.
+        // Pipeline steps run concurrently and share a single DistributedApplicationModel, so one
+        // step can append a resource while another is enumerating. Interleave deterministically by
+        // driving the enumerator by hand rather than relying on thread timing.
+        var collection = new ResourceCollection();
+        collection.Add(new TestResource("res1"));
+        collection.Add(new TestResource("res2"));
+
+        var observed = new List<string>();
+
+        using var enumerator = collection.GetEnumerator();
+
+        Assert.True(enumerator.MoveNext());
+        observed.Add(enumerator.Current.Name);
+
+        collection.Add(new TestResource("added-during-enumeration"));
+        collection.Remove(collection.Single(resource => resource.Name == "res2"));
+
+        while (enumerator.MoveNext())
+        {
+            observed.Add(enumerator.Current.Name);
+        }
+
+        // The enumerator keeps serving the snapshot taken when enumeration started.
+        Assert.Equal(["res1", "res2"], observed);
+    }
+
+    [Fact]
+    public void Enumeration_ReflectsMutationsOnSubsequentEnumeration()
+    {
+        var collection = new ResourceCollection();
+        collection.Add(new TestResource("res1"));
+
+        Assert.Equal(["res1"], collection.Select(resource => resource.Name));
+
+        collection.Add(new TestResource("res2"));
+
+        Assert.Equal(["res1", "res2"], collection.Select(resource => resource.Name));
+
+        collection.RemoveAt(0);
+
+        Assert.Equal(["res2"], collection.Select(resource => resource.Name));
+    }
+
+    [Fact]
+    public async Task ConcurrentAddsAndEnumerations_DoNotCorruptCollection()
+    {
+        const int resourceCount = 500;
+
+        var collection = new ResourceCollection();
+        var startGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var writer = Task.Run(async () =>
+        {
+            await startGate.Task;
+
+            for (var i = 0; i < resourceCount; i++)
+            {
+                collection.Add(new TestResource($"res{i}"));
+            }
+        });
+
+        var reader = Task.Run(async () =>
+        {
+            await startGate.Task;
+
+            // Enumerate continuously while the writer appends. Without snapshot-based reads this
+            // throws "Collection was modified; enumeration operation may not execute."
+            while (!writer.IsCompleted)
+            {
+                foreach (var resource in collection)
+                {
+                    Assert.StartsWith("res", resource.Name, StringComparison.Ordinal);
+                }
+            }
+        });
+
+        startGate.SetResult();
+        await Task.WhenAll(writer, reader).DefaultTimeout();
+
+        var enumerated = collection.ToList();
+
+        Assert.Equal(resourceCount, collection.Count);
+        Assert.Equal(resourceCount, enumerated.Count);
+        Assert.True(collection.TryGetByName($"res{resourceCount - 1}", out _));
+    }
+
+    [Fact]
+    public async Task ConcurrentAdds_KeepListAndNameIndexConsistent()
+    {
+        const int writerCount = 8;
+        const int perWriterCount = 250;
+
+        var collection = new ResourceCollection();
+        var startGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var writers = Enumerable.Range(0, writerCount).Select(writerIndex => Task.Run(async () =>
+        {
+            await startGate.Task;
+
+            for (var i = 0; i < perWriterCount; i++)
+            {
+                collection.Add(new TestResource($"res{writerIndex}-{i}"));
+            }
+        })).ToArray();
+
+        startGate.SetResult();
+        await Task.WhenAll(writers).DefaultTimeout();
+
+        // A torn List<T> append loses entries; a torn Dictionary write loses name lookups.
+        Assert.Equal(writerCount * perWriterCount, collection.Count);
+        Assert.Equal(writerCount * perWriterCount, collection.Select(resource => resource.Name).Distinct().Count());
+
+        foreach (var resource in collection)
+        {
+            Assert.True(collection.TryGetByName(resource.Name, out var found));
+            Assert.Same(resource, found);
+        }
     }
 
     private sealed class TestResource(string name) : Resource(name)

--- a/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ComputeEnvironmentValidationTests.cs
@@ -1,9 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable ASPIREPIPELINES001
+
 using System.Net.Sockets;
+using Aspire.Hosting.Pipelines;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting.Tests;
 
@@ -94,6 +98,53 @@ public class ComputeEnvironmentValidationTests
         Assert.Contains("Endpoint 'redis' must specify a port for scheme 'redis'.", ex.Message);
     }
 
+    [Fact]
+    public async Task MultipleComputeEnvironments_ModelMutatedDuringValidation_DoesNotThrow()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/19266.
+        //
+        // 'validate-compute-environments' is only wired as RequiredBy 'before-start', so the task
+        // DAG schedules it concurrently with every other step that shares that relationship —
+        // including 'azure-prepare-resources', which appends role-assignment and identity resources
+        // to the model. An append landing while validation enumerated model.Resources used to
+        // invalidate the enumerator ("Collection was modified; enumeration operation may not
+        // execute").
+        //
+        // Reproduce that interleaving deterministically rather than racing threads: the gate
+        // resource mutates the model from inside its Annotations getter, which validation invokes
+        // (via GetComputeEnvironment) while its enumerator over model.Resources is still in flight.
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var env1 = builder.AddResource(new TestComputeEnvironmentResource("env1"));
+        builder.AddResource(new TestComputeEnvironmentResource("env2"));
+
+        var gate = new AnnotationGateComputeResource("api");
+        builder.AddResource(gate).WithComputeEnvironment(env1);
+
+        // Validation must pull at least one more element after the gate fires, otherwise the
+        // mutation happens after enumeration has already finished and proves nothing.
+        builder.AddResource(new TestComputeResource("tail")).WithComputeEnvironment(env1);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        // Arming from a step that validation is required by guarantees the gate is inert during
+        // step resolution, which also reads Annotations, and armed by the time validation runs.
+        builder.Pipeline.AddStep(
+            "arm-model-mutation-gate",
+            _ =>
+            {
+                gate.Arm(() => model.Resources.Add(new TestResource("added-during-validation")));
+                return Task.CompletedTask;
+            },
+            requiredBy: WellKnownPipelineSteps.ValidateComputeEnvironments);
+
+        await app.ExecuteBeforeStartHooksAsync(default).DefaultTimeout();
+
+        Assert.True(gate.Fired, "The gate never fired, so the mutation did not overlap validation.");
+        Assert.Contains(model.Resources, resource => resource.Name == "added-during-validation");
+    }
+
     private static EndpointReference CreateEndpointReference(string uriScheme, int? port, int? targetPort)
     {
         var resource = new TestComputeResource("api");
@@ -113,5 +164,41 @@ public class ComputeEnvironmentValidationTests
 
     private sealed class TestComputeResource(string name) : Resource(name), IComputeResource, IResourceWithEndpoints
     {
+    }
+
+    private sealed class TestResource(string name) : Resource(name)
+    {
+    }
+
+    /// <summary>
+    /// A compute resource whose <see cref="Annotations"/> getter runs a one-shot callback once armed.
+    /// Compute-environment validation reads annotations (through <c>GetComputeEnvironment</c>) from
+    /// inside its enumeration of <c>model.Resources</c>, so the callback fires while that enumerator
+    /// is live. That makes it a deterministic stand-in for a concurrently scheduled pipeline step
+    /// mutating the model mid-enumeration, with no reliance on thread timing.
+    /// </summary>
+    private sealed class AnnotationGateComputeResource(string name) : Resource(name), IComputeResource
+    {
+        private Action? _onAnnotationsAccessed;
+
+        public bool Fired { get; private set; }
+
+        public void Arm(Action onAnnotationsAccessed) => Volatile.Write(ref _onAnnotationsAccessed, onAnnotationsAccessed);
+
+        public override ResourceAnnotationCollection Annotations
+        {
+            get
+            {
+                // Exchange so the callback runs exactly once even though annotations are read
+                // repeatedly during application build and step resolution.
+                if (Interlocked.Exchange(ref _onAnnotationsAccessed, null) is { } callback)
+                {
+                    Fired = true;
+                    callback();
+                }
+
+                return base.Annotations;
+            }
+        }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
+++ b/tests/Aspire.Hosting.Tests/Pipelines/DistributedApplicationPipelineTests.cs
@@ -978,6 +978,62 @@ public class DistributedApplicationPipelineTests(ITestOutputHelper testOutputHel
         Assert.True(executionTimes["D"] >= executionTimes["C"], "D should start after C completes");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_ConcurrentStepMutatingModel_DoesNotBreakEnumerationInAnotherStep()
+    {
+        // Regression test for https://github.com/microsoft/aspire/issues/19266.
+        // ExecuteStepsAsTaskDag runs steps with no ordering relationship concurrently, and every
+        // step shares one DistributedApplicationModel. A step appending a resource used to
+        // invalidate an in-flight enumerator in a peer step ("Collection was modified; enumeration
+        // operation may not execute"). Force that exact interleaving with a two-way handshake so
+        // the test never depends on thread timing.
+        using var builder = CreatePipelineTestBuilder();
+        builder.AddResource(new CustomResource("resource-1"));
+        builder.AddResource(new CustomResource("resource-2"));
+
+        var enumerationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var mutationCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var pipeline = new DistributedApplicationPipeline();
+
+        List<string>? observedResources = null;
+        pipeline.AddStep("reader", async ctx =>
+        {
+            var names = new List<string>();
+
+            using var enumerator = ctx.Model.Resources.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            names.Add(enumerator.Current.Name);
+
+            enumerationStarted.SetResult();
+            await mutationCompleted.Task;
+
+            while (enumerator.MoveNext())
+            {
+                names.Add(enumerator.Current.Name);
+            }
+
+            observedResources = names;
+        });
+
+        pipeline.AddStep("mutator", async ctx =>
+        {
+            await enumerationStarted.Task;
+            ctx.Model.Resources.Add(new CustomResource("added-by-mutator"));
+            mutationCompleted.SetResult();
+        });
+
+        var app = builder.Build();
+        var context = CreateDeployingContext(app);
+        await pipeline.ExecuteAsync(context).DefaultTimeout();
+
+        // The reader keeps serving the snapshot it started with, so it never observes the append.
+        Assert.NotNull(observedResources);
+        Assert.DoesNotContain("added-by-mutator", observedResources);
+        Assert.Contains("added-by-mutator", app.Services.GetRequiredService<DistributedApplicationModel>().Resources.Select(r => r.Name));
+    }
+
     private static PipelineContext CreateDeployingContext(DistributedApplication app)
     {
         return new PipelineContext(


### PR DESCRIPTION
## Description

`DistributedApplicationPipeline` executes steps that have no ordering relationship between them **concurrently** (`ExecuteStepsAsTaskDag`), and every step is handed the *same* `DistributedApplicationModel` instance. `DistributedApplicationModel.Resources` was backed by a plain `List<IResource>` with no synchronization at all, so a step appending a resource could invalidate an in-flight enumerator in a peer step:

```
System.InvalidOperationException : Step 'validate-compute-environments' failed: Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.OfTypeIterator[TResult](IEnumerable source)+MoveNext()
   at Aspire.Hosting.Pipelines.DistributedApplicationPipeline.ValidateComputeEnvironmentBindings(DistributedApplicationModel model)
```

This surfaced as an intermittent CI failure on the `Hosting.Azure` leg (1 failure out of 1669 tests).

### Root cause

The two steps involved are peers, not ordered:

| Step | Declared ordering |
| --- | --- |
| `validate-compute-environments` | `RequiredBySteps = [before-start]` only |
| `azure-prepare-resources` | `RequiredBySteps = [before-start]` only |

Neither depends on the other, so the task DAG starts both at the same time. `azure-prepare-resources` runs `AzureResourcePreparer.PrepareResourcesAsync`, which calls `appModel.Resources.Add(...)` to append role-assignment and user-assigned-identity resources, while `validate-compute-environments` is enumerating `model.Resources`. `prepare-cross-scope-acr-pull-identity-{name}` (required by `azure-prepare-resources`) appends resources too and has the same exposure.

Interestingly, `prepare-azure-container-apps-{name}` *does* depend on both `azure-prepare-resources` and `validate-compute-environments` — so ordering was considered elsewhere, just not for this pair.

The enumerator invalidation was only the visible symptom. Because `ResourceCollection` had no locking whatsoever, two concurrent `Add` calls could also corrupt the backing list and the name index.

### The fix

Make `ResourceCollection` safe for reads that are concurrent with mutations:

- Reads (enumeration, indexer get) are served from an immutable **copy-on-write snapshot**, so a reader gets a stable point-in-time view and never observes a torn state.
- The snapshot is built lazily and cached, so a burst of mutations (the common case during application build) costs one rebuild on the next read rather than one per mutation. The lock-free fast path means the steady state is a single volatile read.
- All mutations take a lock and invalidate the snapshot, which also protects the backing list and the name index from concurrent writers.

Fixing the collection rather than the single call site in the stack trace was deliberate: many other places enumerate the shared model from concurrently scheduled steps (`ValidateBuildOnlyContainerReferences`, `GetComputeResources()`, and user-authored pipeline steps), and they all had the same latent bug. Adding a local snapshot at the one failing call site would have papered over a systemic hazard.

Ordering the steps was considered and rejected: `AzureRoleAssignmentResource` and `AzureUserAssignedIdentityResource` are neither `IComputeResource` nor `IComputeEnvironmentResource`, so validation's *result* does not depend on whether the append has happened yet — only enumeration safety does. Serializing the pipeline would have cost concurrency for no semantic benefit and would not have fixed the concurrent-writer corruption.

`ResourceCollection` is `internal sealed` and is the only implementation of `IResourceCollection`, so there is no public API change.

### Validation

Three new deterministic regression tests, none of which rely on sleeps or thread timing:

- `ResourceCollectionTests.Enumeration_IsNotInvalidatedByConcurrentMutation` — drives the enumerator by hand, mutating between `MoveNext()` calls.
- `DistributedApplicationPipelineTests.ExecuteAsync_ConcurrentStepMutatingModel_DoesNotBreakEnumerationInAnotherStep` — two concurrent pipeline steps synchronized with a two-way `TaskCompletionSource` handshake, so the append is guaranteed to land mid-enumeration.
- `ComputeEnvironmentValidationTests.MultipleComputeEnvironments_ModelMutatedDuringValidation_DoesNotThrow` — pins the exact #19266 interleaving. A test resource mutates the model from inside its `Annotations` getter, which the real `ValidateComputeEnvironmentBindings` invokes (via `GetComputeEnvironment`) while its enumerator over `model.Resources` is still live. The gate is armed from a step wired `requiredBy: validate-compute-environments` so it is inert during step resolution.

Plus two concurrency stress tests covering list/name-index consistency under concurrent writers.

**Mutation tested.** With the `ResourceCollection` change reverted, 5 tests fail — including the pipeline-level one reproducing the exact production error string:

```
failed ComputeEnvironmentValidationTests.MultipleComputeEnvironments_ModelMutatedDuringValidation_DoesNotThrow
  System.InvalidOperationException : Step 'validate-compute-environments' failed: Collection was modified; enumeration operation may not execute.
```

With the fix restored, all 113 pass.

Test runs:

- `Aspire.Hosting.Tests` (full): 3232/3236 passed. The 2 distinct failures are `MSBuildTests.CliBundleDnxInvocationAllowsMissingBuildTimeBundle` — confirmed **pre-existing** by re-running them on a clean tree with all changes stashed.
- `Aspire.Hosting.Azure.Tests` (full, the leg that failed in CI): 1664 passed, 5 skipped, **0 failed**.
- `AzureResourcePreparerTests` (the originally failing class) run **25 consecutive times**: 25 passed, 0 failed. The original failure only reproduced under contention, so this builds confidence beyond the deterministic tests.

Fixes #19266

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No