### PR TITLE
Sync ASP.NET Core certificate generation sources

### DIFF
--- a/src/Aspire.Cli/Certificates/CertificateGeneration/CertificateProcessRunner.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/CertificateProcessRunner.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Certificates.Generation;
+
+internal static class CertificateProcessRunner
+{
+    public static CertificateProcessResult Run(ProcessStartInfo startInfo, CancellationToken cancellationToken = default)
+        => RunCore(startInfo, captureOutput: false, cancellationToken);
+
+    public static CertificateProcessResult RunAndCaptureText(ProcessStartInfo startInfo, CancellationToken cancellationToken = default)
+        => RunCore(startInfo, captureOutput: true, cancellationToken);
+
+    private static CertificateProcessResult RunCore(ProcessStartInfo startInfo, bool captureOutput, CancellationToken cancellationToken)
+    {
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Failed to start process '{startInfo.FileName}'.");
+
+        // Drain both redirected pipes concurrently. Waiting for the process before reading, or
+        // reading one pipe to completion before the other, can deadlock when either pipe fills.
+        var standardOutputTask = startInfo.RedirectStandardOutput
+            ? ReadOutputAsync(process.StandardOutput, captureOutput, cancellationToken)
+            : Task.FromResult(string.Empty);
+        var standardErrorTask = startInfo.RedirectStandardError
+            ? ReadOutputAsync(process.StandardError, captureOutput, cancellationToken)
+            : Task.FromResult(string.Empty);
+
+        try
+        {
+            Task.WhenAll(
+                standardOutputTask,
+                standardErrorTask,
+                process.WaitForExitAsync(cancellationToken)).GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit();
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or System.ComponentModel.Win32Exception)
+            {
+                // The process either exited concurrently or could not be killed by this platform.
+            }
+
+            throw;
+        }
+
+        return new CertificateProcessResult(
+            process.ExitCode,
+            standardOutputTask.GetAwaiter().GetResult(),
+            standardErrorTask.GetAwaiter().GetResult());
+    }
+
+    private static async Task<string> ReadOutputAsync(StreamReader reader, bool captureOutput, CancellationToken cancellationToken)
+    {
+        if (captureOutput)
+        {
+            return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await reader.BaseStream.CopyToAsync(Stream.Null, cancellationToken).ConfigureAwait(false);
+        return string.Empty;
+    }
+}
+
+internal readonly record struct CertificateProcessResult(int ExitCode, string StandardOutput, string StandardError);

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/MacOSCertificateManager.cs
@@ -112,15 +112,14 @@ internal sealed class MacOSCertificateManager : CertificateManager
             {
                 Log.MacOSTrustCommandStart($"{MacOSTrustCertificateCommandLine} {s_macOSTrustCertificateCommandLineArguments}{tmpFile}");
             }
-            using (var process = Process.Start(MacOSTrustCertificateCommandLine, s_macOSTrustCertificateCommandLineArguments + tmpFile))
+            var processResult = CertificateProcessRunner.Run(
+                new ProcessStartInfo(MacOSTrustCertificateCommandLine, s_macOSTrustCertificateCommandLineArguments + tmpFile));
+            if (processResult.ExitCode != 0)
             {
-                process.WaitForExit();
-                if (process.ExitCode != 0)
-                {
-                    Log.MacOSTrustCommandError(process.ExitCode);
-                    throw new InvalidOperationException("There was an error trusting the certificate.");
-                }
+                Log.MacOSTrustCommandError(processResult.ExitCode);
+                throw new InvalidOperationException("There was an error trusting the certificate.");
             }
+
             Log.MacOSTrustCommandEnd();
         }
         finally
@@ -174,7 +173,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
             // We can't guarantee that the temp file is in a directory with sensible permissions, but we're not exporting the private key
             ExportCertificate(certificate, tmpFile, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pem);
 
-            using var checkTrustProcess = Process.Start(new ProcessStartInfo(
+            var checkTrustProcessResult = CertificateProcessRunner.Run(new ProcessStartInfo(
                 MacOSVerifyCertificateCommandLine,
                 string.Format(CultureInfo.InvariantCulture, MacOSVerifyCertificateCommandLineArgumentsFormat, tmpFile))
             {
@@ -183,8 +182,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
                 // the cert and replicate the command to see details.
                 RedirectStandardError = true,
             });
-            checkTrustProcess!.WaitForExit();
-            return checkTrustProcess.ExitCode == 0 ? TrustLevel.Full : TrustLevel.None;
+            return checkTrustProcessResult.ExitCode == 0 ? TrustLevel.Full : TrustLevel.None;
         }
         finally
         {
@@ -229,12 +227,10 @@ internal sealed class MacOSCertificateManager : CertificateManager
                     certificatePath
                 ));
 
-            using var process = Process.Start(processInfo);
-            process!.WaitForExit();
-
-            if (process.ExitCode != 0)
+            var processResult = CertificateProcessRunner.Run(processInfo);
+            if (processResult.ExitCode != 0)
             {
-                Log.MacOSRemoveCertificateTrustRuleError(process.ExitCode);
+                Log.MacOSRemoveCertificateTrustRuleError(processResult.ExitCode);
             }
 
             Log.MacOSRemoveCertificateTrustRuleEnd();
@@ -272,18 +268,13 @@ internal sealed class MacOSCertificateManager : CertificateManager
             Log.MacOSRemoveCertificateFromKeyChainStart(keychain, GetDescription(certificate));
         }
 
-        using (var process = Process.Start(processInfo))
+        var processResult = CertificateProcessRunner.RunAndCaptureText(processInfo);
+        if (processResult.ExitCode != 0)
         {
-            var output = process!.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-            process.WaitForExit();
+            Log.MacOSRemoveCertificateFromKeyChainError(processResult.ExitCode);
+            throw new InvalidOperationException($@"There was an error removing the certificate with thumbprint '{certificate.Thumbprint}'.
 
-            if (process.ExitCode != 0)
-            {
-                Log.MacOSRemoveCertificateFromKeyChainError(process.ExitCode);
-                throw new InvalidOperationException($@"There was an error removing the certificate with thumbprint '{certificate.Thumbprint}'.
-
-{output}");
-            }
+{processResult.StandardOutput}{processResult.StandardError}");
         }
 
         Log.MacOSRemoveCertificateFromKeyChainEnd();
@@ -371,16 +362,12 @@ internal sealed class MacOSCertificateManager : CertificateManager
             Log.MacOSAddCertificateToKeyChainStart(s_macOSUserKeychain, GetDescription(certificate));
         }
 
-        using (var process = Process.Start(processInfo))
+        var processResult = CertificateProcessRunner.RunAndCaptureText(processInfo);
+        if (processResult.ExitCode != 0)
         {
-            var output = process!.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                Log.MacOSAddCertificateToKeyChainError(process.ExitCode, output);
-                throw new InvalidOperationException("Failed to add the certificate to the keychain. Are you running in a non-interactive session perhaps?");
-            }
+            var output = processResult.StandardOutput + processResult.StandardError;
+            Log.MacOSAddCertificateToKeyChainError(processResult.ExitCode, output);
+            throw new InvalidOperationException("Failed to add the certificate to the keychain. Are you running in a non-interactive session perhaps?");
         }
 
         Log.MacOSAddCertificateToKeyChainEnd();

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/README.md
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/README.md
@@ -4,7 +4,7 @@ This directory contains code vendored from the ASP.NET Core repository's shared 
 
 **Source:** https://github.com/dotnet/aspnetcore/tree/main/src/Shared/CertificateGeneration
 
-**Last synced:** 2026-02-24 from commit [`3a973a5f4d28242262f27c86eb3f14299fe712ba`](https://github.com/dotnet/aspnetcore/commit/3a973a5f4d28242262f27c86eb3f14299fe712ba) — "Fix memory leaks in CertificateManager by improving certificate disposal patterns (#63321)"
+**Last synced:** 2026-07-02 from commit [`fa8126f62f64eaf37292ff1e334ace99bc757bcf`](https://github.com/dotnet/aspnetcore/commit/fa8126f62f64eaf37292ff1e334ace99bc757bcf) — "Fix typos in code. (#67428)"
 
 ## Local modifications
 
@@ -14,6 +14,8 @@ This directory contains code vendored from the ASP.NET Core repository's shared 
 - Changed `GetDescription` and `ToCertificateDescription` from `static` to instance methods
 - Removed `catch when (Log.IsEnabled())` filter pattern (incompatible with ILogger)
 - Replaced `new X509Certificate2(...)` with `X509CertificateLoader.LoadPkcs12FromFile(...)` (fixes SYSLIB0057)
+- Adapted .NET 11 `Process.Run` and `StandardOutputHandle` usage to `CertificateProcessRunner`, which concurrently drains redirected output on .NET 10
+- Retained support for both the HRESULT and raw Win32 error-code forms of Windows trust cancellation
 
 ## Updating
 

--- a/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Aspire.Cli/Certificates/CertificateGeneration/UnixCertificateManager.cs
@@ -282,7 +282,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             }
             catch
             {
-                // If we couldn't load the file, then we also can't safely overwite it.
+                // If we couldn't load the file, then we also can't safely overwrite it.
                 Log.UnixNotOverwritingCertificate(certPath);
                 return TrustLevel.None;
             }
@@ -693,9 +693,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             RedirectStandardError = true,
         };
 
-        using var process = Process.Start(startInfo)!;
-        process.WaitForExit();
-        return process.ExitCode == 0;
+        return CertificateProcessRunner.Run(startInfo).ExitCode == 0;
     }
 
     /// <remarks>
@@ -712,9 +710,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
         try
         {
-            using var process = Process.Start(startInfo)!;
-            WaitForExit(process, cancellationToken);
-            return process.ExitCode == 0;
+            return CertificateProcessRunner.Run(startInfo, cancellationToken).ExitCode == 0;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -726,25 +722,6 @@ internal sealed partial class UnixCertificateManager : CertificateManager
             // This method is used to determine whether more trust is needed, so it's better to underestimate the amount of trust.
             return false;
         }
-    }
-
-    private static void WaitForExit(Process process, CancellationToken cancellationToken)
-    {
-        using var cancellationRegistration = cancellationToken.Register(static state =>
-        {
-            var process = (Process)state!;
-            try
-            {
-                process.Kill(entireProcessTree: true);
-            }
-            catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or System.ComponentModel.Win32Exception)
-            {
-                // The process either exited concurrently or could not be killed by this platform.
-            }
-        }, process);
-
-        process.WaitForExit();
-        cancellationToken.ThrowIfCancellationRequested();
     }
 
     /// <remarks>
@@ -760,9 +737,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
         try
         {
-            using var process = Process.Start(startInfo)!;
-            process.WaitForExit();
-            return process.ExitCode == 0;
+            return CertificateProcessRunner.Run(startInfo).ExitCode == 0;
         }
         catch (Exception ex)
         {
@@ -780,9 +755,7 @@ internal sealed partial class UnixCertificateManager : CertificateManager
 
         try
         {
-            using var process = Process.Start(startInfo)!;
-            process.WaitForExit();
-            if (process.ExitCode == 0)
+            if (CertificateProcessRunner.Run(startInfo).ExitCode == 0)
             {
                 return true;
             }
@@ -961,17 +934,14 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 RedirectStandardError = true
             };
 
-            using var process = Process.Start(processInfo);
-            var stdout = process!.StandardOutput.ReadToEnd();
-
-            process.WaitForExit();
-            if (process.ExitCode != 0)
+            var processResult = CertificateProcessRunner.RunAndCaptureText(processInfo);
+            if (processResult.ExitCode != 0)
             {
                 Log.UnixOpenSslVersionFailed();
                 return false;
             }
 
-            var match = OpenSslVersionRegex.Match(stdout);
+            var match = OpenSslVersionRegex.Match(processResult.StandardOutput);
             if (!match.Success)
             {
                 Log.UnixOpenSslVersionParsingFailed();
@@ -1005,17 +975,14 @@ internal sealed partial class UnixCertificateManager : CertificateManager
                 RedirectStandardError = true
             };
 
-            using var process = Process.Start(processInfo);
-            var stdout = process!.StandardOutput.ReadToEnd();
-
-            process.WaitForExit();
-            if (process.ExitCode != 0)
+            var processResult = CertificateProcessRunner.RunAndCaptureText(processInfo);
+            if (processResult.ExitCode != 0)
             {
                 Log.UnixOpenSslHashFailed(certificatePath);
                 return false;
             }
 
-            hash = stdout.Trim();
+            hash = processResult.StandardOutput.Trim();
             return true;
         }
         catch (Exception ex)

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateProcessRunnerTests.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Certificates.Generation;
+using Microsoft.AspNetCore.InternalTesting;
+
+namespace Aspire.Cli.Tests.Certificates;
+
+public class CertificateProcessRunnerTests
+{
+    [Fact]
+    public async Task Run_DiscardsRedirectedOutputBeforeWaitingForExit()
+    {
+        var startInfo = CreateProcessStartInfo();
+
+        var result = await Task.Run(() => CertificateProcessRunner.Run(startInfo))
+            .DefaultTimeout();
+
+        Assert.Equal(ExitCode, result.ExitCode);
+        Assert.Equal(string.Empty, result.StandardOutput);
+        Assert.Equal(string.Empty, result.StandardError);
+    }
+
+    [Fact]
+    public async Task RunAndCaptureText_CapturesRedirectedOutputBeforeWaitingForExit()
+    {
+        var startInfo = CreateProcessStartInfo();
+
+        var result = await Task.Run(() => CertificateProcessRunner.RunAndCaptureText(startInfo))
+            .DefaultTimeout();
+
+        var expectedStandardOutput = string.Concat(Enumerable.Repeat(StandardOutputLine + Environment.NewLine, LineCount));
+        var expectedStandardError = string.Concat(Enumerable.Repeat(StandardErrorLine + Environment.NewLine, LineCount));
+
+        Assert.Equal(ExitCode, result.ExitCode);
+        Assert.Equal(expectedStandardOutput, result.StandardOutput);
+        Assert.Equal(expectedStandardError, result.StandardError);
+    }
+
+    private const int LineCount = 2048;
+    private const int ExitCode = 17;
+    private const string StandardOutputLine = "standard-output-0123456789abcdef0123456789abcdef0123456789abcdef";
+    private const string StandardErrorLine = "standard-error--0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private static ProcessStartInfo CreateProcessStartInfo()
+    {
+        ProcessStartInfo startInfo;
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo = new ProcessStartInfo("cmd.exe");
+            startInfo.ArgumentList.Add("/d");
+            startInfo.ArgumentList.Add("/s");
+            startInfo.ArgumentList.Add("/c");
+            startInfo.ArgumentList.Add(
+                $"for /L %i in (1,1,{LineCount}) do @echo {StandardOutputLine} & " +
+                $"for /L %i in (1,1,{LineCount}) do @echo {StandardErrorLine} 1>&2 & " +
+                $"exit /b {ExitCode}");
+        }
+        else
+        {
+            startInfo = new ProcessStartInfo("/bin/sh");
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add(
+                $"i=0; while [ \"$i\" -lt {LineCount} ]; do printf '{StandardOutputLine}\\n'; i=$((i+1)); done; " +
+                $"i=0; while [ \"$i\" -lt {LineCount} ]; do printf '{StandardErrorLine}\\n' >&2; i=$((i+1)); done; " +
+                $"exit {ExitCode}");
+        }
+
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        return startInfo;
+    }
+}

--- a/tests/Aspire.Cli.Tests/Certificates/CertificateProcessRunnerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/CertificateProcessRunnerTests.cs
@@ -48,14 +48,15 @@ public class CertificateProcessRunnerTests
         ProcessStartInfo startInfo;
         if (OperatingSystem.IsWindows())
         {
-            startInfo = new ProcessStartInfo("cmd.exe");
-            startInfo.ArgumentList.Add("/d");
-            startInfo.ArgumentList.Add("/s");
-            startInfo.ArgumentList.Add("/c");
+            startInfo = new ProcessStartInfo("powershell.exe");
+            startInfo.ArgumentList.Add("-NoLogo");
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-NonInteractive");
+            startInfo.ArgumentList.Add("-Command");
             startInfo.ArgumentList.Add(
-                $"for /L %i in (1,1,{LineCount}) do @echo {StandardOutputLine} & " +
-                $"for /L %i in (1,1,{LineCount}) do @echo {StandardErrorLine} 1>&2 & " +
-                $"exit /b {ExitCode}");
+                $"1..{LineCount} | ForEach-Object {{ [Console]::Out.WriteLine('{StandardOutputLine}') }}; " +
+                $"1..{LineCount} | ForEach-Object {{ [Console]::Error.WriteLine('{StandardErrorLine}') }}; " +
+                $"exit {ExitCode}");
         }
         else
         {

--- a/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
+++ b/tests/Aspire.Cli.Tests/Certificates/UnixCertificateManagerTests.cs
@@ -67,6 +67,43 @@ public class UnixCertificateManagerTests
     }
 
     [Fact]
+    public async Task GetTrustLevel_WhenCertUtilFillsOutputPipes_Completes()
+    {
+        Assert.SkipUnless(OperatingSystem.IsLinux(), "NSS certificate trust is only exercised on Linux.");
+
+        var tempDirectory = Directory.CreateTempSubdirectory();
+        var nssDbDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "nssdb"));
+
+        try
+        {
+            var certUtilFile = await CreateNoisyCertUtilAsync(tempDirectory);
+            var environment = TestEnvironment.CreateLinux(new Dictionary<string, string?>
+            {
+                ["PATH"] = tempDirectory.FullName,
+                ["SSL_CERT_DIR"] = tempDirectory.FullName,
+                ["DOTNET_DEV_CERTS_NSSDB_PATHS"] = nssDbDirectory.FullName
+            });
+            var manager = new UnixCertificateManager(NullLogger.Instance, environment, _ => new ProcessStartInfo(certUtilFile.FullName)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            });
+            using var certificate = manager.CreateAspNetCoreHttpsDevelopmentCertificate(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(365));
+
+            var trustLevel = await Task.Run(() => manager.GetTrustLevel(certificate))
+                .DefaultTimeout();
+
+            Assert.Equal(CertificateManager.TrustLevel.None, trustLevel);
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void GetTrustLevel_WithCorruptOpenSslCertificate_DoesNotThrow()
     {
         Assert.SkipUnless(OperatingSystem.IsLinux(), "OpenSSL certificate directory trust is only exercised on Linux.");
@@ -216,6 +253,31 @@ public class UnixCertificateManagerTests
             "sleep 60 &" + Environment.NewLine +
             $"echo $! > '{EscapeShellPath(childPidFile)}'" + Environment.NewLine +
             "wait $!" + Environment.NewLine;
+        await File.WriteAllTextAsync(certUtilFile.FullName, script);
+        File.SetUnixFileMode(
+            certUtilFile.FullName,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        return certUtilFile;
+    }
+
+    private static async Task<FileInfo> CreateNoisyCertUtilAsync(DirectoryInfo directory)
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        var certUtilFile = new FileInfo(Path.Combine(directory.FullName, "certutil"));
+        var script =
+            "#!/usr/bin/env bash" + Environment.NewLine +
+            "for _ in {1..16}; do" + Environment.NewLine +
+            "  printf '%65536s' x" + Environment.NewLine +
+            "  printf '%65536s' x >&2" + Environment.NewLine +
+            "done" + Environment.NewLine +
+            "exit 1" + Environment.NewLine;
         await File.WriteAllTextAsync(certUtilFile.FullName, script);
         File.SetUnixFileMode(
             certUtilFile.FullName,


### PR DESCRIPTION
## Description

Syncs the vendored ASP.NET Core `CertificateGeneration` source through dotnet/aspnetcore commit [`fa8126f62f64eaf37292ff1e334ace99bc757bcf`](https://github.com/dotnet/aspnetcore/commit/fa8126f62f64eaf37292ff1e334ace99bc757bcf).

This ports the Unix/macOS process deadlock fix from [`27a6a87368d65f679665f05d6df43021fc1f3190`](https://github.com/dotnet/aspnetcore/commit/27a6a87368d65f679665f05d6df43021fc1f3190) by concurrently draining redirected stdout and stderr. Because Aspire targets .NET 10, the upstream .NET 11 `Process.Run` and output-handle APIs are adapted through a local `CertificateProcessRunner`.

The sync also includes the upstream typo corrections and preserves Aspire's existing Windows trust-cancellation handling for both HRESULT `0x800704C7` and raw Win32 error code `1223`.

### Validation

- `./restore.sh`
- Affected `CertificateProcessRunnerTests` and `UnixCertificateManagerTests`
- `Aspire.Cli` build

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
