### PR TITLE
Stabilize AppHost tree discovery E2E

### DIFF
--- a/extension/src/test-e2e/appHostTree.e2e.test.ts
+++ b/extension/src/test-e2e/appHostTree.e2e.test.ts
@@ -186,23 +186,21 @@ suite('Aspire AppHost tree E2E', function () {
         await waitForCommandOutcome('aspire-vscode.runAppHost', 'success');
         await waitForRunningAppHost();
 
-        // The loading welcome text is transient. Gate both ps and ls so the test
-        // observes loading before any runtime snapshot can restore the running AppHost.
+        // Gate both refresh paths so the running AppHost can be asserted before workspace
+        // discovery produces a candidate, without depending on the transient loading state.
         const discoveryGate = writeGatedStreamingDiscoveryCliWrapper();
         await setE2eCliPathForE2E(discoveryGate.cliPath);
         const invocationCountBefore = getCommandInvocationCount('aspire-vscode.refreshAppHosts');
         try {
             await executeE2eControlCommand({ name: 'refreshAppHosts' }, { waitFor: 'started' });
 
-            await waitForWorkspaceRediscoveryLoading('workspace AppHost refresh loading state before running AppHost refresh');
-
-            discoveryGate.releasePsSnapshot();
+            await discoveryGate.waitForPsSnapshotRequest();
+            await discoveryGate.waitForLsCandidateRequest();
             const runningBeforeDiscovery = await waitForExtensionState(
-                file => !file.state.isRepositoryLoading
-                    && file.state.isWorkspaceAppHostDiscoveryComplete === false
+                file => file.state.isWorkspaceAppHostDiscoveryComplete === false
                     && file.state.workspaceAppHostCandidatePaths.length === 0
                     && findRunningAppHost(file.state) !== undefined,
-                'running AppHost to clear loading before workspace discovery produces a candidate',
+                'running AppHost before workspace discovery produces a candidate',
                 30000);
             assert.ok(findRunningAppHost(runningBeforeDiscovery.state));
 
@@ -210,6 +208,7 @@ suite('Aspire AppHost tree E2E', function () {
             const runningItem = await waitForTreeItem(section, appHostLabel);
             assert.strictEqual(await runningItem.getLabel(), appHostLabel);
 
+            discoveryGate.releasePsSnapshot();
             discoveryGate.releaseLsCandidate();
             const candidateAfterRunning = await waitForExtensionState(
                 file => file.state.isWorkspaceAppHostDiscoveryComplete === false

--- a/extension/src/test-e2e/helpers/fixtures.ts
+++ b/extension/src/test-e2e/helpers/fixtures.ts
@@ -242,8 +242,16 @@ export function writeStreamingDiscoveryCliWrapper(delayMs = 5_000, initialDelayM
     });
 }
 
-export function writeGatedStreamingDiscoveryCliWrapper(): { cliPath: string; releasePsSnapshot: () => void; releaseLsCandidate: () => void } {
+export function writeGatedStreamingDiscoveryCliWrapper(): {
+    cliPath: string;
+    waitForPsSnapshotRequest: () => Promise<void>;
+    waitForLsCandidateRequest: () => Promise<void>;
+    releasePsSnapshot: () => void;
+    releaseLsCandidate: () => void;
+} {
     const gateDirectory = path.join(getWorkspaceRoot(), '.e2e-cli-wrappers', 'gated-streaming-discovery');
+    const psSnapshotRequestFilePath = path.join(gateDirectory, 'ps-snapshot-request');
+    const lsCandidateRequestFilePath = path.join(gateDirectory, 'ls-candidate-request');
     const psSnapshotReleaseFilePath = path.join(gateDirectory, 'release-ps-snapshot');
     const lsCandidateReleaseFilePath = path.join(gateDirectory, 'release-ls-candidate');
     removePath(gateDirectory, { recursive: true, force: true });
@@ -258,12 +266,16 @@ export function writeGatedStreamingDiscoveryCliWrapper(): { cliPath: string; rel
             selected: true,
         },
         streamedLsDelayMs: 5_000,
+        streamedLsRequestFilePath: lsCandidateRequestFilePath,
         streamedLsReleaseFilePath: lsCandidateReleaseFilePath,
+        psSnapshotRequestFilePath,
         psSnapshotReleaseFilePath,
     });
 
     return {
         cliPath,
+        waitForPsSnapshotRequest: () => waitForPath(psSnapshotRequestFilePath, 30_000),
+        waitForLsCandidateRequest: () => waitForPath(lsCandidateRequestFilePath, 30_000),
         releasePsSnapshot: () => writeFileWithRetry(psSnapshotReleaseFilePath, ''),
         releaseLsCandidate: () => writeFileWithRetry(lsCandidateReleaseFilePath, ''),
     };
@@ -763,10 +775,12 @@ function writeCliWrapper(
         streamedLsCandidate?: unknown;
         streamedLsDelayMs?: number;
         streamedLsInitialDelayMs?: number;
+        streamedLsRequestFilePath?: string;
         streamedLsReleaseFilePath?: string;
         streamedLsInvocationLogPath?: string;
         invocationLogPath?: string;
         psSnapshotDelayMs?: number;
+        psSnapshotRequestFilePath?: string;
         psSnapshotReleaseFilePath?: string;
     },
 ): string {
@@ -814,6 +828,7 @@ ${options.streamedLsInvocationLogPath === undefined ? '' : `  fs.appendFileSync(
     process.exit(126);
   }
 
+${options.streamedLsRequestFilePath === undefined ? '' : `  fs.writeFileSync(${JSON.stringify(options.streamedLsRequestFilePath)}, '');`}
 ${options.streamedLsReleaseFilePath === undefined ? '' : `  waitForReleaseFile(${JSON.stringify(options.streamedLsReleaseFilePath)}, 'streamed ls candidate');`}
   setTimeout(() => {
     console.log(${JSON.stringify(JSON.stringify(options.streamedLsCandidate))});
@@ -822,6 +837,7 @@ ${options.streamedLsReleaseFilePath === undefined ? '' : `  waitForReleaseFile($
 }
 else {`}
 if (args[0] === 'ps') {
+${options.psSnapshotRequestFilePath === undefined ? '' : `  fs.writeFileSync(${JSON.stringify(options.psSnapshotRequestFilePath)}, '');`}
 ${options.psSnapshotReleaseFilePath === undefined ? '' : `  waitForReleaseFile(${JSON.stringify(options.psSnapshotReleaseFilePath)}, 'ps snapshot');`}
   if (!args.includes('--follow')) {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${options.psSnapshotDelayMs ?? 0});

--- a/extension/src/test/e2eLaunchProfile.test.ts
+++ b/extension/src/test/e2eLaunchProfile.test.ts
@@ -516,7 +516,7 @@ suite('E2E launch profile', () => {
         assert.ok(!debugDashboard.includes("file => file.state.stoppingPaths.some(stoppingPath => isSamePath(stoppingPath, appHostPath))"));
     });
 
-    test('gates slow AppHost discovery before asserting transient loading UI', () => {
+    test('waits for durable AppHost discovery gates before asserting running state', () => {
         const extensionRoot = path.resolve(__dirname, '..', '..');
         const fixtures = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'helpers', 'fixtures.ts'), 'utf8');
         const appHostTree = fs.readFileSync(path.join(extensionRoot, 'src', 'test-e2e', 'appHostTree.e2e.test.ts'), 'utf8');
@@ -524,19 +524,26 @@ suite('E2E launch profile', () => {
 
         assert.ok(fixtures.includes('writeGatedStreamingDiscoveryCliWrapper'));
         assert.ok(fixtures.includes('function waitForReleaseFile'));
+        assert.ok(fixtures.includes('waitForPsSnapshotRequest: () => waitForPath(psSnapshotRequestFilePath, 30_000)'));
+        assert.ok(fixtures.includes('waitForLsCandidateRequest: () => waitForPath(lsCandidateRequestFilePath, 30_000)'));
         assert.ok(appHostTree.includes('writeGatedStreamingDiscoveryCliWrapper'));
         assert.ok(appHostTree.includes('discoveryGate.releasePsSnapshot();'));
         assert.ok(appHostTree.includes('discoveryGate.releaseLsCandidate();'));
+        assert.ok(!runningBeforeDiscoveryTest.includes('waitForWorkspaceRediscoveryLoading'));
 
         const cleanupIndex = runningBeforeDiscoveryTest.indexOf('finally {');
         assert.ok(cleanupIndex >= 0, 'Expected the E2E to keep cleanup releases in a finally block.');
         const testBeforeCleanup = runningBeforeDiscoveryTest.slice(0, cleanupIndex);
-        const loadingIndex = testBeforeCleanup.indexOf('await waitForWorkspaceRediscoveryLoading');
+        const waitForPsRequestIndex = testBeforeCleanup.indexOf('await discoveryGate.waitForPsSnapshotRequest();');
+        const waitForLsRequestIndex = testBeforeCleanup.indexOf('await discoveryGate.waitForLsCandidateRequest();');
+        const runningStateIndex = testBeforeCleanup.indexOf('const runningBeforeDiscovery = await waitForExtensionState');
         const releasePsIndex = testBeforeCleanup.indexOf('discoveryGate.releasePsSnapshot();');
         const releaseLsIndex = testBeforeCleanup.indexOf('discoveryGate.releaseLsCandidate();');
 
-        assert.ok(loadingIndex >= 0, 'The E2E must wait for the transient loading UI before releasing the running AppHost snapshot.');
-        assert.ok(releasePsIndex > loadingIndex, 'The running AppHost snapshot must be released after the loading UI has been observed.');
+        assert.ok(waitForPsRequestIndex >= 0, 'The E2E must wait until the running AppHost snapshot reaches its gate.');
+        assert.ok(waitForLsRequestIndex > waitForPsRequestIndex, 'The E2E must wait until workspace discovery reaches its gate.');
+        assert.ok(runningStateIndex > waitForLsRequestIndex, 'The running AppHost must be asserted only after both refresh paths are gated.');
+        assert.ok(releasePsIndex > runningStateIndex, 'The running AppHost snapshot must remain gated until the running AppHost is observed.');
         assert.ok(releaseLsIndex > releasePsIndex, 'The slow workspace candidate must be released after the running AppHost snapshot.');
     });
 


### PR DESCRIPTION
## Description

The AppHost tree E2E could time out while waiting to observe a transient repository loading state even though the running AppHost was already visible. An existing `describe --follow` update could clear that state between the test's polling intervals.

This replaces the transient-state dependency with durable marker files that confirm the fresh `ps` and `ls` requests have reached their gates. The test then verifies the intended behavior: the running AppHost remains visible before slow workspace discovery produces a candidate.

Validation:

- `extension/build.sh`
- Targeted E2E launch-profile regression test
- TypeScript E2E compilation and extension lint
- Formerly flaky E2E scenario: 5/5 repetitions on the original PR head and 3/3 repetitions from current `main`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
