### PR TITLE
Run VS Code extension E2E tests as non-blocking

### DIFF
--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -502,12 +502,12 @@ jobs:
           }
 
       - name: Run extension E2E tests
-        continue-on-error: ${{ matrix.allowFailure }}
         working-directory: extension
         env:
           ASPIRE_EXTENSION_E2E_VSIX: ${{ github.workspace }}/extension/out/aspire-extension.vsix
           ASPIRE_EXTENSION_E2E_SHARD: ${{ matrix.shardName }}
           ASPIRE_EXTENSION_E2E_SPEC: ${{ matrix.spec }}
+          ASPIRE_EXTENSION_E2E_ALLOW_TEST_FAILURE: ${{ matrix.allowFailure }}
           ASPIRE_EXTENSION_E2E_UNSET_CLI_START_TIMEOUT: ${{ matrix.unsetCliStartTimeout }}
           # Linux E2E jobs run under Xvfb, where ffmpeg recordings are compact
           # and useful for diagnosing timing-sensitive flakes after the fact.

--- a/.github/workflows/extension-e2e-tests.yml
+++ b/.github/workflows/extension-e2e-tests.yml
@@ -85,6 +85,7 @@ jobs:
         include:
           - name: Linux
             shardName: command-palette
+            allowFailure: true
             spec: out/test-e2e/test-e2e/commandPalette.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -93,6 +94,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: command-palette
+            allowFailure: true
             spec: out/test-e2e/test-e2e/commandPalette.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -101,6 +103,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: settings-files
+            allowFailure: true
             spec: out/test-e2e/test-e2e/settingsFiles.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -109,6 +112,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: settings-files
+            allowFailure: true
             spec: out/test-e2e/test-e2e/settingsFiles.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -117,6 +121,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: discovery-configuration
+            allowFailure: true
             spec: out/test-e2e/test-e2e/discoveryConfiguration.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -125,6 +130,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: discovery-configuration
+            allowFailure: true
             spec: out/test-e2e/test-e2e/discoveryConfiguration.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -133,6 +139,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: apphost-tree
+            allowFailure: true
             spec: out/test-e2e/test-e2e/appHostTree.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -141,6 +148,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: apphost-tree
+            allowFailure: true
             spec: out/test-e2e/test-e2e/appHostTree.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -149,6 +157,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: tree-actions
+            allowFailure: true
             spec: out/test-e2e/test-e2e/treeActions.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -157,6 +166,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: tree-actions
+            allowFailure: true
             spec: out/test-e2e/test-e2e/treeActions.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -165,6 +175,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: debug-dashboard
+            allowFailure: true
             spec: out/test-e2e/test-e2e/debugDashboard.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -173,6 +184,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: debug-dashboard
+            allowFailure: true
             spec: out/test-e2e/test-e2e/debugDashboard.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -181,6 +193,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: debug-startup-timeout
+            allowFailure: true
             spec: out/test-e2e/test-e2e/debugStartupTimeout.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -190,6 +203,7 @@ jobs:
             unsetCliStartTimeout: true
           - name: Windows
             shardName: debug-startup-timeout
+            allowFailure: true
             spec: out/test-e2e/test-e2e/debugStartupTimeout.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -199,6 +213,7 @@ jobs:
             unsetCliStartTimeout: true
           - name: Linux
             shardName: zero-to-running
+            allowFailure: true
             spec: out/test-e2e/test-e2e/zeroToRunning.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -207,6 +222,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: zero-to-running
+            allowFailure: true
             spec: out/test-e2e/test-e2e/zeroToRunning.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -215,6 +231,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: package-surface
+            allowFailure: true
             spec: out/test-e2e/test-e2e/packageSurface.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -223,6 +240,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: package-surface
+            allowFailure: true
             spec: out/test-e2e/test-e2e/packageSurface.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -231,6 +249,7 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: edge-cases
+            allowFailure: true
             spec: out/test-e2e/test-e2e/edgeCases.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
@@ -239,6 +258,7 @@ jobs:
             useXvfb: true
           - name: Windows
             shardName: edge-cases
+            allowFailure: true
             spec: out/test-e2e/test-e2e/edgeCases.e2e.test.js
             runner: windows-latest
             rid: win-x64
@@ -247,15 +267,13 @@ jobs:
             useXvfb: false
           - name: Linux
             shardName: azure-functions
+            allowFailure: true
             spec: out/test-e2e/test-e2e/azureFunctions.e2e.test.js
             runner: ubuntu-latest
             rid: linux-x64
             archivePattern: aspire-cli-linux-x64*.tar.gz
             cliBinary: aspire
             useXvfb: true
-            # Keep the shard visible in CI, but leave the Functions fixture disabled until
-            # the hosted Linux startup timeout is root-caused.
-            disabledIssue: 'https://github.com/microsoft/aspire/issues/19151'
             installAzureFunctions: true
     defaults:
       run:
@@ -362,13 +380,8 @@ jobs:
             Start-Sleep -Seconds $delay
           }
 
-      - name: Note skipped Azure Functions E2E shard
-        if: ${{ matrix.disabledIssue }}
-        run: |
-          Write-Host "::notice title=Azure Functions E2E shard skipped::${{ matrix.shardName }} is disabled pending ${{ matrix.disabledIssue }}."
-
       - name: Install Azure Functions E2E prerequisites
-        if: ${{ matrix.installAzureFunctions && !matrix.disabledIssue }}
+        if: ${{ matrix.installAzureFunctions }}
         shell: bash
         run: |
           set -euo pipefail
@@ -489,7 +502,7 @@ jobs:
           }
 
       - name: Run extension E2E tests
-        if: ${{ !matrix.disabledIssue }}
+        continue-on-error: ${{ matrix.allowFailure }}
         working-directory: extension
         env:
           ASPIRE_EXTENSION_E2E_VSIX: ${{ github.workspace }}/extension/out/aspire-extension.vsix

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -708,10 +708,7 @@ jobs:
 
   extension_e2e_tests:
     name: Run VS Code extension E2E tests
-    # Temporarily disabled: multiple VS Code extension E2E shards are failing in CI and blocking PRs.
-    # Keep the job defined so the trigger-map binding remains valid, but force it to skip until the
-    # failures are fixed. Re-enable by removing the `false &&` guard and restoring the gate checks below.
-    if: ${{ false && needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
+    if: ${{ needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
     uses: ./.github/workflows/extension-e2e-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux, build_cli_archive_windows, extension_tests_win, extension_bootstrap_linux]
 
@@ -829,9 +826,8 @@ jobs:
         #   bucket actually had work. Before selective CI these were always populated on a full run.
         # - cli_starter_validation_windows: this job only runs for pull requests and is expected to
         #   be skipped for other workflow events.
-        # - extension_e2e_tests: temporarily disabled because multiple E2E shards are failing. While
-        #   disabled, a 'skipped' result must not fail this gate. Restore the skip checks below when
-        #   re-enabling the job.
+        # - extension_e2e_tests: this job only runs when the PR/push changes the VS Code extension,
+        #   Aspire CLI, or the extension E2E workflow wiring.
         # - polyglot_validation: this job runs for pull requests and main branch builds; it is
         #   expected to be skipped for other workflow events.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
@@ -841,6 +837,8 @@ jobs:
                contains(needs.*.result, 'cancelled') ||
                (github.event_name == 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
+                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
+                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.cli_starter_validation_windows.result == 'skipped' && (needs.setup_for_tests.outputs.run_cli_starter == 'true')) ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
@@ -865,6 +863,8 @@ jobs:
                  (needs.polyglot_validation.result == 'skipped' && (needs.setup_for_tests.outputs.run_polyglot == 'true')))) ||
                (github.event_name != 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
+                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
+                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
                  needs.build_cli_archive_macos_x64.result == 'skipped' ||

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -708,7 +708,10 @@ jobs:
 
   extension_e2e_tests:
     name: Run VS Code extension E2E tests
-    if: ${{ needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
+    # Temporarily disabled: multiple VS Code extension E2E shards are failing in CI and blocking PRs.
+    # Keep the job defined so the trigger-map binding remains valid, but force it to skip until the
+    # failures are fixed. Re-enable by removing the `false &&` guard and restoring the gate checks below.
+    if: ${{ false && needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}
     uses: ./.github/workflows/extension-e2e-tests.yml
     needs: [setup_for_tests, build_packages, build_cli_archive_linux, build_cli_archive_windows, extension_tests_win, extension_bootstrap_linux]
 
@@ -826,8 +829,9 @@ jobs:
         #   bucket actually had work. Before selective CI these were always populated on a full run.
         # - cli_starter_validation_windows: this job only runs for pull requests and is expected to
         #   be skipped for other workflow events.
-        # - extension_e2e_tests: this job only runs when the PR/push changes the VS Code extension,
-        #   Aspire CLI, or the extension E2E workflow wiring.
+        # - extension_e2e_tests: temporarily disabled because multiple E2E shards are failing. While
+        #   disabled, a 'skipped' result must not fail this gate. Restore the skip checks below when
+        #   re-enabling the job.
         # - polyglot_validation: this job runs for pull requests and main branch builds; it is
         #   expected to be skipped for other workflow events.
         # All other jobs in this gate are required, and a 'skipped' result is treated as a failure.
@@ -837,8 +841,6 @@ jobs:
                contains(needs.*.result, 'cancelled') ||
                (github.event_name == 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
-                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
-                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.cli_starter_validation_windows.result == 'skipped' && (needs.setup_for_tests.outputs.run_cli_starter == 'true')) ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
@@ -863,8 +865,6 @@ jobs:
                  (needs.polyglot_validation.result == 'skipped' && (needs.setup_for_tests.outputs.run_polyglot == 'true')))) ||
                (github.event_name != 'pull_request' &&
                 ((needs.extension_tests_win.result == 'skipped' && (needs.setup_for_tests.outputs.run_extension_unit == 'true' || needs.setup_for_tests.outputs.run_extension_e2e == 'true')) ||
-                 (needs.setup_for_tests.outputs.run_extension_e2e == 'true' &&
-                  needs.extension_e2e_tests.result == 'skipped') ||
                  (needs.typescript_sdk_tests.result == 'skipped' &&
                   (needs.setup_for_tests.outputs.run_typescript_sdk == 'true')) ||
                  needs.build_cli_archive_macos_x64.result == 'skipped' ||

--- a/extension/scripts/e2e-mocha-results.cjs
+++ b/extension/scripts/e2e-mocha-results.cjs
@@ -1,0 +1,18 @@
+'use strict';
+
+function hasCompletedMochaTestFailures(results) {
+  if (!Array.isArray(results?.tests) || !Array.isArray(results?.failures) || results.failures.length === 0) {
+    return false;
+  }
+
+  // The reporter writes this shape only after Mocha emits EVENT_RUN_END:
+  //   { tests: [{ fullTitle: "suite test" }], failures: [{ fullTitle: "suite test" }] }
+  // Startup crashes and hook failures can appear without a completed matching test. Require every
+  // failure to match EVENT_TEST_END output so only actual test failures become advisory.
+  const completedTestTitles = new Set(results.tests.map(test => test.fullTitle ?? test.title));
+  return results.failures.every(failure => completedTestTitles.has(failure.fullTitle ?? failure.title));
+}
+
+module.exports = {
+  hasCompletedMochaTestFailures,
+};

--- a/extension/scripts/run-e2e.js
+++ b/extension/scripts/run-e2e.js
@@ -740,9 +740,7 @@ async function main() {
     throw testFailure;
   }
 
-  if (completedTests) {
-    printSuccessDiagnosticsSummary();
-  }
+  printSuccessDiagnosticsSummary();
 }
 
 async function runCleanupStep(name, action, cleanupErrors) {

--- a/extension/scripts/run-e2e.js
+++ b/extension/scripts/run-e2e.js
@@ -16,6 +16,7 @@ const {
   runWithRetries,
   terminateOrphanedDescendants,
 } = require('./e2e-download-retry');
+const { hasCompletedMochaTestFailures } = require('./e2e-mocha-results.cjs');
 
 const extensionRoot = path.resolve(__dirname, '..');
 const extensionPackageJson = JSON.parse(fs.readFileSync(path.join(extensionRoot, 'package.json'), 'utf8'));
@@ -87,6 +88,7 @@ const COMMAND_INERT_PATH_ALPHABET = isWindows ? '._-+@~:\\/' : '._-+,=:@%/';
 const primaryAppHostProject = path.join(workspaceRoot, 'AspireE2E.AppHost', 'AspireE2E.AppHost.csproj');
 const workspaceNuGetConfigPath = path.join(workspaceRoot, 'NuGet.config');
 const enableAzureFunctionsE2E = process.env.ASPIRE_EXTENSION_E2E_ENABLE_AZURE_FUNCTIONS === 'true';
+const allowTestFailure = process.env.ASPIRE_EXTENSION_E2E_ALLOW_TEST_FAILURE === 'true';
 let cliPathForCleanup;
 const csharpFileHeader = `// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
@@ -603,7 +605,7 @@ function waitForProcessClose(closed, timeoutMs) {
 async function main() {
   let recording;
   let testFailure;
-  let completedTests = false;
+  let cleanupFailed = false;
   try {
     if (verifyExtesterFeedOnly) {
       verifyExtesterFeed();
@@ -703,7 +705,6 @@ async function main() {
     catch (error) {
       testFailure = error;
     }
-    completedTests = true;
   }
   finally {
     const cleanupErrors = [];
@@ -716,6 +717,7 @@ async function main() {
     await runCleanupStep('cleanup temporary run root', cleanupTemporaryRunRoot, cleanupErrors);
 
     if (cleanupErrors.length > 0) {
+      cleanupFailed = true;
       const cleanupFailure = new AggregateError(cleanupErrors, 'One or more E2E cleanup steps failed.');
       if (testFailure) {
         console.error(cleanupFailure);
@@ -728,6 +730,13 @@ async function main() {
 
   if (testFailure) {
     printFailureDiagnosticsSummary();
+    // Setup failures throw past the run-tests catch, while the reporter's completed-test records
+    // distinguish assertion failures from ExTester startup, hook, crash, and timeout failures.
+    if (allowTestFailure && hasCompletedMochaTestFailures(readMochaResults()) && !cleanupFailed) {
+      console.warn(`::warning title=VS Code extension E2E test failure allowed::${shardName} failed during test execution. Diagnostics were uploaded for investigation.`);
+      return;
+    }
+
     throw testFailure;
   }
 

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -260,6 +260,7 @@ suite('E2E launch profile', () => {
         assert.ok(runner.includes('let cleanupFailed = false;'));
         assert.ok(runner.includes('cleanupFailed = true;'));
         assert.ok(runner.includes('if (allowTestFailure && hasCompletedMochaTestFailures(readMochaResults()) && !cleanupFailed)'));
+        assert.strictEqual(runner.includes('completedTests'), false);
     });
 
     test('keeps Linux E2E recordings for successful runs by default', () => {

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -231,14 +231,12 @@ suite('E2E launch profile', () => {
         const workflow = fs.readFileSync(path.join(extensionRoot, '..', '.github', 'workflows', 'extension-e2e-tests.yml'), 'utf8');
         const resourceGroupsInstallIndex = runner.indexOf("displayName: 'Azure Resource Groups'");
         const functionsInstallIndex = runner.indexOf("displayName: 'Azure Functions'");
-        const skipNoticeIndex = workflow.indexOf('Note skipped Azure Functions E2E shard');
         const runStepIndex = workflow.indexOf('- name: Run extension E2E tests');
         const uploadStepIndex = workflow.indexOf('- name: Upload E2E diagnostics');
         const runStep = workflow.slice(runStepIndex, uploadStepIndex);
 
         assert.ok(workflow.includes('shardName: azure-functions'));
         assert.ok(workflow.includes('installAzureFunctions: true'));
-        assert.ok(workflow.includes("disabledIssue: 'https://github.com/microsoft/aspire/issues/19151'"));
         assert.ok(workflow.includes("core_tools_version='4.12.1'"));
         assert.ok(workflow.includes('faf8fb8d50b5293df338bec70594b12f45730e9fe251805298859b2238cf627e'));
         assert.ok(workflow.includes('vscode-azureresourcegroups/0.12.7/vspackage'));
@@ -250,9 +248,18 @@ suite('E2E launch profile', () => {
         assert.ok(functionsInstallIndex > resourceGroupsInstallIndex);
         assert.ok(runner.includes("path: resolveRequiredVsixPath('ASPIRE_EXTENSION_E2E_AZURE_RESOURCE_GROUPS_VSIX')"));
         assert.ok(runner.includes("path: resolveRequiredVsixPath('ASPIRE_EXTENSION_E2E_AZURE_FUNCTIONS_VSIX')"));
-        assert.ok(skipNoticeIndex >= 0);
-        assert.ok(runStepIndex > skipNoticeIndex);
-        assert.ok(runStep.includes('if: ${{ !matrix.disabledIssue }}'));
+        assert.ok(runStep.includes('ASPIRE_EXTENSION_E2E_ALLOW_TEST_FAILURE: ${{ matrix.allowFailure }}'));
+        assert.strictEqual(runStep.includes('continue-on-error:'), false);
+    });
+
+    test('allows completed E2E test failures without hiding setup or cleanup failures', () => {
+        const extensionRoot = path.resolve(__dirname, '..', '..');
+        const runner = fs.readFileSync(path.join(extensionRoot, 'scripts', 'run-e2e.js'), 'utf8');
+
+        assert.ok(runner.includes("const allowTestFailure = process.env.ASPIRE_EXTENSION_E2E_ALLOW_TEST_FAILURE === 'true';"));
+        assert.ok(runner.includes('let cleanupFailed = false;'));
+        assert.ok(runner.includes('cleanupFailed = true;'));
+        assert.ok(runner.includes('if (allowTestFailure && hasCompletedMochaTestFailures(readMochaResults()) && !cleanupFailed)'));
     });
 
     test('keeps Linux E2E recordings for successful runs by default', () => {

--- a/extension/src/test/e2eMochaReporter.test.ts
+++ b/extension/src/test/e2eMochaReporter.test.ts
@@ -50,6 +50,31 @@ suite('E2E Mocha reporter', () => {
             fs.rmSync(tempDir, { recursive: true, force: true });
         }
     });
+
+    test('only classifies completed test failures as advisory', () => {
+        const { hasCompletedMochaTestFailures } = require(path.join(__dirname, '..', '..', 'scripts', 'e2e-mocha-results.cjs'));
+        const failedTest = {
+            title: 'starts an AppHost',
+            fullTitle: 'Aspire E2E starts an AppHost',
+        };
+
+        assert.strictEqual(hasCompletedMochaTestFailures({
+            tests: [failedTest],
+            failures: [failedTest],
+        }), true);
+        assert.strictEqual(hasCompletedMochaTestFailures(undefined), false);
+        assert.strictEqual(hasCompletedMochaTestFailures({
+            tests: [],
+            failures: [{ title: '"before all" hook', fullTitle: 'Aspire E2E "before all" hook' }],
+        }), false);
+        assert.strictEqual(hasCompletedMochaTestFailures({
+            tests: [failedTest],
+            failures: [
+                failedTest,
+                { title: '"after all" hook', fullTitle: 'Aspire E2E "after all" hook' },
+            ],
+        }), false);
+    });
 });
 
 function createReporterTest(title: string) {

--- a/extension/src/test/e2eShardMatrix.test.ts
+++ b/extension/src/test/e2eShardMatrix.test.ts
@@ -17,12 +17,7 @@ suite('E2E shard matrix', () => {
     // rather than something a workflow edit can do silently. Deriving this from the workflow would
     // make the assertion vacuous. Keys are `name|shardName|spec` and values are the tracking issue.
     // Add an entry when a row gains `disabledIssue`, and delete it when the shard is re-enabled.
-    const expectedDisabledRows = new Map<string, string>([
-        [
-            'Linux|azure-functions|out/test-e2e/test-e2e/azureFunctions.e2e.test.js',
-            'https://github.com/microsoft/aspire/issues/19151',
-        ],
-    ]);
+    const expectedDisabledRows = new Map<string, string>();
 
     function canonicalSpecPaths(specFileNames: readonly string[]): string[] {
         return specFileNames
@@ -60,6 +55,7 @@ suite('E2E shard matrix', () => {
                 name: optionalString(row, 'name', index),
                 shardName: optionalString(row, 'shardName', index),
                 spec: optionalString(row, 'spec', index),
+                allowFailure: optionalBoolean(row, 'allowFailure', index),
                 disabledIssue: optionalString(row, 'disabledIssue', index),
             };
         });
@@ -85,6 +81,16 @@ suite('E2E shard matrix', () => {
 
         assert.strictEqual(typeof value, 'string', `Expected extension_e2e matrix row ${index + 1} field '${key}' to be a string.`);
         return value as string;
+    }
+
+    function optionalBoolean(row: Record<string, unknown>, key: string, index: number): boolean | undefined {
+        const value = row[key];
+        if (value === undefined) {
+            return undefined;
+        }
+
+        assert.strictEqual(typeof value, 'boolean', `Expected extension_e2e matrix row ${index + 1} field '${key}' to be a boolean.`);
+        return value as boolean;
     }
 
     function matrixSpecPaths(workflow: string): string[] {
@@ -122,6 +128,15 @@ suite('E2E shard matrix', () => {
             'Disabled E2E matrix rows must exactly match the explicit allowlist in e2eShardMatrix.test.ts.');
     }
 
+    function assertAllRowsAllowFailure(workflow: string): void {
+        for (const row of matrixRows(workflow)) {
+            assert.strictEqual(
+                row.allowFailure,
+                true,
+                `E2E matrix row '${row.name}|${row.shardName}|${row.spec}' must set allowFailure: true.`);
+        }
+    }
+
     function assertMatrixMatchesSpecs(workflow: string, specFileNames: readonly string[]): void {
         assert.deepStrictEqual(
             matrixSpecPaths(workflow),
@@ -148,6 +163,7 @@ suite('E2E shard matrix', () => {
         assert.ok(canonicalSpecPaths(specFileNames).length > 0, `Expected E2E spec files under ${specDirectory}.`);
         assert.ok(matrixSpecPaths(workflow).length > 0, 'Expected spec entries in the E2E workflow matrix.');
         assertMatrixMatchesSpecs(workflow, specFileNames);
+        assertAllRowsAllowFailure(workflow);
         assertDisabledRowsAreTracked(workflow, expectedDisabledRows);
     });
 
@@ -263,5 +279,6 @@ interface MatrixRow {
     name?: string;
     shardName?: string;
     spec?: string;
+    allowFailure?: boolean;
     disabledIssue?: string;
 }

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
@@ -9,13 +9,13 @@ namespace Infrastructure.Tests.Pipelines;
 /// <summary>
 /// Guards the advisory-failure contract in <c>.github/workflows/extension-e2e-tests.yml</c>.
 ///
-/// Every shard still runs and produces diagnostics, but test failures are temporarily non-blocking.
-/// Setup, compilation, and other harness failures remain blocking because only the test step uses
-/// <c>continue-on-error</c>.
+/// Every shard still runs and produces diagnostics, but failures from the VS Code test execution
+/// are temporarily non-blocking. Setup before test execution and cleanup remain blocking.
 /// </summary>
 public sealed class ExtensionE2eWorkflowTests
 {
     private const string WorkflowRelativePath = ".github/workflows/extension-e2e-tests.yml";
+    private const string CallerWorkflowRelativePath = ".github/workflows/tests.yml";
 
     [Fact]
     public void AllShardRowsRunWithAllowedTestFailures()
@@ -30,7 +30,30 @@ public sealed class ExtensionE2eWorkflowTests
         var steps = ((YamlSequenceNode)job.Children[new YamlScalarNode("steps")]).Cast<YamlMappingNode>().ToList();
         var runSuiteStep = Assert.Single(steps, step => Scalar(step, "name") == "Run extension E2E tests");
         Assert.Null(Scalar(runSuiteStep, "if"));
-        Assert.Equal("${{ matrix.allowFailure }}", Scalar(runSuiteStep, "continue-on-error"));
+        Assert.Null(Scalar(runSuiteStep, "continue-on-error"));
+
+        var environment = (YamlMappingNode)runSuiteStep.Children[new YamlScalarNode("env")];
+        Assert.Equal("${{ matrix.allowFailure }}", Scalar(environment, "ASPIRE_EXTENSION_E2E_ALLOW_TEST_FAILURE"));
+    }
+
+    [Fact]
+    public void SelectedExtensionE2eWorkflowMustRun()
+    {
+        var yaml = new YamlStream();
+        using var reader = new StringReader(File.ReadAllText(Path.Combine(RepoRoot.Path, CallerWorkflowRelativePath)));
+        yaml.Load(reader);
+
+        var root = (YamlMappingNode)yaml.Documents[0].RootNode;
+        var jobs = (YamlMappingNode)root.Children[new YamlScalarNode("jobs")];
+        var extensionE2eJob = (YamlMappingNode)jobs.Children[new YamlScalarNode("extension_e2e_tests")];
+        Assert.Equal("${{ needs.setup_for_tests.outputs.run_extension_e2e == 'true' }}", Scalar(extensionE2eJob, "if"));
+
+        var resultsJob = (YamlMappingNode)jobs.Children[new YamlScalarNode("results")];
+        var steps = (YamlSequenceNode)resultsJob.Children[new YamlScalarNode("steps")];
+        var failureStep = Assert.Single(steps.Cast<YamlMappingNode>(), step => Scalar(step, "name") == "Fail if any dependency failed");
+        var condition = Scalar(failureStep, "if");
+        const string unexpectedSkipCheck = "needs.extension_e2e_tests.result == 'skipped'";
+        Assert.Equal(2, condition?.Split(unexpectedSkipCheck, StringSplitOptions.None).Length - 1);
     }
 
     private static YamlMappingNode LoadExtensionE2eJob()

--- a/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
+++ b/tests/Infrastructure.Tests/Pipelines/ExtensionE2eWorkflowTests.cs
@@ -7,74 +7,30 @@ using YamlDotNet.RepresentationModel;
 namespace Infrastructure.Tests.Pipelines;
 
 /// <summary>
-/// Guards the shard-disable contract in <c>.github/workflows/extension-e2e-tests.yml</c>.
+/// Guards the advisory-failure contract in <c>.github/workflows/extension-e2e-tests.yml</c>.
 ///
-/// A shard row is disabled by adding <c>disabledIssue</c> to its matrix entry, which keeps the job
-/// visible in the checks list while the underlying fixture is broken. That only works if every step
-/// the disabled shard cannot survive is guarded by the same condition: guarding the prerequisite
-/// installation alone leaves the suite itself running against missing prerequisites, so the shard
-/// fails anyway (or worse, passes without running anything and hides the disable).
+/// Every shard still runs and produces diagnostics, but test failures are temporarily non-blocking.
+/// Setup, compilation, and other harness failures remain blocking because only the test step uses
+/// <c>continue-on-error</c>.
 /// </summary>
 public sealed class ExtensionE2eWorkflowTests
 {
     private const string WorkflowRelativePath = ".github/workflows/extension-e2e-tests.yml";
-    private const string DisabledGuard = "!matrix.disabledIssue";
 
     [Fact]
-    public void DisabledShardRowsSkipEveryShardOnlyStep()
+    public void AllShardRowsRunWithAllowedTestFailures()
     {
         var job = LoadExtensionE2eJob();
 
-        var disabledRows = MatrixIncludeRows(job)
-            .Where(row => row.Children.ContainsKey(new YamlScalarNode("disabledIssue")))
-            .ToList();
-        Assert.NotEmpty(disabledRows);
+        var rows = MatrixIncludeRows(job).ToList();
+        Assert.NotEmpty(rows);
+        Assert.All(rows, row => Assert.Equal("true", Scalar(row, "allowFailure")));
+        Assert.All(rows, row => Assert.False(row.Children.ContainsKey(new YamlScalarNode("disabledIssue"))));
 
         var steps = ((YamlSequenceNode)job.Children[new YamlScalarNode("steps")]).Cast<YamlMappingNode>().ToList();
-
-        // The suite itself. Without the guard the disabled shard still runs the E2E tests, which is
-        // exactly what `disabledIssue` is supposed to prevent.
-        var runSuiteSteps = steps.Where(step => Scalar(step, "run")?.Contains("run-e2e.js", StringComparison.Ordinal) == true).ToList();
-        Assert.NotEmpty(runSuiteSteps);
-        foreach (var step in runSuiteSteps)
-        {
-            var condition = Scalar(step, "if");
-            Assert.True(
-                condition?.Contains(DisabledGuard, StringComparison.Ordinal) == true,
-                $"Step '{Scalar(step, "name")}' runs the E2E suite but is not guarded by '{DisabledGuard}' (if: {condition ?? "<none>"}).");
-        }
-
-        // Shard-specific setup. Any step conditioned on a matrix capability flag belongs to one
-        // shard only, so a disabled row must skip it too - otherwise the row keeps paying for (and
-        // can keep failing on) setup for a suite that never runs.
-        var shardSetupSteps = steps
-            .Where(step => Scalar(step, "if") is { } condition
-                && condition.Contains("matrix.installAzureFunctions", StringComparison.Ordinal))
-            .ToList();
-        Assert.NotEmpty(shardSetupSteps);
-        foreach (var step in shardSetupSteps)
-        {
-            var condition = Scalar(step, "if")!;
-            Assert.True(
-                condition.Contains(DisabledGuard, StringComparison.Ordinal),
-                $"Step '{Scalar(step, "name")}' is shard-specific setup but is not guarded by '{DisabledGuard}' (if: {condition}).");
-        }
-    }
-
-    [Fact]
-    public void DisabledShardRowsAnnounceWhyTheyAreSkipped()
-    {
-        var job = LoadExtensionE2eJob();
-        var steps = ((YamlSequenceNode)job.Children[new YamlScalarNode("steps")]).Cast<YamlMappingNode>();
-
-        // A green shard that ran nothing is indistinguishable from a green shard that passed unless
-        // the job says so, so the disable has to be visible in the run itself.
-        var noticeStep = steps.FirstOrDefault(step =>
-            Scalar(step, "if")?.Contains("matrix.disabledIssue", StringComparison.Ordinal) == true
-            && Scalar(step, "if")?.Contains(DisabledGuard, StringComparison.Ordinal) != true);
-
-        Assert.NotNull(noticeStep);
-        Assert.Contains("matrix.disabledIssue", Scalar(noticeStep, "run"), StringComparison.Ordinal);
+        var runSuiteStep = Assert.Single(steps, step => Scalar(step, "name") == "Run extension E2E tests");
+        Assert.Null(Scalar(runSuiteStep, "if"));
+        Assert.Equal("${{ matrix.allowFailure }}", Scalar(runSuiteStep, "continue-on-error"));
     }
 
     private static YamlMappingNode LoadExtensionE2eJob()


### PR DESCRIPTION
## Description

The VS Code extension E2E shards are currently failing in CI and blocking PRs:

- Linux `apphost-tree`
- Windows `discovery-configuration`

Keep the `extension_e2e_tests` workflow enabled, but make failures from VS Code test execution non-blocking for every shard. All 21 shards, including Azure Functions, still run and upload diagnostics. Pre-test setup, dependency installation, compilation, and cleanup failures remain blocking.

The aggregate results gate still requires the reusable E2E workflow to run whenever extension E2E coverage is selected.

Validation:

- `dotnet test --project tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-launch-profile -- --filter-class "*.ExtensionE2eWorkflowTests" --filter-class "*.TestTriggerMapTests" --filter-class "*.SelectTestsWorkflowTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"` (21 passed)
- `git diff --check`

Addresses #19277

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
