### PR TITLE
Fix Dashboard HTML language under invariant culture

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -1,6 +1,6 @@
 ﻿@inject IStringLocalizer<Aspire.Dashboard.Resources.ControlsStrings> ControlsLoc
 <!DOCTYPE html>
-<html lang="@System.Globalization.CultureInfo.CurrentUICulture.Name">
+<html lang="@GlobalizationHelpers.GetHtmlLanguageName(System.Globalization.CultureInfo.CurrentUICulture)">
 
 <head>
     <meta charset="utf-8" />

--- a/src/Aspire.Dashboard/Utils/GlobalizationHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/GlobalizationHelpers.cs
@@ -12,6 +12,7 @@ namespace Aspire.Dashboard.Utils;
 
 internal static class GlobalizationHelpers
 {
+    private const string DefaultHtmlLanguageName = "en";
     private const int MaxCultureParentDepth = 5;
 
     public static List<CultureInfo> OrderedLocalizedCultures { get; }
@@ -30,6 +31,15 @@ internal static class GlobalizationHelpers
 
         // Order cultures for display in the UI with invariant culture. This prevents the order of languages changing when the culture changes.
         OrderedLocalizedCultures = localizedCultureInfos.OrderBy(c => c.NativeName, StringComparer.InvariantCultureIgnoreCase).ToList();
+    }
+
+    /// <summary>
+    /// Returns the language name used by the dashboard's HTML document.
+    /// </summary>
+    public static string GetHtmlLanguageName(CultureInfo culture)
+    {
+        // Invariant culture uses the English base resources, but its Name is empty.
+        return culture.Name is { Length: > 0 } languageName ? languageName : DefaultHtmlLanguageName;
     }
 
     private static Dictionary<string, List<CultureInfo>> GetExpandedLocalizedCultures(List<CultureInfo> localizedCultures, List<CultureInfo> allCultures)

--- a/tests/Aspire.Dashboard.Tests/GlobalizationHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/GlobalizationHelpersTests.cs
@@ -42,6 +42,16 @@ public class GlobalizationHelpersTests
     }
 
     [Theory]
+    [InlineData("", "en")]
+    [InlineData("en-US", "en-US")]
+    public void GetHtmlLanguageName_ReturnsExpectedLanguage(string cultureName, string expectedLanguageName)
+    {
+        var culture = CultureInfo.GetCultureInfo(cultureName);
+
+        Assert.Equal(expectedLanguageName, GlobalizationHelpers.GetHtmlLanguageName(culture));
+    }
+
+    [Theory]
     [InlineData("en", true, "en")]
     [InlineData("en-US", true, "en")]
     [InlineData("fr", true, "fr")]


### PR DESCRIPTION
## Description

The Dashboard accessibility outerloop tests rendered `<html lang="">` when the process used invariant culture. Axe then reported `html-has-lang` across every scanned page, dialog, theme, and viewport.

This change maps invariant culture to `lang="en"`, matching the Dashboard's English base resources, while preserving the name of every non-invariant UI culture.

The separate CLI E2E failure tracked by the same issue is also unblocked: after `@playwright/cli@0.1.18` was seeded, the package downloads anonymously from the internal npm feed.

### Test proof

CI-equivalent Dashboard accessibility coverage used the repository's bundled Chromium headless shell:

```bash
BROWSER_PATH="$PWD/artifacts/bin/playwright-deps/chromium_headless_shell-1187/chrome-mac/headless_shell" \
  dotnet test --project tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj \
  --no-build --no-launch-profile -- \
  --filter-class "*.AccessibilityTests" \
  --filter-not-trait "quarantined=true"
```

```text
Test run summary: Passed!
  total: 19
  failed: 0
  succeeded: 19
```

Full non-outerloop Dashboard suite:

```text
Test run summary: Passed!
  total: 1516
  failed: 0
  succeeded: 1516
```

Build:

```text
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

Internal feed verification:

```text
npm pack --dry-run @playwright/cli@0.1.18
filename: playwright-cli-0.1.18.tgz
package size: 30.9 kB
total files: 15
```

Fixes #18657

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
