### PR TITLE
Fix custom IDE project launch

### DIFF
--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -842,7 +842,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                     return true;
                 }
 
-                return dotnetProjectLaunchResourceArgumentIndex is not null;
+                return dotnetProjectLaunchResourceArgumentIndex is { } index && index >= omittedLaunchToolArgumentCount;
             }
         }
         // Project launch-profile arguments are application arguments. When a custom launch-tool declaration replaces

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -113,7 +113,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             : 0;
 
         var executableArgumentStartIndex = spec.Args?.Count ?? 0;
-        var (launchArgs, dotnetRunArgumentIndex) = BuildLaunchArgs(
+        var (launchArgs, dotnetProjectLaunchArgumentIndex) = BuildLaunchArgs(
             er,
             spec,
             configuration.Arguments,
@@ -123,7 +123,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             launchToolArgumentsData?.ShowInCommandLine ?? true);
         if (resolvedLaunchToolArgumentCount > 0 || !HasProjectLaunchArgsOverride(er.ModelResource))
         {
-            AddDotnetRunArgsForExecutableAnnotatedProject(launchArgs, dotnetRunArgumentIndex, executableArgumentStartIndex);
+            AddDotnetProjectLaunchArgsForExecutableAnnotatedProject(launchArgs, dotnetProjectLaunchArgumentIndex, executableArgumentStartIndex);
         }
         var executableArgs = launchArgs.Where(a => a.Executable).Select(a => a.Value).ToList();
         var displayArgs = launchArgs.Where(a => a.Display).ToList();
@@ -750,7 +750,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         return Path.Join(_locations.DcpSessionDir, exe.Metadata.Name);
     }
 
-    private static (List<LaunchArgument> LaunchArgs, int? DotnetRunArgumentIndex) BuildLaunchArgs(
+    private static (List<LaunchArgument> LaunchArgs, int? DotnetProjectLaunchArgumentIndex) BuildLaunchArgs(
         RenderedModelResource<Executable> er,
         ExecutableSpec spec,
         IEnumerable<(string Value, bool IsSensitive)> appHostArgs,
@@ -781,12 +781,12 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             omittedLaunchToolArgumentCount = Math.Max(0, omittedLaunchToolArgumentCount - 1);
         }
 
-        var dotnetRunResourceArgumentIndex = FindExecutableAnnotatedDotnetRunArgumentIndex(
+        var dotnetProjectLaunchResourceArgumentIndex = FindExecutableAnnotatedDotnetProjectLaunchArgumentIndex(
             er.ModelResource,
             appHostArgList,
             launchToolArgumentCount);
         var launchArgs = new List<LaunchArgument>();
-        int? dotnetRunLaunchArgumentIndex = null;
+        int? dotnetProjectLaunchArgumentIndex = null;
         var nextExecutableArgumentIndex = executableArgumentStartIndex;
         List<string>? projectLaunchProfileArgs = null;
         var includeProfileArgsInSpec = false;
@@ -824,8 +824,9 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                     launchToolArgumentCount == 0 &&
                     HasDotnetApplicationArgumentBoundary())
                 {
-                    // A prepared project command or explicit `dotnet run` invocation needs a double-dash before
-                    // application arguments. Custom IDE launchers receive raw application arguments instead.
+                    // A prepared project command or explicit `dotnet run`/`dotnet watch` invocation needs a
+                    // double-dash before application arguments. Custom IDE launchers receive raw application
+                    // arguments instead.
                     projectLaunchProfileArgs.Insert(0, "--");
                 }
             }
@@ -837,7 +838,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                     return true;
                 }
 
-                return dotnetRunResourceArgumentIndex is not null;
+                return dotnetProjectLaunchResourceArgumentIndex is not null;
             }
         }
         // Project launch-profile arguments are application arguments. When a custom launch-tool declaration replaces
@@ -876,17 +877,17 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                 a.IsSensitive,
                 executable: i >= omittedLaunchToolArgumentCount,
                 display: showLaunchToolArgsInCommandLine || !isLaunchToolArg);
-            if (dotnetRunResourceArgumentIndex == i && launchArgument.Executable)
+            if (dotnetProjectLaunchResourceArgumentIndex == i && launchArgument.Executable)
             {
-                dotnetRunLaunchArgumentIndex = launchArgs.Count;
+                dotnetProjectLaunchArgumentIndex = launchArgs.Count;
             }
             launchArgs.Add(launchArgument);
         }
 
-        return (launchArgs, dotnetRunLaunchArgumentIndex);
+        return (launchArgs, dotnetProjectLaunchArgumentIndex);
     }
 
-    private static int? FindExecutableAnnotatedDotnetRunArgumentIndex(
+    private static int? FindExecutableAnnotatedDotnetProjectLaunchArgumentIndex(
         IResource resource,
         IReadOnlyList<(string Value, bool IsSensitive)> appHostArgs,
         int launchToolArgumentCount)
@@ -898,15 +899,20 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             return null;
         }
 
-        // A declared launch-tool prefix identifies its complete invocation. Without one, project subtypes such as
-        // MAUI historically place the `run` verb first in ordinary resource args. Do not interpret a later
-        // application argument named "run" as the SDK verb.
+        // Recognize the project-launching SDK verb only at the start of a complete invocation:
+        //   dotnet run ...
+        //   dotnet watch ...
+        // A declared launch-tool prefix identifies that invocation. Without one, project subtypes such as MAUI
+        // historically place the verb first in ordinary resource args. A later value is an application argument,
+        // such as "watch" in `dotnet exec app.dll watch`, and must not be interpreted as the SDK verb.
+        // See https://learn.microsoft.com/dotnet/core/tools/dotnet-run and
+        // https://learn.microsoft.com/dotnet/core/tools/dotnet-watch.
         var invocationArgumentCount = launchToolArgumentCount > 0
             ? Math.Min(launchToolArgumentCount, appHostArgs.Count)
             : Math.Min(1, appHostArgs.Count);
         for (var i = 0; i < invocationArgumentCount; i++)
         {
-            if (string.Equals(appHostArgs[i].Value, "run", StringComparison.Ordinal))
+            if (appHostArgs[i].Value is "run" or "watch")
             {
                 return i;
             }
@@ -915,9 +921,9 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         return null;
     }
 
-    private void AddDotnetRunArgsForExecutableAnnotatedProject(List<LaunchArgument> launchArgs, int? dotnetRunArgumentIndex, int executableArgumentStartIndex)
+    private void AddDotnetProjectLaunchArgsForExecutableAnnotatedProject(List<LaunchArgument> launchArgs, int? dotnetProjectLaunchArgumentIndex, int executableArgumentStartIndex)
     {
-        if (dotnetRunArgumentIndex is not { } runIndex)
+        if (dotnetProjectLaunchArgumentIndex is not { } projectLaunchIndex)
         {
             return;
         }
@@ -925,27 +931,27 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         List<LaunchArgument>? launchProfileArgs = null;
         var firstExecutableArgumentIndex = launchArgs.FindIndex(static argument => argument.Executable);
         if (firstExecutableArgumentIndex >= 0 &&
-            runIndex > firstExecutableArgumentIndex &&
+            projectLaunchIndex > firstExecutableArgumentIndex &&
             string.Equals(launchArgs[firstExecutableArgumentIndex].Value, "--", StringComparison.Ordinal))
         {
-            // Executable launch-profile args were composed before the caller-provided `dotnet run` command.
+            // Executable launch-profile args were composed before the caller-provided project launch command.
             // Preserve any non-executable launch-tool display prefix, then move the profile segment after
-            // `dotnet run` so the SDK parses it as application arguments.
-            var launchProfileArgumentCount = runIndex - firstExecutableArgumentIndex;
+            // the project launch command so the SDK parses it as application arguments.
+            var launchProfileArgumentCount = projectLaunchIndex - firstExecutableArgumentIndex;
             launchProfileArgs = launchArgs.GetRange(firstExecutableArgumentIndex, launchProfileArgumentCount);
             launchArgs.RemoveRange(firstExecutableArgumentIndex, launchProfileArgumentCount);
-            runIndex -= launchProfileArgumentCount;
+            projectLaunchIndex -= launchProfileArgumentCount;
         }
 
         var argsToInsert = new List<string>();
         if (!string.IsNullOrEmpty(_distributedApplicationOptions.Configuration) &&
-            !ContainsDotnetRunOption(launchArgs, "--configuration", "-c"))
+            !ContainsDotnetProjectLaunchOption(launchArgs, "--configuration", "-c"))
         {
             argsToInsert.AddRange(["--configuration", _distributedApplicationOptions.Configuration]);
         }
 
-        if (!ContainsDotnetRunOption(launchArgs, "--no-launch-profile") &&
-            !ContainsDotnetRunOption(launchArgs, "--launch-profile"))
+        if (!ContainsDotnetProjectLaunchOption(launchArgs, "--no-launch-profile") &&
+            !ContainsDotnetProjectLaunchOption(launchArgs, "--launch-profile"))
         {
             argsToInsert.Add("--no-launch-profile");
         }
@@ -955,27 +961,27 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             return;
         }
 
-        // Some ProjectResource subtypes provide the `dotnet run` command through resource args
+        // Some ProjectResource subtypes provide a `dotnet run` or `dotnet watch` command through resource args
         // instead of using Aspire's default project wrapper. Keep the SDK-shaped command, but
         // preserve the same AppHost configuration and launch-profile suppression that regular
         // process-launched project resources get.
         if (argsToInsert.Count > 0)
         {
-            launchArgs.InsertRange(runIndex + 1, argsToInsert.Select(argument => new LaunchArgument(argument, IsSensitive: false, Executable: true, Display: false, EffectiveArgumentIndex: null)));
+            launchArgs.InsertRange(projectLaunchIndex + 1, argsToInsert.Select(argument => new LaunchArgument(argument, IsSensitive: false, Executable: true, Display: false, EffectiveArgumentIndex: null)));
         }
 
         if (launchProfileArgs is not null)
         {
             // Launch profile args were originally before the app host args, separated by `--`.
-            // Once this path preserves the caller-provided `dotnet run` command, those args must
-            // move after the inserted SDK options so `dotnet run` parses them as application args.
+            // Once this path preserves the caller-provided project launch command, those args must
+            // move after the inserted SDK options so the SDK parses them as application args.
             launchArgs.AddRange(launchProfileArgs);
         }
 
         ReindexExecutableLaunchArgs(launchArgs, executableArgumentStartIndex);
     }
 
-    private static bool ContainsDotnetRunOption(List<LaunchArgument> launchArgs, params string[] options)
+    private static bool ContainsDotnetProjectLaunchOption(List<LaunchArgument> launchArgs, params string[] options)
     {
         var separatorIndex = launchArgs.FindIndex(argument => argument.Executable && string.Equals(argument.Value, "--", StringComparison.Ordinal));
         var endIndex = separatorIndex < 0 ? launchArgs.Count : separatorIndex;

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -304,16 +304,20 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             return false;
         }
 
-        if (!modelResource.SupportsDebugging(_configuration, out var annotation))
-        {
-            return modelResource is ProjectResource;
-        }
+        var supportsDebugging = modelResource.SupportsDebugging(_configuration, out var annotation);
 
-        // Project-backed resources can leave the process scaffold incomplete when the active launch configuration
-        // owns the invocation. The remaining IDE-only arguments cannot be used as a Process fallback.
-        if (HasIncompleteProcessCommand(modelResource, annotation, resolvedLaunchToolArgumentCount, hasPreparedProjectArguments))
+        // SupportsDebugging can return false while still yielding the resource's annotation, such as when Visual
+        // Studio omits DEBUG_SESSION_INFO for a custom launch type. Check command completeness before the unsupported
+        // path offers every ProjectResource a Process fallback.
+        if (annotation is not null &&
+            HasIncompleteProcessCommand(modelResource, annotation, resolvedLaunchToolArgumentCount, hasPreparedProjectArguments))
         {
             return false;
+        }
+
+        if (!supportsDebugging || annotation is null)
+        {
+            return modelResource is ProjectResource;
         }
 
         return modelResource is ProjectResource

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -113,7 +113,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             : 0;
 
         var executableArgumentStartIndex = spec.Args?.Count ?? 0;
-        var (launchArgs, dotnetProjectLaunchArgumentIndex) = BuildLaunchArgs(
+        var (launchArgs, dotnetProjectLaunchArgumentIndex, canReuseArgsForProcessFallback) = BuildLaunchArgs(
             er,
             spec,
             configuration.Arguments,
@@ -137,7 +137,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
 
         // Argument and launch-configuration callbacks can change on restart. Derive fallback availability from the
         // final execution type and resolved command line every time instead of carrying a preparation-time guess.
-        spec.FallbackExecutionTypes = ShouldOfferProcessFallback(er.ModelResource, spec, resolvedLaunchToolArgumentCount, omittedLaunchToolArgumentCount, hasPreparedProjectArguments)
+        spec.FallbackExecutionTypes = ShouldOfferProcessFallback(er.ModelResource, spec, resolvedLaunchToolArgumentCount, omittedLaunchToolArgumentCount, hasPreparedProjectArguments, canReuseArgsForProcessFallback)
             ? [ExecutionType.Process]
             : null;
 
@@ -297,9 +297,12 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         ExecutableSpec spec,
         int resolvedLaunchToolArgumentCount,
         int omittedLaunchToolArgumentCount,
-        bool hasPreparedProjectArguments)
+        bool hasPreparedProjectArguments,
+        bool canReuseArgsForProcessFallback)
     {
-        if (spec.ExecutionType != ExecutionType.IDE || omittedLaunchToolArgumentCount > 0)
+        if (spec.ExecutionType != ExecutionType.IDE ||
+            omittedLaunchToolArgumentCount > 0 ||
+            !canReuseArgsForProcessFallback)
         {
             return false;
         }
@@ -754,7 +757,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         return Path.Join(_locations.DcpSessionDir, exe.Metadata.Name);
     }
 
-    private static (List<LaunchArgument> LaunchArgs, int? DotnetProjectLaunchArgumentIndex) BuildLaunchArgs(
+    private static (List<LaunchArgument> LaunchArgs, int? DotnetProjectLaunchArgumentIndex, bool CanReuseArgsForProcessFallback) BuildLaunchArgs(
         RenderedModelResource<Executable> er,
         ExecutableSpec spec,
         IEnumerable<(string Value, bool IsSensitive)> appHostArgs,
@@ -790,6 +793,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             appHostArgList);
         var launchArgs = new List<LaunchArgument>();
         int? dotnetProjectLaunchArgumentIndex = null;
+        var canReuseArgsForProcessFallback = true;
         var nextExecutableArgumentIndex = executableArgumentStartIndex;
         List<string>? projectLaunchProfileArgs = null;
         var includeProfileArgsInSpec = false;
@@ -822,6 +826,23 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                     !projectLaunchConfigurationHandlesLaunchProfile;
 
                 projectLaunchProfileArgs = GetLaunchProfileArgs(project.GetEffectiveLaunchProfile()?.LaunchProfile);
+                if (includeProfileArgsInSpec &&
+                    projectLaunchProfileArgs.Count > 0 &&
+                    spec.ExecutionType == ExecutionType.IDE &&
+                    IsExecutableAnnotatedDotnetProject(er.ModelResource) &&
+                    executableArgumentStartIndex == 0 &&
+                    launchToolArgumentCount == 0 &&
+                    dotnetProjectLaunchResourceArgumentIndex is null)
+                {
+                    // Custom IDE launches preserve launch-profile application args before ordinary resource args.
+                    // For an explicit dotnet application command, that can produce:
+                    //   dotnet --profile-arg value exec app.dll
+                    // Process execution requires `exec app.dll` before application args. The executable spec has one
+                    // args list, so retain the IDE order and disable fallback instead of parsing every dotnet form.
+                    // See https://learn.microsoft.com/dotnet/core/tools/dotnet#options-for-running-an-application.
+                    canReuseArgsForProcessFallback = false;
+                }
+
                 if (projectLaunchProfileArgs.Count > 0 &&
                     ordinaryAppHostArgumentCount > 0 &&
                     launchToolArgumentCount == 0 &&
@@ -887,16 +908,14 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             launchArgs.Add(launchArgument);
         }
 
-        return (launchArgs, dotnetProjectLaunchArgumentIndex);
+        return (launchArgs, dotnetProjectLaunchArgumentIndex, canReuseArgsForProcessFallback);
     }
 
     private static int? FindExecutableAnnotatedDotnetProjectLaunchArgumentIndex(
         IResource resource,
         IReadOnlyList<(string Value, bool IsSensitive)> appHostArgs)
     {
-        if (resource is not ProjectResource ||
-            !resource.TryGetLastAnnotation<ExecutableAnnotation>(out var executableAnnotation) ||
-            !string.Equals(Path.GetFileNameWithoutExtension(executableAnnotation.Command), "dotnet", StringComparison.OrdinalIgnoreCase))
+        if (!IsExecutableAnnotatedDotnetProject(resource))
         {
             return null;
         }
@@ -916,6 +935,13 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         }
 
         return null;
+    }
+
+    private static bool IsExecutableAnnotatedDotnetProject(IResource resource)
+    {
+        return resource is ProjectResource &&
+            resource.TryGetLastAnnotation<ExecutableAnnotation>(out var executableAnnotation) &&
+            string.Equals(Path.GetFileNameWithoutExtension(executableAnnotation.Command), "dotnet", StringComparison.OrdinalIgnoreCase);
     }
 
     private void AddDotnetProjectLaunchArgsForExecutableAnnotatedProject(List<LaunchArgument> launchArgs, int? dotnetProjectLaunchArgumentIndex, int executableArgumentStartIndex)

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -309,9 +309,8 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             return modelResource is ProjectResource;
         }
 
-        // Project-backed resources suppress their process scaffold when the active launch configuration owns the
-        // tool invocation. If that prefix resolves empty, the remaining command line is IDE-only and cannot be used
-        // as a Process fallback.
+        // Project-backed resources can leave the process scaffold incomplete when the active launch configuration
+        // owns the invocation. The remaining IDE-only arguments cannot be used as a Process fallback.
         if (HasIncompleteProcessCommand(modelResource, annotation, resolvedLaunchToolArgumentCount, hasPreparedProjectArguments))
         {
             return false;
@@ -327,10 +326,18 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         int resolvedLaunchToolArgumentCount,
         bool hasPreparedProjectArguments)
     {
+        // A custom project launcher such as Azure Functions owns the invocation when the integration has not
+        // supplied an explicit executable. Ordinary WithArgs values are application arguments, so they cannot turn
+        // the default `dotnet` executable into a runnable Process fallback.
+        var customProjectLaunchOwnsInvocation =
+            modelResource is ProjectResource &&
+            annotation.LaunchConfigurationType is not KnownLaunchConfigurationTypes.Project &&
+            !modelResource.HasAnnotationOfType<ExecutableAnnotation>();
+
         return resolvedLaunchToolArgumentCount == 0
             && !hasPreparedProjectArguments
             && modelResource.HasAnnotationOfType<IProjectMetadata>()
-            && modelResource.HasLaunchToolArgsOwnedBy(annotation);
+            && (modelResource.HasLaunchToolArgsOwnedBy(annotation) || customProjectLaunchOwnsInvocation);
     }
 
     private async Task PrepareProjectExecutablesAsync(CancellationToken cancellationToken)
@@ -809,12 +816,25 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                 projectLaunchProfileArgs = GetLaunchProfileArgs(project.GetEffectiveLaunchProfile()?.LaunchProfile);
                 if (projectLaunchProfileArgs.Count > 0 &&
                     ordinaryAppHostArgumentCount > 0 &&
-                    launchToolArgumentCount == 0)
+                    launchToolArgumentCount == 0 &&
+                    HasDotnetApplicationArgumentBoundary())
                 {
-                    // The implicit `dotnet run` scaffold needs a double-dash before application arguments. A custom
-                    // launch-tool declaration owns its complete invocation, including any separator its tool requires.
+                    // A prepared project command or explicit `dotnet run` invocation needs a double-dash before
+                    // application arguments. Custom IDE launchers receive raw application arguments instead.
                     projectLaunchProfileArgs.Insert(0, "--");
                 }
+            }
+
+            bool HasDotnetApplicationArgumentBoundary()
+            {
+                if (executableArgumentStartIndex > 0)
+                {
+                    return true;
+                }
+
+                return er.ModelResource.TryGetLastAnnotation<ExecutableAnnotation>(out var executableAnnotation) &&
+                    string.Equals(executableAnnotation.Command, "dotnet", StringComparison.OrdinalIgnoreCase) &&
+                    appHostArgList.Any(static argument => string.Equals(argument.Value, "run", StringComparison.Ordinal));
             }
         }
         // Project launch-profile arguments are application arguments. When a custom launch-tool declaration replaces

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -113,7 +113,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             : 0;
 
         var executableArgumentStartIndex = spec.Args?.Count ?? 0;
-        var launchArgs = BuildLaunchArgs(
+        var (launchArgs, dotnetRunArgumentIndex) = BuildLaunchArgs(
             er,
             spec,
             configuration.Arguments,
@@ -123,7 +123,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             launchToolArgumentsData?.ShowInCommandLine ?? true);
         if (resolvedLaunchToolArgumentCount > 0 || !HasProjectLaunchArgsOverride(er.ModelResource))
         {
-            AddDotnetRunArgsForExecutableAnnotatedProject(er, launchArgs, executableArgumentStartIndex);
+            AddDotnetRunArgsForExecutableAnnotatedProject(launchArgs, dotnetRunArgumentIndex, executableArgumentStartIndex);
         }
         var executableArgs = launchArgs.Where(a => a.Executable).Select(a => a.Value).ToList();
         var displayArgs = launchArgs.Where(a => a.Display).ToList();
@@ -750,7 +750,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         return Path.Join(_locations.DcpSessionDir, exe.Metadata.Name);
     }
 
-    private static List<LaunchArgument> BuildLaunchArgs(
+    private static (List<LaunchArgument> LaunchArgs, int? DotnetRunArgumentIndex) BuildLaunchArgs(
         RenderedModelResource<Executable> er,
         ExecutableSpec spec,
         IEnumerable<(string Value, bool IsSensitive)> appHostArgs,
@@ -781,7 +781,12 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             omittedLaunchToolArgumentCount = Math.Max(0, omittedLaunchToolArgumentCount - 1);
         }
 
+        var dotnetRunResourceArgumentIndex = FindExecutableAnnotatedDotnetRunArgumentIndex(
+            er.ModelResource,
+            appHostArgList,
+            launchToolArgumentCount);
         var launchArgs = new List<LaunchArgument>();
+        int? dotnetRunLaunchArgumentIndex = null;
         var nextExecutableArgumentIndex = executableArgumentStartIndex;
         List<string>? projectLaunchProfileArgs = null;
         var includeProfileArgsInSpec = false;
@@ -832,9 +837,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                     return true;
                 }
 
-                return er.ModelResource.TryGetLastAnnotation<ExecutableAnnotation>(out var executableAnnotation) &&
-                    string.Equals(executableAnnotation.Command, "dotnet", StringComparison.OrdinalIgnoreCase) &&
-                    appHostArgList.Any(static argument => string.Equals(argument.Value, "run", StringComparison.Ordinal));
+                return dotnetRunResourceArgumentIndex is not null;
             }
         }
         // Project launch-profile arguments are application arguments. When a custom launch-tool declaration replaces
@@ -868,27 +871,53 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
 
             var a = appHostArgList[i];
             var isLaunchToolArg = i < launchToolArgumentCount;
-            launchArgs.Add(CreateLaunchArgument(
+            var launchArgument = CreateLaunchArgument(
                 a.Value,
                 a.IsSensitive,
                 executable: i >= omittedLaunchToolArgumentCount,
-                display: showLaunchToolArgsInCommandLine || !isLaunchToolArg));
+                display: showLaunchToolArgsInCommandLine || !isLaunchToolArg);
+            if (dotnetRunResourceArgumentIndex == i && launchArgument.Executable)
+            {
+                dotnetRunLaunchArgumentIndex = launchArgs.Count;
+            }
+            launchArgs.Add(launchArgument);
         }
 
-        return launchArgs;
+        return (launchArgs, dotnetRunLaunchArgumentIndex);
     }
 
-    private void AddDotnetRunArgsForExecutableAnnotatedProject(RenderedModelResource<Executable> er, List<LaunchArgument> launchArgs, int executableArgumentStartIndex)
+    private static int? FindExecutableAnnotatedDotnetRunArgumentIndex(
+        IResource resource,
+        IReadOnlyList<(string Value, bool IsSensitive)> appHostArgs,
+        int launchToolArgumentCount)
     {
-        if (er.ModelResource is not ProjectResource ||
-            !er.ModelResource.TryGetLastAnnotation<ExecutableAnnotation>(out var executableAnnotation) ||
-            !string.Equals(executableAnnotation.Command, "dotnet", StringComparison.OrdinalIgnoreCase))
+        if (resource is not ProjectResource ||
+            !resource.TryGetLastAnnotation<ExecutableAnnotation>(out var executableAnnotation) ||
+            !string.Equals(Path.GetFileNameWithoutExtension(executableAnnotation.Command), "dotnet", StringComparison.OrdinalIgnoreCase))
         {
-            return;
+            return null;
         }
 
-        var runIndex = launchArgs.FindIndex(argument => argument.Executable && string.Equals(argument.Value, "run", StringComparison.Ordinal));
-        if (runIndex < 0)
+        // A declared launch-tool prefix identifies its complete invocation. Without one, project subtypes such as
+        // MAUI historically place the `run` verb first in ordinary resource args. Do not interpret a later
+        // application argument named "run" as the SDK verb.
+        var invocationArgumentCount = launchToolArgumentCount > 0
+            ? Math.Min(launchToolArgumentCount, appHostArgs.Count)
+            : Math.Min(1, appHostArgs.Count);
+        for (var i = 0; i < invocationArgumentCount; i++)
+        {
+            if (string.Equals(appHostArgs[i].Value, "run", StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return null;
+    }
+
+    private void AddDotnetRunArgsForExecutableAnnotatedProject(List<LaunchArgument> launchArgs, int? dotnetRunArgumentIndex, int executableArgumentStartIndex)
+    {
+        if (dotnetRunArgumentIndex is not { } runIndex)
         {
             return;
         }

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -787,8 +787,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
 
         var dotnetProjectLaunchResourceArgumentIndex = FindExecutableAnnotatedDotnetProjectLaunchArgumentIndex(
             er.ModelResource,
-            appHostArgList,
-            launchToolArgumentCount);
+            appHostArgList);
         var launchArgs = new List<LaunchArgument>();
         int? dotnetProjectLaunchArgumentIndex = null;
         var nextExecutableArgumentIndex = executableArgumentStartIndex;
@@ -893,8 +892,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
 
     private static int? FindExecutableAnnotatedDotnetProjectLaunchArgumentIndex(
         IResource resource,
-        IReadOnlyList<(string Value, bool IsSensitive)> appHostArgs,
-        int launchToolArgumentCount)
+        IReadOnlyList<(string Value, bool IsSensitive)> appHostArgs)
     {
         if (resource is not ProjectResource ||
             !resource.TryGetLastAnnotation<ExecutableAnnotation>(out var executableAnnotation) ||
@@ -903,23 +901,18 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             return null;
         }
 
-        // Recognize the project-launching SDK verb only at the start of a complete invocation:
+        // Recognize the project-launching SDK verb only immediately after the dotnet executable:
         //   dotnet run ...
         //   dotnet watch ...
-        // A declared launch-tool prefix identifies that invocation. Without one, project subtypes such as MAUI
-        // historically place the verb first in ordinary resource args. A later value is an application argument,
-        // such as "watch" in `dotnet exec app.dll watch`, and must not be interpreted as the SDK verb.
+        // Later values belong to another SDK command or the launched application, for example:
+        //   dotnet tool run <command>
+        //   dotnet exec app.dll watch
+        // They must not be interpreted as the top-level project-launch verb.
         // See https://learn.microsoft.com/dotnet/core/tools/dotnet-run and
         // https://learn.microsoft.com/dotnet/core/tools/dotnet-watch.
-        var invocationArgumentCount = launchToolArgumentCount > 0
-            ? Math.Min(launchToolArgumentCount, appHostArgs.Count)
-            : Math.Min(1, appHostArgs.Count);
-        for (var i = 0; i < invocationArgumentCount; i++)
+        if (appHostArgs.Count > 0 && appHostArgs[0].Value is "run" or "watch")
         {
-            if (appHostArgs[i].Value is "run" or "watch")
-            {
-                return i;
-            }
+            return 0;
         }
 
         return null;

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -4733,7 +4733,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ProjectResource_CustomLaunchConfigurationWithoutLaunchToolArgs_DoesNotKeepProcessScaffolding()
+    public async Task ProjectResource_CustomIdeLaunchWithoutProcessInvocation_DoesNotOfferProcessFallback()
     {
         var builder = DistributedApplication.CreateBuilder();
         var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
@@ -4773,6 +4773,54 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var exe = GetCreatedExecutableForResource(kubernetes, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
         Assert.Equal(["app-arg"], exe.Spec.Args);
+        Assert.Null(exe.Spec.FallbackExecutionTypes);
+    }
+
+    [Fact]
+    public async Task ProjectResource_CustomIdeLaunchWithoutProcessInvocation_DoesNotAddDotnetArgumentSeparator()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
+
+        var defaultAnnotation = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (defaultAnnotation is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(defaultAnnotation);
+        }
+
+        projectBuilder
+            .WithArgs("app-arg")
+            .WithDebugSupport(
+                mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode },
+                "azure-functions");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var kubernetes = new TestKubernetesService();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [DcpExecutor.DebugSessionPortVar] = "12345",
+                [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo
+                {
+                    ProtocolsSupported = ["coreclr"],
+                    SupportedLaunchConfigurations = ["azure-functions"]
+                })
+            })
+            .Build();
+
+        var executor = CreateAppExecutor(model, configuration: configuration, kubernetesService: kubernetes);
+
+        await executor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetes, "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.Equal(["--profile-arg", "profile value", "app-arg"], exe.Spec.Args);
+
+        Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
+        Assert.Equal(["--profile-arg", "profile value", "app-arg"], displayArgs.Select(a => a.Argument));
+        AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
     }
 
     [Fact]
@@ -8812,14 +8860,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task Project_NonProjectLaunchConfig_AnnotatorThrows_FallsBackToProcess()
+    public async Task Project_NonProjectLaunchConfig_AnnotatorThrows_FailsWithoutProcessFallback()
     {
-        // Arrange: A ProjectResource with a non-"project" launch config where the annotator throws
-        // should fall back to ExecutionType.Process.
         var builder = DistributedApplication.CreateBuilder();
 
         var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
-        // Remove the default "project" SupportsDebuggingAnnotation and replace with a throwing one
         var annotationToRemove = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
         if (annotationToRemove is not null)
         {
@@ -8839,17 +8884,26 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
 
         var kubernetesService = new TestKubernetesService();
+        var failedResources = new List<IResource>();
+        var events = new DcpExecutorEvents();
+        events.Subscribe<OnResourceFailedToStartContext>(context =>
+        {
+            failedResources.Add(context.Resource);
+            return Task.CompletedTask;
+        });
+
         using var app = builder.Build();
         var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
-        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+        var appExecutor = CreateAppExecutor(
+            distributedAppModel,
+            kubernetesService: kubernetesService,
+            configuration: configuration,
+            events: events);
 
-        // Act
         await appExecutor.RunApplicationAsync();
 
-        // Assert
-        var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
-        // Should fall back to Process execution when the launch configuration producer throws
-        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+        Assert.Empty(kubernetesService.CreatedResources.OfType<Executable>());
+        Assert.Same(projectBuilder.Resource, Assert.Single(failedResources));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -6165,10 +6165,15 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
     }
 
-    [Fact]
-    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectPreservesLaunchProfileArgs()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectPreservesLaunchProfileArgs(bool useFullDotnetPath)
     {
         var builder = DistributedApplication.CreateBuilder();
+        var dotnetCommand = useFullDotnetPath
+            ? Path.GetFullPath(Path.Combine("test-dotnet-root", OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet"))
+            : "dotnet";
         var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
         var defaultAnnotation = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
         if (defaultAnnotation is not null)
@@ -6179,7 +6184,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         projectBuilder
             .WithAnnotation(new ExecutableAnnotation
             {
-                Command = "dotnet",
+                Command = dotnetCommand,
                 WorkingDirectory = "/tmp/mauiapp"
             })
             .WithDebugSupport(
@@ -6211,6 +6216,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.Equal(dotnetCommand, exe.Spec.ExecutablePath);
         var expectedArgs = new List<string> { "run" };
         if (GetTestAssemblyConfiguration() is { } configurationName)
         {
@@ -6223,6 +6229,62 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
         Assert.Equal(
             ["run", "-f", "net10.0-ios", "--", "--profile-arg", "profile value"],
+            displayArgs.Select(a => a.Argument));
+        AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
+    }
+
+    [Fact]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectDoesNotTreatNonLeadingRunAsDotnetRun()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
+        var defaultAnnotation = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (defaultAnnotation is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(defaultAnnotation);
+        }
+
+        projectBuilder
+            .WithAnnotation(new ExecutableAnnotation
+            {
+                Command = "dotnet",
+                WorkingDirectory = "/tmp/mauiapp"
+            })
+            .WithDebugSupport(
+                mode => new TestMauiLaunchConfiguration
+                {
+                    Mode = mode,
+                    ProjectPath = "/tmp/mauiapp/MauiApp.csproj",
+                    TargetFramework = "net10.0-ios",
+                    Platform = "ios",
+                    TargetKind = "simulator"
+                },
+                "maui")
+            .WithArgs("exec", "app.dll", "run");
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [DcpExecutor.DebugSessionPortVar] = "12345",
+                [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["coreclr"], SupportedLaunchConfigurations = ["maui"] })
+            })
+            .Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.Equal(["--profile-arg", "profile value", "exec", "app.dll", "run"], exe.Spec.Args);
+        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes!));
+
+        Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
+        Assert.Equal(
+            ["--profile-arg", "profile value", "exec", "app.dll", "run"],
             displayArgs.Select(a => a.Argument));
         AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
     }

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -6275,9 +6275,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData("run")]
-    [InlineData("watch")]
-    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectDoesNotTreatNonLeadingProjectLaunchVerbAsDotnetInvocation(string nonLeadingLaunchVerb)
+    [InlineData("run", true)]
+    [InlineData("watch", true)]
+    [InlineData("run", false)]
+    [InlineData("watch", false)]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedDotnetApplicationDoesNotOfferInvalidProcessFallback(string nonLeadingLaunchVerb, bool useExec)
     {
         var builder = DistributedApplication.CreateBuilder();
         var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
@@ -6287,6 +6289,9 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             projectBuilder.Resource.Annotations.Remove(defaultAnnotation);
         }
 
+        string[] resourceArgs = useExec
+            ? ["exec", "app.dll", nonLeadingLaunchVerb]
+            : ["app.dll", nonLeadingLaunchVerb];
         projectBuilder
             .WithAnnotation(new ExecutableAnnotation
             {
@@ -6303,7 +6308,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
                     TargetKind = "simulator"
                 },
                 "maui")
-            .WithArgs("exec", "app.dll", nonLeadingLaunchVerb);
+            .WithArgs(resourceArgs);
 
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -6322,13 +6327,61 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
-        var expectedArgs = new[] { "--profile-arg", "profile value", "exec", "app.dll", nonLeadingLaunchVerb };
+        string[] expectedArgs = ["--profile-arg", "profile value", .. resourceArgs];
         Assert.Equal(expectedArgs, exe.Spec.Args);
-        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes!));
+        Assert.Null(exe.Spec.FallbackExecutionTypes);
 
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
         Assert.Equal(expectedArgs, displayArgs.Select(a => a.Argument));
         AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedDotnetApplicationWithoutLaunchProfileArgsOffersProcessFallback(bool useExec)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
+        var defaultAnnotation = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
+        if (defaultAnnotation is not null)
+        {
+            projectBuilder.Resource.Annotations.Remove(defaultAnnotation);
+        }
+
+        string[] resourceArgs = useExec
+            ? ["exec", "app.dll", "run"]
+            : ["app.dll", "run"];
+        projectBuilder
+            .WithAnnotation(new ExecutableAnnotation
+            {
+                Command = "dotnet",
+                WorkingDirectory = "/tmp/mauiapp"
+            })
+            .WithDebugSupport(
+                mode => new ExecutableLaunchConfiguration("custom") { Mode = mode },
+                "custom")
+            .WithArgs(resourceArgs);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [DcpExecutor.DebugSessionPortVar] = "12345",
+                [KnownConfigNames.DebugSessionInfo] = JsonSerializer.Serialize(new RunSessionInfo { ProtocolsSupported = ["coreclr"], SupportedLaunchConfigurations = ["custom"] })
+            })
+            .Build();
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, configuration: configuration);
+
+        await appExecutor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
+        Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
+        Assert.Equal(resourceArgs, exe.Spec.Args);
+        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes!));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -5784,7 +5784,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ProjectWithNonProjectAnnotation_DebugSessionWithoutInfo_FallsBackToProjectIdeExecution()
+    public async Task ProjectWithNonProjectAnnotation_DebugSessionWithoutInfo_UsesProjectIdeExecutionWithoutProcessFallback()
     {
         // Bug #15378: Simulates the Visual Studio scenario for projects with custom debug types.
         // VS sets DEBUG_SESSION_PORT but does NOT send DEBUG_SESSION_INFO. A project resource
@@ -5816,8 +5816,8 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
-        Assert.NotNull(exe.Spec.FallbackExecutionTypes);
-        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes));
+        Assert.Null(exe.Spec.Args);
+        Assert.Null(exe.Spec.FallbackExecutionTypes);
 
         Assert.True(exe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
         Assert.Single(launchConfigs);
@@ -6464,8 +6464,8 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         var customExe = GetCreatedExecutableForResource(kubernetesService, "custom-project");
         Assert.Equal(ExecutionType.IDE, customExe.Spec.ExecutionType);
-        Assert.NotNull(customExe.Spec.FallbackExecutionTypes);
-        Assert.Equal(ExecutionType.Process, Assert.Single(customExe.Spec.FallbackExecutionTypes));
+        Assert.Null(customExe.Spec.Args);
+        Assert.Null(customExe.Spec.FallbackExecutionTypes);
 
         Assert.True(customExe.TryGetAnnotationAsObjectList<ProjectLaunchConfiguration>(Executable.LaunchConfigurationsAnnotation, out var launchConfigs));
         Assert.Single(launchConfigs);
@@ -6527,10 +6527,10 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ProjectWithNonProjectAnnotation_VSFallback_HasProcessFallbackExecutionType()
+    public async Task ProjectWithNonProjectAnnotation_VSFallback_DoesNotOfferIncompleteProcessFallback()
     {
-        // Verifies the VS else-if branch sets FallbackExecutionTypes to [Process],
-        // ensuring DCP can fall back gracefully if IDE launch fails.
+        // VS falls back to a project launch configuration for custom project types without DEBUG_SESSION_INFO.
+        // Ordinary resource arguments are application arguments, so `dotnet app-arg` is not a runnable fallback.
         var builder = DistributedApplication.CreateBuilder();
 
         var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
@@ -6539,7 +6539,9 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         {
             projectBuilder.Resource.Annotations.Remove(annotationToRemove);
         }
-        projectBuilder.WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
+        projectBuilder
+            .WithArgs("app-arg")
+            .WithDebugSupport(mode => new ExecutableLaunchConfiguration("azure-functions") { Mode = mode }, "azure-functions");
 
         var configDict = new Dictionary<string, string?>
         {
@@ -6557,9 +6559,8 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
-        Assert.NotNull(exe.Spec.FallbackExecutionTypes);
-        Assert.Single(exe.Spec.FallbackExecutionTypes);
-        Assert.Equal(ExecutionType.Process, exe.Spec.FallbackExecutionTypes[0]);
+        Assert.Equal(["app-arg"], exe.Spec.Args);
+        Assert.Null(exe.Spec.FallbackExecutionTypes);
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -6166,9 +6166,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectPreservesLaunchProfileArgs(bool useFullDotnetPath)
+    [InlineData("run", false)]
+    [InlineData("run", true)]
+    [InlineData("watch", false)]
+    [InlineData("watch", true)]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectPreservesLaunchProfileArgs(string launchVerb, bool useFullDotnetPath)
     {
         var builder = DistributedApplication.CreateBuilder();
         var dotnetCommand = useFullDotnetPath
@@ -6197,7 +6199,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
                     TargetKind = "simulator"
                 },
                 "maui")
-            .WithArgs("run", "-f", "net10.0-ios");
+            .WithArgs(launchVerb, "-f", "net10.0-ios");
 
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -6217,7 +6219,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
         Assert.Equal(dotnetCommand, exe.Spec.ExecutablePath);
-        var expectedArgs = new List<string> { "run" };
+        var expectedArgs = new List<string> { launchVerb };
         if (GetTestAssemblyConfiguration() is { } configurationName)
         {
             expectedArgs.AddRange(["--configuration", configurationName]);
@@ -6228,13 +6230,15 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
         Assert.Equal(
-            ["run", "-f", "net10.0-ios", "--", "--profile-arg", "profile value"],
+            [launchVerb, "-f", "net10.0-ios", "--", "--profile-arg", "profile value"],
             displayArgs.Select(a => a.Argument));
         AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
     }
 
-    [Fact]
-    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectDoesNotTreatNonLeadingRunAsDotnetRun()
+    [Theory]
+    [InlineData("run")]
+    [InlineData("watch")]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectDoesNotTreatNonLeadingProjectLaunchVerbAsDotnetInvocation(string nonLeadingLaunchVerb)
     {
         var builder = DistributedApplication.CreateBuilder();
         var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
@@ -6260,7 +6264,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
                     TargetKind = "simulator"
                 },
                 "maui")
-            .WithArgs("exec", "app.dll", "run");
+            .WithArgs("exec", "app.dll", nonLeadingLaunchVerb);
 
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -6279,13 +6283,12 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
-        Assert.Equal(["--profile-arg", "profile value", "exec", "app.dll", "run"], exe.Spec.Args);
+        var expectedArgs = new[] { "--profile-arg", "profile value", "exec", "app.dll", nonLeadingLaunchVerb };
+        Assert.Equal(expectedArgs, exe.Spec.Args);
         Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes!));
 
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
-        Assert.Equal(
-            ["--profile-arg", "profile value", "exec", "app.dll", "run"],
-            displayArgs.Select(a => a.Argument));
+        Assert.Equal(expectedArgs, displayArgs.Select(a => a.Argument));
         AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
     }
 

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -4627,6 +4627,43 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ProjectResource_WithDotnetToolRunLaunchArgs_DoesNotInjectProjectLaunchOptions_InProcessMode()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http")
+            .WithAnnotation(new ExecutableAnnotation
+            {
+                Command = "dotnet",
+                WorkingDirectory = "/tmp/project"
+            })
+            .WithLaunchToolArgs(ctx =>
+            {
+                ctx.Args.Add("tool");
+                ctx.Args.Add("run");
+                ctx.Args.Add("package");
+                ctx.Args.Add("--");
+            })
+            .WithArgs("app-arg");
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var kubernetes = new TestKubernetesService();
+        var executor = CreateAppExecutor(model, kubernetesService: kubernetes);
+
+        await executor.RunApplicationAsync();
+
+        var exe = GetCreatedExecutableForResource(kubernetes, "proj");
+        var expectedArgs = new[] { "tool", "run", "package", "--", "--profile-arg", "profile value", "app-arg" };
+
+        Assert.Equal(ExecutionType.Process, exe.Spec.ExecutionType);
+        Assert.Equal(expectedArgs, exe.Spec.Args);
+        Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var argAnnotations));
+        Assert.Equal(expectedArgs, argAnnotations.Select(a => a.Argument));
+        AssertEffectiveArgumentIndexesMatchSpecArgs(argAnnotations, exe.Spec.Args);
+    }
+
+    [Fact]
     public async Task ProjectResource_EmptyLaunchToolArgs_KeepsDotnetRunScaffolding_InProcessMode()
     {
         var builder = DistributedApplication.CreateBuilder();
@@ -6116,7 +6153,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ProjectResource_CustomIdeLaunch_OwnedLaunchToolArgsPreserveLaunchProfileArgs()
+    public async Task ProjectResource_CustomIdeLaunch_OwnedDotnetToolRunArgsPreserveLaunchProfileArgs()
     {
         var builder = DistributedApplication.CreateBuilder();
         var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
@@ -6132,6 +6169,8 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
                 static context =>
                 {
                     context.Args.Add("tool");
+                    context.Args.Add("run");
+                    context.Args.Add("package");
                     context.Args.Add("--");
                 },
                 ownedByLaunchConfigurationType: "custom")
@@ -6160,8 +6199,8 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         Assert.Null(exe.Spec.FallbackExecutionTypes);
 
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
-        Assert.Equal(["tool", "--", "--profile-arg", "profile value", "app-arg"], displayArgs.Select(a => a.Argument));
-        Assert.All(displayArgs.Take(2), argument => Assert.Null(argument.EffectiveArgumentIndex));
+        Assert.Equal(["tool", "run", "package", "--", "--profile-arg", "profile value", "app-arg"], displayArgs.Select(a => a.Argument));
+        Assert.All(displayArgs.Take(4), argument => Assert.Null(argument.EffectiveArgumentIndex));
         AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
     }
 


### PR DESCRIPTION
## Description

Custom IDE project launches that combine launch-profile arguments with AppHost arguments could receive a .NET-only `--` separator even though the custom launcher consumes the arguments directly. For Azure Functions, this produced an invalid command shape such as:

```text
dotnet -- --useHttps --cert <certificate> --password <password> --port <port>
```

This was a regression from #18999: materializing launch-profile arguments for custom IDE launches caused separator insertion to be inferred from the argument shape rather than an actual `dotnet run` or `dotnet watch` invocation. The invalid Process fallback eligibility predated #18999, but that PR's fallback refactoring preserved the behavior.

This change emits the separator only when a real .NET project invocation exists and suppresses Process fallback when a custom IDE launch has no complete process command. Explicit executable annotations and prepared project or launch-tool commands retain their existing fallback behavior.

### User-facing behavior

Custom launchers such as Azure Functions now receive their application arguments directly:

```text
--useHttps --cert <certificate> --password <password> --port <port>
```

If the IDE launch fails, Aspire no longer attempts an invalid `dotnet` Process fallback when no runnable process invocation was prepared.

### Validation

- Added focused regression coverage for raw custom-launch arguments and fallback eligibility.
- Verified the focused regression and control tests.
- Verified all 242 `DcpExecutorTests` (241 passed, 1 platform skip).
- Verified all 3,232 `Aspire.Hosting.Tests` (3,229 passed, 3 platform skips).

Fixes #19299

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
