### PR TITLE
Add IServiceProvider support to Cosmos DB extensions

### DIFF
--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
@@ -15,6 +15,7 @@
     <Compile Include="..\..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
     <Compile Include="..\..\Shared\StableConnectionStringBuilder.cs" Link="Shared\StableConnectionStringBuilder.cs" />
     <Compile Include="..\..\Shared\AzureCredentialHelper.cs" Link="AzureCredentialHelper.cs" />
+    <Compile Include="$(SharedDir)OverloadResolutionPriorityAttribute.cs" Link="Utils\OverloadResolutionPriorityAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Aspire;
 using Aspire.Hosting.Azure.CosmosDB;
 using Aspire.Microsoft.Azure.Cosmos;
@@ -27,6 +28,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
+    [OverloadResolutionPriority(1)]
     public static void AddAzureCosmosClient(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -61,6 +63,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <see cref="CosmosDatabaseBuilder.AddKeyedContainer(string)"/> for each container.
     /// </remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
+    [OverloadResolutionPriority(1)]
     public static void AddAzureCosmosContainer(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -87,6 +90,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
+    [OverloadResolutionPriority(1)]
     public static void AddKeyedAzureCosmosClient(
         this IHostApplicationBuilder builder,
         string name,
@@ -129,6 +133,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <see cref="CosmosDatabaseBuilder.AddKeyedContainer(string)"/> for each container.
     /// </remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
+    [OverloadResolutionPriority(1)]
     public static void AddKeyedAzureCosmosContainer(
         this IHostApplicationBuilder builder,
         string name,
@@ -155,6 +160,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
+    [OverloadResolutionPriority(1)]
     public static CosmosDatabaseBuilder AddAzureCosmosDatabase(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -181,6 +187,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
+    [OverloadResolutionPriority(1)]
     public static CosmosDatabaseBuilder AddKeyedAzureCosmosDatabase(
        this IHostApplicationBuilder builder,
        string name,

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -32,11 +32,16 @@ public static class AspireMicrosoftAzureCosmosExtensions
         string connectionName,
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
-    {
-        var settings = builder.GetSettings(connectionName, configureSettings);
-        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        builder.Services.AddSingleton(sp => GetCosmosClient(connectionName, settings, clientOptions));
-    }
+        => AddCosmosClient(builder, connectionName, serviceKey: null, configureSettings, Wrap(configureClientOptions));
+
+    /// <inheritdoc cref="AddAzureCosmosClient(IHostApplicationBuilder, string, Action{MicrosoftAzureCosmosSettings}?, Action{CosmosClientOptions}?)"/>
+    /// <remarks>The client options callback receives the service provider used to create the client.</remarks>
+    public static void AddAzureCosmosClient(
+        this IHostApplicationBuilder builder,
+        string connectionName,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+        => AddCosmosClient(builder, connectionName, serviceKey: null, configureSettings, configureClientOptions);
 
     /// <summary>
     /// Registers the <see cref="Container"/> as a singleton in the services provided by the <paramref name="builder"/>.
@@ -61,19 +66,16 @@ public static class AspireMicrosoftAzureCosmosExtensions
         string connectionName,
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
-    {
-        var settings = builder.GetSettings(connectionName, configureSettings);
-        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        builder.Services.AddSingleton(sp =>
-        {
-            if (string.IsNullOrEmpty(settings.ContainerName) || string.IsNullOrEmpty(settings.DatabaseName))
-            {
-                throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the container name or database name.");
-            }
-            var client = GetCosmosClient(connectionName, settings, clientOptions);
-            return client.GetContainer(settings.DatabaseName, settings.ContainerName);
-        });
-    }
+        => AddCosmosContainer(builder, connectionName, serviceKey: null, configureSettings, Wrap(configureClientOptions));
+
+    /// <inheritdoc cref="AddAzureCosmosContainer(IHostApplicationBuilder, string, Action{MicrosoftAzureCosmosSettings}?, Action{CosmosClientOptions}?)"/>
+    /// <remarks>The client options callback receives the service provider used to create the client.</remarks>
+    public static void AddAzureCosmosContainer(
+        this IHostApplicationBuilder builder,
+        string connectionName,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+        => AddCosmosContainer(builder, connectionName, serviceKey: null, configureSettings, configureClientOptions);
 
     /// <summary>
     /// Registers the <see cref="CosmosClient" /> as a singleton for given <paramref name="name" /> in the services provided by the <paramref name="builder"/>.
@@ -93,13 +95,20 @@ public static class AspireMicrosoftAzureCosmosExtensions
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var settings = builder.GetSettings(name, configureSettings);
-        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        builder.Services.AddKeyedSingleton(name, (sp, key) =>
-        {
-            var client = GetCosmosClient(name, settings, clientOptions);
-            return client;
-        });
+        AddCosmosClient(builder, name, name, configureSettings, Wrap(configureClientOptions));
+    }
+
+    /// <inheritdoc cref="AddKeyedAzureCosmosClient(IHostApplicationBuilder, string, Action{MicrosoftAzureCosmosSettings}?, Action{CosmosClientOptions}?)"/>
+    /// <remarks>The client options callback receives the service provider used to create the client.</remarks>
+    public static void AddKeyedAzureCosmosClient(
+        this IHostApplicationBuilder builder,
+        string name,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        AddCosmosClient(builder, name, name, configureSettings, configureClientOptions);
     }
 
     /// <summary>
@@ -125,19 +134,16 @@ public static class AspireMicrosoftAzureCosmosExtensions
         string name,
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
-    {
-        var settings = builder.GetSettings(name, configureSettings);
-        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        builder.Services.AddKeyedSingleton(name, (sp, key) =>
-        {
-            if (string.IsNullOrEmpty(settings.ContainerName) || string.IsNullOrEmpty(settings.DatabaseName))
-            {
-                throw new InvalidOperationException($"The connection string '{name}' does not exist or is missing the container name or database name.");
-            }
-            var client = GetCosmosClient(name, settings, clientOptions);
-            return client.GetContainer(settings.DatabaseName, settings.ContainerName);
-        });
-    }
+        => AddCosmosContainer(builder, name, name, configureSettings, Wrap(configureClientOptions));
+
+    /// <inheritdoc cref="AddKeyedAzureCosmosContainer(IHostApplicationBuilder, string, Action{MicrosoftAzureCosmosSettings}?, Action{CosmosClientOptions}?)"/>
+    /// <remarks>The client options callback receives the service provider used to create the client.</remarks>
+    public static void AddKeyedAzureCosmosContainer(
+        this IHostApplicationBuilder builder,
+        string name,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+        => AddCosmosContainer(builder, name, name, configureSettings, configureClientOptions);
 
     /// <summary>
     /// Registers the <see cref="Database"/> as a singleton the services provided by the <paramref name="builder"/>
@@ -154,13 +160,16 @@ public static class AspireMicrosoftAzureCosmosExtensions
         string connectionName,
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
-    {
-        var settings = builder.GetSettings(connectionName, configureSettings);
-        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        var cosmosDatabaseBuilder = new CosmosDatabaseBuilder(builder, connectionName, settings, clientOptions);
-        cosmosDatabaseBuilder.AddDatabase();
-        return cosmosDatabaseBuilder;
-    }
+        => AddCosmosDatabase(builder, connectionName, serviceKey: null, configureSettings, Wrap(configureClientOptions));
+
+    /// <inheritdoc cref="AddAzureCosmosDatabase(IHostApplicationBuilder, string, Action{MicrosoftAzureCosmosSettings}?, Action{CosmosClientOptions}?)"/>
+    /// <remarks>The client options callback receives the service provider used to create the client.</remarks>
+    public static CosmosDatabaseBuilder AddAzureCosmosDatabase(
+        this IHostApplicationBuilder builder,
+        string connectionName,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+        => AddCosmosDatabase(builder, connectionName, serviceKey: null, configureSettings, configureClientOptions);
 
     /// <summary>
     /// Registers the <see cref="Database"/> as a singleton for given <paramref name="name" /> in the services provided by the <paramref name="builder"/>
@@ -177,12 +186,123 @@ public static class AspireMicrosoftAzureCosmosExtensions
        string name,
        Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
        Action<CosmosClientOptions>? configureClientOptions = null)
+        => AddCosmosDatabase(builder, name, name, configureSettings, Wrap(configureClientOptions));
+
+    /// <inheritdoc cref="AddKeyedAzureCosmosDatabase(IHostApplicationBuilder, string, Action{MicrosoftAzureCosmosSettings}?, Action{CosmosClientOptions}?)"/>
+    /// <remarks>The client options callback receives the service provider used to create the client.</remarks>
+    public static CosmosDatabaseBuilder AddKeyedAzureCosmosDatabase(
+        this IHostApplicationBuilder builder,
+        string name,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+        => AddCosmosDatabase(builder, name, name, configureSettings, configureClientOptions);
+
+    private static void AddCosmosClient(
+        IHostApplicationBuilder builder,
+        string connectionName,
+        string? serviceKey,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
     {
-        var settings = builder.GetSettings(name, configureSettings);
-        var clientOptions = builder.GetClientOptions(settings, configureClientOptions);
-        var cosmosDatabaseBuilder = new CosmosDatabaseBuilder(builder, name, settings, clientOptions);
-        cosmosDatabaseBuilder.AddKeyedDatabase();
-        return cosmosDatabaseBuilder;
+        var (_, clientFactory) = GetClientRegistration(builder, connectionName, configureSettings, configureClientOptions);
+
+        if (serviceKey is null)
+        {
+            builder.Services.AddSingleton(clientFactory);
+        }
+        else
+        {
+            builder.Services.AddKeyedSingleton<CosmosClient>(serviceKey, (serviceProvider, _) => clientFactory(serviceProvider));
+        }
+    }
+
+    private static void AddCosmosContainer(
+        IHostApplicationBuilder builder,
+        string connectionName,
+        string? serviceKey,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+    {
+        var (settings, clientFactory) = GetClientRegistration(builder, connectionName, configureSettings, configureClientOptions);
+
+        Container Factory(IServiceProvider serviceProvider)
+        {
+            if (string.IsNullOrEmpty(settings.ContainerName) || string.IsNullOrEmpty(settings.DatabaseName))
+            {
+                throw new InvalidOperationException($"The connection string '{connectionName}' does not exist or is missing the container name or database name.");
+            }
+
+            return clientFactory(serviceProvider).GetContainer(settings.DatabaseName, settings.ContainerName);
+        }
+
+        if (serviceKey is null)
+        {
+            builder.Services.AddSingleton(Factory);
+        }
+        else
+        {
+            builder.Services.AddKeyedSingleton<Container>(serviceKey, (serviceProvider, _) => Factory(serviceProvider));
+        }
+    }
+
+    private static CosmosDatabaseBuilder AddCosmosDatabase(
+        IHostApplicationBuilder builder,
+        string connectionName,
+        string? serviceKey,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+    {
+        var (settings, clientFactory) = GetClientRegistration(builder, connectionName, configureSettings, configureClientOptions);
+        var cosmosDatabaseBuilder = new CosmosDatabaseBuilder(
+            builder,
+            connectionName,
+            settings,
+            clientFactory);
+
+        return serviceKey is null
+            ? cosmosDatabaseBuilder.AddDatabase()
+            : cosmosDatabaseBuilder.AddKeyedDatabase();
+    }
+
+    private static (MicrosoftAzureCosmosSettings Settings, Func<IServiceProvider, CosmosClient> ClientFactory) GetClientRegistration(
+        IHostApplicationBuilder builder,
+        string connectionName,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
+        Action<IServiceProvider, CosmosClientOptions>? configureClientOptions)
+    {
+        var settings = builder.GetSettings(connectionName, configureSettings);
+        if (!settings.DisableTracing)
+        {
+            builder.Services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
+            {
+                tracerProviderBuilder.AddSource("Azure.Cosmos.Operation");
+            });
+        }
+
+        return (settings, serviceProvider =>
+        {
+            var clientOptions = new CosmosClientOptions();
+            // Needs to be enabled for either logging or tracing to work.
+            clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = false;
+
+            if (CosmosUtils.IsEmulatorConnectionString(settings.ConnectionString))
+            {
+                clientOptions.ConnectionMode = ConnectionMode.Gateway;
+                clientOptions.LimitToEndpoint = true;
+            }
+
+            configureClientOptions?.Invoke(serviceProvider, clientOptions);
+
+            var cosmosApplicationName = CosmosConstants.CosmosApplicationName;
+            if (!string.IsNullOrEmpty(clientOptions.ApplicationName))
+            {
+                cosmosApplicationName = $"{cosmosApplicationName}/{clientOptions.ApplicationName}";
+            }
+
+            clientOptions.ApplicationName = cosmosApplicationName;
+
+            return GetCosmosClient(connectionName, settings, clientOptions);
+        });
     }
 
     internal static CosmosConnectionInfo? GetCosmosConnectionInfo(this IHostApplicationBuilder builder, string connectionName)
@@ -229,39 +349,14 @@ public static class AspireMicrosoftAzureCosmosExtensions
         return settings;
     }
 
-    private static CosmosClientOptions GetClientOptions(
-        this IHostApplicationBuilder builder,
-        MicrosoftAzureCosmosSettings settings,
-        Action<CosmosClientOptions>? configureClientOptions)
+    private static Action<IServiceProvider, CosmosClientOptions>? Wrap(Action<CosmosClientOptions>? action)
     {
-        var clientOptions = new CosmosClientOptions();
-        // Needs to be enabled for either logging or tracing to work.
-        clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = false;
-        if (!settings.DisableTracing)
+        if (action is null)
         {
-            builder.Services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
-            {
-                tracerProviderBuilder.AddSource("Azure.Cosmos.Operation");
-            });
+            return null;
         }
 
-        if (CosmosUtils.IsEmulatorConnectionString(settings.ConnectionString))
-        {
-            clientOptions.ConnectionMode = ConnectionMode.Gateway;
-            clientOptions.LimitToEndpoint = true;
-        }
-
-        configureClientOptions?.Invoke(clientOptions);
-
-        var cosmosApplicationName = CosmosConstants.CosmosApplicationName;
-        if (!string.IsNullOrEmpty(clientOptions.ApplicationName))
-        {
-            cosmosApplicationName = $"{cosmosApplicationName}/{clientOptions.ApplicationName}";
-        }
-
-        clientOptions.ApplicationName = cosmosApplicationName;
-
-        return clientOptions;
+        return (_, clientOptions) => action(clientOptions);
     }
 
     internal static CosmosClient GetCosmosClient(string connectionName, MicrosoftAzureCosmosSettings settings, CosmosClientOptions clientOptions)

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/CosmosDatabaseBuilder.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/CosmosDatabaseBuilder.cs
@@ -11,25 +11,55 @@ namespace Aspire.Microsoft.Azure.Cosmos;
 /// Represents a builder that can be used to register multiple container
 /// instances against the same Cosmos database connection.
 /// </summary>
-public sealed class CosmosDatabaseBuilder(
-    IHostApplicationBuilder hostBuilder,
-    string connectionName,
-    MicrosoftAzureCosmosSettings settings,
-    CosmosClientOptions clientOptions)
+public sealed class CosmosDatabaseBuilder
 {
-    private CosmosClient? _client;
+    private readonly IHostApplicationBuilder _hostBuilder;
+    private readonly string _connectionName;
+    private readonly MicrosoftAzureCosmosSettings _settings;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CosmosDatabaseBuilder"/> class.
+    /// </summary>
+    /// <param name="hostBuilder">The application builder used to register Cosmos services.</param>
+    /// <param name="connectionName">The connection name used to configure the Cosmos client.</param>
+    /// <param name="settings">The settings used to configure the Cosmos client.</param>
+    /// <param name="clientOptions">The options used to configure the Cosmos client.</param>
+    public CosmosDatabaseBuilder(
+        IHostApplicationBuilder hostBuilder,
+        string connectionName,
+        MicrosoftAzureCosmosSettings settings,
+        CosmosClientOptions clientOptions)
+        : this(
+            hostBuilder,
+            connectionName,
+            settings,
+            _ => AspireMicrosoftAzureCosmosExtensions.GetCosmosClient(connectionName, settings, clientOptions))
+    {
+    }
+
+    internal CosmosDatabaseBuilder(
+        IHostApplicationBuilder hostBuilder,
+        string connectionName,
+        MicrosoftAzureCosmosSettings settings,
+        Func<IServiceProvider, CosmosClient> clientFactory)
+    {
+        _hostBuilder = hostBuilder;
+        _connectionName = connectionName;
+        _settings = settings;
+        _hostBuilder.Services.AddKeyedSingleton<CosmosClient>(this, (serviceProvider, _) => clientFactory(serviceProvider));
+    }
 
     internal CosmosDatabaseBuilder AddDatabase()
     {
-        hostBuilder.Services.AddSingleton(sp =>
+        _hostBuilder.Services.AddSingleton(sp =>
         {
-            if (string.IsNullOrEmpty(settings.DatabaseName))
+            if (string.IsNullOrEmpty(_settings.DatabaseName))
             {
                 throw new InvalidOperationException(
-                    $"A Database could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}'.");
+                    $"A Database could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{_connectionName}'.");
             }
-            _client ??= AspireMicrosoftAzureCosmosExtensions.GetCosmosClient(connectionName, settings, clientOptions);
-            return _client.GetDatabase(settings.DatabaseName);
+
+            return GetClient(sp).GetDatabase(_settings.DatabaseName);
         });
 
         return this;
@@ -37,15 +67,15 @@ public sealed class CosmosDatabaseBuilder(
 
     internal CosmosDatabaseBuilder AddKeyedDatabase()
     {
-        hostBuilder.Services.AddKeyedSingleton(connectionName, (sp, _) =>
+        _hostBuilder.Services.AddKeyedSingleton(_connectionName, (sp, _) =>
         {
-            if (string.IsNullOrEmpty(settings.DatabaseName))
+            if (string.IsNullOrEmpty(_settings.DatabaseName))
             {
                 throw new InvalidOperationException(
-                    $"A Database could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}'.");
+                    $"A Database could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{_connectionName}'.");
             }
-            _client ??= AspireMicrosoftAzureCosmosExtensions.GetCosmosClient(connectionName, settings, clientOptions);
-            return _client.GetDatabase(settings.DatabaseName);
+
+            return GetClient(sp).GetDatabase(_settings.DatabaseName);
         });
 
         return this;
@@ -59,11 +89,9 @@ public sealed class CosmosDatabaseBuilder(
     /// <returns>A <see cref="CosmosDatabaseBuilder"/> that can be used for further chaining.</returns>
     public CosmosDatabaseBuilder AddKeyedContainer(string name)
     {
-        _client ??= AspireMicrosoftAzureCosmosExtensions.GetCosmosClient(connectionName, settings, clientOptions);
+        var connectionInfo = _hostBuilder.GetCosmosConnectionInfo(name);
 
-        var connectionInfo = hostBuilder.GetCosmosConnectionInfo(name);
-
-        hostBuilder.Services.AddKeyedSingleton(name, (sp, _) =>
+        _hostBuilder.Services.AddKeyedSingleton(name, (sp, _) =>
         {
             // If a connection string was provided, check that it contains a valid container name.
             if (connectionInfo is not null && string.IsNullOrEmpty(connectionInfo?.ContainerName))
@@ -73,9 +101,12 @@ public sealed class CosmosDatabaseBuilder(
             }
 
             // Use the container name from the connection string if provided, otherwise use the name
-            return _client.GetContainer(settings.DatabaseName, connectionInfo?.ContainerName ?? name);
+            return GetClient(sp).GetContainer(_settings.DatabaseName, connectionInfo?.ContainerName ?? name);
         });
 
         return this;
     }
+
+    private CosmosClient GetClient(IServiceProvider serviceProvider)
+        => serviceProvider.GetRequiredKeyedService<CosmosClient>(this);
 }

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -108,6 +108,17 @@ You can also setup the [CosmosClientOptions](https://learn.microsoft.com/dotnet/
 builder.AddAzureCosmosClient("cosmosConnectionName", configureClientOptions: clientOptions => clientOptions.ApplicationName = "myapp");
 ```
 
+The client options callback can also receive the application's `IServiceProvider`. This allows options such as custom request handlers to be resolved from dependency injection:
+
+```csharp
+builder.Services.AddSingleton<MyRequestHandler>();
+builder.AddAzureCosmosClient(
+    "cosmosConnectionName",
+    configureSettings: null,
+    configureClientOptions: (serviceProvider, clientOptions) =>
+        clientOptions.CustomHandlers.Add(serviceProvider.GetRequiredService<MyRequestHandler>()));
+```
+
 ## AppHost extensions
 
 In your AppHost project, install the Aspire Azure CosmosDB Hosting library with [NuGet](https://www.nuget.org):

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/AspireMicrosoftAzureCosmosExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/AspireMicrosoftAzureCosmosExtensionsTests.cs
@@ -241,6 +241,166 @@ public class AspireMicrosoftAzureCosmosExtensionsTests
         Assert.False(client.ClientOptions.LimitToEndpoint);
     }
 
+    [Theory]
+    [InlineData("client")]
+    [InlineData("keyed-client")]
+    [InlineData("container")]
+    [InlineData("keyed-container")]
+    [InlineData("database")]
+    [InlineData("keyed-database")]
+    public void LegacyClientOptionsCallbackIsApplied(string registrationType)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        const string connectionName = "cosmos";
+        var connectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=fake;Database=testdb;Container=testcontainer;";
+        var clientOptionsCallbackCount = 0;
+
+        PopulateConfiguration(builder.Configuration, connectionString);
+
+        Action<CosmosClientOptions> configureClientOptions = _ => clientOptionsCallbackCount++;
+
+        switch (registrationType)
+        {
+            case "client":
+                builder.AddAzureCosmosClient(connectionName, configureClientOptions: configureClientOptions);
+                break;
+            case "keyed-client":
+                builder.AddKeyedAzureCosmosClient(connectionName, configureClientOptions: configureClientOptions);
+                break;
+            case "container":
+                builder.AddAzureCosmosContainer(connectionName, configureClientOptions: configureClientOptions);
+                break;
+            case "keyed-container":
+                builder.AddKeyedAzureCosmosContainer(connectionName, configureClientOptions: configureClientOptions);
+                break;
+            case "database":
+                builder.AddAzureCosmosDatabase(connectionName, configureClientOptions: configureClientOptions);
+                break;
+            case "keyed-database":
+                builder.AddKeyedAzureCosmosDatabase(connectionName, configureClientOptions: configureClientOptions);
+                break;
+            default:
+                throw new InvalidOperationException();
+        }
+
+        Assert.Equal(0, clientOptionsCallbackCount);
+
+        using var host = builder.Build();
+
+        _ = registrationType switch
+        {
+            "client" => (object)host.Services.GetRequiredService<CosmosClient>(),
+            "keyed-client" => host.Services.GetRequiredKeyedService<CosmosClient>(connectionName),
+            "container" => host.Services.GetRequiredService<Container>(),
+            "keyed-container" => host.Services.GetRequiredKeyedService<Container>(connectionName),
+            "database" => host.Services.GetRequiredService<Database>(),
+            "keyed-database" => host.Services.GetRequiredKeyedService<Database>(connectionName),
+            _ => throw new InvalidOperationException()
+        };
+
+        Assert.Equal(1, clientOptionsCallbackCount);
+    }
+
+    [Theory]
+    [InlineData("client", false)]
+    [InlineData("client", true)]
+    [InlineData("keyed-client", false)]
+    [InlineData("keyed-client", true)]
+    [InlineData("container", false)]
+    [InlineData("container", true)]
+    [InlineData("keyed-container", false)]
+    [InlineData("keyed-container", true)]
+    [InlineData("database", false)]
+    [InlineData("database", true)]
+    [InlineData("keyed-database", false)]
+    [InlineData("keyed-database", true)]
+    public void ProviderAwareClientOptionsCallbackResolvesServices(
+        string registrationType,
+        bool configureSettings)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        const string connectionName = "cosmos";
+        const string applicationName = "ConfiguredFromServices";
+        var connectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=fake;Database=testdb;Container=testcontainer;";
+        var clientOptionsCallbackCount = 0;
+        var configureSettingsCallbackCount = 0;
+
+        PopulateConfiguration(builder.Configuration, connectionString);
+        builder.Services.AddSingleton(applicationName);
+
+        Action<MicrosoftAzureCosmosSettings> configureSettingsCallback = settings =>
+        {
+            settings.DisableTracing = true;
+            configureSettingsCallbackCount++;
+        };
+        Action<IServiceProvider, CosmosClientOptions> configureClientOptionsCallback = (serviceProvider, clientOptions) =>
+        {
+            clientOptions.ApplicationName = serviceProvider.GetRequiredService<string>();
+            clientOptionsCallbackCount++;
+        };
+
+        switch (registrationType, configureSettings)
+        {
+            case ("client", false):
+                builder.AddAzureCosmosClient(connectionName, configureSettings: null, configureClientOptions: configureClientOptionsCallback);
+                break;
+            case ("client", true):
+                builder.AddAzureCosmosClient(connectionName, configureSettingsCallback, configureClientOptionsCallback);
+                break;
+            case ("keyed-client", false):
+                builder.AddKeyedAzureCosmosClient(connectionName, configureSettings: null, configureClientOptions: configureClientOptionsCallback);
+                break;
+            case ("keyed-client", true):
+                builder.AddKeyedAzureCosmosClient(connectionName, configureSettingsCallback, configureClientOptionsCallback);
+                break;
+            case ("container", false):
+                builder.AddAzureCosmosContainer(connectionName, configureSettings: null, configureClientOptions: configureClientOptionsCallback);
+                break;
+            case ("container", true):
+                builder.AddAzureCosmosContainer(connectionName, configureSettingsCallback, configureClientOptionsCallback);
+                break;
+            case ("keyed-container", false):
+                builder.AddKeyedAzureCosmosContainer(connectionName, configureSettings: null, configureClientOptions: configureClientOptionsCallback);
+                break;
+            case ("keyed-container", true):
+                builder.AddKeyedAzureCosmosContainer(connectionName, configureSettingsCallback, configureClientOptionsCallback);
+                break;
+            case ("database", false):
+                builder.AddAzureCosmosDatabase(connectionName, configureSettings: null, configureClientOptions: configureClientOptionsCallback);
+                break;
+            case ("database", true):
+                builder.AddAzureCosmosDatabase(connectionName, configureSettingsCallback, configureClientOptionsCallback);
+                break;
+            case ("keyed-database", false):
+                builder.AddKeyedAzureCosmosDatabase(connectionName, configureSettings: null, configureClientOptions: configureClientOptionsCallback);
+                break;
+            case ("keyed-database", true):
+                builder.AddKeyedAzureCosmosDatabase(connectionName, configureSettingsCallback, configureClientOptionsCallback);
+                break;
+            default:
+                throw new InvalidOperationException();
+        }
+
+        Assert.Equal(configureSettings ? 1 : 0, configureSettingsCallbackCount);
+        Assert.Equal(0, clientOptionsCallbackCount);
+
+        using var host = builder.Build();
+
+        var client = registrationType switch
+        {
+            "client" => host.Services.GetRequiredService<CosmosClient>(),
+            "keyed-client" => host.Services.GetRequiredKeyedService<CosmosClient>(connectionName),
+            "container" => host.Services.GetRequiredService<Container>().Database.Client,
+            "keyed-container" => host.Services.GetRequiredKeyedService<Container>(connectionName).Database.Client,
+            "database" => host.Services.GetRequiredService<Database>().Client,
+            "keyed-database" => host.Services.GetRequiredKeyedService<Database>(connectionName).Client,
+            _ => throw new InvalidOperationException()
+        };
+
+        Assert.EndsWith($"/{applicationName}", client.ClientOptions.ApplicationName);
+        Assert.Equal(1, clientOptionsCallbackCount);
+    }
+
     [Fact]
     public void AddAzureCosmosContainer_DoesNoReuseExistingClient()
     {
@@ -468,6 +628,43 @@ public class AspireMicrosoftAzureCosmosExtensionsTests
 
         // With the same client
         Assert.Same(container2.Database.Client, container1.Database.Client);
+    }
+
+    [Fact]
+    public async Task AddAzureCosmosDatabase_ProviderAwareOptionsCreatesOneSharedClientConcurrently()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        const string connectionName = "cosmos";
+        const string applicationName = "ConfiguredFromServices";
+        var connectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=fake;Database=testdb;";
+        var clientOptionsCallbackCount = 0;
+
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>($"ConnectionStrings:{connectionName}", connectionString),
+            new KeyValuePair<string, string?>("ConnectionStrings:container1", $"{connectionString}Container=container1;"),
+            new KeyValuePair<string, string?>("ConnectionStrings:container2", $"{connectionString}Container=container2;")
+        ]);
+        builder.Services.AddSingleton(applicationName);
+
+        builder.AddAzureCosmosDatabase(connectionName, configureSettings: null, configureClientOptions: (serviceProvider, clientOptions) =>
+        {
+            clientOptions.ApplicationName = serviceProvider.GetRequiredService<string>();
+            Interlocked.Increment(ref clientOptionsCallbackCount);
+        })
+            .AddKeyedContainer("container1")
+            .AddKeyedContainer("container2");
+
+        using var host = builder.Build();
+
+        var containerTasks = Enumerable.Range(0, 20)
+            .Select(index => Task.Run(() => host.Services.GetRequiredKeyedService<Container>($"container{index % 2 + 1}")))
+            .ToArray();
+        var containers = await Task.WhenAll(containerTasks);
+        var client = containers[0].Database.Client;
+
+        Assert.All(containers, container => Assert.Same(client, container.Database.Client));
+        Assert.EndsWith($"/{applicationName}", client.ClientOptions.ApplicationName);
+        Assert.Equal(1, clientOptionsCallbackCount);
     }
 
     [Fact]

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/MicrosoftAzureCosmosPublicApiTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/MicrosoftAzureCosmosPublicApiTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
@@ -62,5 +63,51 @@ public class MicrosoftAzureCosmosPublicApiTests
             ? Assert.Throws<ArgumentNullException>(action)
             : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("client")]
+    [InlineData("container")]
+    [InlineData("database")]
+    public void ProviderAwareOverloadsShouldThrowWhenBuilderIsNull(string registrationType)
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "cosmos";
+        Action<MicrosoftAzureCosmosSettings>? settingsCallback = null;
+        Action<IServiceProvider, CosmosClientOptions>? clientOptionsCallback = null;
+
+        Action action = registrationType switch
+        {
+            "client" => () => builder.AddAzureCosmosClient(connectionName, settingsCallback, clientOptionsCallback),
+            "container" => () => builder.AddAzureCosmosContainer(connectionName, settingsCallback, clientOptionsCallback),
+            "database" => () => builder.AddAzureCosmosDatabase(connectionName, settingsCallback, clientOptionsCallback),
+            _ => throw new InvalidOperationException()
+        };
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("client")]
+    [InlineData("container")]
+    [InlineData("database")]
+    public void KeyedProviderAwareOverloadsShouldThrowWhenBuilderIsNull(string registrationType)
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "cosmos";
+        Action<MicrosoftAzureCosmosSettings>? settingsCallback = null;
+        Action<IServiceProvider, CosmosClientOptions>? clientOptionsCallback = null;
+
+        Action action = registrationType switch
+        {
+            "client" => () => builder.AddKeyedAzureCosmosClient(name, settingsCallback, clientOptionsCallback),
+            "container" => () => builder.AddKeyedAzureCosmosContainer(name, settingsCallback, clientOptionsCallback),
+            "database" => () => builder.AddKeyedAzureCosmosDatabase(name, settingsCallback, clientOptionsCallback),
+            _ => throw new InvalidOperationException()
+        };
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
     }
 }

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/MicrosoftAzureCosmosPublicApiTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/MicrosoftAzureCosmosPublicApiTests.cs
@@ -38,6 +38,17 @@ public class MicrosoftAzureCosmosPublicApiTests
     }
 
     [Fact]
+    public void AddAzureCosmosClientWithNullCallbacksShouldCompile()
+    {
+        IHostApplicationBuilder builder = null!;
+
+        var action = () => builder.AddAzureCosmosClient("cosmos", null, null);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
     public void AddKeyedAzureCosmosClientShouldThrowWhenBuilderIsNull()
     {
         IHostApplicationBuilder builder = null!;


### PR DESCRIPTION
## Description

Add IServiceProvider support to Cosmos DB extensions - co-authored with GPT 5.6-Sol

The benefit would be using the DI container to resolve `RequestHandler` instances that may require container services to instantiate as part of calling `clientOptions.CustomHanndlers.Add(...);`

All existing AspireMicrosoftAzureCosmosExtensions overloads remain with the same signature for binary compatibility.

Added `Action<IServiceProvider, CosmosClientOptions>? configureClientOptions` overloads to AspireMicrosoftAzureCosmosExtensions.
- Same pattern as observed in Kafka integrations where `Wrap()` funnels the non-IServiceProvider Actions into the same code path.
- Behavior change - previously, exceptions thrown by `Action<CosmosClientOptions>? configureClientOptions` would throw upon registration. Now, they will only throw upon client resolution from the DI container.

CosmosDatabaseBuilder maintains a binary compatible constructor, though isn't a primary constructor syntax anymore.
- Behavior change - previously, the Builder instance would keep a client in a field as a singleton, now the DI container is used to enforce a singleton because DI is now a requirement to resolve client options. Consumers didn't have access to the private _client previously and won't be able to resolve this CosmosClient from the container due to using an instance as the Keyed registration. This feels like consistent behavior, just a different implementation detail.

Partially addresses #667

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] Yes - If you count [Eric Erhardt's comment in 667](https://github.com/microsoft/aspire/issues/667#issuecomment-2905865096)
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No

## Testing

Built local packages and pulled them into a real Microsoft internal project. Built and executed, with a breakpoint to watch the `clientOptions` callback get called. Deleted my internal copy of `AspireMicrosoftAzureCosmosExtensions` to call the package version added by this PR.

Old overloads still work:
<img width="1316" height="325" alt="image" src="https://github.com/user-attachments/assets/0a475736-62b9-4908-b1f4-6c8e36efbf63" />

New overloads work as expected:
<img width="1325" height="305" alt="image" src="https://github.com/user-attachments/assets/6ddeefdc-62de-4df4-aca2-d9abb645c8e6" />
