### PR TITLE
Stop redisplaying dismissed unresolved parameters notification

### DIFF
--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -544,6 +544,12 @@ public sealed class ParameterProcessor(
                     },
                     cancellationToken).ConfigureAwait(false);
 
+                if (result.Canceled)
+                {
+                    logger.LogDebug("Unresolved parameters notification was dismissed. The notification will not be shown again.");
+                    break;
+                }
+
                 proceedToInputs = result.Data;
             }
 

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -548,7 +548,9 @@ public sealed class ParameterProcessor(
                 {
                     logger.LogDebug("Unresolved parameters notification was dismissed. The notification will not be shown again.");
 
-                    // Keep waitForResolution callers blocked until resource commands resolve the remaining parameters.
+                    // OnParameterResolved cancels this token after the last parameter is resolved. Convert that
+                    // cancellation into successful task completion so waitForResolution callers remain blocked
+                    // without surfacing an OperationCanceledException.
                     var allParametersResolved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     using var registration = allParametersResolvedToken.Register(static state => ((TaskCompletionSource)state!).TrySetResult(), allParametersResolved);
                     await allParametersResolved.Task.ConfigureAwait(false);

--- a/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
+++ b/src/Aspire.Hosting/Orchestrator/ParameterProcessor.cs
@@ -519,7 +519,7 @@ public sealed class ParameterProcessor(
     }
 
     // Internal for testing purposes - allows passing specific parameters to test.
-    internal async Task HandleUnresolvedParametersAsync(IList<ParameterResource> unresolvedParameters, CancellationToken cancellationToken)
+    internal async Task HandleUnresolvedParametersAsync(IList<ParameterResource> unresolvedParameters, CancellationToken allParametersResolvedToken)
     {
         var stateModified = false;
 
@@ -542,11 +542,16 @@ public sealed class ParameterProcessor(
                         Intent = MessageIntent.Warning,
                         PrimaryButtonText = InteractionStrings.ParametersBarPrimaryButtonText
                     },
-                    cancellationToken).ConfigureAwait(false);
+                    allParametersResolvedToken).ConfigureAwait(false);
 
                 if (result.Canceled)
                 {
                     logger.LogDebug("Unresolved parameters notification was dismissed. The notification will not be shown again.");
+
+                    // Keep waitForResolution callers blocked until resource commands resolve the remaining parameters.
+                    var allParametersResolved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    using var registration = allParametersResolvedToken.Register(static state => ((TaskCompletionSource)state!).TrySetResult(), allParametersResolved);
+                    await allParametersResolved.Task.ConfigureAwait(false);
                     break;
                 }
 
@@ -588,7 +593,7 @@ public sealed class ParameterProcessor(
                         ShowDismiss = true,
                         EnableMessageMarkdown = true,
                     },
-                    cancellationToken).ConfigureAwait(false);
+                    allParametersResolvedToken).ConfigureAwait(false);
 
                 if (!valuesPrompt.Canceled)
                 {
@@ -607,7 +612,7 @@ public sealed class ParameterProcessor(
                             continue;
                         }
 
-                        await ApplyParameterValueAsync(parameter, inputValue, shouldSave, cancellationToken).ConfigureAwait(false);
+                        await ApplyParameterValueAsync(parameter, inputValue, shouldSave, allParametersResolvedToken).ConfigureAwait(false);
 
                         if (shouldSave)
                         {

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -271,7 +271,7 @@ public class ParameterProcessorTests
     }
 
     [Fact]
-    public async Task HandleUnresolvedParametersAsync_WhenUserCancelsInteraction_ParametersRemainUnresolved()
+    public async Task HandleUnresolvedParametersAsync_WhenUserDismissesNotification_DoesNotShowNotificationAgain()
     {
         // Arrange
         var testInteractionService = new TestInteractionService();
@@ -281,22 +281,21 @@ public class ParameterProcessorTests
         parameterWithMissingValue.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         // Act - Start handling unresolved parameters
-        _ = parameterProcessor.HandleUnresolvedParametersAsync([parameterWithMissingValue], CancellationToken.None);
+        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync([parameterWithMissingValue], CancellationToken.None);
 
         // Wait for the message bar interaction
         var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
         Assert.Equal(InteractionStrings.ParametersBarTitle, messageBarInteraction.Title);
 
-        // Complete the message bar interaction with false (user chose not to enter values)
+        // Dismiss the message bar interaction
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Cancel<bool>());
 
-        // Assert that the message bar will show up again if there are still unresolved parameters
-        var nextMessageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
-        Assert.Equal(InteractionStrings.ParametersBarTitle, nextMessageBarInteraction.Title);
+        await handleTask.DefaultTimeout();
 
-        // Assert - Parameter should remain unresolved since user cancelled
+        // Assert - Parameter should remain unresolved without another notification
         Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);
         Assert.False(parameterWithMissingValue.WaitForValueTcs.Task.IsCompleted);
+        Assert.False(testInteractionService.Interactions.Reader.TryRead(out _));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Orchestrator/ParameterProcessorTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 #pragma warning disable ASPIREPIPELINES002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 #pragma warning disable ASPIREUSERSECRETS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
@@ -271,17 +272,25 @@ public class ParameterProcessorTests
     }
 
     [Fact]
-    public async Task HandleUnresolvedParametersAsync_WhenUserDismissesNotification_DoesNotShowNotificationAgain()
+    public async Task InitializeParametersAsync_WhenUserDismissesNotification_WaitsWithoutShowingNotificationAgain()
     {
         // Arrange
         var testInteractionService = new TestInteractionService();
-        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService);
+        var notificationDismissed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testSink = new TestSink();
+        testSink.MessageLogged += context =>
+        {
+            if (context.Message == "Unresolved parameters notification was dismissed. The notification will not be shown again.")
+            {
+                notificationDismissed.TrySetResult();
+            }
+        };
+        var testLogger = new TestLogger<ParameterProcessor>(new TestLoggerFactory(testSink, enabled: true));
+        var parameterProcessor = CreateParameterProcessor(interactionService: testInteractionService, logger: testLogger);
         var parameterWithMissingValue = CreateParameterWithMissingValue("missingParam");
 
-        parameterWithMissingValue.WaitForValueTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-
         // Act - Start handling unresolved parameters
-        var handleTask = parameterProcessor.HandleUnresolvedParametersAsync([parameterWithMissingValue], CancellationToken.None);
+        var initializeTask = parameterProcessor.InitializeParametersAsync([parameterWithMissingValue], waitForResolution: true);
 
         // Wait for the message bar interaction
         var messageBarInteraction = await testInteractionService.Interactions.Reader.ReadAsync().DefaultTimeout();
@@ -289,13 +298,16 @@ public class ParameterProcessorTests
 
         // Dismiss the message bar interaction
         messageBarInteraction.CompletionTcs.SetResult(InteractionResult.Cancel<bool>());
+        await notificationDismissed.Task.DefaultTimeout();
 
-        await handleTask.DefaultTimeout();
-
-        // Assert - Parameter should remain unresolved without another notification
+        // Assert - Parameter should remain unresolved without another notification and initialization should keep waiting
         Assert.NotNull(parameterWithMissingValue.WaitForValueTcs);
         Assert.False(parameterWithMissingValue.WaitForValueTcs.Task.IsCompleted);
+        Assert.False(initializeTask.IsCompleted);
         Assert.False(testInteractionService.Interactions.Reader.TryRead(out _));
+
+        await parameterProcessor.SetParameterCoreAsync(parameterWithMissingValue, CreateSetParameterArguments("resolvedValue"), CancellationToken.None).DefaultTimeout();
+        await initializeTask.DefaultTimeout();
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Closing the unresolved parameters notification caused the AppHost to immediately display it again. The notification handler now stops automatic prompting when the user dismisses the notification, while leaving the parameters unresolved so they can still be set from their resource commands.

Callers using `waitForResolution: true` continue waiting after dismissal until all remaining parameters are resolved through those commands. The dismissal is recorded at debug level, and the regression test verifies that no second notification is queued, initialization remains pending, and command resolution completes the wait.

### User-facing usage

Users can close the unresolved parameters notification without it immediately reappearing.

Validation:

```text
ParameterProcessorTests: 49 passed
```

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No