### PR TITLE
Close the dashboard debug browser when the Aspire session ends

### DIFF
--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -932,7 +932,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
 
   /**
    * Opens the dashboard URL in the specified browser.
-   * For debugChrome/debugEdge/debugFirefox, launches as a child debug session that auto-closes with the Aspire debug session.
+   * For debugChrome/debugEdge/debugFirefox, launches as a child debug session that is stopped
+   * explicitly when this Aspire session is disposed.
    */
   async openDashboard(url: string, browserType: DashboardBrowserType): Promise<void> {
     extensionLogOutputChannel.info(`Opening dashboard in browser: ${browserType}.`);
@@ -966,7 +967,8 @@ export class AspireDebugSession implements vscode.DebugAdapter {
 
   /**
    * Launches a browser as a child debug session.
-   * The browser will automatically close when the parent Aspire debug session ends.
+   * VS Code does not stop this child session when the parent Aspire session terminates, so the
+   * started session is tracked here and stopped explicitly from `dispose` via `closeDashboard`.
    */
   private async launchDebugBrowser(url: string, debugType: 'pwa-chrome' | 'pwa-msedge' | 'firefox'): Promise<void> {
     const debugConfig: vscode.DebugConfiguration = {
@@ -987,15 +989,26 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       debugConfig.pathMappings = [];
     }
 
-    // Register listener before starting so we don't miss the event
+    // Register listener before starting so we don't miss the event.
+    // The started session must be matched to *this* Aspire session: concurrent Aspire
+    // debug sessions all launch their dashboard with the same configuration name and
+    // browser type, so name and type alone would let one session adopt (and later close)
+    // another session's browser.
     const disposable = vscode.debug.onDidStartDebugSession((session) => {
-      if (session.configuration.name === aspireDashboard && session.type === debugType) {
+      if (session.parentSession?.id === this._session.id && session.configuration.name === aspireDashboard && session.type === debugType) {
         this._dashboardDebugSession = session;
         disposable.dispose();
+
+        // The Aspire session can be disposed while the browser is still launching, for
+        // example when the AppHost exits right after reporting the dashboard URL. Run the
+        // close path again here so the late-arriving browser is not left orphaned.
+        if (this._disposed) {
+          this.closeDashboard();
+        }
       }
     });
 
-    // Start as a child debug session - it will close when parent closes
+    // Start as a child debug session so it is stopped alongside this session in `dispose`.
     const didStart = await vscode.debug.startDebugging(
       undefined,
       debugConfig,
@@ -1005,6 +1018,13 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     if (!didStart) {
       disposable.dispose();
       extensionLogOutputChannel.warn(`Failed to start debug browser (${debugType}), falling back to default browser`);
+
+      // Falling back after disposal would pop an untracked browser window open during
+      // teardown, long after the user stopped the session.
+      if (this._disposed) {
+        return;
+      }
+
       await vscode.env.openExternal(vscode.Uri.parse(url));
     }
   }

--- a/extension/src/debugger/AspireDebugSession.ts
+++ b/extension/src/debugger/AspireDebugSession.ts
@@ -1031,6 +1031,10 @@ export class AspireDebugSession implements vscode.DebugAdapter {
     const debugSessionId = this.debugSessionId;
     const dcpServer = this._dcpServer;
 
+    // Dashboard debug browser sessions do not reliably stop when VS Code terminates
+    // their parent session.
+    this.closeDashboard();
+
     // Stop child debug sessions first so their `sessionTerminated`
     // notifications can flow back through `AspireDcpServer.sendNotification`
     // and update the aggregate stats BEFORE we snapshot them for
@@ -1103,10 +1107,7 @@ export class AspireDebugSession implements vscode.DebugAdapter {
       this._dashboardDebugSession = null;
       return;
     }
-    // At this point there is no tracked dashboard debug session to stop.
-    // Any debug browser child sessions (debugChrome, debugEdge, debugFirefox) will
-    // automatically close when the parent Aspire session is stopped, so no further
-    // cleanup is required here.
+    // No dashboard debug session was started or its launch did not complete.
   }
 
   private sendResponse(request: any, body: any = {}) {

--- a/extension/src/test-e2e/debugDashboard.e2e.test.ts
+++ b/extension/src/test-e2e/debugDashboard.e2e.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import { getCommandInvocationCount, getDebugLaunchCount, getStoppingPathEventCount, getTreeAppHostLabel, isSamePath, waitForAppHostLaunching, waitForCommandOutcome, waitForDebugConsoleOutput, waitForDebugDashboardUrl, waitForDebugLaunch, waitForDebugSessionStartup, waitForExtensionState, waitForHttpText, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForRunningAppHost, waitForStoppingPathEvent, waitForWorkspaceAppHost } from './helpers/assertions';
+import { getBrowserDebugSessions, getCommandInvocationCount, getDebugLaunchCount, getStoppingPathEventCount, getTreeAppHostLabel, isSamePath, waitForAppHostLaunching, waitForBrowserDebugSession, waitForCommandOutcome, waitForDebugConsoleOutput, waitForDebugDashboardUrl, waitForDebugLaunch, waitForDebugSessionStartup, waitForExtensionState, waitForHttpText, waitForNoBrowserDebugSessions, waitForNoDebugSessions, waitForNoRunningAppHost, waitForRepositoryIdle, waitForRunningAppHost, waitForStoppingPathEvent, waitForWorkspaceAppHost } from './helpers/assertions';
 import { executeE2eControlCommand, resetDashboardDefaultChangedNotificationForE2E, restoreWorkspaceCliPath, runE2eTeardown, setCliUnavailableForE2E, setShowStatusDelayForE2E, stopPrimaryAppHostIfRunning, writeFileWithRetry, writeWorkspaceSetting } from './helpers/fixtures';
 import { getPrimaryAppHostProjectPath } from './helpers/paths';
 import { openAspireView, waitForEditorTitle, waitForNotificationMessage, waitForTreeItem, waitForWorkbenchTextAfterIntegratedBrowserNavigation } from './helpers/vscode';
@@ -20,6 +20,7 @@ suite('Aspire debug dashboard E2E', function () {
             () => executeE2eControlCommand({ name: 'stopDebugging' }),
             () => stopPrimaryAppHostIfRunning(),
             () => waitForNoDebugSessions().catch(() => undefined),
+            () => waitForNoBrowserDebugSessions(15000).catch(() => undefined),
             () => waitForNoRunningAppHost().catch(() => undefined),
         ], 'Debug dashboard E2E teardown failed.');
     });
@@ -89,8 +90,42 @@ suite('Aspire debug dashboard E2E', function () {
         await waitForNoDebugSessions();
     });
 
-    test('workspace debug stop removes running apphost', async () => {
+    test('closes the dashboard debug browser when the AppHost debug session stops', async () => {
+        writeWorkspaceSetting('aspire.dashboardBrowser', 'debugChrome');
+
         await openAspireView();
+        await waitForRepositoryIdle();
+        const discovered = await waitForWorkspaceAppHost();
+        const appHostPath = discovered.state.workspaceAppHostPath ?? getPrimaryAppHostProjectPath();
+
+        const before = getCommandInvocationCount('aspire-vscode.debugAppHost');
+        await executeE2eControlCommand({ name: 'debugAppHost', appHostPath }, { waitFor: 'started' });
+        await waitForCommandOutcome('aspire-vscode.debugAppHost', 'success', 60000, before);
+
+        await waitForDebugSessionStartup();
+
+        // The debug browser is only launched once the dashboard URL is known, so wait for that
+        // milestone separately. Folding both waits into one budget makes a slow dashboard start
+        // look like a missing browser session.
+        await waitForDebugDashboardUrl();
+
+        const browserSession = await waitForBrowserDebugSession();
+        assert.deepStrictEqual(
+            getBrowserDebugSessions().filter(session => session.parentSessionType === 'aspire').map(session => ({ id: session.id, type: session.type })),
+            [{ id: browserSession.id, type: 'pwa-chrome' }]);
+
+        await executeE2eControlCommand({ name: 'stopDebugging' });
+        await waitForNoDebugSessions();
+
+        // The Aspire session ending is not enough on its own. VS Code leaves the child browser
+        // session running unless the extension stops it explicitly, which is what left orphaned
+        // dashboard browsers behind in https://github.com/microsoft/aspire/issues/19289. Asserting
+        // on the extension's own debugSessions cannot catch that regression: it was already empty
+        // while the browser kept running.
+        await waitForNoBrowserDebugSessions();
+    });
+
+    test('workspace debug stop removes running apphost', async () => {
         await waitForRepositoryIdle();
         const discovered = await waitForWorkspaceAppHost();
         const appHostPath = discovered.state.workspaceAppHostPath ?? getPrimaryAppHostProjectPath();

--- a/extension/src/test-e2e/debugDashboard.e2e.test.ts
+++ b/extension/src/test-e2e/debugDashboard.e2e.test.ts
@@ -90,7 +90,16 @@ suite('Aspire debug dashboard E2E', function () {
         await waitForNoDebugSessions();
     });
 
-    test('closes the dashboard debug browser when the AppHost debug session stops', async () => {
+    test('closes the dashboard debug browser when the AppHost debug session stops', async function () {
+        // js-debug cannot launch Chrome under the Linux xvfb runner: it activates on
+        // `onDebugResolve:pwa-chrome` and then never resolves `startDebugging`. Because
+        // `openDashboard` awaits that launch, the AppHost startup handshake stalls and every
+        // later test in this file fails too. Windows runs the real browser, so the shutdown
+        // behavior still gets end-to-end coverage there.
+        if (process.platform !== 'win32') {
+            this.skip();
+        }
+
         writeWorkspaceSetting('aspire.dashboardBrowser', 'debugChrome');
 
         await openAspireView();

--- a/extension/src/test-e2e/helpers/assertions.ts
+++ b/extension/src/test-e2e/helpers/assertions.ts
@@ -6,6 +6,7 @@ import type { AspireAppHostState as AppHostState, AspireDebugSessionState, Aspir
 import { getControlFilePath, getPrimaryAppHostProjectPath, getStateFilePath, getWorkspaceRoot } from './paths';
 
 type CommandInvocation = ExtensionE2EStateFile['commandInvocations'][number];
+type BrowserDebugSession = ExtensionE2EStateFile['browserDebugSessions'][number];
 interface Deadline {
     readonly started: number;
     readonly timeoutMs: number;
@@ -103,6 +104,27 @@ export async function waitForHttpText(url: string, expectedText: string, timeout
 
 export async function waitForNoDebugSessions(timeoutMs = 90000): Promise<ExtensionE2EStateFile> {
     return await waitForExtensionState(file => file.state.debugSessions.length === 0, 'debug sessions to stop', timeoutMs);
+}
+
+export async function waitForBrowserDebugSession(timeoutMs = 120000): Promise<BrowserDebugSession> {
+    const file = await waitForExtensionState(
+        stateFile => stateFile.browserDebugSessions.some(session => session.parentSessionType === 'aspire'),
+        'dashboard browser debug session to start',
+        timeoutMs);
+    const session = file.browserDebugSessions.find(candidate => candidate.parentSessionType === 'aspire');
+    if (!session) {
+        throw new Error('Dashboard browser debug session was not found even though the state predicate matched.');
+    }
+
+    return session;
+}
+
+export async function waitForNoBrowserDebugSessions(timeoutMs = 120000): Promise<ExtensionE2EStateFile> {
+    return await waitForExtensionState(file => file.browserDebugSessions.length === 0, 'browser debug sessions to terminate', timeoutMs);
+}
+
+export function getBrowserDebugSessions(): readonly BrowserDebugSession[] {
+    return readStateFile().browserDebugSessions;
 }
 
 export async function waitForTaskProcessEvent(

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -13,6 +13,7 @@ import { extensionLogOutputChannel } from '../utils/logging';
 import { appHostTelemetryTargetPathConfigKey } from '../debugger/AspireDebugConfigurationMetadata';
 import { AspireResourceExtendedDebugConfiguration } from '../dcp/types';
 import { __resetCommonPropertiesForTests, __setReporterForTests } from '../utils/telemetry';
+import { aspireDashboard } from '../loc/strings';
 
 interface RecordedEvent {
     name: string;
@@ -796,6 +797,120 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
 
         sinon.assert.calledOnceWithExactly(stopDebugging, parentDebugSession);
         assert.strictEqual((aspireDebugSession as any)._dashboardDebugSession, null);
+    });
+
+    test('launching the dashboard browser ignores a dashboard session belonging to another Aspire session', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        const foreignDashboardSession = {
+            id: 'foreign-dashboard-session',
+            type: 'pwa-msedge',
+            name: aspireDashboard,
+            configuration: { name: aspireDashboard },
+            parentSession: { id: 'other-aspire-session' },
+        } as unknown as vscode.DebugSession;
+        const ownDashboardSession = {
+            id: 'own-dashboard-session',
+            type: 'pwa-msedge',
+            name: aspireDashboard,
+            configuration: { name: aspireDashboard },
+            parentSession: parentDebugSession,
+        } as unknown as vscode.DebugSession;
+        let startSessionCallback: ((session: vscode.DebugSession) => void) | undefined;
+        let listenerDisposed = false;
+        sinon.stub(vscode.debug, 'onDidStartDebugSession').callsFake(callback => {
+            // Mirror VS Code: once the listener is disposed it stops receiving events. Without
+            // this, a listener that wrongly consumed a foreign session would still observe the
+            // session it was supposed to capture and hide the bug.
+            startSessionCallback = session => {
+                if (!listenerDisposed) {
+                    callback(session);
+                }
+            };
+            return { dispose: () => { listenerDisposed = true; } };
+        });
+        sinon.stub(vscode.debug, 'startDebugging').resolves(true);
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+
+        const openPromise = aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
+        await Promise.resolve();
+        startSessionCallback?.(foreignDashboardSession);
+        const trackedAfterForeignSession = (aspireDebugSession as any)._dashboardDebugSession;
+        startSessionCallback?.(ownDashboardSession);
+        await openPromise;
+
+        assert.strictEqual(trackedAfterForeignSession, null);
+        assert.strictEqual((aspireDebugSession as any)._dashboardDebugSession, ownDashboardSession);
+    });
+
+    test('launching the dashboard browser stops a session that starts after the Aspire session was disposed', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        const dashboardDebugSession = {
+            id: 'dashboard-session',
+            type: 'pwa-msedge',
+            name: aspireDashboard,
+            configuration: { name: aspireDashboard },
+            parentSession: parentDebugSession,
+        } as unknown as vscode.DebugSession;
+        sinon.stub(vscode.workspace, 'getConfiguration').withArgs('aspire').returns({
+            get: <T>(section: string, defaultValue: T) =>
+                section === 'closeDashboardOnDebugEnd' ? true as T : defaultValue,
+        } as vscode.WorkspaceConfiguration);
+        let startSessionCallback: ((session: vscode.DebugSession) => void) | undefined;
+        sinon.stub(vscode.debug, 'onDidStartDebugSession').callsFake(callback => {
+            startSessionCallback = callback;
+            return { dispose: sinon.stub() };
+        });
+        let resolveStartDebugging: ((didStart: boolean) => void) | undefined;
+        sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(resolve => {
+            resolveStartDebugging = resolve;
+        }));
+        const stopDebugging = sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+
+        const openPromise = aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
+        await Promise.resolve();
+        aspireDebugSession.dispose();
+        startSessionCallback?.(dashboardDebugSession);
+        resolveStartDebugging?.(true);
+        await openPromise;
+
+        assert.strictEqual(stopDebugging.calledWith(dashboardDebugSession), true);
+        assert.strictEqual((aspireDebugSession as any)._dashboardDebugSession, null);
+    });
+
+    test('launching the dashboard browser does not fall back to an external browser after the Aspire session was disposed', async () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        sinon.stub(vscode.debug, 'onDidStartDebugSession').callsFake(() => ({ dispose: sinon.stub() }));
+        let resolveStartDebugging: ((didStart: boolean) => void) | undefined;
+        sinon.stub(vscode.debug, 'startDebugging').returns(new Promise<boolean>(resolve => {
+            resolveStartDebugging = resolve;
+        }));
+        sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const openExternal = sinon.stub(vscode.env, 'openExternal').resolves(true);
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+
+        const openPromise = aspireDebugSession.openDashboard('https://localhost:1234', 'debugEdge');
+        await Promise.resolve();
+        aspireDebugSession.dispose();
+        resolveStartDebugging?.(false);
+        await openPromise;
+
+        assert.strictEqual(openExternal.called, false);
     });
 
     test('stopDebugging stops the AppHost debug session before the Aspire parent session', async () => {

--- a/extension/src/test/aspireDebugSession.test.ts
+++ b/extension/src/test/aspireDebugSession.test.ts
@@ -743,6 +743,61 @@ var builder = Aspire.Hosting.DistributedApplication.CreateBuilder(args);
         assert.strictEqual(spawnStub.called, false);
     });
 
+    test('dispose stops a tracked dashboard debug session when closeDashboardOnDebugEnd is enabled', () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        const dashboardDebugSession = {
+            id: 'dashboard-session',
+            type: 'pwa-msedge',
+            name: 'Aspire Dashboard',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        sinon.stub(vscode.workspace, 'getConfiguration').withArgs('aspire').returns({
+            get: <T>(section: string, defaultValue: T) =>
+                section === 'closeDashboardOnDebugEnd' ? true as T : defaultValue,
+        } as vscode.WorkspaceConfiguration);
+        const stopDebugging = sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+        (aspireDebugSession as any)._dashboardDebugSession = dashboardDebugSession;
+
+        aspireDebugSession.dispose();
+
+        assert.strictEqual(stopDebugging.callCount, 2);
+        assert.strictEqual(stopDebugging.firstCall.args[0], dashboardDebugSession);
+        assert.strictEqual(stopDebugging.secondCall.args[0], parentDebugSession);
+    });
+
+    test('dispose leaves a tracked dashboard debug session running when closeDashboardOnDebugEnd is disabled', () => {
+        const parentDebugSession = {
+            id: 'aspire-session',
+            type: 'aspire',
+            name: 'Aspire',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        const dashboardDebugSession = {
+            id: 'dashboard-session',
+            type: 'pwa-msedge',
+            name: 'Aspire Dashboard',
+            configuration: {},
+        } as unknown as vscode.DebugSession;
+        sinon.stub(vscode.workspace, 'getConfiguration').withArgs('aspire').returns({
+            get: <T>(section: string, defaultValue: T) =>
+                section === 'closeDashboardOnDebugEnd' ? false as T : defaultValue,
+        } as vscode.WorkspaceConfiguration);
+        const stopDebugging = sinon.stub(vscode.debug, 'stopDebugging').resolves();
+        const aspireDebugSession = new AspireDebugSession(parentDebugSession, {} as any, {} as any, {} as any, () => { });
+        (aspireDebugSession as any)._dashboardDebugSession = dashboardDebugSession;
+
+        aspireDebugSession.dispose();
+
+        sinon.assert.calledOnceWithExactly(stopDebugging, parentDebugSession);
+        assert.strictEqual((aspireDebugSession as any)._dashboardDebugSession, null);
+    });
+
     test('stopDebugging stops the AppHost debug session before the Aspire parent session', async () => {
         const parentDebugSession = {
             id: 'aspire-session',

--- a/extension/src/testing/e2eStateFileBridge.ts
+++ b/extension/src/testing/e2eStateFileBridge.ts
@@ -10,7 +10,7 @@ import { cleanupRun } from '../debugger/runCleanupRegistry';
 import type { AspireResourceExtendedDebugConfiguration, EnvVar, ExecutableLaunchConfiguration } from '../dcp/types';
 import { createStateSnapshot, getSensitiveDashboardUrl, isSamePath } from '../extensionState';
 import { AppHostLaunchRequestedEvent, AppHostLaunchService } from '../services/AppHostLaunchService';
-import type { AspireDebugConsoleOutputEvent, AspireExtensionE2ECommandInvocation, AspireExtensionE2EControlCommand, AspireExtensionE2EControlPayload, AspireExtensionE2EControlStatus, AspireExtensionE2EDebugConsoleOutput, AspireExtensionE2EDebugLaunch, AspireExtensionE2EStoppingPathEvent, AspireExtensionE2ETaskProcessEvent, AspireExtensionE2ETerminalCommand, AspireExtensionStateSnapshot } from '../types/extensionApi';
+import type { AspireDebugConsoleOutputEvent, AspireExtensionE2EBrowserDebugSession, AspireExtensionE2ECommandInvocation, AspireExtensionE2EControlCommand, AspireExtensionE2EControlPayload, AspireExtensionE2EControlStatus, AspireExtensionE2EDebugConsoleOutput, AspireExtensionE2EDebugLaunch, AspireExtensionE2EStoppingPathEvent, AspireExtensionE2ETaskProcessEvent, AspireExtensionE2ETerminalCommand, AspireExtensionStateSnapshot } from '../types/extensionApi';
 import { AspireTerminalCommandEvent, AspireTerminalProvider } from '../utils/AspireTerminalProvider';
 import { dashboardDefaultChangedNotificationKey } from '../utils/dashboardNotificationState';
 import { extensionLogOutputChannel } from '../utils/logging';
@@ -41,6 +41,11 @@ export function createE2eStateFileBridge(
   const debugConsoleOutputs: AspireExtensionE2EDebugConsoleOutput[] = [];
   const stoppingPathEvents: AspireExtensionE2EStoppingPathEvent[] = [];
   const taskProcessEvents: AspireExtensionE2ETaskProcessEvent[] = [];
+  // VS Code's browser debug sessions are not part of the extension's state snapshot, so they are
+  // tracked here. Tests need this to tell "the extension thinks it stopped" apart from "the
+  // browser session actually terminated" — the two diverged in
+  // https://github.com/microsoft/aspire/issues/19289.
+  const browserDebugSessions: AspireExtensionE2EBrowserDebugSession[] = [];
   const clipboardSnapshot: E2eClipboardSnapshot = { hasSnapshot: false };
   const clipboardExpectation: E2eClipboardExpectation = {};
   let commandInvocationSequence = 0;
@@ -68,6 +73,7 @@ export function createE2eStateFileBridge(
       debugConsoleOutputs,
       stoppingPathEvents,
       taskProcessEvents,
+      browserDebugSessions,
       control: controlStatus,
     });
   };
@@ -163,6 +169,29 @@ export function createE2eStateFileBridge(
   });
 
   let controlProcessing: Promise<void> | undefined;
+  const browserDebugSessionStartSubscription = vscode.debug.onDidStartDebugSession(session => {
+    if (!isBrowserDebugSessionType(session.type)) {
+      return;
+    }
+
+    browserDebugSessions.push({
+      id: session.id,
+      type: session.type,
+      name: session.name,
+      parentSessionId: session.parentSession?.id,
+      parentSessionType: session.parentSession?.type,
+    });
+    writeStateFile();
+  });
+  const browserDebugSessionEndSubscription = vscode.debug.onDidTerminateDebugSession(session => {
+    const index = browserDebugSessions.findIndex(tracked => tracked.id === session.id);
+    if (index < 0) {
+      return;
+    }
+
+    browserDebugSessions.splice(index, 1);
+    writeStateFile();
+  });
   const controlInterval = controlFile
     ? setInterval(() => {
       if (controlProcessing) {
@@ -237,7 +266,11 @@ export function createE2eStateFileBridge(
     }
   });
 
-  return vscode.Disposable.from(stateSubscription, commandSubscription, terminalCommandSubscription, debugLaunchSubscription, debugConsoleOutputSubscription, taskStartSubscription, taskEndSubscription, controlSubscription);
+  return vscode.Disposable.from(stateSubscription, commandSubscription, terminalCommandSubscription, debugLaunchSubscription, debugConsoleOutputSubscription, taskStartSubscription, taskEndSubscription, browserDebugSessionStartSubscription, browserDebugSessionEndSubscription, controlSubscription);
+}
+
+function isBrowserDebugSessionType(type: string): boolean {
+  return type === 'pwa-chrome' || type === 'pwa-msedge' || type === 'firefox';
 }
 
 function trimTaskProcessEvents(events: AspireExtensionE2ETaskProcessEvent[]): void {

--- a/extension/src/types/extensionApi.ts
+++ b/extension/src/types/extensionApi.ts
@@ -106,7 +106,21 @@ export interface AspireExtensionE2EStateFile {
     debugConsoleOutputs: readonly AspireExtensionE2EDebugConsoleOutput[];
     stoppingPathEvents: readonly AspireExtensionE2EStoppingPathEvent[];
     taskProcessEvents: readonly AspireExtensionE2ETaskProcessEvent[];
+    browserDebugSessions: readonly AspireExtensionE2EBrowserDebugSession[];
     control?: AspireExtensionE2EControlStatus;
+}
+
+/**
+ * A browser debug session (`pwa-chrome`, `pwa-msedge`, or `firefox`) that VS Code currently
+ * reports as active. Browser sessions are not part of the extension's own state snapshot, so
+ * E2E tests use this to observe whether a launched dashboard browser actually terminated.
+ */
+export interface AspireExtensionE2EBrowserDebugSession {
+    id: string;
+    type: string;
+    name: string;
+    parentSessionId?: string;
+    parentSessionType?: string;
 }
 
 export interface AspireExtensionE2ESequence {


### PR DESCRIPTION
## Description

When you stop an Aspire debug session in VS Code, the dashboard browser window stays open. You end up collecting orphaned Edge/Chrome windows pointing at dashboards for AppHosts that are long gone.

`AspireDebugSession` already had a `closeDashboard()` that implements the `aspire.closeDashboardOnDebugEnd` setting (default `true`), but nothing ever called it — it was dead code. VS Code does not stop a child browser debug session when its parent session terminates, so the browser just outlived the session. This calls it from `dispose()`.

Reviewing that one-line call surfaced two more holes in the same path that the call site turns into user-visible behavior:

- The started-session listener matched only on configuration name and browser type. Every Aspire session launches its dashboard with the same name and the same user-configured browser type, so with two AppHosts running, session A could adopt session B's browser, close B's window on stop, and leave its own orphaned. It now matches on the parent session id.
- The Aspire session can be disposed while the browser is still launching — an AppHost that exits right after reporting the dashboard URL does exactly this. The late-arriving session was stored on an already-disposed instance and never stopped, and a failed launch fell back to `openExternal` *after* teardown, popping a window open during shutdown. Both paths re-check disposal now, and the first routes back through `closeDashboard()` so the opt-out setting is still honored.

Also fixes two doc comments that still claimed VS Code auto-closes the dashboard child session, since that assumption is what caused this.

Note this is a different path from #18626, which handles the DCP `WithBrowserDebugger()` browser lifecycle. This one is the dashboard browser launched by `openDashboard`.

Fixes #19289

### Verification

Five unit tests, all written first and observed failing (`extension/src/test/aspireDebugSession.test.ts`).

Beyond that, I ran an A/B against a real VS Code Extension Development Host, a real Aspire AppHost, and the real Edge instance js-debug launches. Playwright CLI confirms the dashboard actually rendered before the stop; the Edge pid is then polled for 30s after the stop:

| Build | `closeDashboardOnDebugEnd` | Edge after stop | Result |
|---|---|---|---|
| with fix | `true` | exited (~1s) | closes, as expected |
| fix reverted | `true` | still running after 30s | reproduces #19289 |
| with fix | `false` | still running | opt-out honored |

The only difference between rows 1 and 2 is the `closeDashboard()` call. Worth noting `debugSessions` is empty in all three runs — the extension always believed the session had ended, which is why this was invisible from extension state and only observable at the process level.

There is also a new E2E test, `closes the dashboard debug browser when the AppHost debug session stops` in `extension/src/test-e2e/debugDashboard.e2e.test.ts`. It configures `aspire.dashboardBrowser: debugChrome`, starts the AppHost, asserts the dashboard browser session is parented to the Aspire session, stops debugging, and requires the browser session to terminate.

That test needed a new observable. The extension's own `debugSessions` was empty in every repro run, so asserting on extension state cannot catch this regression; the divergence only exists in VS Code's debug sessions, which the state snapshot does not expose. The test-only E2E state file bridge now tracks `pwa-chrome`/`pwa-msedge`/`firefox` sessions as `browserDebugSessions`. Re-running the live A/B against that field: empty after stop with the fix, and with the fix reverted both the root `Aspire Dashboard` session and its page child are still present, so the new assertion fails without the fix.

One aside for anyone trying to reproduce this with Playwright directly: js-debug launches Edge with `--remote-debugging-pipe`, not `--remote-debugging-port`, so there's no HTTP CDP endpoint and no `DevToolsActivePort` file to attach to. You have to track the process instead.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

