### PR TITLE
Clean up uploaded interaction files

### DIFF
--- a/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
+++ b/src/Aspire.Cli/Backchannel/AppHostCliBackchannel.cs
@@ -27,7 +27,7 @@ internal interface IAppHostCliBackchannel
     Task CompletePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     Task UpdatePromptResponseAsync(string promptId, PublishingPromptInputAnswer[] answers, CancellationToken cancellationToken);
     Task<GetPipelineStepsResponse> GetPipelineStepsAsync(string? step, CancellationToken cancellationToken);
-    Task<UploadFileResponse> UploadFileAsync(string filePath, string fileName, CancellationToken cancellationToken);
+    Task<UploadFileResponse> UploadFileAsync(string filePath, string fileName, int interactionId, string inputName, CancellationToken cancellationToken);
 }
 
 internal sealed class AppHostCliBackchannel(
@@ -554,7 +554,7 @@ internal sealed class AppHostCliBackchannel(
         return response;
     }
 
-    public async Task<UploadFileResponse> UploadFileAsync(string filePath, string fileName, CancellationToken cancellationToken)
+    public async Task<UploadFileResponse> UploadFileAsync(string filePath, string fileName, int interactionId, string inputName, CancellationToken cancellationToken)
     {
         using var activity = telemetry.StartDiagnosticActivity();
 
@@ -585,7 +585,7 @@ internal sealed class AppHostCliBackchannel(
             profilingTelemetry,
             "apphost",
             "UploadFileAsync",
-            [new UploadFileRequest { Data = data, FileName = fileName }],
+            [new UploadFileRequest { Data = data, FileName = fileName, InteractionId = interactionId, InputName = inputName }],
             cancellationToken).ConfigureAwait(false);
 
         logger.LogDebug("File uploaded with ID {FileId}", response.FileId);

--- a/src/Aspire.Cli/Commands/PipelineCommandBase.cs
+++ b/src/Aspire.Cli/Commands/PipelineCommandBase.cs
@@ -901,7 +901,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                 // Build the prompt text based on number of inputs
                 var promptText = BuildPromptText(input, inputs.Count, activity.Data.StatusText, activity.Data);
 
-                result = await HandleSingleInputAsync(input, promptText, backchannel, cancellationToken);
+                result = await HandleSingleInputAsync(input, promptText, backchannel, activity.Data.Id, cancellationToken);
             }
             else
             {
@@ -919,7 +919,7 @@ internal abstract class PipelineCommandBase : BaseCommand
         await backchannel.CompletePromptResponseAsync(activity.Data.Id, answers, cancellationToken);
     }
 
-    private async Task<string?> HandleSingleInputAsync(PublishingPromptInput input, string promptText, IAppHostCliBackchannel backchannel, CancellationToken cancellationToken)
+    private async Task<string?> HandleSingleInputAsync(PublishingPromptInput input, string promptText, IAppHostCliBackchannel backchannel, string interactionId, CancellationToken cancellationToken)
     {
         // The wire format uses hyphens (e.g. "secret-text") but the enum uses PascalCase (SecretText).
         var normalizedType = input.InputType.Replace("-", "", StringComparison.Ordinal);
@@ -958,7 +958,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
             InputType.Number => await HandleNumberInputAsync(input, promptText, cancellationToken),
 
-            InputType.File => await HandleFileInputAsync(input, promptText, backchannel, cancellationToken),
+            InputType.File => await HandleFileInputAsync(input, promptText, backchannel, interactionId, cancellationToken),
 
             _ => throw new InvalidOperationException($"Unsupported input type: {input.InputType}"),
         };
@@ -1020,8 +1020,14 @@ internal abstract class PipelineCommandBase : BaseCommand
             cancellationToken: cancellationToken);
     }
 
-    private async Task<string?> HandleFileInputAsync(PublishingPromptInput input, string promptText, IAppHostCliBackchannel backchannel, CancellationToken cancellationToken)
+    private async Task<string?> HandleFileInputAsync(PublishingPromptInput input, string promptText, IAppHostCliBackchannel backchannel, string interactionId, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrEmpty(input.Name))
+        {
+            throw new InvalidOperationException("File prompt input is missing a name.");
+        }
+        var inputName = input.Name;
+
         ValidationResult Validator(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
@@ -1093,7 +1099,7 @@ internal abstract class PipelineCommandBase : BaseCommand
                 filePaths.Add(Path.GetFullPath(value));
             }
 
-            return await UploadFilesAsync(filePaths, backchannel, cancellationToken);
+            return await UploadFilesAsync(filePaths, backchannel, interactionId, inputName, cancellationToken);
         }
 
         var singleValue = await InteractionService.PromptForFilePathAsync(
@@ -1108,14 +1114,18 @@ internal abstract class PipelineCommandBase : BaseCommand
             return string.Empty;
         }
 
-        return await UploadFilesAsync([Path.GetFullPath(singleValue)], backchannel, cancellationToken);
+        return await UploadFilesAsync([Path.GetFullPath(singleValue)], backchannel, interactionId, inputName, cancellationToken);
     }
 
-    private static async Task<string> UploadFilesAsync(List<string> filePaths, IAppHostCliBackchannel backchannel, CancellationToken cancellationToken)
+    private static async Task<string> UploadFilesAsync(List<string> filePaths, IAppHostCliBackchannel backchannel, string interactionId, string inputName, CancellationToken cancellationToken)
     {
         if (filePaths.Count == 0)
         {
             return string.Empty;
+        }
+        if (!int.TryParse(interactionId, CultureInfo.InvariantCulture, out var interactionIdValue))
+        {
+            throw new InvalidOperationException($"Prompt ID '{interactionId}' is not a valid interaction ID.");
         }
 
         var fileRefs = new List<FileReferenceDto>(filePaths.Count);
@@ -1127,7 +1137,7 @@ internal abstract class PipelineCommandBase : BaseCommand
 
             // Upload the file to the AppHost and collect the reference.
             // Matching the same format the dashboard uses: [{"Id":"...","Name":"..."}]
-            var uploadResponse = await backchannel.UploadFileAsync(fullPath, fileName, cancellationToken);
+            var uploadResponse = await backchannel.UploadFileAsync(fullPath, fileName, interactionIdValue, inputName, cancellationToken);
             fileRefs.Add(new FileReferenceDto { Id = uploadResponse.FileId, Name = fileName });
         }
 

--- a/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/InteractionsInputDialog.razor.cs
@@ -246,7 +246,7 @@ public partial class InteractionsInputDialog : IAsyncDisposable
             try
             {
                 using var stream = file.OpenReadStream(maxFileSize);
-                var fileId = await DashboardClient.UploadFileAsync(stream, file.Name, file.Size, _disposalCts.Token);
+                var fileId = await DashboardClient.UploadFileAsync(stream, file.Name, file.Size, Content.Interaction.InteractionId, inputModel.Input.Name, _disposalCts.Token);
                 fileReferences.Add(new FileReferenceViewModel { Id = fileId, Name = file.Name });
             }
             catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/DashboardClient.cs
@@ -1035,7 +1035,7 @@ internal sealed class DashboardClient : IDashboardClient
         }
     }
 
-    public async Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, CancellationToken cancellationToken)
+    public async Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken)
     {
         EnsureInitialized();
 
@@ -1064,6 +1064,8 @@ internal sealed class DashboardClient : IDashboardClient
             if (isFirst)
             {
                 chunk.FileName = fileName;
+                chunk.InteractionId = interactionId;
+                chunk.InputName = inputName;
             }
 
             await call.RequestStream.WriteAsync(chunk, combinedTokens.Token).ConfigureAwait(false);
@@ -1073,7 +1075,7 @@ internal sealed class DashboardClient : IDashboardClient
         // Handle case where the file was empty — still send filename.
         if (isFirst)
         {
-            await call.RequestStream.WriteAsync(new UploadFileChunk { FileName = fileName }, combinedTokens.Token).ConfigureAwait(false);
+            await call.RequestStream.WriteAsync(new UploadFileChunk { FileName = fileName, InteractionId = interactionId, InputName = inputName }, combinedTokens.Token).ConfigureAwait(false);
         }
 
         await call.RequestStream.CompleteAsync().ConfigureAwait(false);

--- a/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/ServiceClient/IDashboardClient.cs
@@ -94,7 +94,7 @@ public interface IDashboardClient : IAsyncDisposable
 
     Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken);
 
-    Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, CancellationToken cancellationToken);
+    Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken);
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -22,7 +22,7 @@ internal class AppHostRpcTarget(
     IHostApplicationLifetime lifetime,
     DistributedApplicationOptions options,
     AppHostStartupState startupState,
-    IFileUploadStore fileUploadStore,
+    IInteractionFileUploadStore fileUploadStore,
     IConfiguration configuration)
 {
     private readonly CancellationTokenSource _shutdownCts = new();

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -257,7 +257,16 @@ internal class AppHostRpcTarget(
             throw new InvalidOperationException($"File '{request.FileName}' exceeds the maximum upload size of {maxUploadSize} bytes.");
         }
 
-        var (fileId, filePath) = fileUploadStore.CreateEntry(request.FileName);
+        if (request.InteractionId <= 0)
+        {
+            throw new InvalidOperationException("An interaction ID is required when uploading a file.");
+        }
+        if (string.IsNullOrEmpty(request.InputName))
+        {
+            throw new InvalidOperationException("An input name is required when uploading a file.");
+        }
+
+        var (fileId, filePath) = fileUploadStore.CreateEntry(request.FileName, request.InteractionId, request.InputName);
 
         try
         {
@@ -272,6 +281,8 @@ internal class AppHostRpcTarget(
             fileUploadStore.RemoveEntry(fileId);
             throw;
         }
+
+        fileUploadStore.CompleteUpload(fileId);
 
         return new UploadFileResponse { FileId = fileId };
     }

--- a/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
+++ b/src/Aspire.Hosting/Backchannel/AppHostRpcTarget.cs
@@ -278,11 +278,11 @@ internal class AppHostRpcTarget(
         }
         catch
         {
-            fileUploadStore.RemoveEntry(fileId);
+            fileUploadStore.RemoveEntry(request.InteractionId, fileId);
             throw;
         }
 
-        fileUploadStore.CompleteUpload(fileId);
+        fileUploadStore.CompleteUpload(request.InteractionId, fileId);
 
         return new UploadFileResponse { FileId = fileId };
     }

--- a/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
+++ b/src/Aspire.Hosting/Backchannel/BackchannelDataTypes.cs
@@ -967,6 +967,8 @@ internal sealed class UploadFileRequest
 {
     public required byte[] Data { get; set; }
     public required string FileName { get; set; }
+    public required int InteractionId { get; set; }
+    public required string InputName { get; set; }
 }
 
 internal sealed class UploadFileResponse

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -519,9 +519,17 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                     {
                         throw new RpcException(new Status(StatusCode.InvalidArgument, "First chunk must include a file name."));
                     }
+                    if (chunk.InteractionId <= 0)
+                    {
+                        throw new RpcException(new Status(StatusCode.InvalidArgument, "First chunk must include an interaction ID."));
+                    }
+                    if (string.IsNullOrEmpty(chunk.InputName))
+                    {
+                        throw new RpcException(new Status(StatusCode.InvalidArgument, "First chunk must include an input name."));
+                    }
 
                     string path;
-                    (fileId, path) = fileUploadStore.CreateEntry(chunk.FileName);
+                    (fileId, path) = fileUploadStore.CreateEntry(chunk.FileName, chunk.InteractionId, chunk.InputName);
                     fileStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
                 }
 
@@ -566,6 +574,8 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                 await fileStream.DisposeAsync().ConfigureAwait(false);
             }
         }
+
+        fileUploadStore.CompleteUpload(fileId!);
 
         return new UploadFileResponse { FileId = fileId };
     }

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -504,6 +504,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
         var cancellationToken = context.CancellationToken;
         long totalBytesWritten = 0;
         string? fileId = null;
+        int? interactionId = null;
         FileStream? fileStream = null;
 
         try
@@ -529,7 +530,8 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                     }
 
                     string path;
-                    (fileId, path) = fileUploadStore.CreateEntry(chunk.FileName, chunk.InteractionId, chunk.InputName);
+                    interactionId = chunk.InteractionId;
+                    (fileId, path) = fileUploadStore.CreateEntry(chunk.FileName, interactionId.Value, chunk.InputName);
                     fileStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
                 }
 
@@ -560,9 +562,9 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                 fileStream = null;
             }
 
-            if (fileId is not null)
+            if (fileId is not null && interactionId is not null)
             {
-                fileUploadStore.RemoveEntry(fileId);
+                fileUploadStore.RemoveEntry(interactionId.Value, fileId);
             }
 
             throw;
@@ -575,7 +577,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             }
         }
 
-        fileUploadStore.CompleteUpload(fileId!);
+        fileUploadStore.CompleteUpload(interactionId!.Value, fileId!);
 
         return new UploadFileResponse { FileId = fileId };
     }

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -23,7 +23,7 @@ namespace Aspire.Hosting.Dashboard;
 /// required beyond a single request. Longer-scoped data is stored in <see cref="DashboardServiceData"/>.
 /// </remarks>
 [Authorize(Policy = ResourceServiceApiKeyAuthorization.PolicyName)]
-internal sealed partial class DashboardService(DashboardServiceData serviceData, IHostEnvironment hostEnvironment, IHostApplicationLifetime hostApplicationLifetime, IConfiguration configuration, ILogger<DashboardService> logger, IFileUploadStore fileUploadStore)
+internal sealed partial class DashboardService(DashboardServiceData serviceData, IHostEnvironment hostEnvironment, IHostApplicationLifetime hostApplicationLifetime, IConfiguration configuration, ILogger<DashboardService> logger, IInteractionFileUploadStore fileUploadStore)
     : Aspire.DashboardService.Proto.V1.DashboardService.DashboardServiceBase
 {
     // gRPC has a maximum receive size of 4MB. Force logs into batches to avoid exceeding receive size.

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -531,7 +531,14 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
                     string path;
                     interactionId = chunk.InteractionId;
-                    (fileId, path) = fileUploadStore.CreateEntry(chunk.FileName, interactionId.Value, chunk.InputName);
+                    try
+                    {
+                        (fileId, path) = fileUploadStore.CreateEntry(chunk.FileName, interactionId.Value, chunk.InputName);
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        throw new RpcException(new Status(StatusCode.FailedPrecondition, ex.Message));
+                    }
                     fileStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
                 }
 
@@ -551,6 +558,15 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             {
                 throw new RpcException(new Status(StatusCode.InvalidArgument, "Upload stream is empty."));
             }
+
+            // Close and flush the file before marking the upload complete. If disposal fails,
+            // the catch path removes the entry so a partial upload is never retained.
+            await fileStream.DisposeAsync().ConfigureAwait(false);
+            fileStream = null;
+
+            fileUploadStore.CompleteUpload(interactionId!.Value, fileId!);
+
+            return new UploadFileResponse { FileId = fileId };
         }
         catch
         {
@@ -558,8 +574,14 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             // before attempting deletion — on Windows, open handles prevent file deletion.
             if (fileStream is not null)
             {
-                await fileStream.DisposeAsync().ConfigureAwait(false);
-                fileStream = null;
+                try
+                {
+                    await fileStream.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to close incomplete uploaded file {FileId}.", fileId);
+                }
             }
 
             if (fileId is not null && interactionId is not null)
@@ -569,16 +591,5 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
             throw;
         }
-        finally
-        {
-            if (fileStream is not null)
-            {
-                await fileStream.DisposeAsync().ConfigureAwait(false);
-            }
-        }
-
-        fileUploadStore.CompleteUpload(interactionId!.Value, fileId!);
-
-        return new UploadFileResponse { FileId = fileId };
     }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -217,7 +217,7 @@ internal sealed class DashboardServiceData : IDisposable
                             serviceProvider,
                             logger,
                             inputsInfo,
-                            request.InputsDialog.InputItems.Select(i => MapInputDto(interaction.InteractionId, i)).ToList(),
+                            request.InputsDialog.InputItems.Select(i => MapInputDto(interaction.InteractionId, inputsInfo, i)).ToList(),
                             request.ResponseUpdate,
                             interaction.CancellationToken);
 
@@ -230,9 +230,14 @@ internal sealed class DashboardServiceData : IDisposable
             cancellationToken).ConfigureAwait(false);
     }
 
-    private InputDto MapInputDto(int interactionId, Aspire.DashboardService.Proto.V1.InteractionInput i)
+    private InputDto MapInputDto(int interactionId, Interaction.InputsInteractionInfo inputsInfo, Aspire.DashboardService.Proto.V1.InteractionInput i)
     {
-        var inputType = DashboardService.MapInputType(i.InputType);
+        if (!inputsInfo.Inputs.TryGetByName(i.Name, out var modelInput))
+        {
+            return new InputDto(i.Name, i.Value, DashboardService.MapInputType(i.InputType));
+        }
+
+        var inputType = modelInput.InputType;
 
         // For file inputs, Value contains a JSON array of objects with file IDs and names.
         // Resolve each ID to the temp file path and build InputFileDto entries.

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -217,7 +217,7 @@ internal sealed class DashboardServiceData : IDisposable
                             serviceProvider,
                             logger,
                             inputsInfo,
-                            request.InputsDialog.InputItems.Select(i => MapInputDto(i)).ToList(),
+                            request.InputsDialog.InputItems.Select(i => MapInputDto(interaction.InteractionId, i)).ToList(),
                             request.ResponseUpdate,
                             interaction.CancellationToken);
 
@@ -230,7 +230,7 @@ internal sealed class DashboardServiceData : IDisposable
             cancellationToken).ConfigureAwait(false);
     }
 
-    private InputDto MapInputDto(Aspire.DashboardService.Proto.V1.InteractionInput i)
+    private InputDto MapInputDto(int interactionId, Aspire.DashboardService.Proto.V1.InteractionInput i)
     {
         var inputType = DashboardService.MapInputType(i.InputType);
 
@@ -238,7 +238,7 @@ internal sealed class DashboardServiceData : IDisposable
         // Resolve each ID to the temp file path and build InputFileDto entries.
         if (inputType == InputType.File)
         {
-            var files = FileUploadStore.ResolveFileReferences(_fileUploadStore, i.Value, i.Name, _logger);
+            var files = FileUploadStore.ResolveFileReferences(_fileUploadStore, i.Value, interactionId, i.Name, _logger);
             if (files is not null)
             {
                 return new InputDto(i.Name, i.Value, inputType, files);

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -19,7 +19,7 @@ internal sealed class DashboardServiceData : IDisposable
     private readonly ResourceCommandService _resourceCommandService;
     private readonly InteractionService _interactionService;
     private readonly ResourceLoggerService _resourceLoggerService;
-    private readonly IFileUploadStore _fileUploadStore;
+    private readonly IInteractionFileUploadStore _fileUploadStore;
     private readonly ILogger<DashboardServiceData> _logger;
 
     public DashboardServiceData(
@@ -28,7 +28,7 @@ internal sealed class DashboardServiceData : IDisposable
         ILogger<DashboardServiceData> logger,
         ResourceCommandService resourceCommandService,
         InteractionService interactionService,
-        IFileUploadStore fileUploadStore)
+        IInteractionFileUploadStore fileUploadStore)
     {
         _resourceLoggerService = resourceLoggerService;
         _resourcePublisher = new ResourcePublisher(_cts.Token);
@@ -238,7 +238,7 @@ internal sealed class DashboardServiceData : IDisposable
         // Resolve each ID to the temp file path and build InputFileDto entries.
         if (inputType == InputType.File)
         {
-            var files = FileUploadStore.ResolveFileReferences(_fileUploadStore, i.Value, interactionId, i.Name, _logger);
+            var files = InteractionFileUploadStore.ResolveFileReferences(_fileUploadStore, i.Value, interactionId, i.Name, _logger);
             if (files is not null)
             {
                 return new InputDto(i.Name, i.Value, inputType, files);

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -50,7 +50,7 @@ internal sealed class DashboardServiceHost : IHostedService
         ResourceLoggerService resourceLoggerService,
         ResourceCommandService resourceCommandService,
         InteractionService interactionService,
-        IFileSystemService fileSystemService)
+        IFileUploadStore fileUploadStore)
     {
         _logger = loggerFactory.CreateLogger<DashboardServiceHost>();
 
@@ -109,8 +109,7 @@ internal sealed class DashboardServiceHost : IHostedService
             builder.Services.AddSingleton(resourceNotificationService);
             builder.Services.AddSingleton(resourceLoggerService);
             builder.Services.AddSingleton(interactionService);
-            builder.Services.AddSingleton(fileSystemService);
-            builder.Services.AddSingleton<IFileUploadStore, FileUploadStore>();
+            builder.Services.AddSingleton(fileUploadStore);
 
             builder.WebHost.ConfigureKestrel(ConfigureKestrel);
 

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -50,7 +50,7 @@ internal sealed class DashboardServiceHost : IHostedService
         ResourceLoggerService resourceLoggerService,
         ResourceCommandService resourceCommandService,
         InteractionService interactionService,
-        IFileUploadStore fileUploadStore)
+        IInteractionFileUploadStore fileUploadStore)
     {
         _logger = loggerFactory.CreateLogger<DashboardServiceHost>();
 

--- a/src/Aspire.Hosting/Dashboard/FileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/FileUploadStore.cs
@@ -21,7 +21,6 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<int, FileInteraction> _interactions = new();
     private readonly ITempFileSystemService _tempFileSystem;
-    private readonly bool _preserveTempFiles;
     private readonly ILogger<FileUploadStore> _logger;
     private readonly CancellationTokenSource _cleanupCts = new();
     private readonly Task _cleanupTask;
@@ -34,7 +33,6 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     public FileUploadStore(IFileSystemService fileSystemService, ILogger<FileUploadStore> logger)
     {
         _tempFileSystem = fileSystemService.TempDirectory;
-        _preserveTempFiles = fileSystemService is FileSystemService { ShouldPreserveTempFiles: true };
         _logger = logger;
         _cleanupTask = RunCleanupAsync(_cleanupCts.Token);
     }
@@ -151,22 +149,19 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
         {
             entry.RemovalRequested = true;
 
-            if (!_preserveTempFiles)
+            try
             {
-                try
-                {
-                    File.Delete(entry.TempFile.Path);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(
-                        ex,
-                        "Failed to remove uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}. Cleanup will be retried.",
-                        fileId,
-                        entry.InteractionId,
-                        entry.InputName);
-                    return;
-                }
+                entry.TempFile.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to remove uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}. Cleanup will be retried.",
+                    fileId,
+                    entry.InteractionId,
+                    entry.InputName);
+                return;
             }
 
             if (!_files.TryRemove(KeyValuePair.Create(fileId, entry)))
@@ -181,18 +176,6 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
             {
                 interaction.FileIds.Remove(fileId);
             }
-        }
-
-        try
-        {
-            entry.TempFile.Dispose();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to dispose temporary file tracking for uploaded file entry {FileId}.",
-                fileId);
         }
 
         _logger.LogDebug(

--- a/src/Aspire.Hosting/Dashboard/FileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/FileUploadStore.cs
@@ -6,6 +6,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using static Aspire.Hosting.Dashboard.DashboardServiceData;
 
 namespace Aspire.Hosting.Dashboard;
@@ -15,38 +16,99 @@ namespace Aspire.Hosting.Dashboard;
 /// </summary>
 internal sealed class FileUploadStore : IFileUploadStore, IDisposable
 {
-    private readonly ConcurrentDictionary<string, TempFile> _files = new(StringComparer.Ordinal);
+    private static readonly TimeSpan s_cleanupInterval = TimeSpan.FromSeconds(10);
+
+    private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<int, FileInteraction> _interactions = new();
     private readonly ITempFileSystemService _tempFileSystem;
+    private readonly ILogger<FileUploadStore> _logger;
+    private readonly CancellationTokenSource _cleanupCts = new();
+    private readonly Task _cleanupTask;
 
     public FileUploadStore(IFileSystemService fileSystemService)
+        : this(fileSystemService, NullLogger<FileUploadStore>.Instance)
+    {
+    }
+
+    public FileUploadStore(IFileSystemService fileSystemService, ILogger<FileUploadStore> logger)
     {
         _tempFileSystem = fileSystemService.TempDirectory;
+        _logger = logger;
+        _cleanupTask = RunCleanupAsync(_cleanupCts.Token);
+    }
+
+    /// <summary>
+    /// Registers an interaction that can own uploaded files.
+    /// </summary>
+    public void StartInteraction(int interactionId)
+    {
+        _interactions.TryAdd(interactionId, new FileInteraction());
     }
 
     /// <summary>
     /// Creates a new temp file path and returns the file ID and path.
     /// </summary>
-    public (string FileId, string FilePath) CreateEntry(string originalFileName)
+    public (string FileId, string FilePath) CreateEntry(string originalFileName, int interactionId, string inputName)
     {
-        // Sanitize the file name to prevent path traversal attacks.
-        // Strip directory components for both Unix (/) and Windows (\) separators
-        // regardless of the current platform, since the name comes from a remote client.
-        var lastSep = originalFileName.AsSpan().LastIndexOfAny('/', '\\');
-        var safeName = lastSep >= 0 ? originalFileName[(lastSep + 1)..] : originalFileName;
+        if (!_interactions.TryGetValue(interactionId, out var interaction))
+        {
+            throw new InvalidOperationException($"Interaction '{interactionId}' is not accepting file uploads.");
+        }
 
-        var tempFile = _tempFileSystem.CreateTempFile(string.IsNullOrEmpty(safeName) ? null : safeName);
-        var fileId = Guid.NewGuid().ToString("N");
+        lock (interaction)
+        {
+            if (interaction.State != FileInteractionState.InProgress)
+            {
+                throw new InvalidOperationException($"Interaction '{interactionId}' is not accepting file uploads.");
+            }
 
-        _files[fileId] = tempFile;
-        return (fileId, tempFile.Path);
+            // Sanitize the file name to prevent path traversal attacks.
+            // Strip directory components for both Unix (/) and Windows (\) separators
+            // regardless of the current platform, since the name comes from a remote client.
+            var lastSep = originalFileName.AsSpan().LastIndexOfAny('/', '\\');
+            var safeName = lastSep >= 0 ? originalFileName[(lastSep + 1)..] : originalFileName;
+
+            var tempFile = _tempFileSystem.CreateTempFile(string.IsNullOrEmpty(safeName) ? null : safeName);
+            var fileId = Guid.NewGuid().ToString("N");
+
+            _files[fileId] = new FileEntry(tempFile, interactionId, inputName);
+            interaction.FileIds.Add(fileId);
+            return (fileId, tempFile.Path);
+        }
     }
 
     /// <summary>
-    /// Gets the file path for a given file ID.
+    /// Marks a file upload as successfully completed.
     /// </summary>
-    public string? GetFilePath(string fileId)
+    public void CompleteUpload(string fileId)
     {
-        return _files.TryGetValue(fileId, out var tempFile) ? tempFile.Path : null;
+        if (!_files.TryGetValue(fileId, out var entry))
+        {
+            return;
+        }
+
+        bool removeEntry;
+        lock (entry)
+        {
+            entry.UploadComplete = true;
+            removeEntry = entry.InteractionState == FileInteractionState.Canceled;
+        }
+
+        if (removeEntry)
+        {
+            RemoveEntry(fileId);
+        }
+    }
+
+    /// <summary>
+    /// Gets the file path for a given file ID and input name.
+    /// </summary>
+    public string? GetFilePath(string fileId, string inputName)
+    {
+        return _files.TryGetValue(fileId, out var entry) &&
+            string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
+                ? entry.TempFile.Path
+                : null;
     }
 
     /// <summary>
@@ -54,25 +116,149 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     /// </summary>
     public string? GetFileName(string fileId)
     {
-        return _files.TryGetValue(fileId, out var tempFile) ? Path.GetFileName(tempFile.Path) : null;
+        return _files.TryGetValue(fileId, out var entry) ? Path.GetFileName(entry.TempFile.Path) : null;
     }
 
     /// <summary>
     /// Removes a file entry and deletes the associated file on disk.
-    /// Used to clean up after failed uploads.
     /// </summary>
     public void RemoveEntry(string fileId)
     {
-        if (_files.TryRemove(fileId, out var tempFile))
+        if (_files.TryRemove(fileId, out var entry))
         {
+            if (_interactions.TryGetValue(entry.InteractionId, out var interaction))
+            {
+                lock (interaction)
+                {
+                    interaction.FileIds.Remove(fileId);
+                }
+            }
+
             try
             {
-                tempFile.Dispose();
+                entry.TempFile.Dispose();
             }
             catch
             {
                 // Best effort cleanup.
             }
+        }
+    }
+
+    /// <summary>
+    /// Marks an interaction as completed and starts weak-reference tracking for its uploaded files.
+    /// </summary>
+    public void CompleteInteraction(int interactionId, IReadOnlyList<InteractionFile> files)
+    {
+        if (!_interactions.TryGetValue(interactionId, out var interaction))
+        {
+            return;
+        }
+
+        var filesById = files.ToLookup(file => file.Id, StringComparer.Ordinal);
+        string[] fileIds;
+
+        lock (interaction)
+        {
+            interaction.State = FileInteractionState.Complete;
+            fileIds = [.. interaction.FileIds];
+        }
+        _interactions.TryRemove(KeyValuePair.Create(interactionId, interaction));
+
+        foreach (var fileId in fileIds)
+        {
+            if (!_files.TryGetValue(fileId, out var entry))
+            {
+                continue;
+            }
+            lock (entry)
+            {
+                entry.InteractionState = FileInteractionState.Complete;
+                entry.References = filesById[fileId]
+                    .Select(file => new WeakReference<InteractionFile>(file))
+                    .ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Cancels an interaction and removes uploads that are no longer in progress.
+    /// </summary>
+    public void CancelInteraction(int interactionId)
+    {
+        if (!_interactions.TryGetValue(interactionId, out var interaction))
+        {
+            return;
+        }
+
+        string[] fileIds;
+        lock (interaction)
+        {
+            interaction.State = FileInteractionState.Canceled;
+            fileIds = [.. interaction.FileIds];
+        }
+        _interactions.TryRemove(KeyValuePair.Create(interactionId, interaction));
+
+        foreach (var fileId in fileIds)
+        {
+            if (!_files.TryGetValue(fileId, out var entry))
+            {
+                continue;
+            }
+            bool removeEntry;
+            lock (entry)
+            {
+                entry.InteractionState = FileInteractionState.Canceled;
+                removeEntry = entry.UploadComplete;
+            }
+
+            if (removeEntry)
+            {
+                RemoveEntry(fileId);
+            }
+        }
+    }
+
+    internal void RemoveUnreferencedFiles()
+    {
+        foreach (var (fileId, entry) in _files)
+        {
+            bool removeEntry;
+            lock (entry)
+            {
+                removeEntry = entry.UploadComplete &&
+                    (entry.InteractionState == FileInteractionState.Canceled ||
+                     entry.InteractionState == FileInteractionState.Complete &&
+                     (entry.References is null || entry.References.All(reference => !reference.TryGetTarget(out _))));
+            }
+
+            if (removeEntry)
+            {
+                RemoveEntry(fileId);
+            }
+        }
+    }
+
+    private async Task RunCleanupAsync(CancellationToken cancellationToken)
+    {
+        using var timer = new PeriodicTimer(s_cleanupInterval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    RemoveUnreferencedFiles();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to clean up unreferenced uploaded files. Cleanup will be retried.");
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
         }
     }
 
@@ -107,7 +293,7 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
         for (var idx = 0; idx < fileRefs.Length; idx++)
         {
             var fileRef = fileRefs[idx];
-            var filePath = store.GetFilePath(fileRef.Id);
+            var filePath = store.GetFilePath(fileRef.Id, inputName);
             if (filePath is null)
             {
                 // Unknown file ID — skip to prevent using client-supplied IDs as arbitrary file paths.
@@ -123,11 +309,15 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
 
     public void Dispose()
     {
-        foreach (var tempFile in _files.Values)
+        _cleanupCts.Cancel();
+        _cleanupTask.GetAwaiter().GetResult();
+        _cleanupCts.Dispose();
+
+        foreach (var entry in _files.Values)
         {
             try
             {
-                tempFile.Dispose();
+                entry.TempFile.Dispose();
             }
             catch
             {
@@ -135,6 +325,7 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
             }
         }
         _files.Clear();
+        _interactions.Clear();
     }
 
     // Shared type used by ResolveFileReferences for JSON deserialization of file input values.
@@ -143,5 +334,28 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     {
         public string Id { get; set; } = "";
         public string Name { get; set; } = "";
+    }
+
+    private sealed class FileEntry(TempFile tempFile, int interactionId, string inputName)
+    {
+        public TempFile TempFile { get; } = tempFile;
+        public int InteractionId { get; } = interactionId;
+        public string InputName { get; } = inputName;
+        public bool UploadComplete { get; set; }
+        public FileInteractionState InteractionState { get; set; }
+        public IReadOnlyList<WeakReference<InteractionFile>>? References { get; set; }
+    }
+
+    private sealed class FileInteraction
+    {
+        public HashSet<string> FileIds { get; } = new(StringComparer.Ordinal);
+        public FileInteractionState State { get; set; }
+    }
+
+    private enum FileInteractionState
+    {
+        InProgress,
+        Complete,
+        Canceled
     }
 }

--- a/src/Aspire.Hosting/Dashboard/FileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/FileUploadStore.cs
@@ -21,6 +21,7 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<int, FileInteraction> _interactions = new();
     private readonly ITempFileSystemService _tempFileSystem;
+    private readonly bool _preserveTempFiles;
     private readonly ILogger<FileUploadStore> _logger;
     private readonly CancellationTokenSource _cleanupCts = new();
     private readonly Task _cleanupTask;
@@ -33,6 +34,7 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     public FileUploadStore(IFileSystemService fileSystemService, ILogger<FileUploadStore> logger)
     {
         _tempFileSystem = fileSystemService.TempDirectory;
+        _preserveTempFiles = fileSystemService is FileSystemService { ShouldPreserveTempFiles: true };
         _logger = logger;
         _cleanupTask = RunCleanupAsync(_cleanupCts.Token);
     }
@@ -116,11 +118,12 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     }
 
     /// <summary>
-    /// Gets the file path for a given file ID and input name.
+    /// Gets the file path for a given file ID, interaction ID, and input name.
     /// </summary>
-    public string? GetFilePath(string fileId, string inputName)
+    public string? GetFilePath(string fileId, int interactionId, string inputName)
     {
         return _files.TryGetValue(fileId, out var entry) &&
+            entry.InteractionId == interactionId &&
             string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
                 ? entry.TempFile.Path
                 : null;
@@ -139,31 +142,64 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     /// </summary>
     public void RemoveEntry(string fileId)
     {
-        if (_files.TryRemove(fileId, out var entry))
+        if (!_files.TryGetValue(fileId, out var entry))
         {
-            _logger.LogDebug(
-                "Removing uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}.",
-                fileId,
-                entry.InteractionId,
-                entry.InputName);
+            return;
+        }
 
-            if (_interactions.TryGetValue(entry.InteractionId, out var interaction))
+        lock (entry)
+        {
+            entry.RemovalRequested = true;
+
+            if (!_preserveTempFiles)
             {
-                lock (interaction)
+                try
                 {
-                    interaction.FileIds.Remove(fileId);
+                    File.Delete(entry.TempFile.Path);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Failed to remove uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}. Cleanup will be retried.",
+                        fileId,
+                        entry.InteractionId,
+                        entry.InputName);
+                    return;
                 }
             }
 
-            try
+            if (!_files.TryRemove(KeyValuePair.Create(fileId, entry)))
             {
-                entry.TempFile.Dispose();
-            }
-            catch
-            {
-                // Best effort cleanup.
+                return;
             }
         }
+
+        if (_interactions.TryGetValue(entry.InteractionId, out var interaction))
+        {
+            lock (interaction)
+            {
+                interaction.FileIds.Remove(fileId);
+            }
+        }
+
+        try
+        {
+            entry.TempFile.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to dispose temporary file tracking for uploaded file entry {FileId}.",
+                fileId);
+        }
+
+        _logger.LogDebug(
+            "Removed uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}.",
+            fileId,
+            entry.InteractionId,
+            entry.InputName);
     }
 
     /// <summary>
@@ -258,7 +294,8 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
             bool removeEntry;
             lock (entry)
             {
-                removeEntry = entry.UploadComplete &&
+                removeEntry = entry.RemovalRequested ||
+                    entry.UploadComplete &&
                     (entry.InteractionState == FileInteractionState.Canceled ||
                      entry.InteractionState == FileInteractionState.Complete &&
                      (entry.References is null || entry.References.All(reference => !reference.TryGetTarget(out _))));
@@ -298,7 +335,7 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     /// Resolves a JSON-encoded file reference array into InputFileDto entries.
     /// Returns null if the value is empty, malformed, or contains no resolvable files.
     /// </summary>
-    public static IReadOnlyList<InputFileDto>? ResolveFileReferences(IFileUploadStore store, string? jsonValue, string inputName, ILogger logger)
+    public static IReadOnlyList<InputFileDto>? ResolveFileReferences(IFileUploadStore store, string? jsonValue, int interactionId, string inputName, ILogger logger)
     {
         if (string.IsNullOrEmpty(jsonValue))
         {
@@ -325,7 +362,7 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
         for (var idx = 0; idx < fileRefs.Length; idx++)
         {
             var fileRef = fileRefs[idx];
-            var filePath = store.GetFilePath(fileRef.Id, inputName);
+            var filePath = store.GetFilePath(fileRef.Id, interactionId, inputName);
             if (filePath is null)
             {
                 // Unknown file ID — skip to prevent using client-supplied IDs as arbitrary file paths.
@@ -379,6 +416,7 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
         public int InteractionId { get; } = interactionId;
         public string InputName { get; } = inputName;
         public bool UploadComplete { get; set; }
+        public bool RemovalRequested { get; set; }
         public FileInteractionState InteractionState { get; set; }
         public IReadOnlyList<WeakReference<InteractionFile>>? References { get; set; }
     }

--- a/src/Aspire.Hosting/Dashboard/FileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/FileUploadStore.cs
@@ -42,7 +42,10 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     /// </summary>
     public void StartInteraction(int interactionId)
     {
-        _interactions.TryAdd(interactionId, new FileInteraction());
+        if (_interactions.TryAdd(interactionId, new FileInteraction()))
+        {
+            _logger.LogDebug("Started tracking file uploads for interaction {InteractionId}.", interactionId);
+        }
     }
 
     /// <summary>
@@ -73,6 +76,12 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
 
             _files[fileId] = new FileEntry(tempFile, interactionId, inputName);
             interaction.FileIds.Add(fileId);
+            _logger.LogDebug(
+                "Created uploaded file entry {FileId} for interaction {InteractionId}, input {InputName}, and file {FileName}.",
+                fileId,
+                interactionId,
+                inputName,
+                safeName);
             return (fileId, tempFile.Path);
         }
     }
@@ -93,6 +102,12 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
             entry.UploadComplete = true;
             removeEntry = entry.InteractionState == FileInteractionState.Canceled;
         }
+
+        _logger.LogDebug(
+            "Completed upload for file entry {FileId}, interaction {InteractionId}, and input {InputName}.",
+            fileId,
+            entry.InteractionId,
+            entry.InputName);
 
         if (removeEntry)
         {
@@ -126,6 +141,12 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     {
         if (_files.TryRemove(fileId, out var entry))
         {
+            _logger.LogDebug(
+                "Removing uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}.",
+                fileId,
+                entry.InteractionId,
+                entry.InputName);
+
             if (_interactions.TryGetValue(entry.InteractionId, out var interaction))
             {
                 lock (interaction)
@@ -165,6 +186,12 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
         }
         _interactions.TryRemove(KeyValuePair.Create(interactionId, interaction));
 
+        _logger.LogDebug(
+            "Completed file upload tracking for interaction {InteractionId} with {FileCount} uploaded files and {ReferenceCount} file references.",
+            interactionId,
+            fileIds.Length,
+            files.Count);
+
         foreach (var fileId in fileIds)
         {
             if (!_files.TryGetValue(fileId, out var entry))
@@ -198,6 +225,11 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
             fileIds = [.. interaction.FileIds];
         }
         _interactions.TryRemove(KeyValuePair.Create(interactionId, interaction));
+
+        _logger.LogDebug(
+            "Canceled file upload tracking for interaction {InteractionId} with {FileCount} uploaded files.",
+            interactionId,
+            fileIds.Length);
 
         foreach (var fileId in fileIds)
         {
@@ -312,6 +344,11 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
         _cleanupCts.Cancel();
         _cleanupTask.GetAwaiter().GetResult();
         _cleanupCts.Dispose();
+
+        _logger.LogDebug(
+            "Disposing file upload store with {FileCount} uploaded files and {InteractionCount} active interactions.",
+            _files.Count,
+            _interactions.Count);
 
         foreach (var entry in _files.Values)
         {

--- a/src/Aspire.Hosting/Dashboard/IFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IFileUploadStore.cs
@@ -24,9 +24,9 @@ internal interface IFileUploadStore
     void CompleteUpload(string fileId);
 
     /// <summary>
-    /// Gets the file path for a given file ID and input name.
+    /// Gets the file path for a given file ID, interaction ID, and input name.
     /// </summary>
-    string? GetFilePath(string fileId, string inputName);
+    string? GetFilePath(string fileId, int interactionId, string inputName);
 
     /// <summary>
     /// Gets the original file name for a given file ID.

--- a/src/Aspire.Hosting/Dashboard/IFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IFileUploadStore.cs
@@ -9,14 +9,24 @@ namespace Aspire.Hosting;
 internal interface IFileUploadStore
 {
     /// <summary>
-    /// Creates a new entry for an uploaded file and returns the file ID and path.
+    /// Registers an interaction that can own uploaded files.
     /// </summary>
-    (string FileId, string FilePath) CreateEntry(string originalFileName);
+    void StartInteraction(int interactionId);
 
     /// <summary>
-    /// Gets the file path for a given file ID.
+    /// Creates a new entry for an uploaded file and returns the file ID and path.
     /// </summary>
-    string? GetFilePath(string fileId);
+    (string FileId, string FilePath) CreateEntry(string originalFileName, int interactionId, string inputName);
+
+    /// <summary>
+    /// Marks a file upload as successfully completed.
+    /// </summary>
+    void CompleteUpload(string fileId);
+
+    /// <summary>
+    /// Gets the file path for a given file ID and input name.
+    /// </summary>
+    string? GetFilePath(string fileId, string inputName);
 
     /// <summary>
     /// Gets the original file name for a given file ID.
@@ -24,7 +34,17 @@ internal interface IFileUploadStore
     string? GetFileName(string fileId);
 
     /// <summary>
-    /// Removes a file entry. Used to clean up after failed uploads.
+    /// Removes a file entry and cleans up its uploaded content.
     /// </summary>
     void RemoveEntry(string fileId);
+
+    /// <summary>
+    /// Marks an interaction as completed and starts weak-reference tracking for its uploaded files.
+    /// </summary>
+    void CompleteInteraction(int interactionId, IReadOnlyList<InteractionFile> files);
+
+    /// <summary>
+    /// Cancels an interaction and removes its completed uploads.
+    /// </summary>
+    void CancelInteraction(int interactionId);
 }

--- a/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
@@ -39,9 +39,9 @@ internal interface IInteractionFileUploadStore
     void RemoveEntry(int interactionId, string fileId);
 
     /// <summary>
-    /// Marks an interaction as completed and starts weak-reference tracking for its uploaded files.
+    /// Marks an interaction as completed.
     /// </summary>
-    void CompleteInteraction(int interactionId, IReadOnlyList<InteractionFile> files);
+    void CompleteInteraction(int interactionId);
 
     /// <summary>
     /// Cancels an interaction and removes its completed uploads.

--- a/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
@@ -6,7 +6,7 @@ namespace Aspire.Hosting;
 /// <summary>
 /// Stores uploaded files and maps file IDs to their paths or content.
 /// </summary>
-internal interface IFileUploadStore
+internal interface IInteractionFileUploadStore
 {
     /// <summary>
     /// Registers an interaction that can own uploaded files.

--- a/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/IInteractionFileUploadStore.cs
@@ -19,9 +19,9 @@ internal interface IInteractionFileUploadStore
     (string FileId, string FilePath) CreateEntry(string originalFileName, int interactionId, string inputName);
 
     /// <summary>
-    /// Marks a file upload as successfully completed.
+    /// Marks a file upload for an interaction as successfully completed.
     /// </summary>
-    void CompleteUpload(string fileId);
+    void CompleteUpload(int interactionId, string fileId);
 
     /// <summary>
     /// Gets the file path for a given file ID, interaction ID, and input name.
@@ -29,14 +29,14 @@ internal interface IInteractionFileUploadStore
     string? GetFilePath(string fileId, int interactionId, string inputName);
 
     /// <summary>
-    /// Gets the original file name for a given file ID.
+    /// Gets the original file name for a given interaction and file ID.
     /// </summary>
-    string? GetFileName(string fileId);
+    string? GetFileName(int interactionId, string fileId);
 
     /// <summary>
-    /// Removes a file entry and cleans up its uploaded content.
+    /// Removes a file entry from an interaction and cleans up its uploaded content.
     /// </summary>
-    void RemoveEntry(string fileId);
+    void RemoveEntry(int interactionId, string fileId);
 
     /// <summary>
     /// Marks an interaction as completed and starts weak-reference tracking for its uploaded files.

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -115,10 +115,18 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     /// </summary>
     public string? GetFilePath(string fileId, int interactionId, string inputName)
     {
-        return TryGetEntry(interactionId, fileId, out var entry) &&
-            string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
-                ? entry.TempFile.Path
-                : null;
+        if (!TryGetEntry(interactionId, fileId, out var entry))
+        {
+            return null;
+        }
+
+        lock (entry)
+        {
+            return entry.UploadComplete &&
+                string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
+                    ? entry.TempFile.Path
+                    : null;
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -140,34 +140,9 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     /// </summary>
     public void RemoveEntry(string fileId)
     {
-        if (!_files.TryGetValue(fileId, out var entry))
+        if (!_files.TryRemove(fileId, out var entry))
         {
             return;
-        }
-
-        lock (entry)
-        {
-            entry.RemovalRequested = true;
-
-            try
-            {
-                entry.TempFile.Dispose();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(
-                    ex,
-                    "Failed to remove uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}. Cleanup will be retried.",
-                    fileId,
-                    entry.InteractionId,
-                    entry.InputName);
-                return;
-            }
-
-            if (!_files.TryRemove(KeyValuePair.Create(fileId, entry)))
-            {
-                return;
-            }
         }
 
         if (_interactions.TryGetValue(entry.InteractionId, out var interaction))
@@ -177,6 +152,8 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                 interaction.FileIds.Remove(fileId);
             }
         }
+
+        entry.TempFile.Dispose();
 
         _logger.LogDebug(
             "Removed uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}.",
@@ -277,8 +254,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             bool removeEntry;
             lock (entry)
             {
-                removeEntry = entry.RemovalRequested ||
-                    entry.UploadComplete &&
+                removeEntry = entry.UploadComplete &&
                     (entry.InteractionState == FileInteractionState.Canceled ||
                      entry.InteractionState == FileInteractionState.Complete &&
                      (entry.References is null || entry.References.All(reference => !reference.TryGetTarget(out _))));
@@ -399,7 +375,6 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         public int InteractionId { get; } = interactionId;
         public string InputName { get; } = inputName;
         public bool UploadComplete { get; set; }
-        public bool RemovalRequested { get; set; }
         public FileInteractionState InteractionState { get; set; }
         public IReadOnlyList<WeakReference<InteractionFile>>? References { get; set; }
     }

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -17,13 +17,9 @@ namespace Aspire.Hosting.Dashboard;
 /// </summary>
 internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, IAsyncDisposable
 {
-    private static readonly TimeSpan s_cleanupInterval = TimeSpan.FromSeconds(10);
-
     private readonly ConcurrentDictionary<int, FileInteraction> _interactions = new();
     private readonly ITempFileSystemService _tempFileSystem;
     private readonly ILogger<InteractionFileUploadStore> _logger;
-    private readonly CancellationTokenSource _cleanupCts = new();
-    private readonly Task _cleanupTask;
     private int _disposed;
 
     public InteractionFileUploadStore(IFileSystemService fileSystemService)
@@ -35,7 +31,6 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     {
         _tempFileSystem = fileSystemService.TempDirectory;
         _logger = logger;
-        _cleanupTask = RunCleanupAsync(_cleanupCts.Token);
     }
 
     /// <summary>
@@ -225,49 +220,6 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         RemoveInteractionIfEmpty(interactionId, interaction);
     }
 
-    internal void RemoveCanceledFiles()
-    {
-        foreach (var (interactionId, interaction) in _interactions)
-        {
-            foreach (var (fileId, entry) in interaction.Files)
-            {
-                bool removeEntry;
-                lock (entry)
-                {
-                    removeEntry = entry.UploadComplete && entry.InteractionState == FileInteractionState.Canceled;
-                }
-
-                if (removeEntry)
-                {
-                    RemoveEntry(interactionId, fileId);
-                }
-            }
-        }
-    }
-
-    private async Task RunCleanupAsync(CancellationToken cancellationToken)
-    {
-        using var timer = new PeriodicTimer(s_cleanupInterval);
-
-        try
-        {
-            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
-            {
-                try
-                {
-                    RemoveCanceledFiles();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to clean up canceled uploaded files. Cleanup will be retried.");
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
-    }
-
     /// <summary>
     /// Resolves a JSON-encoded file reference array into InputFileDto entries.
     /// Returns null if the value is empty, malformed, or contains no resolvable files.
@@ -319,16 +271,12 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         return files.Count > 0 ? files : null;
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
-            return;
+            return ValueTask.CompletedTask;
         }
-
-        _cleanupCts.Cancel();
-        await _cleanupTask.ConfigureAwait(false);
-        _cleanupCts.Dispose();
 
         _logger.LogDebug(
             "Disposing file upload store with {FileCount} uploaded files and {InteractionCount} tracked interactions.",
@@ -347,6 +295,8 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             }
         }
         _interactions.Clear();
+
+        return ValueTask.CompletedTask;
     }
 
     // Shared type used by ResolveFileReferences for JSON deserialization of file input values.

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Dashboard;
 /// <summary>
 /// Stores uploaded files from the Dashboard and maps file IDs to their temporary paths on disk.
 /// </summary>
-internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, IAsyncDisposable
+internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, IDisposable
 {
     private readonly ConcurrentDictionary<int, FileInteraction> _interactions = new();
     private readonly ITempFileSystemService _tempFileSystem;
@@ -271,11 +271,11 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         return files.Count > 0 ? files : null;
     }
 
-    public ValueTask DisposeAsync()
+    public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
-            return ValueTask.CompletedTask;
+            return;
         }
 
         _logger.LogDebug(
@@ -295,8 +295,6 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             }
         }
         _interactions.Clear();
-
-        return ValueTask.CompletedTask;
     }
 
     // Shared type used by ResolveFileReferences for JSON deserialization of file input values.

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -15,7 +15,7 @@ namespace Aspire.Hosting.Dashboard;
 /// <summary>
 /// Stores uploaded files from the Dashboard and maps file IDs to their temporary paths on disk.
 /// </summary>
-internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, IDisposable
+internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, IAsyncDisposable
 {
     private static readonly TimeSpan s_cleanupInterval = TimeSpan.FromSeconds(10);
 
@@ -24,6 +24,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     private readonly ILogger<InteractionFileUploadStore> _logger;
     private readonly CancellationTokenSource _cleanupCts = new();
     private readonly Task _cleanupTask;
+    private int _disposed;
 
     public InteractionFileUploadStore(IFileSystemService fileSystemService)
         : this(fileSystemService, NullLogger<InteractionFileUploadStore>.Instance)
@@ -320,10 +321,15 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         return files.Count > 0 ? files : null;
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        _cleanupCts.Cancel();
-        _cleanupTask.GetAwaiter().GetResult();
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        await _cleanupCts.CancelAsync().ConfigureAwait(false);
+        await _cleanupTask.ConfigureAwait(false);
         _cleanupCts.Dispose();
 
         _logger.LogDebug(

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -14,23 +14,23 @@ namespace Aspire.Hosting.Dashboard;
 /// <summary>
 /// Stores uploaded files from the Dashboard and maps file IDs to their temporary paths on disk.
 /// </summary>
-internal sealed class FileUploadStore : IFileUploadStore, IDisposable
+internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, IDisposable
 {
     private static readonly TimeSpan s_cleanupInterval = TimeSpan.FromSeconds(10);
 
     private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<int, FileInteraction> _interactions = new();
     private readonly ITempFileSystemService _tempFileSystem;
-    private readonly ILogger<FileUploadStore> _logger;
+    private readonly ILogger<InteractionFileUploadStore> _logger;
     private readonly CancellationTokenSource _cleanupCts = new();
     private readonly Task _cleanupTask;
 
-    public FileUploadStore(IFileSystemService fileSystemService)
-        : this(fileSystemService, NullLogger<FileUploadStore>.Instance)
+    public InteractionFileUploadStore(IFileSystemService fileSystemService)
+        : this(fileSystemService, NullLogger<InteractionFileUploadStore>.Instance)
     {
     }
 
-    public FileUploadStore(IFileSystemService fileSystemService, ILogger<FileUploadStore> logger)
+    public InteractionFileUploadStore(IFileSystemService fileSystemService, ILogger<InteractionFileUploadStore> logger)
     {
         _tempFileSystem = fileSystemService.TempDirectory;
         _logger = logger;
@@ -318,7 +318,7 @@ internal sealed class FileUploadStore : IFileUploadStore, IDisposable
     /// Resolves a JSON-encoded file reference array into InputFileDto entries.
     /// Returns null if the value is empty, malformed, or contains no resolvable files.
     /// </summary>
-    public static IReadOnlyList<InputFileDto>? ResolveFileReferences(IFileUploadStore store, string? jsonValue, int interactionId, string inputName, ILogger logger)
+    public static IReadOnlyList<InputFileDto>? ResolveFileReferences(IInteractionFileUploadStore store, string? jsonValue, int interactionId, string inputName, ILogger logger)
     {
         if (string.IsNullOrEmpty(jsonValue))
         {

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -157,35 +157,30 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     }
 
     /// <summary>
-    /// Marks an interaction as completed and starts weak-reference tracking for its uploaded files.
+    /// Marks an interaction as completed.
     /// </summary>
-    public void CompleteInteraction(int interactionId, IReadOnlyList<InteractionFile> files)
+    public void CompleteInteraction(int interactionId)
     {
         if (!_interactions.TryGetValue(interactionId, out var interaction))
         {
             return;
         }
 
-        var filesById = files.ToLookup(file => file.Id, StringComparer.Ordinal);
         lock (interaction)
         {
             interaction.State = FileInteractionState.Complete;
         }
 
         _logger.LogDebug(
-            "Completed file upload tracking for interaction {InteractionId} with {FileCount} uploaded files and {ReferenceCount} file references.",
+            "Completed file upload tracking for interaction {InteractionId} with {FileCount} uploaded files.",
             interactionId,
-            interaction.Files.Count,
-            files.Count);
+            interaction.Files.Count);
 
-        foreach (var (fileId, entry) in interaction.Files)
+        foreach (var entry in interaction.Files.Values)
         {
             lock (entry)
             {
                 entry.InteractionState = FileInteractionState.Complete;
-                entry.References = filesById[fileId]
-                    .Select(file => new WeakReference<InteractionFile>(file))
-                    .ToArray();
             }
         }
 
@@ -230,7 +225,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         RemoveInteractionIfEmpty(interactionId, interaction);
     }
 
-    internal void RemoveUnreferencedFiles()
+    internal void RemoveCanceledFiles()
     {
         foreach (var (interactionId, interaction) in _interactions)
         {
@@ -239,10 +234,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                 bool removeEntry;
                 lock (entry)
                 {
-                    removeEntry = entry.UploadComplete &&
-                        (entry.InteractionState == FileInteractionState.Canceled ||
-                         entry.InteractionState == FileInteractionState.Complete &&
-                         (entry.References is null || entry.References.All(reference => !reference.TryGetTarget(out _))));
+                    removeEntry = entry.UploadComplete && entry.InteractionState == FileInteractionState.Canceled;
                 }
 
                 if (removeEntry)
@@ -263,11 +255,11 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             {
                 try
                 {
-                    RemoveUnreferencedFiles();
+                    RemoveCanceledFiles();
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to clean up unreferenced uploaded files. Cleanup will be retried.");
+                    _logger.LogWarning(ex, "Failed to clean up canceled uploaded files. Cleanup will be retried.");
                 }
             }
         }
@@ -287,10 +279,10 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             return null;
         }
 
-        FileReference[]? fileRefs;
+        FileReference?[]? fileRefs;
         try
         {
-            fileRefs = JsonSerializer.Deserialize<FileReference[]>(jsonValue);
+            fileRefs = JsonSerializer.Deserialize<FileReference?[]>(jsonValue);
         }
         catch (JsonException ex)
         {
@@ -307,6 +299,12 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         for (var idx = 0; idx < fileRefs.Length; idx++)
         {
             var fileRef = fileRefs[idx];
+            if (fileRef is null || string.IsNullOrEmpty(fileRef.Id))
+            {
+                logger.LogWarning("Received malformed file reference in interaction input '{InputName}'. Skipping.", inputName);
+                continue;
+            }
+
             var filePath = store.GetFilePath(fileRef.Id, interactionId, inputName);
             if (filePath is null)
             {
@@ -355,8 +353,8 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     // The shape matches what the Dashboard sends: [{"Id":"...","Name":"..."}]
     private sealed class FileReference
     {
-        public string Id { get; set; } = "";
-        public string Name { get; set; } = "";
+        public string? Id { get; set; }
+        public string? Name { get; set; }
     }
 
     private bool TryGetEntry(int interactionId, string fileId, [NotNullWhen(true)] out FileEntry? entry)
@@ -383,7 +381,6 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         public string InputName { get; } = inputName;
         public bool UploadComplete { get; set; }
         public FileInteractionState InteractionState { get; set; }
-        public IReadOnlyList<WeakReference<InteractionFile>>? References { get; set; }
     }
 
     private sealed class FileInteraction

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -328,7 +328,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             return;
         }
 
-        await _cleanupCts.CancelAsync().ConfigureAwait(false);
+        _cleanupCts.Cancel();
         await _cleanupTask.ConfigureAwait(false);
         _cleanupCts.Dispose();
 

--- a/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
+++ b/src/Aspire.Hosting/Dashboard/InteractionFileUploadStore.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,7 +19,6 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
 {
     private static readonly TimeSpan s_cleanupInterval = TimeSpan.FromSeconds(10);
 
-    private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<int, FileInteraction> _interactions = new();
     private readonly ITempFileSystemService _tempFileSystem;
     private readonly ILogger<InteractionFileUploadStore> _logger;
@@ -74,8 +74,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             var tempFile = _tempFileSystem.CreateTempFile(string.IsNullOrEmpty(safeName) ? null : safeName);
             var fileId = Guid.NewGuid().ToString("N");
 
-            _files[fileId] = new FileEntry(tempFile, interactionId, inputName);
-            interaction.FileIds.Add(fileId);
+            interaction.Files[fileId] = new FileEntry(tempFile, inputName);
             _logger.LogDebug(
                 "Created uploaded file entry {FileId} for interaction {InteractionId}, input {InputName}, and file {FileName}.",
                 fileId,
@@ -89,9 +88,9 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     /// <summary>
     /// Marks a file upload as successfully completed.
     /// </summary>
-    public void CompleteUpload(string fileId)
+    public void CompleteUpload(int interactionId, string fileId)
     {
-        if (!_files.TryGetValue(fileId, out var entry))
+        if (!TryGetEntry(interactionId, fileId, out var entry))
         {
             return;
         }
@@ -106,12 +105,12 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         _logger.LogDebug(
             "Completed upload for file entry {FileId}, interaction {InteractionId}, and input {InputName}.",
             fileId,
-            entry.InteractionId,
+            interactionId,
             entry.InputName);
 
         if (removeEntry)
         {
-            RemoveEntry(fileId);
+            RemoveEntry(interactionId, fileId);
         }
     }
 
@@ -120,8 +119,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     /// </summary>
     public string? GetFilePath(string fileId, int interactionId, string inputName)
     {
-        return _files.TryGetValue(fileId, out var entry) &&
-            entry.InteractionId == interactionId &&
+        return TryGetEntry(interactionId, fileId, out var entry) &&
             string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
                 ? entry.TempFile.Path
                 : null;
@@ -130,27 +128,20 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
     /// <summary>
     /// Gets the original file name for a given file ID.
     /// </summary>
-    public string? GetFileName(string fileId)
+    public string? GetFileName(int interactionId, string fileId)
     {
-        return _files.TryGetValue(fileId, out var entry) ? Path.GetFileName(entry.TempFile.Path) : null;
+        return TryGetEntry(interactionId, fileId, out var entry) ? Path.GetFileName(entry.TempFile.Path) : null;
     }
 
     /// <summary>
     /// Removes a file entry and deletes the associated file on disk.
     /// </summary>
-    public void RemoveEntry(string fileId)
+    public void RemoveEntry(int interactionId, string fileId)
     {
-        if (!_files.TryRemove(fileId, out var entry))
+        if (!_interactions.TryGetValue(interactionId, out var interaction) ||
+            !interaction.Files.TryRemove(fileId, out var entry))
         {
             return;
-        }
-
-        if (_interactions.TryGetValue(entry.InteractionId, out var interaction))
-        {
-            lock (interaction)
-            {
-                interaction.FileIds.Remove(fileId);
-            }
         }
 
         entry.TempFile.Dispose();
@@ -158,8 +149,10 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         _logger.LogDebug(
             "Removed uploaded file entry {FileId} for interaction {InteractionId} and input {InputName}.",
             fileId,
-            entry.InteractionId,
+            interactionId,
             entry.InputName);
+
+        RemoveInteractionIfEmpty(interactionId, interaction);
     }
 
     /// <summary>
@@ -173,27 +166,19 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         }
 
         var filesById = files.ToLookup(file => file.Id, StringComparer.Ordinal);
-        string[] fileIds;
-
         lock (interaction)
         {
             interaction.State = FileInteractionState.Complete;
-            fileIds = [.. interaction.FileIds];
         }
-        _interactions.TryRemove(KeyValuePair.Create(interactionId, interaction));
 
         _logger.LogDebug(
             "Completed file upload tracking for interaction {InteractionId} with {FileCount} uploaded files and {ReferenceCount} file references.",
             interactionId,
-            fileIds.Length,
+            interaction.Files.Count,
             files.Count);
 
-        foreach (var fileId in fileIds)
+        foreach (var (fileId, entry) in interaction.Files)
         {
-            if (!_files.TryGetValue(fileId, out var entry))
-            {
-                continue;
-            }
             lock (entry)
             {
                 entry.InteractionState = FileInteractionState.Complete;
@@ -202,6 +187,8 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                     .ToArray();
             }
         }
+
+        RemoveInteractionIfEmpty(interactionId, interaction);
     }
 
     /// <summary>
@@ -214,25 +201,18 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
             return;
         }
 
-        string[] fileIds;
         lock (interaction)
         {
             interaction.State = FileInteractionState.Canceled;
-            fileIds = [.. interaction.FileIds];
         }
-        _interactions.TryRemove(KeyValuePair.Create(interactionId, interaction));
 
         _logger.LogDebug(
             "Canceled file upload tracking for interaction {InteractionId} with {FileCount} uploaded files.",
             interactionId,
-            fileIds.Length);
+            interaction.Files.Count);
 
-        foreach (var fileId in fileIds)
+        foreach (var (fileId, entry) in interaction.Files)
         {
-            if (!_files.TryGetValue(fileId, out var entry))
-            {
-                continue;
-            }
             bool removeEntry;
             lock (entry)
             {
@@ -242,27 +222,32 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
 
             if (removeEntry)
             {
-                RemoveEntry(fileId);
+                RemoveEntry(interactionId, fileId);
             }
         }
+
+        RemoveInteractionIfEmpty(interactionId, interaction);
     }
 
     internal void RemoveUnreferencedFiles()
     {
-        foreach (var (fileId, entry) in _files)
+        foreach (var (interactionId, interaction) in _interactions)
         {
-            bool removeEntry;
-            lock (entry)
+            foreach (var (fileId, entry) in interaction.Files)
             {
-                removeEntry = entry.UploadComplete &&
-                    (entry.InteractionState == FileInteractionState.Canceled ||
-                     entry.InteractionState == FileInteractionState.Complete &&
-                     (entry.References is null || entry.References.All(reference => !reference.TryGetTarget(out _))));
-            }
+                bool removeEntry;
+                lock (entry)
+                {
+                    removeEntry = entry.UploadComplete &&
+                        (entry.InteractionState == FileInteractionState.Canceled ||
+                         entry.InteractionState == FileInteractionState.Complete &&
+                         (entry.References is null || entry.References.All(reference => !reference.TryGetTarget(out _))));
+                }
 
-            if (removeEntry)
-            {
-                RemoveEntry(fileId);
+                if (removeEntry)
+                {
+                    RemoveEntry(interactionId, fileId);
+                }
             }
         }
     }
@@ -328,7 +313,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                 logger.LogWarning("Received unknown file ID '{FileId}' in interaction input '{InputName}'. Skipping.", fileRef.Id, inputName);
                 continue;
             }
-            var fileName = string.IsNullOrEmpty(fileRef.Name) ? store.GetFileName(fileRef.Id) ?? "" : fileRef.Name;
+            var fileName = string.IsNullOrEmpty(fileRef.Name) ? store.GetFileName(interactionId, fileRef.Id) ?? "" : fileRef.Name;
             files.Add(new InputFileDto(fileRef.Id, fileName, filePath));
         }
 
@@ -342,11 +327,11 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         _cleanupCts.Dispose();
 
         _logger.LogDebug(
-            "Disposing file upload store with {FileCount} uploaded files and {InteractionCount} active interactions.",
-            _files.Count,
+            "Disposing file upload store with {FileCount} uploaded files and {InteractionCount} tracked interactions.",
+            _interactions.Values.Sum(interaction => interaction.Files.Count),
             _interactions.Count);
 
-        foreach (var entry in _files.Values)
+        foreach (var entry in _interactions.Values.SelectMany(interaction => interaction.Files.Values))
         {
             try
             {
@@ -357,7 +342,6 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
                 // Best effort cleanup.
             }
         }
-        _files.Clear();
         _interactions.Clear();
     }
 
@@ -369,10 +353,27 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
         public string Name { get; set; } = "";
     }
 
-    private sealed class FileEntry(TempFile tempFile, int interactionId, string inputName)
+    private bool TryGetEntry(int interactionId, string fileId, [NotNullWhen(true)] out FileEntry? entry)
+    {
+        entry = null;
+        return _interactions.TryGetValue(interactionId, out var interaction) &&
+            interaction.Files.TryGetValue(fileId, out entry);
+    }
+
+    private void RemoveInteractionIfEmpty(int interactionId, FileInteraction interaction)
+    {
+        lock (interaction)
+        {
+            if (interaction.State != FileInteractionState.InProgress && interaction.Files.IsEmpty)
+            {
+                _interactions.TryRemove(KeyValuePair.Create(interactionId, interaction));
+            }
+        }
+    }
+
+    private sealed class FileEntry(TempFile tempFile, string inputName)
     {
         public TempFile TempFile { get; } = tempFile;
-        public int InteractionId { get; } = interactionId;
         public string InputName { get; } = inputName;
         public bool UploadComplete { get; set; }
         public FileInteractionState InteractionState { get; set; }
@@ -381,7 +382,7 @@ internal sealed class InteractionFileUploadStore : IInteractionFileUploadStore, 
 
     private sealed class FileInteraction
     {
-        public HashSet<string> FileIds { get; } = new(StringComparer.Ordinal);
+        public ConcurrentDictionary<string, FileEntry> Files { get; } = new(StringComparer.Ordinal);
         public FileInteractionState State { get; set; }
     }
 

--- a/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/dashboard_service.proto
@@ -463,6 +463,10 @@ message UploadFileChunk {
     bytes data = 1;
     // The original file name provided by the user (sent in the first chunk).
     string file_name = 2;
+    // The interaction that owns the upload (sent in the first chunk).
+    int32 interaction_id = 3;
+    // The interaction input that owns the upload (sent in the first chunk).
+    string input_name = 4;
 }
 
 message UploadFileResponse {

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -426,7 +426,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddSingleton<AuxiliaryBackchannelService>();
         _innerBuilder.Services.AddHostedService<AuxiliaryBackchannelService>(sp => sp.GetRequiredService<AuxiliaryBackchannelService>());
         _innerBuilder.Services.AddSingleton<AppHostRpcTarget>();
-        _innerBuilder.Services.AddSingleton<IFileUploadStore, Dashboard.FileUploadStore>();
+        _innerBuilder.Services.AddSingleton<IInteractionFileUploadStore, Dashboard.InteractionFileUploadStore>();
 
         ConfigureHealthChecks();
 

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -245,19 +245,7 @@ internal class InteractionService : IInteractionService
             var completion = await newState.CompletionTcs.Task.ConfigureAwait(false);
             if (completion.State is not IReadOnlyList<InteractionInput> inputState)
             {
-                if (hasFileInputs)
-                {
-                    _fileUploadStore.CancelInteraction(newState.InteractionId);
-                }
                 return InteractionResult.Cancel<InteractionInputCollection>();
-            }
-
-            if (hasFileInputs)
-            {
-                var interactionFiles = inputState
-                    .SelectMany(input => input.Files ?? [])
-                    .ToArray();
-                _fileUploadStore.CompleteInteraction(newState.InteractionId, interactionFiles);
             }
 
             return InteractionResult.Ok(new InteractionInputCollection(inputState));
@@ -414,10 +402,17 @@ internal class InteractionService : IInteractionService
     private void OnInteractionCancellation(object? newState)
     {
         var interactionState = (Interaction)newState!;
+        var completion = new InteractionCompletionState { Complete = true };
 
-        interactionState.State = Interaction.InteractionState.Complete;
-        interactionState.CompletionTcs.TrySetResult(new InteractionCompletionState { Complete = true });
-        AddInteractionUpdate(interactionState);
+        lock (_onInteractionUpdatedLock)
+        {
+            if (!_interactionCollection.Contains(interactionState.InteractionId))
+            {
+                return;
+            }
+
+            CompleteInteractionCore(interactionState, completion);
+        }
     }
 
     private void AddInteractionUpdate(Interaction interactionUpdate)
@@ -501,14 +496,40 @@ internal class InteractionService : IInteractionService
 
             if (result.Complete)
             {
-                interactionState.CompletionTcs.TrySetResult(result);
-                interactionState.State = Interaction.InteractionState.Complete;
-                _interactionCollection.Remove(interactionId);
+                CompleteInteractionCore(interactionState, result);
             }
-
-            // Either broadcast out the interaction is complete, or its updated state.
-            OnInteractionUpdated?.Invoke(interactionState);
+            else
+            {
+                // Broadcast the updated interaction when validation failed or input state changed.
+                OnInteractionUpdated?.Invoke(interactionState);
+            }
         }
+    }
+
+    private void CompleteInteractionCore(Interaction interactionState, InteractionCompletionState completion)
+    {
+        Debug.Assert(Monitor.IsEntered(_onInteractionUpdatedLock));
+
+        if (interactionState.InteractionInfo is Interaction.InputsInteractionInfo inputsInfo &&
+            inputsInfo.Inputs.Any(input => input.InputType == InputType.File))
+        {
+            if (completion.State is IReadOnlyList<InteractionInput> inputs)
+            {
+                var files = inputs
+                    .SelectMany(input => input.Files ?? [])
+                    .ToArray();
+                _fileUploadStore.CompleteInteraction(interactionState.InteractionId, files);
+            }
+            else
+            {
+                _fileUploadStore.CancelInteraction(interactionState.InteractionId);
+            }
+        }
+
+        interactionState.State = Interaction.InteractionState.Complete;
+        interactionState.CompletionTcs.TrySetResult(completion);
+        _interactionCollection.Remove(interactionState.InteractionId);
+        OnInteractionUpdated?.Invoke(interactionState);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -513,12 +513,9 @@ internal class InteractionService : IInteractionService
         if (interactionState.InteractionInfo is Interaction.InputsInteractionInfo inputsInfo &&
             inputsInfo.Inputs.Any(input => input.InputType == InputType.File))
         {
-            if (completion.State is IReadOnlyList<InteractionInput> inputs)
+            if (completion.State is IReadOnlyList<InteractionInput>)
             {
-                var files = inputs
-                    .SelectMany(input => input.Files ?? [])
-                    .ToArray();
-                _fileUploadStore.CompleteInteraction(interactionState.InteractionId, files);
+                _fileUploadStore.CompleteInteraction(interactionState.InteractionId);
             }
             else
             {

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -27,13 +27,15 @@ internal class InteractionService : IInteractionService
     private readonly DistributedApplicationOptions _distributedApplicationOptions;
     private readonly IServiceProvider _serviceProvider;
     private readonly IConfiguration _configuration;
+    private readonly IFileUploadStore _fileUploadStore;
 
-    public InteractionService(ILogger<InteractionService> logger, DistributedApplicationOptions distributedApplicationOptions, IServiceProvider serviceProvider, IConfiguration configuration)
+    public InteractionService(ILogger<InteractionService> logger, DistributedApplicationOptions distributedApplicationOptions, IServiceProvider serviceProvider, IConfiguration configuration, IFileUploadStore fileUploadStore)
     {
         _logger = logger;
         _distributedApplicationOptions = distributedApplicationOptions;
         _serviceProvider = serviceProvider;
         _configuration = configuration;
+        _fileUploadStore = fileUploadStore;
     }
 
     public bool IsAvailable
@@ -157,6 +159,7 @@ internal class InteractionService : IInteractionService
 
         // Create the collection early to validate names and generate missing ones
         var inputCollection = new InteractionInputCollection(inputs);
+        var hasFileInputs = inputs.Any(input => input.InputType == InputType.File);
 
         // Validate inputs.
         for (var i = 0; i < inputs.Count; i++)
@@ -190,6 +193,10 @@ internal class InteractionService : IInteractionService
             options ??= InputsDialogInteractionOptions.Default;
 
             var newState = new Interaction(title, message, options, new Interaction.InputsInteractionInfo(inputCollection), interactionCts.Token);
+            if (hasFileInputs)
+            {
+                _fileUploadStore.StartInteraction(newState.InteractionId);
+            }
             AddInteractionUpdate(newState);
 
             using var _ = cancellationToken.Register(OnInteractionCancellation, state: newState);
@@ -236,9 +243,24 @@ internal class InteractionService : IInteractionService
             }
 
             var completion = await newState.CompletionTcs.Task.ConfigureAwait(false);
-            return completion.State is not IReadOnlyList<InteractionInput> inputState
-                ? InteractionResult.Cancel<InteractionInputCollection>()
-                : InteractionResult.Ok(new InteractionInputCollection(inputState));
+            if (completion.State is not IReadOnlyList<InteractionInput> inputState)
+            {
+                if (hasFileInputs)
+                {
+                    _fileUploadStore.CancelInteraction(newState.InteractionId);
+                }
+                return InteractionResult.Cancel<InteractionInputCollection>();
+            }
+
+            if (hasFileInputs)
+            {
+                var interactionFiles = inputState
+                    .SelectMany(input => input.Files ?? [])
+                    .ToArray();
+                _fileUploadStore.CompleteInteraction(newState.InteractionId, interactionFiles);
+            }
+
+            return InteractionResult.Ok(new InteractionInputCollection(inputState));
         }
         finally
         {

--- a/src/Aspire.Hosting/InteractionService.cs
+++ b/src/Aspire.Hosting/InteractionService.cs
@@ -27,9 +27,9 @@ internal class InteractionService : IInteractionService
     private readonly DistributedApplicationOptions _distributedApplicationOptions;
     private readonly IServiceProvider _serviceProvider;
     private readonly IConfiguration _configuration;
-    private readonly IFileUploadStore _fileUploadStore;
+    private readonly IInteractionFileUploadStore _fileUploadStore;
 
-    public InteractionService(ILogger<InteractionService> logger, DistributedApplicationOptions distributedApplicationOptions, IServiceProvider serviceProvider, IConfiguration configuration, IFileUploadStore fileUploadStore)
+    public InteractionService(ILogger<InteractionService> logger, DistributedApplicationOptions distributedApplicationOptions, IServiceProvider serviceProvider, IConfiguration configuration, IInteractionFileUploadStore fileUploadStore)
     {
         _logger = logger;
         _distributedApplicationOptions = distributedApplicationOptions;

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -435,7 +435,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
                                     matchingInput = inputsInfo.Inputs[i];
                                 }
 
-                                dtos.Add(CreateInputDto(matchingInput, responseAnswer));
+                                dtos.Add(CreateInputDto(interactionId, matchingInput, responseAnswer));
                             }
 
                             DashboardServiceData.ProcessInputs(
@@ -484,13 +484,13 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
     /// Creates an InputDto, resolving file references from the FileUploadStore for File inputs.
     /// The CLI sends Value as JSON [{"Id":"...","Name":"..."}] matching the dashboard format.
     /// </summary>
-    private InputDto CreateInputDto(InteractionInput matchingInput, PublishingPromptInputAnswer responseAnswer)
+    private InputDto CreateInputDto(int interactionId, InteractionInput matchingInput, PublishingPromptInputAnswer responseAnswer)
     {
         var value = responseAnswer.Value ?? "";
 
         if (matchingInput.InputType == InputType.File)
         {
-            var files = FileUploadStore.ResolveFileReferences(_fileUploadStore, value, matchingInput.Name, _logger);
+            var files = FileUploadStore.ResolveFileReferences(_fileUploadStore, value, interactionId, matchingInput.Name, _logger);
             if (files is not null)
             {
                 return new InputDto(matchingInput.Name, value, matchingInput.InputType, files);

--- a/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
+++ b/src/Aspire.Hosting/Pipelines/PipelineActivityReporter.cs
@@ -18,12 +18,12 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
     private readonly ConcurrentDictionary<string, ReportingStep> _steps = new();
     private readonly ConcurrentDictionary<string, string> _stepIdsByTitle = new(StringComparer.Ordinal);
     private readonly InteractionService _interactionService;
-    private readonly IFileUploadStore _fileUploadStore;
+    private readonly IInteractionFileUploadStore _fileUploadStore;
     private readonly ILogger<PipelineActivityReporter> _logger;
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly Task _interactionServiceSubscriber;
 
-    public PipelineActivityReporter(InteractionService interactionService, IFileUploadStore fileUploadStore, ILogger<PipelineActivityReporter> logger)
+    public PipelineActivityReporter(InteractionService interactionService, IInteractionFileUploadStore fileUploadStore, ILogger<PipelineActivityReporter> logger)
     {
         _interactionService = interactionService;
         _fileUploadStore = fileUploadStore;
@@ -481,7 +481,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
     }
 
     /// <summary>
-    /// Creates an InputDto, resolving file references from the FileUploadStore for File inputs.
+    /// Creates an InputDto, resolving file references from the InteractionFileUploadStore for File inputs.
     /// The CLI sends Value as JSON [{"Id":"...","Name":"..."}] matching the dashboard format.
     /// </summary>
     private InputDto CreateInputDto(int interactionId, InteractionInput matchingInput, PublishingPromptInputAnswer responseAnswer)
@@ -490,7 +490,7 @@ internal sealed class PipelineActivityReporter : IPipelineActivityReporter, IAsy
 
         if (matchingInput.InputType == InputType.File)
         {
-            var files = FileUploadStore.ResolveFileReferences(_fileUploadStore, value, interactionId, matchingInput.Name, _logger);
+            var files = InteractionFileUploadStore.ResolveFileReferences(_fileUploadStore, value, interactionId, matchingInput.Name, _logger);
             if (files is not null)
             {
                 return new InputDto(matchingInput.Name, value, matchingInput.InputType, files);

--- a/src/Aspire.Hosting/Utils/FileSystemService.cs
+++ b/src/Aspire.Hosting/Utils/FileSystemService.cs
@@ -246,38 +246,33 @@ internal sealed class FileSystemService : IFileSystemService, IDisposable
                 return;
             }
 
-            _disposed = true;
-
-            // Remove from tracking
-            _parent.UntrackItem(_path);
-
             // Skip deletion if preserve flag is set
             if (_parent.ShouldPreserveTempFiles)
             {
+                _disposed = true;
+                _parent.UntrackItem(_path);
                 return;
             }
 
-            try
+            // Only mark the file as disposed and untrack it after cleanup succeeds. Callers can
+            // retry disposal when a transient failure, such as an open file handle, blocks deletion.
+            if (File.Exists(_path))
             {
-                if (File.Exists(_path))
-                {
-                    File.Delete(_path);
-                    _parent.Logger?.LogDebug("Cleaned up temporary file: {Path}", _path);
-                }
+                File.Delete(_path);
+                _parent.Logger?.LogDebug("Cleaned up temporary file: {Path}", _path);
+            }
 
-                if (_deleteParentDirectory)
+            if (_deleteParentDirectory)
+            {
+                var parentDir = System.IO.Path.GetDirectoryName(_path);
+                if (parentDir is not null && Directory.Exists(parentDir))
                 {
-                    var parentDir = System.IO.Path.GetDirectoryName(_path);
-                    if (parentDir is not null && Directory.Exists(parentDir))
-                    {
-                        Directory.Delete(parentDir, recursive: true);
-                    }
+                    Directory.Delete(parentDir, recursive: true);
                 }
             }
-            catch
-            {
-                // Ignore errors during cleanup
-            }
+
+            _disposed = true;
+            _parent.UntrackItem(_path);
         }
     }
 }

--- a/src/Aspire.Hosting/Utils/FileSystemService.cs
+++ b/src/Aspire.Hosting/Utils/FileSystemService.cs
@@ -246,33 +246,38 @@ internal sealed class FileSystemService : IFileSystemService, IDisposable
                 return;
             }
 
+            _disposed = true;
+
+            // Remove from tracking
+            _parent.UntrackItem(_path);
+
             // Skip deletion if preserve flag is set
             if (_parent.ShouldPreserveTempFiles)
             {
-                _disposed = true;
-                _parent.UntrackItem(_path);
                 return;
             }
 
-            // Only mark the file as disposed and untrack it after cleanup succeeds. Callers can
-            // retry disposal when a transient failure, such as an open file handle, blocks deletion.
-            if (File.Exists(_path))
+            try
             {
-                File.Delete(_path);
-                _parent.Logger?.LogDebug("Cleaned up temporary file: {Path}", _path);
-            }
-
-            if (_deleteParentDirectory)
-            {
-                var parentDir = System.IO.Path.GetDirectoryName(_path);
-                if (parentDir is not null && Directory.Exists(parentDir))
+                if (File.Exists(_path))
                 {
-                    Directory.Delete(parentDir, recursive: true);
+                    File.Delete(_path);
+                    _parent.Logger?.LogDebug("Cleaned up temporary file: {Path}", _path);
+                }
+
+                if (_deleteParentDirectory)
+                {
+                    var parentDir = System.IO.Path.GetDirectoryName(_path);
+                    if (parentDir is not null && Directory.Exists(parentDir))
+                    {
+                        Directory.Delete(parentDir, recursive: true);
+                    }
                 }
             }
-
-            _disposed = true;
-            _parent.UntrackItem(_path);
+            catch
+            {
+                // Ignore errors during cleanup
+            }
         }
     }
 }

--- a/tests/Aspire.Cli.Tests/Backchannel/AppHostCliBackchannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Backchannel/AppHostCliBackchannelTests.cs
@@ -35,7 +35,7 @@ public class AppHostCliBackchannelTests
             await File.WriteAllBytesAsync(tempFile, new byte[2048]); // 2 KB exceeds the 1 KB limit
 
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => backchannel.UploadFileAsync(tempFile, "large.bin", CancellationToken.None));
+                () => backchannel.UploadFileAsync(tempFile, "large.bin", 1, "File", CancellationToken.None));
 
             Assert.Contains("large.bin", ex.Message);
             Assert.Contains("2048", ex.Message);
@@ -74,7 +74,7 @@ public class AppHostCliBackchannelTests
             // exception proves the size check passed.
             using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
             var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(
-                () => backchannel.UploadFileAsync(tempFile, "small.bin", cts.Token));
+                () => backchannel.UploadFileAsync(tempFile, "small.bin", 1, "File", cts.Token));
 
             // If we get a cancellation exception (waiting for RPC), the size check passed.
             Assert.DoesNotContain("exceeds the maximum upload size", ex.Message);

--- a/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/PublishCommandPromptingIntegrationTests.cs
@@ -268,7 +268,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var promptBackchannel = new TestPromptBackchannel();
         var consoleService = new TestInteractionService();
 
-        promptBackchannel.AddPrompt("file-prompt-1", "Artifact", InputTypes.File, "Select artifact:", isRequired: true);
+        promptBackchannel.AddPrompt("1", "Artifact", InputTypes.File, "Select artifact:", isRequired: true);
         consoleService.SetupSequentialResponses(
             (relativeMissingFile, ResponseType.String),
             (relativeSelectedFile, ResponseType.String));
@@ -305,7 +305,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var promptBackchannel = new TestPromptBackchannel();
         var consoleService = new TestInteractionService();
 
-        promptBackchannel.AddPrompt("file-prompt-1", "Artifact", InputTypes.File, "Select artifact:", isRequired: false);
+        promptBackchannel.AddPrompt("1", "Artifact", InputTypes.File, "Select artifact:", isRequired: false);
         consoleService.SetupStringPromptResponse("   ");
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -812,7 +812,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var promptBackchannel = new TestPromptBackchannel();
         var consoleService = new TestInteractionService();
 
-        promptBackchannel.AddPrompt("file-prompt-1", "Upload", InputTypes.File, "Select file:", isRequired: true, maxFileSize: 10);
+        promptBackchannel.AddPrompt("1", "Upload", InputTypes.File, "Select file:", isRequired: true, maxFileSize: 10);
         consoleService.SetupSequentialResponses(
             (relativeOversized, ResponseType.String),
             (relativeValid, ResponseType.String));
@@ -858,7 +858,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var promptBackchannel = new TestPromptBackchannel();
         var consoleService = new TestInteractionService();
 
-        promptBackchannel.AddPrompt("file-prompt-1", "Certificate", InputTypes.File, "Select certificate:", isRequired: true, fileFilter: ".pem,.crt");
+        promptBackchannel.AddPrompt("1", "Certificate", InputTypes.File, "Select certificate:", isRequired: true, fileFilter: ".pem,.crt");
         consoleService.SetupSequentialResponses(
             (relativeWrong, ResponseType.String),
             (relativeCorrect, ResponseType.String));
@@ -900,7 +900,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var promptBackchannel = new TestPromptBackchannel();
         var consoleService = new TestInteractionService();
 
-        promptBackchannel.AddPrompt("file-prompt-1", "Package", InputTypes.File, "Select package:", isRequired: true, maxFileSize: 1024, fileFilter: ".zip,.tar.gz");
+        promptBackchannel.AddPrompt("1", "Package", InputTypes.File, "Select package:", isRequired: true, maxFileSize: 1024, fileFilter: ".zip,.tar.gz");
         consoleService.SetupStringPromptResponse(relativePath);
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -923,9 +923,11 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var filePromptCall = Assert.Single(consoleService.FilePathPromptCalls);
         Assert.Equal("[bold]Select package:[/]\nPackage: ", filePromptCall.PromptText);
 
-        var (uploadedFilePath, uploadedFileName) = Assert.Single(promptBackchannel.UploadedFiles);
+        var (uploadedFilePath, uploadedFileName, interactionId, inputName) = Assert.Single(promptBackchannel.UploadedFiles);
         Assert.Equal(Path.GetFullPath(validFile), uploadedFilePath);
         Assert.Equal("deploy.zip", uploadedFileName);
+        Assert.Equal(1, interactionId);
+        Assert.Equal("1", inputName);
 
         var completedPrompt = Assert.Single(promptBackchannel.CompletedPrompts);
         var answer = Assert.Single(completedPrompt.Answers);
@@ -944,7 +946,7 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         var promptBackchannel = new TestPromptBackchannel();
         var consoleService = new TestInteractionService();
 
-        promptBackchannel.AddPrompt("file-prompt-1", "Archive", InputTypes.File, "Select archive:", isRequired: true, fileFilter: ".tar.gz,.zip");
+        promptBackchannel.AddPrompt("1", "Archive", InputTypes.File, "Select archive:", isRequired: true, fileFilter: ".tar.gz,.zip");
         consoleService.SetupStringPromptResponse(relativePath);
 
         var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper, options =>
@@ -964,9 +966,11 @@ public class PublishCommandPromptingIntegrationTests(ITestOutputHelper outputHel
         Assert.Equal(0, exitCode);
         Assert.Empty(consoleService.ValidationFailures);
 
-        var (uploadedFilePath, uploadedFileName) = Assert.Single(promptBackchannel.UploadedFiles);
+        var (uploadedFilePath, uploadedFileName, interactionId, inputName) = Assert.Single(promptBackchannel.UploadedFiles);
         Assert.Equal(Path.GetFullPath(validFile), uploadedFilePath);
         Assert.Equal("archive.tar.gz", uploadedFileName);
+        Assert.Equal(1, interactionId);
+        Assert.Equal("1", inputName);
     }
 
     [Fact]
@@ -1008,7 +1012,7 @@ internal sealed class TestPromptBackchannel : IAppHostCliBackchannel
 
     public List<PromptData> ReceivedPrompts { get; } = [];
     public List<PromptCompletion> CompletedPrompts { get; } = [];
-    public List<(string FilePath, string FileName)> UploadedFiles { get; } = [];
+    public List<(string FilePath, string FileName, int InteractionId, string InputName)> UploadedFiles { get; } = [];
 
     public void AddPrompt(string promptId, string label, string inputType, string message, bool isRequired, IReadOnlyList<KeyValuePair<string, string>>? options = null, string? defaultValue = null, IReadOnlyList<string>? validationErrors = null, long? maxFileSize = null, string? fileFilter = null)
     {
@@ -1116,9 +1120,9 @@ internal sealed class TestPromptBackchannel : IAppHostCliBackchannel
     public Task<GetPipelineStepsResponse> GetPipelineStepsAsync(string? step, CancellationToken cancellationToken) =>
         Task.FromResult(new GetPipelineStepsResponse { Steps = [] });
 
-    public Task<UploadFileResponse> UploadFileAsync(string filePath, string fileName, CancellationToken cancellationToken)
+    public Task<UploadFileResponse> UploadFileAsync(string filePath, string fileName, int interactionId, string inputName, CancellationToken cancellationToken)
     {
-        UploadedFiles.Add((filePath, fileName));
+        UploadedFiles.Add((filePath, fileName, interactionId, inputName));
         return Task.FromResult(new UploadFileResponse { FileId = "testfileid0000000000000000000000" });
     }
 }

--- a/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
+++ b/tests/Aspire.Cli.Tests/TestServices/TestAppHostCliBackchannel.cs
@@ -281,7 +281,7 @@ internal sealed class TestAppHostBackchannel : IAppHostCliBackchannel
 
     public Func<string, string, CancellationToken, Task<UploadFileResponse>>? UploadFileAsyncCallback { get; set; }
 
-    public async Task<UploadFileResponse> UploadFileAsync(string filePath, string fileName, CancellationToken cancellationToken)
+    public async Task<UploadFileResponse> UploadFileAsync(string filePath, string fileName, int interactionId, string inputName, CancellationToken cancellationToken)
     {
         if (UploadFileAsyncCallback is not null)
         {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -49,7 +49,7 @@ public sealed class MockDashboardClient : IDashboardClient
     public Task ReconnectAsync() => Task.CompletedTask;
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, CancellationToken cancellationToken) => throw new NotImplementedException();
+    public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken) => throw new NotImplementedException();
     public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
     public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
 

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -589,7 +589,7 @@ public class ResourceOutgoingPeerResolverTests
         public Task ReconnectAsync() => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public ResourceViewModel? GetResource(string resourceName) => null;
         public IReadOnlyList<ResourceViewModel> GetResources() => [];
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/tests/Aspire.Dashboard.Tests/Terminal/DefaultTerminalConnectionResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Terminal/DefaultTerminalConnectionResolverTests.cs
@@ -150,7 +150,7 @@ public class DefaultTerminalConnectionResolverTests
         public Task ReconnectAsync() => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, ExecuteResourceCommandOptions options, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> GetConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -55,7 +55,7 @@
     <Compile Include="$(SharedDir)ComputeEnvironmentEndpointResolver.cs" LinkBase="shared/ComputeEnvironmentEndpointResolver.cs" />
     <Compile Include="$(TestsSharedDir)TestInteractionService.cs" LinkBase="shared" />
     <Compile Include="$(TestsSharedDir)TestPipelineActivityReporter.cs" Link="shared/TestPipelineActivityReporter.cs" />
-    <Compile Include="$(TestsSharedDir)TestFileUploadStore.cs" Link="shared/TestFileUploadStore.cs" />
+    <Compile Include="$(TestsSharedDir)TestInteractionFileUploadStore.cs" Link="shared/TestInteractionFileUploadStore.cs" />
     <Compile Include="$(TestsSharedDir)TestFileSystemService.cs" Link="shared/TestFileSystemService.cs" />
     <Compile Include="$(TestsSharedDir)TestModuleInitializer.cs" Link="shared/TestModuleInitalizer.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.PostgreSQL\PostgresContainerImageTags.cs" />

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
@@ -99,7 +99,7 @@ public class AppHostRpcTargetUploadTests(ITestOutputHelper outputHelper)
             InputName = inputName
         }, cancellationTokenSource.Token));
 
-        fileUploadStore.CompleteInteraction(interactionId, []);
+        fileUploadStore.CompleteInteraction(interactionId);
         fileUploadStore.StartInteraction(interactionId);
         var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.txt", interactionId, inputName);
 

--- a/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
+++ b/tests/Aspire.Hosting.Tests/Backchannel/AppHostRpcTargetUploadTests.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Backchannel;
+
+[Trait("Partition", "4")]
+public class AppHostRpcTargetUploadTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    public async Task UploadFileAsync_ValidRequest_StoresAndCompletesUpload()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        await using var app = builder.Build();
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+        var fileUploadStore = app.Services.GetRequiredService<IInteractionFileUploadStore>();
+        const int interactionId = 1;
+        const string inputName = "File";
+        fileUploadStore.StartInteraction(interactionId);
+        var data = Encoding.UTF8.GetBytes("uploaded content");
+
+        var response = await target.UploadFileAsync(new UploadFileRequest
+        {
+            Data = data,
+            FileName = "test.txt",
+            InteractionId = interactionId,
+            InputName = inputName
+        });
+
+        var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, interactionId, inputName));
+        Assert.Equal(data, await File.ReadAllBytesAsync(filePath));
+
+        fileUploadStore.CancelInteraction(interactionId);
+
+        Assert.Null(fileUploadStore.GetFilePath(response.FileId, interactionId, inputName));
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Theory]
+    [InlineData(0, "File", "An interaction ID is required when uploading a file.")]
+    [InlineData(1, "", "An input name is required when uploading a file.")]
+    public async Task UploadFileAsync_InvalidOwnership_Throws(int interactionId, string inputName, string expectedMessage)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        await using var app = builder.Build();
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => target.UploadFileAsync(new UploadFileRequest
+        {
+            Data = [],
+            FileName = "test.txt",
+            InteractionId = interactionId,
+            InputName = inputName
+        }));
+
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_ExceedsConfiguredLimit_Throws()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        builder.Configuration[KnownConfigNames.MaxFileUploadSize] = "1";
+        await using var app = builder.Build();
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => target.UploadFileAsync(new UploadFileRequest
+        {
+            Data = [1, 2],
+            FileName = "large.bin",
+            InteractionId = 1,
+            InputName = "File"
+        }));
+
+        Assert.Contains("exceeds the maximum upload size of 1 bytes", exception.Message);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_WriteCanceled_RemovesEntry()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(outputHelper);
+        await using var app = builder.Build();
+        var target = app.Services.GetRequiredService<AppHostRpcTarget>();
+        var fileUploadStore = app.Services.GetRequiredService<IInteractionFileUploadStore>();
+        const int interactionId = 1;
+        const string inputName = "File";
+        fileUploadStore.StartInteraction(interactionId);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => target.UploadFileAsync(new UploadFileRequest
+        {
+            Data = [1],
+            FileName = "test.txt",
+            InteractionId = interactionId,
+            InputName = inputName
+        }, cancellationTokenSource.Token));
+
+        fileUploadStore.CompleteInteraction(interactionId, []);
+        fileUploadStore.StartInteraction(interactionId);
+        var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.txt", interactionId, inputName);
+
+        Assert.True(File.Exists(replacementPath));
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceDataTerminalTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceDataTerminalTests.cs
@@ -198,14 +198,14 @@ public class DashboardServiceDataTerminalTests
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             new ConfigurationBuilder().Build(),
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
         var data = new DashboardServiceData(
             notifications,
             loggerService,
             NullLogger<DashboardServiceData>.Instance,
             new ResourceCommandService(notifications, loggerService, new ServiceCollection().BuildServiceProvider()),
             interactions,
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
         return (data, notifications, resource);
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceDataTerminalTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceDataTerminalTests.cs
@@ -197,7 +197,8 @@ public class DashboardServiceDataTerminalTests
             NullLogger<InteractionService>.Instance,
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            new ConfigurationBuilder().Build());
+            new ConfigurationBuilder().Build(),
+            new TestFileUploadStore());
         var data = new DashboardServiceData(
             notifications,
             loggerService,

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -470,7 +470,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             loggerFactory.CreateLogger<InteractionService>(),
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            new ConfigurationBuilder().Build());
+            new ConfigurationBuilder().Build(),
+            new TestFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -540,7 +541,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             loggerFactory.CreateLogger<InteractionService>(),
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            new ConfigurationBuilder().Build());
+            new ConfigurationBuilder().Build(),
+            new TestFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -587,7 +589,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             loggerFactory.CreateLogger<InteractionService>(),
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            new ConfigurationBuilder().Build());
+            new ConfigurationBuilder().Build(),
+            new TestFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -646,7 +649,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             loggerFactory.CreateLogger<InteractionService>(),
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            new ConfigurationBuilder().Build());
+            new ConfigurationBuilder().Build(),
+            new TestFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -683,7 +687,8 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             loggerFactory.CreateLogger<InteractionService>(),
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            new ConfigurationBuilder().Build());
+            new ConfigurationBuilder().Build(),
+            new TestFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -829,6 +834,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var data = new byte[1024]; // 1 KB
@@ -836,14 +842,19 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         var context = TestServerCallContext.Create();
         var requestStream = new TestAsyncStreamReader<UploadFileChunk>(context);
-        requestStream.AddMessage(new UploadFileChunk { FileName = "test.txt", Data = ByteString.CopyFrom(data) });
+        requestStream.AddMessage(new UploadFileChunk { FileName = "test.txt", Data = ByteString.CopyFrom(data), InteractionId = 1, InputName = "File" });
         requestStream.Complete();
 
         var response = await dashboardService.UploadFile(requestStream, context);
 
         Assert.NotNull(response.FileId);
         Assert.NotEmpty(response.FileId);
-        Assert.NotNull(fileUploadStore.GetFilePath(response.FileId));
+        var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, "File"));
+
+        fileUploadStore.CancelInteraction(1);
+
+        Assert.Null(fileUploadStore.GetFilePath(response.FileId, "File"));
+        Assert.False(File.Exists(filePath));
     }
 
     [Fact]
@@ -852,6 +863,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -865,7 +877,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         var context = TestServerCallContext.Create();
         var requestStream = new TestAsyncStreamReader<UploadFileChunk>(context);
-        requestStream.AddMessage(new UploadFileChunk { FileName = "large.txt", Data = ByteString.CopyFrom(data) });
+        requestStream.AddMessage(new UploadFileChunk { FileName = "large.txt", Data = ByteString.CopyFrom(data), InteractionId = 1, InputName = "File" });
         requestStream.Complete();
 
         var ex = await Assert.ThrowsAsync<RpcException>(() => dashboardService.UploadFile(requestStream, context));
@@ -878,6 +890,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -893,7 +906,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         var context = TestServerCallContext.Create();
         var requestStream = new TestAsyncStreamReader<UploadFileChunk>(context);
-        requestStream.AddMessage(new UploadFileChunk { FileName = "large.txt", Data = ByteString.CopyFrom(chunk1) });
+        requestStream.AddMessage(new UploadFileChunk { FileName = "large.txt", Data = ByteString.CopyFrom(chunk1), InteractionId = 1, InputName = "File" });
         requestStream.AddMessage(new UploadFileChunk { Data = ByteString.CopyFrom(chunk2) });
         requestStream.Complete();
 
@@ -907,6 +920,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -920,7 +934,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         var context = TestServerCallContext.Create();
         var requestStream = new TestAsyncStreamReader<UploadFileChunk>(context);
-        requestStream.AddMessage(new UploadFileChunk { FileName = "medium.bin", Data = ByteString.CopyFrom(data) });
+        requestStream.AddMessage(new UploadFileChunk { FileName = "medium.bin", Data = ByteString.CopyFrom(data), InteractionId = 1, InputName = "File" });
         requestStream.Complete();
 
         var response = await dashboardService.UploadFile(requestStream, context);
@@ -952,13 +966,14 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         // Upload a file
         var data = Encoding.UTF8.GetBytes("certificate-content");
         var context = TestServerCallContext.Create();
         var requestStream = new TestAsyncStreamReader<UploadFileChunk>(context);
-        requestStream.AddMessage(new UploadFileChunk { FileName = "cert.pem", Data = ByteString.CopyFrom(data) });
+        requestStream.AddMessage(new UploadFileChunk { FileName = "cert.pem", Data = ByteString.CopyFrom(data), InteractionId = 1, InputName = "CertInput" });
         requestStream.Complete();
 
         var uploadResponse = await dashboardService.UploadFile(requestStream, context);
@@ -1027,11 +1042,13 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         resourceLoggerService ??= new ResourceLoggerService();
         loggerFactory ??= NullLoggerFactory.Instance;
         resourceNotificationService ??= CreateResourceNotificationService(resourceLoggerService);
+        var fileUploadStore = new TestFileUploadStore();
         interactionService ??= new InteractionService(
             NullLogger<InteractionService>.Instance,
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            new ConfigurationBuilder().Build());
+            new ConfigurationBuilder().Build(),
+            fileUploadStore);
 
         return new DashboardServiceData(
             resourceNotificationService,
@@ -1039,7 +1056,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             loggerFactory.CreateLogger<DashboardServiceData>(),
             new ResourceCommandService(resourceNotificationService, resourceLoggerService, new ServiceCollection().BuildServiceProvider()),
             interactionService,
-            new TestFileUploadStore());
+            fileUploadStore);
     }
 
     private static ResourceNotificationService CreateResourceNotificationService(ResourceLoggerService resourceLoggerService)

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -471,7 +471,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             new ConfigurationBuilder().Build(),
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -542,7 +542,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             new ConfigurationBuilder().Build(),
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -590,7 +590,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             new ConfigurationBuilder().Build(),
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -650,7 +650,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             new ConfigurationBuilder().Build(),
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -688,7 +688,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             new ConfigurationBuilder().Build(),
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
         using var dashboardServiceData = CreateDashboardServiceData(loggerFactory: loggerFactory, interactionService: interactionService);
         var dashboardService = CreateDashboardService(dashboardServiceData, logger: loggerFactory.CreateLogger<DashboardServiceImpl>());
 
@@ -833,7 +833,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
@@ -862,7 +862,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -889,7 +889,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -919,7 +919,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -948,7 +948,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var context = TestServerCallContext.Create();
@@ -965,7 +965,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
@@ -980,7 +980,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         // Resolve the file reference using the same store
         var json = $"[{{\"Id\":\"{uploadResponse.FileId}\",\"Name\":\"cert.pem\"}}]";
-        var resolvedFiles = FileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "CertInput", NullLogger.Instance);
+        var resolvedFiles = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "CertInput", NullLogger.Instance);
 
         Assert.NotNull(resolvedFiles);
         var file = Assert.Single(resolvedFiles);
@@ -997,10 +997,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     public void ResolveFileReferences_UnknownId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -1009,10 +1009,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     public void ResolveFileReferences_MalformedJson_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -1022,7 +1022,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         IHostEnvironment? hostEnvironment = null,
         IConfiguration? configuration = null,
         ILogger<DashboardServiceImpl>? logger = null,
-        IFileUploadStore? fileUploadStore = null)
+        IInteractionFileUploadStore? fileUploadStore = null)
     {
         return new DashboardServiceImpl(
             dashboardServiceData,
@@ -1030,7 +1030,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
             new TestHostApplicationLifetime(),
             configuration ?? new ConfigurationBuilder().Build(),
             logger ?? NullLogger<DashboardServiceImpl>.Instance,
-            fileUploadStore ?? new TestFileUploadStore());
+            fileUploadStore ?? new TestInteractionFileUploadStore());
     }
 
     private static DashboardServiceData CreateDashboardServiceData(
@@ -1042,7 +1042,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         resourceLoggerService ??= new ResourceLoggerService();
         loggerFactory ??= NullLoggerFactory.Instance;
         resourceNotificationService ??= CreateResourceNotificationService(resourceLoggerService);
-        var fileUploadStore = new TestFileUploadStore();
+        var fileUploadStore = new TestInteractionFileUploadStore();
         interactionService ??= new InteractionService(
             NullLogger<InteractionService>.Instance,
             new DistributedApplicationOptions(),

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -833,7 +833,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
@@ -862,7 +862,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -889,7 +889,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -919,7 +919,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -948,7 +948,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var context = TestServerCallContext.Create();
@@ -965,7 +965,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
@@ -994,10 +994,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public void ResolveFileReferences_UnknownId_ReturnsNull()
+    public async Task ResolveFileReferences_UnknownId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
@@ -1006,10 +1006,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public void ResolveFileReferences_MalformedJson_ReturnsNull()
+    public async Task ResolveFileReferences_MalformedJson_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -833,7 +833,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
@@ -862,7 +862,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -889,7 +889,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -919,7 +919,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -948,7 +948,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var context = TestServerCallContext.Create();
@@ -972,7 +972,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
@@ -992,7 +992,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
         var context = TestServerCallContext.Create();
@@ -1010,7 +1010,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     {
         var dashboardServiceData = CreateDashboardServiceData();
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         fileUploadStore.StartInteraction(1);
         var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
 
@@ -1039,10 +1039,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task ResolveFileReferences_UnknownId_ReturnsNull()
+    public void ResolveFileReferences_UnknownId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
@@ -1051,10 +1051,10 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task ResolveFileReferences_MalformedJson_ReturnsNull()
+    public void ResolveFileReferences_MalformedJson_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -849,11 +849,11 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         Assert.NotNull(response.FileId);
         Assert.NotEmpty(response.FileId);
-        var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, "File"));
+        var filePath = Assert.IsType<string>(fileUploadStore.GetFilePath(response.FileId, 1, "File"));
 
         fileUploadStore.CancelInteraction(1);
 
-        Assert.Null(fileUploadStore.GetFilePath(response.FileId, "File"));
+        Assert.Null(fileUploadStore.GetFilePath(response.FileId, 1, "File"));
         Assert.False(File.Exists(filePath));
     }
 
@@ -980,7 +980,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         // Resolve the file reference using the same store
         var json = $"[{{\"Id\":\"{uploadResponse.FileId}\",\"Name\":\"cert.pem\"}}]";
-        var resolvedFiles = FileUploadStore.ResolveFileReferences(fileUploadStore, json, "CertInput", NullLogger.Instance);
+        var resolvedFiles = FileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "CertInput", NullLogger.Instance);
 
         Assert.NotNull(resolvedFiles);
         var file = Assert.Single(resolvedFiles);
@@ -1000,7 +1000,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         using var fileUploadStore = new FileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, "TestInput", NullLogger.Instance);
+        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -1012,7 +1012,7 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         using var fileUploadStore = new FileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, "TestInput", NullLogger.Instance);
+        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, 1, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -960,6 +960,51 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(StatusCode.InvalidArgument, ex.StatusCode);
     }
 
+    [Theory]
+    [InlineData("", 1, "File", "First chunk must include a file name.")]
+    [InlineData("file.txt", 0, "File", "First chunk must include an interaction ID.")]
+    [InlineData("file.txt", 1, "", "First chunk must include an input name.")]
+    public async Task UploadFile_FirstChunkMissingRequiredMetadata_ThrowsInvalidArgument(
+        string fileName,
+        int interactionId,
+        string inputName,
+        string expectedMessage)
+    {
+        var dashboardServiceData = CreateDashboardServiceData();
+        using var fileSystemService = new TestFileSystemService();
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        fileUploadStore.StartInteraction(1);
+        var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
+
+        var context = TestServerCallContext.Create();
+        var requestStream = new TestAsyncStreamReader<UploadFileChunk>(context);
+        requestStream.AddMessage(new UploadFileChunk { FileName = fileName, InteractionId = interactionId, InputName = inputName });
+        requestStream.Complete();
+
+        var exception = await Assert.ThrowsAsync<RpcException>(() => dashboardService.UploadFile(requestStream, context));
+
+        Assert.Equal(StatusCode.InvalidArgument, exception.StatusCode);
+        Assert.Equal(expectedMessage, exception.Status.Detail);
+    }
+
+    [Fact]
+    public async Task UploadFile_UnknownInteraction_RejectsUpload()
+    {
+        var dashboardServiceData = CreateDashboardServiceData();
+        using var fileSystemService = new TestFileSystemService();
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        var dashboardService = CreateDashboardService(dashboardServiceData, fileUploadStore: fileUploadStore);
+
+        var context = TestServerCallContext.Create();
+        var requestStream = new TestAsyncStreamReader<UploadFileChunk>(context);
+        requestStream.AddMessage(new UploadFileChunk { FileName = "file.txt", InteractionId = 1, InputName = "File" });
+        requestStream.Complete();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => dashboardService.UploadFile(requestStream, context));
+
+        Assert.Equal("Interaction '1' is not accepting file uploads.", exception.Message);
+    }
+
     [Fact]
     public async Task UploadFile_ThenResolveFileReferences_ResolvesCorrectly()
     {

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -882,6 +882,11 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
 
         var ex = await Assert.ThrowsAsync<RpcException>(() => dashboardService.UploadFile(requestStream, context));
         Assert.Equal(StatusCode.ResourceExhausted, ex.StatusCode);
+
+        fileUploadStore.CancelInteraction(1);
+        fileUploadStore.StartInteraction(1);
+        var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.txt", 1, "File");
+        Assert.True(File.Exists(replacementPath));
     }
 
     [Fact]
@@ -1000,9 +1005,48 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         requestStream.AddMessage(new UploadFileChunk { FileName = "file.txt", InteractionId = 1, InputName = "File" });
         requestStream.Complete();
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => dashboardService.UploadFile(requestStream, context));
+        var exception = await Assert.ThrowsAsync<RpcException>(() => dashboardService.UploadFile(requestStream, context));
 
-        Assert.Equal("Interaction '1' is not accepting file uploads.", exception.Message);
+        Assert.Equal(StatusCode.FailedPrecondition, exception.StatusCode);
+        Assert.Equal("Interaction '1' is not accepting file uploads.", exception.Status.Detail);
+    }
+
+    [Fact]
+    public async Task SendInteractionRequestAsync_ClientFileTypeForTextInput_DoesNotAttachFile()
+    {
+        var fileUploadStore = new TestInteractionFileUploadStore();
+        var interactionService = new InteractionService(
+            NullLogger<InteractionService>.Instance,
+            new DistributedApplicationOptions(),
+            new ServiceCollection().BuildServiceProvider(),
+            new ConfigurationBuilder().Build(),
+            fileUploadStore);
+        using var dashboardServiceData = CreateDashboardServiceData(interactionService: interactionService, fileUploadStore: fileUploadStore);
+        var fileInput = new InteractionInput { Name = "File", InputType = InputType.File };
+        var textInput = new InteractionInput { Name = "Text", InputType = InputType.Text };
+        var resultTask = interactionService.PromptInputsAsync("Inputs", "Enter values", [fileInput, textInput]);
+        var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+        var (fileId, _) = fileUploadStore.CreateEntry("spoofed.txt", interaction.InteractionId, textInput.Name);
+        var value = $"[{{\"Id\":\"{fileId}\",\"Name\":\"spoofed.txt\"}}]";
+
+        var request = new WatchInteractionsRequestUpdate
+        {
+            InteractionId = interaction.InteractionId,
+            InputsDialog = new InteractionInputsDialog()
+        };
+        request.InputsDialog.InputItems.Add(new Aspire.DashboardService.Proto.V1.InteractionInput
+        {
+            Name = textInput.Name,
+            InputType = Aspire.DashboardService.Proto.V1.InputType.File,
+            Value = value
+        });
+
+        await dashboardServiceData.SendInteractionRequestAsync(request, CancellationToken.None);
+        var result = await resultTask;
+        var resultInputs = Assert.IsType<InteractionInputCollection>(result.Data);
+
+        Assert.Null(resultInputs[textInput.Name].Files);
+        Assert.Equal(value, resultInputs[textInput.Name].Value);
     }
 
     [Fact]
@@ -1082,12 +1126,13 @@ public class DashboardServiceTests(ITestOutputHelper testOutputHelper)
         ResourceLoggerService? resourceLoggerService = null,
         ResourceNotificationService? resourceNotificationService = null,
         ILoggerFactory? loggerFactory = null,
-        InteractionService? interactionService = null)
+        InteractionService? interactionService = null,
+        IInteractionFileUploadStore? fileUploadStore = null)
     {
         resourceLoggerService ??= new ResourceLoggerService();
         loggerFactory ??= NullLoggerFactory.Instance;
         resourceNotificationService ??= CreateResourceNotificationService(resourceLoggerService);
-        var fileUploadStore = new TestInteractionFileUploadStore();
+        fileUploadStore ??= new TestInteractionFileUploadStore();
         interactionService ??= new InteractionService(
             NullLogger<InteractionService>.Instance,
             new DistributedApplicationOptions(),

--- a/tests/Aspire.Hosting.Tests/Dashboard/FileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/FileUploadStoreTests.cs
@@ -179,7 +179,7 @@ public class FileUploadStoreTests
     [Fact]
     public void RemoveUnreferencedFiles_DeletionFails_RetriesOnNextCleanup()
     {
-        using var fileSystemService = new TestFileSystemService(createDirectoryAtTempFilePath: true);
+        using var fileSystemService = new TestFileSystemService(failFirstTempFileDispose: true);
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
@@ -189,10 +189,7 @@ public class FileUploadStoreTests
         fileUploadStore.RemoveUnreferencedFiles();
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
-        Assert.True(Directory.Exists(filePath));
-
-        Directory.Delete(filePath);
-        File.Create(filePath).Dispose();
+        Assert.True(File.Exists(filePath));
 
         fileUploadStore.RemoveUnreferencedFiles();
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/FileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/FileUploadStoreTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable ASPIREFILESYSTEM001 // Type is for evaluation purposes only
 
+using System.Runtime.CompilerServices;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,13 +12,16 @@ namespace Aspire.Hosting.Tests.Dashboard;
 
 public class FileUploadStoreTests
 {
+    private const int InteractionId = 1;
+    private const string InputName = "File";
+
     [Fact]
     public void CreateEntry_ValidFileName_ReturnsIdAndPath()
     {
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var (fileId, filePath) = fileUploadStore.CreateEntry("test.txt");
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
         Assert.NotNull(fileId);
         Assert.NotEmpty(fileId);
@@ -31,9 +35,9 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var (fileId, filePath) = fileUploadStore.CreateEntry("test.txt");
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId));
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
     }
 
     [Fact]
@@ -42,7 +46,7 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        Assert.Null(fileUploadStore.GetFilePath("nonexistent"));
+        Assert.Null(fileUploadStore.GetFilePath("nonexistent", InputName));
     }
 
     [Fact]
@@ -51,7 +55,7 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var (fileId, _) = fileUploadStore.CreateEntry("cert.pem");
+        var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
 
         Assert.Equal("cert.pem", fileUploadStore.GetFileName(fileId));
     }
@@ -62,12 +66,114 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var (fileId, filePath) = fileUploadStore.CreateEntry("temp.bin");
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         Assert.True(File.Exists(filePath));
 
         fileUploadStore.RemoveEntry(fileId);
 
-        Assert.Null(fileUploadStore.GetFilePath(fileId));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void RemoveUnreferencedFiles_UploadInProgress_KeepsFile()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+        fileUploadStore.CompleteInteraction(InteractionId, []);
+
+        fileUploadStore.RemoveUnreferencedFiles();
+
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void RemoveUnreferencedFiles_UploadCompleteInteractionInProgress_KeepsFile()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+        fileUploadStore.CompleteUpload(fileId);
+
+        fileUploadStore.RemoveUnreferencedFiles();
+
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void CancelInteraction_UploadComplete_RemovesFileImmediately()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+        fileUploadStore.CompleteUpload(fileId);
+
+        fileUploadStore.CancelInteraction(InteractionId);
+
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void CancelInteraction_UploadInProgress_RemovesFileAfterUploadCompletes()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+
+        fileUploadStore.CancelInteraction(InteractionId);
+
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.True(File.Exists(filePath));
+
+        fileUploadStore.CompleteUpload(fileId);
+
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void RemoveUnreferencedFiles_CompleteInteractionWithLiveReference_KeepsFile()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+        fileUploadStore.CompleteUpload(fileId);
+        var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
+        fileUploadStore.CompleteInteraction(InteractionId, [interactionFile]);
+
+        fileUploadStore.RemoveUnreferencedFiles();
+
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.True(File.Exists(filePath));
+        GC.KeepAlive(interactionFile);
+    }
+
+    [Fact]
+    public void RemoveUnreferencedFiles_CompleteInteractionWithoutLiveReference_RemovesFile()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+        fileUploadStore.CompleteUpload(fileId);
+        var weakReference = CompleteInteractionWithFile(fileUploadStore, fileId, filePath);
+
+        GC.Collect();
+        Assert.False(weakReference.TryGetTarget(out _));
+
+        fileUploadStore.RemoveUnreferencedFiles();
+
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.False(File.Exists(filePath));
     }
 
     [Theory]
@@ -80,7 +186,7 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var (fileId, filePath) = fileUploadStore.CreateEntry(maliciousFileName);
+        var (fileId, filePath) = CreateEntry(fileUploadStore, maliciousFileName);
 
         Assert.NotEqual(maliciousFileName, filePath);
         Assert.Equal(expectedLeafName, Path.GetFileName(filePath));
@@ -95,7 +201,7 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var (fileId, filePath) = fileUploadStore.CreateEntry(emptyFileName);
+        var (fileId, filePath) = CreateEntry(fileUploadStore, emptyFileName);
 
         Assert.NotNull(fileId);
         Assert.NotEmpty(Path.GetFileName(filePath));
@@ -107,7 +213,7 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var (fileId, filePath) = fileUploadStore.CreateEntry("cert.pem");
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "cert.pem", "CertInput");
         File.WriteAllText(filePath, "certificate-content");
 
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
@@ -118,6 +224,20 @@ public class FileUploadStoreTests
         Assert.Equal(fileId, file.Id);
         Assert.Equal("cert.pem", file.Name);
         Assert.Equal(filePath, file.FilePath);
+    }
+
+    [Fact]
+    public void ResolveFileReferences_DifferentInputName_ReturnsNull()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
+        var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
+
+        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, "OtherFile", NullLogger.Instance);
+
+        Assert.Null(result);
     }
 
     [Fact]
@@ -161,14 +281,39 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var (_, filePath1) = fileUploadStore.CreateEntry("file1.txt");
-        var (_, filePath2) = fileUploadStore.CreateEntry("file2.txt");
+        var (_, filePath1) = CreateEntry(fileUploadStore, "file1.txt");
+        var (_, filePath2) = CreateEntry(fileUploadStore, "file2.txt");
 
         Assert.True(File.Exists(filePath1));
         Assert.True(File.Exists(filePath2));
 
         fileUploadStore.Dispose();
 
-        Assert.Null(fileUploadStore.GetFilePath("anything"));
+        Assert.Null(fileUploadStore.GetFilePath("anything", InputName));
+    }
+
+    [Fact]
+    public void CreateEntry_UnknownInteraction_Throws()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("temp.bin", InteractionId, InputName));
+
+        Assert.Equal($"Interaction '{InteractionId}' is not accepting file uploads.", exception.Message);
+    }
+
+    private static (string FileId, string FilePath) CreateEntry(FileUploadStore fileUploadStore, string fileName, string inputName = InputName)
+    {
+        fileUploadStore.StartInteraction(InteractionId);
+        return fileUploadStore.CreateEntry(fileName, InteractionId, inputName);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference<InteractionFile> CompleteInteractionWithFile(FileUploadStore fileUploadStore, string fileId, string filePath)
+    {
+        var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
+        fileUploadStore.CompleteInteraction(InteractionId, [interactionFile]);
+        return new WeakReference<InteractionFile>(interactionFile);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/FileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/FileUploadStoreTests.cs
@@ -37,7 +37,7 @@ public class FileUploadStoreTests
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        Assert.Null(fileUploadStore.GetFilePath("nonexistent", InputName));
+        Assert.Null(fileUploadStore.GetFilePath("nonexistent", InteractionId, InputName));
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class FileUploadStoreTests
 
         fileUploadStore.RemoveEntry(fileId);
 
-        Assert.Null(fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.False(File.Exists(filePath));
     }
 
@@ -86,7 +86,7 @@ public class FileUploadStoreTests
 
         fileUploadStore.RemoveUnreferencedFiles();
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
     }
 
@@ -101,7 +101,7 @@ public class FileUploadStoreTests
 
         fileUploadStore.RemoveUnreferencedFiles();
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
     }
 
@@ -116,7 +116,7 @@ public class FileUploadStoreTests
 
         fileUploadStore.CancelInteraction(InteractionId);
 
-        Assert.Null(fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.False(File.Exists(filePath));
     }
 
@@ -130,12 +130,12 @@ public class FileUploadStoreTests
 
         fileUploadStore.CancelInteraction(InteractionId);
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
 
         fileUploadStore.CompleteUpload(fileId);
 
-        Assert.Null(fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.False(File.Exists(filePath));
     }
 
@@ -152,7 +152,7 @@ public class FileUploadStoreTests
 
         fileUploadStore.RemoveUnreferencedFiles();
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
         GC.KeepAlive(interactionFile);
     }
@@ -172,7 +172,31 @@ public class FileUploadStoreTests
 
         fileUploadStore.RemoveUnreferencedFiles();
 
-        Assert.Null(fileUploadStore.GetFilePath(fileId, InputName));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void RemoveUnreferencedFiles_DeletionFails_RetriesOnNextCleanup()
+    {
+        using var fileSystemService = new TestFileSystemService(createDirectoryAtTempFilePath: true);
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+        fileUploadStore.CompleteUpload(fileId);
+        fileUploadStore.CompleteInteraction(InteractionId, []);
+
+        fileUploadStore.RemoveUnreferencedFiles();
+
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.True(Directory.Exists(filePath));
+
+        Directory.Delete(filePath);
+        File.Create(filePath).Dispose();
+
+        fileUploadStore.RemoveUnreferencedFiles();
+
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.False(File.Exists(filePath));
     }
 
@@ -217,7 +241,7 @@ public class FileUploadStoreTests
         File.WriteAllText(filePath, "certificate-content");
 
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
-        var resolvedFiles = FileUploadStore.ResolveFileReferences(fileUploadStore, json, "CertInput", NullLogger.Instance);
+        var resolvedFiles = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "CertInput", NullLogger.Instance);
 
         Assert.NotNull(resolvedFiles);
         var file = Assert.Single(resolvedFiles);
@@ -235,7 +259,21 @@ public class FileUploadStoreTests
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, "OtherFile", NullLogger.Instance);
+        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "OtherFile", NullLogger.Instance);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ResolveFileReferences_DifferentInteractionId_ReturnsNull()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new FileUploadStore(fileSystemService);
+
+        var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
+        var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
+
+        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId + 1, InputName, NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -247,7 +285,7 @@ public class FileUploadStoreTests
         using var fileUploadStore = new FileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, "TestInput", NullLogger.Instance);
+        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -259,7 +297,7 @@ public class FileUploadStoreTests
         using var fileUploadStore = new FileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, "TestInput", NullLogger.Instance);
+        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -270,7 +308,7 @@ public class FileUploadStoreTests
         using var fileSystemService = new TestFileSystemService();
         using var fileUploadStore = new FileUploadStore(fileSystemService);
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, "", "TestInput", NullLogger.Instance);
+        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, "", InteractionId, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -289,7 +327,7 @@ public class FileUploadStoreTests
 
         fileUploadStore.Dispose();
 
-        Assert.Null(fileUploadStore.GetFilePath("anything", InputName));
+        Assert.Null(fileUploadStore.GetFilePath("anything", InteractionId, InputName));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -16,10 +16,10 @@ public class InteractionFileUploadStoreTests
     private const string InputName = "File";
 
     [Fact]
-    public async Task CreateEntry_ValidFileName_ReturnsIdAndPath()
+    public void CreateEntry_ValidFileName_ReturnsIdAndPath()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
@@ -30,10 +30,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task GetFilePath_ExistingEntry_ReturnsPath()
+    public void GetFilePath_ExistingEntry_ReturnsPath()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
@@ -41,19 +41,19 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task GetFilePath_NonexistentEntry_ReturnsNull()
+    public void GetFilePath_NonexistentEntry_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         Assert.Null(fileUploadStore.GetFilePath("nonexistent", InteractionId, InputName));
     }
 
     [Fact]
-    public async Task GetFileName_ExistingEntry_ReturnsFileName()
+    public void GetFileName_ExistingEntry_ReturnsFileName()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
 
@@ -61,10 +61,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task RemoveEntry_ExistingEntry_DeletesFile()
+    public void RemoveEntry_ExistingEntry_DeletesFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         Assert.True(File.Exists(filePath));
@@ -76,10 +76,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task RemoveEntry_LastFile_RemovesCompletedInteraction()
+    public void RemoveEntry_LastFile_RemovesCompletedInteraction()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -95,10 +95,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task RemoveEntry_TerminalInteraction_RemainsUntilLastFileRemoved()
+    public void RemoveEntry_TerminalInteraction_RemainsUntilLastFileRemoved()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId1, filePath1) = CreateEntry(fileUploadStore, "file1.bin");
         var (fileId2, filePath2) = fileUploadStore.CreateEntry("file2.bin", InteractionId, InputName);
@@ -120,10 +120,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task FileOperations_DifferentInteractionId_DoNotMutateEntry()
+    public void FileOperations_DifferentInteractionId_DoNotMutateEntry()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         var otherInteractionId = InteractionId + 1;
@@ -144,10 +144,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task CompleteInteraction_UploadInProgress_KeepsFile()
+    public void CompleteInteraction_UploadInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteInteraction(InteractionId);
@@ -157,10 +157,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task UploadCompleteInteractionInProgress_KeepsFile()
+    public void UploadCompleteInteractionInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -170,10 +170,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task CancelInteraction_UploadComplete_RemovesFileImmediately()
+    public void CancelInteraction_UploadComplete_RemovesFileImmediately()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -185,10 +185,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task CancelInteraction_UploadInProgress_RemovesFileAfterUploadCompletes()
+    public void CancelInteraction_UploadInProgress_RemovesFileAfterUploadCompletes()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
 
@@ -204,10 +204,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task CompleteInteraction_KeepsFile()
+    public void CompleteInteraction_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -218,10 +218,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task CompleteInteraction_AfterInteractionFileCollected_KeepsFile()
+    public void CompleteInteraction_AfterInteractionFileCollected_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -239,10 +239,10 @@ public class InteractionFileUploadStoreTests
     [InlineData("/etc/cron.d/evil", "evil")]
     [InlineData("..\\..\\windows\\system32\\evil.exe", "evil.exe")]
     [InlineData("C:\\windows\\system32\\config.sys", "config.sys")]
-    public async Task CreateEntry_PathTraversalFileName_SanitizesToLeafName(string maliciousFileName, string expectedLeafName)
+    public void CreateEntry_PathTraversalFileName_SanitizesToLeafName(string maliciousFileName, string expectedLeafName)
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, maliciousFileName);
 
@@ -254,10 +254,10 @@ public class InteractionFileUploadStoreTests
     [InlineData("")]
     [InlineData("/")]
     [InlineData("\\")]
-    public async Task CreateEntry_EmptyOrRootOnlyFileName_GeneratesRandomName(string emptyFileName)
+    public void CreateEntry_EmptyOrRootOnlyFileName_GeneratesRandomName(string emptyFileName)
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, emptyFileName);
 
@@ -266,10 +266,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task ResolveFileReferences_ValidReference_ResolvesCorrectly()
+    public void ResolveFileReferences_ValidReference_ResolvesCorrectly()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "cert.pem", "CertInput");
         File.WriteAllText(filePath, "certificate-content");
@@ -285,10 +285,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task ResolveFileReferences_DifferentInputName_ReturnsNull()
+    public void ResolveFileReferences_DifferentInputName_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
@@ -299,10 +299,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task ResolveFileReferences_DifferentInteractionId_ReturnsNull()
+    public void ResolveFileReferences_DifferentInteractionId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
@@ -313,10 +313,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task ResolveFileReferences_UnknownId_ReturnsNull()
+    public void ResolveFileReferences_UnknownId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
@@ -325,10 +325,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task ResolveFileReferences_MalformedJson_ReturnsNull()
+    public void ResolveFileReferences_MalformedJson_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
@@ -340,10 +340,10 @@ public class InteractionFileUploadStoreTests
     [InlineData("[null]")]
     [InlineData("[{\"Id\":null}]")]
     [InlineData("[{\"Id\":\"\"}]")]
-    public async Task ResolveFileReferences_MalformedReference_ReturnsNull(string json)
+    public void ResolveFileReferences_MalformedReference_ReturnsNull(string json)
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
 
@@ -351,10 +351,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task ResolveFileReferences_EmptyValue_ReturnsNull()
+    public void ResolveFileReferences_EmptyValue_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, "", InteractionId, "TestInput", NullLogger.Instance);
 
@@ -362,7 +362,7 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task DisposeAsync_CleansUpAllFiles()
+    public void Dispose_CleansUpAllFiles()
     {
         using var fileSystemService = new TestFileSystemService();
         var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
@@ -373,8 +373,8 @@ public class InteractionFileUploadStoreTests
         Assert.True(File.Exists(filePath1));
         Assert.True(File.Exists(filePath2));
 
-        await fileUploadStore.DisposeAsync();
-        await fileUploadStore.DisposeAsync();
+        fileUploadStore.Dispose();
+        fileUploadStore.Dispose();
 
         Assert.Null(fileUploadStore.GetFilePath("anything", InteractionId, InputName));
         Assert.False(File.Exists(filePath1));
@@ -382,10 +382,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task CreateEntry_UnknownInteraction_Throws()
+    public void CreateEntry_UnknownInteraction_Throws()
     {
         using var fileSystemService = new TestFileSystemService();
-        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var exception = Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("temp.bin", InteractionId, InputName));
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -82,9 +82,8 @@ public class InteractionFileUploadStoreTests
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
-        var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
         fileUploadStore.CompleteUpload(InteractionId, fileId);
-        fileUploadStore.CompleteInteraction(InteractionId, [interactionFile]);
+        fileUploadStore.CompleteInteraction(InteractionId);
 
         Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("other.bin", InteractionId, InputName));
 
@@ -103,11 +102,9 @@ public class InteractionFileUploadStoreTests
 
         var (fileId1, filePath1) = CreateEntry(fileUploadStore, "file1.bin");
         var (fileId2, filePath2) = fileUploadStore.CreateEntry("file2.bin", InteractionId, InputName);
-        var interactionFile1 = new InteractionFile(fileId1, "file1.bin", filePath1);
-        var interactionFile2 = new InteractionFile(fileId2, "file2.bin", filePath2);
         fileUploadStore.CompleteUpload(InteractionId, fileId1);
         fileUploadStore.CompleteUpload(InteractionId, fileId2);
-        fileUploadStore.CompleteInteraction(InteractionId, [interactionFile1, interactionFile2]);
+        fileUploadStore.CompleteInteraction(InteractionId);
 
         fileUploadStore.RemoveEntry(InteractionId, fileId1);
 
@@ -147,22 +144,22 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task RemoveUnreferencedFiles_UploadInProgress_KeepsFile()
+    public async Task RemoveCanceledFiles_CompletedInteractionWithUploadInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
-        fileUploadStore.CompleteInteraction(InteractionId, []);
+        fileUploadStore.CompleteInteraction(InteractionId);
 
-        fileUploadStore.RemoveUnreferencedFiles();
+        fileUploadStore.RemoveCanceledFiles();
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
     }
 
     [Fact]
-    public async Task RemoveUnreferencedFiles_UploadCompleteInteractionInProgress_KeepsFile()
+    public async Task RemoveCanceledFiles_UploadCompleteInteractionInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
@@ -170,7 +167,7 @@ public class InteractionFileUploadStoreTests
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
 
-        fileUploadStore.RemoveUnreferencedFiles();
+        fileUploadStore.RemoveCanceledFiles();
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
@@ -211,25 +208,23 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task RemoveUnreferencedFiles_CompleteInteractionWithLiveReference_KeepsFile()
+    public async Task RemoveCanceledFiles_CompletedInteraction_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
-        var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
-        fileUploadStore.CompleteInteraction(InteractionId, [interactionFile]);
+        fileUploadStore.CompleteInteraction(InteractionId);
 
-        fileUploadStore.RemoveUnreferencedFiles();
+        fileUploadStore.RemoveCanceledFiles();
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
-        GC.KeepAlive(interactionFile);
     }
 
     [Fact]
-    public async Task RemoveUnreferencedFiles_CompleteInteractionWithoutLiveReference_RemovesFile()
+    public async Task RemoveCanceledFiles_CompletedInteractionAfterInteractionFileCollected_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
@@ -241,10 +236,10 @@ public class InteractionFileUploadStoreTests
         GC.Collect();
         Assert.False(weakReference.TryGetTarget(out _));
 
-        fileUploadStore.RemoveUnreferencedFiles();
+        fileUploadStore.RemoveCanceledFiles();
 
-        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
-        Assert.False(File.Exists(filePath));
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.True(File.Exists(filePath));
     }
 
     [Theory]
@@ -349,6 +344,20 @@ public class InteractionFileUploadStoreTests
         Assert.Null(result);
     }
 
+    [Theory]
+    [InlineData("[null]")]
+    [InlineData("[{\"Id\":null}]")]
+    [InlineData("[{\"Id\":\"\"}]")]
+    public async Task ResolveFileReferences_MalformedReference_ReturnsNull(string json)
+    {
+        using var fileSystemService = new TestFileSystemService();
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+
+        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
+
+        Assert.Null(result);
+    }
+
     [Fact]
     public async Task ResolveFileReferences_EmptyValue_ReturnsNull()
     {
@@ -401,7 +410,7 @@ public class InteractionFileUploadStoreTests
     private static WeakReference<InteractionFile> CompleteInteractionWithFile(InteractionFileUploadStore fileUploadStore, string fileId, string filePath)
     {
         var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
-        fileUploadStore.CompleteInteraction(InteractionId, [interactionFile]);
+        fileUploadStore.CompleteInteraction(InteractionId);
         return new WeakReference<InteractionFile>(interactionFile);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -57,7 +57,7 @@ public class InteractionFileUploadStoreTests
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
 
-        Assert.Equal("cert.pem", fileUploadStore.GetFileName(fileId));
+        Assert.Equal("cert.pem", fileUploadStore.GetFileName(InteractionId, fileId));
     }
 
     [Fact]
@@ -69,10 +69,30 @@ public class InteractionFileUploadStoreTests
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         Assert.True(File.Exists(filePath));
 
-        fileUploadStore.RemoveEntry(fileId);
+        fileUploadStore.RemoveEntry(InteractionId, fileId);
 
         Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void RemoveEntry_LastFile_RemovesCompletedInteraction()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+        var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
+        fileUploadStore.CompleteInteraction(InteractionId, [interactionFile]);
+
+        Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("other.bin", InteractionId, InputName));
+
+        fileUploadStore.RemoveEntry(InteractionId, fileId);
+        fileUploadStore.StartInteraction(InteractionId);
+        var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.bin", InteractionId, InputName);
+
+        Assert.True(File.Exists(replacementPath));
     }
 
     [Fact]
@@ -97,7 +117,7 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
-        fileUploadStore.CompleteUpload(fileId);
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
         fileUploadStore.RemoveUnreferencedFiles();
 
@@ -112,7 +132,7 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
-        fileUploadStore.CompleteUpload(fileId);
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
         fileUploadStore.CancelInteraction(InteractionId);
 
@@ -133,7 +153,7 @@ public class InteractionFileUploadStoreTests
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
 
-        fileUploadStore.CompleteUpload(fileId);
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
         Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.False(File.Exists(filePath));
@@ -146,7 +166,7 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
-        fileUploadStore.CompleteUpload(fileId);
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
         var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
         fileUploadStore.CompleteInteraction(InteractionId, [interactionFile]);
 
@@ -164,7 +184,7 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
-        fileUploadStore.CompleteUpload(fileId);
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
         var weakReference = CompleteInteractionWithFile(fileUploadStore, fileId, filePath);
 
         GC.Collect();

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.Tests.Dashboard;
 
-public class FileUploadStoreTests
+public class InteractionFileUploadStoreTests
 {
     private const int InteractionId = 1;
     private const string InputName = "File";
@@ -19,7 +19,7 @@ public class FileUploadStoreTests
     public void CreateEntry_ValidFileName_ReturnsIdAndPath()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
@@ -33,7 +33,7 @@ public class FileUploadStoreTests
     public void GetFilePath_ExistingEntry_ReturnsPath()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
@@ -44,7 +44,7 @@ public class FileUploadStoreTests
     public void GetFilePath_NonexistentEntry_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         Assert.Null(fileUploadStore.GetFilePath("nonexistent", InteractionId, InputName));
     }
@@ -53,7 +53,7 @@ public class FileUploadStoreTests
     public void GetFileName_ExistingEntry_ReturnsFileName()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
 
@@ -64,7 +64,7 @@ public class FileUploadStoreTests
     public void RemoveEntry_ExistingEntry_DeletesFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         Assert.True(File.Exists(filePath));
@@ -79,7 +79,7 @@ public class FileUploadStoreTests
     public void RemoveUnreferencedFiles_UploadInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteInteraction(InteractionId, []);
@@ -94,7 +94,7 @@ public class FileUploadStoreTests
     public void RemoveUnreferencedFiles_UploadCompleteInteractionInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(fileId);
@@ -109,7 +109,7 @@ public class FileUploadStoreTests
     public void CancelInteraction_UploadComplete_RemovesFileImmediately()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(fileId);
@@ -124,7 +124,7 @@ public class FileUploadStoreTests
     public void CancelInteraction_UploadInProgress_RemovesFileAfterUploadCompletes()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
 
@@ -143,7 +143,7 @@ public class FileUploadStoreTests
     public void RemoveUnreferencedFiles_CompleteInteractionWithLiveReference_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(fileId);
@@ -161,7 +161,7 @@ public class FileUploadStoreTests
     public void RemoveUnreferencedFiles_CompleteInteractionWithoutLiveReference_RemovesFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(fileId);
@@ -180,7 +180,7 @@ public class FileUploadStoreTests
     public void RemoveUnreferencedFiles_DeletionFails_RetriesOnNextCleanup()
     {
         using var fileSystemService = new TestFileSystemService(failFirstTempFileDispose: true);
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(fileId);
@@ -205,7 +205,7 @@ public class FileUploadStoreTests
     public void CreateEntry_PathTraversalFileName_SanitizesToLeafName(string maliciousFileName, string expectedLeafName)
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, maliciousFileName);
 
@@ -220,7 +220,7 @@ public class FileUploadStoreTests
     public void CreateEntry_EmptyOrRootOnlyFileName_GeneratesRandomName(string emptyFileName)
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, emptyFileName);
 
@@ -232,13 +232,13 @@ public class FileUploadStoreTests
     public void ResolveFileReferences_ValidReference_ResolvesCorrectly()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "cert.pem", "CertInput");
         File.WriteAllText(filePath, "certificate-content");
 
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
-        var resolvedFiles = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "CertInput", NullLogger.Instance);
+        var resolvedFiles = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "CertInput", NullLogger.Instance);
 
         Assert.NotNull(resolvedFiles);
         var file = Assert.Single(resolvedFiles);
@@ -251,12 +251,12 @@ public class FileUploadStoreTests
     public void ResolveFileReferences_DifferentInputName_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "OtherFile", NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "OtherFile", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -265,12 +265,12 @@ public class FileUploadStoreTests
     public void ResolveFileReferences_DifferentInteractionId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId + 1, InputName, NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId + 1, InputName, NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -279,10 +279,10 @@ public class FileUploadStoreTests
     public void ResolveFileReferences_UnknownId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -291,10 +291,10 @@ public class FileUploadStoreTests
     public void ResolveFileReferences_MalformedJson_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -303,9 +303,9 @@ public class FileUploadStoreTests
     public void ResolveFileReferences_EmptyValue_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
-        var result = FileUploadStore.ResolveFileReferences(fileUploadStore, "", InteractionId, "TestInput", NullLogger.Instance);
+        var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, "", InteractionId, "TestInput", NullLogger.Instance);
 
         Assert.Null(result);
     }
@@ -314,7 +314,7 @@ public class FileUploadStoreTests
     public void Dispose_CleansUpAllFiles()
     {
         using var fileSystemService = new TestFileSystemService();
-        var fileUploadStore = new FileUploadStore(fileSystemService);
+        var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (_, filePath1) = CreateEntry(fileUploadStore, "file1.txt");
         var (_, filePath2) = CreateEntry(fileUploadStore, "file2.txt");
@@ -331,21 +331,21 @@ public class FileUploadStoreTests
     public void CreateEntry_UnknownInteraction_Throws()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new FileUploadStore(fileSystemService);
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var exception = Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("temp.bin", InteractionId, InputName));
 
         Assert.Equal($"Interaction '{InteractionId}' is not accepting file uploads.", exception.Message);
     }
 
-    private static (string FileId, string FilePath) CreateEntry(FileUploadStore fileUploadStore, string fileName, string inputName = InputName)
+    private static (string FileId, string FilePath) CreateEntry(InteractionFileUploadStore fileUploadStore, string fileName, string inputName = InputName)
     {
         fileUploadStore.StartInteraction(InteractionId);
         return fileUploadStore.CreateEntry(fileName, InteractionId, inputName);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static WeakReference<InteractionFile> CompleteInteractionWithFile(FileUploadStore fileUploadStore, string fileId, string filePath)
+    private static WeakReference<InteractionFile> CompleteInteractionWithFile(InteractionFileUploadStore fileUploadStore, string fileId, string filePath)
     {
         var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
         fileUploadStore.CompleteInteraction(InteractionId, [interactionFile]);

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -96,6 +96,57 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
+    public async Task RemoveEntry_TerminalInteraction_RemainsUntilLastFileRemoved()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+
+        var (fileId1, filePath1) = CreateEntry(fileUploadStore, "file1.bin");
+        var (fileId2, filePath2) = fileUploadStore.CreateEntry("file2.bin", InteractionId, InputName);
+        var interactionFile1 = new InteractionFile(fileId1, "file1.bin", filePath1);
+        var interactionFile2 = new InteractionFile(fileId2, "file2.bin", filePath2);
+        fileUploadStore.CompleteUpload(InteractionId, fileId1);
+        fileUploadStore.CompleteUpload(InteractionId, fileId2);
+        fileUploadStore.CompleteInteraction(InteractionId, [interactionFile1, interactionFile2]);
+
+        fileUploadStore.RemoveEntry(InteractionId, fileId1);
+
+        fileUploadStore.StartInteraction(InteractionId);
+        Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("other.bin", InteractionId, InputName));
+        Assert.Equal(filePath2, fileUploadStore.GetFilePath(fileId2, InteractionId, InputName));
+
+        fileUploadStore.RemoveEntry(InteractionId, fileId2);
+        fileUploadStore.StartInteraction(InteractionId);
+        var (_, replacementPath) = fileUploadStore.CreateEntry("replacement.bin", InteractionId, InputName);
+
+        Assert.True(File.Exists(replacementPath));
+    }
+
+    [Fact]
+    public async Task FileOperations_DifferentInteractionId_DoNotMutateEntry()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
+        var otherInteractionId = InteractionId + 1;
+        fileUploadStore.StartInteraction(otherInteractionId);
+
+        Assert.Null(fileUploadStore.GetFileName(otherInteractionId, fileId));
+        fileUploadStore.CompleteUpload(otherInteractionId, fileId);
+        fileUploadStore.RemoveEntry(otherInteractionId, fileId);
+        fileUploadStore.CancelInteraction(InteractionId);
+
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.True(File.Exists(filePath));
+
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
+
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
     public async Task RemoveUnreferencedFiles_UploadInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
@@ -325,6 +376,8 @@ public class InteractionFileUploadStoreTests
         await fileUploadStore.DisposeAsync();
 
         Assert.Null(fileUploadStore.GetFilePath("anything", InteractionId, InputName));
+        Assert.False(File.Exists(filePath1));
+        Assert.False(File.Exists(filePath2));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -36,6 +36,22 @@ public class InteractionFileUploadStoreTests
         using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
+
+        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+    }
+
+    [Fact]
+    public void GetFilePath_UploadInProgress_ReturnsNull()
+    {
+        using var fileSystemService = new TestFileSystemService();
+        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+
+        var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
+
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
     }
@@ -134,7 +150,7 @@ public class InteractionFileUploadStoreTests
         fileUploadStore.RemoveEntry(otherInteractionId, fileId);
         fileUploadStore.CancelInteraction(InteractionId);
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
 
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -152,7 +168,7 @@ public class InteractionFileUploadStoreTests
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteInteraction(InteractionId);
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
     }
 
@@ -194,7 +210,7 @@ public class InteractionFileUploadStoreTests
 
         fileUploadStore.CancelInteraction(InteractionId);
 
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
+        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
 
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -273,6 +289,7 @@ public class InteractionFileUploadStoreTests
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "cert.pem", "CertInput");
         File.WriteAllText(filePath, "certificate-content");
+        fileUploadStore.CompleteUpload(InteractionId, fileId);
 
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
         var resolvedFiles = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "CertInput", NullLogger.Instance);

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -16,10 +16,10 @@ public class InteractionFileUploadStoreTests
     private const string InputName = "File";
 
     [Fact]
-    public void CreateEntry_ValidFileName_ReturnsIdAndPath()
+    public async Task CreateEntry_ValidFileName_ReturnsIdAndPath()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
@@ -30,10 +30,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void GetFilePath_ExistingEntry_ReturnsPath()
+    public async Task GetFilePath_ExistingEntry_ReturnsPath()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "test.txt");
 
@@ -41,19 +41,19 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void GetFilePath_NonexistentEntry_ReturnsNull()
+    public async Task GetFilePath_NonexistentEntry_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         Assert.Null(fileUploadStore.GetFilePath("nonexistent", InteractionId, InputName));
     }
 
     [Fact]
-    public void GetFileName_ExistingEntry_ReturnsFileName()
+    public async Task GetFileName_ExistingEntry_ReturnsFileName()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
 
@@ -61,10 +61,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void RemoveEntry_ExistingEntry_DeletesFile()
+    public async Task RemoveEntry_ExistingEntry_DeletesFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         Assert.True(File.Exists(filePath));
@@ -76,10 +76,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void RemoveEntry_LastFile_RemovesCompletedInteraction()
+    public async Task RemoveEntry_LastFile_RemovesCompletedInteraction()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         var interactionFile = new InteractionFile(fileId, "temp.bin", filePath);
@@ -96,10 +96,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void RemoveUnreferencedFiles_UploadInProgress_KeepsFile()
+    public async Task RemoveUnreferencedFiles_UploadInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteInteraction(InteractionId, []);
@@ -111,10 +111,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void RemoveUnreferencedFiles_UploadCompleteInteractionInProgress_KeepsFile()
+    public async Task RemoveUnreferencedFiles_UploadCompleteInteractionInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -126,10 +126,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void CancelInteraction_UploadComplete_RemovesFileImmediately()
+    public async Task CancelInteraction_UploadComplete_RemovesFileImmediately()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -141,10 +141,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void CancelInteraction_UploadInProgress_RemovesFileAfterUploadCompletes()
+    public async Task CancelInteraction_UploadInProgress_RemovesFileAfterUploadCompletes()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
 
@@ -160,10 +160,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void RemoveUnreferencedFiles_CompleteInteractionWithLiveReference_KeepsFile()
+    public async Task RemoveUnreferencedFiles_CompleteInteractionWithLiveReference_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -178,10 +178,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void RemoveUnreferencedFiles_CompleteInteractionWithoutLiveReference_RemovesFile()
+    public async Task RemoveUnreferencedFiles_CompleteInteractionWithoutLiveReference_RemovesFile()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
@@ -201,10 +201,10 @@ public class InteractionFileUploadStoreTests
     [InlineData("/etc/cron.d/evil", "evil")]
     [InlineData("..\\..\\windows\\system32\\evil.exe", "evil.exe")]
     [InlineData("C:\\windows\\system32\\config.sys", "config.sys")]
-    public void CreateEntry_PathTraversalFileName_SanitizesToLeafName(string maliciousFileName, string expectedLeafName)
+    public async Task CreateEntry_PathTraversalFileName_SanitizesToLeafName(string maliciousFileName, string expectedLeafName)
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, maliciousFileName);
 
@@ -216,10 +216,10 @@ public class InteractionFileUploadStoreTests
     [InlineData("")]
     [InlineData("/")]
     [InlineData("\\")]
-    public void CreateEntry_EmptyOrRootOnlyFileName_GeneratesRandomName(string emptyFileName)
+    public async Task CreateEntry_EmptyOrRootOnlyFileName_GeneratesRandomName(string emptyFileName)
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, emptyFileName);
 
@@ -228,10 +228,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void ResolveFileReferences_ValidReference_ResolvesCorrectly()
+    public async Task ResolveFileReferences_ValidReference_ResolvesCorrectly()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "cert.pem", "CertInput");
         File.WriteAllText(filePath, "certificate-content");
@@ -247,10 +247,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void ResolveFileReferences_DifferentInputName_ReturnsNull()
+    public async Task ResolveFileReferences_DifferentInputName_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
@@ -261,10 +261,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void ResolveFileReferences_DifferentInteractionId_ReturnsNull()
+    public async Task ResolveFileReferences_DifferentInteractionId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, _) = CreateEntry(fileUploadStore, "cert.pem");
         var json = $"[{{\"Id\":\"{fileId}\",\"Name\":\"cert.pem\"}}]";
@@ -275,10 +275,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void ResolveFileReferences_UnknownId_ReturnsNull()
+    public async Task ResolveFileReferences_UnknownId_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "[{\"Id\":\"nonexistent-id\",\"Name\":\"file.txt\"}]";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
@@ -287,10 +287,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void ResolveFileReferences_MalformedJson_ReturnsNull()
+    public async Task ResolveFileReferences_MalformedJson_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
         var json = "not-valid-json";
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, json, InteractionId, "TestInput", NullLogger.Instance);
@@ -299,10 +299,10 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void ResolveFileReferences_EmptyValue_ReturnsNull()
+    public async Task ResolveFileReferences_EmptyValue_ReturnsNull()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var result = InteractionFileUploadStore.ResolveFileReferences(fileUploadStore, "", InteractionId, "TestInput", NullLogger.Instance);
 
@@ -310,7 +310,7 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public void Dispose_CleansUpAllFiles()
+    public async Task DisposeAsync_CleansUpAllFiles()
     {
         using var fileSystemService = new TestFileSystemService();
         var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
@@ -321,16 +321,17 @@ public class InteractionFileUploadStoreTests
         Assert.True(File.Exists(filePath1));
         Assert.True(File.Exists(filePath2));
 
-        fileUploadStore.Dispose();
+        await fileUploadStore.DisposeAsync();
+        await fileUploadStore.DisposeAsync();
 
         Assert.Null(fileUploadStore.GetFilePath("anything", InteractionId, InputName));
     }
 
     [Fact]
-    public void CreateEntry_UnknownInteraction_Throws()
+    public async Task CreateEntry_UnknownInteraction_Throws()
     {
         using var fileSystemService = new TestFileSystemService();
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
+        await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var exception = Assert.Throws<InvalidOperationException>(() => fileUploadStore.CreateEntry("temp.bin", InteractionId, InputName));
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -176,27 +176,6 @@ public class InteractionFileUploadStoreTests
         Assert.False(File.Exists(filePath));
     }
 
-    [Fact]
-    public void RemoveUnreferencedFiles_DeletionFails_RetriesOnNextCleanup()
-    {
-        using var fileSystemService = new TestFileSystemService(failFirstTempFileDispose: true);
-        using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
-
-        var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
-        fileUploadStore.CompleteUpload(fileId);
-        fileUploadStore.CompleteInteraction(InteractionId, []);
-
-        fileUploadStore.RemoveUnreferencedFiles();
-
-        Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
-        Assert.True(File.Exists(filePath));
-
-        fileUploadStore.RemoveUnreferencedFiles();
-
-        Assert.Null(fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
-        Assert.False(File.Exists(filePath));
-    }
-
     [Theory]
     [InlineData("../../../etc/passwd", "passwd")]
     [InlineData("/etc/cron.d/evil", "evil")]

--- a/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/InteractionFileUploadStoreTests.cs
@@ -144,7 +144,7 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task RemoveCanceledFiles_CompletedInteractionWithUploadInProgress_KeepsFile()
+    public async Task CompleteInteraction_UploadInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
@@ -152,22 +152,18 @@ public class InteractionFileUploadStoreTests
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteInteraction(InteractionId);
 
-        fileUploadStore.RemoveCanceledFiles();
-
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
     }
 
     [Fact]
-    public async Task RemoveCanceledFiles_UploadCompleteInteractionInProgress_KeepsFile()
+    public async Task UploadCompleteInteractionInProgress_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
 
         var (fileId, filePath) = CreateEntry(fileUploadStore, "temp.bin");
         fileUploadStore.CompleteUpload(InteractionId, fileId);
-
-        fileUploadStore.RemoveCanceledFiles();
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
@@ -208,7 +204,7 @@ public class InteractionFileUploadStoreTests
     }
 
     [Fact]
-    public async Task RemoveCanceledFiles_CompletedInteraction_KeepsFile()
+    public async Task CompleteInteraction_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
@@ -217,14 +213,12 @@ public class InteractionFileUploadStoreTests
         fileUploadStore.CompleteUpload(InteractionId, fileId);
         fileUploadStore.CompleteInteraction(InteractionId);
 
-        fileUploadStore.RemoveCanceledFiles();
-
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));
     }
 
     [Fact]
-    public async Task RemoveCanceledFiles_CompletedInteractionAfterInteractionFileCollected_KeepsFile()
+    public async Task CompleteInteraction_AfterInteractionFileCollected_KeepsFile()
     {
         using var fileSystemService = new TestFileSystemService();
         await using var fileUploadStore = new InteractionFileUploadStore(fileSystemService);
@@ -235,8 +229,6 @@ public class InteractionFileUploadStoreTests
 
         GC.Collect();
         Assert.False(weakReference.TryGetTarget(out _));
-
-        fileUploadStore.RemoveCanceledFiles();
 
         Assert.Equal(filePath, fileUploadStore.GetFilePath(fileId, InteractionId, InputName));
         Assert.True(File.Exists(filePath));

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -220,7 +220,7 @@ public class InteractionServiceTests
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             configuration,
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
 
         // Assert
         Assert.Equal(expected, interactionService.IsAvailable);
@@ -248,7 +248,7 @@ public class InteractionServiceTests
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             configuration,
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
 
         // Assert - Invalid values should be ignored, defaulting to true (since dashboard is enabled)
         Assert.True(interactionService.IsAvailable);
@@ -271,7 +271,7 @@ public class InteractionServiceTests
             new DistributedApplicationOptions { DisableDashboard = true },
             new ServiceCollection().BuildServiceProvider(),
             configuration,
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
 
         // Assert - Both conditions should result in false
         Assert.False(interactionService.IsAvailable);
@@ -1325,7 +1325,7 @@ public class InteractionServiceTests
             CancellationToken.None);
     }
 
-    private static InteractionService CreateInteractionService(DistributedApplicationOptions? options = null, IFileUploadStore? fileUploadStore = null)
+    private static InteractionService CreateInteractionService(DistributedApplicationOptions? options = null, IInteractionFileUploadStore? fileUploadStore = null)
     {
         var configuration = new ConfigurationBuilder().Build();
         return new InteractionService(
@@ -1333,13 +1333,13 @@ public class InteractionServiceTests
             options ?? new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             configuration,
-            fileUploadStore ?? new TestFileUploadStore());
+            fileUploadStore ?? new TestInteractionFileUploadStore());
     }
 
     [Fact]
     public async Task PromptInputsAsync_FileWithValue_PassesValidation()
     {
-        var fileUploadStore = new TestFileUploadStore();
+        var fileUploadStore = new TestInteractionFileUploadStore();
         var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
 
         var input = new InteractionInput { Name = "File", Label = "File", InputType = InputType.File, Required = true };
@@ -1367,7 +1367,7 @@ public class InteractionServiceTests
     [Fact]
     public async Task PromptInputsAsync_Canceled_CancelsFileUploads()
     {
-        var fileUploadStore = new TestFileUploadStore();
+        var fileUploadStore = new TestInteractionFileUploadStore();
         var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
 
         var input = new InteractionInput { Name = "File", Label = "File", InputType = InputType.File };
@@ -1390,7 +1390,7 @@ public class InteractionServiceTests
     [Fact]
     public async Task PromptInputsAsync_TextInputComplete_DoesNotUseFileUploadStore()
     {
-        var fileUploadStore = new TestFileUploadStore();
+        var fileUploadStore = new TestInteractionFileUploadStore();
         var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
 
         var input = new InteractionInput { Name = "Text", InputType = InputType.Text };
@@ -1414,7 +1414,7 @@ public class InteractionServiceTests
     [Fact]
     public async Task PromptInputsAsync_TextInputCanceled_DoesNotUseFileUploadStore()
     {
-        var fileUploadStore = new TestFileUploadStore();
+        var fileUploadStore = new TestInteractionFileUploadStore();
         var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
 
         var input = new InteractionInput { Name = "Text", InputType = InputType.Text };

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -1346,6 +1346,7 @@ public class InteractionServiceTests
         var resultTask = interactionService.PromptInputAsync("Select file", "please", input);
 
         var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+        fileUploadStore.CompleteInteractionCallback = (_, _) => Assert.False(interaction.CompletionTcs.Task.IsCompleted);
 
         await CompleteInteractionAsync(
             interactionService,
@@ -1373,6 +1374,7 @@ public class InteractionServiceTests
         var input = new InteractionInput { Name = "File", Label = "File", InputType = InputType.File };
         var resultTask = interactionService.PromptInputAsync("Select file", "please", input);
         var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+        fileUploadStore.CancelInteractionCallback = _ => Assert.False(interaction.CompletionTcs.Task.IsCompleted);
 
         await CompleteInteractionAsync(
             interactionService,

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Channels;
 using Aspire.Hosting.Dashboard;
+using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -218,7 +219,8 @@ public class InteractionServiceTests
             NullLogger<InteractionService>.Instance,
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            configuration);
+            configuration,
+            new TestFileUploadStore());
 
         // Assert
         Assert.Equal(expected, interactionService.IsAvailable);
@@ -245,7 +247,8 @@ public class InteractionServiceTests
             NullLogger<InteractionService>.Instance,
             new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            configuration);
+            configuration,
+            new TestFileUploadStore());
 
         // Assert - Invalid values should be ignored, defaulting to true (since dashboard is enabled)
         Assert.True(interactionService.IsAvailable);
@@ -267,7 +270,8 @@ public class InteractionServiceTests
             NullLogger<InteractionService>.Instance,
             new DistributedApplicationOptions { DisableDashboard = true },
             new ServiceCollection().BuildServiceProvider(),
-            configuration);
+            configuration,
+            new TestFileUploadStore());
 
         // Assert - Both conditions should result in false
         Assert.False(interactionService.IsAvailable);
@@ -1321,23 +1325,25 @@ public class InteractionServiceTests
             CancellationToken.None);
     }
 
-    private static InteractionService CreateInteractionService(DistributedApplicationOptions? options = null)
+    private static InteractionService CreateInteractionService(DistributedApplicationOptions? options = null, IFileUploadStore? fileUploadStore = null)
     {
         var configuration = new ConfigurationBuilder().Build();
         return new InteractionService(
             NullLogger<InteractionService>.Instance,
             options ?? new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            configuration);
+            configuration,
+            fileUploadStore ?? new TestFileUploadStore());
     }
 
     [Fact]
     public async Task PromptInputsAsync_FileWithValue_PassesValidation()
     {
-        var interactionService = CreateInteractionService();
+        var fileUploadStore = new TestFileUploadStore();
+        var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
 
         var input = new InteractionInput { Name = "File", Label = "File", InputType = InputType.File, Required = true };
-        _ = interactionService.PromptInputAsync("Select file", "please", input);
+        var resultTask = interactionService.PromptInputAsync("Select file", "please", input);
 
         var interaction = Assert.Single(interactionService.GetCurrentInteractions());
 
@@ -1347,8 +1353,86 @@ public class InteractionServiceTests
             new InteractionCompletionState { Complete = true, State = new[] { input } },
             inputs: [new InputDto("File", "file-content-here", InputType.File, Files: [new InputFileDto("file1", "test.txt", "/tmp/test.txt")])]);
 
+        var result = await resultTask;
+
         Assert.True(interaction.CompletionTcs.Task.IsCompletedSuccessfully);
         Assert.Empty(input.ValidationErrors);
+        Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.StartedInteractions));
+        var completedInteraction = Assert.Single(fileUploadStore.CompletedInteractions);
+        Assert.Equal(interaction.InteractionId, completedInteraction.InteractionId);
+        var resultInput = Assert.IsType<InteractionInput>(result.Data);
+        Assert.Same(Assert.Single(resultInput.Files!), Assert.Single(completedInteraction.Files));
+    }
+
+    [Fact]
+    public async Task PromptInputsAsync_Canceled_CancelsFileUploads()
+    {
+        var fileUploadStore = new TestFileUploadStore();
+        var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
+
+        var input = new InteractionInput { Name = "File", Label = "File", InputType = InputType.File };
+        var resultTask = interactionService.PromptInputAsync("Select file", "please", input);
+        var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+
+        await CompleteInteractionAsync(
+            interactionService,
+            interaction.InteractionId,
+            new InteractionCompletionState { Complete = true },
+            inputs: []);
+
+        var result = await resultTask;
+
+        Assert.True(result.Canceled);
+        Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.StartedInteractions));
+        Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.CanceledInteractions));
+    }
+
+    [Fact]
+    public async Task PromptInputsAsync_TextInputComplete_DoesNotUseFileUploadStore()
+    {
+        var fileUploadStore = new TestFileUploadStore();
+        var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
+
+        var input = new InteractionInput { Name = "Text", InputType = InputType.Text };
+        var resultTask = interactionService.PromptInputAsync("Enter text", "please", input);
+        var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+
+        await CompleteInteractionAsync(
+            interactionService,
+            interaction.InteractionId,
+            new InteractionCompletionState { Complete = true, State = new[] { input } },
+            inputs: [new InputDto("Text", "value", InputType.Text)]);
+
+        var result = await resultTask;
+
+        Assert.False(result.Canceled);
+        Assert.Empty(fileUploadStore.StartedInteractions);
+        Assert.Empty(fileUploadStore.CompletedInteractions);
+        Assert.Empty(fileUploadStore.CanceledInteractions);
+    }
+
+    [Fact]
+    public async Task PromptInputsAsync_TextInputCanceled_DoesNotUseFileUploadStore()
+    {
+        var fileUploadStore = new TestFileUploadStore();
+        var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
+
+        var input = new InteractionInput { Name = "Text", InputType = InputType.Text };
+        var resultTask = interactionService.PromptInputAsync("Enter text", "please", input);
+        var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+
+        await CompleteInteractionAsync(
+            interactionService,
+            interaction.InteractionId,
+            new InteractionCompletionState { Complete = true },
+            inputs: []);
+
+        var result = await resultTask;
+
+        Assert.True(result.Canceled);
+        Assert.Empty(fileUploadStore.StartedInteractions);
+        Assert.Empty(fileUploadStore.CompletedInteractions);
+        Assert.Empty(fileUploadStore.CanceledInteractions);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -1390,6 +1390,26 @@ public class InteractionServiceTests
     }
 
     [Fact]
+    public async Task PromptInputsAsync_FileInputCancellationToken_CancelsFileUploadsBeforeCompletion()
+    {
+        var fileUploadStore = new TestInteractionFileUploadStore();
+        var interactionService = CreateInteractionService(fileUploadStore: fileUploadStore);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var input = new InteractionInput { Name = "File", Label = "File", InputType = InputType.File };
+        var resultTask = interactionService.PromptInputAsync("Select file", "please", input, cancellationToken: cancellationTokenSource.Token);
+        var interaction = Assert.Single(interactionService.GetCurrentInteractions());
+        fileUploadStore.CancelInteractionCallback = _ => Assert.False(interaction.CompletionTcs.Task.IsCompleted);
+
+        await cancellationTokenSource.CancelAsync();
+        var result = await resultTask;
+
+        Assert.True(result.Canceled);
+        Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.StartedInteractions));
+        Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.CanceledInteractions));
+    }
+
+    [Fact]
     public async Task PromptInputsAsync_TextInputComplete_DoesNotUseFileUploadStore()
     {
         var fileUploadStore = new TestInteractionFileUploadStore();

--- a/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/InteractionServiceTests.cs
@@ -1346,7 +1346,7 @@ public class InteractionServiceTests
         var resultTask = interactionService.PromptInputAsync("Select file", "please", input);
 
         var interaction = Assert.Single(interactionService.GetCurrentInteractions());
-        fileUploadStore.CompleteInteractionCallback = (_, _) => Assert.False(interaction.CompletionTcs.Task.IsCompleted);
+        fileUploadStore.CompleteInteractionCallback = _ => Assert.False(interaction.CompletionTcs.Task.IsCompleted);
 
         await CompleteInteractionAsync(
             interactionService,
@@ -1359,10 +1359,9 @@ public class InteractionServiceTests
         Assert.True(interaction.CompletionTcs.Task.IsCompletedSuccessfully);
         Assert.Empty(input.ValidationErrors);
         Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.StartedInteractions));
-        var completedInteraction = Assert.Single(fileUploadStore.CompletedInteractions);
-        Assert.Equal(interaction.InteractionId, completedInteraction.InteractionId);
+        Assert.Equal(interaction.InteractionId, Assert.Single(fileUploadStore.CompletedInteractions));
         var resultInput = Assert.IsType<InteractionInput>(result.Data);
-        Assert.Same(Assert.Single(resultInput.Files!), Assert.Single(completedInteraction.Files));
+        Assert.Single(resultInput.Files!);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -1175,7 +1175,8 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
             NullLogger<InteractionService>.Instance,
             options ?? new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
-            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
+            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(),
+            new TestFileUploadStore());
     }
 
     private sealed class MockDeploymentStateManager : IDeploymentStateManager

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ApplicationOrchestratorTests.cs
@@ -1176,7 +1176,7 @@ public class ApplicationOrchestratorTests(ITestOutputHelper testOutputHelper)
             options ?? new DistributedApplicationOptions(),
             new ServiceCollection().BuildServiceProvider(),
             new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(),
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
     }
 
     private sealed class MockDeploymentStateManager : IDeploymentStateManager

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -1231,7 +1231,8 @@ public class ParameterProcessorTests
             new NullLogger<InteractionService>(),
             new DistributedApplicationOptions { DisableDashboard = disableDashboard },
             new ServiceCollection().BuildServiceProvider(),
-            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
+            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(),
+            new TestFileUploadStore());
     }
 
     private sealed class MockDeploymentStateManager : IDeploymentStateManager

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -1232,7 +1232,7 @@ public class ParameterProcessorTests
             new DistributedApplicationOptions { DisableDashboard = disableDashboard },
             new ServiceCollection().BuildServiceProvider(),
             new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build(),
-            new TestFileUploadStore());
+            new TestInteractionFileUploadStore());
     }
 
     private sealed class MockDeploymentStateManager : IDeploymentStateManager

--- a/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
@@ -17,7 +17,7 @@ namespace Aspire.Hosting.Tests.Publishing;
 public class PublishingActivityReporterTests
 {
     private readonly InteractionService _interactionService = CreateInteractionService();
-    private readonly TestFileUploadStore _fileUploadStore = new();
+    private readonly TestInteractionFileUploadStore _fileUploadStore = new();
 
     [Fact]
     public async Task CreateStepAsync_CreatesStepAndEmitsActivity()
@@ -1335,6 +1335,6 @@ public class PublishingActivityReporterTests
         var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<InteractionService>>();
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
-        return new InteractionService(logger, new DistributedApplicationOptions(), provider, configuration, new TestFileUploadStore());
+        return new InteractionService(logger, new DistributedApplicationOptions(), provider, configuration, new TestInteractionFileUploadStore());
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PipelineActivityReporterTests.cs
@@ -1335,6 +1335,6 @@ public class PublishingActivityReporterTests
         var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<InteractionService>>();
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
-        return new InteractionService(logger, new DistributedApplicationOptions(), provider, configuration);
+        return new InteractionService(logger, new DistributedApplicationOptions(), provider, configuration, new TestFileUploadStore());
     }
 }

--- a/tests/Aspire.Hosting.Tests/Publishing/PublishingExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Publishing/PublishingExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace Aspire.Hosting.Tests.Publishing;
 public class PublishingExtensionsTests
 {
     private readonly InteractionService _interactionService = PublishingActivityReporterTests.CreateInteractionService();
-    private readonly TestFileUploadStore _fileUploadStore = new();
+    private readonly TestInteractionFileUploadStore _fileUploadStore = new();
 
     [Fact]
     public async Task PublishingStepExtensions_CreateTask_WorksCorrectly()

--- a/tests/Shared/TestDashboardClient.cs
+++ b/tests/Shared/TestDashboardClient.cs
@@ -75,7 +75,7 @@ public class TestDashboardClient : IDashboardClient
         return _resourceCommandsChannel.Reader.ReadAsync(cancellationToken).AsTask();
     }
 
-    public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, CancellationToken cancellationToken)
+    public Task<string> UploadFileAsync(Stream fileStream, string fileName, long expectedSize, int interactionId, string inputName, CancellationToken cancellationToken)
     {
         return Task.FromResult(Guid.NewGuid().ToString("N"));
     }

--- a/tests/Shared/TestFileSystemService.cs
+++ b/tests/Shared/TestFileSystemService.cs
@@ -13,16 +13,16 @@ internal sealed class TestFileSystemService : IFileSystemService, IDisposable
 {
     private readonly TestTempFileSystemService _tempDirectory;
 
-    public TestFileSystemService(bool createDirectoryAtTempFilePath = false)
+    public TestFileSystemService(bool failFirstTempFileDispose = false)
     {
-        _tempDirectory = new TestTempFileSystemService(createDirectoryAtTempFilePath);
+        _tempDirectory = new TestTempFileSystemService(failFirstTempFileDispose);
     }
 
     public ITempFileSystemService TempDirectory => _tempDirectory;
 
     public void Dispose() => _tempDirectory.Dispose();
 
-    private sealed class TestTempFileSystemService(bool createDirectoryAtTempFilePath) : ITempFileSystemService, IDisposable
+    private sealed class TestTempFileSystemService(bool failFirstTempFileDispose) : ITempFileSystemService, IDisposable
     {
         private readonly List<string> _directories = [];
 
@@ -39,15 +39,8 @@ internal sealed class TestFileSystemService : IFileSystemService, IDisposable
             _directories.Add(tempDir.FullName);
             var resolvedName = fileName ?? System.IO.Path.GetRandomFileName();
             var filePath = System.IO.Path.Combine(tempDir.FullName, resolvedName);
-            if (createDirectoryAtTempFilePath)
-            {
-                Directory.CreateDirectory(filePath);
-            }
-            else
-            {
-                File.Create(filePath).Dispose();
-            }
-            return new TestTempFile(filePath, tempDir.FullName);
+            File.Create(filePath).Dispose();
+            return new TestTempFile(filePath, tempDir.FullName, failFirstTempFileDispose);
         }
 
         public void Dispose()
@@ -89,22 +82,23 @@ internal sealed class TestFileSystemService : IFileSystemService, IDisposable
         }
     }
 
-    private sealed class TestTempFile(string path, string parentDir) : TempFile
+    private sealed class TestTempFile(string path, string parentDir, bool failFirstDispose) : TempFile
     {
+        private bool _failDispose = failFirstDispose;
+
         public override string Path => path;
 
         public override void Dispose()
         {
-            try
+            if (_failDispose)
             {
-                if (Directory.Exists(parentDir))
-                {
-                    Directory.Delete(parentDir, recursive: true);
-                }
+                _failDispose = false;
+                throw new IOException("Simulated temporary file deletion failure.");
             }
-            catch
+
+            if (Directory.Exists(parentDir))
             {
-                // Best-effort cleanup.
+                Directory.Delete(parentDir, recursive: true);
             }
         }
     }

--- a/tests/Shared/TestFileSystemService.cs
+++ b/tests/Shared/TestFileSystemService.cs
@@ -11,18 +11,13 @@ namespace Aspire.Hosting.Utils;
 /// </summary>
 internal sealed class TestFileSystemService : IFileSystemService, IDisposable
 {
-    private readonly TestTempFileSystemService _tempDirectory;
-
-    public TestFileSystemService(bool failFirstTempFileDispose = false)
-    {
-        _tempDirectory = new TestTempFileSystemService(failFirstTempFileDispose);
-    }
+    private readonly TestTempFileSystemService _tempDirectory = new();
 
     public ITempFileSystemService TempDirectory => _tempDirectory;
 
     public void Dispose() => _tempDirectory.Dispose();
 
-    private sealed class TestTempFileSystemService(bool failFirstTempFileDispose) : ITempFileSystemService, IDisposable
+    private sealed class TestTempFileSystemService : ITempFileSystemService, IDisposable
     {
         private readonly List<string> _directories = [];
 
@@ -40,7 +35,7 @@ internal sealed class TestFileSystemService : IFileSystemService, IDisposable
             var resolvedName = fileName ?? System.IO.Path.GetRandomFileName();
             var filePath = System.IO.Path.Combine(tempDir.FullName, resolvedName);
             File.Create(filePath).Dispose();
-            return new TestTempFile(filePath, tempDir.FullName, failFirstTempFileDispose);
+            return new TestTempFile(filePath, tempDir.FullName);
         }
 
         public void Dispose()
@@ -82,23 +77,22 @@ internal sealed class TestFileSystemService : IFileSystemService, IDisposable
         }
     }
 
-    private sealed class TestTempFile(string path, string parentDir, bool failFirstDispose) : TempFile
+    private sealed class TestTempFile(string path, string parentDir) : TempFile
     {
-        private bool _failDispose = failFirstDispose;
-
         public override string Path => path;
 
         public override void Dispose()
         {
-            if (_failDispose)
+            try
             {
-                _failDispose = false;
-                throw new IOException("Simulated temporary file deletion failure.");
+                if (Directory.Exists(parentDir))
+                {
+                    Directory.Delete(parentDir, recursive: true);
+                }
             }
-
-            if (Directory.Exists(parentDir))
+            catch
             {
-                Directory.Delete(parentDir, recursive: true);
+                // Best-effort cleanup.
             }
         }
     }

--- a/tests/Shared/TestFileSystemService.cs
+++ b/tests/Shared/TestFileSystemService.cs
@@ -11,13 +11,18 @@ namespace Aspire.Hosting.Utils;
 /// </summary>
 internal sealed class TestFileSystemService : IFileSystemService, IDisposable
 {
-    private readonly TestTempFileSystemService _tempDirectory = new();
+    private readonly TestTempFileSystemService _tempDirectory;
+
+    public TestFileSystemService(bool createDirectoryAtTempFilePath = false)
+    {
+        _tempDirectory = new TestTempFileSystemService(createDirectoryAtTempFilePath);
+    }
 
     public ITempFileSystemService TempDirectory => _tempDirectory;
 
     public void Dispose() => _tempDirectory.Dispose();
 
-    private sealed class TestTempFileSystemService : ITempFileSystemService, IDisposable
+    private sealed class TestTempFileSystemService(bool createDirectoryAtTempFilePath) : ITempFileSystemService, IDisposable
     {
         private readonly List<string> _directories = [];
 
@@ -34,7 +39,14 @@ internal sealed class TestFileSystemService : IFileSystemService, IDisposable
             _directories.Add(tempDir.FullName);
             var resolvedName = fileName ?? System.IO.Path.GetRandomFileName();
             var filePath = System.IO.Path.Combine(tempDir.FullName, resolvedName);
-            File.Create(filePath).Dispose();
+            if (createDirectoryAtTempFilePath)
+            {
+                Directory.CreateDirectory(filePath);
+            }
+            else
+            {
+                File.Create(filePath).Dispose();
+            }
             return new TestTempFile(filePath, tempDir.FullName);
         }
 

--- a/tests/Shared/TestFileUploadStore.cs
+++ b/tests/Shared/TestFileUploadStore.cs
@@ -36,9 +36,10 @@ internal sealed class TestFileUploadStore : IFileUploadStore
     {
     }
 
-    public string? GetFilePath(string fileId, string inputName)
+    public string? GetFilePath(string fileId, int interactionId, string inputName)
     {
         return _files.TryGetValue(fileId, out var entry) &&
+            entry.InteractionId == interactionId &&
             string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
                 ? entry.FilePath
                 : null;

--- a/tests/Shared/TestFileUploadStore.cs
+++ b/tests/Shared/TestFileUploadStore.cs
@@ -13,19 +13,35 @@ internal sealed class TestFileUploadStore : IFileUploadStore
 {
     private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
 
-    public (string FileId, string FilePath) CreateEntry(string originalFileName)
+    public ConcurrentQueue<int> StartedInteractions { get; } = new();
+    public ConcurrentQueue<(int InteractionId, IReadOnlyList<InteractionFile> Files)> CompletedInteractions { get; } = new();
+    public ConcurrentQueue<int> CanceledInteractions { get; } = new();
+
+    public void StartInteraction(int interactionId)
+    {
+        StartedInteractions.Enqueue(interactionId);
+    }
+
+    public (string FileId, string FilePath) CreateEntry(string originalFileName, int interactionId, string inputName)
     {
         var fileId = Guid.NewGuid().ToString("N");
         // Use a synthetic path that won't conflict with real files.
         var filePath = Path.Combine("memory", fileId);
 
-        _files[fileId] = new FileEntry(filePath, originalFileName);
+        _files[fileId] = new FileEntry(filePath, originalFileName, interactionId, inputName);
         return (fileId, filePath);
     }
 
-    public string? GetFilePath(string fileId)
+    public void CompleteUpload(string fileId)
     {
-        return _files.TryGetValue(fileId, out var entry) ? entry.FilePath : null;
+    }
+
+    public string? GetFilePath(string fileId, string inputName)
+    {
+        return _files.TryGetValue(fileId, out var entry) &&
+            string.Equals(entry.InputName, inputName, StringComparisons.InteractionInputName)
+                ? entry.FilePath
+                : null;
     }
 
     public string? GetFileName(string fileId)
@@ -38,5 +54,23 @@ internal sealed class TestFileUploadStore : IFileUploadStore
         _files.TryRemove(fileId, out _);
     }
 
-    private sealed record FileEntry(string FilePath, string OriginalFileName);
+    public void CompleteInteraction(int interactionId, IReadOnlyList<InteractionFile> files)
+    {
+        CompletedInteractions.Enqueue((interactionId, files));
+    }
+
+    public void CancelInteraction(int interactionId)
+    {
+        CanceledInteractions.Enqueue(interactionId);
+
+        foreach (var (fileId, entry) in _files)
+        {
+            if (entry.InteractionId == interactionId)
+            {
+                _files.TryRemove(fileId, out _);
+            }
+        }
+    }
+
+    private sealed record FileEntry(string FilePath, string OriginalFileName, int InteractionId, string InputName);
 }

--- a/tests/Shared/TestInteractionFileUploadStore.cs
+++ b/tests/Shared/TestInteractionFileUploadStore.cs
@@ -16,6 +16,8 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
     public ConcurrentQueue<int> StartedInteractions { get; } = new();
     public ConcurrentQueue<(int InteractionId, IReadOnlyList<InteractionFile> Files)> CompletedInteractions { get; } = new();
     public ConcurrentQueue<int> CanceledInteractions { get; } = new();
+    public Action<int, IReadOnlyList<InteractionFile>>? CompleteInteractionCallback { get; set; }
+    public Action<int>? CancelInteractionCallback { get; set; }
 
     public void StartInteraction(int interactionId)
     {
@@ -57,11 +59,13 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
 
     public void CompleteInteraction(int interactionId, IReadOnlyList<InteractionFile> files)
     {
+        CompleteInteractionCallback?.Invoke(interactionId, files);
         CompletedInteractions.Enqueue((interactionId, files));
     }
 
     public void CancelInteraction(int interactionId)
     {
+        CancelInteractionCallback?.Invoke(interactionId);
         CanceledInteractions.Enqueue(interactionId);
 
         foreach (var (fileId, entry) in _files)

--- a/tests/Shared/TestInteractionFileUploadStore.cs
+++ b/tests/Shared/TestInteractionFileUploadStore.cs
@@ -34,7 +34,7 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
         return (fileId, filePath);
     }
 
-    public void CompleteUpload(string fileId)
+    public void CompleteUpload(int interactionId, string fileId)
     {
     }
 
@@ -47,14 +47,17 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
                 : null;
     }
 
-    public string? GetFileName(string fileId)
+    public string? GetFileName(int interactionId, string fileId)
     {
-        return _files.TryGetValue(fileId, out var entry) ? entry.OriginalFileName : null;
+        return _files.TryGetValue(fileId, out var entry) && entry.InteractionId == interactionId ? entry.OriginalFileName : null;
     }
 
-    public void RemoveEntry(string fileId)
+    public void RemoveEntry(int interactionId, string fileId)
     {
-        _files.TryRemove(fileId, out _);
+        if (_files.TryGetValue(fileId, out var entry) && entry.InteractionId == interactionId)
+        {
+            _files.TryRemove(fileId, out _);
+        }
     }
 
     public void CompleteInteraction(int interactionId, IReadOnlyList<InteractionFile> files)

--- a/tests/Shared/TestInteractionFileUploadStore.cs
+++ b/tests/Shared/TestInteractionFileUploadStore.cs
@@ -14,9 +14,9 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
     private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
 
     public ConcurrentQueue<int> StartedInteractions { get; } = new();
-    public ConcurrentQueue<(int InteractionId, IReadOnlyList<InteractionFile> Files)> CompletedInteractions { get; } = new();
+    public ConcurrentQueue<int> CompletedInteractions { get; } = new();
     public ConcurrentQueue<int> CanceledInteractions { get; } = new();
-    public Action<int, IReadOnlyList<InteractionFile>>? CompleteInteractionCallback { get; set; }
+    public Action<int>? CompleteInteractionCallback { get; set; }
     public Action<int>? CancelInteractionCallback { get; set; }
 
     public void StartInteraction(int interactionId)
@@ -60,10 +60,10 @@ internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadSto
         }
     }
 
-    public void CompleteInteraction(int interactionId, IReadOnlyList<InteractionFile> files)
+    public void CompleteInteraction(int interactionId)
     {
-        CompleteInteractionCallback?.Invoke(interactionId, files);
-        CompletedInteractions.Enqueue((interactionId, files));
+        CompleteInteractionCallback?.Invoke(interactionId);
+        CompletedInteractions.Enqueue(interactionId);
     }
 
     public void CancelInteraction(int interactionId)

--- a/tests/Shared/TestInteractionFileUploadStore.cs
+++ b/tests/Shared/TestInteractionFileUploadStore.cs
@@ -6,10 +6,10 @@ using System.Collections.Concurrent;
 namespace Aspire.Hosting.Utils;
 
 /// <summary>
-/// An in-memory implementation of <see cref="IFileUploadStore"/> for tests.
+/// An in-memory implementation of <see cref="IInteractionFileUploadStore"/> for tests.
 /// Does not write to disk or implement IDisposable.
 /// </summary>
-internal sealed class TestFileUploadStore : IFileUploadStore
+internal sealed class TestInteractionFileUploadStore : IInteractionFileUploadStore
 {
     private readonly ConcurrentDictionary<string, FileEntry> _files = new(StringComparer.Ordinal);
 


### PR DESCRIPTION
## Description

Uploaded files used by `IInteractionService` were retained on disk without lifecycle ownership or cleanup for failed and canceled interactions.

This change adds lifecycle-aware management for interaction file uploads:

- Files are retained while an upload or its interaction is in progress.
- Failed uploads and canceled interaction uploads are removed immediately once their upload stream is closed.
- Completed interaction uploads remain available until explicit removal or AppHost/store disposal, including for polyglot callers that receive serialized file metadata.
- Dashboard and CLI uploads carry the owning interaction ID and input name, preventing uploads from being attached to inactive interactions or resolved through a different input.
- The dashboard child host and AppHost share the same upload store instance.

### Security considerations

File names continue to be sanitized before creating temporary files. Uploaded file IDs are accepted only for active interactions and the input name that owns the upload. Server-side interaction input metadata determines whether submitted file references are accepted. No formal threat model or security review has been completed.

### Validation

- `InteractionFileUploadStoreTests`: 33 passed
- `InteractionServiceTests`: 74 passed
- `DashboardServiceTests`: 36 passed
- AppHost RPC upload tests: 5 passed
- `FileSystemServiceTests`: 24 passed
- CLI file-prompt integration tests: 6 passed
- CLI backchannel upload tests: 2 passed
- Dashboard interaction dialog tests: 2 passed
- Dashboard client test assembly: passed
- `git diff --check`

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [ ] No
