### PR TITLE
Document current MCP machine information source

### DIFF
--- a/src/Aspire.Cli/Telemetry/DefaultMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/DefaultMachineInformationProvider.cs
@@ -5,7 +5,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// Current upstream: https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 /// <summary>

--- a/src/Aspire.Cli/Telemetry/DefaultMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/DefaultMachineInformationProvider.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 /// <summary>

--- a/src/Aspire.Cli/Telemetry/IMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/IMachineInformationProvider.cs
@@ -3,7 +3,8 @@
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// Current upstream: https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 internal interface IMachineInformationProvider

--- a/src/Aspire.Cli/Telemetry/IMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/IMachineInformationProvider.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 internal interface IMachineInformationProvider

--- a/src/Aspire.Cli/Telemetry/LinuxMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/LinuxMachineInformationProvider.cs
@@ -6,7 +6,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// Current upstream: https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 [SupportedOSPlatform("linux")]

--- a/src/Aspire.Cli/Telemetry/LinuxMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/LinuxMachineInformationProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 [SupportedOSPlatform("linux")]

--- a/src/Aspire.Cli/Telemetry/MacOSXMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/MacOSXMachineInformationProvider.cs
@@ -6,7 +6,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// Current upstream: https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 [SupportedOSPlatform("osx")]

--- a/src/Aspire.Cli/Telemetry/MacOSXMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/MacOSXMachineInformationProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 [SupportedOSPlatform("osx")]

--- a/src/Aspire.Cli/Telemetry/MachineInformationProviderBase.cs
+++ b/src/Aspire.Cli/Telemetry/MachineInformationProviderBase.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 internal abstract class MachineInformationProviderBase(ILogger<MachineInformationProviderBase> logger)

--- a/src/Aspire.Cli/Telemetry/MachineInformationProviderBase.cs
+++ b/src/Aspire.Cli/Telemetry/MachineInformationProviderBase.cs
@@ -8,7 +8,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// Current upstream: https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 internal abstract class MachineInformationProviderBase(ILogger<MachineInformationProviderBase> logger)

--- a/src/Aspire.Cli/Telemetry/UnixMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/UnixMachineInformationProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 internal abstract class UnixMachineInformationProvider(ILogger<UnixMachineInformationProvider> logger)

--- a/src/Aspire.Cli/Telemetry/UnixMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/UnixMachineInformationProvider.cs
@@ -6,7 +6,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// Current upstream: https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 internal abstract class UnixMachineInformationProvider(ILogger<UnixMachineInformationProvider> logger)

--- a/src/Aspire.Cli/Telemetry/WindowsMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/WindowsMachineInformationProvider.cs
@@ -7,7 +7,8 @@ using Microsoft.Win32;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// Current upstream: https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 [SupportedOSPlatform("windows")]

--- a/src/Aspire.Cli/Telemetry/WindowsMachineInformationProvider.cs
+++ b/src/Aspire.Cli/Telemetry/WindowsMachineInformationProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.Win32;
 
 namespace Aspire.Cli.Telemetry;
 
-// This is copied from https://github.com/microsoft/mcp/tree/6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a/core/Azure.Mcp.Core/src/Services/Telemetry
+// This is copied from https://github.com/microsoft/mcp/tree/e9f5da8fa093239d42d4b867afdf5e73e291d472/core/Microsoft.Mcp.Core/src/Services/Telemetry
 // Keep in sync with updates there.
 
 [SupportedOSPlatform("windows")]


### PR DESCRIPTION
## Description

Documents both the provenance and current synchronization point for the Aspire CLI machine-information telemetry providers copied from `microsoft/mcp`.

The immutable provenance remains commit `6bb4d76a63d24854efe0fa0bd96f5ab6f699ed3a` under `core/Azure.Mcp.Core/src/Services/Telemetry`, which is the source used by Aspire PR #13963. A separate link now identifies current upstream commit `e9f5da8fa093239d42d4b867afdf5e73e291d472` under the moved `core/Microsoft.Mcp.Core/src/Services/Telemetry` path.

This is intentionally documentation-only. Comparing the Aspire implementation with current upstream found no meaningful applicable behavior changes. The only subsequent Aspire edit to a copied provider was modifier ordering in PR #18251, which did not change behavior.

Validation:

- `dotnet build src/Aspire.Cli/Aspire.Cli.csproj --no-restore`
- `dotnet test --project tests/Aspire.Cli.Tests/Aspire.Cli.Tests.csproj --no-launch-profile -- --filter-class "*.LinuxInformationProviderTests" --filter-class "*.MacOSXInformationProviderTests" --filter-class "*.WindowsInformationProviderTests" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No