### PR TITLE
Require confirmation before change-location deletes Azure resources

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
@@ -83,6 +83,7 @@ internal sealed class AzureProvisioningController(
 {
     internal const string ForgetStateCommandName = "forget-state";
     internal const string ChangeResourceLocationCommandName = "change-location";
+    internal const string ConfirmDeleteArgumentName = "confirmDelete";
     internal const string GetAzureResourceCommandName = "get-azure-resource";
     internal const string CancelCommandName = "cancel-azure-operation";
     internal const string DeleteAzureResourceCommandName = "delete-azure-resource";
@@ -365,8 +366,18 @@ internal sealed class AzureProvisioningController(
                 AlwaysLoadOnStart = true,
                 LoadCallback = context => LoadLocationArgumentOptionsAsync(context, deploymentStateResourceName)
             }
-        }
+        },
+        CreateChangeLocationDeleteConfirmationArgument()
     ];
+
+    private static InteractionInput CreateChangeLocationDeleteConfirmationArgument() => new()
+    {
+        Name = ConfirmDeleteArgumentName,
+        Label = AzureProvisioningStrings.ChangeResourceLocationConfirmDeleteLabel,
+        Description = AzureProvisioningStrings.ChangeResourceLocationConfirmDeleteDescription,
+        InputType = InputType.Boolean,
+        Value = "false"
+    };
 
     private static async Task LoadTenantArgumentOptionsAsync(LoadInputContext context)
     {
@@ -672,7 +683,8 @@ internal sealed class AzureProvisioningController(
                     Required = true,
                     Value = currentLocation,
                     Options = locationOptions
-                }
+                },
+                CreateChangeLocationDeleteConfirmationArgument()
             ],
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -687,10 +699,20 @@ internal sealed class AzureProvisioningController(
             return false;
         }
 
-        return await ChangeResourceLocationAsync(model, resourceName, location, cancellationToken).ConfigureAwait(false);
+        return await ChangeResourceLocationAsync(
+            model,
+            resourceName,
+            location,
+            IsResourceDeletionConfirmed(result.Data),
+            cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<bool> ChangeResourceLocationAsync(DistributedApplicationModel model, string resourceName, string location, CancellationToken cancellationToken)
+    private async Task<bool> ChangeResourceLocationAsync(
+        DistributedApplicationModel model,
+        string resourceName,
+        string location,
+        bool confirmDelete,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(model);
         ArgumentException.ThrowIfNullOrEmpty(resourceName);
@@ -700,7 +722,10 @@ internal sealed class AzureProvisioningController(
 
         location = NormalizeLocation(location, await GetLocationOptionsAsync(cancellationToken).ConfigureAwait(false));
 
-        return await RunOperationAsync<bool>(model, new ChangeResourceLocationIntent(resourceName, location), cancellationToken).ConfigureAwait(false);
+        return await RunOperationAsync<bool>(
+            model,
+            new ChangeResourceLocationIntent(resourceName, location, confirmDelete),
+            cancellationToken).ConfigureAwait(false);
     }
 
     private Task<ExecuteCommandResult> ExecuteResetProvisioningStateCommandAsync(ExecuteCommandContext context)
@@ -880,8 +905,18 @@ internal sealed class AzureProvisioningController(
             return Task.FromResult(false);
         }
 
-        return ChangeResourceLocationAsync(model, resourceName, location, cancellationToken);
+        return ChangeResourceLocationAsync(
+            model,
+            resourceName,
+            location,
+            IsResourceDeletionConfirmed(arguments),
+            cancellationToken);
     }
+
+    private static bool IsResourceDeletionConfirmed(InteractionInputCollection arguments)
+        => arguments.TryGetByName(ConfirmDeleteArgumentName, out var input) &&
+            bool.TryParse(input.Value, out var confirmDelete) &&
+            confirmDelete;
 
     internal ResourceCommandState GetEnvironmentCommandState()
     {
@@ -1874,7 +1909,7 @@ internal sealed class AzureProvisioningController(
                 intent,
                 AzureProvisioningStrings.OperationPhaseDeletingAzureResource,
                 FormatUserString(AzureProvisioningStrings.OperationPhaseDeletingExistingAzureResourceBeforeChangingLocationFormat, intent.Location));
-            await DeleteCachedResourceForLocationChangeAsync(targetBicepResource, intent.Location, cancellationToken).ConfigureAwait(false);
+            await DeleteCachedResourceForLocationChangeAsync(targetBicepResource, intent.Location, intent.ConfirmDelete, cancellationToken).ConfigureAwait(false);
             await SetResourceLocationOverrideAsync(targetBicepResource.Name, intent.Location, cancellationToken).ConfigureAwait(false);
         }
 
@@ -3360,7 +3395,11 @@ internal sealed class AzureProvisioningController(
         }
     }
 
-    private async Task DeleteCachedResourceForLocationChangeAsync(AzureBicepResource resource, string requestedLocation, CancellationToken cancellationToken)
+    private async Task DeleteCachedResourceForLocationChangeAsync(
+        AzureBicepResource resource,
+        string requestedLocation,
+        bool confirmDelete,
+        CancellationToken cancellationToken)
     {
         var currentLocation = TryGetCurrentResourceLocation(resource) ??
             await TryGetPersistedResourceLocationAsync(resource, cancellationToken).ConfigureAwait(false);
@@ -3396,6 +3435,17 @@ internal sealed class AzureProvisioningController(
             // Cached state can point at a resource that has already been manually deleted. In that
             // case the location change only needs to update local override state and reprovision.
             return;
+        }
+
+        if (!confirmDelete)
+        {
+            // Resource command confirmations are UI metadata and are not enforced by non-interactive
+            // CLI or MCP callers. Require an explicit command argument at the destructive boundary so
+            // every caller must acknowledge possible data loss before the live resource is deleted.
+            throw new InvalidOperationException(FormatUserString(
+                AzureProvisioningStrings.ChangeResourceLocationDeleteConfirmationRequiredFormat,
+                resource.Name,
+                ConfirmDeleteArgumentName));
         }
 
         _logger.LogInformation(
@@ -4295,7 +4345,7 @@ internal sealed class AzureProvisioningController(
 
     private sealed record ForgetResourceStateIntent(string ResourceName) : AzureIntent(AzureOperationState.Resource(ResourceName, "Reset provisioning state"));
 
-    private sealed record ChangeResourceLocationIntent(string ResourceName, string Location) : AzureIntent(AzureOperationState.Resource(ResourceName, "Change Azure resource location"));
+    private sealed record ChangeResourceLocationIntent(string ResourceName, string Location, bool ConfirmDelete) : AzureIntent(AzureOperationState.Resource(ResourceName, "Change Azure resource location"));
 
     private sealed record ReprovisionResourceIntent(string ResourceName) : AzureIntent(AzureOperationState.Resource(ResourceName, "Reprovision Azure resource"));
 

--- a/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningController.cs
@@ -1887,6 +1887,19 @@ internal sealed class AzureProvisioningController(
         var targetResources = GetTargetAzureResources(model, intent.ResourceName, includeAnnotationParentRelationships: false);
         ThrowIfKeyVaultLocationChangeTarget(targetResources);
 
+        var targetBicepResource = targetResources[0].AzureResource as AzureBicepResource;
+        LocationChangeResourceDeletion? resourceDeletion = null;
+        if (targetBicepResource is not null)
+        {
+            // Validate the potentially destructive step before publishing ChangingLocation. A rejected
+            // invocation must leave the resource tree at its prior terminal state so drift checks continue.
+            resourceDeletion = await PrepareCachedResourceDeletionForLocationChangeAsync(
+                targetBicepResource,
+                intent.Location,
+                intent.ConfirmDelete,
+                cancellationToken).ConfigureAwait(false);
+        }
+
         var parentChildLookup = model.Resources.OfType<IResourceWithParent>().ToLookup(r => r.Parent);
         UpdateActiveOperationPhase(
             intent,
@@ -1900,7 +1913,7 @@ internal sealed class AzureProvisioningController(
             }).ConfigureAwait(false);
         }
 
-        if (targetResources[0].AzureResource is AzureBicepResource targetBicepResource)
+        if (targetBicepResource is not null)
         {
             // ARM rejects redeploying many resource types to a different location while the old
             // resource still exists. Delete the cached live resource first, then save the override
@@ -1909,7 +1922,7 @@ internal sealed class AzureProvisioningController(
                 intent,
                 AzureProvisioningStrings.OperationPhaseDeletingAzureResource,
                 FormatUserString(AzureProvisioningStrings.OperationPhaseDeletingExistingAzureResourceBeforeChangingLocationFormat, intent.Location));
-            await DeleteCachedResourceForLocationChangeAsync(targetBicepResource, intent.Location, intent.ConfirmDelete, cancellationToken).ConfigureAwait(false);
+            await DeleteCachedResourceForLocationChangeAsync(targetBicepResource, intent.Location, resourceDeletion, cancellationToken).ConfigureAwait(false);
             await SetResourceLocationOverrideAsync(targetBicepResource.Name, intent.Location, cancellationToken).ConfigureAwait(false);
         }
 
@@ -3395,7 +3408,7 @@ internal sealed class AzureProvisioningController(
         }
     }
 
-    private async Task DeleteCachedResourceForLocationChangeAsync(
+    private async Task<LocationChangeResourceDeletion?> PrepareCachedResourceDeletionForLocationChangeAsync(
         AzureBicepResource resource,
         string requestedLocation,
         bool confirmDelete,
@@ -3408,14 +3421,14 @@ internal sealed class AzureProvisioningController(
         {
             // If the current location is unknown or already matches the requested location, there is
             // nothing safe or necessary to delete before reprovisioning.
-            return;
+            return null;
         }
 
         if (await TryGetResourceIdFromDeploymentStateAsync(resource, cancellationToken).ConfigureAwait(false) is not { } resourceId)
         {
             // Without a cached resource ID we cannot target the old live resource. Let
             // reprovisioning proceed and surface any ARM conflict through the normal deployment path.
-            return;
+            return null;
         }
 
         var context = await GetCurrentAzureContextAsync(cancellationToken).ConfigureAwait(false);
@@ -3424,7 +3437,7 @@ internal sealed class AzureProvisioningController(
             // Deleting for a location change is a best-effort preflight. If context is invalid, avoid
             // making a destructive call and let the subsequent provisioning validation report the
             // missing subscription configuration.
-            return;
+            return null;
         }
 
         var armClientProvider = serviceProvider.GetRequiredService<IArmClientProvider>();
@@ -3434,42 +3447,63 @@ internal sealed class AzureProvisioningController(
         {
             // Cached state can point at a resource that has already been manually deleted. In that
             // case the location change only needs to update local override state and reprovision.
-            return;
+            return null;
         }
 
         if (!confirmDelete)
         {
             // Resource command confirmations are UI metadata and are not enforced by non-interactive
-            // CLI or MCP callers. Require an explicit command argument at the destructive boundary so
-            // every caller must acknowledge possible data loss before the live resource is deleted.
+            // CLI or MCP callers. Require an explicit command argument before publishing transient
+            // state or reaching the destructive boundary.
             throw new InvalidOperationException(FormatUserString(
                 AzureProvisioningStrings.ChangeResourceLocationDeleteConfirmationRequiredFormat,
                 resource.Name,
                 ConfirmDeleteArgumentName));
         }
 
+        return new(armClient, resourceId, currentLocation);
+    }
+
+    private async Task DeleteCachedResourceForLocationChangeAsync(
+        AzureBicepResource resource,
+        string requestedLocation,
+        LocationChangeResourceDeletion? resourceDeletion,
+        CancellationToken cancellationToken)
+    {
+        if (resourceDeletion is null)
+        {
+            return;
+        }
+
         _logger.LogInformation(
             "Deleting Azure resource {ResourceId} before reprovisioning {ResourceName} from {CurrentLocation} to {RequestedLocation}.",
-            resourceId,
+            resourceDeletion.ResourceId,
             resource.Name,
-            currentLocation,
+            resourceDeletion.CurrentLocation,
             requestedLocation);
 
         try
         {
-            await armClient.DeleteResourceAsync(resourceId, cancellationToken).ConfigureAwait(false);
+            await resourceDeletion.ArmClient.DeleteResourceAsync(resourceDeletion.ResourceId, cancellationToken).ConfigureAwait(false);
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
             _logger.LogInformation(
                 "Azure resource {ResourceId} was already absent before reprovisioning {ResourceName} from {CurrentLocation} to {RequestedLocation}.",
-                resourceId,
+                resourceDeletion.ResourceId,
                 resource.Name,
-                currentLocation,
+                resourceDeletion.CurrentLocation,
                 requestedLocation);
         }
 
-        await PurgeDeletedKeyVaultAsync(armClient, resourceId, resource.Name, currentLocation, null, allowTimeout: false, cancellationToken).ConfigureAwait(false);
+        await PurgeDeletedKeyVaultAsync(
+            resourceDeletion.ArmClient,
+            resourceDeletion.ResourceId,
+            resource.Name,
+            resourceDeletion.CurrentLocation,
+            null,
+            allowTimeout: false,
+            cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<string?> TryGetPersistedResourceLocationAsync(AzureBicepResource resource, CancellationToken cancellationToken)
@@ -4346,6 +4380,8 @@ internal sealed class AzureProvisioningController(
     private sealed record ForgetResourceStateIntent(string ResourceName) : AzureIntent(AzureOperationState.Resource(ResourceName, "Reset provisioning state"));
 
     private sealed record ChangeResourceLocationIntent(string ResourceName, string Location, bool ConfirmDelete) : AzureIntent(AzureOperationState.Resource(ResourceName, "Change Azure resource location"));
+
+    private sealed record LocationChangeResourceDeletion(IArmClient ArmClient, string ResourceId, string CurrentLocation);
 
     private sealed record ReprovisionResourceIntent(string ResourceName) : AzureIntent(AzureOperationState.Resource(ResourceName, "Reprovision Azure resource"));
 

--- a/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.Designer.cs
+++ b/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.Designer.cs
@@ -423,11 +423,38 @@ namespace Aspire.Hosting.Azure.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Overrides the Azure location for this resource and reprovisions it using that location..
+        ///   Looks up a localized string similar to Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost..
         /// </summary>
         internal static string ChangeResourceLocationCommandDescription {
             get {
                 return ResourceManager.GetString("ChangeResourceLocationCommandDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost..
+        /// </summary>
+        internal static string ChangeResourceLocationConfirmDeleteDescription {
+            get {
+                return ResourceManager.GetString("ChangeResourceLocationConfirmDeleteDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Allow deletion and possible permanent data loss.
+        /// </summary>
+        internal static string ChangeResourceLocationConfirmDeleteLabel {
+            get {
+                return ResourceManager.GetString("ChangeResourceLocationConfirmDeleteLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue..
+        /// </summary>
+        internal static string ChangeResourceLocationDeleteConfirmationRequiredFormat {
+            get {
+                return ResourceManager.GetString("ChangeResourceLocationDeleteConfirmationRequiredFormat", resourceCulture);
             }
         }
 
@@ -558,7 +585,7 @@ namespace Aspire.Hosting.Azure.Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location..
+        ///   Looks up a localized string similar to Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost..
         /// </summary>
         internal static string ChangeResourceLocationPromptMessage {
             get {

--- a/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.resx
+++ b/src/Aspire.Hosting.Azure/Resources/AzureProvisioningStrings.resx
@@ -244,7 +244,16 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/aspire/azure/pro
     <value>Change location</value>
   </data>
   <data name="ChangeResourceLocationCommandDescription" xml:space="preserve">
-    <value>Overrides the Azure location for this resource and reprovisions it using that location.</value>
+    <value>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</value>
+  </data>
+  <data name="ChangeResourceLocationConfirmDeleteLabel" xml:space="preserve">
+    <value>Allow deletion and possible permanent data loss</value>
+  </data>
+  <data name="ChangeResourceLocationConfirmDeleteDescription" xml:space="preserve">
+    <value>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</value>
+  </data>
+  <data name="ChangeResourceLocationDeleteConfirmationRequiredFormat" xml:space="preserve">
+    <value>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</value>
   </data>
   <data name="ChangeResourceLocationCommandSuccess" xml:space="preserve">
     <value>Azure resource location updated and reprovisioning completed.</value>
@@ -289,7 +298,7 @@ To learn more, see the [Azure provisioning docs](https://aka.ms/aspire/azure/pro
     <value>Change Azure resource location</value>
   </data>
   <data name="ChangeResourceLocationPromptMessage" xml:space="preserve">
-    <value>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</value>
+    <value>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</value>
   </data>
   <data name="ReprovisionResourceCommandName" xml:space="preserve">
     <value>Reprovision</value>

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.cs.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.cs.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.de.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.de.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.es.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.es.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.fr.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.fr.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.it.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.it.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ja.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ja.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ko.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ko.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pl.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pl.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pt-BR.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.pt-BR.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ru.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.ru.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.tr.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.tr.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hans.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hans.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hant.xlf
+++ b/src/Aspire.Hosting.Azure/Resources/xlf/AzureProvisioningStrings.zh-Hant.xlf
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandDescription">
-        <source>Overrides the Azure location for this resource and reprovisions it using that location.</source>
-        <target state="new">Overrides the Azure location for this resource and reprovisions it using that location.</target>
+        <source>Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Changes the Azure location for this resource. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationCommandName">
@@ -57,14 +57,29 @@
         <target state="new">Azure resource location updated and reprovisioning completed.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteDescription">
+        <source>Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</source>
+        <target state="new">Allow Aspire to delete and recreate the existing Azure resource when changing its location. Any data in the deleted resource may be permanently lost.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationConfirmDeleteLabel">
+        <source>Allow deletion and possible permanent data loss</source>
+        <target state="new">Allow deletion and possible permanent data loss</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChangeResourceLocationDeleteConfirmationRequiredFormat">
+        <source>Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</source>
+        <target state="new">Changing the location of Azure resource '{0}' requires deleting and recreating it. Any data in the deleted resource may be permanently lost. Set the '{1}' command argument to true to continue.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeResourceLocationKeyVaultUnsupported">
         <source>Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</source>
         <target state="new">Azure Key Vault resources cannot change location because soft-deleted vault names remain reserved globally. Use delete, reprovision, or forget state to recover this resource.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptMessage">
-        <source>Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</source>
-        <target state="new">Select or enter a new Azure location for '{0}'. The resource will then be reprovisioned using that location.</target>
+        <source>Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</source>
+        <target state="new">Select or enter a new Azure location for '{0}'. If Aspire must delete and recreate the existing Azure resource, any data in it may be permanently lost.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeResourceLocationPromptTitle">

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
@@ -3036,6 +3036,8 @@ public class AzureEnvironmentResourceExtensionsTests
         Assert.False(result.Success);
         Assert.False(result.Canceled);
         Assert.Contains(AzureProvisioningController.ConfirmDeleteArgumentName, result.Message, StringComparison.Ordinal);
+        Assert.True(notifications.TryGetCurrentState(storage.Resource.Name, out var storageEvent));
+        Assert.Equal(KnownResourceStates.Running, storageEvent.Snapshot.State?.Text);
         Assert.Empty(deletedResourceIds);
         Assert.DoesNotContain("storage", testBicepProvisioner.ProvisionedLocations.Keys);
 

--- a/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureEnvironmentResourceExtensionsTests.cs
@@ -656,10 +656,22 @@ public class AzureEnvironmentResourceExtensionsTests
 
         Assert.Contains(storage.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.ForgetStateCommandName);
         var changeLocationCommand = Assert.Single(storage.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.ChangeResourceLocationCommandName);
-        var locationArgument = Assert.Single(changeLocationCommand.Arguments);
-        Assert.Equal(AzureBicepResource.KnownParameters.Location, locationArgument.Name);
-        Assert.True(locationArgument.Required);
-        Assert.True(locationArgument.Disabled);
+        Assert.Contains("permanently lost", changeLocationCommand.DisplayDescription, StringComparison.Ordinal);
+        Assert.Collection(
+            changeLocationCommand.Arguments,
+            locationArgument =>
+            {
+                Assert.Equal(AzureBicepResource.KnownParameters.Location, locationArgument.Name);
+                Assert.True(locationArgument.Required);
+                Assert.True(locationArgument.Disabled);
+            },
+            confirmDeleteArgument =>
+            {
+                Assert.Equal(AzureProvisioningController.ConfirmDeleteArgumentName, confirmDeleteArgument.Name);
+                Assert.Equal(InputType.Boolean, confirmDeleteArgument.InputType);
+                Assert.Equal("false", confirmDeleteArgument.Value);
+                Assert.Contains("permanently lost", confirmDeleteArgument.Description, StringComparison.Ordinal);
+            });
         Assert.Contains(storage.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.GetAzureResourceCommandName);
         var cancelCommand = Assert.Single(storage.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.CancelCommandName);
         var deleteCommand = Assert.Single(storage.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.DeleteAzureResourceCommandName);
@@ -2969,6 +2981,69 @@ public class AzureEnvironmentResourceExtensionsTests
     }
 
     [Fact]
+    public async Task ChangeLocationCommand_RequiresConfirmationBeforeDeletingCachedResource()
+    {
+        var builder = CreateBuilder(isRunMode: true);
+        var deploymentStateManager = new TestDeploymentStateManager();
+        var testBicepProvisioner = new TestBicepProvisioner();
+        var deletedResourceIds = new List<string>();
+        const string resourceId = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/storage26wmkwq4f4li52";
+
+        builder.Configuration["Azure:SubscriptionId"] = "12345678-1234-1234-1234-123456789012";
+        builder.Configuration["Azure:Location"] = "westus2";
+        builder.Configuration["Azure:ResourceGroup"] = "test-rg";
+        AddTestAzureProvisioning(builder, armClientProvider: ProvisioningTestHelpers.CreateArmClientProvider([resourceId], deletedResourceIds), bicepProvisioner: testBicepProvisioner, deploymentStateManager: deploymentStateManager);
+
+        var storage = builder.AddBicepTemplateString("storage", "resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {}");
+
+        using var app = builder.Build();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var notifications = app.Services.GetRequiredService<ResourceNotificationService>();
+        var preparer = new AzureResourcePreparer(
+            app.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>(),
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>());
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+
+        var storageSection = await deploymentStateManager.AcquireSectionAsync("Azure:Deployments:storage");
+        storageSection.Data["Outputs"] = new JsonObject
+        {
+            ["id"] = new JsonObject
+            {
+                ["type"] = "String",
+                ["value"] = resourceId
+            }
+        }.ToJsonString();
+        await deploymentStateManager.SaveSectionAsync(storageSection);
+
+        await notifications.PublishUpdateAsync(storage.Resource, state => state with
+        {
+            State = KnownResourceStates.Running,
+            Properties = [new("azure.location", "westus2")]
+        });
+
+        var changeLocationCommand = Assert.Single(storage.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.ChangeResourceLocationCommandName);
+        var result = await changeLocationCommand.ExecuteCommand(new ExecuteCommandContext
+        {
+            Services = app.Services,
+            ResourceName = storage.Resource.Name,
+            CancellationToken = CancellationToken.None,
+            Logger = NullLogger.Instance,
+            Arguments = CreateArguments((AzureBicepResource.KnownParameters.Location, "westus3"))
+        });
+
+        Assert.False(result.Success);
+        Assert.False(result.Canceled);
+        Assert.Contains(AzureProvisioningController.ConfirmDeleteArgumentName, result.Message, StringComparison.Ordinal);
+        Assert.Empty(deletedResourceIds);
+        Assert.DoesNotContain("storage", testBicepProvisioner.ProvisionedLocations.Keys);
+
+        storageSection = await deploymentStateManager.AcquireSectionAsync("Azure:Deployments:storage");
+        Assert.False(storageSection.Data.ContainsKey(AzureProvisioningController.LocationOverrideKey));
+    }
+
+    [Fact]
     public async Task ChangeLocationCommand_DeletesCachedResourceBeforeReprovisioningNewLocation()
     {
         var builder = CreateBuilder(isRunMode: true);
@@ -3019,6 +3094,7 @@ public class AzureEnvironmentResourceExtensionsTests
 
         var interaction = await testInteractionService.Interactions.Reader.ReadAsync();
         interaction.Inputs[AzureBicepResource.KnownParameters.Location].Value = "westus3";
+        interaction.Inputs[AzureProvisioningController.ConfirmDeleteArgumentName].Value = "true";
         interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
 
         var result = await executionTask;
@@ -3082,7 +3158,9 @@ public class AzureEnvironmentResourceExtensionsTests
             ResourceName = storage.Resource.Name,
             CancellationToken = CancellationToken.None,
             Logger = NullLogger.Instance,
-            Arguments = CreateArguments((AzureBicepResource.KnownParameters.Location, "westus3"))
+            Arguments = CreateArguments(
+                (AzureBicepResource.KnownParameters.Location, "westus3"),
+                (AzureProvisioningController.ConfirmDeleteArgumentName, "true"))
         });
 
         Assert.True(result.Success);
@@ -3142,6 +3220,7 @@ public class AzureEnvironmentResourceExtensionsTests
 
         var interaction = await testInteractionService.Interactions.Reader.ReadAsync();
         interaction.Inputs[AzureBicepResource.KnownParameters.Location].Value = "westus3";
+        interaction.Inputs[AzureProvisioningController.ConfirmDeleteArgumentName].Value = "true";
         interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
 
         var result = await executionTask;
@@ -3204,11 +3283,77 @@ public class AzureEnvironmentResourceExtensionsTests
 
         var interaction = await testInteractionService.Interactions.Reader.ReadAsync();
         interaction.Inputs[AzureBicepResource.KnownParameters.Location].Value = "westus3";
+        interaction.Inputs[AzureProvisioningController.ConfirmDeleteArgumentName].Value = "true";
         interaction.CompletionTcs.SetResult(InteractionResult.Ok(interaction.Inputs));
 
         var result = await executionTask;
 
         Assert.True(result.Success);
+        Assert.Equal("westus3", testBicepProvisioner.ProvisionedLocations["storage"]);
+
+        storageSection = await deploymentStateManager.AcquireSectionAsync("Azure:Deployments:storage");
+        Assert.Equal("westus3", storageSection.Data[AzureProvisioningController.LocationOverrideKey]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ChangeLocationCommand_DoesNotRequireConfirmationWhenCachedResourceIsAlreadyAbsent()
+    {
+        var builder = CreateBuilder(isRunMode: true);
+        var deploymentStateManager = new TestDeploymentStateManager();
+        var testBicepProvisioner = new TestBicepProvisioner();
+        var deletedResourceIds = new List<string>();
+        const string resourceId = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/storage26wmkwq4f4li52";
+
+        builder.Configuration["Azure:SubscriptionId"] = "12345678-1234-1234-1234-123456789012";
+        builder.Configuration["Azure:Location"] = "westus2";
+        builder.Configuration["Azure:ResourceGroup"] = "test-rg";
+        AddTestAzureProvisioning(
+            builder,
+            armClientProvider: ProvisioningTestHelpers.CreateArmClientProvider(Array.Empty<string>(), deletedResourceIds),
+            bicepProvisioner: testBicepProvisioner,
+            deploymentStateManager: deploymentStateManager);
+
+        var storage = builder.AddBicepTemplateString("storage", "resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {}");
+
+        using var app = builder.Build();
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var notifications = app.Services.GetRequiredService<ResourceNotificationService>();
+        var preparer = new AzureResourcePreparer(
+            app.Services.GetRequiredService<IOptions<AzureProvisioningOptions>>(),
+            app.Services.GetRequiredService<DistributedApplicationExecutionContext>());
+
+        await preparer.OnBeforeStartAsync(new BeforeStartEvent(app.Services, model), CancellationToken.None);
+
+        var storageSection = await deploymentStateManager.AcquireSectionAsync("Azure:Deployments:storage");
+        storageSection.Data["Outputs"] = new JsonObject
+        {
+            ["id"] = new JsonObject
+            {
+                ["type"] = "String",
+                ["value"] = resourceId
+            }
+        }.ToJsonString();
+        await deploymentStateManager.SaveSectionAsync(storageSection);
+
+        await notifications.PublishUpdateAsync(storage.Resource, state => state with
+        {
+            State = KnownResourceStates.Running,
+            Properties = [new("azure.location", "westus2")]
+        });
+
+        var changeLocationCommand = Assert.Single(storage.Resource.Annotations.OfType<ResourceCommandAnnotation>(), c => c.Name == AzureProvisioningController.ChangeResourceLocationCommandName);
+        var result = await changeLocationCommand.ExecuteCommand(new ExecuteCommandContext
+        {
+            Services = app.Services,
+            ResourceName = storage.Resource.Name,
+            CancellationToken = CancellationToken.None,
+            Logger = NullLogger.Instance,
+            Arguments = CreateArguments((AzureBicepResource.KnownParameters.Location, "westus3"))
+        });
+
+        Assert.True(result.Success);
+        Assert.Empty(deletedResourceIds);
         Assert.Equal("westus3", testBicepProvisioner.ProvisionedLocations["storage"]);
 
         storageSection = await deploymentStateManager.AcquireSectionAsync("Azure:Deployments:storage");
@@ -6009,4 +6154,5 @@ public class AzureEnvironmentResourceExtensionsTests
         public IAsyncEnumerable<AzureDeploymentOperationDetails> GetDeploymentOperationsAsync(string deploymentId, bool recursive = true, CancellationToken cancellationToken = default)
             => _inner.GetDeploymentOperationsAsync(deploymentId, recursive, cancellationToken);
     }
+
 }


### PR DESCRIPTION
## Description

The `change-location` dev-time command could delete and recreate an existing location-immutable Azure resource without warning, which could permanently destroy its data.

This change adds an explicit `confirmDelete` acknowledgement to the resource command and enforces it immediately before deleting a live Azure resource. The argument projects to the dashboard as a warning checkbox, to the CLI as `--confirm-delete`, and to MCP as `arguments.confirmDelete=true`. The command fails before deletion, override persistence, reset, or reprovisioning when acknowledgement is missing.

Same-location changes, resources without cached Azure IDs, and cached resources that are already absent in Azure remain ungated.

### User-facing usage

In the dashboard, users must acknowledge the possible permanent data loss before changing the location of an existing live resource:

![Aspire dashboard change-location dialog showing the deletion and data-loss acknowledgement](https://github.com/user-attachments/assets/63cf897a-e6ee-43f1-a470-d4388a4ddf8a)

CLI callers can acknowledge deletion with `--confirm-delete`. MCP callers can set `arguments.confirmDelete=true`.

### Validation

```text
dotnet test --project tests\Aspire.Hosting.Azure.Tests\Aspire.Hosting.Azure.Tests.csproj --no-launch-profile -- --filter-method "*ChangeLocationCommand*" --filter-method "*OnBeforeStartAsync_AddsPerResourceCommandsToDeployableAzureResourcesOnly" --filter-not-trait "quarantined=true" --filter-not-trait "outerloop=true"

Passed: 17, Failed: 0, Skipped: 0
```

Fixes #19341

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
