### PR TITLE
Honor --source during template discovery

### DIFF
--- a/src/Aspire.Cli/Commands/BaseCommand.cs
+++ b/src/Aspire.Cli/Commands/BaseCommand.cs
@@ -23,6 +23,9 @@ internal abstract class BaseCommand : Command
 
     internal virtual bool PrefetchesTemplatePackageMetadata => false;
 
+    internal bool PrefetchesTemplatePackageMetadataForInvocation
+        => _prefetchesTemplatePackageMetadataForInvocation ?? PrefetchesTemplatePackageMetadata;
+
     // JSON output cannot display update notifications, so apply this invocation-level gate outside
     // the overridable command policy to prevent metadata-only consumers from bypassing it.
     internal bool PrefetchesCliPackageMetadata => (UpdateNotificationsEnabled || RequiresCliPackageMetadata) && !_isJsonFormatRequested;
@@ -49,6 +52,7 @@ internal abstract class BaseCommand : Command
 
     private readonly CliExecutionContext _executionContext;
     private bool _isJsonFormatRequested;
+    private bool? _prefetchesTemplatePackageMetadataForInvocation;
 
     protected CliExecutionContext ExecutionContext => _executionContext;
 
@@ -93,8 +97,14 @@ internal abstract class BaseCommand : Command
     internal void SelectForExecution(ParseResult parseResult)
     {
         _isJsonFormatRequested = IsJsonFormatRequested(parseResult);
+        _prefetchesTemplatePackageMetadataForInvocation = PrefetchesTemplatePackageMetadata;
         PrepareForExecution(parseResult);
         _executionContext.Command = this;
+    }
+
+    protected void DisableTemplatePackageMetadataPrefetchingForInvocation()
+    {
+        _prefetchesTemplatePackageMetadataForInvocation = false;
     }
 
     internal virtual void PrepareForExecution(ParseResult parseResult)

--- a/src/Aspire.Cli/Commands/InitCommand.cs
+++ b/src/Aspire.Cli/Commands/InitCommand.cs
@@ -439,6 +439,7 @@ internal sealed class InitCommand : BaseCommand
         // (or after a CLI update) the template will be missing. Install first.
         var installOutcome = await _templateNuGetConfigService.InstallTemplatePackageAsync(
             selection,
+            sourceOverride: null,
             _runner,
             InitCommandStrings.InstallingAspireProjectTemplates,
             statusEmoji: null,

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -45,7 +45,7 @@ internal sealed class NewCommand : BaseCommand
         Description = NewCommandStrings.OutputArgumentDescription,
         Recursive = true
     };
-    private static readonly Option<string?> s_sourceOption = new("--source", "-s")
+    internal static readonly Option<string?> s_sourceOption = new("--source", "-s")
     {
         Description = NewCommandStrings.SourceArgumentDescription,
         Recursive = true
@@ -127,6 +127,16 @@ internal sealed class NewCommand : BaseCommand
     {
         var explicitLanguageId = parseResult.GetValue(_languageOption);
         return string.IsNullOrWhiteSpace(explicitLanguageId) ? null : NormalizeLanguageId(explicitLanguageId);
+    }
+
+    internal override void PrepareForExecution(ParseResult parseResult)
+    {
+        if (!string.IsNullOrWhiteSpace(parseResult.GetValue(s_sourceOption)))
+        {
+            // The foreground template lookup applies --source. Background prefetch does not know
+            // about invocation options, so letting it run would still contact fallback feeds.
+            DisableTemplatePackageMetadataPrefetchingForInvocation();
+        }
     }
 
     private static string NormalizeLanguageId(string languageId)

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -406,9 +406,13 @@ internal sealed class NewCommand : BaseCommand
                     return new ResolveTemplateVersionResult { ErrorMessage = errorMessage };
                 }
 
+                // Apply the source override after selection so it cannot change implicit/explicit channel selection.
+                // Keep the original channel authoritative for persistence because mappings make the adjusted copy explicit.
+                var templateDiscoveryChannel = selectedChannel.WithFallbackSourceOverride(parseResult.GetValue(s_sourceOption));
+
                 try
                 {
-                    var packages = (await selectedChannel.GetTemplatePackagesAsync(ExecutionContext.WorkingDirectory, cancellationToken))
+                    var packages = (await templateDiscoveryChannel.GetTemplatePackagesAsync(ExecutionContext.WorkingDirectory, cancellationToken))
                         .Where(p => Semver.SemVersion.TryParse(p.Version, Semver.SemVersionStyles.Strict, out _))
                         .ToArray();
                     var hasPrHives = ExecutionContext.GetHiveCount() > 0;

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -340,7 +340,7 @@ internal sealed class NewCommand : BaseCommand
         public string? ErrorMessage { get; init; }
     }
 
-    private async Task<ResolveTemplateVersionResult> ResolveCliTemplateVersionAsync(ParseResult parseResult, CancellationToken cancellationToken)
+    private async Task<ResolveTemplateVersionResult> ResolveCliTemplateVersionAsync(ParseResult parseResult, string? source, CancellationToken cancellationToken)
     {
         return await InteractionService.ShowStatusAsync(
             NewCommandStrings.ResolvingTemplateVersion,
@@ -408,7 +408,7 @@ internal sealed class NewCommand : BaseCommand
 
                 // Apply the source override after selection so it cannot change implicit/explicit channel selection.
                 // Keep the original channel authoritative for persistence because mappings make the adjusted copy explicit.
-                var templateDiscoveryChannel = selectedChannel.WithFallbackSourceOverride(parseResult.GetValue(s_sourceOption));
+                var templateDiscoveryChannel = selectedChannel.WithFallbackSourceOverride(source);
 
                 try
                 {
@@ -453,6 +453,10 @@ internal sealed class NewCommand : BaseCommand
             InteractionService.DisplayError(NewCommandStrings.SourceWithCredentialsCannotBePersisted);
             return CommandResult.Failure(CliExitCodes.InvalidCommand);
         }
+        if (!string.IsNullOrWhiteSpace(source))
+        {
+            source = PackageSourceOverrideMappings.ResolveForWorkingDirectory(source, ExecutionContext.WorkingDirectory);
+        }
 
         // Resolve which templates are actually available at runtime (performs
         // async checks like SDK availability). This may be a subset of the
@@ -485,7 +489,7 @@ internal sealed class NewCommand : BaseCommand
         if (ShouldResolveCliTemplateVersion(template) &&
             string.IsNullOrWhiteSpace(version))
         {
-            var resolveResult = await ResolveCliTemplateVersionAsync(parseResult, cancellationToken);
+            var resolveResult = await ResolveCliTemplateVersionAsync(parseResult, source, cancellationToken);
             if (!resolveResult.Success)
             {
                 return CommandResult.Failure(CliExitCodes.InvalidCommand, resolveResult.ErrorMessage);

--- a/src/Aspire.Cli/Commands/NewCommand.cs
+++ b/src/Aspire.Cli/Commands/NewCommand.cs
@@ -417,12 +417,14 @@ internal sealed class NewCommand : BaseCommand
                 }
 
                 // Apply the source override after selection so it cannot change implicit/explicit channel selection.
-                // Keep the original channel authoritative for persistence because mappings make the adjusted copy explicit.
-                var templateDiscoveryChannel = selectedChannel.WithFallbackSourceOverride(source);
+                // Pass the adjusted mappings directly so the original channel remains authoritative for persistence.
+                var templateDiscoveryMappings = string.IsNullOrWhiteSpace(source)
+                    ? selectedChannel.Mappings
+                    : PackageSourceOverrideMappings.CreateForTemplateOperations(source);
 
                 try
                 {
-                    var packages = (await templateDiscoveryChannel.GetTemplatePackagesAsync(ExecutionContext.WorkingDirectory, cancellationToken))
+                    var packages = (await selectedChannel.GetTemplatePackagesAsync(ExecutionContext.WorkingDirectory, templateDiscoveryMappings, cancellationToken))
                         .Where(p => Semver.SemVersion.TryParse(p.Version, Semver.SemVersionStyles.Strict, out _))
                         .ToArray();
                     var hasPrHives = ExecutionContext.GetHiveCount() > 0;
@@ -466,6 +468,14 @@ internal sealed class NewCommand : BaseCommand
         if (!string.IsNullOrWhiteSpace(source))
         {
             source = PackageSourceOverrideMappings.ResolveForWorkingDirectory(source, ExecutionContext.WorkingDirectory);
+            if (PackageSourceOverrideMappings.GetMissingLocalDirectory(source) is { } missingDirectory)
+            {
+                InteractionService.DisplayError(string.Format(
+                    CultureInfo.CurrentCulture,
+                    NewCommandStrings.SourceDirectoryNotFound,
+                    missingDirectory));
+                return CommandResult.Failure(CliExitCodes.InvalidCommand);
+            }
         }
 
         // Resolve which templates are actually available at runtime (performs

--- a/src/Aspire.Cli/Commands/TemplateCommand.cs
+++ b/src/Aspire.Cli/Commands/TemplateCommand.cs
@@ -26,6 +26,16 @@ internal sealed class TemplateCommand : BaseCommand
     // and should show update notifications, just like the parent NewCommand.
     protected override bool UpdateNotificationsEnabled => true;
 
+    internal override void PrepareForExecution(ParseResult parseResult)
+    {
+        if (!string.IsNullOrWhiteSpace(parseResult.GetValue(NewCommand.s_sourceOption)))
+        {
+            // The foreground template lookup applies --source. Background prefetch does not know
+            // about invocation options, so letting it run would still contact fallback feeds.
+            DisableTemplatePackageMetadataPrefetchingForInvocation();
+        }
+    }
+
     protected override Task<CommandResult> ExecuteAsync(ParseResult parseResult, CancellationToken cancellationToken)
     {
         return _executeCallback(parseResult, cancellationToken);

--- a/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
+++ b/src/Aspire.Cli/NuGet/NuGetPackagePrefetcher.cs
@@ -117,7 +117,7 @@ internal sealed class NuGetPackagePrefetcher(ILogger<NuGetPackagePrefetcher> log
     }
 
     private static bool ShouldPrefetchTemplatePackages(SystemCommand? command)
-        => command is BaseCommand { PrefetchesTemplatePackageMetadata: true };
+        => command is BaseCommand { PrefetchesTemplatePackageMetadataForInvocation: true };
 
     private static bool ShouldPrefetchCliPackages(SystemCommand? command, bool updateNotificationsEnabled)
         => command is BaseCommand baseCommand && baseCommand.ShouldPrefetchCliPackageMetadata(updateNotificationsEnabled);

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -560,6 +560,27 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         return CreateScopedChannelForPackages([packageId]);
     }
 
+    /// <summary>
+    /// Returns a channel with its fallback package source replaced by the specified override.
+    /// </summary>
+    public PackageChannel WithFallbackSourceOverride(string? sourceOverride)
+    {
+        if (string.IsNullOrWhiteSpace(sourceOverride))
+        {
+            return this;
+        }
+
+        var mappings = (Mappings ?? [])
+            .Where(static mapping => !string.Equals(mapping.PackageFilter, PackageMapping.AllPackages, StringComparison.Ordinal))
+            .Append(new PackageMapping(PackageMapping.AllPackages, sourceOverride))
+            .ToArray();
+
+        // PackageChannel is immutable, so copy the selected channel and replace only its fallback mapping.
+        // Apply this only after channel selection: making an implicit channel explicit earlier changes
+        // channel selection and template-hive behavior.
+        return new PackageChannel(Name, Quality, mappings, nuGetPackageCache, _features, logger, ConfigureGlobalPackagesFolder, CliDownloadBaseUrl, PinnedVersion, _currentCliVersion, validateTemplatePackageMetadataPrefetching);
+    }
+
     public PackageChannel CreateScopedChannelForPackages(IEnumerable<string> packageIds)
     {
         ArgumentNullException.ThrowIfNull(packageIds);

--- a/src/Aspire.Cli/Packaging/PackageChannel.cs
+++ b/src/Aspire.Cli/Packaging/PackageChannel.cs
@@ -126,18 +126,26 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
         }
     }
 
-    public async Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    public Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        return GetTemplatePackagesAsync(workingDirectory, Mappings, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets template packages using the specified mappings without changing this channel's identity.
+    /// </summary>
+    public async Task<IEnumerable<NuGetPackage>> GetTemplatePackagesAsync(DirectoryInfo workingDirectory, PackageMapping[]? mappings, CancellationToken cancellationToken)
     {
         validateTemplatePackageMetadataPrefetching?.Invoke();
 
         if (PinnedVersion is not null)
         {
-            return [new NuGetPackage { Id = "Aspire.ProjectTemplates", Version = PinnedVersion, Source = SourceDetails }];
+            return [new NuGetPackage { Id = "Aspire.ProjectTemplates", Version = PinnedVersion, Source = ComputeSourceDetails(mappings) }];
         }
 
         var tasks = new List<Task<IEnumerable<NuGetPackage>>>();
 
-        using var tempNuGetConfig = Type is PackageChannelType.Explicit ? await TemporaryNuGetConfig.CreateAsync(Mappings!) : null;
+        using var tempNuGetConfig = mappings is not null ? await TemporaryNuGetConfig.CreateAsync(mappings) : null;
 
         if (Quality is PackageChannelQuality.Stable || Quality is PackageChannelQuality.Both)
         {
@@ -558,27 +566,6 @@ internal class PackageChannel(string name, PackageChannelQuality quality, Packag
     public PackageChannel CreateScopedChannelForPackage(string packageId)
     {
         return CreateScopedChannelForPackages([packageId]);
-    }
-
-    /// <summary>
-    /// Returns a channel with its fallback package source replaced by the specified override.
-    /// </summary>
-    public PackageChannel WithFallbackSourceOverride(string? sourceOverride)
-    {
-        if (string.IsNullOrWhiteSpace(sourceOverride))
-        {
-            return this;
-        }
-
-        var mappings = (Mappings ?? [])
-            .Where(static mapping => !string.Equals(mapping.PackageFilter, PackageMapping.AllPackages, StringComparison.Ordinal))
-            .Append(new PackageMapping(PackageMapping.AllPackages, sourceOverride))
-            .ToArray();
-
-        // PackageChannel is immutable, so copy the selected channel and replace only its fallback mapping.
-        // Apply this only after channel selection: making an implicit channel explicit earlier changes
-        // channel selection and template-hive behavior.
-        return new PackageChannel(Name, Quality, mappings, nuGetPackageCache, _features, logger, ConfigureGlobalPackagesFolder, CliDownloadBaseUrl, PinnedVersion, _currentCliVersion, validateTemplatePackageMetadataPrefetching);
     }
 
     public PackageChannel CreateScopedChannelForPackages(IEnumerable<string> packageIds)

--- a/src/Aspire.Cli/Packaging/PackageSourceOverrideMappings.cs
+++ b/src/Aspire.Cli/Packaging/PackageSourceOverrideMappings.cs
@@ -15,18 +15,30 @@ internal static class PackageSourceOverrideMappings
         ArgumentException.ThrowIfNullOrWhiteSpace(source);
         ArgumentNullException.ThrowIfNull(workingDirectory);
 
+        var sourceKind = ClassifySource(source, out _);
+
         // On Unix, Uri treats DOS-shaped paths such as C:/feed as absolute file URIs.
         // Preserve a file URI only when the source explicitly includes the file: scheme.
         if (Path.IsPathFullyQualified(source) ||
-            UrlHelper.IsHttpUrl(source) ||
-            (source.StartsWith("file:", StringComparison.OrdinalIgnoreCase) &&
-                Uri.TryCreate(source, UriKind.Absolute, out var uri) &&
-                uri.IsFile))
+            sourceKind is PackageSourceKind.Http or PackageSourceKind.FileUri)
         {
             return source;
         }
 
         return Path.GetFullPath(source, workingDirectory.FullName);
+    }
+
+    public static string? GetMissingLocalDirectory(string source)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+
+        var sourceKind = ClassifySource(source, out var localDirectory);
+        if (sourceKind is PackageSourceKind.Http)
+        {
+            return null;
+        }
+
+        return Directory.Exists(localDirectory) ? null : localDirectory;
     }
 
     public static PackageMapping[] Create(string packageSourceOverride, PackageChannel? requestedChannel, string? nugetServiceIndexOverride)
@@ -69,6 +81,20 @@ internal static class PackageSourceOverrideMappings
         return [.. mappings.DistinctBy(static mapping => $"{mapping.PackageFilter}\0{mapping.Source}")];
     }
 
+    public static PackageMapping[] CreateForTemplateOperations(string packageSourceOverride)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageSourceOverride);
+
+        // NuGet package search queries every configured source without applying package source
+        // mapping. Keep the temporary config exclusive to --source so discovery and installation
+        // cannot contact a channel feed or NuGet.org behind the user's approved proxy.
+        return
+        [
+            new("Aspire*", packageSourceOverride),
+            new(PackageMapping.AllPackages, packageSourceOverride)
+        ];
+    }
+
     public static bool HasCredentialMaterial(string source)
     {
         return Uri.TryCreate(source.Trim(), UriKind.Absolute, out var uri) &&
@@ -77,5 +103,32 @@ internal static class PackageSourceOverrideMappings
             (!string.IsNullOrEmpty(uri.UserInfo) ||
                 !string.IsNullOrEmpty(uri.Query) ||
                 !string.IsNullOrEmpty(uri.Fragment));
+    }
+
+    private static PackageSourceKind ClassifySource(string source, out string? localDirectory)
+    {
+        if (UrlHelper.IsHttpUrl(source))
+        {
+            localDirectory = null;
+            return PackageSourceKind.Http;
+        }
+
+        if (source.StartsWith("file:", StringComparison.OrdinalIgnoreCase) &&
+            Uri.TryCreate(source, UriKind.Absolute, out var uri) &&
+            uri.IsFile)
+        {
+            localDirectory = uri.LocalPath;
+            return PackageSourceKind.FileUri;
+        }
+
+        localDirectory = source;
+        return PackageSourceKind.LocalPath;
+    }
+
+    private enum PackageSourceKind
+    {
+        Http,
+        FileUri,
+        LocalPath
     }
 }

--- a/src/Aspire.Cli/Packaging/PackageSourceOverrideMappings.cs
+++ b/src/Aspire.Cli/Packaging/PackageSourceOverrideMappings.cs
@@ -1,18 +1,28 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Cli.Utils;
+
 namespace Aspire.Cli.Packaging;
 
 internal static class PackageSourceOverrideMappings
 {
+    /// <summary>
+    /// Resolves a command-line package source against the invocation directory, returning relative local sources as absolute paths so persisted mappings remain valid elsewhere.
+    /// </summary>
     public static string ResolveForWorkingDirectory(string source, DirectoryInfo workingDirectory)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(source);
         ArgumentNullException.ThrowIfNull(workingDirectory);
 
-        return Uri.TryCreate(source, UriKind.Absolute, out _) || Path.IsPathFullyQualified(source)
-            ? source
-            : Path.GetFullPath(source, workingDirectory.FullName);
+        if (Path.IsPathFullyQualified(source) ||
+            UrlHelper.IsHttpUrl(source) ||
+            (Uri.TryCreate(source, UriKind.Absolute, out var uri) && uri.IsFile))
+        {
+            return source;
+        }
+
+        return Path.GetFullPath(source, workingDirectory.FullName);
     }
 
     public static PackageMapping[] Create(string packageSourceOverride, PackageChannel? requestedChannel, string? nugetServiceIndexOverride)

--- a/src/Aspire.Cli/Packaging/PackageSourceOverrideMappings.cs
+++ b/src/Aspire.Cli/Packaging/PackageSourceOverrideMappings.cs
@@ -5,6 +5,16 @@ namespace Aspire.Cli.Packaging;
 
 internal static class PackageSourceOverrideMappings
 {
+    public static string ResolveForWorkingDirectory(string source, DirectoryInfo workingDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+        ArgumentNullException.ThrowIfNull(workingDirectory);
+
+        return Uri.TryCreate(source, UriKind.Absolute, out _) || Path.IsPathFullyQualified(source)
+            ? source
+            : Path.GetFullPath(source, workingDirectory.FullName);
+    }
+
     public static PackageMapping[] Create(string packageSourceOverride, PackageChannel? requestedChannel, string? nugetServiceIndexOverride)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageSourceOverride);

--- a/src/Aspire.Cli/Packaging/PackageSourceOverrideMappings.cs
+++ b/src/Aspire.Cli/Packaging/PackageSourceOverrideMappings.cs
@@ -15,9 +15,13 @@ internal static class PackageSourceOverrideMappings
         ArgumentException.ThrowIfNullOrWhiteSpace(source);
         ArgumentNullException.ThrowIfNull(workingDirectory);
 
+        // On Unix, Uri treats DOS-shaped paths such as C:/feed as absolute file URIs.
+        // Preserve a file URI only when the source explicitly includes the file: scheme.
         if (Path.IsPathFullyQualified(source) ||
             UrlHelper.IsHttpUrl(source) ||
-            (Uri.TryCreate(source, UriKind.Absolute, out var uri) && uri.IsFile))
+            (source.StartsWith("file:", StringComparison.OrdinalIgnoreCase) &&
+                Uri.TryCreate(source, UriKind.Absolute, out var uri) &&
+                uri.IsFile))
         {
             return source;
         }

--- a/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.Designer.cs
@@ -69,6 +69,12 @@ namespace Aspire.Cli.Resources {
             }
         }
 
+        public static string SourceDirectoryNotFound {
+            get {
+                return ResourceManager.GetString("SourceDirectoryNotFound", resourceCulture);
+            }
+        }
+
         public static string SourceWithCredentialsCannotBePersisted {
             get {
                 return ResourceManager.GetString("SourceWithCredentialsCannotBePersisted", resourceCulture);

--- a/src/Aspire.Cli/Resources/NewCommandStrings.resx
+++ b/src/Aspire.Cli/Resources/NewCommandStrings.resx
@@ -118,6 +118,9 @@
   <data name="SourceArgumentDescription" xml:space="preserve">
     <value>The NuGet source to use for the project templates</value>
   </data>
+  <data name="SourceDirectoryNotFound" xml:space="preserve">
+    <value>The local NuGet source directory '{0}' does not exist.</value>
+  </data>
   <data name="SourceWithCredentialsCannotBePersisted" xml:space="preserve">
     <value>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</value>
   </data>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.cs.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Zdroj NuGet, který se má použít pro šablony projektu</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.de.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Die NuGet-Quelle, die für die Projektvorlagen verwendet werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.es.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">El origen de NuGet que se va a usar para las plantillas de proyecto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.fr.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">La source NuGet à utiliser pour les modèles de projet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.it.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Origine NuGet da utilizzare per i modelli di progetto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ja.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">プロジェクト テンプレートに使用する NuGet ソース。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ko.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">프로젝트 템플릿에 사용할 NuGet 소스입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pl.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Źródło NuGet, które ma być używane dla szablonów projektu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.pt-BR.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">A origem do NuGet a ser usada para os modelos de projeto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.ru.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Источник NuGet для использования в шаблонах проекта.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.tr.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">Proje şablonları için kullanılacak NuGet kaynağı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hans.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">要用于项目模板的 NuGet 源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
+++ b/src/Aspire.Cli/Resources/xlf/NewCommandStrings.zh-Hant.xlf
@@ -112,6 +112,11 @@
         <target state="needs-review-translation">要用於專案範本的 NuGet 來源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SourceDirectoryNotFound">
+        <source>The local NuGet source directory '{0}' does not exist.</source>
+        <target state="new">The local NuGet source directory '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SourceWithCredentialsCannotBePersisted">
         <source>The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</source>
         <target state="new">The --source URL includes credentials, a query string, or a fragment and cannot be written to the project's NuGet.config. Configure credentials with NuGet credential providers or user-level NuGet configuration, then pass the feed URL without embedded secrets.</target>

--- a/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
+++ b/src/Aspire.Cli/Templating/DotNetTemplateFactory.cs
@@ -473,6 +473,7 @@ internal class DotNetTemplateFactory(
 
             var installOutcome = await templateNuGetConfigService.InstallTemplatePackageAsync(
                 selectedTemplateDetails,
+                sourceOverride: inputs.Source,
                 runner,
                 TemplatingStrings.GettingTemplates,
                 statusEmoji: KnownEmojis.Ice,

--- a/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
+++ b/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
@@ -279,7 +279,8 @@ internal sealed class TemplateNuGetConfigService(
 
             await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
             {
-                var templatePackages = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, ct);
+                var templateSearchChannel = channel.WithFallbackSourceOverride(query.SourceOverride);
+                var templatePackages = await templateSearchChannel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, ct);
                 lock (resultsLock)
                 {
                     results.AddRange(templatePackages.Select(p => (p, channel)));
@@ -347,9 +348,10 @@ internal sealed class TemplateNuGetConfigService(
     }
 
     /// <summary>
-    /// Installs the resolved Aspire project templates package, generating a temporary NuGet.config from the channel mappings when the channel is explicit.
+    /// Installs the resolved Aspire project templates package, generating a temporary NuGet.config from the source-adjusted channel mappings when the channel is explicit.
     /// </summary>
     /// <param name="selection">The template package + channel returned by <see cref="ResolveTemplatePackageAsync"/>.</param>
+    /// <param name="sourceOverride">Optional package source override applied to the selected channel's fallback source for installation.</param>
     /// <param name="runner">The .NET CLI runner used to invoke <c>dotnet new install</c>. Passed in (rather than injected) because the runner has a transient DI lifetime.</param>
     /// <param name="statusMessage">Status text shown while the install runs.</param>
     /// <param name="statusEmoji">Optional emoji prefix shown next to the status message.</param>
@@ -357,23 +359,25 @@ internal sealed class TemplateNuGetConfigService(
     /// <returns>The install exit code, the parsed template version (if available), and the captured stdout/stderr lines.</returns>
     public async Task<TemplateInstallOutcome> InstallTemplatePackageAsync(
         TemplatePackageSelection selection,
+        string? sourceOverride,
         IDotNetCliRunner runner,
         string statusMessage,
         KnownEmoji? statusEmoji,
         CancellationToken cancellationToken)
     {
-        // Whilst we install the templates - if we are using an explicit channel we need to
-        // generate a temporary NuGet.config file to make sure we install the right package
-        // from the right feed. If we are using an implicit channel then we just use the
-        // ambient configuration (although we should still specify the source) because
-        // the user would have selected it.
+        var templateInstallChannel = selection.Channel.WithFallbackSourceOverride(sourceOverride);
+
+        // Whilst we install the templates - if the source-adjusted channel is explicit we need
+        // to generate a temporary NuGet.config file to make sure we install the right package
+        // from the right feed. If it remains implicit then we just use the ambient configuration
+        // (although we should still specify the source) because the user would have selected it.
         //
         // The temporary config is disposed when this method returns. That is intentional —
         // only `dotnet new install` consumes the config; the subsequent `dotnet new <template>`
         // call (in DotNetTemplateFactory and InitCommand) operates against the already-installed
         // template hive and uses the ambient NuGet configuration.
-        using var temporaryConfig = selection.Channel.Type == PackageChannelType.Explicit
-            ? await TemporaryNuGetConfig.CreateAsync(selection.Channel.Mappings!)
+        using var temporaryConfig = templateInstallChannel.Type == PackageChannelType.Explicit
+            ? await TemporaryNuGetConfig.CreateAsync(templateInstallChannel.Mappings!)
             : null;
 
         var collector = new OutputCollector();
@@ -413,7 +417,7 @@ internal sealed class TemplateNuGetConfigService(
 /// back to PR-hive discovery or implicit-only depending on <paramref name="IncludePrHives"/>.
 /// </param>
 /// <param name="VersionOverride">Optional explicit template version (e.g. from <c>--version</c>).</param>
-/// <param name="SourceOverride">Optional source override carried for symmetry with <see cref="TemplateInputs"/>; not consulted by resolution today.</param>
+/// <param name="SourceOverride">Optional package source override consulted during package search, after channel selection, to replace the selected channel's fallback source.</param>
 /// <param name="IncludePrHives">When true (e.g. for <c>aspire new</c>), local PR hive directories under <c>~/.aspire/hives</c> participate in channel discovery; when false (e.g. for <c>aspire init</c>), they are ignored.</param>
 internal sealed record TemplatePackageQuery(
     string? RequestedChannel,

--- a/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
+++ b/src/Aspire.Cli/Templating/TemplateNuGetConfigService.cs
@@ -263,6 +263,13 @@ internal sealed class TemplateNuGetConfigService(
                     $"{string.Join(", ", allChannels.Select(c => c.Name))}");
             channels = [matchingChannel];
         }
+        else if (!string.IsNullOrWhiteSpace(query.SourceOverride))
+        {
+            // Every channel would query the same explicit source, so querying PR/local channels as
+            // well would attach identical results to whichever channel finishes first. Keep the
+            // implicit channel as the deterministic owner unless the user requested a channel.
+            channels = allChannels.Where(c => c.Type is PackageChannelType.Implicit);
+        }
         else
         {
             // If there are hives (PR build directories), include all channels.
@@ -279,8 +286,10 @@ internal sealed class TemplateNuGetConfigService(
 
             await Parallel.ForEachAsync(channels, cancellationToken, async (channel, ct) =>
             {
-                var templateSearchChannel = channel.WithFallbackSourceOverride(query.SourceOverride);
-                var templatePackages = await templateSearchChannel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, ct);
+                var templateSearchMappings = string.IsNullOrWhiteSpace(query.SourceOverride)
+                    ? channel.Mappings
+                    : PackageSourceOverrideMappings.CreateForTemplateOperations(query.SourceOverride);
+                var templatePackages = await channel.GetTemplatePackagesAsync(executionContext.WorkingDirectory, templateSearchMappings, ct);
                 lock (resultsLock)
                 {
                     results.AddRange(templatePackages.Select(p => (p, channel)));
@@ -348,10 +357,10 @@ internal sealed class TemplateNuGetConfigService(
     }
 
     /// <summary>
-    /// Installs the resolved Aspire project templates package, generating a temporary NuGet.config from the source-adjusted channel mappings when the channel is explicit.
+    /// Installs the resolved Aspire project templates package, generating a temporary NuGet.config from source-adjusted mappings when needed.
     /// </summary>
     /// <param name="selection">The template package + channel returned by <see cref="ResolveTemplatePackageAsync"/>.</param>
-    /// <param name="sourceOverride">Optional package source override applied to the selected channel's fallback source for installation.</param>
+    /// <param name="sourceOverride">Optional package source override applied to Aspire packages for installation.</param>
     /// <param name="runner">The .NET CLI runner used to invoke <c>dotnet new install</c>. Passed in (rather than injected) because the runner has a transient DI lifetime.</param>
     /// <param name="statusMessage">Status text shown while the install runs.</param>
     /// <param name="statusEmoji">Optional emoji prefix shown next to the status message.</param>
@@ -365,19 +374,21 @@ internal sealed class TemplateNuGetConfigService(
         KnownEmoji? statusEmoji,
         CancellationToken cancellationToken)
     {
-        var templateInstallChannel = selection.Channel.WithFallbackSourceOverride(sourceOverride);
+        var templateInstallMappings = string.IsNullOrWhiteSpace(sourceOverride)
+            ? selection.Channel.Mappings
+            : PackageSourceOverrideMappings.CreateForTemplateOperations(sourceOverride);
 
-        // Whilst we install the templates - if the source-adjusted channel is explicit we need
+        // Whilst we install the templates - if source mappings are available we need
         // to generate a temporary NuGet.config file to make sure we install the right package
-        // from the right feed. If it remains implicit then we just use the ambient configuration
+        // from the right feed. Without mappings we just use the ambient configuration
         // (although we should still specify the source) because the user would have selected it.
         //
         // The temporary config is disposed when this method returns. That is intentional —
         // only `dotnet new install` consumes the config; the subsequent `dotnet new <template>`
         // call (in DotNetTemplateFactory and InitCommand) operates against the already-installed
         // template hive and uses the ambient NuGet configuration.
-        using var temporaryConfig = templateInstallChannel.Type == PackageChannelType.Explicit
-            ? await TemporaryNuGetConfig.CreateAsync(templateInstallChannel.Mappings!)
+        using var temporaryConfig = templateInstallMappings is not null
+            ? await TemporaryNuGetConfig.CreateAsync(templateInstallMappings)
             : null;
 
         var collector = new OutputCollector();
@@ -396,7 +407,7 @@ internal sealed class TemplateNuGetConfigService(
                     packageName: TemplatesPackageName,
                     version: selection.Package.Version,
                     nugetConfigFile: temporaryConfig?.ConfigFile,
-                    nugetSource: selection.Package.Source,
+                    nugetSource: string.IsNullOrWhiteSpace(sourceOverride) ? selection.Package.Source : sourceOverride,
                     force: true,
                     options: options,
                     cancellationToken: cancellationToken);
@@ -417,7 +428,11 @@ internal sealed class TemplateNuGetConfigService(
 /// back to PR-hive discovery or implicit-only depending on <paramref name="IncludePrHives"/>.
 /// </param>
 /// <param name="VersionOverride">Optional explicit template version (e.g. from <c>--version</c>).</param>
-/// <param name="SourceOverride">Optional package source override consulted during package search, after channel selection, to replace the selected channel's fallback source.</param>
+/// <param name="SourceOverride">
+/// Optional package source override used exclusively for template discovery and installation. Without
+/// <paramref name="RequestedChannel"/>, the implicit channel owns the result so installed hives cannot
+/// assign an unrelated channel identity to a package discovered from this source.
+/// </param>
 /// <param name="IncludePrHives">When true (e.g. for <c>aspire new</c>), local PR hive directories under <c>~/.aspire/hives</c> participate in channel discovery; when false (e.g. for <c>aspire init</c>), they are ignored.</param>
 internal sealed record TemplatePackageQuery(
     string? RequestedChannel,

--- a/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
@@ -43,7 +43,7 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
 
     [CaptureWorkspaceOnFailure]
     [Fact]
-    public async Task CreateEmptyAppHostWithSourceOverrideDoesNotContactNuGetOrg()
+    public async Task CreateDotNetTemplateWithSourceOverrideDoesNotContactOtherSources()
     {
         var repoRoot = CliE2ETestHelpers.GetRepoRoot();
         var strategy = CliInstallStrategy.Detect(output.WriteLine);
@@ -60,30 +60,50 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
 
         await auto.RunCommandAsync("mkdir source-feed && cp \"$HOME\"/.aspire/hives/*/packages/Aspire.ProjectTemplates.*.nupkg source-feed/", counter);
         await auto.RunCommandAsync("aspire --version > /tmp/aspire-source-version", counter);
+
+        // CLI update checks are independent from template source selection. Disable them so the
+        // TCP tripwire isolates template discovery and installation traffic from the update notifier.
         await auto.RunCommandAsync("aspire config set features.updateNotificationsEnabled false -g", counter);
-        await auto.RunCommandAsync("export ASPIRE_CLI_CHANNEL=staging ASPIRE_CLI_VERSION=\"$(cat /tmp/aspire-source-version)\"", counter);
+        await auto.RunCommandAsync("aspire config set features.showAllTemplates true -g", counter);
+        await auto.RunCommandAsync(
+            "export ASPIRE_CLI_CHANNEL=staging ASPIRE_CLI_VERSION=\"$(cat /tmp/aspire-source-version)\" " +
+            "ASPIRE_CLI_COMMIT=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            counter);
+
+        // The selected .NET template restores after scaffolding. Keep that independent post-action
+        // on the local feed so the tripwire remains scoped to template discovery and installation.
+        await auto.RunCommandAsync("dotnet nuget disable source nuget.org", counter);
+        await auto.RunCommandAsync("dotnet nuget add source \"$PWD/source-feed\" --name source-override-e2e", counter);
 
         // Package search can suppress source failures, so use a TCP tripwire to detect connection attempts independently of logs.
-        await auto.RunCommandAsync("printf '127.0.0.1 api.nuget.org azuresearch-usnc.nuget.org azuresearch-ussc.nuget.org\\n' >> /etc/hosts", counter);
         await auto.RunCommandAsync(
-            "rm -f /tmp/nuget-org-contacted /tmp/nuget-org-listener-ready && " +
+            "printf '127.0.0.1 api.nuget.org azuresearch-usnc.nuget.org azuresearch-ussc.nuget.org pkgs.dev.azure.com\\n' >> /etc/hosts",
+            counter);
+        await auto.RunCommandAsync(
+            "rm -f /tmp/unexpected-nuget-source-contacted /tmp/nuget-source-listener-ready && " +
             "python3 -c 'import pathlib,socket; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); " +
-            "s.bind((\"0.0.0.0\",443)); s.listen(); pathlib.Path(\"/tmp/nuget-org-listener-ready\").touch(); " +
-            "c,_=s.accept(); pathlib.Path(\"/tmp/nuget-org-contacted\").touch(); c.close()' >/tmp/nuget-org-listener.log 2>&1 & " +
-            "while [ ! -f /tmp/nuget-org-listener-ready ]; do sleep 0.1; done",
+            "s.bind((\"0.0.0.0\",443)); s.listen(); pathlib.Path(\"/tmp/nuget-source-listener-ready\").touch(); " +
+            "c,_=s.accept(); pathlib.Path(\"/tmp/unexpected-nuget-source-contacted\").touch(); c.close()' >/tmp/nuget-source-listener.log 2>&1 & " +
+            "for i in $(seq 1 100); do [ -f /tmp/nuget-source-listener-ready ] && break; sleep 0.1; done; " +
+            "if [ ! -f /tmp/nuget-source-listener-ready ]; then cat /tmp/nuget-source-listener.log; (exit 1); fi",
             counter);
         await auto.RunCommandAsync("rm -rf \"$HOME/.aspire/logs\" && mkdir -p \"$HOME/.aspire/logs\"", counter);
 
         await auto.RunCommandAsync(
-            "aspire new aspire-empty --name SourceOverrideApp --output SourceOverrideApp --language csharp " +
-            "--source source-feed --non-interactive --suppress-agent-init --localhost-tld false --log-level Debug",
+            "aspire new aspire-servicedefaults --name SourceOverrideServiceDefaults --output SourceOverrideServiceDefaults " +
+            "--channel staging --source source-feed --non-interactive --suppress-agent-init --log-level Debug",
             counter,
             TimeSpan.FromMinutes(2));
 
-        await auto.RunCommandAsync("test -f SourceOverrideApp/apphost.cs", counter);
+        await auto.RunCommandAsync("test -f SourceOverrideServiceDefaults/SourceOverrideServiceDefaults.csproj", counter);
         await auto.RunCommandAsync(
-            "test ! -e /tmp/nuget-org-contacted && " +
+            "test ! -e /tmp/unexpected-nuget-source-contacted && " +
             "find \"$HOME/.aspire/logs\" -type f -name '*.log' -print -quit | grep -q . && " +
+            "grep -R -F \"Resolved 'staging' channel\" \"$HOME/.aspire/logs\" && " +
+            "grep -R -F -- '--nuget-config /tmp/aspire-nuget-config' \"$HOME/.aspire/logs\" && " +
+            "grep -R -F 'Searching 1 source(s)' \"$HOME/.aspire/logs\" && " +
+            "grep -R -F 'Running dotnet in /tmp/aspire-nuget-config' \"$HOME/.aspire/logs\" && " +
+            "grep -R -F 'source-feed' \"$HOME/.aspire/logs\" && " +
             "! grep -R -F 'api.nuget.org' \"$HOME/.aspire/logs\"",
             counter);
     }

--- a/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
@@ -40,4 +40,39 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
         await auto.AspireStartAsync(counter);
         await auto.AspireStopAsync(counter);
     }
+
+    [CaptureWorkspaceOnFailure]
+    [Fact]
+    public async Task CreateEmptyAppHostWithSourceOverrideDoesNotContactNuGetOrg()
+    {
+        var repoRoot = CliE2ETestHelpers.GetRepoRoot();
+        var strategy = CliInstallStrategy.Detect(output.WriteLine);
+        var workspace = TemporaryWorkspace.Create(output);
+
+        using var terminal = CliE2ETestHelpers.CreateDockerTestTerminal(repoRoot, strategy, output, workspace: workspace);
+
+        var counter = new SequenceCounter();
+        var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromSeconds(500));
+        await using var terminalRun = CliE2ETestHelpers.StartRun(terminal, workspace, auto, counter, output, TestContext.Current.CancellationToken);
+
+        await auto.PrepareDockerEnvironmentAsync(counter, workspace);
+        await auto.InstallAspireCliAsync(strategy, counter);
+
+        await auto.RunCommandAsync("mkdir source-feed && cp \"$HOME\"/.aspire/hives/*/packages/Aspire.ProjectTemplates.*.nupkg source-feed/", counter);
+        await auto.RunCommandAsync("aspire --version > /tmp/aspire-source-version", counter);
+        await auto.RunCommandAsync("export ASPIRE_CLI_CHANNEL=staging ASPIRE_CLI_VERSION=\"$(cat /tmp/aspire-source-version)\"", counter);
+        await auto.RunCommandAsync("rm -rf \"$HOME/.aspire/logs\" && mkdir -p \"$HOME/.aspire/logs\"", counter);
+
+        await auto.RunCommandAsync(
+            "aspire new aspire-empty --name SourceOverrideApp --output SourceOverrideApp --language csharp " +
+            "--source source-feed --non-interactive --suppress-agent-init --localhost-tld false --log-level Debug",
+            counter,
+            TimeSpan.FromMinutes(2));
+
+        await auto.RunCommandAsync("test -f SourceOverrideApp/apphost.cs", counter);
+        await auto.RunCommandAsync(
+            "find \"$HOME/.aspire/logs\" -type f -name '*.log' -print -quit | grep -q . && " +
+            "! grep -R -F 'api.nuget.org' \"$HOME/.aspire/logs\"",
+            counter);
+    }
 }

--- a/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/EmptyAppHostTemplateTests.cs
@@ -60,7 +60,18 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
 
         await auto.RunCommandAsync("mkdir source-feed && cp \"$HOME\"/.aspire/hives/*/packages/Aspire.ProjectTemplates.*.nupkg source-feed/", counter);
         await auto.RunCommandAsync("aspire --version > /tmp/aspire-source-version", counter);
+        await auto.RunCommandAsync("aspire config set features.updateNotificationsEnabled false -g", counter);
         await auto.RunCommandAsync("export ASPIRE_CLI_CHANNEL=staging ASPIRE_CLI_VERSION=\"$(cat /tmp/aspire-source-version)\"", counter);
+
+        // Package search can suppress source failures, so use a TCP tripwire to detect connection attempts independently of logs.
+        await auto.RunCommandAsync("printf '127.0.0.1 api.nuget.org azuresearch-usnc.nuget.org azuresearch-ussc.nuget.org\\n' >> /etc/hosts", counter);
+        await auto.RunCommandAsync(
+            "rm -f /tmp/nuget-org-contacted /tmp/nuget-org-listener-ready && " +
+            "python3 -c 'import pathlib,socket; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); " +
+            "s.bind((\"0.0.0.0\",443)); s.listen(); pathlib.Path(\"/tmp/nuget-org-listener-ready\").touch(); " +
+            "c,_=s.accept(); pathlib.Path(\"/tmp/nuget-org-contacted\").touch(); c.close()' >/tmp/nuget-org-listener.log 2>&1 & " +
+            "while [ ! -f /tmp/nuget-org-listener-ready ]; do sleep 0.1; done",
+            counter);
         await auto.RunCommandAsync("rm -rf \"$HOME/.aspire/logs\" && mkdir -p \"$HOME/.aspire/logs\"", counter);
 
         await auto.RunCommandAsync(
@@ -71,6 +82,7 @@ public sealed class EmptyAppHostTemplateTests(ITestOutputHelper output)
 
         await auto.RunCommandAsync("test -f SourceOverrideApp/apphost.cs", counter);
         await auto.RunCommandAsync(
+            "test ! -e /tmp/nuget-org-contacted && " +
             "find \"$HOME/.aspire/logs\" -type f -name '*.log' -print -quit | grep -q . && " +
             "! grep -R -F 'api.nuget.org' \"$HOME/.aspire/logs\"",
             counter);

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1185,13 +1185,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData("https://proxy.example/v3/index.json")]
-    [InlineData("relative-feed")]
-    public async Task NewCommandWithCSharpEmptyTemplateAndSourceOverrideUsesSourceForTemplateDiscovery(string sourceOverride)
+    [InlineData("https://proxy.example/v3/index.json", false)]
+    [InlineData("relative-feed", true)]
+    public async Task NewCommandWithCSharpEmptyTemplateAndSourceOverrideUsesSourceForTemplateDiscovery(string sourceOverride, bool isRelative)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        var expectedSource = sourceOverride == "relative-feed"
-            ? Path.GetFullPath(sourceOverride, workspace.WorkspaceRoot.FullName)
+        var expectedSource = isRelative
+            ? Path.Combine(workspace.WorkspaceRoot.FullName, sourceOverride)
             : sourceOverride;
         string? discoveryCatchAllSource = null;
 
@@ -1238,6 +1238,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(CliExitCodes.Success, exitCode);
         Assert.Equal(expectedSource, discoveryCatchAllSource);
+        AssertSourceOverrideNuGetConfig(Path.Combine(workspace.WorkspaceRoot.FullName, "output"), expectedSource);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1250,7 +1250,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandWithEmptyTemplateAndSourceOverridePersistsSourceForLaterRestore(string language, string? featureFlag, string scaffoldFileName)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        const string sourceOverride = "/tmp/aspire-pr-hive/packages";
+        var sourceOverride = Path.Combine(workspace.WorkspaceRoot.FullName, "source-feed");
         string? capturedPackageSourceOverride = null;
         TestInteractionService? interactionService = null;
 
@@ -1280,7 +1280,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse($"new aspire-empty --name TestApp --output ./output --language {language} --localhost-tld false --suppress-agent-init --source {sourceOverride}");
+        var result = command.Parse($"new aspire-empty --name TestApp --output ./output --language {language} --localhost-tld false --suppress-agent-init --source \"{sourceOverride}\"");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
         Assert.Equal(CliExitCodes.Success, exitCode);
@@ -1296,13 +1296,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandWithCSharpEmptyTemplateAndSourceOverridePersistsSourceForLaterRestore()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        const string sourceOverride = "/tmp/aspire-pr-hive/packages";
+        var sourceOverride = Path.Combine(workspace.WorkspaceRoot.FullName, "source-feed");
 
         var services = CreateServiceCollection(workspace);
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse($"new aspire-empty --name TestApp --output ./output --language csharp --localhost-tld false --suppress-agent-init --source {sourceOverride}");
+        var result = command.Parse($"new aspire-empty --name TestApp --output ./output --language csharp --localhost-tld false --suppress-agent-init --source \"{sourceOverride}\"");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
@@ -1988,7 +1988,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandWithTypeScriptStarterAndSourceOverridePersistsSourceAndPlumbsOverride()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        const string sourceOverride = "/tmp/aspire-pr-hive/packages";
+        var sourceOverride = Path.Combine(workspace.WorkspaceRoot.FullName, "source-feed");
 
         TestInteractionService? interactionService = null;
         var services = CreateServiceCollection(workspace, options =>
@@ -2031,7 +2031,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<RootCommand>();
-        var result = command.Parse($"new aspire-ts-starter --name TestApp --output ./output --channel daily --localhost-tld false --source {sourceOverride}");
+        var result = command.Parse($"new aspire-ts-starter --name TestApp --output ./output --channel daily --localhost-tld false --source \"{sourceOverride}\"");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1184,6 +1184,58 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.mts")));
     }
 
+    [Fact]
+    public async Task NewCommandWithCSharpEmptyTemplateAndSourceOverrideUsesSourceForTemplateDiscovery()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        const string sourceOverride = "https://proxy.example/v3/index.json";
+        string? discoveryCatchAllSource = null;
+
+        var cache = new FakeNuGetPackageCache
+        {
+            GetTemplatePackagesAsyncCallback = (_, _, nugetConfig, _) =>
+            {
+                Assert.NotNull(nugetConfig);
+
+                var document = XDocument.Load(nugetConfig.FullName);
+                var catchAllSource = document.Root!
+                    .Element("packageSourceMapping")!
+                    .Elements("packageSource")
+                    .Single(source => source
+                        .Elements("package")
+                        .Any(package => (string?)package.Attribute("pattern") == PackageMapping.AllPackages));
+
+                discoveryCatchAllSource = (string?)catchAllSource.Attribute("key");
+
+                return Task.FromResult<IEnumerable<NuGetPackage>>(
+                    [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = sourceOverride, Version = "9.2.0" }]);
+            }
+        };
+        var channel = PackageChannel.CreateExplicitChannel(
+            PackageChannelNames.Stable,
+            PackageChannelQuality.Stable,
+            [new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)],
+            cache,
+            new TestFeatures(),
+            NullLogger.Instance);
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.PackagingServiceFactory = _ => new TestPackagingService
+            {
+                GetChannelsAsyncCallback = _ => Task.FromResult<IEnumerable<PackageChannel>>([channel])
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse($"new aspire-empty --name TestApp --output ./output --language csharp --localhost-tld false --suppress-agent-init --source {sourceOverride}");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        Assert.Equal(CliExitCodes.Success, exitCode);
+        Assert.Equal(sourceOverride, discoveryCatchAllSource);
+    }
+
     [Theory]
     [InlineData("typescript", null, "apphost.mts")]
     [InlineData("java", "experimentalPolyglot:java", "AppHost.java")]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1184,11 +1184,15 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.True(File.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output", "apphost.mts")));
     }
 
-    [Fact]
-    public async Task NewCommandWithCSharpEmptyTemplateAndSourceOverrideUsesSourceForTemplateDiscovery()
+    [Theory]
+    [InlineData("https://proxy.example/v3/index.json")]
+    [InlineData("relative-feed")]
+    public async Task NewCommandWithCSharpEmptyTemplateAndSourceOverrideUsesSourceForTemplateDiscovery(string sourceOverride)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        const string sourceOverride = "https://proxy.example/v3/index.json";
+        var expectedSource = sourceOverride == "relative-feed"
+            ? Path.GetFullPath(sourceOverride, workspace.WorkspaceRoot.FullName)
+            : sourceOverride;
         string? discoveryCatchAllSource = null;
 
         var cache = new FakeNuGetPackageCache
@@ -1208,7 +1212,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 discoveryCatchAllSource = (string?)catchAllSource.Attribute("key");
 
                 return Task.FromResult<IEnumerable<NuGetPackage>>(
-                    [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = sourceOverride, Version = "9.2.0" }]);
+                    [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = expectedSource, Version = "9.2.0" }]);
             }
         };
         var channel = PackageChannel.CreateExplicitChannel(
@@ -1233,7 +1237,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.Equal(sourceOverride, discoveryCatchAllSource);
+        Assert.Equal(expectedSource, discoveryCatchAllSource);
     }
 
     [Theory]

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -1193,7 +1193,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         var expectedSource = isRelative
             ? Path.Combine(workspace.WorkspaceRoot.FullName, sourceOverride)
             : sourceOverride;
-        string? discoveryCatchAllSource = null;
+        if (isRelative)
+        {
+            Directory.CreateDirectory(expectedSource);
+        }
+
+        string? discoveryAspireSource = null;
+        string? discoveryFallbackSource = null;
 
         var cache = new FakeNuGetPackageCache
         {
@@ -1202,23 +1208,31 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 Assert.NotNull(nugetConfig);
 
                 var document = XDocument.Load(nugetConfig.FullName);
-                var catchAllSource = document.Root!
+                var sourceMappings = document.Root!
                     .Element("packageSourceMapping")!
-                    .Elements("packageSource")
+                    .Elements("packageSource");
+                discoveryAspireSource = (string?)sourceMappings
                     .Single(source => source
                         .Elements("package")
-                        .Any(package => (string?)package.Attribute("pattern") == PackageMapping.AllPackages));
-
-                discoveryCatchAllSource = (string?)catchAllSource.Attribute("key");
+                        .Any(package => (string?)package.Attribute("pattern") == "Aspire*"))
+                    .Attribute("key");
+                discoveryFallbackSource = (string?)sourceMappings
+                    .Single(source => source
+                        .Elements("package")
+                        .Any(package => (string?)package.Attribute("pattern") == PackageMapping.AllPackages))
+                    .Attribute("key");
 
                 return Task.FromResult<IEnumerable<NuGetPackage>>(
                     [new NuGetPackage { Id = "Aspire.ProjectTemplates", Source = expectedSource, Version = "9.2.0" }]);
             }
         };
         var channel = PackageChannel.CreateExplicitChannel(
-            PackageChannelNames.Stable,
+            PackageChannelNames.Staging,
             PackageChannelQuality.Stable,
-            [new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)],
+            [
+                new PackageMapping("Aspire*", "https://channel.example/v3/index.json"),
+                new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
+            ],
             cache,
             new TestFeatures(),
             NullLogger.Instance);
@@ -1232,12 +1246,13 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
 
         using var provider = services.BuildServiceProvider();
         var command = provider.GetRequiredService<NewCommand>();
-        var result = command.Parse($"new aspire-empty --name TestApp --output ./output --language csharp --localhost-tld false --suppress-agent-init --source {sourceOverride}");
+        var result = command.Parse($"new aspire-empty --name TestApp --output ./output --language csharp --localhost-tld false --suppress-agent-init --channel staging --source {sourceOverride}");
 
         var exitCode = await result.InvokeAsync().DefaultTimeout();
 
         Assert.Equal(CliExitCodes.Success, exitCode);
-        Assert.Equal(expectedSource, discoveryCatchAllSource);
+        Assert.Equal(expectedSource, discoveryAspireSource);
+        Assert.Equal(expectedSource, discoveryFallbackSource);
         AssertSourceOverrideNuGetConfig(Path.Combine(workspace.WorkspaceRoot.FullName, "output"), expectedSource);
     }
 
@@ -1251,6 +1266,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var sourceOverride = Path.Combine(workspace.WorkspaceRoot.FullName, "source-feed");
+        Directory.CreateDirectory(sourceOverride);
         string? capturedPackageSourceOverride = null;
         TestInteractionService? interactionService = null;
 
@@ -1297,6 +1313,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var sourceOverride = Path.Combine(workspace.WorkspaceRoot.FullName, "source-feed");
+        Directory.CreateDirectory(sourceOverride);
 
         var services = CreateServiceCollection(workspace);
 
@@ -1345,6 +1362,41 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         Assert.False(Directory.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output")));
         Assert.NotNull(interactionService);
         Assert.Contains(NewCommandStrings.SourceWithCredentialsCannotBePersisted, interactionService!.DisplayedErrors);
+    }
+
+    [Fact]
+    public async Task NewCommandWithMissingLocalSourceFailsBeforeCreatingProject()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var scaffoldingInvoked = false;
+        TestInteractionService? interactionService = null;
+
+        var services = CreateServiceCollection(workspace, options =>
+        {
+            options.InteractionServiceFactory = _ => interactionService = new TestInteractionService();
+        });
+
+        services.AddSingleton<IScaffoldingService>(new TestScaffoldingService
+        {
+            ScaffoldAsyncCallback = (_, _) =>
+            {
+                scaffoldingInvoked = true;
+                return Task.FromResult(true);
+            }
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var command = provider.GetRequiredService<NewCommand>();
+        var result = command.Parse("new aspire-empty --name TestApp --output ./output --language typescript --localhost-tld false --suppress-agent-init --source nuget.org");
+
+        var exitCode = await result.InvokeAsync().DefaultTimeout();
+
+        var expectedSource = Path.Combine(workspace.WorkspaceRoot.FullName, "nuget.org");
+        Assert.Equal(CliExitCodes.InvalidCommand, exitCode);
+        Assert.False(scaffoldingInvoked);
+        Assert.False(Directory.Exists(Path.Combine(workspace.WorkspaceRoot.FullName, "output")));
+        Assert.NotNull(interactionService);
+        Assert.Contains(interactionService!.DisplayedErrors, error => error.Contains(expectedSource, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -1989,7 +2041,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
         var sourceOverride = Path.Combine(workspace.WorkspaceRoot.FullName, "source-feed");
-
+        Directory.CreateDirectory(sourceOverride);
         TestInteractionService? interactionService = null;
         var services = CreateServiceCollection(workspace, options =>
         {
@@ -2095,7 +2147,8 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
         // restore would just add noise behind a more prominent error. Pin that the starter path
         // mirrors the empty-template path here.
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        const string sourceOverride = "/tmp/aspire-pr-hive/packages";
+        var sourceOverride = Path.Combine(workspace.WorkspaceRoot.FullName, "source-feed");
+        Directory.CreateDirectory(sourceOverride);
 
         TestInteractionService? interactionService = null;
         var services = CreateServiceCollection(workspace, options =>

--- a/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
+++ b/tests/Aspire.Cli.Tests/Commands/NewCommandTests.cs
@@ -2043,7 +2043,7 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
     public async Task NewCommandWithDotNetTemplateAndSourceOverridePersistsSourceForLaterRestore()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
-        const string sourceOverride = "/tmp/aspire-pr-hive/packages";
+        const string sourceOverride = "https://proxy.example/v3/index.json";
 
         var services = CreateServiceCollection(workspace, options =>
         {
@@ -2052,6 +2052,17 @@ public class NewCommandTests(ITestOutputHelper outputHelper)
                 var runner = CreateTestRunnerWithStandardPackages();
                 runner.InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, force, invocationOptions, cancellationToken) =>
                 {
+                    Assert.NotNull(nugetConfigFile);
+
+                    var document = XDocument.Load(nugetConfigFile.FullName);
+                    var installPackageSources = document.Root!
+                        .Element("packageSources")!
+                        .Elements("add")
+                        .Select(element => (string)element.Attribute("value")!)
+                        .ToArray();
+
+                    Assert.Equal([sourceOverride], installPackageSources);
+
                     return (0, version);
                 };
                 runner.NewProjectAsyncCallback = (templateName, projectName, outputPath, invocationOptions, cancellationToken) =>

--- a/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
+++ b/tests/Aspire.Cli.Tests/NuGet/NuGetPackagePrefetcherTests.cs
@@ -274,6 +274,33 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
         await AssertPrefetchingAsync(provider, templateCommand, templateCommand.Name, expectedTemplatePrefetch: true, expectedCliPrefetch: true);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task NewSourceOverrideSkipsTemplatePackageMetadataPrefetching(bool useTemplateSubcommand)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var services = CliTestHelper.CreateServiceCollection(workspace, outputHelper);
+        using var provider = services.BuildServiceProvider();
+
+        var newCommand = provider.GetRequiredService<NewCommand>();
+        BaseCommand command = useTemplateSubcommand
+            ? Assert.IsType<TemplateCommand>(newCommand.Subcommands.First())
+            : newCommand;
+        var commandLine = useTemplateSubcommand
+            ? $"new {command.Name} --source source-feed"
+            : "new --source source-feed";
+        var parseResult = newCommand.Parse(commandLine);
+
+        await AssertPrefetchingAsync(
+            provider,
+            command,
+            commandLine,
+            expectedTemplatePrefetch: false,
+            expectedCliPrefetch: true,
+            parseResult: parseResult);
+    }
+
     [Fact]
     public async Task DetachedRunStartsNoPackageMetadataPrefetching()
     {
@@ -452,7 +479,8 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
         string commandLine,
         bool expectedTemplatePrefetch,
         bool expectedCliPrefetch,
-        bool updateNotificationsEnabled = true)
+        bool updateNotificationsEnabled = true,
+        ParseResult? parseResult = null)
     {
         var features = new TestFeatures();
         features.SetFeature(KnownFeatures.UpdateNotificationsEnabled, updateNotificationsEnabled);
@@ -481,7 +509,7 @@ public class NuGetPackagePrefetcherTests(ITestOutputHelper outputHelper)
         var prefetcher = CreatePrefetcher(executionContext, features, packagingService, updateNotifier);
 
         await prefetcher.StartAsync(CancellationToken.None).DefaultTimeout();
-        command.SelectForExecution(command.Parse(commandLine));
+        command.SelectForExecution(parseResult ?? command.Parse(commandLine));
         await prefetcher.ExecuteTask!.DefaultTimeout();
         await prefetcher.StopAsync(CancellationToken.None).DefaultTimeout();
 

--- a/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageChannelTests.cs
@@ -104,6 +104,35 @@ public class PackageChannelTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task GetTemplatePackagesAsync_PinnedChannelWithMappingsOverride_UsesOverrideSource()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        const string pinnedVersion = "13.5.0-preview.1";
+        const string channelSource = "https://channel.example/v3/index.json";
+        const string sourceOverride = "https://proxy.example/v3/index.json";
+        var channel = PackageChannel.CreateExplicitChannel(
+            "staging",
+            PackageChannelQuality.Prerelease,
+            [
+                new PackageMapping("Aspire*", channelSource),
+                new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
+            ],
+            new FakeNuGetPackageCache(),
+            new TestFeatures(),
+            NullLogger.Instance,
+            pinnedVersion: pinnedVersion);
+
+        var package = Assert.Single(await channel.GetTemplatePackagesAsync(
+            workspace.WorkspaceRoot,
+            PackageSourceOverrideMappings.CreateForTemplateOperations(sourceOverride),
+            CancellationToken.None));
+
+        Assert.Equal(pinnedVersion, package.Version);
+        Assert.Equal(sourceOverride, package.Source);
+        Assert.Equal(channelSource, channel.SourceDetails);
+    }
+
+    [Fact]
     public async Task GetIntegrationPackagesAsync_WithPinnedLocalSource_ReturnsOnlyPinnedLocalIntegrationPackages()
     {
         using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);

--- a/tests/Aspire.Cli.Tests/Packaging/PackageSourceOverrideMappingsTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageSourceOverrideMappingsTests.cs
@@ -17,4 +17,17 @@ public class PackageSourceOverrideMappingsTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(Path.Combine(workspace.WorkspaceRoot.FullName, "relative:feed"), result);
     }
+
+    [Theory]
+    [InlineData("C:/feed")]
+    [InlineData("a:/feed")]
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public void ResolveForWorkingDirectory_DosShapedRelativePath_ResolvesAgainstWorkingDirectory(string source)
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var result = PackageSourceOverrideMappings.ResolveForWorkingDirectory(source, workspace.WorkspaceRoot);
+
+        Assert.Equal(Path.Combine(workspace.WorkspaceRoot.FullName, source), result);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Packaging/PackageSourceOverrideMappingsTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageSourceOverrideMappingsTests.cs
@@ -30,4 +30,27 @@ public class PackageSourceOverrideMappingsTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(Path.Combine(workspace.WorkspaceRoot.FullName, source), result);
     }
+
+    [Fact]
+    public void ResolveForWorkingDirectory_FileUri_ReturnsUnchanged()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        const string source = "file:///tmp/feed";
+
+        var result = PackageSourceOverrideMappings.ResolveForWorkingDirectory(source, workspace.WorkspaceRoot);
+
+        Assert.Equal(source, result);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void ResolveForWorkingDirectory_WindowsFullyQualifiedPath_ReturnsUnchanged()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        const string source = @"C:\feed";
+
+        var result = PackageSourceOverrideMappings.ResolveForWorkingDirectory(source, workspace.WorkspaceRoot);
+
+        Assert.Equal(source, result);
+    }
 }

--- a/tests/Aspire.Cli.Tests/Packaging/PackageSourceOverrideMappingsTests.cs
+++ b/tests/Aspire.Cli.Tests/Packaging/PackageSourceOverrideMappingsTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Cli.Packaging;
+
+namespace Aspire.Cli.Tests.Packaging;
+
+public class PackageSourceOverrideMappingsTests(ITestOutputHelper outputHelper)
+{
+    [Fact]
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    public void ResolveForWorkingDirectory_RelativePathContainingColon_ResolvesAgainstWorkingDirectory()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+
+        var result = PackageSourceOverrideMappings.ResolveForWorkingDirectory("relative:feed", workspace.WorkspaceRoot);
+
+        Assert.Equal(Path.Combine(workspace.WorkspaceRoot.FullName, "relative:feed"), result);
+    }
+}

--- a/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
@@ -320,6 +320,62 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task ResolveTemplatePackageAsync_RequestedChannelWithSourceOverride_ReplacesFallbackSource()
+    {
+        const string channelName = "staging";
+        const string channelSource = "https://channel.example/v3/index.json";
+        const string sourceOverride = "https://proxy.example/v3/index.json";
+
+        var packageCache = new FakeNuGetPackageCache
+        {
+            GetTemplatePackagesAsyncCallback = (_, _, nugetConfigFile, _) =>
+            {
+                Assert.NotNull(nugetConfigFile);
+                var doc = XDocument.Load(nugetConfigFile.FullName);
+                var sources = doc.Root!.Element("packageSources")!.Elements("add")
+                    .Select(e => (string)e.Attribute("value")!)
+                    .ToArray();
+                Assert.Equal([channelSource, sourceOverride], sources);
+
+                return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(
+                [
+                    new Aspire.Shared.NuGetPackageCli
+                    {
+                        Id = TemplateNuGetConfigService.TemplatesPackageName,
+                        Version = "13.5.0-preview.1",
+                        Source = channelSource
+                    }
+                ]);
+            }
+        };
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                var channel = PackageChannel.CreateExplicitChannel(
+                    channelName,
+                    PackageChannelQuality.Prerelease,
+                    [
+                        new PackageMapping("Aspire*", channelSource),
+                        new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
+                    ],
+                    packageCache,
+                    features: new TestFeatures(),
+                    NullLogger.Instance);
+                return Task.FromResult<IEnumerable<PackageChannel>>([channel]);
+            }
+        };
+        var service = CreateService(packagingService: packagingService);
+        var query = new TemplatePackageQuery(
+            RequestedChannel: channelName,
+            VersionOverride: null,
+            SourceOverride: sourceOverride,
+            IncludePrHives: false);
+
+        await service.ResolveTemplatePackageAsync(query, CancellationToken.None);
+    }
+
+    [Fact]
     public async Task ResolveTemplatePackageAsync_NonExistentRequestedChannel_NotLocal_StillThrowsChannelNotFound()
     {
         // Companion to RequestedChannel_NotFound_Throws: any unrecognized name (typo

--- a/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
+++ b/tests/Aspire.Cli.Tests/Templating/TemplateNuGetConfigServiceTests.cs
@@ -320,7 +320,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task ResolveTemplatePackageAsync_RequestedChannelWithSourceOverride_ReplacesFallbackSource()
+    public async Task ResolveTemplatePackageAsync_RequestedChannelWithSourceOverride_ReplacesAspireSource()
     {
         const string channelName = "staging";
         const string channelSource = "https://channel.example/v3/index.json";
@@ -335,7 +335,8 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                 var sources = doc.Root!.Element("packageSources")!.Elements("add")
                     .Select(e => (string)e.Attribute("value")!)
                     .ToArray();
-                Assert.Equal([channelSource, sourceOverride], sources);
+                Assert.Equal([sourceOverride], sources);
+                Assert.Equal(["Aspire*", PackageMapping.AllPackages], GetPackagePatternsForSource(doc, sourceOverride));
 
                 return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(
                 [
@@ -343,7 +344,7 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
                     {
                         Id = TemplateNuGetConfigService.TemplatesPackageName,
                         Version = "13.5.0-preview.1",
-                        Source = channelSource
+                        Source = sourceOverride
                     }
                 ]);
             }
@@ -373,6 +374,125 @@ public class TemplateNuGetConfigServiceTests(ITestOutputHelper outputHelper)
             IncludePrHives: false);
 
         await service.ResolveTemplatePackageAsync(query, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ResolveTemplatePackageAsync_SourceOverrideWithoutRequestedChannel_UsesImplicitChannelOnly()
+    {
+        using var workspace = TemporaryWorkspace.CreateForCli(outputHelper);
+        var hivesDirectory = workspace.CreateDirectory("hives");
+        hivesDirectory.CreateSubdirectory("pr-12345");
+        var executionContext = CreateExecutionContextWithHives(workspace.WorkspaceRoot, hivesDirectory);
+        const string sourceOverride = "https://proxy.example/v3/index.json";
+
+        var packageCache = new FakeNuGetPackageCache
+        {
+            GetTemplatePackagesAsyncCallback = (_, _, nugetConfigFile, _) =>
+            {
+                Assert.NotNull(nugetConfigFile);
+                var doc = XDocument.Load(nugetConfigFile.FullName);
+                var sources = doc.Root!.Element("packageSources")!.Elements("add")
+                    .Select(e => (string)e.Attribute("value")!)
+                    .ToArray();
+                Assert.Equal([sourceOverride], sources);
+
+                return Task.FromResult<IEnumerable<Aspire.Shared.NuGetPackageCli>>(
+                [
+                    new Aspire.Shared.NuGetPackageCli
+                    {
+                        Id = TemplateNuGetConfigService.TemplatesPackageName,
+                        Version = "13.5.0",
+                        Source = sourceOverride
+                    }
+                ]);
+            }
+        };
+        var packagingService = new TestPackagingService
+        {
+            GetChannelsAsyncCallback = _ =>
+            {
+                var implicitChannel = PackageChannel.CreateImplicitChannel(packageCache, new TestFeatures(), NullLogger.Instance);
+                var hiveChannel = PackageChannel.CreateExplicitChannel(
+                    "pr-12345",
+                    PackageChannelQuality.Both,
+                    [new PackageMapping("Aspire*", "pr-source")],
+                    new FakeNuGetPackageCache(),
+                    new TestFeatures(),
+                    NullLogger.Instance,
+                    pinnedVersion: "99.0.0");
+                return Task.FromResult<IEnumerable<PackageChannel>>([implicitChannel, hiveChannel]);
+            }
+        };
+        var service = CreateService(packagingService: packagingService, executionContext: executionContext);
+        var query = new TemplatePackageQuery(
+            RequestedChannel: null,
+            VersionOverride: null,
+            SourceOverride: sourceOverride,
+            IncludePrHives: true);
+
+        var selection = await service.ResolveTemplatePackageAsync(query, CancellationToken.None);
+
+        Assert.Equal("13.5.0", selection.Package.Version);
+        Assert.Equal(sourceOverride, selection.Package.Source);
+        Assert.Equal(PackageChannelType.Implicit, selection.Channel.Type);
+    }
+
+    [Fact]
+    public async Task InstallTemplatePackageAsync_SourceOverride_UsesExclusiveSource()
+    {
+        const string channelSource = "https://channel.example/v3/index.json";
+        const string sourceOverride = "https://proxy.example/v3/index.json";
+        const string packageVersion = "13.5.0-preview.1";
+        var channel = PackageChannel.CreateExplicitChannel(
+            "staging",
+            PackageChannelQuality.Prerelease,
+            [
+                new PackageMapping("Aspire*", channelSource),
+                new PackageMapping(PackageMapping.AllPackages, PackageSources.NuGetOrg)
+            ],
+            new FakeNuGetPackageCache(),
+            new TestFeatures(),
+            NullLogger.Instance,
+            pinnedVersion: packageVersion);
+        var selection = new TemplatePackageSelection(
+            new Aspire.Shared.NuGetPackageCli
+            {
+                Id = TemplateNuGetConfigService.TemplatesPackageName,
+                Version = packageVersion,
+                Source = channelSource
+            },
+            channel);
+        var runner = new TestDotNetCliRunner
+        {
+            InstallTemplateAsyncCallback = (packageName, version, nugetConfigFile, nugetSource, _, _, _) =>
+            {
+                Assert.Equal(TemplateNuGetConfigService.TemplatesPackageName, packageName);
+                Assert.Equal(packageVersion, version);
+                Assert.Equal(sourceOverride, nugetSource);
+                Assert.NotNull(nugetConfigFile);
+
+                var doc = XDocument.Load(nugetConfigFile.FullName);
+                var sources = doc.Root!.Element("packageSources")!.Elements("add")
+                    .Select(e => (string)e.Attribute("value")!)
+                    .ToArray();
+                Assert.Equal([sourceOverride], sources);
+                Assert.Equal(["Aspire*", PackageMapping.AllPackages], GetPackagePatternsForSource(doc, sourceOverride));
+
+                return (0, packageVersion);
+            }
+        };
+        var service = CreateService();
+
+        var outcome = await service.InstallTemplatePackageAsync(
+            selection,
+            sourceOverride,
+            runner,
+            "Installing templates",
+            statusEmoji: null,
+            CancellationToken.None);
+
+        Assert.Equal(0, outcome.ExitCode);
+        Assert.Equal(packageVersion, outcome.TemplateVersion);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

`aspire new --source` currently ignores the explicit source while resolving template versions and can contact NuGet.org from an isolated temporary configuration. This breaks project creation in environments where NuGet.org is blocked and package traffic must use an approved proxy.

This change makes the explicit source exclusive for template discovery and installation, including pinned daily, staging, local, and PR channels. The selected channel identity stays unchanged when a channel is requested; without one, the implicit channel owns the result so stale hives cannot attach an unrelated channel identity.

Relative local sources are resolved against the invocation working directory. Missing local directories now fail before discovery or scaffolding, while HTTP sources and `file:` URIs keep their existing forms.

### User-facing usage

```bash
aspire new aspire-empty \
  --name SourceTest \
  --output ./SourceTest \
  --language csharp \
  --source https://packagefeedproxy.microsoft.io/nuget/v3/index.json \
  --non-interactive \
  --suppress-agent-init
```

With an explicit source, template discovery and installation use only that source. The generated project still maps `Aspire*` to the explicit source and retains the selected channel's non-Aspire fallback for later restores.

### Validation

- Reproduced NuGet.org contact with the reported `13.5.0+11a1277e...` staging CLI.
- Verified a synthesized staging channel discovers and installs `Aspire.ProjectTemplates` from one explicit local feed while TCP tripwires for NuGet.org and `pkgs.dev.azure.com` remain untouched.
- Verified missing local sources fail before scaffolding, including a plausible `--source nuget.org` typo.
- Verified relative paths, `file:` URIs, and Windows fully qualified paths.
- `Aspire.Cli.Tests`: 4,944 passed, 33 platform-specific skipped.
- Full repository build: 0 warnings, 0 errors.

Fixes #19338

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
