### PR TITLE
Support advanced dotnet invocation options

### DIFF
--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -791,6 +791,12 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         var dotnetProjectLaunchResourceArgumentIndex = FindExecutableAnnotatedDotnetProjectLaunchArgumentIndex(
             er.ModelResource,
             appHostArgList);
+        var dotnetProjectApplicationArgumentBoundaryIndex =
+            dotnetProjectLaunchResourceArgumentIndex is { } boundarySearchStartIndex
+                ? appHostArgList.FindIndex(
+                    boundarySearchStartIndex + 1,
+                    static argument => string.Equals(argument.Value, "--", StringComparison.Ordinal))
+                : -1;
         var launchArgs = new List<LaunchArgument>();
         int? dotnetProjectLaunchArgumentIndex = null;
         var canReuseArgsForProcessFallback = true;
@@ -846,11 +852,13 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                 if (projectLaunchProfileArgs.Count > 0 &&
                     ordinaryAppHostArgumentCount > 0 &&
                     launchToolArgumentCount == 0 &&
-                    HasDotnetApplicationArgumentBoundary())
+                    HasDotnetApplicationArgumentBoundary() &&
+                    dotnetProjectApplicationArgumentBoundaryIndex < 0)
                 {
                     // A prepared project command or explicit `dotnet run`/`dotnet watch` invocation needs a
                     // double-dash before application arguments. Custom IDE launchers receive raw application
-                    // arguments instead.
+                    // arguments instead. An explicit command can already contain that boundary, in which case
+                    // its launch-profile arguments are inserted after the existing separator below.
                     projectLaunchProfileArgs.Insert(0, "--");
                 }
             }
@@ -865,14 +873,17 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                 return dotnetProjectLaunchResourceArgumentIndex is { } index && index >= omittedLaunchToolArgumentCount;
             }
         }
-        // Project launch-profile arguments are application arguments. Append them after an explicit executable
-        // `dotnet run`/`dotnet watch` command so its SDK options stay before the `--` separator. When a custom
-        // launch-tool declaration replaces that command, keep its prefix first and insert profile arguments before
+        // Project launch-profile arguments are application arguments. Place them after an explicit executable
+        // `dotnet run`/`dotnet watch` command so its SDK options stay before the `--` separator. If the command
+        // already has a separator, put profile arguments before its existing application arguments. When a custom
+        // launch-tool declaration replaces the command, keep its prefix first and insert profile arguments before
         // ordinary app-host arguments. Without either form, preserve the existing profile-before-app-host ordering.
         var projectLaunchProfileArgumentInsertIndex =
             dotnetProjectLaunchResourceArgumentIndex is { } projectLaunchResourceArgumentIndex &&
             projectLaunchResourceArgumentIndex >= omittedLaunchToolArgumentCount
-                ? appHostArgList.Count
+                ? dotnetProjectApplicationArgumentBoundaryIndex >= 0
+                    ? dotnetProjectApplicationArgumentBoundaryIndex + 1
+                    : appHostArgList.Count
                 : launchToolArgumentCount > 0
                     ? Math.Min(launchToolArgumentCount, appHostArgList.Count)
                     : 0;
@@ -927,7 +938,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
 
         // Recognize the project-launching SDK verb after supported non-terminating command prefixes:
         //   dotnet run ...
-        //   dotnet [env:ASPNETCORE_ENVIRONMENT=Development] --diagnostics run ...
+        //   dotnet [env:ASPNETCORE_ENVIRONMENT=Development] [env:DOTNET_ENVIRONMENT=Development] --diagnostics run ...
         //   dotnet -d watch ...
         // The System.CommandLine environment directive works for built-in SDK commands such as run, but .NET 10
         // does not resolve the external watch command through it. Response files are also valid CLI inputs, but they
@@ -944,11 +955,11 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         // https://learn.microsoft.com/dotnet/core/tools/dotnet-watch. The environment directive is defined at
         // https://github.com/dotnet/command-line-api/blob/main/src/System.CommandLine/EnvironmentVariablesDirective.cs.
         var projectLaunchArgumentIndex = 0;
-        var hasEnvironmentVariableDirective =
-            projectLaunchArgumentIndex < appHostArgs.Count &&
-            IsDotnetEnvironmentVariableDirective(appHostArgs[projectLaunchArgumentIndex].Value);
-        if (hasEnvironmentVariableDirective)
+        var hasEnvironmentVariableDirective = false;
+        while (projectLaunchArgumentIndex < appHostArgs.Count &&
+            IsDotnetEnvironmentVariableDirective(appHostArgs[projectLaunchArgumentIndex].Value))
         {
+            hasEnvironmentVariableDirective = true;
             projectLaunchArgumentIndex++;
         }
 
@@ -995,21 +1006,6 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             return;
         }
 
-        List<LaunchArgument>? launchProfileArgs = null;
-        var firstExecutableArgumentIndex = launchArgs.FindIndex(static argument => argument.Executable);
-        if (firstExecutableArgumentIndex >= 0 &&
-            projectLaunchIndex > firstExecutableArgumentIndex &&
-            string.Equals(launchArgs[firstExecutableArgumentIndex].Value, "--", StringComparison.Ordinal))
-        {
-            // Executable launch-profile args were composed before the caller-provided project launch command.
-            // Preserve any non-executable launch-tool display prefix, then move the profile segment after
-            // the project launch command so the SDK parses it as application arguments.
-            var launchProfileArgumentCount = projectLaunchIndex - firstExecutableArgumentIndex;
-            launchProfileArgs = launchArgs.GetRange(firstExecutableArgumentIndex, launchProfileArgumentCount);
-            launchArgs.RemoveRange(firstExecutableArgumentIndex, launchProfileArgumentCount);
-            projectLaunchIndex -= launchProfileArgumentCount;
-        }
-
         var argsToInsert = new List<string>();
         if (!string.IsNullOrEmpty(_distributedApplicationOptions.Configuration) &&
             !ContainsDotnetProjectLaunchOption(launchArgs, "--configuration", "-c"))
@@ -1023,7 +1019,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             argsToInsert.Add("--no-launch-profile");
         }
 
-        if (argsToInsert.Count == 0 && launchProfileArgs is null)
+        if (argsToInsert.Count == 0)
         {
             return;
         }
@@ -1035,14 +1031,6 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         if (argsToInsert.Count > 0)
         {
             launchArgs.InsertRange(projectLaunchIndex + 1, argsToInsert.Select(argument => new LaunchArgument(argument, IsSensitive: false, Executable: true, Display: false, EffectiveArgumentIndex: null)));
-        }
-
-        if (launchProfileArgs is not null)
-        {
-            // Launch profile args were originally before the app host args, separated by `--`.
-            // Once this path preserves the caller-provided project launch command, those args must
-            // move after the inserted SDK options so the SDK parses them as application args.
-            launchArgs.AddRange(launchProfileArgs);
         }
 
         ReindexExecutableLaunchArgs(launchArgs, executableArgumentStartIndex);

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -865,12 +865,17 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                 return dotnetProjectLaunchResourceArgumentIndex is { } index && index >= omittedLaunchToolArgumentCount;
             }
         }
-        // Project launch-profile arguments are application arguments. When a custom launch-tool declaration replaces
-        // the implicit `dotnet run` scaffold, keep its prefix first and insert profile arguments before ordinary
-        // app-host arguments. Without such a declaration, preserve the existing profile-before-app-host ordering.
-        var projectLaunchProfileArgumentInsertIndex = launchToolArgumentCount > 0
-            ? Math.Min(launchToolArgumentCount, appHostArgList.Count)
-            : 0;
+        // Project launch-profile arguments are application arguments. Append them after an explicit executable
+        // `dotnet run`/`dotnet watch` command so its SDK options stay before the `--` separator. When a custom
+        // launch-tool declaration replaces that command, keep its prefix first and insert profile arguments before
+        // ordinary app-host arguments. Without either form, preserve the existing profile-before-app-host ordering.
+        var projectLaunchProfileArgumentInsertIndex =
+            dotnetProjectLaunchResourceArgumentIndex is { } projectLaunchResourceArgumentIndex &&
+            projectLaunchResourceArgumentIndex >= omittedLaunchToolArgumentCount
+                ? appHostArgList.Count
+                : launchToolArgumentCount > 0
+                    ? Math.Min(launchToolArgumentCount, appHostArgList.Count)
+                    : 0;
 
         // Launch tool arguments (the tool-invocation prefix such as `run ./cmd/api`) are the leading app-host args,
         // and the two decisions about them are independent:
@@ -920,21 +925,60 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             return null;
         }
 
-        // Recognize the project-launching SDK verb only immediately after the dotnet executable:
+        // Recognize the project-launching SDK verb after supported non-terminating command prefixes:
         //   dotnet run ...
-        //   dotnet watch ...
-        // Later values belong to another SDK command or the launched application, for example:
+        //   dotnet [env:ASPNETCORE_ENVIRONMENT=Development] --diagnostics run ...
+        //   dotnet -d watch ...
+        // The System.CommandLine environment directive works for built-in SDK commands such as run, but .NET 10
+        // does not resolve the external watch command through it. Response files are also valid CLI inputs, but they
+        // can expand to arbitrary options, commands, or application paths, so do not skip an opaque @file token:
+        //   dotnet @options.rsp run ...
+        // Do not skip arbitrary options. Runtime options introduce an application path rather than an SDK command:
+        //   dotnet --roll-forward LatestMajor app.dll run
+        // Other later values can also belong to another SDK command or the launched application:
         //   dotnet tool run <command>
         //   dotnet exec app.dll watch
-        // They must not be interpreted as the top-level project-launch verb.
-        // See https://learn.microsoft.com/dotnet/core/tools/dotnet-run and
-        // https://learn.microsoft.com/dotnet/core/tools/dotnet-watch.
-        if (appHostArgs.Count > 0 && appHostArgs[0].Value is "run" or "watch")
+        // Those later run/watch values must not be interpreted as the top-level project-launch verb.
+        // See https://learn.microsoft.com/dotnet/core/tools/dotnet,
+        // https://learn.microsoft.com/dotnet/core/tools/dotnet-run, and
+        // https://learn.microsoft.com/dotnet/core/tools/dotnet-watch. The environment directive is defined at
+        // https://github.com/dotnet/command-line-api/blob/main/src/System.CommandLine/EnvironmentVariablesDirective.cs.
+        var projectLaunchArgumentIndex = 0;
+        var hasEnvironmentVariableDirective =
+            projectLaunchArgumentIndex < appHostArgs.Count &&
+            IsDotnetEnvironmentVariableDirective(appHostArgs[projectLaunchArgumentIndex].Value);
+        if (hasEnvironmentVariableDirective)
         {
-            return 0;
+            projectLaunchArgumentIndex++;
+        }
+
+        while (projectLaunchArgumentIndex < appHostArgs.Count &&
+            IsDotnetSdkDiagnosticOption(appHostArgs[projectLaunchArgumentIndex].Value))
+        {
+            projectLaunchArgumentIndex++;
+        }
+
+        if (projectLaunchArgumentIndex < appHostArgs.Count)
+        {
+            var candidate = appHostArgs[projectLaunchArgumentIndex].Value;
+            if (candidate == "run" || (candidate == "watch" && !hasEnvironmentVariableDirective))
+            {
+                return projectLaunchArgumentIndex;
+            }
         }
 
         return null;
+    }
+
+    private static bool IsDotnetEnvironmentVariableDirective(string argument)
+    {
+        return string.Equals(argument, "[env]", StringComparison.OrdinalIgnoreCase) ||
+            argument.StartsWith("[env:", StringComparison.OrdinalIgnoreCase) && argument.EndsWith(']');
+    }
+
+    private static bool IsDotnetSdkDiagnosticOption(string argument)
+    {
+        return argument is "-d" or "--diagnostics";
     }
 
     private static bool IsExecutableAnnotatedDotnetProject(IResource resource)

--- a/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
+++ b/src/Aspire.Hosting/Dcp/ExecutableCreator.cs
@@ -788,7 +788,7 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
             omittedLaunchToolArgumentCount = Math.Max(0, omittedLaunchToolArgumentCount - 1);
         }
 
-        var dotnetProjectLaunchResourceArgumentIndex = FindExecutableAnnotatedDotnetProjectLaunchArgumentIndex(
+        var (dotnetProjectLaunchResourceArgumentIndex, canReuseArgsForProcessFallback) = AnalyzeExecutableAnnotatedDotnetProjectArguments(
             er.ModelResource,
             appHostArgList);
         var dotnetProjectApplicationArgumentBoundaryIndex =
@@ -799,7 +799,6 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
                 : -1;
         var launchArgs = new List<LaunchArgument>();
         int? dotnetProjectLaunchArgumentIndex = null;
-        var canReuseArgsForProcessFallback = true;
         var nextExecutableArgumentIndex = executableArgumentStartIndex;
         List<string>? projectLaunchProfileArgs = null;
         var includeProfileArgsInSpec = false;
@@ -927,13 +926,13 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         return (launchArgs, dotnetProjectLaunchArgumentIndex, canReuseArgsForProcessFallback);
     }
 
-    private static int? FindExecutableAnnotatedDotnetProjectLaunchArgumentIndex(
+    private static (int? ProjectLaunchArgumentIndex, bool CanReuseArgsForProcessFallback) AnalyzeExecutableAnnotatedDotnetProjectArguments(
         IResource resource,
         IReadOnlyList<(string Value, bool IsSensitive)> appHostArgs)
     {
         if (!IsExecutableAnnotatedDotnetProject(resource))
         {
-            return null;
+            return (null, true);
         }
 
         // Recognize the project-launching SDK verb after supported non-terminating command prefixes:
@@ -972,13 +971,20 @@ internal sealed class ExecutableCreator : IObjectCreator<Executable, EmptyCreati
         if (projectLaunchArgumentIndex < appHostArgs.Count)
         {
             var candidate = appHostArgs[projectLaunchArgumentIndex].Value;
-            if (candidate == "run" || (candidate == "watch" && !hasEnvironmentVariableDirective))
+            if (candidate == "run")
             {
-                return projectLaunchArgumentIndex;
+                return (projectLaunchArgumentIndex, true);
+            }
+
+            if (candidate == "watch")
+            {
+                return hasEnvironmentVariableDirective
+                    ? (null, false)
+                    : (projectLaunchArgumentIndex, true);
             }
         }
 
-        return null;
+        return (null, true);
     }
 
     private static bool IsDotnetEnvironmentVariableDirective(string argument)

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -6410,9 +6410,12 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedDotnetApplicationWithoutLaunchProfileArgsOffersProcessFallback(bool useExec)
+    [InlineData(new string[] { "exec", "app.dll", "run" }, true)]
+    [InlineData(new string[] { "app.dll", "run" }, true)]
+    [InlineData(new string[] { "[env:ASPIRE_PREFIX_PROBE=1]", "watch" }, false)]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedDotnetApplicationWithoutLaunchProfileArgsSetsExpectedProcessFallback(
+        string[] resourceArgs,
+        bool offersProcessFallback)
     {
         var builder = DistributedApplication.CreateBuilder();
         var projectBuilder = builder.AddProject<TestProject>("proj", launchProfileName: null);
@@ -6422,9 +6425,6 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             projectBuilder.Resource.Annotations.Remove(defaultAnnotation);
         }
 
-        string[] resourceArgs = useExec
-            ? ["exec", "app.dll", "run"]
-            : ["app.dll", "run"];
         projectBuilder
             .WithAnnotation(new ExecutableAnnotation
             {
@@ -6454,7 +6454,14 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
         Assert.Equal(resourceArgs, exe.Spec.Args);
-        Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes!));
+        if (offersProcessFallback)
+        {
+            Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes!));
+        }
+        else
+        {
+            Assert.Null(exe.Spec.FallbackExecutionTypes);
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -6205,16 +6205,36 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData("run", false)]
-    [InlineData("run", true)]
-    [InlineData("watch", false)]
-    [InlineData("watch", true)]
-    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectPreservesLaunchProfileArgs(string launchVerb, bool useFullDotnetPath)
+    [InlineData("run", false, null, null)]
+    [InlineData("run", true, null, null)]
+    [InlineData("watch", false, null, null)]
+    [InlineData("watch", true, null, null)]
+    [InlineData("run", false, "-d", null)]
+    [InlineData("watch", false, "--diagnostics", null)]
+    [InlineData("run", false, null, "[env:ASPIRE_PREFIX_PROBE=1]")]
+    [InlineData("run", false, "--diagnostics", "[env:ASPIRE_PREFIX_PROBE=1]")]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectPreservesLaunchProfileArgs(
+        string launchVerb,
+        bool useFullDotnetPath,
+        string? sdkOption,
+        string? environmentVariableDirective)
     {
         var builder = DistributedApplication.CreateBuilder();
         var dotnetCommand = useFullDotnetPath
             ? Path.GetFullPath(Path.Combine("test-dotnet-root", OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet"))
             : "dotnet";
+        var resourceArgs = new List<string>();
+        if (environmentVariableDirective is not null)
+        {
+            resourceArgs.Add(environmentVariableDirective);
+        }
+
+        if (sdkOption is not null)
+        {
+            resourceArgs.Add(sdkOption);
+        }
+
+        resourceArgs.AddRange([launchVerb, "-f", "net10.0-ios"]);
         var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
         var defaultAnnotation = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
         if (defaultAnnotation is not null)
@@ -6238,7 +6258,7 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
                     TargetKind = "simulator"
                 },
                 "maui")
-            .WithArgs(launchVerb, "-f", "net10.0-ios");
+            .WithArgs([.. resourceArgs]);
 
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -6258,7 +6278,16 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         var exe = GetCreatedExecutableForResource(kubernetesService, "proj");
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
         Assert.Equal(dotnetCommand, exe.Spec.ExecutablePath);
-        var expectedArgs = new List<string> { launchVerb };
+        var expectedArgs = new List<string>();
+        if (environmentVariableDirective is not null)
+        {
+            expectedArgs.Add(environmentVariableDirective);
+        }
+        if (sdkOption is not null)
+        {
+            expectedArgs.Add(sdkOption);
+        }
+        expectedArgs.Add(launchVerb);
         if (GetTestAssemblyConfiguration() is { } configurationName)
         {
             expectedArgs.AddRange(["--configuration", configurationName]);
@@ -6269,17 +6298,26 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
 
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
         Assert.Equal(
-            [launchVerb, "-f", "net10.0-ios", "--", "--profile-arg", "profile value"],
+            [.. resourceArgs, "--", "--profile-arg", "profile value"],
             displayArgs.Select(a => a.Argument));
         AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
     }
 
     [Theory]
-    [InlineData("run", true)]
-    [InlineData("watch", true)]
-    [InlineData("run", false)]
-    [InlineData("watch", false)]
-    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedDotnetApplicationDoesNotOfferInvalidProcessFallback(string nonLeadingLaunchVerb, bool useExec)
+    [InlineData("run", true, false, null)]
+    [InlineData("watch", true, false, null)]
+    [InlineData("run", false, false, null)]
+    [InlineData("watch", false, false, null)]
+    [InlineData("run", false, true, null)]
+    [InlineData("watch", false, true, null)]
+    [InlineData("watch", false, false, "[env:ASPIRE_PREFIX_PROBE=1]")]
+    [InlineData("run", false, false, "@options.rsp")]
+    [InlineData("watch", false, false, "@options.rsp")]
+    public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedDotnetApplicationDoesNotOfferInvalidProcessFallback(
+        string nonLeadingLaunchVerb,
+        bool useExec,
+        bool useRuntimeOptions,
+        string? commandPrefix)
     {
         var builder = DistributedApplication.CreateBuilder();
         var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
@@ -6289,9 +6327,13 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
             projectBuilder.Resource.Annotations.Remove(defaultAnnotation);
         }
 
-        string[] resourceArgs = useExec
-            ? ["exec", "app.dll", nonLeadingLaunchVerb]
-            : ["app.dll", nonLeadingLaunchVerb];
+        string[] resourceArgs = commandPrefix is not null
+            ? [commandPrefix, nonLeadingLaunchVerb]
+            : useRuntimeOptions
+                ? ["--roll-forward", "LatestMajor", "app.dll", nonLeadingLaunchVerb]
+                : useExec
+                    ? ["exec", "app.dll", nonLeadingLaunchVerb]
+                    : ["app.dll", nonLeadingLaunchVerb];
         projectBuilder
             .WithAnnotation(new ExecutableAnnotation
             {

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -6205,28 +6205,31 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
     }
 
     [Theory]
-    [InlineData("run", false, null, null)]
-    [InlineData("run", true, null, null)]
-    [InlineData("watch", false, null, null)]
-    [InlineData("watch", true, null, null)]
-    [InlineData("run", false, "-d", null)]
-    [InlineData("watch", false, "--diagnostics", null)]
-    [InlineData("run", false, null, "[env:ASPIRE_PREFIX_PROBE=1]")]
-    [InlineData("run", false, "--diagnostics", "[env:ASPIRE_PREFIX_PROBE=1]")]
+    [InlineData("run", false, null, null, null)]
+    [InlineData("run", true, null, null, null)]
+    [InlineData("watch", false, null, null, null)]
+    [InlineData("watch", true, null, null, null)]
+    [InlineData("run", false, "-d", null, null)]
+    [InlineData("watch", false, "--diagnostics", null, null)]
+    [InlineData("run", false, null, new string[] { "[env:ASPIRE_PREFIX_PROBE=1]" }, null)]
+    [InlineData("run", false, "--diagnostics", new string[] { "[env:ASPIRE_PREFIX_PROBE=1]" }, null)]
+    [InlineData("run", false, "--diagnostics", new string[] { "[env:ASPIRE_PREFIX_PROBE_A=1]", "[env:ASPIRE_PREFIX_PROBE_B=2]" }, null)]
+    [InlineData("run", false, "--diagnostics", new string[] { "[env:ASPIRE_PREFIX_PROBE=1]" }, "app-arg")]
     public async Task ProjectResource_CustomIdeLaunch_ExecutableAnnotatedProjectPreservesLaunchProfileArgs(
         string launchVerb,
         bool useFullDotnetPath,
         string? sdkOption,
-        string? environmentVariableDirective)
+        string[]? environmentVariableDirectives,
+        string? applicationArgument)
     {
         var builder = DistributedApplication.CreateBuilder();
         var dotnetCommand = useFullDotnetPath
             ? Path.GetFullPath(Path.Combine("test-dotnet-root", OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet"))
             : "dotnet";
         var resourceArgs = new List<string>();
-        if (environmentVariableDirective is not null)
+        if (environmentVariableDirectives is not null)
         {
-            resourceArgs.Add(environmentVariableDirective);
+            resourceArgs.AddRange(environmentVariableDirectives);
         }
 
         if (sdkOption is not null)
@@ -6235,6 +6238,11 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         }
 
         resourceArgs.AddRange([launchVerb, "-f", "net10.0-ios"]);
+        if (applicationArgument is not null)
+        {
+            resourceArgs.AddRange(["--", applicationArgument]);
+        }
+
         var projectBuilder = builder.AddProject<TestProjectWithLaunchProfileCommandLineArgs>("proj", launchProfileName: "http");
         var defaultAnnotation = projectBuilder.Resource.Annotations.OfType<SupportsDebuggingAnnotation>().FirstOrDefault();
         if (defaultAnnotation is not null)
@@ -6279,27 +6287,50 @@ public class DcpExecutorTests(ITestOutputHelper outputHelper)
         Assert.Equal(ExecutionType.IDE, exe.Spec.ExecutionType);
         Assert.Equal(dotnetCommand, exe.Spec.ExecutablePath);
         var expectedArgs = new List<string>();
-        if (environmentVariableDirective is not null)
+        if (environmentVariableDirectives is not null)
         {
-            expectedArgs.Add(environmentVariableDirective);
+            expectedArgs.AddRange(environmentVariableDirectives);
         }
+
         if (sdkOption is not null)
         {
             expectedArgs.Add(sdkOption);
         }
+
         expectedArgs.Add(launchVerb);
         if (GetTestAssemblyConfiguration() is { } configurationName)
         {
             expectedArgs.AddRange(["--configuration", configurationName]);
         }
+
         expectedArgs.AddRange(["--no-launch-profile", "-f", "net10.0-ios", "--", "--profile-arg", "profile value"]);
+        if (applicationArgument is not null)
+        {
+            expectedArgs.Add(applicationArgument);
+        }
+
         Assert.Equal(expectedArgs, exe.Spec.Args);
         Assert.Equal(ExecutionType.Process, Assert.Single(exe.Spec.FallbackExecutionTypes!));
 
         Assert.True(exe.TryGetAnnotationAsObjectList<AppLaunchArgumentAnnotation>(CustomResource.ResourceAppArgsAnnotation, out var displayArgs));
-        Assert.Equal(
-            [.. resourceArgs, "--", "--profile-arg", "profile value"],
-            displayArgs.Select(a => a.Argument));
+        var expectedDisplayArgs = new List<string>();
+        if (environmentVariableDirectives is not null)
+        {
+            expectedDisplayArgs.AddRange(environmentVariableDirectives);
+        }
+
+        if (sdkOption is not null)
+        {
+            expectedDisplayArgs.Add(sdkOption);
+        }
+
+        expectedDisplayArgs.AddRange([launchVerb, "-f", "net10.0-ios", "--", "--profile-arg", "profile value"]);
+        if (applicationArgument is not null)
+        {
+            expectedDisplayArgs.Add(applicationArgument);
+        }
+
+        Assert.Equal(expectedDisplayArgs, displayArgs.Select(a => a.Argument));
         AssertEffectiveArgumentIndexesMatchSpecArgs(displayArgs, exe.Spec.Args);
     }
 


### PR DESCRIPTION
## Description

Executable-annotated project resources only recognized `dotnet run` and `dotnet watch` when the verb immediately followed the `dotnet` executable. Valid non-terminating command prefixes could therefore prevent Aspire from applying the expected configuration, launch-profile suppression, application-argument ordering, and Process fallback behavior.

This change recognizes the supported inline prefix grammar while remaining conservative around command shapes that can switch the muxer into application mode or expand into an unknown command.

### User-facing usage

Custom project integrations can use command forms such as:

```text
dotnet --diagnostics run ...
dotnet [env:ASPNETCORE_ENVIRONMENT=Development] --diagnostics run ...
dotnet -d watch ...
```

Runtime application forms such as `dotnet --roll-forward LatestMajor app.dll run`, nested commands such as `dotnet tool run`, and opaque response-file prefixes remain excluded from project-verb detection.

The regression coverage verifies prefix preservation, injected SDK option placement, launch-profile argument ordering, effective argument indexes, and fallback eligibility.

Follow-up to #19348. Detected via AI code review. Minor issue, does NOT need to be included in 13.5 release.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
