### PR TITLE
[automated] Fix AppHost discovery E2E synchronization

### DIFF
--- a/extension/src/test-e2e/commandPalette.e2e.test.ts
+++ b/extension/src/test-e2e/commandPalette.e2e.test.ts
@@ -103,8 +103,11 @@ suite('Aspire command palette E2E', function () {
         await waitForCommandOutcome('aspire-vscode.refreshAppHosts', 'success', 60000, beforeRefresh);
 
         const stateFile = await waitForExtensionState(
-            file => file.state.workspaceAppHostCandidatePaths.some(candidate => isSamePath(candidate, secondaryAppHostPath)),
-            'secondary AppHost candidate',
+            file => file.state.isWorkspaceAppHostDiscoveryComplete
+                && !file.state.isRepositoryLoading
+                && file.state.workspaceAppHostCandidatePaths.length >= 2
+                && file.state.workspaceAppHostCandidatePaths.some(candidate => isSamePath(candidate, secondaryAppHostPath)),
+            'completed discovery with multiple AppHost candidates',
             180000);
 
         assert.ok(stateFile.state.workspaceAppHostCandidatePaths.length >= 2);

--- a/extension/src/test-e2e/discoveryConfiguration.e2e.test.ts
+++ b/extension/src/test-e2e/discoveryConfiguration.e2e.test.ts
@@ -42,8 +42,11 @@ suite('Aspire workspace discovery and configuration E2E', function () {
         await waitForCommandOutcome('aspire-vscode.refreshAppHosts', 'success', 60000, refreshWithSecondCandidateBefore);
 
         const multipleCandidates = await waitForExtensionState(
-            file => file.state.workspaceAppHostCandidatePaths.some(candidate => isSamePath(candidate, secondaryAppHostPath)),
-            'secondary AppHost candidate',
+            file => file.state.isWorkspaceAppHostDiscoveryComplete
+                && !file.state.isRepositoryLoading
+                && file.state.workspaceAppHostCandidatePaths.length >= 2
+                && file.state.workspaceAppHostCandidatePaths.some(candidate => isSamePath(candidate, secondaryAppHostPath)),
+            'completed discovery with multiple AppHost candidates',
             60000);
         assert.ok(multipleCandidates.state.workspaceAppHostCandidatePaths.length >= 2);
 


### PR DESCRIPTION
## Description

The VS Code extension E2E tests could accept an incremental AppHost discovery state containing only the secondary candidate, then immediately fail while asserting that both candidates were present.

Wait for discovery to complete, repository loading to finish, and at least two candidates to be present before accepting the secondary candidate. The same synchronization bug existed in the command-palette and discovery-configuration shards.

Failure: https://github.com/microsoft/aspire/actions/runs/31656131071/job/94313496218

Validation:

- `extension/build.sh`
- `corepack yarn compile-e2e`
- `corepack yarn lint`
- Command-palette E2E shard: 4 passed, 1 platform skip
- Discovery-configuration E2E shard: 3 passed

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
