### PR TITLE
Remove dashboard dependency on Microsoft.OpenApi

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -255,7 +255,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiLTSVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisLTSVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostLTSVersion)" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="3.5.3" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftExtensionsCachingStackExchangeRedisLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCoreLTSVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksLTSVersion)" />

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -60,7 +60,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" />
-    <PackageReference Include="Microsoft.OpenApi" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIMessages.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
-using Microsoft.OpenApi;
 
 namespace Aspire.Dashboard.Model.GenAI;
 
@@ -198,7 +197,7 @@ public class ToolDefinition
     public string Type { get; set; } = "function";
     public string? Name { get; set; }
     public string? Description { get; set; }
-    public OpenApiSchema? Parameters { get; set; }
+    internal ToolDefinitionSchema? Parameters { get; set; }
 }
 
 /// <summary>

--- a/src/Aspire.Dashboard/Model/GenAI/GenAISchemaHelpers.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAISchemaHelpers.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Nodes;
-using Microsoft.OpenApi;
 
 namespace Aspire.Dashboard.Model.GenAI;
 
@@ -16,9 +15,9 @@ internal static class GenAISchemaHelpers
     private const string TypeObject = "object";
     private const string TypeArray = "array";
 
-    internal static OpenApiSchema? ParseOpenApiSchema(JsonObject schemaObj)
+    internal static ToolDefinitionSchema ParseToolDefinitionSchema(JsonObject schemaObj)
     {
-        var schema = new OpenApiSchema
+        var schema = new ToolDefinitionSchema
         {
             Type = ParseTypeValue(schemaObj["type"]),
             Description = schemaObj["description"]?.GetValue<string>()
@@ -27,16 +26,12 @@ internal static class GenAISchemaHelpers
         // Parse properties
         if (schemaObj["properties"] is JsonObject propsObj)
         {
-            schema.Properties = new Dictionary<string, IOpenApiSchema>();
+            schema.Properties = new Dictionary<string, ToolDefinitionSchema>();
             foreach (var prop in propsObj)
             {
                 if (prop.Value is JsonObject propSchemaObj)
                 {
-                    var parsedSchema = ParseOpenApiSchema(propSchemaObj);
-                    if (parsedSchema != null)
-                    {
-                        schema.Properties[prop.Key] = parsedSchema;
-                    }
+                    schema.Properties[prop.Key] = ParseToolDefinitionSchema(propSchemaObj);
                 }
             }
         }
@@ -44,7 +39,7 @@ internal static class GenAISchemaHelpers
         // Parse items (for array types)
         if (schemaObj["items"] is JsonObject itemsObj)
         {
-            schema.Items = ParseOpenApiSchema(itemsObj);
+            schema.Items = ParseToolDefinitionSchema(itemsObj);
         }
 
         // Parse required
@@ -140,7 +135,7 @@ internal static class GenAISchemaHelpers
         return schemaType != default;
     }
 
-    internal static IList<string> ConvertTypeToNames(IOpenApiSchema? schema)
+    internal static IList<string> ConvertTypeToNames(ToolDefinitionSchema? schema)
     {
         if (schema?.Type == null)
         {
@@ -187,7 +182,7 @@ internal static class GenAISchemaHelpers
             return type == JsonSchemaType.Null ? type : type & ~JsonSchemaType.Null;
         }
 
-        static string GetArrayTypeName(IOpenApiSchema? itemsSchema)
+        static string GetArrayTypeName(ToolDefinitionSchema? itemsSchema)
         {
             if (itemsSchema?.Type != null)
             {

--- a/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/GenAIVisualizerDialogViewModel.cs
@@ -79,7 +79,8 @@ public sealed class GenAIVisualizerDialogViewModel
         {
             try
             {
-                // Deserialize to intermediate format since OpenApiSchema doesn't work well with System.Text.Json
+                // JSON Schema permits "type" to be either a string or an array of strings, so parse
+                // the payload through JsonNode before converting it to the dashboard's schema model.
                 var documentOptions = new JsonDocumentOptions
                 {
                     CommentHandling = JsonCommentHandling.Skip,
@@ -107,7 +108,7 @@ public sealed class GenAIVisualizerDialogViewModel
                         // Parse parameters if present
                         if (obj["parameters"] is JsonObject paramsObj)
                         {
-                            toolDef.Parameters = GenAISchemaHelpers.ParseOpenApiSchema(paramsObj);
+                            toolDef.Parameters = GenAISchemaHelpers.ParseToolDefinitionSchema(paramsObj);
                         }
 
                         viewModel.ToolDefinitions.Add(new ToolDefinitionViewModel { ToolDefinition = toolDef });

--- a/src/Aspire.Dashboard/Model/GenAI/ToolDefinitionSchema.cs
+++ b/src/Aspire.Dashboard/Model/GenAI/ToolDefinitionSchema.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+
+namespace Aspire.Dashboard.Model.GenAI;
+
+internal sealed class ToolDefinitionSchema
+{
+    public JsonSchemaType? Type { get; set; }
+    public string? Description { get; set; }
+    public Dictionary<string, ToolDefinitionSchema>? Properties { get; set; }
+    public ToolDefinitionSchema? Items { get; set; }
+    public HashSet<string>? Required { get; set; }
+    public List<JsonNode>? Enum { get; set; }
+}
+
+[Flags]
+internal enum JsonSchemaType
+{
+    Null = 1,
+    Boolean = 2,
+    Integer = 4,
+    Number = 8,
+    String = 16,
+    Object = 32,
+    Array = 64,
+}

--- a/tests/Aspire.Dashboard.Tests/Model/GenAISchemaHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAISchemaHelpersTests.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json.Nodes;
 using Aspire.Dashboard.Model.GenAI;
-using Microsoft.OpenApi;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Model;
@@ -14,39 +13,39 @@ public sealed class GenAISchemaHelpersTests
     public void ConvertTypeToNames_HandlesVariousTypeCombinations()
     {
         // Test single types
-        var stringSchema = new OpenApiSchema { Type = JsonSchemaType.String };
+        var stringSchema = new ToolDefinitionSchema { Type = JsonSchemaType.String };
         var typeNames = GenAISchemaHelpers.ConvertTypeToNames(stringSchema);
         Assert.Single(typeNames);
         Assert.Equal("string", typeNames[0]);
 
         // Test multiple types (nullable string) - null should be excluded from display
-        var nullableStringSchema = new OpenApiSchema { Type = JsonSchemaType.String | JsonSchemaType.Null };
+        var nullableStringSchema = new ToolDefinitionSchema { Type = JsonSchemaType.String | JsonSchemaType.Null };
         typeNames = GenAISchemaHelpers.ConvertTypeToNames(nullableStringSchema);
         Assert.Single(typeNames);
         Assert.Equal("string", typeNames[0]);
 
         // Test array with items
-        var arraySchema = new OpenApiSchema 
+        var arraySchema = new ToolDefinitionSchema
         { 
             Type = JsonSchemaType.Array,
-            Items = new OpenApiSchema { Type = JsonSchemaType.String }
+            Items = new ToolDefinitionSchema { Type = JsonSchemaType.String }
         };
         typeNames = GenAISchemaHelpers.ConvertTypeToNames(arraySchema);
         Assert.Single(typeNames);
         Assert.Equal("array<string>", typeNames[0]);
 
         // Test nullable array with items - null should be excluded
-        var nullableArraySchema = new OpenApiSchema 
+        var nullableArraySchema = new ToolDefinitionSchema
         { 
             Type = JsonSchemaType.Array | JsonSchemaType.Null,
-            Items = new OpenApiSchema { Type = JsonSchemaType.Number }
+            Items = new ToolDefinitionSchema { Type = JsonSchemaType.Number }
         };
         typeNames = GenAISchemaHelpers.ConvertTypeToNames(nullableArraySchema);
         Assert.Single(typeNames);
         Assert.Equal("array<number>", typeNames[0]);
 
         // Test array without items
-        var arrayNoItemsSchema = new OpenApiSchema { Type = JsonSchemaType.Array };
+        var arrayNoItemsSchema = new ToolDefinitionSchema { Type = JsonSchemaType.Array };
         typeNames = GenAISchemaHelpers.ConvertTypeToNames(arrayNoItemsSchema);
         Assert.Single(typeNames);
         Assert.Equal("array", typeNames[0]);
@@ -56,18 +55,18 @@ public sealed class GenAISchemaHelpersTests
         Assert.Empty(typeNames);
 
         // Test schema with no type - should return empty list
-        var noTypeSchema = new OpenApiSchema();
+        var noTypeSchema = new ToolDefinitionSchema();
         typeNames = GenAISchemaHelpers.ConvertTypeToNames(noTypeSchema);
         Assert.Empty(typeNames);
 
         // Test schema with only null type - should return "null" since type is only null
-        var onlyNullSchema = new OpenApiSchema { Type = JsonSchemaType.Null };
+        var onlyNullSchema = new ToolDefinitionSchema { Type = JsonSchemaType.Null };
         typeNames = GenAISchemaHelpers.ConvertTypeToNames(onlyNullSchema);
         Assert.Single(typeNames);
         Assert.Equal("null", typeNames[0]);
 
         // Test multiple types without null
-        var multiTypeSchema = new OpenApiSchema { Type = JsonSchemaType.String | JsonSchemaType.Number };
+        var multiTypeSchema = new ToolDefinitionSchema { Type = JsonSchemaType.String | JsonSchemaType.Number };
         typeNames = GenAISchemaHelpers.ConvertTypeToNames(multiTypeSchema);
         Assert.Equal(2, typeNames.Count);
         Assert.Contains("number", typeNames);
@@ -165,9 +164,9 @@ public sealed class GenAISchemaHelpersTests
     }
 
     [Fact]
-    public void ParseOpenApiSchema_HandlesUnexpectedTypeObject_ReturnsSchemaWithNullType()
+    public void ParseToolDefinitionSchema_HandlesUnexpectedTypeObject_ReturnsSchemaWithNullType()
     {
-        // Test the full ParseOpenApiSchema method with an unexpected "type" field
+        // Test the full schema parser with an unexpected "type" field.
         var schemaJson = """
         {
             "properties": {
@@ -184,22 +183,19 @@ public sealed class GenAISchemaHelpersTests
         """;
         
         var schemaObj = JsonNode.Parse(schemaJson) as JsonObject;
-        var schema = GenAISchemaHelpers.ParseOpenApiSchema(schemaObj!);
+        var schema = GenAISchemaHelpers.ParseToolDefinitionSchema(schemaObj!);
         
-        Assert.NotNull(schema);
-        Assert.NotNull(schema!.Properties);
+        Assert.NotNull(schema.Properties);
         Assert.Equal(2, schema.Properties.Count);
         
         // param1 should be parsed correctly
         Assert.True(schema.Properties.ContainsKey("param1"));
-        var param1 = schema.Properties["param1"] as OpenApiSchema;
-        Assert.NotNull(param1);
-        Assert.Equal(JsonSchemaType.String, param1!.Type);
+        var param1 = schema.Properties["param1"];
+        Assert.Equal(JsonSchemaType.String, param1.Type);
         
         // param2 should be parsed but with null type (since type is an object)
         Assert.True(schema.Properties.ContainsKey("param2"));
-        var param2 = schema.Properties["param2"] as OpenApiSchema;
-        Assert.NotNull(param2);
-        Assert.Null(param2!.Type);
+        var param2 = schema.Properties["param2"];
+        Assert.Null(param2.Type);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/GenAIVisualizerDialogViewModelTests.cs
@@ -8,7 +8,6 @@ using Aspire.Dashboard.Model.GenAI;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
-using Microsoft.OpenApi;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
@@ -1095,7 +1094,8 @@ public sealed class GenAIVisualizerDialogViewModelTests
         // Arrange
         var repository = CreateRepository();
 
-        // Create tool definitions JSON manually since OpenApiSchema doesn't serialize well with System.Text.Json
+        // Create the telemetry JSON manually because JSON Schema represents types as strings,
+        // while the dashboard model uses a flags enum.
         var toolDefinitionsJson = """
         [
           {


### PR DESCRIPTION
## Description

`Aspire.Dashboard` used `Microsoft.OpenApi` only for a small schema object displayed by the GenAI tool-definition UI. This removes that package dependency and its central version, replacing it with an internal `ToolDefinitionSchema` containing only the type, description, properties, items, required names, and enum values the dashboard consumes.

The internal flags enum preserves JSON Schema behavior that `System.Text.Json.JsonValueKind` cannot represent, including `integer` versus `number` and union types such as `["string", "null"]`. Existing parsing and rendering behavior is unchanged.

Validation:

- 40 GenAI schema and tool-definition tests pass.
- `Aspire.Dashboard` builds with no warnings or errors.
- Dashboard project assets no longer contain `Microsoft.OpenApi`.

Fixes: #19314

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No