### PR TITLE
Tolerate NuGet credential-provider stdout preamble in package search parsing

### DIFF
--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -8,6 +8,7 @@ using Aspire.Cli.Bundles;
 using Aspire.Cli.Configuration;
 using Aspire.Cli.Layout;
 using Aspire.Cli.Resources;
+using Aspire.Shared;
 using Microsoft.Extensions.Logging;
 using NuGetPackage = Aspire.Shared.NuGetPackageCli;
 
@@ -224,7 +225,11 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
                 return [];
             }
 
-            var result = JsonSerializer.Deserialize(output, BundleSearchJsonContext.Default.BundleSearchResult);
+            // The aspire-managed helper writes the search result as JSON to stdout, but a NuGet credential
+            // provider (e.g. the Azure Artifacts Credential Provider) can prepend "[CredentialProvider]..."
+            // progress lines to that stdout before the payload. Trim any non-JSON preamble before deserializing.
+            // See https://github.com/microsoft/aspire/issues/19339.
+            var result = JsonSerializer.Deserialize(PackageUpdateHelpers.ExtractJsonPayload(output), BundleSearchJsonContext.Default.BundleSearchResult);
             if (result?.Packages is null)
             {
                 return [];

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -226,10 +226,10 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             }
 
             // The aspire-managed helper writes the search result as JSON to stdout, but a NuGet credential
-            // provider (e.g. the Azure Artifacts Credential Provider) can prepend "[CredentialProvider]..."
-            // progress lines to that stdout before the payload. Trim any non-JSON preamble before deserializing.
+            // provider can write diagnostics before or after that payload. Extract exactly one complete root object
+            // with the expected "packages" array so provider diagnostics cannot be deserialized as the result.
             // See https://github.com/microsoft/aspire/issues/19339.
-            var result = JsonSerializer.Deserialize(PackageUpdateHelpers.ExtractJsonPayload(output), BundleSearchJsonContext.Default.BundleSearchResult);
+            var result = JsonSerializer.Deserialize(PackageUpdateHelpers.ExtractJsonPayload(output, "packages"), BundleSearchJsonContext.Default.BundleSearchResult);
             if (result?.Packages is null)
             {
                 return [];

--- a/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
+++ b/src/Aspire.Cli/NuGet/BundleNuGetPackageCache.cs
@@ -227,9 +227,9 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
 
             // The aspire-managed helper writes the search result as JSON to stdout, but a NuGet credential
             // provider can write diagnostics before or after that payload. Extract exactly one complete root object
-            // with the expected "packages" array so provider diagnostics cannot be deserialized as the result.
+            // with the expected bundle-search shape so provider diagnostics cannot be deserialized as the result.
             // See https://github.com/microsoft/aspire/issues/19339.
-            var result = JsonSerializer.Deserialize(PackageUpdateHelpers.ExtractJsonPayload(output, "packages"), BundleSearchJsonContext.Default.BundleSearchResult);
+            var result = JsonSerializer.Deserialize(PackageUpdateHelpers.ExtractJsonPayload(output, IsBundleSearchPayload), BundleSearchJsonContext.Default.BundleSearchResult);
             if (result?.Packages is null)
             {
                 return [];
@@ -266,6 +266,15 @@ internal sealed class BundleNuGetPackageCache : INuGetPackageCache
             _logger.LogError(ex, "Failed to parse search results");
             throw new NuGetPackageCacheException(ErrorStrings.FailedToParsePackageSearchResults);
         }
+    }
+
+    private static bool IsBundleSearchPayload(JsonElement root)
+    {
+        return root.ValueKind == JsonValueKind.Object &&
+            root.TryGetProperty("packages", out var packages) &&
+            packages.ValueKind == JsonValueKind.Array &&
+            root.TryGetProperty("totalHits", out var totalHits) &&
+            totalHits.ValueKind == JsonValueKind.Number;
     }
 
     private IEnumerable<NuGetPackage> FilterPackages(IEnumerable<NuGetPackage> packages, Func<string, bool>? filter)

--- a/src/Shared/PackageUpdateHelpers.cs
+++ b/src/Shared/PackageUpdateHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Semver;
@@ -129,7 +130,7 @@ internal static class PackageUpdateHelpers
     {
         var foundPackages = new List<NuGetPackage>();
 
-        using var document = JsonDocument.Parse(ExtractJsonPayload(stdout));
+        using var document = JsonDocument.Parse(ExtractJsonPayload(stdout, "searchResult", "packages"));
         if (!document.RootElement.TryGetProperty("searchResult", out var searchResultsArray))
         {
             return [];
@@ -163,24 +164,102 @@ internal static class PackageUpdateHelpers
         return foundPackages;
     }
 
-    // `dotnet package search <id> --format json` is expected to write a single JSON object to stdout, but some
-    // NuGet credential providers write progress lines to stdout *before* the JSON payload while the command still
-    // exits 0. The common case is the NuGet Azure Artifacts Credential Provider: with an authenticated Azure DevOps
-    // feed configured, captured stdout looks like this (stderr empty, exit code 0):
+    // `dotnet package search <id> --format json` is expected to write a single JSON object to stdout, but NuGet
+    // credential providers use an inherited stdout handle. Their diagnostics can therefore appear before or after
+    // the payload while the command still exits 0, and can themselves contain braces or complete JSON objects:
     //
-    //     [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'
-    //     [CredentialProvider]Requested 8/13/2026 2:36:13 AM but received 8/12/2026 11:37:51 PM
+    //     [CredentialProvider]Acquiring token for request {42}
+    //     {"error":{"packages":[]}}
     //     {"version":2,"problems":[],"searchResult":[{"sourceName":"azure-default","packages":[ ... ]}]}
+    //     [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'
     //
-    // Parsing the whole string as JSON then throws, because the leading '[' is read as the start of an array and
-    // 'C' from "CredentialProvider" is an invalid value start. Skip the preamble by starting at the first '{' so
-    // the JSON object parses. See https://github.com/microsoft/aspire/issues/19339.
-    internal static string ExtractJsonPayload(string stdout)
+    // Parse each complete object candidate and validate the expected array shape so a diagnostic object cannot be
+    // mistaken for the payload. Return only the consumed object so trailing provider output is excluded.
+    // See https://github.com/microsoft/aspire/issues/19339.
+    internal static string ExtractJsonPayload(string stdout, string rootArrayPropertyName)
     {
-        var start = stdout.IndexOf('{');
+        return ExtractJsonPayloadCore(stdout, rootArrayPropertyName, itemArrayPropertyName: null);
+    }
 
-        // start == 0: already pure JSON, nothing to trim. start < 0: no object token, so return the input
-        // unchanged and let JsonDocument.Parse throw the same JsonException as before for empty/malformed output.
-        return start > 0 ? stdout[start..] : stdout;
+    internal static string ExtractJsonPayload(string stdout, string rootArrayPropertyName, string itemArrayPropertyName)
+    {
+        return ExtractJsonPayloadCore(stdout, rootArrayPropertyName, itemArrayPropertyName);
+    }
+
+    private static string ExtractJsonPayloadCore(string stdout, string rootArrayPropertyName, string? itemArrayPropertyName)
+    {
+        var utf8 = Encoding.UTF8.GetBytes(stdout);
+        var searchOffset = 0;
+
+        while (searchOffset < utf8.Length)
+        {
+            var relativeCandidateOffset = utf8.AsSpan(searchOffset).IndexOf((byte)'{');
+            if (relativeCandidateOffset < 0)
+            {
+                break;
+            }
+
+            var candidateOffset = searchOffset + relativeCandidateOffset;
+            var candidate = utf8.AsSpan(candidateOffset);
+            var reader = new Utf8JsonReader(candidate);
+
+            try
+            {
+                if (JsonDocument.TryParseValue(ref reader, out var document) && document is not null)
+                {
+                    var consumed = checked((int)reader.BytesConsumed);
+                    using (document)
+                    {
+                        if (HasExpectedShape(document.RootElement, rootArrayPropertyName, itemArrayPropertyName))
+                        {
+                            return Encoding.UTF8.GetString(candidate[..consumed]);
+                        }
+                    }
+
+                    // Do not inspect nested objects inside a complete diagnostic object. A nested object could
+                    // coincidentally have the expected shape even though its containing diagnostic is not the payload.
+                    searchOffset = candidateOffset + consumed;
+                    continue;
+                }
+            }
+            catch (JsonException)
+            {
+                // A diagnostic can contain an unmatched brace or other non-JSON fragment. Advance past this brace
+                // and keep looking for the package-search payload.
+            }
+
+            searchOffset = candidateOffset + 1;
+        }
+
+        // Preserve the existing behavior when no expected payload is present: callers parse the original output
+        // and surface the same JsonException (or handle a valid object with no results) as before.
+        return stdout;
+    }
+
+    private static bool HasExpectedShape(JsonElement root, string rootArrayPropertyName, string? itemArrayPropertyName)
+    {
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty(rootArrayPropertyName, out var rootArray) ||
+            rootArray.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        if (itemArrayPropertyName is null)
+        {
+            return true;
+        }
+
+        foreach (var item in rootArray.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object ||
+                !item.TryGetProperty(itemArrayPropertyName, out var itemArray) ||
+                itemArray.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Shared/PackageUpdateHelpers.cs
+++ b/src/Shared/PackageUpdateHelpers.cs
@@ -130,7 +130,7 @@ internal static class PackageUpdateHelpers
     {
         var foundPackages = new List<NuGetPackage>();
 
-        using var document = JsonDocument.Parse(ExtractJsonPayload(stdout, "searchResult", "packages"));
+        using var document = JsonDocument.Parse(ExtractJsonPayload(stdout, IsPackageSearchPayload));
         if (!document.RootElement.TryGetProperty("searchResult", out var searchResultsArray))
         {
             return [];
@@ -173,20 +173,10 @@ internal static class PackageUpdateHelpers
     //     {"version":2,"problems":[],"searchResult":[{"sourceName":"azure-default","packages":[ ... ]}]}
     //     [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'
     //
-    // Parse each complete object candidate and validate the expected array shape so a diagnostic object cannot be
+    // Parse each complete object candidate and validate the expected payload shape so a diagnostic object cannot be
     // mistaken for the payload. Return only the consumed object so trailing provider output is excluded.
     // See https://github.com/microsoft/aspire/issues/19339.
-    internal static string ExtractJsonPayload(string stdout, string rootArrayPropertyName)
-    {
-        return ExtractJsonPayloadCore(stdout, rootArrayPropertyName, itemArrayPropertyName: null);
-    }
-
-    internal static string ExtractJsonPayload(string stdout, string rootArrayPropertyName, string itemArrayPropertyName)
-    {
-        return ExtractJsonPayloadCore(stdout, rootArrayPropertyName, itemArrayPropertyName);
-    }
-
-    private static string ExtractJsonPayloadCore(string stdout, string rootArrayPropertyName, string? itemArrayPropertyName)
+    internal static string ExtractJsonPayload(string stdout, Func<JsonElement, bool> isExpectedPayload)
     {
         var utf8 = Encoding.UTF8.GetBytes(stdout);
         var searchOffset = 0;
@@ -210,7 +200,7 @@ internal static class PackageUpdateHelpers
                     var consumed = checked((int)reader.BytesConsumed);
                     using (document)
                     {
-                        if (HasExpectedShape(document.RootElement, rootArrayPropertyName, itemArrayPropertyName))
+                        if (isExpectedPayload(document.RootElement))
                         {
                             return Encoding.UTF8.GetString(candidate[..consumed]);
                         }
@@ -236,25 +226,24 @@ internal static class PackageUpdateHelpers
         return stdout;
     }
 
-    private static bool HasExpectedShape(JsonElement root, string rootArrayPropertyName, string? itemArrayPropertyName)
+    private static bool IsPackageSearchPayload(JsonElement root)
     {
         if (root.ValueKind != JsonValueKind.Object ||
-            !root.TryGetProperty(rootArrayPropertyName, out var rootArray) ||
-            rootArray.ValueKind != JsonValueKind.Array)
+            !root.TryGetProperty("version", out var version) ||
+            version.ValueKind != JsonValueKind.Number ||
+            !root.TryGetProperty("searchResult", out var searchResults) ||
+            searchResults.ValueKind != JsonValueKind.Array)
         {
             return false;
         }
 
-        if (itemArrayPropertyName is null)
+        foreach (var sourceResult in searchResults.EnumerateArray())
         {
-            return true;
-        }
-
-        foreach (var item in rootArray.EnumerateArray())
-        {
-            if (item.ValueKind != JsonValueKind.Object ||
-                !item.TryGetProperty(itemArrayPropertyName, out var itemArray) ||
-                itemArray.ValueKind != JsonValueKind.Array)
+            if (sourceResult.ValueKind != JsonValueKind.Object ||
+                !sourceResult.TryGetProperty("sourceName", out var sourceName) ||
+                sourceName.ValueKind != JsonValueKind.String ||
+                !sourceResult.TryGetProperty("packages", out var packages) ||
+                packages.ValueKind != JsonValueKind.Array)
             {
                 return false;
             }

--- a/src/Shared/PackageUpdateHelpers.cs
+++ b/src/Shared/PackageUpdateHelpers.cs
@@ -129,7 +129,7 @@ internal static class PackageUpdateHelpers
     {
         var foundPackages = new List<NuGetPackage>();
 
-        using var document = JsonDocument.Parse(stdout);
+        using var document = JsonDocument.Parse(ExtractJsonPayload(stdout));
         if (!document.RootElement.TryGetProperty("searchResult", out var searchResultsArray))
         {
             return [];
@@ -161,5 +161,26 @@ internal static class PackageUpdateHelpers
         }
 
         return foundPackages;
+    }
+
+    // `dotnet package search <id> --format json` is expected to write a single JSON object to stdout, but some
+    // NuGet credential providers write progress lines to stdout *before* the JSON payload while the command still
+    // exits 0. The common case is the NuGet Azure Artifacts Credential Provider: with an authenticated Azure DevOps
+    // feed configured, captured stdout looks like this (stderr empty, exit code 0):
+    //
+    //     [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'
+    //     [CredentialProvider]Requested 8/13/2026 2:36:13 AM but received 8/12/2026 11:37:51 PM
+    //     {"version":2,"problems":[],"searchResult":[{"sourceName":"azure-default","packages":[ ... ]}]}
+    //
+    // Parsing the whole string as JSON then throws, because the leading '[' is read as the start of an array and
+    // 'C' from "CredentialProvider" is an invalid value start. Skip the preamble by starting at the first '{' so
+    // the JSON object parses. See https://github.com/microsoft/aspire/issues/19339.
+    internal static string ExtractJsonPayload(string stdout)
+    {
+        var start = stdout.IndexOf('{');
+
+        // start == 0: already pure JSON, nothing to trim. start < 0: no object token, so return the input
+        // unchanged and let JsonDocument.Parse throw the same JsonException as before for empty/malformed output.
+        return start > 0 ? stdout[start..] : stdout;
     }
 }

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
@@ -111,4 +111,61 @@ public class BundleNuGetPackageCacheTests(ITestOutputHelper outputHelper)
 
         Assert.True(executionFactory.LastProcessInvocationOptions?.KillOnParentExit);
     }
+
+    [Fact]
+    public async Task GetPackageVersionsAsync_ToleratesCredentialProviderStdoutPreamble()
+    {
+        // The aspire-managed search helper's stdout can be polluted by NuGet credential-provider
+        // "[CredentialProvider]..." progress lines written before the JSON payload (the process still exits 0),
+        // which previously broke JSON parsing. See https://github.com/microsoft/aspire/issues/19339.
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var layout = new LayoutConfiguration
+        {
+            LayoutPath = workspace.WorkspaceRoot.FullName,
+            Components = new LayoutComponents
+            {
+                Managed = "managed"
+            }
+        };
+
+        var managedDirectory = workspace.WorkspaceRoot.CreateSubdirectory("managed");
+        var managedPath = layout.GetManagedPath();
+        Assert.NotNull(managedPath);
+        await File.WriteAllTextAsync(managedPath!, string.Empty);
+
+        var bundleService = new TestBundleService(isBundle: true)
+        {
+            Layout = layout
+        };
+
+        var pollutedStdout =
+            "    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'\n" +
+            "    [CredentialProvider]Requested 8/13/2026 2:36:13 AM but received 8/12/2026 11:37:51 PM\n" +
+            """{"packages":[{"id":"Aspire.Hosting.Redis","version":"13.3.0","allVersions":["13.3.0","13.2.0"],"source":"nuget.org"}],"totalHits":1}""";
+
+        var executionFactory = new TestProcessExecutionFactory
+        {
+            AttemptCallback = (_, _) => (0, pollutedStdout)
+        };
+
+        var cache = new BundleNuGetPackageCache(
+            bundleService,
+            new LayoutProcessRunner(executionFactory),
+            NullLogger<BundleNuGetPackageCache>.Instance,
+            new TestFeatures());
+
+        var packages = (await cache.GetPackageVersionsAsync(
+            workspace.WorkspaceRoot,
+            "Aspire.Hosting.Redis",
+            prerelease: false,
+            nugetConfigFile: null,
+            useCache: true,
+            CancellationToken.None)).OrderBy(package => package.Version).ToArray();
+
+        Assert.Collection(
+            packages,
+            package => Assert.Equal("13.2.0", package.Version),
+            package => Assert.Equal("13.3.0", package.Version));
+    }
 }

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
@@ -117,7 +117,7 @@ public class BundleNuGetPackageCacheTests(ITestOutputHelper outputHelper)
     {
         // Credential-provider diagnostics use an inherited stdout handle, so braced text or JSON can arrive before
         // the package-search payload and additional output can arrive after it. The diagnostic JSON deliberately
-        // contains a nested object with the expected shape to ensure only root payload objects are considered.
+        // has the expected root array but omits other required bundle-search fields.
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
 
         var layout = new LayoutConfiguration
@@ -141,7 +141,7 @@ public class BundleNuGetPackageCacheTests(ITestOutputHelper outputHelper)
 
         var pollutedStdout =
             "    [CredentialProvider]Acquiring token for request {request-42}\n" +
-            """{"error":{"packages":[]}}""" + "\n" +
+            """{"packages":[]}""" + "\n" +
             """{"packages":[{"id":"Aspire.Hosting.Redis","version":"13.3.0","allVersions":["13.3.0","13.2.0"],"source":"nuget.org"}],"totalHits":1}""" +
             "\n    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'";
 

--- a/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/BundleNuGetPackageCacheTests.cs
@@ -113,11 +113,11 @@ public class BundleNuGetPackageCacheTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task GetPackageVersionsAsync_ToleratesCredentialProviderStdoutPreamble()
+    public async Task GetPackageVersionsAsync_ToleratesCredentialProviderOutputAroundPayload()
     {
-        // The aspire-managed search helper's stdout can be polluted by NuGet credential-provider
-        // "[CredentialProvider]..." progress lines written before the JSON payload (the process still exits 0),
-        // which previously broke JSON parsing. See https://github.com/microsoft/aspire/issues/19339.
+        // Credential-provider diagnostics use an inherited stdout handle, so braced text or JSON can arrive before
+        // the package-search payload and additional output can arrive after it. The diagnostic JSON deliberately
+        // contains a nested object with the expected shape to ensure only root payload objects are considered.
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
 
         var layout = new LayoutConfiguration
@@ -140,9 +140,10 @@ public class BundleNuGetPackageCacheTests(ITestOutputHelper outputHelper)
         };
 
         var pollutedStdout =
-            "    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'\n" +
-            "    [CredentialProvider]Requested 8/13/2026 2:36:13 AM but received 8/12/2026 11:37:51 PM\n" +
-            """{"packages":[{"id":"Aspire.Hosting.Redis","version":"13.3.0","allVersions":["13.3.0","13.2.0"],"source":"nuget.org"}],"totalHits":1}""";
+            "    [CredentialProvider]Acquiring token for request {request-42}\n" +
+            """{"error":{"packages":[]}}""" + "\n" +
+            """{"packages":[{"id":"Aspire.Hosting.Redis","version":"13.3.0","allVersions":["13.3.0","13.2.0"],"source":"nuget.org"}],"totalHits":1}""" +
+            "\n    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'";
 
         var executionFactory = new TestProcessExecutionFactory
         {

--- a/tests/Aspire.Hosting.Tests/VersionChecking/PackageUpdateHelpersTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/PackageUpdateHelpersTests.cs
@@ -215,4 +215,36 @@ public class PackageUpdateHelpersTests
         // Assert
         Assert.Equal(new SemVersion(9, 0, 0), latestVersion);
     }
+
+    [Fact]
+    public void ParsePackageSearchResults_WithCredentialProviderPreamble_ParsesPackages()
+    {
+        // The NuGet Azure Artifacts Credential Provider writes "[CredentialProvider]..." progress lines to stdout
+        // before the JSON payload while `dotnet package search --format json` still exits 0, which previously broke
+        // parsing. See https://github.com/microsoft/aspire/issues/19339.
+        var pollutedStdout =
+            "    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'\n" +
+            "    [CredentialProvider]Requested 8/13/2026 2:36:13 AM but received 8/12/2026 11:37:51 PM\n" +
+            """
+            {
+              "version": 2,
+              "problems": [],
+              "searchResult": [
+                {
+                  "sourceName": "azure-default",
+                  "packages": [
+                    { "id": "Aspire.Hosting.AppHost", "latestVersion": "9.3.1" }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        var packages = PackageUpdateHelpers.ParsePackageSearchResults(pollutedStdout, "Aspire.Hosting.AppHost");
+
+        var package = Assert.Single(packages);
+        Assert.Equal("Aspire.Hosting.AppHost", package.Id);
+        Assert.Equal("9.3.1", package.Version);
+        Assert.Equal("azure-default", package.Source);
+    }
 }

--- a/tests/Aspire.Hosting.Tests/VersionChecking/PackageUpdateHelpersTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/PackageUpdateHelpersTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Aspire.Shared;
 using Microsoft.Extensions.Logging.Abstractions;
 using Semver;
@@ -221,9 +222,10 @@ public class PackageUpdateHelpersTests
     {
         // Credential-provider diagnostics use an inherited stdout handle, so braced text or JSON can arrive before
         // the package-search payload and additional output can arrive after it. The diagnostic JSON deliberately
-        // contains a nested object with the expected shape to ensure only root payload objects are considered.
+        // contains nested package-search property names to ensure only complete root payload objects are considered.
+        // The accented characters ensure the scanner handles UTF-8 byte offsets correctly.
         var pollutedStdout =
-            "    [CredentialProvider]Acquiring token for request {request-42}\n" +
+            "    [CredentialProvider]R\u00e9ponse re\u00e7ue for request {request-42}\n" +
             """{"error":{"searchResult":[{"packages":[]}]}}""" + "\n" +
             """
             {
@@ -247,5 +249,57 @@ public class PackageUpdateHelpersTests
         Assert.Equal("Aspire.Hosting.AppHost", package.Id);
         Assert.Equal("9.3.1", package.Version);
         Assert.Equal("azure-default", package.Source);
+    }
+
+    [Fact]
+    public void ParsePackageSearchResults_EmptyPayloadWithOutputAroundIt_ReturnsEmpty()
+    {
+        var pollutedStdout =
+            "    [CredentialProvider]Acquiring token\n" +
+            """{"version":2,"problems":[],"searchResult":[]}""" +
+            "\n    [CredentialProvider]Token acquired";
+
+        var packages = PackageUpdateHelpers.ParsePackageSearchResults(pollutedStdout);
+
+        Assert.Empty(packages);
+    }
+
+    [Theory]
+    [InlineData("""{"searchResult":[{"sourceName":"feed","packages":[]}]}""")]
+    [InlineData("""{"version":2,"searchResult":[{"packages":[]}]}""")]
+    [InlineData("""{"version":2,"searchResult":[{"sourceName":"feed","packages":{}}]}""")]
+    public void ParsePackageSearchResults_RootNearMatchBeforePayload_ParsesExpectedPayload(string nearMatch)
+    {
+        var pollutedStdout =
+            nearMatch + "\n" +
+            """
+            {
+              "version": 2,
+              "problems": [],
+              "searchResult": [
+                {
+                  "sourceName": "azure-default",
+                  "packages": [
+                    { "id": "Aspire.Hosting.AppHost", "latestVersion": "9.3.1" }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        var packages = PackageUpdateHelpers.ParsePackageSearchResults(pollutedStdout);
+
+        var package = Assert.Single(packages);
+        Assert.Equal("Aspire.Hosting.AppHost", package.Id);
+        Assert.Equal("9.3.1", package.Version);
+        Assert.Equal("azure-default", package.Source);
+    }
+
+    [Fact]
+    public void ParsePackageSearchResults_WithoutExpectedPayload_PreservesParseFailure()
+    {
+        var pollutedStdout = "    [CredentialProvider]Acquiring token for request {request-42}";
+
+        Assert.ThrowsAny<JsonException>(() => PackageUpdateHelpers.ParsePackageSearchResults(pollutedStdout));
     }
 }

--- a/tests/Aspire.Hosting.Tests/VersionChecking/PackageUpdateHelpersTests.cs
+++ b/tests/Aspire.Hosting.Tests/VersionChecking/PackageUpdateHelpersTests.cs
@@ -217,14 +217,14 @@ public class PackageUpdateHelpersTests
     }
 
     [Fact]
-    public void ParsePackageSearchResults_WithCredentialProviderPreamble_ParsesPackages()
+    public void ParsePackageSearchResults_WithCredentialProviderOutputAroundPayload_ParsesExpectedPayload()
     {
-        // The NuGet Azure Artifacts Credential Provider writes "[CredentialProvider]..." progress lines to stdout
-        // before the JSON payload while `dotnet package search --format json` still exits 0, which previously broke
-        // parsing. See https://github.com/microsoft/aspire/issues/19339.
+        // Credential-provider diagnostics use an inherited stdout handle, so braced text or JSON can arrive before
+        // the package-search payload and additional output can arrive after it. The diagnostic JSON deliberately
+        // contains a nested object with the expected shape to ensure only root payload objects are considered.
         var pollutedStdout =
-            "    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'\n" +
-            "    [CredentialProvider]Requested 8/13/2026 2:36:13 AM but received 8/12/2026 11:37:51 PM\n" +
+            "    [CredentialProvider]Acquiring token for request {request-42}\n" +
+            """{"error":{"searchResult":[{"packages":[]}]}}""" + "\n" +
             """
             {
               "version": 2,
@@ -238,7 +238,8 @@ public class PackageUpdateHelpersTests
                 }
               ]
             }
-            """;
+            """ +
+            "\n    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'";
 
         var packages = PackageUpdateHelpers.ParsePackageSearchResults(pollutedStdout, "Aspire.Hosting.AppHost");
 


### PR DESCRIPTION
## Description

`dotnet package search <id> --format json` is parsed as if its entire stdout were a single JSON document. When an authenticated Azure DevOps / Azure Artifacts feed is configured, the **NuGet Azure Artifacts Credential Provider** writes `[CredentialProvider]…` progress lines to **stdout before** the JSON payload while the command still exits `0`. Parsing the whole stdout then throws:

```
System.Text.Json.JsonReaderException: 'C' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 5.
```

Example polluted stdout (JSON begins after the preamble; stderr empty; exit code 0):

```
    [CredentialProvider]VstsCredentialProvider - Acquired bearer token using 'MSAL Silent'
    [CredentialProvider]Requested 8/13/2026 2:36:13 AM but received 8/12/2026 11:37:51 PM
    {"version":2,"problems":[],"searchResult":[{"sourceName":"azure-default","packages":[ … ]}]}
```

**Impact:** the background version check is silently broken (a `JsonReaderException` is logged every `aspire run` and no upgrade prompts appear), and CLI package operations (`aspire add`) can report "no packages found" — affecting essentially every developer with an authenticated Azure DevOps feed.

**Fix:** add a small, well-documented shared helper `PackageUpdateHelpers.ExtractJsonPayload` that skips the non-JSON preamble by starting at the first `{`, and apply it everywhere `dotnet package search` (and the bundle `aspire-managed` search) stdout is parsed:

1. **Version check** — `PackageFetcher.TryFetchPackagesAsync` → `ParsePackageSearchResults`.
2. **CLI package search** — `DotNetCliRunner.SearchPackagesAsync`, both the live parse and the disk-cache read → `ParsePackageSearchResults`.
3. **Bundle path** (defense-in-depth) — `BundleNuGetPackageCache` deserializes the `aspire-managed` helper stdout directly.

Clean JSON (no preamble) and genuinely empty/malformed output (no `{`) are returned unchanged, so existing `JsonException` handling is preserved. This matches the direction validated by the issue author ("Isolating from the first `{` parses the captured output cleanly").

Fixes #19339

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No