### PR TITLE
Avoid MongoDB credential false positive

### DIFF
--- a/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
+++ b/src/Aspire.Dashboard/Model/ConnectionStringParser.cs
@@ -184,7 +184,7 @@ internal static partial class ConnectionStringParser
         databaseName = null;
 
         // Database URI paths use these shapes:
-        //   mongodb://user:password@localhost:27017/catalogdb
+        //   mongodb://PlaceholderUser:PlaceholderPassword@localhost:27017/catalogdb
         //   jdbc:postgresql://localhost:5432/catalogdb
         // Restrict parsing to database schemes so paths in endpoint URLs aren't treated as database names.
         var uriValue = connectionString.StartsWith(jdbcPrefix, StringComparison.OrdinalIgnoreCase)

--- a/tests/Aspire.Dashboard.Tests/ConnectionStringParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConnectionStringParserTests.cs
@@ -124,7 +124,7 @@ public class ConnectionStringParserTests
     [InlineData("Data Source=localhost;Initial Catalog=Catalog", true, "Catalog")]
     [InlineData("Server=localhost;Database Name=Catalog", true, "Catalog")]
     [InlineData("jdbc:sqlserver://localhost:1433;databaseName=Catalog", true, "Catalog")]
-    [InlineData("mongodb://user:password@localhost:27017/catalogdb", true, "catalogdb")]
+    [InlineData("mongodb://PlaceholderUser:PlaceholderPassword@localhost:27017/catalogdb", true, "catalogdb")]
     [InlineData("mongodb+srv://cluster0.example.mongodb.net/catalogdb", true, "catalogdb")]
     [InlineData("mssql://localhost:1433/Catalog", true, "Catalog")]
     [InlineData("postgresql://localhost:5432/catalog%20db", true, "catalog db")]


### PR DESCRIPTION
## Description

The internal Azure Repos mirror is blocked by secret push protection on the fake MongoDB credentials added in #19224. Because the internal `main` ref cannot advance, the official Aspire pipeline never sees newer GitHub commits and does not queue a batched CI build.

This replaces the two flagged examples with `Placeholder`-prefixed credentials, following the Azure Repos guidance for example secrets while preserving the MongoDB URI parsing coverage.

### Merge requirement

The squash commit message must retain:

```text
skip-secret-scanning:true
```

The flagged commit is already in GitHub history, so changing the current source alone cannot unblock the mirror. The bypass marker allows Azure Repos to accept that existing false positive with the follow-up commit.

### Validation

- `ConnectionStringParserTests`: 85 passed, 0 failed.
- Pushed the exact commit to a temporary personal branch in the internal mirror; Azure Repos accepted the full blocked history.
- Confirmed the temporary internal branch was deleted after validation.

### Security considerations

The bypass is limited to two public, fake credentials in a parser comment and test case. No real credential is included. Azure Repos records the bypass and generates a secret-scanning alert for review.

Fixes #19304

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
