### PR TITLE
Simplify dashboard design token scope

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -37,12 +37,8 @@
 
 <body class="before-upgrade"
       data-scroll-to-bottom-label="@ControlsLoc[nameof(Aspire.Dashboard.Resources.ControlsStrings.ScrollToBottom)]">
-    @* Fluent design tokens are element-scoped. This ancestor gives app-theme.js one stable target whose
-       emitted token properties are inherited by every Fluent Blazor component in the dashboard. *@
-    <div id="aspire-design-system">
-        <Routes @rendermode="@(new InteractiveServerRenderMode(prerender: false))" />
-        <ReconnectModal />
-    </div>
+    <Routes @rendermode="@(new InteractiveServerRenderMode(prerender: false))" />
+    <ReconnectModal />
     <BlazorScript />
     <script src="js/app.js"></script>
     <script src="js/app-reconnect.js"></script>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -238,8 +238,8 @@ fluent-combobox {
     --focus-stroke-width: var(--aspire-focus-stroke-width);
     --focus-stroke-outer: var(--dash-focus-ring-color);
     --focus-stroke-inner: var(--dash-focus-ring-color);
-    /* This default supports content outside the application token scope. The application scope below
-       redeclares the focus properties so they resolve against its explicit Fluent accent tokens. */
+    /* The body redeclares the focus properties below so they resolve against its explicit Fluent
+       accent tokens. */
     --dash-focus-ring-color: var(--accent-fill-rest);
     /* Message bar surfaces derive from the shared --aspire-status-* seeds (tokens.css)
        so each intent hue is defined once and every theme mixes its own surface from it.
@@ -341,9 +341,9 @@ fluent-combobox {
     --accent-olive-text: #fff;
 }
 
-#aspire-design-system {
-    /* Fluent emits the approved semantic accent values on this scope. Resolve the focus-ring variables
-       here as well so they do not capture the generated accent value from the document ancestor. */
+body {
+    /* Fluent emits the approved semantic accent values on the body. Resolve the focus-ring variables
+       here as well so they do not capture the generated accent value from the document root. */
     --dash-focus-ring-color: var(--accent-fill-rest);
     --focus-stroke-outer: var(--dash-focus-ring-color);
     --focus-stroke-inner: var(--dash-focus-ring-color);

--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -206,13 +206,9 @@ function setAccentColor(theme) {
     const hover = theme === themeSettingDark ? brandLight : brandPrimary;
     const active = rest;
     const focus = rest;
-    // Fluent design tokens are scoped to an element subtree. The body already receives generated
-    // defaults during Fluent initialization, so use the dashboard's dedicated ancestor to ensure
-    // FAST emits these explicit semantic values and every Fluent Blazor component inherits them.
-    const root = document.getElementById("aspire-design-system");
-    if (!root) {
-        throw new Error("The Aspire design-system token scope was not found.");
-    }
+    // Scope the explicit semantic values to the body so dashboard content and UI mounted directly
+    // under the body inherit the same branded Fluent tokens.
+    const root = document.body;
 
     accentFillRest.setValueFor(root, rest);
     accentFillHover.setValueFor(root, hover);

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AccessibilityTests.cs
@@ -194,11 +194,7 @@ public sealed class AccessibilityTests : PlaywrightTestsBase<AccessibilityTests.
                 button.setAttribute('appearance', 'accent');
                 button.textContent = 'Primary action';
                 button.style.cssText = 'position:fixed;left:16px;top:16px;z-index:10000;';
-                const root = document.getElementById('aspire-design-system');
-                if (!root) {
-                    throw new Error('The Aspire design-system token scope was not found.');
-                }
-                root.appendChild(button);
+                document.body.appendChild(button);
                 await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
             }
             """).DefaultTimeout();

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -89,7 +89,7 @@ public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
                 """
                 async () => {
                     const fluent = await import('/_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js');
-                    const root = document.getElementById('aspire-design-system');
+                    const root = document.body;
                     const style = getComputedStyle(root);
 
                     function normalize(color) {


### PR DESCRIPTION
## Description

Follow-up to #19247. Fluent design tokens can be scoped directly to `document.body`, which is already the dashboard's application boundary and the target used for the Fluent fill token. The additional `#aspire-design-system` wrapper is therefore unnecessary and excludes auxiliary UI that is mounted directly under the body.

This removes the wrapper, applies the branded semantic accent tokens to `document.body`, and keeps the focus variables on that same scope so they resolve against the explicit accent values. The Playwright token and contrast probes now exercise the body scope directly. There is no intended visual change.

Validation:
- `AppBar_AccentColors_UseFluentDesignTokens` passed for light and dark themes.
- `DarkAccentButtonInteractionStates_MeetWcagAaContrast` passed.
- `git diff --check` passed.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
